### PR TITLE
added spacing between navbar and main content

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -446,6 +446,7 @@ const Navbar = () => {
           </div>
         </div>
       </nav>
+      <div className="h-20"></div>
     </>
   );
 };


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #227 

## Rationale for this change

The navbar was fixed to the top of the page but did not account for spacing with the main content. As a result, sections like **Contributors** and **Leaderboard** were partially hidden underneath the navbar. This PR ensures that the main content starts below the navbar, improving readability and layout consistency.

## What changes are included in this PR?

* Added proper spacing below the navbar so page content no longer overlaps.
* Ensured the fix applies globally across all pages without requiring individual adjustments.

## Are these changes tested?

* Manually tested across multiple pages (`Contributors`, `Leaderboard`, `Home`, etc.) to confirm that the content is fully visible and no overlap occurs.
* Verified that responsive views (desktop and mobile) are unaffected by the change.

## Implementation
Before
<img width="1908" height="885" alt="image" src="https://github.com/user-attachments/assets/f64490b2-9c39-490c-85fb-bb8cd8c5b682" />
<img width="1919" height="901" alt="image" src="https://github.com/user-attachments/assets/11c63297-19f9-4502-b583-d372f828d41a" />

After
<img width="1891" height="854" alt="image" src="https://github.com/user-attachments/assets/95435051-7c1a-4544-bc1f-73a02ca7e7b4" />
<img width="1885" height="875" alt="image" src="https://github.com/user-attachments/assets/1097cab1-f061-4e68-998e-705ad0c0e3c4" />

