### PR TITLE
Restrict Floating Shapes to Hero Section Only

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -138,135 +138,152 @@ const FAQPage = () => {
 
   // Floating shapes data
   const shapes = [
-    { size: 60, pos: { top: "5%", left: "10%" }, color: "from-indigo-400 to-blue-400" },
-    { size: 70, pos: { top: "3%", right: "10%" }, color: "from-indigo-400 to-blue-400" },
-    { size: 80, pos: { top: "15%", right: "15%" }, color: "from-purple-400 to-pink-400" },
-    { size: 100, pos: { bottom: "5%", left: "20%" }, color: "from-blue-300 to-indigo-300" },
-    { size: 100, pos: { top: "15%", left: "15%" }, color: "from-pink-300 to-purple-200" },
-    { size: 70, pos: { bottom: "10%", right: "10%" }, color: "from-pink-300 to-purple-300" },
-    { size: 50, pos: { top: "50%", left: "2%" }, color: "from-indigo-300 to-blue-200" },
-    { size: 90, pos: { top: "40%", right: "15%" }, color: "from-purple-300 to-indigo-300" },
-    { size: 65, pos: { top: "30%", left: "3%" }, color: "from-blue-200 to-indigo-400" },
+    {
+      size: 40,
+      pos: { top: "5%", left: "10%" },
+      color: "from-indigo-400 to-blue-400",
+    },
+    {
+      size: 50,
+      pos: { top: "3%", right: "10%" },
+      color: "from-indigo-400 to-blue-400",
+    },
+
+    {
+      size: 50,
+      pos: { bottom: "10%", right: "10%" },
+      color: "from-pink-300 to-purple-300",
+    },
+    {
+      size: 50,
+      pos: { top: "50%", left: "2%" },
+      color: "from-indigo-300 to-blue-200",
+    },
+    {
+      size: 40,
+      pos: { top: "40%", right: "15%" },
+      color: "from-purple-300 to-indigo-300",
+    },
+    {
+      size: 30,
+      pos: { top: "30%", left: "3%" },
+      color: "from-blue-200 to-indigo-400",
+    },
   ];
 
   return (
     <div className="relative flex flex-col min-h-screen bg-gradient-to-br from-indigo-50 via-white to-purple-50 dark:from-gray-900 dark:via-black dark:to-gray-900 overflow-hidden">
       {/* Floating Background Layer */}
-      <div className="fixed inset-0 z-0 pointer-events-none overflow-hidden">
-        {shapes.map((shape, i) => (
-          <motion.div
-            key={i}
-            animate={{
-              y: [0, -20 - i * 5, 0],
-              x: [0, 20 + i * 5, 0],
-              rotate: [0, 15, -15, 0],
-            }}
-            transition={{
-              duration: 6 + i,
-              repeat: Infinity,
-              ease: "easeInOut",
-            }}
-            className={`absolute rounded-full bg-gradient-to-tr ${shape.color} opacity-30 dark:opacity-10`}
-            style={{
-              width: `${shape.size}px`,
-              height: `${shape.size}px`,
-              ...shape.pos,
-            }}
-          />
-        ))}
-      </div>
-
-      {/* Foreground Content Layer */}
-      <div className="relative z-10">
-        {/* HERO */}
-        <section className="py-20 relative overflow-hidden">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      {/* HERO */}
+      <section className="py-20 relative overflow-hidden">
+        {/* Floating Background Layer (only inside Hero) */}
+        <div className="absolute inset-0 z-0 pointer-events-none overflow-hidden">
+          {shapes.map((shape, i) => (
             <motion.div
-              variants={container}
-              initial="hidden"
-              animate={controls}
-            >
-              <motion.div variants={item}>
-                <div className="inline-flex items-center justify-center w-20 h-20 bg-indigo-600 rounded-full mb-6 question-icon">
-                  <HelpCircle className="w-10 h-10 text-white" />
-                </div>
-                <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 dark:text-white mb-6">
-                  Frequently Asked{" "}
-                  <span className="text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 via-purple-600 to-indigo-600">
-                    Questions
-                  </span>
-                </h1>
-                <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
-                  Everything you need to know about using Eventra, from getting
+              key={i}
+              animate={{
+                y: [0, -20 - i * 5, 0],
+                x: [0, 20 + i * 5, 0],
+                rotate: [0, 15, -15, 0],
+              }}
+              transition={{
+                duration: 6 + i,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }}
+              className={`absolute rounded-full bg-gradient-to-tr ${shape.color} opacity-30 dark:opacity-10`}
+              style={{
+                width: `${shape.size}px`,
+                height: `${shape.size}px`,
+                ...shape.pos,
+              }}
+            />
+          ))}
+        </div>
+
+        {/* HERO Content */}
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
+          <motion.div variants={container} initial="hidden" animate={controls}>
+            <motion.div variants={item}>
+              <div className="inline-flex items-center justify-center w-20 h-20 bg-indigo-600 rounded-full mb-6 question-icon">
+                <HelpCircle className="w-10 h-10 text-white" />
+              </div>
+              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-gray-900 dark:text-white mb-6">
+                Frequently Asked{" "}
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 via-purple-600 to-indigo-600">
+                  Questions
+                </span>
+              </h1>
+              <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">
+                Everything you need to know about using Eventra, from getting
                 started to hosting your own events. Can't find what you're
                 looking for? Reach out to our community!
-                </p>
-              </motion.div>
+              </p>
             </motion.div>
-          </div>
-        </section>
+          </motion.div>
+        </div>
+      </section>
 
-        {/* FAQ SECTION */}
-        <section className="pb-20" data-aos="fade-up" data-aos-duration="1000">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
-            {faqData.map((faq, index) => (
-              <motion.div
-                key={faq.id}
-                className="bg-white dark:bg-gray-800 rounded-2xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100 dark:border-gray-700 overflow-hidden"
-                data-aos="zoom-in-up"
-                data-aos-delay={index * 100}
+      {/* FAQ SECTION */}
+      <section className="pb-20" data-aos="fade-up" data-aos-duration="1000">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+          {faqData.map((faq, index) => (
+            <motion.div
+              key={faq.id}
+              className="bg-white dark:bg-gray-800 rounded-2xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100 dark:border-gray-700 overflow-hidden"
+              data-aos="zoom-in-up"
+              data-aos-delay={index * 100}
+            >
+              <button
+                onClick={() => toggleFAQ(faq.id)}
+                className="w-full p-6 text-left flex items-center justify-between outline-none focus:outline-none focus:ring-0 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
               >
-                <button
-                  onClick={() => toggleFAQ(faq.id)}
-                  className="w-full p-6 text-left flex items-center justify-between outline-none focus:outline-none focus:ring-0 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
-                >
-                  <div className="flex items-center space-x-4">
-                    <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center">
-                      <span className="text-indigo-600 dark:text-indigo-400">
-                        {faq.icon}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-xs font-medium text-indigo-600 dark:text-indigo-400 uppercase tracking-wide">
-                        {faq.category}
-                      </span>
-                      <h3 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-white mt-1">
-                        {faq.question}
-                      </h3>
-                    </div>
+                <div className="flex items-center space-x-4">
+                  <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-xl flex items-center justify-center">
+                    <span className="text-indigo-600 dark:text-indigo-400">
+                      {faq.icon}
+                    </span>
                   </div>
-
-                  <motion.div
-                    animate={{ rotate: openFAQ === faq.id ? 180 : 0 }}
-                    transition={{ duration: 0.3 }}
-                  >
-                    <ChevronDown className="w-5 h-5 text-gray-500 dark:text-gray-400" />
-                  </motion.div>
-                </button>
+                  <div>
+                    <span className="text-xs font-medium text-indigo-600 dark:text-indigo-400 uppercase tracking-wide">
+                      {faq.category}
+                    </span>
+                    <h3 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-white mt-1">
+                      {faq.question}
+                    </h3>
+                  </div>
+                </div>
 
                 <motion.div
-                  initial={{ height: 0, opacity: 0 }}
-                  animate={
-                    openFAQ === faq.id
-                      ? { height: "auto", opacity: 1 }
-                      : { height: 0, opacity: 0 }
-                  }
-                  transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
-                  className="px-6 overflow-hidden"
+                  animate={{ rotate: openFAQ === faq.id ? 180 : 0 }}
+                  transition={{ duration: 0.3 }}
                 >
-                  <div className="ml-16 pt-4 pb-6 border-t border-gray-100 dark:border-gray-700">
-                    <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
-                      {faq.answer}
-                    </p>
-                  </div>
+                  <ChevronDown className="w-5 h-5 text-gray-500 dark:text-gray-400" />
                 </motion.div>
-              </motion.div>
-            ))}
-          </div>
-        </section>
+              </button>
 
-        <FAQCTA />
-      </div>
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={
+                  openFAQ === faq.id
+                    ? { height: "auto", opacity: 1 }
+                    : { height: 0, opacity: 0 }
+                }
+                transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+                className="px-6 overflow-hidden"
+              >
+                <div className="ml-16 pt-4 pb-6 border-t border-gray-100 dark:border-gray-700">
+                  <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+                    {faq.answer}
+                  </p>
+                </div>
+              </motion.div>
+            </motion.div>
+          ))}
+        </div>
+      </section>
+
+      <FAQCTA />
     </div>
   );
 };


### PR DESCRIPTION
### 🔧 PR Title: Restrict Floating Shapes to Hero Section Only

**Problem:**
Currently, the floating decorative shapes on the FAQ page appear across the entire page, including the FAQ section and CTA. This causes visual clutter and distracts from the content, especially when scrolling.

**Solution:**
- Moved the floating shapes inside the Hero `<section>` only.  
- Changed shapes’ position from `fixed` to `absolute` relative to the Hero, so they no longer cover other sections.  
- Ensured Hero content has `relative z-10` to stay above the shapes.  
- Removed floating shapes from FAQ section and CTA, improving readability and overall UI focus.

Closes #689
