### PR TITLE
Enhance HackathonCard Scroll Animation

### DIFF
--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -31,14 +31,23 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
 
   return (
     <motion.div
-      // AOS Implementation
-      data-aos="zoom-in"
-      // UPDATED: Card background, border, and featured ring
+      initial={{ opacity: 0, y: 50, rotateX: 15, scale: 0.95 }}
+      whileInView={{
+        opacity: 1,
+        y: 0,
+        rotateX: 0,
+        scale: 1,
+      }}
+      transition={{
+        duration: 0.6,
+        ease: "easeOut",
+      }}
+      viewport={{ once: true, amount: 0.3 }} // triggers when 30% visible
+      whileHover={{ y: -4, scale: 1.02 }} // keeps your hover lift effect
       className={`bg-gradient-to-br from-white to-white dark:from-gray-800 dark:to-black rounded-xl shadow-sm hover:shadow-md transition-all duration-300 border border-indigo-300 dark:border-gray-700 relative card-with-floating-elements ${
         isFeatured ? "ring-2 ring-indigo-500 dark:ring-indigo-400" : ""
       }`}
-      whileHover={{ y: -4 }}
-      {...props} // Spread props to include data-aos attributes from parent
+      {...props}
     >
       {/* Featured Ribbon */}
       {isFeatured && (


### PR DESCRIPTION
## ✨ Pull Request: Enhance HackathonCard Scroll Animation

### 🎯 Summary
This PR replaces the old **AOS-based scroll animation** (`data-aos="zoom-in"`) in the `HackathonCard` component with a **Framer Motion scroll-triggered animation** for a smoother and more modern visual effect.

### 🧩 Changes Made
- Removed: `data-aos="zoom-in"`
- Added: Framer Motion-based animation that:
  - Fades in as the card scrolls into view  
  - Slightly lifts upward (`y: 50 → 0`)  
  - Gently rotates from `rotateX: 15° → 0°` to create a **3D stand-up effect**
  - Scales from `0.95 → 1` for a natural pop-in feel  
- Kept hover animation (`whileHover={{ y: -4, scale: 1.02 }}`) for interactivity.
- Added viewport trigger `{ once: true, amount: 0.3 }` to animate only once when 30% visible.

Closes #769