### PR TITLE
removed non-functional links from footer

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -12,10 +12,10 @@ import {
   FaEnvelope,
   FaBookOpen,
   FaPlus,
-  FaClipboardList,
+  // FaClipboardList,  //can be reactivated later
   FaUsers,
   FaBook,
-  FaServer,
+  // FaServer,   //can be reactivated later
   FaHome,
   FaCalendarAlt,
   FaRocket,
@@ -108,11 +108,14 @@ const Footer = () => {
         href: "/create-event",
         icon: <FaPlus size={14} />,
       },
-      {
-        name: "Event Templates",
-        href: "#templates",
-        icon: <FaClipboardList size={14} />,
-      },
+
+      //Can be reactivated later
+      // {
+      //   name: "Event Templates",
+      //   href: "#templates",
+      //   icon: <FaClipboardList size={14} />,
+      // },
+
       {
         name: "Community Events",
         href: "/communityEvent",
@@ -148,7 +151,9 @@ const Footer = () => {
       { name: "Contact Us", href: "/contact", icon: <FaEnvelope size={14} /> },
       { name: "Feedback", href: "/feedback", icon: <FaComments size={14} /> },
       { name: "API Docs", href: "/apiDocs", icon: <FaBookOpen size={14} /> },
-      { name: "Status", href: "#status", icon: <FaServer size={14} /> },
+
+      //Can be reactivated later
+      // { name: "Status", href: "#status", icon: <FaServer size={14} /> },
     ],
   };
 


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #696 .

### Refactor(footer): Temporarily disable unused links and verify existing ones

**Description**

This pull request cleans up the footer component by temporarily disabling links that currently do not lead to a dedicated page or content. This improves the user experience by preventing clicks on dead links and also helps declutter the UI. Additionally, all remaining active links in the footer have been thoroughly checked to ensure they redirect to a functional page with content.

The corresponding icon imports for the disabled links have also been commented out to prevent unused import warnings. Comments have been added to the code to make it clear that these links can be easily reactivated in the future when their respective pages are ready.

---

**Changes Made**

* **Verified Active Links:** Thoroughly checked all existing links and ensured that they have dedicated content and redirect to the correct page.
* **Disabled Unused Footer Links:**
    * In the "Community" section, the **`Event Templates`** link has been commented out.
    * In the "Support" section, the **`Status`** link has been commented out.
* **Removed Unused Imports:**
    * Commented out the imports for `FaClipboardList` and `FaServer` from `react-icons/fa` to align with the disabled links and avoid console warnings.
* **Added Code Comments:**
    * Included a `// Can be reactivated later` comment above the disabled links and their corresponding imports to provide context for future development.


**Screenshots**
<img width="1852" height="528" alt="image" src="https://github.com/user-attachments/assets/8aa6c4bb-b0ed-4371-bff7-f3899164204c" />
