### PR TITLE
fix: improve dark mode visibility for project filter options

### DIFF
--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -234,10 +234,10 @@ const ProjectGallery = () => {
                     className="flex items-center justify-between px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm bg-white dark:bg-gray-700 hover:ring-2 hover:ring-indigo-500 transition-all"
                     onClick={() => setSortOpen((prev) => !prev)}
                   >
-                    <span className="text-gray-700">
+                    <span className="text-gray-700 dark:text-gray-300">
                       {sortByLabels[sortBy]}
                     </span>
-                    <FiX className="ml-2 text-gray-400" />
+                    <FiX className="ml-2 text-gray-400 dark:text-gray-500" />
                   </div>
 
                   {/* Sort Dropdown Menu */}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #607

## Rationale for this change

In dark mode, the filter options (Recently Updated, Most Stars, Most Forks, Most Issues) were not visible due to insufficient contrast. This fix improves accessibility by ensuring these important UI elements are visible regardless of the selected theme.

## What changes are included in this PR?

- Added `dark:text-gray-300` to the sort button text span to ensure proper visibility in dark mode
- Added `dark:text-gray-500` to the dropdown icon to improve visibility in dark mode
- These changes ensure consistent visibility and usability between light and dark themes

## Are these changes tested?

Yes, I've tested the changes by:
- Running the application locally
- Confirming the filter labels are now visible in dark mode
- Verifying the fix doesn't affect light mode appearance
- Checking that the contrast meets accessibility standards

## Are there any user-facing changes?

Yes, this is a user-facing change that improves visibility of UI elements in dark mode. Users will now be able to see and use the filter options when using dark mode, which was previously difficult or impossible due to poor contrast.