### PR TITLE
Enhance mobile nav: focus trap + ARIA for accessibility

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 import { motion } from "framer-motion";
@@ -26,6 +26,11 @@ import { RocketLaunchIcon } from "@heroicons/react/20/solid";
 const Navbar = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [showProfileDropdown, setShowProfileDropdown] = useState(false);
+  const drawerRef = useRef(null);
+  const closeBtnRef = useRef(null);
+  const toggleBtnRef = useRef(null);
+  const touchStartXRef = useRef(null);
+  const touchCurrentXRef = useRef(null);
 
   const { user, isAuthenticated, logout } = useAuth();
   const navigate = useNavigate();
@@ -53,7 +58,136 @@ const Navbar = () => {
   const closeAllMenus = () => {
     setShowProfileDropdown(false);
     setIsMobileMenuOpen(false);
-    document.body.style.overflow = "";
+    // restore any body lock that might be set
+    try {
+      const stored = document.body.style.top;
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.left = "";
+      document.body.style.right = "";
+      document.body.style.width = "";
+      if (stored) {
+        const scrollY = parseInt(stored || "0", 10) * -1 || 0;
+        window.scrollTo(0, scrollY);
+      }
+    } catch (e) {
+      // ignore in environments without document
+    }
+
+    // restore focus to the mobile toggle when the drawer is closed
+    try {
+      toggleBtnRef.current?.focus();
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  // When mobile menu opens, lock body scroll using position:fixed and focus the close button.
+  useEffect(() => {
+    let prevTop = null;
+    if (isMobileMenuOpen) {
+      prevTop = window.scrollY || window.pageYOffset || 0;
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${prevTop}px`;
+      document.body.style.left = "0";
+      document.body.style.right = "0";
+      document.body.style.width = "100%";
+      // focus close button shortly after open
+      setTimeout(() => closeBtnRef.current?.focus(), 50);
+    } else {
+      // restore
+      const stored = document.body.style.top;
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.left = "";
+      document.body.style.right = "";
+      document.body.style.width = "";
+      if (stored) {
+        const scrollY = parseInt(stored || "0", 10) * -1 || 0;
+        window.scrollTo(0, scrollY);
+      }
+    }
+
+    return () => {
+      // cleanup on unmount
+      try {
+        const stored = document.body.style.top;
+        document.body.style.position = "";
+        document.body.style.top = "";
+        document.body.style.left = "";
+        document.body.style.right = "";
+        document.body.style.width = "";
+        if (stored) {
+          const scrollY = parseInt(stored || "0", 10) * -1 || 0;
+          window.scrollTo(0, scrollY);
+        }
+      } catch (e) {
+        // ignore
+      }
+    };
+  }, [isMobileMenuOpen]);
+
+  // Close menus on route change
+  useEffect(() => {
+    closeAllMenus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
+  // Focus trap + Escape handling while drawer is open
+  useEffect(() => {
+    if (!isMobileMenuOpen || !drawerRef.current) return;
+
+    const drawer = drawerRef.current;
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeAllMenus();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const focusable = drawer.querySelectorAll(
+          'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobileMenuOpen]);
+
+  // Touch handlers for swipe-to-close on mobile
+  const handleTouchStart = (e) => {
+    touchStartXRef.current = e.touches[0].clientX;
+    touchCurrentXRef.current = e.touches[0].clientX;
+  };
+
+  const handleTouchMove = (e) => {
+    touchCurrentXRef.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = () => {
+    const start = touchStartXRef.current;
+    const end = touchCurrentXRef.current;
+    if (typeof start !== "number" || typeof end !== "number") return;
+    const deltaX = end - start;
+    // if swiped left more than 50px, close
+    if (deltaX < -50) {
+      closeAllMenus();
+    }
+    touchStartXRef.current = null;
+    touchCurrentXRef.current = null;
   };
 
   const navItems = [
@@ -425,10 +559,14 @@ const Navbar = () => {
 
           <div className="lg:hidden">
             <button
+              ref={toggleBtnRef}
               onClick={(e) => {
                 e.stopPropagation();
                 setIsMobileMenuOpen(!isMobileMenuOpen);
               }}
+              aria-controls="mobile-drawer"
+              aria-expanded={isMobileMenuOpen}
+              aria-label={isMobileMenuOpen ? "Close navigation" : "Open navigation"}
               className="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
             >
               <svg
@@ -449,11 +587,19 @@ const Navbar = () => {
         </div>
 
         <div
+          id="mobile-drawer"
+          ref={drawerRef}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
           className={`fixed top-0 right-0 h-screen overflow-y-auto w-72 bg-white dark:bg-gray-800 shadow-2xl z-50 flex flex-col transform transition-transform duration-300 ease-in-out 
           ${isMobileMenuOpen ? "translate-x-0" : "translate-x-full"}`}
+          role="dialog"
+          aria-modal={isMobileMenuOpen}
         >
           <div className="flex items-center justify-end px-5 py-2 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
             <button
+              ref={closeBtnRef}
               onClick={closeAllMenus}
               className="p-2 rounded-full text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
             >


### PR DESCRIPTION
Which issue does this PR close?

Closes https://github.com/SandeepVashishtha/Eventra/issues/153

Rationale for this change
The current mobile navigation works but lacks proper accessibility support. Without a focus trap and ARIA attributes, keyboard and screen reader users can have a poor experience. This change improves usability and accessibility, aligning the navbar with best practices.

What changes are included in this PR?

Added a focus trap to the mobile drawer so keyboard users cannot tab outside the menu when it is open.
Added ARIA attributes (aria-expanded, aria-controls, aria-modal, role="dialog") for screen reader support.
Improved escape key handling to close the drawer.
Preserved existing behavior of closing on route change and overlay click.

Are these changes tested?
Verified manually in the browser:
Drawer traps focus and cycles through menu items correctly.

Escape key closes the drawer.
Drawer closes on navigation.