### PR TITLE
Add Google Calendar integration to Event and Hackathon cards

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -11,6 +11,7 @@ import {
   BookOpen,
   Gift,
 } from "lucide-react";
+import { addEventToGoogleCalendar } from "../../utils/calendarUtils";
 
 const EventCard = ({ event }) => {
   // Array of icons to choose from
@@ -96,14 +97,28 @@ const EventCard = ({ event }) => {
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:from-black/50 transition-all duration-500"></div>
         
-        {/* Floating badge on image */}
-        <motion.div 
-          className="absolute top-4 right-4 bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-full p-2 shadow-lg"
-          whileHover={{ scale: 1.1, rotate: 5 }}
-          transition={{ type: "spring", stiffness: 400, damping: 10 }}
+        {/* Google Calendar button */}
+        <a 
+          href={addEventToGoogleCalendar(event)}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          title="Add to Google Calendar"
+          className="group/cal"
         >
-          <Calendar size={16} className="text-indigo-500" />
-        </motion.div>
+          <motion.div 
+            className="absolute top-4 right-4 bg-white/90 dark:bg-gray-900/90 backdrop-blur-sm rounded-full p-2 shadow-lg cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-900/40"
+            whileHover={{ scale: 1.1, rotate: 5 }}
+            transition={{ type: "spring", stiffness: 400, damping: 10 }}
+          >
+            <Calendar size={16} className="text-indigo-500" />
+            
+            {/* Tooltip */}
+            <div className="absolute invisible group-hover/cal:visible opacity-0 group-hover/cal:opacity-100 transition-opacity duration-300 -top-10 left-1/2 transform -translate-x-1/2 bg-indigo-600 text-white text-xs py-1 px-2 rounded whitespace-nowrap">
+              Add to Google Calendar
+            </div>
+          </motion.div>
+        </a>
       </div>
 
       {/* --- Enhanced Description --- */}

--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -8,6 +8,7 @@ import {
   BuildingLibraryIcon,
   DocumentTextIcon,
 } from "@heroicons/react/24/outline";
+import { addHackathonToGoogleCalendar } from "../../utils/calendarUtils";
 
 const HackathonCard = ({ hackathon, isFeatured = false }) => {
   const stats = {
@@ -226,10 +227,25 @@ const HackathonCard = ({ hackathon, isFeatured = false }) => {
               <button className="px-4 py-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white text-sm font-medium rounded-lg hover:from-indigo-600 hover:to-purple-700 transition-colors">
                 Register
               </button>
-              {/* UPDATED: Secondary button colors */}
-              <button className="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
-                Set Reminder
-              </button>
+              {/* Google Calendar integration */}
+              <a 
+                href={addHackathonToGoogleCalendar(hackathon)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block group/calendar relative"
+                onClick={(e) => e.stopPropagation()}
+                title="Add to Google Calendar"
+              >
+                <button className="w-full px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-sm font-medium rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors flex items-center justify-center gap-2">
+                  <CalendarIcon className="w-4 h-4 text-indigo-500" />
+                  Set Reminder
+                </button>
+                
+                {/* Tooltip */}
+                <div className="absolute invisible group-hover/calendar:visible opacity-0 group-hover/calendar:opacity-100 transition-opacity duration-300 -top-8 left-1/2 transform -translate-x-1/2 bg-indigo-600 text-white text-xs py-1 px-2 rounded whitespace-nowrap z-10">
+                  Add to Google Calendar
+                </div>
+              </a>
             </div>
           ) : (
             <div className="grid grid-cols-2 gap-3">

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -1,0 +1,137 @@
+/**
+ * Google Calendar utility functions
+ * These functions help create Google Calendar event URLs for adding events to Google Calendar
+ */
+
+/**
+ * Generates a Google Calendar event URL based on event data
+ * @param {Object} eventData - The event data
+ * @param {string} eventData.title - The title of the event
+ * @param {string} eventData.description - The description of the event
+ * @param {string} eventData.location - The location of the event
+ * @param {string} eventData.startDate - The start date of the event in ISO format (YYYY-MM-DD)
+ * @param {string} eventData.endDate - The end date of the event in ISO format (YYYY-MM-DD)
+ * @param {string} eventData.startTime - The start time of the event (optional)
+ * @param {string} eventData.endTime - The end time of the event (optional)
+ * @returns {string} The Google Calendar URL
+ */
+export const generateGoogleCalendarUrl = (eventData) => {
+  // Base URL for Google Calendar
+  const baseUrl = 'https://calendar.google.com/calendar/render';
+  
+  // Convert dates to the format Google Calendar expects
+  let startDateTime, endDateTime;
+  
+  if (eventData.startTime) {
+    // If we have a start time, combine date and time
+    const [hours, minutes] = eventData.startTime.split(':');
+    const startDate = new Date(eventData.startDate);
+    startDate.setHours(parseInt(hours), parseInt(minutes), 0);
+    startDateTime = startDate.toISOString().replace(/-|:|\.\d+/g, '');
+  } else {
+    // If no time, use the date only (all day event)
+    startDateTime = eventData.startDate.replace(/-/g, '');
+  }
+
+  // Handle end date/time
+  if (eventData.endDate) {
+    if (eventData.endTime) {
+      // If we have an end time, combine date and time
+      const [hours, minutes] = eventData.endTime.split(':');
+      const endDate = new Date(eventData.endDate);
+      endDate.setHours(parseInt(hours), parseInt(minutes), 0);
+      endDateTime = endDate.toISOString().replace(/-|:|\.\d+/g, '');
+    } else {
+      // If no time, use the date only (all day event)
+      endDateTime = eventData.endDate.replace(/-/g, '');
+    }
+  } else {
+    // If no end date, use the start date
+    endDateTime = startDateTime;
+  }
+  
+  // Parameters for the Google Calendar URL
+  const params = {
+    action: 'TEMPLATE',
+    text: encodeURIComponent(eventData.title || ''),
+    details: encodeURIComponent(eventData.description || ''),
+    location: encodeURIComponent(eventData.location || ''),
+    dates: `${startDateTime}/${endDateTime}`
+  };
+
+  // Build the URL with parameters
+  const queryString = Object.keys(params)
+    .map(key => `${key}=${params[key]}`)
+    .join('&');
+
+  return `${baseUrl}?${queryString}`;
+};
+
+/**
+ * Convenience function to generate a Google Calendar URL for an event
+ */
+export const addEventToGoogleCalendar = (event) => {
+  // Extract time from the event time string if available
+  let startTime = null;
+  if (event.time) {
+    // Assuming time format like "10:00 AM"
+    const timeParts = event.time.match(/(\d+):(\d+)\s*([APap][Mm])/);
+    if (timeParts) {
+      let hours = parseInt(timeParts[1]);
+      const minutes = parseInt(timeParts[2]);
+      const period = timeParts[3].toUpperCase();
+      
+      // Convert to 24-hour format
+      if (period === 'PM' && hours < 12) hours += 12;
+      if (period === 'AM' && hours === 12) hours = 0;
+      
+      startTime = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+    }
+  }
+
+  // Calculate end time (assuming events are 2 hours long if not specified)
+  const eventEndDate = event.endDate || event.date;
+  
+  return generateGoogleCalendarUrl({
+    title: event.title,
+    description: event.description || '',
+    location: event.location || '',
+    startDate: event.date || event.startDate,
+    endDate: eventEndDate,
+    startTime: startTime,
+    endTime: startTime ? calculateEndTime(startTime) : null
+  });
+};
+
+/**
+ * Calculate end time based on start time (default: 2 hours later)
+ * @param {string} startTime - Start time in 24-hour format (HH:MM)
+ * @param {number} durationHours - Duration in hours
+ * @returns {string} End time in 24-hour format (HH:MM)
+ */
+const calculateEndTime = (startTime, durationHours = 2) => {
+  const [hours, minutes] = startTime.split(':').map(Number);
+  
+  // Create a date object to handle hour/minute calculations
+  const date = new Date();
+  date.setHours(hours, minutes, 0);
+  
+  // Add duration hours
+  date.setHours(date.getHours() + durationHours);
+  
+  // Format to HH:MM
+  return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+};
+
+/**
+ * Convenience function to generate a Google Calendar URL for a hackathon
+ */
+export const addHackathonToGoogleCalendar = (hackathon) => {
+  return generateGoogleCalendarUrl({
+    title: hackathon.title,
+    description: hackathon.description || '',
+    location: hackathon.location || '',
+    startDate: hackathon.startDate,
+    endDate: hackathon.endDate
+  });
+};


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #617 

## Rationale for this change

This PR adds a lightweight Google Calendar integration to the frontend so that users can quickly add Events and Hackathons to their Google Calendar.

Rationale:
- Improves user experience by reducing friction when saving event dates.
- Encourages attendance by making reminders easy to add.

## What changes are included in this PR?

- Added `src/utils/calendarUtils.js` to generate Google Calendar `TEMPLATE` URLs for events and hackathons.
- Updated `src/Pages/Events/EventCard.js` to turn the calendar badge into a clickable "Add to Google Calendar" button (opens Google Calendar in a new tab).
- Updated `src/Pages/Hackathons/HackathonCard.js` to make the "Set Reminder" button open Google Calendar with hackathon details pre-filled. On hover the button shows the tooltip "Add to Google Calendar".
- Minor UI/UX improvements: tooltips and hover states for clarity.

## Are these changes tested?

- Manual testing performed locally:
  - Clicking the calendar badge on an event card opens a new tab to Google Calendar with event details.
  - Clicking "Set Reminder" on a hackathon opens Google Calendar with hackathon details.

- No automated tests were added because this is a UI/UX feature that primarily opens external URLs.

## Are there any user-facing changes?

Yes — the event and hackathon cards now include an "Add to Google Calendar" action:
- Event cards: calendar badge in the top-right of the cover image becomes a button labeled with a tooltip.
- Hackathon cards: "Set Reminder" is the visible button label; hovering shows "Add to Google Calendar" and clicking opens Google Calendar.
