### PR TITLE
fix two eye in password field

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,8 +12,8 @@ html {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -24,7 +24,7 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
 
@@ -82,7 +82,8 @@ code {
 .btn-primary:hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 25px rgba(102, 126, 234, 0.3);
-  color:#FFFFFF}
+  color: #ffffff;
+}
 
 .btn-secondary {
   background: transparent;
@@ -102,7 +103,6 @@ code {
   border-color: #667eea;
   color: #ffffffff;
   transform: translateY(-2px);
-  
 }
 
 .fade-in {
@@ -123,14 +123,20 @@ code {
   .container {
     padding: 0 16px;
   }
-  
+
   .section-padding {
     padding: 60px 0;
   }
-  
+
   .btn-primary,
   .btn-secondary {
     padding: 10px 24px;
     font-size: 14px;
   }
+}
+input::-ms-reveal,
+input::-ms-clear,
+input::-webkit-clear-button,
+input::-webkit-password-toggle {
+  display: none !important;
 }


### PR DESCRIPTION
## PR: Fix duplicate eye icon in password field

### Summary
This PR addresses the issue of a duplicate eye icon appearing in the password input field. The extra icon was coming from the browser’s built-in password reveal button, which appeared alongside our custom animated eye toggle.  

### Changes
- Added CSS rules to disable the browser’s default password reveal/clear icons.  
- Ensured that only our custom eye toggle remains visible across all browsers.  
- Improved visual consistency for the password input field.  

### Before
Typing in the password field displayed **two eye icons**:  
1. The browser’s default reveal icon.  
2. The custom animated eye toggle.  
3. <img width="659" height="494" alt="image" src="https://github.com/user-attachments/assets/e9604f49-8dab-43a2-9083-f2c86d7ac973" />

### After
Now the password field shows **only the custom eye toggle**, removing confusion and keeping the UI clean.  
<img width="651" height="410" alt="image" src="https://github.com/user-attachments/assets/3c24346b-99ab-4f69-b991-c70071f2ad81" />

---

### Related Issues
Fixes issue -- #282 
