### PR TITLE
Fix "Explore Hackathon" Button Redirect Behavior

### DIFF
--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -131,7 +131,7 @@ export default function HackathonHero({
           <motion.button
             whileHover={{ scale: 1.07 }}
             whileTap={{ scale: 0.95 }}
-            onClick={() => navigate("/host-hackathon")}
+            onClick={scrollToCards}
             className="relative px-7 py-3.5 rounded-xl font-medium text-gray-800 dark:text-gray-200 shadow-md backdrop-blur-md border border-gray-300 dark:border-gray-600 hover:border-indigo-400 transition-all duration-300 bg-white/70 dark:bg-gray-800/70"
           >
             <span className="relative flex items-center">

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -80,37 +80,36 @@ const HackathonHub = () => {
   };
 
   const fuse = new Fuse(hackathons, {
-  keys: ["title", "description", "location", "techStack"],
-  threshold: 0.4, // adjust sensitivity (0 = exact, 1 = loose)
-});
-
-const searchedHackathons = searchQuery
-  ? fuse.search(searchQuery).map((result) => result.item)
-  : hackathons;
-
-const filteredHackathons = searchedHackathons
-  .filter((hackathon) => {
-    if (activeTab === "all") return true;
-    return hackathon.status === activeTab;
-  })
-  .filter((hackathon) => {
-    if (filters.difficulty && hackathon.difficulty !== filters.difficulty)
-      return false;
-    if (
-      filters.prize &&
-      !hackathon.prize.toLowerCase().includes(filters.prize.toLowerCase())
-    )
-      return false;
-    if (
-      filters.location &&
-      !hackathon.location
-        .toLowerCase()
-        .includes(filters.location.toLowerCase())
-    )
-      return false;
-    return true;
+    keys: ["title", "description", "location", "techStack"],
+    threshold: 0.4, // adjust sensitivity (0 = exact, 1 = loose)
   });
 
+  const searchedHackathons = searchQuery
+    ? fuse.search(searchQuery).map((result) => result.item)
+    : hackathons;
+
+  const filteredHackathons = searchedHackathons
+    .filter((hackathon) => {
+      if (activeTab === "all") return true;
+      return hackathon.status === activeTab;
+    })
+    .filter((hackathon) => {
+      if (filters.difficulty && hackathon.difficulty !== filters.difficulty)
+        return false;
+      if (
+        filters.prize &&
+        !hackathon.prize.toLowerCase().includes(filters.prize.toLowerCase())
+      )
+        return false;
+      if (
+        filters.location &&
+        !hackathon.location
+          .toLowerCase()
+          .includes(filters.location.toLowerCase())
+      )
+        return false;
+      return true;
+    });
 
   const featuredHackathons = [...hackathons]
     .filter((h) => h.featured)
@@ -487,7 +486,10 @@ const filteredHackathons = searchedHackathons
                 {/* Subtitle with dynamic message based on filters */}
                 {/* ------------------------------ */}
                 <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-                  {searchQuery || filters.difficulty || filters.prize || filters.location
+                  {searchQuery ||
+                  filters.difficulty ||
+                  filters.prize ||
+                  filters.location
                     ? "No hackathons match your current filters. Try adjusting your search or filters."
                     : "Check back later for exciting new hackathons!"}
                 </p>
@@ -517,7 +519,7 @@ const filteredHackathons = searchedHackathons
                     whileTap={{ scale: 0.95 }}
                     onClick={() => {}} // Placeholder function for navigation
                     className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-lg text-indigo-600 dark:text-indigo-400 border border-indigo-200 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-indigo-50 dark:hover:bg-gray-600 shadow-md transition-all"
-                >
+                  >
                     Explore Hackathons
                     <FiCompass className="w-4 h-4" />
                   </motion.button>


### PR DESCRIPTION
## Title
Fix "Explore Hackathon" Button Redirect Behavior

## Problem
- The "Explore Hackathon" button incorrectly redirects users to the Sign Up page.  
- This breaks the intended flow and confuses users trying to view the Hackathon card section.  

## Fix
- Updated the button logic to trigger smooth scrolling to the Hackathon card section.  
- Removed unwanted navigation to the Sign Up page.  
- Ensured consistent behavior for both logged-in and non-logged-in users.  

## Result
- Clicking "Explore Hackathon" now smoothly scrolls to the Hackathon card section.  
- No unexpected redirects occur, improving user flow and navigation.  

Closes #474