### PR TITLE
fix dark theme of participate btn on events page

### DIFF
--- a/src/Pages/Events/EventCTA.js
+++ b/src/Pages/Events/EventCTA.js
@@ -70,7 +70,7 @@ const EventCTA = () => {
           {/* UPDATED: The secondary button needs dark mode styles for when the main page is dark. */}
           <motion.button
             onClick={() => setShowModal(true)}
-            className="inline-flex items-center justify-center gap-2 bg-white text-purple-700 dark:bg-gray-200 dark:text-purple-800 font-semibold px-8 py-4 rounded-full shadow-lg hover:scale-105 transition-transform duration-300"
+            className="relative inline-flex items-center px-8 py-4 rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-semibold shadow hover:shadow-lg hover:bg-gray-100 hover:text-gray-900 hover:dark:bg-gray-700 hover:dark:text-white hover:scale-105 transition-all duration-300"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             data-aos="zoom-in"


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #654 

## Rationale for this change
The "Participate" button on the events page had styling that was not well-integrated with the dark theme, causing poor contrast and visual inconsistency. This PR refactors the button's styling to be fully theme-aware, providing a clean and consistent appearance in both light and dark modes.

## What changes are included in this PR?

- The className attribute for the "Participate" button component on the events page has been replaced.
- The new styling introduces distinct, theme-appropriate styles for light and dark modes (e.g., dark:bg-gray-800, dark:border-gray-600).
- A border has been added to give the button better definition.
- The hover effects are now more detailed and responsive to the current theme, including a shadow enhancement (hover:shadow-lg).
- The color scheme has been updated to a neutral gray palette for better UI harmony.
- Screenshot:
<img width="192" height="119" alt="image" src="https://github.com/user-attachments/assets/a0f9e596-d03a-4fa0-a743-bd3bbbbdb0d6" />

## Are these changes tested?

Yes, this is a visual change that has been tested manually. I have verified on the events page that the "Participate" button displays correctly in both light and dark modes and that the new hover transitions are smooth and function as expected.

## Are there any user-facing changes?

Yes. Users will notice a visual redesign of the "Participate" button. It now has a more refined, bordered style that properly adapts to light and dark themes, creating a more professional and integrated user experience on the events page.