### PR TITLE
Missing Hamburger Icon in events and Hackathon page fixed

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -21,16 +21,16 @@ export default function EventHero({
 
   return (
     <div
-      className="relative bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-24"
+      className="relative bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-16 sm:py-20 md:py-24"
       data-aos="fade-down"
       data-aos-once="true"
       data-aos-duration="1000"
     >
-      <div className="absolute inset-0 z-0 pointer-events-none overflow-visible">
+      <div className="absolute inset-0 z-0 pointer-events-none overflow-hidden">
         {floatingCircles.map((circle, idx) => (
           <motion.div
             key={idx}
-            className="absolute rounded-full"
+            className="absolute rounded-full hidden sm:block"
             style={{
               width: circle.size,
               height: circle.size,
@@ -55,12 +55,12 @@ export default function EventHero({
       </div>
 
       {/* Hero Content */}
-      <div className="relative max-w-6xl mx-auto px-6 text-center z-10">
+      <div className="relative max-w-6xl mx-auto px-4 sm:px-6 text-center z-10">
         <motion.h1
           initial={{ opacity: 0, y: -30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.7 }}
-          className="text-4xl sm:text-6xl font-extrabold leading-tight"
+          className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold leading-tight px-4 sm:px-0"
         >
           Discover{" "}
           <span className="bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 dark:from-indigo-400 dark:via-purple-400 dark:to-pink-400 bg-clip-text text-transparent animate-gradient">
@@ -72,7 +72,7 @@ export default function EventHero({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.7 }}
-          className="mt-4 text-base sm:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto"
+          className="mt-4 text-sm sm:text-base md:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto px-4 sm:px-0"
         >
           "Discover exciting events, compete with talented participants, learn
           new skills, and{" "}
@@ -87,17 +87,17 @@ export default function EventHero({
           initial={{ opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ delay: 0.4, duration: 0.6 }}
-          className="w-full max-w-3xl mx-auto mt-12"
+          className="w-full max-w-3xl mx-auto mt-8 sm:mt-12 px-4 sm:px-0"
         >
           <div className="relative group">
-            <div className="absolute inset-y-0 left-0 pl-4 flex items-center z-10 pointer-events-none">
-              <Search className="h-5 w-5 text-gray-400 dark:text-gray-500 group-focus-within:text-indigo-500 dark:group-focus-within:text-indigo-400 transition-colors" />
+            <div className="absolute inset-y-0 left-0 pl-3 sm:pl-4 flex items-center z-10 pointer-events-none">
+              <Search className="h-4 w-4 sm:h-5 sm:w-5 text-gray-400 dark:text-gray-500 group-focus-within:text-indigo-500 dark:group-focus-within:text-indigo-400 transition-colors" />
             </div>
 
             <input
               type="text"
               placeholder="Search events by name, location, or tags..."
-              className="block w-full pl-12 pr-12 py-4 text-base text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 bg-white/60 dark:bg-gray-800/60 backdrop-blur-xl border border-gray-200 dark:border-gray-700 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 transition-all duration-300 shadow-lg hover:shadow-xl"
+              className="block w-full pl-10 sm:pl-12 pr-10 sm:pr-12 py-3 sm:py-4 text-sm sm:text-base text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 bg-white/60 dark:bg-gray-800/60 backdrop-blur-xl border border-gray-200 dark:border-gray-700 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 transition-all duration-300 shadow-lg hover:shadow-xl"
               value={searchQuery}
               onChange={(e) => handleSearch(e.target.value)}
             />
@@ -107,16 +107,16 @@ export default function EventHero({
                 whileHover={{ scale: 1.1 }}
                 whileTap={{ scale: 0.9 }}
                 onClick={() => handleSearch("")}
-                className="absolute inset-y-0 right-0 pr-4 flex items-center text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors z-10"
+                className="absolute inset-y-0 right-0 pr-3 sm:pr-4 flex items-center text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors z-10"
               >
-                <X className="h-5 w-5" />
+                <X className="h-4 w-4 sm:h-5 sm:w-5" />
               </motion.button>
             )}
           </div>
 
           {/* Tags + Count */}
-          <div className="mt-4 flex items-center justify-between flex-wrap gap-3 px-2">
-            <div className="flex gap-2 flex-wrap">
+          <div className="mt-4 flex items-center justify-between flex-wrap gap-2 sm:gap-3 px-2">
+            <div className="flex gap-1.5 sm:gap-2 flex-wrap">
               {[
                 "AI",
                 "Blockchain",
@@ -130,13 +130,13 @@ export default function EventHero({
                   key={idx}
                   whileHover={{ scale: 1.1 }}
                   onClick={() => handleSearch(tag)}
-                  className="px-3 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/50 rounded-full cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-900 transition"
+                  className="px-2 sm:px-3 py-1 text-xs font-medium text-indigo-600 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/50 rounded-full cursor-pointer hover:bg-indigo-100 dark:hover:bg-indigo-900 transition"
                 >
                   {tag}
                 </motion.span>
               ))}
             </div>
-            <span className="text-sm text-indigo-600 dark:text-indigo-400 font-semibold">
+            <span className="text-xs sm:text-sm text-indigo-600 dark:text-indigo-400 font-semibold whitespace-nowrap">
               {filteredEvents.length}{" "}
               {filteredEvents.length === 1 ? "event" : "events"} found
             </span>
@@ -148,18 +148,18 @@ export default function EventHero({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.6, duration: 0.7 }}
-          className="mt-12 flex justify-center gap-5 flex-wrap"
+          className="mt-8 sm:mt-12 flex justify-center gap-3 sm:gap-5 flex-wrap px-4 sm:px-0"
         >
           <motion.button
             whileHover={{ scale: 1.07 }}
             whileTap={{ scale: 0.95 }}
-            className="relative px-7 py-3.5 rounded-xl font-semibold text-white shadow-lg overflow-hidden group"
+            className="relative px-5 sm:px-7 py-2.5 sm:py-3.5 rounded-xl text-sm sm:text-base font-semibold text-white shadow-lg overflow-hidden group"
             onClick={scrollToCard}
           >
             <span className="absolute inset-0 bg-gradient-to-r from-purple-600 to-indigo-800 group-hover:from-indigo-500 group-hover:to-indigo-600 transition-all duration-500" />
             <span className="absolute inset-0 w-full h-full bg-gradient-to-r from-transparent via-white/30 to-transparent translate-x-[-200%] group-hover:translate-x-[200%] transition-transform duration-700 ease-in-out" />
             <span className="relative flex items-center">
-              <Rocket className="inline-block w-5 h-5 mr-2" />
+              <Rocket className="inline-block w-4 h-4 sm:w-5 sm:h-5 mr-2" />
               Explore Events
             </span>
           </motion.button>
@@ -168,10 +168,10 @@ export default function EventHero({
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             onClick={() => navigate("/create-event")}
-            className="relative px-7 py-3.5 rounded-xl font-medium text-gray-800 dark:text-gray-200 shadow-md backdrop-blur-md border border-gray-300 dark:border-gray-600 hover:border-indigo-400 transition-all duration-300 bg-white/70 dark:bg-gray-800/70"
+            className="relative px-5 sm:px-7 py-2.5 sm:py-3.5 rounded-xl text-sm sm:text-base font-medium text-gray-800 dark:text-gray-200 shadow-md backdrop-blur-md border border-gray-300 dark:border-gray-600 hover:border-indigo-400 transition-all duration-300 bg-white/70 dark:bg-gray-800/70"
           >
             <span className="relative flex items-center">
-              <Users className="inline-block w-5 h-5 mr-2 text-indigo-600 dark:text-indigo-400" />
+              <Users className="inline-block w-4 h-4 sm:w-5 sm:h-5 mr-2 text-indigo-600 dark:text-indigo-400" />
               Host an Event
             </span>
           </motion.button>
@@ -179,7 +179,7 @@ export default function EventHero({
       </div>
       {/* Stats Section */}
       <div
-        className="relative max-w-6xl mx-auto px-6 mt-20 mb-16 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8"
+        className="relative max-w-6xl mx-auto px-4 sm:px-6 mt-12 sm:mt-16 md:mt-20 mb-8 sm:mb-12 md:mb-16 grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 md:gap-8"
         data-aos="fade-up"
         data-aos-duration="1000"
         data-aos-delay="200"
@@ -201,28 +201,28 @@ export default function EventHero({
             data-aos="zoom-in"
             data-aos-delay={200 + idx * 150}
             // UPDATED: Stat card styles
-            className="relative bg-gradient-to-br from-indigo-50 to-white dark:from-gray-800 dark:to-gray-800 rounded-3xl shadow-lg p-6 flex flex-col items-center text-center hover:shadow-2xl transition-all duration-300"
+            className="relative bg-gradient-to-br from-indigo-50 to-white dark:from-gray-800 dark:to-gray-800 rounded-2xl sm:rounded-3xl shadow-lg p-4 sm:p-6 flex flex-col items-center text-center hover:shadow-2xl transition-all duration-300"
           >
             {/* Animated Icon in a circular container */}
             <motion.div
               whileHover={{ rotate: 360, scale: 1.2 }}
               transition={{ type: "spring", stiffness: 200, damping: 10 }}
-              className="mb-4 flex items-center justify-center h-14 w-14 rounded-full bg-gradient-to-tr from-indigo-800 to-indigo-300 shadow-md"
+              className="mb-3 sm:mb-4 flex items-center justify-center h-10 w-10 sm:h-14 sm:w-14 rounded-full bg-gradient-to-tr from-indigo-800 to-indigo-300 shadow-md"
             >
-              <stat.icon className="h-7 w-7 text-white" />
+              <stat.icon className="h-5 w-5 sm:h-7 sm:w-7 text-white" />
             </motion.div>
 
             {/* Stat Value (big bold number) */}
             {/* UPDATED: Text colors */}
-            <p className="text-3xl font-extrabold text-gray-900 dark:text-gray-100 tracking-tight">
+            <p className="text-xl sm:text-2xl md:text-3xl font-extrabold text-gray-900 dark:text-gray-100 tracking-tight">
               {stat.value}
             </p>
-            <p className="mt-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+            <p className="mt-1 text-xs sm:text-sm font-medium text-gray-600 dark:text-gray-400">
               {stat.label}
             </p>
 
             {/* UPDATED: Decorative glow */}
-            <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-indigo-500/10 to-indigo-600/10 dark:from-indigo-500/20 dark:to-indigo-600/20 blur-2xl opacity-40 -z-10" />
+            <div className="absolute inset-0 rounded-2xl sm:rounded-3xl bg-gradient-to-br from-indigo-500/10 to-indigo-600/10 dark:from-indigo-500/20 dark:to-indigo-600/20 blur-2xl opacity-40 -z-10" />
           </motion.div>
         ))}
       </div>

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -123,19 +123,19 @@ const EventsPage = () => {
       {/* Main content wrapper */}
       <div
         ref={cardSectionRef}
-        className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12"
+        className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12"
       >
         {/* Filters + Sort + Toggle View Section */}
         <motion.div
-          className="mb-10 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4"
+          className="mb-8 sm:mb-10 flex flex-col gap-4"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           // AOS Implementation
           data-aos="fade-up"
           data-aos-duration="800"
         >
-          <div className="flex flex-wrap gap-3 items-center">
-            {/* Filter Buttons */}
+          {/* Filter Buttons */}
+          <div className="flex flex-wrap gap-2 sm:gap-3 items-center justify-center sm:justify-start">
             {[
               { key: "all", label: "All" },
               { key: "upcoming", label: "Upcoming" },
@@ -146,7 +146,7 @@ const EventsPage = () => {
               <button
                 key={filter.key}
                 onClick={() => setFilterType(filter.key)}
-                className={`px-4 py-2 text-sm rounded-full transition ${
+                className={`px-3 sm:px-4 py-2 text-xs sm:text-sm rounded-full transition ${
                   filterType === filter.key
                     ? "bg-gradient-to-r from-indigo-600 to-purple-600 text-white"
                     : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:bg-indigo-50 dark:hover:bg-gray-700"
@@ -158,13 +158,16 @@ const EventsPage = () => {
                 {filter.label}
               </button>
             ))}
+          </div>
 
+          {/* Sort Dropdown and View Toggle */}
+          <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4">
             {/* Sort Dropdown */}
-            <div className="ml-4">
+            <div className="w-full sm:w-auto">
               <label htmlFor="sort-events" className="sr-only">Sort events</label>
               <select
                 id="sort-events"
-                className="p-2 text-sm rounded-3xl border border-gray-200 
+                className="w-full sm:w-auto p-2 text-xs sm:text-sm rounded-3xl border border-gray-200 
                 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 
                 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 value={sortType}
@@ -177,38 +180,38 @@ const EventsPage = () => {
                 <option value="upcoming">Upcoming Soonest</option>
               </select>
             </div>
-          </div>
 
-          {/* Toggle View Buttons (Grid / List) */}
-          <div 
-            className="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg p-1 shadow-sm"
-            data-aos="zoom-in"
-            data-aos-delay="400"
-          >
-            <button
-              onClick={() => setViewMode("grid")}
-              className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
-                viewMode === "grid"
-                  ? "bg-gradient-to-r from-indigo-400 to-purple-400 text-white shadow-md"
-                  : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-              }`}
-              aria-label="Grid view"
-              aria-pressed={viewMode === "grid"}
+            {/* Toggle View Buttons (Grid / List) */}
+            <div 
+              className="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg p-1 shadow-sm"
+              data-aos="zoom-in"
+              data-aos-delay="400"
             >
-              <Grid size={16} />
-            </button>
-            <button
-              onClick={() => setViewMode("list")}
-              className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
-                viewMode === "list"
-                  ? "bg-gradient-to-r from-indigo-400 to-purple-400 text-white shadow-md"
-                  : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-              }`}
-              aria-label="List view"
-              aria-pressed={viewMode === "list"}
-            >
-              <List size={16} />
-            </button>
+              <button
+                onClick={() => setViewMode("grid")}
+                className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
+                  viewMode === "grid"
+                    ? "bg-gradient-to-r from-indigo-400 to-purple-400 text-white shadow-md"
+                    : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                }`}
+                aria-label="Grid view"
+                aria-pressed={viewMode === "grid"}
+              >
+                <Grid size={16} />
+              </button>
+              <button
+                onClick={() => setViewMode("list")}
+                className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
+                  viewMode === "list"
+                    ? "bg-gradient-to-r from-indigo-400 to-purple-400 text-white shadow-md"
+                    : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                }`}
+                aria-label="List view"
+                aria-pressed={viewMode === "list"}
+              >
+                <List size={16} />
+              </button>
+            </div>
           </div>
         </motion.div>
 

--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -51,13 +51,13 @@ export default function HackathonHero({
   );
 
   return (
-    <div className="bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black relative overflow-visible">
+    <div className="bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black relative overflow-hidden">
       {/* ======================= FLOATING SHAPES ======================= */}
       {shapes.map((shape, i) => (
         <motion.div
           key={i}
           animate={floatShape(i)}
-          className={`absolute rounded-full bg-gradient-to-tr ${shape.color} opacity-30 dark:opacity-15`}
+          className={`hidden sm:block absolute rounded-full bg-gradient-to-tr ${shape.color} opacity-30 dark:opacity-15`}
           style={{
             width: `${shape.size}px`,
             height: `${shape.size}px`,
@@ -67,7 +67,7 @@ export default function HackathonHero({
       ))}
 
       {/* ======================= HERO SECTION ======================= */}
-      <div className="relative max-w-6xl mx-auto px-8 text-center mt-12">
+      <div className="relative max-w-6xl mx-auto px-4 sm:px-6 md:px-8 text-center mt-8 sm:mt-12">
         <motion.h1
           initial={{ opacity: 0, y: -30 }}
           animate={{ opacity: 1, y: 0 }}
@@ -186,7 +186,7 @@ export default function HackathonHero({
 
       {/* ======================= STATS SECTION ======================= */}
       <div
-        className="relative max-w-6xl mx-auto px-6 mt-20 mb-16 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8"
+        className="relative max-w-6xl mx-auto px-4 sm:px-6 mt-12 sm:mt-16 md:mt-20 mb-12 sm:mb-16 grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 md:gap-8"
         data-aos="fade-up"
         data-aos-duration="1000"
         data-aos-delay="200"

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -148,7 +148,7 @@ const HackathonHub = () => {
 
   return (
     // UPDATED: Main page background
-    <div className="bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-6 ">
+    <div className="bg-gradient-to-l from-indigo-200 to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-6 overflow-x-hidden">
       {/* Floating Action Button */}
       <motion.div
         className="fixed right-6 z-50"


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #730.

## Rationale for this change
- The main reason for this issue is responsiveness.
- The main content is styled with fixed width and height and that's the reason for disappearance


## What changes are included in this PR?
- The main section is styled to make the hamburger icon visible.
- The styling is done for both events and hackathon pages.


## Are these changes tested?
- Here are the screenshots
- Events page

<img width="430" height="761" alt="image" src="https://github.com/user-attachments/assets/62b5dae1-bb73-4292-950f-ad0582bc32d9" />

<br>
<br>

- Hackathons page

<img width="444" height="798" alt="image" src="https://github.com/user-attachments/assets/e03e85c4-99be-4753-9f0b-5c779db6cbf9" />
