### PR TITLE
Restore missing social media icons in footer

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FaLinkedin, FaDiscord, FaTelegram } from "react-icons/fa";
+import { FaLinkedin, FaDiscord, FaTelegram, FaInstagram } from "react-icons/fa";
 import { SiX } from "react-icons/si";
 import {
   FaInfoCircle,
@@ -169,7 +169,38 @@ const Footer = () => {
           size={20}
         />
       ),
-    }
+    },
+    {
+      name: "Discord",
+      href: "https://discord.com/",
+      icon: (
+        <FaDiscord
+          className="size-10 p-2 rounded-full text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 shadow-sm hover:shadow-lg transition-all duration-300 hover:bg-blue-900 hover:text-white dark:hover:bg-black-600 dark:hover:text-white hover:scale-110 hover:-translate-y-1"
+          size={20}
+        />
+      ),
+    },
+    {
+      name: "Telegram",
+      href: "https://telegram.com/",
+      icon: (
+        <FaTelegram
+          className="size-10 p-2 rounded-full text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 shadow-sm hover:shadow-lg transition-all duration-300 hover:bg-blue-700 hover:text-white dark:hover:bg-blue-600 dark:hover:text-white hover:scale-110 hover:-translate-y-1"
+          size={20}
+        />
+      ),
+    },
+    {
+      name: "Instagram",
+      href: "https://instagram.com/",
+      icon: (
+        <FaInstagram
+          className="size-10 p-2 rounded-full text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 shadow-sm hover:shadow-lg transition-all duration-300 hover:bg-pink-600 hover:text-white dark:hover:bg-pink-600 dark:hover:text-white hover:scale-110 hover:-translate-y-1"
+          size={20}
+        />
+      ),
+    },
+    
   ];
 
   return (


### PR DESCRIPTION
### Summary:
This PR restores the missing social media icons in the footer. Previously, only GitHub and LinkedIn were visible, while other icons (Telegram, Discord, Instagram, etc.) were not showing up.

### Fixes: #552 

### Changes Introduced:
Added back the missing social media icons in the "Follow Us" section.
Applied consistent sizing, spacing, and padding across all icons.
Ensured icons inherit dark/light mode styles.
Unified hover effects (scale, color change, shadow) to match existing GitHub and LinkedIn icons.
Verified responsiveness across different screen sizes.

### Outcome:
The footer now correctly displays all intended social media icons.
Improved visual consistency and alignment in the "Follow Us" section.
Enhanced user accessibility by providing direct links to all supported platforms.