### PR TITLE
Add "Explore Hackathons" Button

### DIFF
--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -157,7 +157,7 @@ export default function HackathonHero({
             <span className="relative flex items-center">
               {/* UPDATED: Icon color */}
               <Users className="inline-block w-5 h-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-              Host a Hackathon
+              Explore Hackathons
             </span>
           </motion.button>
 


### PR DESCRIPTION
### Description:
On the Hackathon page, there were two identical "Host a Hackathon" buttons displayed side by side. This creates confusion for users, as it was not clear how to explore existing hackathons if they are participants rather than organizers.

### Fixes: #411 

### Change Introduced:
Updated one of the duplicate "Host a Hackathon" buttons to "Explore Hackathons".
This ensures the page now clearly distinguishes between two primary user actions:

Organizers → Host a Hackathon
Participants → Explore Hackathons

### Why this change?
Improves user experience by removing ambiguity.
Provides clear navigation paths for both hackathon organizers and participants.
Prevents users from mistakenly assuming they can only host, not explore, hackathons.

### Testing:
Verified that both buttons are visible with correct labels.
Confirmed that "Explore Hackathons" leads users to the appropriate page.

### Screenshot:
<img width="724" height="112" alt="image" src="https://github.com/user-attachments/assets/c2489a8d-bad8-4b8c-8abc-f8ba0e9aa50c" />
