### PR TITLE
Fix Linkedin Link on Contact Page

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -141,7 +141,7 @@ const socialLinks = [
   { 
     name: "LinkedIn", 
     icon: <FaLinkedin className="w-5 h-5" />, 
-    href: "https://linkedin.com/in" 
+    href: "https://www.linkedin.com/in/sandeepvashishtha/" 
   },
   { 
     name: "Discord", 


### PR DESCRIPTION
### Description
This PR fixes the LinkedIn link on the Contact Page.
Corrected the broken/incorrect LinkedIn URL.
Ensured the link opens the official LinkedIn profile in a new tab.
Verified styling and icon remain consistent with other social/contact links.

### Fixes: #368

### Why
The LinkedIn link on the Contact Page was incorrect, leading to a broken or unintended destination. This fix ensures users can correctly navigate to the LinkedIn profile.

### Testing Done
 Verified the LinkedIn link now navigates to the correct URL.
 Checked that it opens in a new tab (target="_blank").
 Confirmed no regressions in layout or styling.