### PR TITLE
Update 3rd rank badge color to improve distinction from gold

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -294,7 +294,7 @@ export default function LeaderBoard() {
                                 : rank === 2
                                 ? "bg-gray-300 text-gray-800"
                                 : rank === 3
-                                ? "bg-amber-500 text-white"
+                                ? "bg-amber-800 text-white"
                                 : "bg-indigo-50 text-indigo-700"
                             }`}
                           >


### PR DESCRIPTION
### Description:
The 3rd rank badge was previously styled in orange, which looks visually close to the gold color used for the 1st rank badge. This similarity may confuse users about rank distinctions.

### Fixes: #302 

### Changes Made:
Updated the 3rd rank badge color to a more distinct shade (e.g., bronze) to clearly differentiate it from gold.
Verified that the new color improves visual clarity across the UI.

### Reason for Change:
Ensures clear visual distinction between ranking badges (1st = gold, 2nd = silver, 3rd = bronze), avoiding user confusion.

### Screenshots : 
<img width="121" height="337" alt="image" src="https://github.com/user-attachments/assets/3ae249c8-3e9b-42c4-b76e-70b9de900963" />
