### PR TITLE
Ensured Help Center page scrolls to top on load

### DIFF
--- a/src/Pages/HelpCenter.js
+++ b/src/Pages/HelpCenter.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { motion } from "framer-motion";
+import React, { useState, useEffect } from "react";
+import { motion, useAnimation } from "framer-motion";
 import { FiChevronDown, FiChevronUp } from "react-icons/fi";
 import {
   Search,
@@ -153,9 +153,18 @@ const faqs = [
 
 const HelpCenter = () => {
   const [expandedFAQ, setExpandedFAQ] = useState(null);
+  const controls = useAnimation();
+
   const toggleFAQ = (id) => {
     setExpandedFAQ(expandedFAQ === id ? null : id);
   };
+  useEffect(() => {
+    controls.start("show");
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  }, [controls]);
   return (
     <div className="flex flex-col min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       {/* Hero Section */}


### PR DESCRIPTION
## 🧩 PR Title: Fix: Ensured Help Center page scrolls to top on load

### 🧠 Problem:
Previously, when navigating to the **Help Center** page, it retained the scroll position from the previous route.  
This caused the page to open midway instead of starting at the top, confusing users and breaking the expected navigation flow.

### 🔧 Solution Implemented:
- Added a scroll reset inside the Help Center component to ensure it always loads from the top:
Added a useEffect hook in the Help Center component that triggers window.scrollTo(0, 0) when the page loads. This ensures that the page always opens from the top each time it is accessed.
Closes #746