### PR TITLE
Move message icon from bottom-right to bottom-left

### DIFF
--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -17,7 +17,7 @@ const FeedbackButton = () => {
     <motion.div
       layout 
       transition={{ type: "spring", stiffness: 300, damping: 30 }}
-      className={`fixed right-[1.625rem] z-[10] translate-y-1/2 ${
+      className={`fixed left-[1.625rem] z-[10] translate-y-1/2 ${
         isScrollTopVisible ? "bottom-24" : "bottom-6"
       }`}
       initial={{ opacity: 0, scale: 0 }}


### PR DESCRIPTION
### Problem
The message icon is currently positioned at the bottom-right corner, where it conflicts with the “Back to Top” button. This creates UI overlap and reduces usability.

### Fixes: #569

### Solution
Repositioned the message icon to the bottom-left corner of the page. This area was unused, ensuring better visibility and avoiding conflicts with other elements.

### Changes Made
Updated CSS to move the message icon from bottom-right to bottom-left
Verified no overlap with existing elements
Maintained responsiveness across screen sizes

### Result
The message icon is now clearly visible on the bottom-left corner, improving overall UI/UX.