### PR TITLE
Fix UI overlap between default “Share Feedback” button and custom feedback icon

### DIFF
--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -26,7 +26,7 @@ const FeedbackButton = () => {
       <Link
         to="/feedback"
         className="relative flex items-center justify-center p-3.5 bg-gradient-to-r from-purple-600 to-pink-500 text-white rounded-full shadow-lg hover:from-purple-600 hover:to-pink-700 transition-all duration-300 border-2 border-white group"
-        title="Share Feedback"
+        // title="Share Feedback"
         aria-label="Share Feedback"
       >
         <motion.div
@@ -37,9 +37,9 @@ const FeedbackButton = () => {
           <FiMessageSquare className="text-2xl" />
         </motion.div>
 
-        <div className="pointer-events-none absolute right-full mr-3 whitespace-nowrap rounded-lg bg-gray-800 dark:bg-gray-700 px-3 py-2 text-sm text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+        <div className="pointer-events-none absolute left-full mr-3 whitespace-nowrap rounded-lg bg-gray-800 dark:bg-gray-700 px-3 py-2 text-sm text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
           Share your feedback
-          <div className="absolute left-full top-1/2 -translate-y-1/2 transform border-4 border-transparent border-l-gray-800 dark:border-l-gray-700"></div>
+          <div className=" absolute right-full top-1/2 -translate-y-1/2 transform border-4 border-transparent border-r-gray-800 dark:border-r-gray-700"></div>
         </div>
       </Link>
     </motion.div>


### PR DESCRIPTION
### Description:
Currently, the default “Share Feedback” button appears on the page and overlaps with a manually added custom feedback icon, causing the custom icon to be partially hidden on the left side.

### Fixes: #598 

### Changes:
Removes the default “Share Feedback” button.
Ensures the custom feedback icon is fully visible.
Maintains a clean and user-friendly page layout.

### Before:
Default and custom feedback icons overlap.
Custom icon partially hidden.

### After:
Only the custom feedback icon is visible.
Layout is clean and unobstructed.