### PR TITLE
fixed login issue

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../context/AuthContext';
@@ -13,7 +13,7 @@ const Login = () => {
   const [showPassword, setShowPassword] = useState(false);
 
   const navigate = useNavigate();
-  const { login } = useAuth();
+  const { login, isAuthenticated } = useAuth();
 
   // Email regex for validation
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -49,6 +49,13 @@ const Login = () => {
     return Object.keys(newErrors).length === 0;
   };
 
+  // Redirect if already authenticated (e.g., came back here or state just updated)
+  useEffect(() => {
+    if (isAuthenticated()) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
   // Handle Form submit
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -58,8 +65,11 @@ const Login = () => {
     setLoading(true);
     try {
       // assuming login(email, password) exists in your auth context
-      await login(formData.email, formData.password);
-      navigate("/dashboard");
+      const ok = await login(formData.email, formData.password);
+      if (ok) {
+        // Defer navigation until auth state is reflected
+        navigate('/dashboard', { replace: true });
+      }
     } catch (err) {
       console.error("Login error:", err);
       setError({ general: "Invalid email or password" });


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #326 

## Rationale for this change


After successful login, users were not being redirected to /dashboard, causing confusion and blocking access to protected pages. This aligns the UX with expected behavior and ensures protected routes work immediately post-login.

## What changes are included in this PR?

Added an authentication-state guard in Login.js to navigate to /dashboard when isAuthenticated() becomes true.
Updated login submit flow to navigate with { replace: true } after login(...) resolves, avoiding race conditions with ProtectedRoute.
Left ProtectedRoute intact; it now works as intended once auth state is set.

## Are these changes tested?

Manual testing:
Entered valid credentials on /login and verified redirect to /dashboard.
Refreshed the app and confirmed protected routes remain accessible while authenticated.
Attempted access to /dashboard when not authenticated and confirmed redirect to /login.
No automated tests are included as the project currently lacks a test harness for routing/auth flows.

## Are there any user-facing changes?

Yes:
Users are now redirected to /dashboard immediately after successful login.
Improved UX by preventing the user from staying stuck on the login page post-authentication.
No breaking changes to public APIs or routes.
If there are any breaking changes to public APIs, please add the `api change` label.
