### PR TITLE
Fix: Display social media icons in “Follow Us” section on Contact page

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { FaTwitter, FaGithub, FaLinkedin, FaDiscord } from "react-icons/fa";
 
 // Toast Component
 const Toast = ({ message, type = "success", onClose }) => {
@@ -125,6 +126,30 @@ const FloatingInput = ({
 };
 
 // Contact Us Page Component
+
+const socialLinks = [
+  { 
+    name: "Twitter", 
+    icon: <FaTwitter className="w-5 h-5" />, 
+    href: "https://twitter.com" 
+  },
+  { 
+    name: "GitHub", 
+    icon: <FaGithub className="w-5 h-5" />, 
+    href: "https://github.com" 
+  },
+  { 
+    name: "LinkedIn", 
+    icon: <FaLinkedin className="w-5 h-5" />, 
+    href: "https://linkedin.com/in" 
+  },
+  { 
+    name: "Discord", 
+    icon: <FaDiscord className="w-5 h-5" />, 
+    href: "https://discord.gg/" 
+  },
+];
+
 const ContactUs = () => {
   const [formData, setFormData] = useState({
     name: "",
@@ -336,26 +361,18 @@ const ContactUs = () => {
               <div className="mt-10">
                 <h3 className="font-medium mb-4">Follow Us</h3>
                 <div className="flex space-x-4">
-                  {["twitter", "github", "linkedin", "discord"].map(
-                    (platform) => (
+                  {socialLinks.map(
+                    ({name , icon , href}) => (
                       <motion.a
-                        key={platform}
-                        href="#"
+                        key={name}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
                         whileHover={{ y: -3 }}
                         className="bg-white bg-opacity-20 p-2 rounded-full"
                       >
-                        <span className="sr-only">{platform}</span>
-                        <div className="w-5 h-5">
-                          {/* In a real app, you would use proper icons for each platform */}
-                          <svg
-                            className="w-5 h-5"
-                            fill="currentColor"
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2z" />
-                          </svg>
-                        </div>
+                        <span className="sr-only">{name}</span>
+                        {icon}
                       </motion.a>
                     )
                   )}

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -119,7 +119,7 @@ const Footer = () => {
         href: "#help",
         icon: <FaQuestionCircle size={14} />,
       },
-      { name: "Contact Us", href: "#contact", icon: <FaEnvelope size={14} /> },
+      { name: "Contact Us", href: "/contact", icon: <FaEnvelope size={14} /> },
       { name: "API Docs", href: "#api", icon: <FaBookOpen size={14} /> },
       { name: "Status", href: "#status", icon: <FaServer size={14} /> },
     ],


### PR DESCRIPTION
### Problem:
The social media icons under the “Follow Us” section on the Contact page were not visible.
This made it unclear to users how they could follow or contact the organization through platforms such as Twitter, GitHub, LinkedIn, or Discord.

### Fixes: #204

### Solution:
Integrated React Icons to provide proper icons for each social platform.
Updated the Contact page to render the icons dynamically with proper styling.
Ensured hover animations and accessibility labels are in place (sr-only for screen readers).
Verified links open in new tabs with target="_blank" and secure attributes (rel="noopener noreferrer").

### Outcome
Users can now clearly see and interact with the social media icons under the “Follow Us” section on the Contact page, improving navigation and engagement with the organization’s social platforms.

### Screenshot:
- Before:
<img width="400" height="178" alt="image" src="https://github.com/user-attachments/assets/1c7c7f9e-76ee-42cb-932c-36281d70fe91" />


- After:
<img width="400" height="167" alt="image" src="https://github.com/user-attachments/assets/317e7b80-67bf-4154-8c10-4d13ab129c84" />
