### PR TITLE
Signin page alignment

### DIFF
--- a/frontend/src/components/auth/Login.js
+++ b/frontend/src/components/auth/Login.js
@@ -49,7 +49,7 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8 mt-10">
       <div className="w-full max-w-md space-y-6 bg-white border border-gray-200 p-8 rounded-lg shadow-lg">
         <div className="space-y-2 text-center">
           <h1 className="text-2xl font-semibold text-gray-900">


### PR DESCRIPTION
Signin page is properly aligned!!
space between navbar and signin page is given
Fix: #91 

<img width="1904" height="869" alt="image" src="https://github.com/user-attachments/assets/1d0e8098-c4a3-4ee9-8161-cd7c85834528" />
