### PR TITLE
Replace Twitter bird logo with X logo 

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { FaTwitter, FaGithub, FaLinkedin, FaDiscord } from "react-icons/fa";
+import { FaGithub, FaLinkedin, FaDiscord } from "react-icons/fa";
 
 // Toast Component
 const Toast = ({ message, type = "success", onClose }) => {
@@ -129,9 +129,9 @@ const FloatingInput = ({
 
 const socialLinks = [
   { 
-    name: "Twitter", 
-    icon: <FaTwitter className="w-5 h-5" />, 
-    href: "https://twitter.com" 
+    name: "X", 
+    icon: <span className="w-5 h-5 flex items-center justify-center font-bold">X</span>, 
+    href: "https://x.com" 
   },
   { 
     name: "GitHub", 


### PR DESCRIPTION
### Description:
This PR updates the social media icons by replacing the old Twitter bird logo with the new X branding.

### Fixes: #356 

### Changes Made:
Removed the Twitter bird (FaTwitter) icon.
Added the X logo.
Updated the socialLinks array in the Contact page to use the new X logo.
Verified that the link correctly redirects to https://x.com/

### Reason for Change:
Twitter has officially rebranded to X, so updating the logo ensures the UI reflects the current branding.

