### PR TITLE
fixed white gap on about page in dark mode

### DIFF
--- a/src/Pages/About/AboutCTA .js
+++ b/src/Pages/About/AboutCTA .js
@@ -62,7 +62,7 @@ const AboutCTA = () => {
   ];
 
   return (
-    <section className="relative py-16 px-12 m-8 rounded-3xl bg-gradient-to-r from-black via-indigo-950 via-purple-950 to-pink-950 text-center overflow-hidden shadow-2xl">
+    <section className="relative py-16 px-12 m-8 rounded-3xl bg-gradient-to-r from-black via-purple-950 to-pink-950 text-center overflow-hidden shadow-2xl">
       {/* Animated Bubbles */}
       {bubbles.map((bubble, idx) => (
         <motion.div

--- a/src/Pages/About/AboutPage.js
+++ b/src/Pages/About/AboutPage.js
@@ -3,11 +3,11 @@ import AboutCTA from "./AboutCTA ";
 
 const AboutPage = () => {
   return (
-    <>
+    <div className="flex flex-col min-h-screen bg-gradient-to-b from-white/0 via-white/30 to-white dark:from-transparent dark:to-gray-900">
       <ModernAbout />
       {/* 💡 NOTE: This CTA Section is already dark by design and works well in both modes. No changes are needed. */}
       <AboutCTA></AboutCTA>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #540.

# Fix Footer Gap on About Page

## Description
This PR removes the awkward white gap between the main content and the footer on the About page.  

The fix was achieved by:  
- Adding a full-page dark gradient background for the About page in dark mode and light background in light mode.  
- Ensuring proper padding and margins for the content sections.  

## Impact
- Footer now aligns seamlessly with the content above.  
- Visual continuity is maintained in both mobile and desktop views.  

## Testing
1. Navigate to the About page in dark mode.  
2. Scroll to the bottom of the content.  
3. Confirm there is no white gap and spacing looks consistent.

## Screenshots
| State  | Screenshot / Description |
|--------|-------------------------|
| Before |<img width="1890" height="867" alt="image" src="https://github.com/user-attachments/assets/28dcdd84-67c0-44e3-8d28-378bd4e7ff9f" />
| |<img width="410" height="740" alt="image" src="https://github.com/user-attachments/assets/29e07b01-a378-491d-9c73-1fd67a7af8d8" />|
| After  | <img width="1888" height="780" alt="image" src="https://github.com/user-attachments/assets/42c5ce54-cbfa-4743-882b-ff9854de4cd5" />|
| |<img width="416" height="741" alt="image" src="https://github.com/user-attachments/assets/f09967bc-9384-421a-ba85-feda533ce714" />|
