### PR TITLE
fix dark mode styling of leaderboard page's stats section

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -308,132 +308,50 @@ export default function LeaderBoard() {
         </div>
 
         {/* stats */}
-        <div
-          style={{
-            display: "flex",
-            gap: 18,
-            marginBottom: 16,
-            flexWrap: "wrap",
-          }}
-        >
-          <div
-            style={{
-              flex: 1,
-              minWidth: 220,
-              padding: 24,
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              background: isDark
-                ? "linear-gradient(135deg,#23272f,#1a1d23)"
-                : "linear-gradient(135deg,#e0e7ff,#f3f4f6)",
-            }}
-          >
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <div
-                style={{
-                  padding: 12,
-                  borderRadius: 12,
-                  background: isDark ? "rgba(59,130,246,0.2)" : "#dbeafe",
-                  color: isDark ? "#60a5fa" : "#2563eb",
-                  marginRight: 16,
-                }}
-              >
-                <FaUsers style={{ fontSize: 22 }} />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+          {/* Contributors Card */}
+          <div className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-indigo-50 to-gray-50 dark:bg-gradient-to-br dark:from-gray-800 dark:to-gray-900">
+            <div className="flex items-center">
+              <div className="p-3 rounded-xl mr-4 bg-blue-100 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400">
+                <FaUsers className="text-2xl" />
               </div>
               <div>
-                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Contributors
                 </p>
-                <p
-                  style={{
-                    fontSize: 22,
-                    fontWeight: 700,
-                    color: isDark ? "#fff" : "#222",
-                  }}
-                >
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {loading ? "..." : stats.totalContributors}
                 </p>
               </div>
             </div>
           </div>
-          <div
-            style={{
-              flex: 1,
-              minWidth: 220,
-              padding: 24,
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              background: isDark
-                ? "linear-gradient(135deg,#23272f,#1a1d23)"
-                : "linear-gradient(135deg,#e0e7ff,#f3f4f6)",
-            }}
-          >
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <div
-                style={{
-                  padding: 12,
-                  borderRadius: 12,
-                  background: isDark ? "rgba(16,185,129,0.2)" : "#bbf7d0",
-                  color: isDark ? "#34d399" : "#059669",
-                  marginRight: 16,
-                }}
-              >
-                <FaCode style={{ fontSize: 22 }} />
+          {/* Pull Requests Card */}
+          <div className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-indigo-50 to-gray-50 dark:bg-gradient-to-br dark:from-gray-800 dark:to-gray-900">
+            <div className="flex items-center">
+              <div className="p-3 rounded-xl mr-4 bg-green-100 text-green-600 dark:bg-green-500/20 dark:text-green-400">
+                <FaCode className="text-2xl" />
               </div>
               <div>
-                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Pull Requests
                 </p>
-                <p
-                  style={{
-                    fontSize: 22,
-                    fontWeight: 700,
-                    color: isDark ? "#fff" : "#222",
-                  }}
-                >
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {loading ? "..." : stats.flooredTotalPRs}
                 </p>
               </div>
             </div>
           </div>
-          <div
-            style={{
-              flex: 1,
-              minWidth: 220,
-              padding: 24,
-              borderRadius: 16,
-              boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-              border: `1px solid ${isDark ? "#444" : "#eee"}`,
-              background: isDark
-                ? "linear-gradient(135deg,#23272f,#1a1d23)"
-                : "linear-gradient(135deg,#e0e7ff,#f3f4f6)",
-            }}
-          >
-            <div style={{ display: "flex", alignItems: "center" }}>
-              <div
-                style={{
-                  padding: 12,
-                  borderRadius: 12,
-                  background: isDark ? "rgba(139,92,246,0.2)" : "#ede9fe",
-                  color: isDark ? "#a78bfa" : "#7c3aed",
-                  marginRight: 16,
-                }}
-              >
-                <FaStar style={{ fontSize: 22 }} />
+          {/* Total Points Card */}
+          <div className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-indigo-50 to-gray-50 dark:bg-gradient-to-br dark:from-gray-800 dark:to-gray-900">
+            <div className="flex items-center">
+              <div className="p-3 rounded-xl mr-4 bg-violet-100 text-violet-600 dark:bg-violet-500/20 dark:text-violet-400">
+                <FaStar className="text-2xl" />
               </div>
               <div>
-                <p style={{ fontSize: 14, color: isDark ? "#b3b3b3" : "#555" }}>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Total Points
                 </p>
-                <p
-                  style={{
-                    fontSize: 22,
-                    fontWeight: 700,
-                    color: isDark ? "#fff" : "#222",
-                  }}
-                >
+                <p className="text-2xl font-bold text-gray-900 dark:text-white">
                   {loading ? "..." : stats.flooredTotalPoints}
                 </p>
               </div>


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #655 

## Rationale for this change

The statistics cards ("Contributors," "Pull Requests," "Total Points") on the Leaderboard page were not theme-aware, appearing with a jarring white background in dark mode. This PR fixes the visual inconsistency by refactoring the component to use Tailwind CSS classes instead of inline styles, ensuring the cards match the overall design in both light and dark themes.



## What changes are included in this PR?

- Removed Inline Styles: The entire stats section in leaderboard.jsx has been refactored. All inline style objects have been replaced with Tailwind CSS className attributes.
- Theme-Aware Styling: The stat cards now have proper dark: variants for backgrounds, borders, and text, ensuring they integrate seamlessly with the dark mode UI.
- Code Cleanup: The redundant isDark state variable has been removed from the component, as theme detection is now handled automatically by Tailwind.
- Consistent Design: The new styling for the cards and their inner elements (icons, text) now uses the project's design system, improving visual consistency.
- Screenshot:
<img width="1372" height="142" alt="image" src="https://github.com/user-attachments/assets/59c725e6-b0ff-4fdb-9e6a-8f776fa1bb9e" />


## Are these changes tested?

Yes, the changes have been tested manually. I have verified that the leaderboard stats cards now render correctly in both light and dark modes. The new styling is responsive and aligns with the design of the rest of the page.



## Are there any user-facing changes?

Yes. Users will see a significant visual improvement on the Contributor Leaderboard page when using dark mode. The statistics cards are no longer bright white and now match the dark theme, providing a more cohesive and pleasant user experience.

