### PR TITLE
Added Confetti Animation on Leaderboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.0.16",
         "@tailwindcss/cli": "^4.1.12",
+        "canvas-confetti": "^1.9.3",
         "framer-motion": "^8.5.2",
         "lucide-react": "^0.542.0",
         "react": "^18.2.0",
@@ -5367,6 +5368,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@heroicons/react": "^2.0.16",
     "@tailwindcss/cli": "^4.1.12",
+    "canvas-confetti": "^1.9.3",
     "framer-motion": "^8.5.2",
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",

--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { FaCode, FaStar } from "react-icons/fa";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
+import confetti from "canvas-confetti"; // 🎉 Import confetti
 
 const GITHUB_REPO = "SandeepVashishtha/Eventra";
 const TOKEN = process.env.REACT_APP_GITHUB_TOKEN || "";
@@ -19,6 +20,19 @@ export default function LeaderBoard() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const CONTRIBUTORS_PER_PAGE = 10;
+
+  // 🎉 Trigger confetti once on page load
+  useEffect(() => {
+    // Fire a "party bomb" burst 🎉
+    confetti({
+      particleCount: 150, // number of confetti pieces
+      spread: 80, // how wide they fly out
+      origin: { x: 0.5, y: 0.6 }, // center-bottom of screen
+      startVelocity: 45, // smooth upward speed
+      gravity: 0.9, // fall speed
+      scalar: 1.2, // size scaling
+    });
+  }, []);
 
   const loadLeaderboardData = async () => {
     setLoading(true);


### PR DESCRIPTION
## 🎉 Feature: Added Confetti Animation on Leaderboard

### Summary
This PR introduces a confetti animation that triggers when a user navigates to the **Leaderboard page**.  
The effect is styled like a smooth party popper 🎊, creating a celebratory feel for contributors.

### Changes Made

- Added a `useEffect` hook inside the `LeaderBoard` component to trigger confetti on page load.
- Configured confetti to appear as a **centered burst** for a neat and festive effect.

### Motivation
The leaderboard highlights the amazing contributions from our community.  
Adding confetti makes the experience **more engaging and rewarding** for contributors.

### Screenshots / Demo

https://github.com/user-attachments/assets/15dd9a39-686b-4e00-a22b-0a9a5490671d


### Notes
- Confetti fires once when navigating to the leaderboard.
- Can be further extended to trigger on special achievements (e.g., top rank changes).

Fixes issue - #271 

