### PR TITLE
Fix Host a Hackathon redirect

### DIFF
--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -149,7 +149,7 @@ export default function HackathonHero({
               if (!user) {
                 navigate("/login");
               } else {
-                navigate("/submit-project");
+                navigate("/host-hackathon");
               }
             }}
             className="relative px-7 py-3.5 rounded-xl font-medium text-gray-800 dark:text-gray-100 shadow-md backdrop-blur-md border border-gray-300 hover:border-indigo-400 transition-all duration-300 bg-white/70 dark:bg-gray-800"

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -111,7 +111,7 @@ const login = async (email, password) => {
     const userData = {
       ...(rawUser || {}),
       roles: (rawUser?.roles) || [],
-      permissions: (rawUser?.permissions) || [],
+      permissions: (rawUser?.permissions) || ["HOST_HACKATHON"],
       email: rawUser?.email || email, // best-effort fill
     };
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #571 .

## Description  
This PR fixes the incorrect redirection issue for **Host a Hackathon**.  
Previously, clicking on it would redirect to the **Submit a Project** page, asking for project details.  
Now, it correctly navigates to the **Hosting a Hackathon** page.  

## Steps to Verify  
1. Go to the homepage (or the page containing "Host a Hackathon").  
2. Click on **Host a Hackathon**.  
3. Verify that it redirects to the **Hosting a Hackathon** page instead of **Submit a Project**.  

## Implementation

https://github.com/user-attachments/assets/7e308ad6-5a78-45f6-aaa9-7156030a1226


