### PR TITLE
changed guidelines to visible color in dark mode

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -65,7 +65,7 @@ const HostHackathon = () => {
           <ClipboardDocumentListIcon className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
           <h2 className="text-xl font-semibold text-indigo-700 dark:text-indigo-400">Guidelines</h2>
         </div>
-        <ul className="list-disc pl-6 space-y-3 text-gray-700 text-sm sm:text-base">
+        <ul className="list-disc pl-6 space-y-3 text-gray-700 dark:text-gray-300 text-sm sm:text-base">
           <li>
             Clearly define the{" "}
             <span className="font-medium">objectives, theme, and rules</span> of


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #590 .

##  Bug Fix: Guidelines Content Not Visible in Dark Mode

### Description
This PR fixes the issue where the **Guidelines section content on the "Host a Hackathon" page** was not clearly visible in **Dark Mode** due to insufficient text/background contrast.  

###  Issue
- In Dark Mode, the Guidelines text blended with the background and became hard to read.  

### Fix Implemented
- Updated the **Guidelines section styling** to ensure proper text contrast in Dark Mode.  
- Applied consistent text color for dark backgrounds.  


###  Steps to Verify
1. Navigate to the **Host a Hackathon** page.  
2. Enable **Dark Mode**.  
3. Scroll to the **Guidelines** section.  
4. Confirm that the text is clearly visible with sufficient contrast.  

### Screenshots
**Before (Dark Mode):**  
<img width="1343" height="766" alt="image" src="https://github.com/user-attachments/assets/bbb9efdb-db62-4bf9-ba08-44da7b6421b5" />


**After (Dark Mode):**  
<img width="1160" height="782" alt="image" src="https://github.com/user-attachments/assets/0bb85eed-82dd-448b-b62e-308ed56b4153" />


### 🔍 Additional Notes
- This change only affects the **Guidelines section** and does not alter other page elements.  
- Tested in both **Light Mode** and **Dark Mode** for consistency.  


