### PR TITLE
Added Placeholder Image for Events Without Image

### DIFF
--- a/frontend/public/placeholder-event.svg
+++ b/frontend/public/placeholder-event.svg
@@ -1,0 +1,70 @@
+<svg width="400" height="200" viewBox="0 0 400 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background Gradient -->
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8B5CF6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#7C3AED;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="iconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#DDD6FE;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#C4B5FD;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="shimmerGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:rgba(255,255,255,0);stop-opacity:0" />
+      <stop offset="50%" style="stop-color:rgba(255,255,255,0.3);stop-opacity:1" />
+      <stop offset="100%" style="stop-color:rgba(255,255,255,0);stop-opacity:0" />
+    </linearGradient>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge> 
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/> 
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <rect width="400" height="200" fill="url(#bgGradient)"/>
+  
+  <!-- Decorative floating elements -->
+  <circle cx="50" cy="50" r="30" fill="rgba(255,255,255,0.1)">
+    <animate attributeName="cy" values="50;30;50" dur="6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="350" cy="150" r="25" fill="rgba(255,255,255,0.08)">
+    <animate attributeName="cx" values="350;370;350" dur="8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="320" cy="30" r="20" fill="rgba(255,255,255,0.12)">
+    <animate attributeName="r" values="20;25;20" dur="4s" repeatCount="indefinite"/>
+  </circle>
+  
+  <!-- Modern Event Icon -->
+  <g transform="translate(175, 75)">
+    <!-- Icon background -->
+    <circle cx="25" cy="25" r="25" fill="rgba(255,255,255,0.2)" filter="url(#softGlow)"/>
+    
+    <!-- Calendar Icon -->
+    <rect x="10" y="12" width="30" height="26" rx="3" fill="url(#iconGradient)" stroke="rgba(255,255,255,0.8)" stroke-width="1"/>
+    
+    <!-- Calendar header -->
+    <rect x="10" y="12" width="30" height="8" rx="3" fill="rgba(255,255,255,0.9)"/>
+    
+    <!-- Calendar rings -->
+    <rect x="16" y="8" width="2" height="8" rx="1" fill="rgba(124,58,237,0.8)"/>
+    <rect x="32" y="8" width="2" height="8" rx="1" fill="rgba(124,58,237,0.8)"/>
+    
+    <!-- Calendar dots -->
+    <circle cx="18" cy="25" r="2" fill="rgba(255,255,255,0.8)"/>
+    <circle cx="25" cy="25" r="2" fill="rgba(255,255,255,0.6)"/>
+    <circle cx="32" cy="25" r="2" fill="rgba(255,255,255,0.8)"/>
+    <circle cx="18" cy="31" r="2" fill="rgba(255,255,255,0.6)"/>
+    <circle cx="25" cy="31" r="2" fill="rgba(255,255,255,0.9)"/>
+  </g>
+  
+  <!-- Event text -->
+  <text x="200" y="155" text-anchor="middle" fill="rgba(255,255,255,0.95)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="18" font-weight="600">No Image Available</text>
+  <text x="200" y="175" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="13">Event details will appear here</text>
+  
+  <!-- Subtle shimmer effect -->
+  <rect x="0" y="0" width="400" height="200" fill="url(#shimmerGradient)" opacity="0.3">
+    <animate attributeName="opacity" values="0.3;0.6;0.3" dur="3s" repeatCount="indefinite"/>
+  </rect>
+</svg>

--- a/frontend/src/components/EventsSection.js
+++ b/frontend/src/components/EventsSection.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import '../components/styles/EventSection.css'; 
+import '../components/styles/EventSection.css';
+import EventImage from './common/EventImage';
 
 const EventsSection = () => {
   const [events, setEvents] = useState([]);
@@ -93,6 +94,48 @@ const EventsSection = () => {
         maxAttendees: 200,
         image: "https://images.unsplash.com/photo-1550751827-4bd374c3f58b?w=400&h=200&fit=crop",
         tags: ["Security", "Privacy", "Protection"]
+      },
+      {
+        id: 7,
+        title: "Mobile App Development Workshop",
+        date: "2025-07-15",
+        time: "11:00 AM",
+        location: "Chicago, IL",
+        type: "workshop",
+        status: "upcoming",
+        description: "Build your first mobile app from scratch using modern frameworks and best practices.",
+        attendees: 95,
+        maxAttendees: 120,
+        image: null, // No image provided
+        tags: ["Mobile", "React Native", "Development"]
+      },
+      {
+        id: 8,
+        title: "Cloud Computing Summit",
+        date: "2025-08-20",
+        time: "9:00 AM",
+        location: "Denver, CO",
+        type: "summit",
+        status: "upcoming",
+        description: "Discover the latest trends in cloud computing and serverless architectures.",
+        attendees: 220,
+        maxAttendees: 280,
+        image: "", // Empty image string
+        tags: ["Cloud", "AWS", "Azure"]
+      },
+      {
+        id: 9,
+        title: "Data Science Bootcamp",
+        date: "2025-09-10",
+        time: "1:30 PM",
+        location: "Online",
+        type: "bootcamp",
+        status: "upcoming",
+        description: "Intensive data science training covering Python, machine learning, and data visualization.",
+        attendees: 45,
+        maxAttendees: 60,
+        image: "https://invalid-url-that-will-fail.com/image.jpg", // Invalid URL to test error handling
+        tags: ["Data Science", "Python", "Analytics"]
       }
     ];
     setEvents(mockEvents);
@@ -142,7 +185,7 @@ const EventsSection = () => {
       whileTap={{ scale: 0.98 }}
     >
       <div className="event-image">
-        <motion.img 
+        <EventImage 
           src={event.image} 
           alt={event.title}
           whileHover={{ scale: 1.1 }}

--- a/frontend/src/components/common/EventImage.css
+++ b/frontend/src/components/common/EventImage.css
@@ -28,7 +28,7 @@
   50% { opacity: 0.6; }
 }
 
-/* Ensure placeholder images are always properly displayed */
+
 .event-image-container img {
   position: relative;
   z-index: 1;
@@ -36,24 +36,24 @@
 }
 
 .event-image-container.showing-placeholder img {
-  /* Ensure SVG placeholders scale properly */
+  
   object-fit: contain;
   background: transparent;
 }
 
-/* Hover effects for placeholder images */
+
 .event-image-container.showing-placeholder:hover::before {
   animation-duration: 1.5s;
 }
 
-/* Special styling to ensure SVG renders correctly */
+
 .event-image-container.showing-placeholder img[src$='.svg'] {
   object-fit: fill;
   width: 100%;
   height: 100%;
 }
 
-/* Accessibility improvements */
+
 @media (prefers-reduced-motion: reduce) {
   .event-image-container.showing-placeholder::before {
     animation: none;
@@ -101,7 +101,7 @@
   100% { transform: rotate(360deg); }
 }
 
-/* Responsive spinner sizing */
+
 @media (max-width: 768px) {
   .spinner {
     width: 30px;

--- a/frontend/src/components/common/EventImage.css
+++ b/frontend/src/components/common/EventImage.css
@@ -1,0 +1,111 @@
+.event-image-container {
+  overflow: hidden;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #8B5CF6 0%, #7C3AED 100%);
+  transition: all 0.3s ease;
+}
+
+.event-image-container.showing-placeholder {
+  background: linear-gradient(135deg, #8B5CF6 0%, #7C3AED 100%);
+  position: relative;
+}
+
+.event-image-container.showing-placeholder::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.1) 0%, transparent 50%),
+              radial-gradient(circle at 70% 70%, rgba(255,255,255,0.08) 0%, transparent 50%);
+  z-index: 0;
+  animation: pulse 3s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.6; }
+}
+
+/* Ensure placeholder images are always properly displayed */
+.event-image-container img {
+  position: relative;
+  z-index: 1;
+  transition: all 0.3s ease;
+}
+
+.event-image-container.showing-placeholder img {
+  /* Ensure SVG placeholders scale properly */
+  object-fit: contain;
+  background: transparent;
+}
+
+/* Hover effects for placeholder images */
+.event-image-container.showing-placeholder:hover::before {
+  animation-duration: 1.5s;
+}
+
+/* Special styling to ensure SVG renders correctly */
+.event-image-container.showing-placeholder img[src$='.svg'] {
+  object-fit: fill;
+  width: 100%;
+  height: 100%;
+}
+
+/* Accessibility improvements */
+@media (prefers-reduced-motion: reduce) {
+  .event-image-container.showing-placeholder::before {
+    animation: none;
+    opacity: 0.4;
+  }
+  
+  .spinner {
+    animation: none;
+    border: 3px solid rgba(255, 255, 255, 0.6);
+    border-top: 3px solid rgba(255, 255, 255, 0.9);
+  }
+}
+
+.image-loading-placeholder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #8B5CF6 0%, #7C3AED 100%);
+  border-radius: inherit;
+  z-index: 1;
+}
+
+.loading-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  border-top: 3px solid rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Responsive spinner sizing */
+@media (max-width: 768px) {
+  .spinner {
+    width: 30px;
+    height: 30px;
+    border-width: 2px;
+  }
+}

--- a/frontend/src/components/common/EventImage.js
+++ b/frontend/src/components/common/EventImage.js
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import './EventImage.css';
+
+const EventImage = ({ 
+  src, 
+  alt = "Event Image", 
+  className = "", 
+  whileHover = { scale: 1.1 },
+  transition = { duration: 0.3 },
+  style = {},
+  onError = null,
+  ...props 
+}) => {
+  const [imageError, setImageError] = useState(false);
+  const [imageLoading, setImageLoading] = useState(true);
+  const [isPlaceholder, setIsPlaceholder] = useState(false);
+
+  const placeholderPath = '/placeholder-event.svg';
+  
+  // Check if we should use placeholder initially
+  useEffect(() => {
+    const shouldUsePlaceholder = !src || src.trim() === '' || src === null;
+    setIsPlaceholder(shouldUsePlaceholder);
+    if (shouldUsePlaceholder) {
+      setImageLoading(false);
+    } else {
+      setImageLoading(true);
+    }
+  }, [src]);
+  
+  const handleImageError = () => {
+    setImageError(true);
+    setImageLoading(false);
+    setIsPlaceholder(true);
+    if (onError) {
+      onError();
+    }
+  };
+
+  const handleImageLoad = () => {
+    setImageLoading(false);
+    setIsPlaceholder(false);
+  };
+
+  // Determine which image source to use
+  const imageSrc = (isPlaceholder || imageError) ? placeholderPath : src;
+
+  return (
+    <div 
+      className={`event-image-container ${isPlaceholder || imageError ? 'showing-placeholder' : ''}`} 
+      style={{ position: 'relative', overflow: 'hidden', ...style }}
+    >
+      {imageLoading && !imageError && src && (
+        <div className="image-loading-placeholder">
+          <div className="loading-spinner">
+            <div className="spinner"></div>
+          </div>
+        </div>
+      )}
+      
+      <motion.img
+        src={imageSrc}
+        alt={alt}
+        className={className}
+        whileHover={whileHover}
+        transition={transition}
+        onError={handleImageError}
+        onLoad={handleImageLoad}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          opacity: imageLoading && src && !imageError ? 0 : 1,
+          transition: 'opacity 0.3s ease-in-out',
+        }}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default EventImage;

--- a/frontend/src/components/common/EventImage.js
+++ b/frontend/src/components/common/EventImage.js
@@ -18,7 +18,7 @@ const EventImage = ({
 
   const placeholderPath = '/placeholder-event.svg';
   
-  // Check if we should use placeholder initially
+  
   useEffect(() => {
     const shouldUsePlaceholder = !src || src.trim() === '' || src === null;
     setIsPlaceholder(shouldUsePlaceholder);
@@ -43,7 +43,7 @@ const EventImage = ({
     setIsPlaceholder(false);
   };
 
-  // Determine which image source to use
+  
   const imageSrc = (isPlaceholder || imageError) ? placeholderPath : src;
 
   return (

--- a/frontend/src/components/user/UserDashboard.css
+++ b/frontend/src/components/user/UserDashboard.css
@@ -73,6 +73,9 @@
   padding: 1.5rem;
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
 .event-card.available {
@@ -118,4 +121,70 @@
   padding: 1rem;
   border-radius: 4px;
   margin-bottom: 1rem;
+}
+
+/* New styles for event cards with images */
+.event-image-small {
+  flex: 0 0 80px;
+  width: 80px;
+  height: 80px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: linear-gradient(135deg, #8B5CF6 0%, #7C3AED 100%);
+}
+
+.event-image-small img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.event-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.event-info h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #333;
+}
+
+.event-info .event-date {
+  margin: 0;
+}
+
+.event-info .event-description {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: #666;
+}
+
+.event-info .event-actions {
+  margin-top: auto;
+}
+
+/* Mobile responsive adjustments */
+@media (max-width: 768px) {
+  .events-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .event-card {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  
+  .event-image-small {
+    flex: none;
+    margin-bottom: 1rem;
+  }
+  
+  .event-info {
+    align-items: center;
+  }
 }

--- a/frontend/src/components/user/UserDashboard.js
+++ b/frontend/src/components/user/UserDashboard.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { Link } from 'react-router-dom';
 import { API_ENDPOINTS, apiUtils } from '../../config/api';
+import EventImage from '../common/EventImage';
 import './UserDashboard.css';
 
 const UserDashboard = () => {
@@ -110,14 +111,23 @@ const UserDashboard = () => {
           <div className="events-grid">
             {userEvents.map(event => (
               <div key={event.id} className="event-card">
-                <h3>{event.title}</h3>
-                <p className="event-date">{new Date(event.date).toLocaleDateString()}</p>
-                <p className="event-description">{event.description}</p>
-                <div className="event-actions">
-                  <button className="btn-small">View Details</button>
-                  {hasPermission('CREATE_FEEDBACK') && (
-                    <button className="btn-small">Leave Feedback</button>
-                  )}
+                <div className="event-image-small">
+                  <EventImage 
+                    src={event.image} 
+                    alt={event.title}
+                    style={{ height: '80px', borderRadius: '8px' }}
+                  />
+                </div>
+                <div className="event-info">
+                  <h3>{event.title}</h3>
+                  <p className="event-date">{new Date(event.date).toLocaleDateString()}</p>
+                  <p className="event-description">{event.description}</p>
+                  <div className="event-actions">
+                    <button className="btn-small">View Details</button>
+                    {hasPermission('CREATE_FEEDBACK') && (
+                      <button className="btn-small">Leave Feedback</button>
+                    )}
+                  </div>
                 </div>
               </div>
             ))}
@@ -131,19 +141,28 @@ const UserDashboard = () => {
           <div className="events-grid">
             {availableEvents.slice(0, 6).map(event => (
               <div key={event.id} className="event-card available">
-                <h3>{event.title}</h3>
-                <p className="event-date">{new Date(event.date).toLocaleDateString()}</p>
-                <p className="event-description">{event.description}</p>
-                <div className="event-actions">
-                  <button className="btn-small">View Details</button>
-                  {hasPermission('PARTICIPATE_EVENT') && (
-                    <button 
-                      className="btn-small btn-primary"
-                      onClick={() => joinEvent(event.id)}
-                    >
-                      Join Event
-                    </button>
-                  )}
+                <div className="event-image-small">
+                  <EventImage 
+                    src={event.image} 
+                    alt={event.title}
+                    style={{ height: '80px', borderRadius: '8px' }}
+                  />
+                </div>
+                <div className="event-info">
+                  <h3>{event.title}</h3>
+                  <p className="event-date">{new Date(event.date).toLocaleDateString()}</p>
+                  <p className="event-description">{event.description}</p>
+                  <div className="event-actions">
+                    <button className="btn-small">View Details</button>
+                    {hasPermission('PARTICIPATE_EVENT') && (
+                      <button 
+                        className="btn-small btn-primary"
+                        onClick={() => joinEvent(event.id)}
+                      >
+                        Join Event
+                      </button>
+                    )}
+                  </div>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
Implemented a placeholder image system for events that don't have their own images. Here's a comprehensive overview of all the changes,
Added useEffect hook to detect missing/empty images immediately
 Added isPlaceholder state to track when placeholder should be shown
Added CSS class (showing-placeholder) when displaying placeholders for styling
More robust detection of when to show placeholders vs real image
Added gradient background matching app's purple theme
Created animated pulse effect for placeholder containers
  Implemented hover effects specific to placeholders
<img width="1840" height="845" alt="image" src="https://github.com/user-attachments/assets/3da42921-2765-444c-b198-5ef513bb95b0" />
Please let me know if there is any issues . i will fix it asap.