### PR TITLE
Fix  Navbar Toggle Button Size & Spacing

### DIFF
--- a/src/components/common/ThemeToggleButton.js
+++ b/src/components/common/ThemeToggleButton.js
@@ -7,13 +7,13 @@ const ThemeToggleButton = () => {
   );
 
   useEffect(() => {
-    const root = document.documentElement; 
+    const root = document.documentElement;
     if (darkMode) {
-      root.classList.add("dark"); 
-      localStorage.setItem("theme", "dark"); 
+      root.classList.add("dark");
+      localStorage.setItem("theme", "dark");
     } else {
-      root.classList.remove("dark"); 
-      localStorage.setItem("theme", "light"); 
+      root.classList.remove("dark");
+      localStorage.setItem("theme", "light");
     }
   }, [darkMode]);
 
@@ -23,17 +23,17 @@ const ThemeToggleButton = () => {
       onClick={() => setDarkMode((prev) => !prev)}
     >
       <div
-        className={`w-16 h-8 rounded-full p-1 bg-gray-300 dark:bg-gray-700 relative`}
+        className={`w-12 h-6 rounded-full p-1 bg-gray-300 dark:bg-gray-700 relative`} // reduced size
       >
         <div
-          className={`w-6 h-6 bg-white rounded-full shadow-lg flex items-center justify-center
-            transform transition-all duration-300 ease-in-out absolute top-1
-            ${darkMode ? "translate-x-8" : "translate-x-0"}`}
+          className={`w-5 h-5 bg-white rounded-full shadow-lg flex items-center justify-center
+            transform transition-all duration-300 ease-in-out absolute top-0.5
+            ${darkMode ? "translate-x-6" : "translate-x-0"}`} // adjusted translation
         >
           {darkMode ? (
-            <FiSun className="text-yellow-500" /> 
+            <FiSun className="text-yellow-500 text-sm" /> // smaller icon
           ) : (
-            <FiMoon className="text-gray-700" /> 
+            <FiMoon className="text-gray-700 text-sm" /> // smaller icon
           )}
         </div>
       </div>


### PR DESCRIPTION
# PR: Fix Navbar Toggle Button Size & Spacing

## Description
- Made the theme toggle button smaller (`w-12 h-6`) with a smaller inner circle (`w-5 h-5`).  
- Adjusted slide translation (`translate-x-6`) and icon size (`text-sm`).  
- Improved spacing and alignment in the navbar.  
- Dark/light mode functionality remains unchanged.

<img width="1891" height="275" alt="image" src="https://github.com/user-attachments/assets/191d131b-a8df-42a2-b509-6c64e5a6efee" />
<img width="1881" height="162" alt="image" src="https://github.com/user-attachments/assets/675753e9-3d76-49e4-8ef7-0ed84f70858d" />
<img width="1532" height="135" alt="image" src="https://github.com/user-attachments/assets/f2e39c0f-d306-46bd-8f80-ac37b7f231e3" />


Closes #631