### PR TITLE
Fix Contribute section navigation button overlap

### DIFF
--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -80,6 +80,7 @@ const Contributors = () => {
     };
   }, []);
 
+  // Replace your previous `useEffect` for itemsPerView with this:
   useEffect(() => {
     const updateItemsPerView = () => {
       if (window.innerWidth < 640) {
@@ -87,7 +88,7 @@ const Contributors = () => {
       } else if (window.innerWidth < 1024) {
         setItemsPerView(2); // Tablet: 2 items
       } else {
-        setItemsPerView(4); // Desktop: 4 items
+        setItemsPerView(3); // Desktop: 3 items instead of 4
       }
     };
 
@@ -237,10 +238,10 @@ const Contributors = () => {
           {/* Navigation Arrows */}
           <button
             onClick={prevSlide}
-            className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-4 z-10
-                     bg-white/90 backdrop-blur-sm p-3 rounded-full shadow-lg
-                     hover:bg-white hover:scale-110 transition-all duration-300
-                     border border-gray-200"
+            className="absolute left-0 top-[35%] -translate-y-1/2 -translate-x-4 z-10
+           bg-white/90 backdrop-blur-sm p-3 rounded-full shadow-lg
+           hover:bg-white hover:scale-110 transition-all duration-300
+           border border-gray-200"
             disabled={currentIndex === 0}
           >
             <FaChevronLeft className="text-indigo-600 text-xl" />
@@ -248,17 +249,17 @@ const Contributors = () => {
 
           <button
             onClick={nextSlide}
-            className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-4 z-10
-                     bg-white/90 backdrop-blur-sm p-3 rounded-full shadow-lg
-                     hover:bg-white hover:scale-110 transition-all duration-300
-                     border border-gray-200"
+            className="absolute right-0 top-[35%] -translate-y-1/2 translate-x-4 z-10
+           bg-white/90 backdrop-blur-sm p-3 rounded-full shadow-lg
+           hover:bg-white hover:scale-110 transition-all duration-300
+           border border-gray-200"
             disabled={currentIndex + itemsPerView >= contributors.length}
           >
             <FaChevronRight className="text-indigo-600 text-xl" />
           </button>
 
           {/* Carousel Content */}
-          <div className="overflow-hidden">
+          <div className="overflow-hidden px-10">
             <motion.div
               className="flex gap-6 items-stretch"
               animate={{ x: 0 }}
@@ -268,9 +269,8 @@ const Contributors = () => {
                 <motion.div
                   key={c.id}
                   className="relative bg-gradient-to-br from-white/90 to-indigo-50/80 backdrop-blur-xl 
-             p-4 pt-10 rounded-xl shadow-md border border-gray-100 
-             flex flex-col items-center text-center mb-6
-             transition-all duration-300 ease-out flex-shrink-0"
+     p-4 pt-10 rounded-xl shadow-md border flex flex-col items-center text-center mb-6
+     transition-all duration-300 ease-out flex-shrink-0"
                   style={{
                     flex: `0 0 calc((100% - ${
                       itemsPerView - 1


### PR DESCRIPTION
### Pull Request: Fix Contribute section navigation button overlap

**Bug**  
Contribute section navigation buttons were overlapping with the content.  
- This issue occurred on both desktop and mobile viewports.  
- It negatively affected readability and usability.  

**Problem**  
- Left and right navigation buttons were positioned in a way that caused them to cover text and images.  
- The overlap made it harder for users to interact with content.  

**Solution**  
- Adjusted button positioning to prevent overlap with the content.  
- Added proper spacing and alignment for different screen sizes.  
- Verified responsiveness on both desktop and mobile.  

**Goal**  
- Ensure navigation buttons remain clearly visible without blocking content.  
- Improve readability and user experience across all devices.  
- Provide consistent design and accessibility.  

**Screenshots / Images**  

<img width="1894" height="886" alt="image" src="https://github.com/user-attachments/assets/48260395-21b9-43aa-8834-1609a28f0a75" />
<img width="1524" height="828" alt="image" src="https://github.com/user-attachments/assets/51a8ce78-4e81-4185-aa12-4d75587f91e6" />
<img width="933" height="1019" alt="image" src="https://github.com/user-attachments/assets/d057cf63-745d-43f3-93c4-f0668f294c3a" />


Fixes issue -- #265 