### PR TITLE
Fix: Remove Duplicate Labels on Login Form

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -138,12 +138,10 @@ const Login = () => {
               transition={{ duration: 0.4, delay: 0.6 }}
               className="space-y-2"
             >
-              <label htmlFor="email" className="block text-sm font-semibold text-gray-700">
-                Email address <sup className='text-sm text-red-500'>*</sup>
-              </label>
+            
               {/* UPDATED: Label text color */}
               <label htmlFor="email" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Email address
+                Email address <sup className='ml-1 text-sm text-red-500'>*</sup>
               </label>
               <div className="relative group">
                 <motion.div 
@@ -183,12 +181,10 @@ const Login = () => {
               transition={{ duration: 0.4, delay: 0.8 }}
               className="space-y-2"
             >
-              <label htmlFor="password" className="block text-sm font-semibold text-gray-700">
-                Password <sup className='ml-1 text-sm text-red-500'>*</sup>
-              </label>
+
               {/* UPDATED: Label text color */}
               <label htmlFor="password" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                Password
+                Password <sup className='ml-1 text-sm text-red-500'>*</sup>
               </label>
               <div className="relative group">
                 <motion.div 


### PR DESCRIPTION
### Issue:
On the Login page, the Email Address and Password fields displayed duplicate labels - one above the field and another directly before the input. This redundancy made the form look cluttered and could potentially confuse users.

### Fixes: #409 

### Changes:
Removed the extra labels to ensure each field has a single, clear label.
Confirmed consistent alignment and spacing across both fields.

### Impact:
The login form now has a cleaner design, improving readability and user experience.

### Screenshot: 
<img width="567" height="267" alt="image" src="https://github.com/user-attachments/assets/b995c3b7-c535-4786-a16e-04521523a04b" />
