### PR TITLE
Remove duplicate Theme Toggle button from footer

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -314,11 +314,7 @@ const Footer = () => {
             <p className="text-sm text-gray-500 dark:text-gray-400">
               © {currentYear} Eventra. All rights reserved.
             </p>
-            {/* Theme Toggle in Footer */}
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-gray-500 dark:text-gray-400">Theme:</span>
-              <ThemeToggleButton size="small" showLabel={true} />
-            </div>
+            
           </div>
         </div>
       </footer>


### PR DESCRIPTION
### Description
This PR removes the Theme Toggle button from the footer, as it was redundant.
The same button already exists in the navbar, so having two caused unnecessary duplication and possible user confusion.

### Fixes: #532

### Changes Made
Removed the ThemeToggle component from the footer.
Verified that the navbar Theme Toggle remains functional.

### Why This Change?
Improves UI consistency by keeping a single toggle.
Prevents user confusion caused by duplicate buttons.
Simplifies the codebase by removing unnecessary components.