### PR TITLE
Add smooth scroll-to-top on route change

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^9.4.1",
         "react-router-dom": "^6.8.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "tailwindcss": "^4.1.12"
       }
     },
@@ -12871,6 +12871,8 @@
     },
     "node_modules/react-scripts": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
+      "integrity": "sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^9.4.1",
     "react-router-dom": "^6.8.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "tailwindcss": "^4.1.12"
   },
   "scripts": {

--- a/frontend/src/Pages/About/AboutPage.js
+++ b/frontend/src/Pages/About/AboutPage.js
@@ -143,6 +143,13 @@ const AboutPage = () => {
     controls.start('show');
   }, [controls]);
 
+  useEffect(()=>{
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  },[])
+
   return (
     <div className="bg-indigo-50/80">
       {/* Hero Section */}

--- a/frontend/src/Pages/Events/EventsPage.js
+++ b/frontend/src/Pages/Events/EventsPage.js
@@ -73,6 +73,13 @@ const EventsPage = () => {
     }
   };
 
+  useEffect(()=>{
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  },[])
+
   const EventCard = ({ event }) => (
     <motion.div
       className="bg-white rounded-xl overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-300"

--- a/frontend/src/Pages/Hackathons/HackathonPage.js
+++ b/frontend/src/Pages/Hackathons/HackathonPage.js
@@ -242,6 +242,13 @@ const HackathonHub = () => {
   const difficulties = [...new Set(hackathons.map(h => h.difficulty))];
   const locations = [...new Set(hackathons.map(h => h.location))];
 
+  useEffect(()=>{
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  },[])
+
   return (
     <div className="min-h-screen bg-white relative">
       {/* Floating Action Button */}

--- a/frontend/src/Pages/Home/components/Hero.js
+++ b/frontend/src/Pages/Home/components/Hero.js
@@ -45,6 +45,13 @@ const Hero = () => {
     controls.start('show');
   }, [controls]);
 
+  useEffect(()=>{
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  },[])
+
   return (
     <section
       className="relative overflow-hidden bg-indigo-50/80 py-20 sm:py-28"

--- a/frontend/src/Pages/Projects/ProjectsPage.js
+++ b/frontend/src/Pages/Projects/ProjectsPage.js
@@ -123,6 +123,13 @@ const ProjectGallery = () => {
       }
     };
 
+    useEffect(()=>{
+      window.scrollTo({
+        top: 0,
+        behavior: "smooth"
+      });
+    },[])
+
     return (
       <motion.div
         className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden transition-all duration-300 hover:shadow-md"

--- a/frontend/src/components/Contributors.js
+++ b/frontend/src/components/Contributors.js
@@ -209,6 +209,13 @@ const Contributors = () => {
     fetchContributors();
   }, [fetchContributors]);
 
+  useEffect(()=>{
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
+  },[])
+
   // Skeleton loader component
   const SkeletonCard = () => (
     <div className="bg-white rounded-xl shadow-sm overflow-hidden border-2 border-gray-100">


### PR DESCRIPTION

## Which issue does this PR close?

* Closes #122 

## Rationale for this change

Currently, when navigating between routes, the page loads at the **bottom** instead of resetting to the **top**. This disrupts the user experience. Adding a **smooth scroll-to-top** ensures that every route change starts at the correct position and provides a more polished navigation flow.

## What changes are included in this PR?

* Implemented `window.scrollTo` with `behavior: "smooth"` on route changes.
* Ensured that page navigation consistently starts from the top.
* Improved overall UX by making scroll transitions smoother.

## Are these changes tested?

* Manually tested by navigating between multiple routes.
* Verified that pages now load from the top with smooth scrolling.
* Checked across different browsers for consistent behavior.

## Are there any user-facing changes?

Yes ✅

* On route change, pages will now scroll smoothly to the **top** instead of jumping or loading at the bottom.

## Requested Tags

This PR involves changes to the **frontend navigation and UI behavior**.

I kindly request you to consider the following tags for this PR:

* `bug`
* `ui`
* `enhancement`
* `GSSoC25`
* `Level 2`

---

# Images

https://github.com/user-attachments/assets/9c6621f6-79da-4875-8326-348e9f0b636e

