### PR TITLE
fix know us better btn on home page stlying for both modes

### DIFF
--- a/src/Pages/Home/components/HomeCTA.jsx
+++ b/src/Pages/Home/components/HomeCTA.jsx
@@ -98,7 +98,7 @@ export default function CTASection() {
             -------------------------- */}
             <a
               href="about"
-              className="inline-flex items-center gap-3 bg-white text-pink-700 font-semibold px-8 py-4 rounded-full shadow-lg hover:bg-white/90 transition"
+              className="inline-flex items-center gap-2 bg-gradient-to-r from-indigo-600 to-purple-600 text-white px-8 py-3 rounded-full font-semibold shadow-lg hover:from-indigo-700 hover:to-purple-700 hover:scale-105 transition-all duration-300 ease-out"
             >
               Know us better
               <Rocket className="w-5 h-5" />


### PR DESCRIPTION
## Which issue does this PR close?



- Closes #653 

## Rationale for this change

Similar to the "Explore Hackathons" button, the "Know us better" button previously used a static, light-colored background that did not adapt to dark mode. This created a visual inconsistency in the UI. This PR resolves the issue by applying an updated style that is visually consistent in both light and dark themes.

## What changes are included in this PR?

- The className attribute for the "Know us better" button within the CTASection component has been updated.
- The new style applies the same gradient background (bg-gradient-to-r from-indigo-600 to-purple-600) and hover animation (hover:scale-105) as the "Explore Hackathons" button, ensuring visual consistency between the two calls-to-action.
- This PR's scope is limited to the "Know us better" button only.
- Screenshot:
<img width="242" height="82" alt="image" src="https://github.com/user-attachments/assets/3fd8e606-b72c-40ed-ae8e-d0cf1accb7b1" />


## Are these changes tested?

Yes, this change has been tested manually. I have confirmed that the new style renders correctly on the "Know us better" button in both light and dark modes and that the hover effects work as expected. As this is a stylistic change limited to CSS classes, no automated tests have been added.

## Are there any user-facing changes?

Yes. The "Know us better" button has been visually updated. It now features a purple-indigo gradient style, which makes it consistent with the adjacent "Explore Hackathons" button and improves the overall aesthetic of the component.