### PR TITLE
Add hover effect to discord icon

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -175,7 +175,7 @@ const Footer = () => {
       href: "https://discord.com/",
       icon: (
         <FaDiscord
-          className="size-10 p-2 rounded-full text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 shadow-sm hover:shadow-lg transition-all duration-300 hover:bg-blue-900 hover:text-white dark:hover:bg-black-600 dark:hover:text-white hover:scale-110 hover:-translate-y-1"
+          className="size-10 p-2 rounded-full text-gray-600 dark:text-gray-400 bg-white dark:bg-gray-700 shadow-sm hover:shadow-lg transition-all duration-300 hover:bg-blue-900 hover:text-white dark:hover:bg-blue-600 dark:hover:text-white hover:scale-110 hover:-translate-y-1"
           size={20}
         />
       ),


### PR DESCRIPTION
### Description
This PR fixes the hover effect for the Discord icon in the footer. Previously, all social media icons (Telegram, LinkedIn, GitHub, etc.) displayed a hover effect except Discord. With this update, the Discord icon now responds correctly to hover, ensuring a consistent user experience across all social media icons.

### Fixes: #578 

### Changes
Added missing hover styles for the Discord icon.
Verified hover effects for all social media icons in the footer.
Ensured consistency in styling and transitions.

### Testing
Tested hover effects on all social media icons across different browsers.
Confirmed that Discord icon now matches the behavior of other icons.