### PR TITLE
Fixed Spacing btw navbar and home page content

### DIFF
--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -147,7 +147,7 @@ const Hero = () => {
   ];
 
   return (
-    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-50 via-white to-purple-50 dark:from-gray-900 dark:via-black dark:to-gray-900">
+    <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-indigo-50 via-white to-purple-50 dark:from-gray-900 dark:via-black dark:to-gray-900 xl:pt-28 pt-24">
       {/* Floating Gradient Shapes */}
       {shapes.map((shape, i) => (
         <motion.div
@@ -172,10 +172,10 @@ const Hero = () => {
           animate={controls}
         >
           {/* Headline */}
-          <motion.h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold mb-6 leading-snug">
+          <motion.h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold mb-6 leading-snug">
             <motion.span
               // Main headline text color
-              className="block text-gray-900 dark:text-gray-100"
+              className="block text-gray-900 dark:text-gray-100 mb-2 md:mb-0"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2 }}
@@ -183,12 +183,12 @@ const Hero = () => {
               Discover & Join
             </motion.span>
 
-            <div className="relative h-16 sm:h-20 md:h-24 lg:h-28 overflow-hidden flex justify-center items-center">
+            <div className="relative mt-3 h-16 sm:h-20 md:h-24 lg:h-28 overflow-hidden flex justify-center items-center">
               <AnimatePresence mode="wait">
                 <motion.span
                   key={index}
                   // Animated text gradient for dark mode
-                  className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-indigo-800 via-blue-500 to-purple-700 dark:from-indigo-400 dark:via-blue-400 dark:to-purple-500 mb-4"
+                  className="text-2xl mt-2 sm:text-3xl md:text-4xl lg:text-5xl bg-clip-text text-transparent bg-gradient-to-r from-indigo-800 via-blue-500 to-purple-700 dark:from-indigo-400 dark:via-blue-400 dark:to-purple-500 mb-4 pb-2"
                   initial={{ opacity: 0, y: 40 }}
                   animate={{
                     opacity: 1,


### PR DESCRIPTION
### ✅ Fix: Add Top Spacing Between Navbar and Hero Section

#### Summary

This PR resolves the issue where the homepage hero section (`"Discover & Join..."`) was positioned too close to the navbar in both mobile and desktop views, resulting in a cramped layout.

#### Changes Made

- Added appropriate **top margin/padding** to the hero section container.
- Ensured consistent spacing across mobile and desktop breakpoints.
- Confirmed that the spacing update does not impact other sections of the layout.

#### Before / After

| Before | After |
|--------|-------|
| <img width="417" height="740" alt="image" src="https://github.com/user-attachments/assets/1d23bbe4-2c2c-4f46-bc10-57895f4ba744" /> | <img width="412" height="741" alt="image" src="https://github.com/user-attachments/assets/b3eef7d6-31ba-410e-95af-4851214664e9" />|
| <img width="1891" height="872" alt="image" src="https://github.com/user-attachments/assets/61585361-8da3-4f38-8fee-01339aba00bd" />|<img width="1892" height="871" alt="image" src="https://github.com/user-attachments/assets/b5bef8f5-7924-4d76-8629-14ae3a125a63" />|



- Closes #538 .
