### PR TITLE
Add required field indicators (*) in signup form fields

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -254,6 +254,7 @@ const Signup = () => {
             <p className="text-sm text-gray-600">
               Join Eventra and start building amazing events
             </p>
+            
           </motion.div>
 
           <motion.form
@@ -642,6 +643,8 @@ const Signup = () => {
                 Sign in here
               </Link>
             </p>
+              <p class="text-gray-500 text-sm mb-4">* indicates required fields</p>
+
           </motion.div>
 
           <motion.p

--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -275,8 +275,8 @@ const Signup = () => {
                   htmlFor="firstName"
                   className="block text-sm font-medium text-gray-700"
                 >
-                  First name
-                </label>
+                  First name <sup className="ml-2 text-red-500 text-sm">*</sup>
+                </label> 
                 <motion.input
                   id="firstName"
                   name="firstName"
@@ -301,7 +301,7 @@ const Signup = () => {
                   htmlFor="lastName"
                   className="block text-sm font-medium text-gray-700"
                 >
-                  Last name
+                  Last name<sup className="ml-2 text-red-500 text-sm">*</sup>
                 </label>
                 <motion.input
                   id="lastName"
@@ -334,7 +334,7 @@ const Signup = () => {
                 htmlFor="email"
                 className="block text-sm font-medium text-gray-700"
               >
-                Email address
+                Email address<sup className="ml-2 text-red-500 text-sm">*</sup>
               </label>
               <motion.input
                 id="email"
@@ -376,7 +376,7 @@ const Signup = () => {
                 htmlFor="phone"
                 className="block text-sm font-medium text-gray-700"
               >
-                Contact Number{" "}
+                Contact Number{" "}<sup className="ml-2 text-red-500 text-sm">*</sup>
               </label>
 
               <div className="flex gap-2">
@@ -435,7 +435,7 @@ const Signup = () => {
                 htmlFor="password"
                 className="block text-sm font-medium text-gray-700"
               >
-                Password
+                Password<sup className="ml-2 text-red-500 text-sm">*</sup>
               </label>
               <motion.input
                 id="password"
@@ -550,7 +550,7 @@ const Signup = () => {
                 htmlFor="password"
                 className="block text-sm font-medium text-gray-700"
               >
-                Confirm Password
+                Confirm Password<sup className="ml-2 text-red-500 text-sm">*</sup>
               </label>
               <motion.input
                 id="confirm_password"


### PR DESCRIPTION
### Description:
This PR improves the signup form UX by adding important marks (*) to fields that are mandatory. The marks are styled as small red superscripts to clearly indicate required fields to users.

### Fixes: #303 

### Changes Made:
Added red asterisk mark (*) next to required labels (e.g., First Name, Last Name, Email, Password, etc).
Ensured marks are consistently styled across all form fields.
Verified that the indicators are visually aligned with the labels.

### Reason for Change:
Users should be able to quickly identify which fields are mandatory during signup. Adding required field indicators improves clarity and reduces form submission errors.

### Screenshots: 
<img width="300" height="350" alt="image" src="https://github.com/user-attachments/assets/a64828e1-2ec9-48ed-a160-e33d5acc9be0" />
