### PR TITLE
Fix Dark Mode Inconsistency on Hackathon Page

### DIFF
--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -19,7 +19,7 @@ const HackathonCard = ({ hackathon, isFeatured = false }) => {
   return (
     <motion.div
       // UPDATED: Card background, border, and featured ring
-      className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm hover:shadow-md transition-all duration-300 border border-gray-100 dark:border-gray-700 overflow-hidden relative ${
+      className={`bg-gradient-to-br from-indigo-200 to-white dark:from-gray-800 dark:to-black rounded-xl shadow-sm hover:shadow-md transition-all duration-300 border border-gray-100 dark:border-gray-700 overflow-hidden relative ${
         isFeatured ? "ring-2 ring-indigo-500 dark:ring-indigo-400" : ""
       }`}
       whileHover={{ y: -4 }}
@@ -82,7 +82,7 @@ const HackathonCard = ({ hackathon, isFeatured = false }) => {
           <BuildingLibraryIcon className="w-4 h-4 text-purple-500" />
           <span>{hackathon.organizer}</span>
         </div>
-        
+
         {/* UPDATED: Divider color */}
         <div className="border-b border-gray-200 dark:border-gray-700" />
 
@@ -164,18 +164,30 @@ const HackathonCard = ({ hackathon, isFeatured = false }) => {
         <div className="grid grid-cols-3 gap-4 bg-gray-50 dark:bg-gray-700/50 p-3 rounded-lg min-h-[60px]">
           <div className="text-center">
             <UserGroupIcon className="w-5 h-5 text-red-500 mx-auto mb-1" />
-            <div className="text-lg font-bold text-red-500">{stats.participants || "--"}</div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">Participants</div>
+            <div className="text-lg font-bold text-red-500">
+              {stats.participants || "--"}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              Participants
+            </div>
           </div>
           <div className="text-center">
             <UserGroupIcon className="w-5 h-5 text-green-500 mx-auto mb-1 rotate-90" />
-            <div className="text-lg font-bold text-green-500">{stats.teams || "--"}</div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">Teams</div>
+            <div className="text-lg font-bold text-green-500">
+              {stats.teams || "--"}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              Teams
+            </div>
           </div>
           <div className="text-center">
             <UserGroupIcon className="w-5 h-5 text-blue-500 mx-auto mb-1" />
-            <div className="text-lg font-bold text-blue-500">{stats.submissions || "--"}</div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">Submissions</div>
+            <div className="text-lg font-bold text-blue-500">
+              {stats.submissions || "--"}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              Submissions
+            </div>
           </div>
         </div>
 

--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -25,7 +25,7 @@ export default function HackathonHero({
 
   return (
     // UPDATED: Main background gradient and base text color
-    <div className="relative bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-6 ">
+    <div className="bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black">
       <div className="relative max-w-6xl mx-auto px-8 text-center mt-12">
         <motion.h1
           initial={{ opacity: 0, y: -30 }}
@@ -152,7 +152,7 @@ export default function HackathonHero({
                 navigate("/submit-project");
               }
             }}
-            className="relative px-7 py-3.5 rounded-xl font-medium text-gray-800 shadow-md backdrop-blur-md border border-gray-300 hover:border-indigo-400 transition-all duration-300 bg-white/70"
+            className="relative px-7 py-3.5 rounded-xl font-medium text-gray-800 dark:text-gray-100 shadow-md backdrop-blur-md border border-gray-300 hover:border-indigo-400 transition-all duration-300 bg-white/70 dark:bg-gray-800"
           >
             <span className="relative flex items-center">
               <Users className="inline-block w-5 h-5 mr-2 text-indigo-600" />
@@ -178,7 +178,7 @@ export default function HackathonHero({
             transition={{ delay: 0.2 + idx * 0.15, duration: 0.6 }}
             whileHover={{ scale: 1.05 }}
             // UPDATED: Stat card styles
-            className="relative bg-gradient-to-br from-indigo-50 to-white dark:from-gray-800 dark:to-gray-700 rounded-3xl shadow-lg p-6 flex flex-col items-center text-center hover:shadow-2xl transition-all duration-300"
+            className="relative bg-gradient-to-br from-indigo-50 to-white dark:from-gray-800 dark:to-gray-800 rounded-3xl shadow-lg p-6 flex flex-col items-center text-center hover:shadow-2xl transition-all duration-300"
           >
             {/* Animated Icon in a circular container */}
             <motion.div

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -80,37 +80,36 @@ const HackathonHub = () => {
   };
 
   const fuse = new Fuse(hackathons, {
-  keys: ["title", "description", "location", "techStack"],
-  threshold: 0.4, // adjust sensitivity (0 = exact, 1 = loose)
-});
-
-const searchedHackathons = searchQuery
-  ? fuse.search(searchQuery).map((result) => result.item)
-  : hackathons;
-
-const filteredHackathons = searchedHackathons
-  .filter((hackathon) => {
-    if (activeTab === "all") return true;
-    return hackathon.status === activeTab;
-  })
-  .filter((hackathon) => {
-    if (filters.difficulty && hackathon.difficulty !== filters.difficulty)
-      return false;
-    if (
-      filters.prize &&
-      !hackathon.prize.toLowerCase().includes(filters.prize.toLowerCase())
-    )
-      return false;
-    if (
-      filters.location &&
-      !hackathon.location
-        .toLowerCase()
-        .includes(filters.location.toLowerCase())
-    )
-      return false;
-    return true;
+    keys: ["title", "description", "location", "techStack"],
+    threshold: 0.4, // adjust sensitivity (0 = exact, 1 = loose)
   });
 
+  const searchedHackathons = searchQuery
+    ? fuse.search(searchQuery).map((result) => result.item)
+    : hackathons;
+
+  const filteredHackathons = searchedHackathons
+    .filter((hackathon) => {
+      if (activeTab === "all") return true;
+      return hackathon.status === activeTab;
+    })
+    .filter((hackathon) => {
+      if (filters.difficulty && hackathon.difficulty !== filters.difficulty)
+        return false;
+      if (
+        filters.prize &&
+        !hackathon.prize.toLowerCase().includes(filters.prize.toLowerCase())
+      )
+        return false;
+      if (
+        filters.location &&
+        !hackathon.location
+          .toLowerCase()
+          .includes(filters.location.toLowerCase())
+      )
+        return false;
+      return true;
+    });
 
   const featuredHackathons = [...hackathons]
     .filter((h) => h.featured)
@@ -139,7 +138,7 @@ const filteredHackathons = searchedHackathons
 
   return (
     // UPDATED: Main page background
-    <div className="bg-white dark:bg-black relative">
+    <div className="bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-6 ">
       {/* Floating Action Button */}
       <motion.div
         className="fixed bottom-6 right-6 z-50"
@@ -487,7 +486,10 @@ const filteredHackathons = searchedHackathons
                 {/* Subtitle with dynamic message based on filters */}
                 {/* ------------------------------ */}
                 <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-                  {searchQuery || filters.difficulty || filters.prize || filters.location
+                  {searchQuery ||
+                  filters.difficulty ||
+                  filters.prize ||
+                  filters.location
                     ? "No hackathons match your current filters. Try adjusting your search or filters."
                     : "Check back later for exciting new hackathons!"}
                 </p>
@@ -517,7 +519,7 @@ const filteredHackathons = searchedHackathons
                     whileTap={{ scale: 0.95 }}
                     onClick={() => {}} // Placeholder function for navigation
                     className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-lg text-indigo-600 dark:text-indigo-400 border border-indigo-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-indigo-50 dark:hover:bg-gray-600 shadow-md transition-all"
-                >
+                  >
                     Explore Hackathons
                     <FiCompass className="w-4 h-4" />
                   </motion.button>


### PR DESCRIPTION
## Title
Fix Dark Mode Inconsistency on Hackathon Page

## Problem
- The Hackathon page had inconsistent dark mode styling.  
- Some sections retained light mode colors while others applied dark mode correctly.  
- This caused readability issues and a broken user experience when switching themes.  

## Fix
- Unified the dark mode styles across all Hackathon page components.  
- Ensured proper usage of `dark:` classes for background, text, and border elements.  
- Verified consistent appearance in both light and dark themes.  

## Result
- Dark mode now applies seamlessly across the Hackathon page.  
- Improved user experience with consistent theme support.  


<img width="1915" height="1033" alt="image" src="https://github.com/user-attachments/assets/585fc00f-43a5-410e-af9c-7aa5238c205d" />
<img width="1883" height="1012" alt="image" src="https://github.com/user-attachments/assets/29288387-90e7-45d8-8dac-222865616ecb" />
<img width="1887" height="1024" alt="image" src="https://github.com/user-attachments/assets/cccb61ae-7a1c-4fc2-a0a1-2df066f5bfb7" />
<img width="1884" height="620" alt="image" src="https://github.com/user-attachments/assets/0102a649-6c08-413a-bedf-4064b05215ef" />

Closes #473