### PR TITLE
Fix Horizontal Scrolling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@
 
 html {
   scroll-behavior: smooth;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
### Description:
Resolved unwanted horizontal scrolling issue caused by the sidebar overflowing beyond the viewport.

### Fixes: #214 

### Changes
Applied overflow-x: hidden; globally to prevent horizontal scrollbars.
Improved close behavior .

- Before
Sidebar caused page shift and horizontal scroll.
No overlay when open.

- After
Sidebar slides in smoothly.
No more horizontal scrolling.

