### PR TITLE
Fix: Chatbot Icon Overlaps with Mobile Drawer/Menu

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -212,6 +212,14 @@ const Chatbot = () => {
   { label: "Get Help", query: "I need help with something", route: "/contact" },
 ];
 
+const [hideChatbot, setHideChatbot] = useState(false);
+
+  useEffect(() => {
+    const handleToggle = (e) => setHideChatbot(e.detail);
+    window.addEventListener("mobileMenuToggle", handleToggle);
+    return () => window.removeEventListener("mobileMenuToggle", handleToggle);
+  }, []);
+
   const QuickActionsMenu = ({ quickActions, onActionClick }) => (
   <div className="bg-gray-50 dark:bg-gray-800 rounded-xl p-3 border border-gray-200 dark:border-gray-700">
     <div className="flex items-center justify-between mb-2">
@@ -250,7 +258,7 @@ const Chatbot = () => {
     <>
       {/* Floating Chat Button */}
       <AnimatePresence>
-        {!isOpen && (
+        {!isOpen && !hideChatbot && (
           <motion.button
             initial={{ scale: 0, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
@@ -292,7 +300,7 @@ const Chatbot = () => {
 
       {/* Chat Window */}
       <AnimatePresence>
-        {(isOpen || isAnimating) && (
+        {(isOpen || isAnimating) && !hideChatbot && (
           <motion.div
             data-chatbot-open={isOpen}
             initial={{ opacity: 0, y: 100, scale: 0.9 }}

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -102,6 +102,11 @@ const scrolledClasses = "bg-white/80 backdrop-blur-lg border-b border-gray-200/8
   };
 
   useEffect(() => {
+    const event = new CustomEvent("mobileMenuToggle", { detail: isMobileMenuOpen });
+    window.dispatchEvent(event);
+  }, [isMobileMenuOpen]);
+
+  useEffect(() => {
     if (isMobileMenuOpen) {
       const prevTop = window.scrollY || window.pageYOffset || 0;
       document.body.style.position = "fixed";


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #757 .


## Fix: Chatbot Icon Overlaps with Mobile Drawer/Menu



## Description
In mobile view, the chatbot icon was overlapping the navigation drawer, obstructing menu visibility and interaction.

---

### Summary of Changes

* Added a global event listener to detect when the mobile navigation drawer opens or closes (`mobileMenuToggle`).
* Updated the **Chatbot** component to listen for this event and automatically hide itself when the drawer is active.
* Ensured smooth visibility transition so that the chatbot reappears once the drawer is closed.
* Maintained consistent z-index layering without affecting desktop behavior.

---

### 🧩 Implementation Details

* **In `Navbar.js`:**

  * Dispatched a `CustomEvent("mobileMenuToggle")` whenever `isMobileMenuOpen` changes.
* **In `Chatbot.jsx`:**

  * Subscribed to the `mobileMenuToggle` event to toggle chatbot visibility dynamically.

---

### 🎯 Result

* The chatbot icon now correctly hides when the mobile drawer is open.
* No more UI overlap or interaction issues on small screens.
* Desktop and other screen sizes remain unaffected.

---



### 📸 Before vs After


<img width="1179" height="1967" alt="image" src="https://github.com/user-attachments/assets/0aa907c8-349b-4b3f-8509-d7d1cec1b293" /> 

https://github.com/user-attachments/assets/e45437a2-2f31-4d20-bb35-4f0d1332f218

 

---

### 🧾 Notes

This fix improves mobile UX and ensures consistent layering between UI elements (`Navbar`, `Chatbot`, and drawer overlay).

---



