### PR TITLE
fix: closes the form when clicked outside

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -443,7 +443,11 @@ const FeedbackPage = () => {
 
   return (
     // UPDATED: Main page background
-    <div className="min-h-screen bg-white dark:bg-black flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 relative overflow-hidden">
+    <div className="min-h-screen bg-white dark:bg-black flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 relative overflow-hidden" onClick={(e) => {
+    if (e.target === e.currentTarget) {
+      navigate("/"); // Closes the form when clicking outside
+    }
+  }}>
       <div className="max-w-4xl w-full mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #651

## Rationale for this change

The feedback form remained open when clicking outside of it, causing confusion and poor UX. This change allows users to close the form by clicking anywhere outside the form area.

## What changes are included in this PR?

- Added a onClick handler on the overlay to close the form when clicking outside

- Ensured that the clicks inside the form do not trigger closure (e.target === e.currentTarget)

## Are these changes tested?

The changes were tested manually by running the project locally.

## Are there any user-facing changes?

Yes, users can now close the feedback form by clicking outside the form area.