### PR TITLE
fix: password input sync fixes #383

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -557,7 +557,7 @@ const Signup = () => {
                 id="confirm_password"
                 name="confirm_password"
                 type="password"
-                value={formData.password}
+                value={formData.confirm_password}
                 onChange={handleChange}
                 required
                 disabled={loading}


### PR DESCRIPTION
This PR aims to solve a bug in the signup page that caused the password and confirm password fields to sync causing a poor User experience.
