### PR TITLE
Make theme toggle switch tabbable 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16219,6 +16219,20 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",

--- a/src/components/common/ThemeToggleButton.js
+++ b/src/components/common/ThemeToggleButton.js
@@ -18,7 +18,7 @@ const ThemeToggleButton = () => {
   }, [darkMode]);
 
   return (
-    <div
+    <button
       className="flex items-center cursor-pointer select-none"
       onClick={() => setDarkMode((prev) => !prev)}
     >
@@ -37,7 +37,7 @@ const ThemeToggleButton = () => {
           )}
         </div>
       </div>
-    </div>
+    </button>
   );
 };
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #788 .

## Rationale for this change

The `ThemeToggleButton` component was updated to improve accessibility and usability. The changes ensure that the button is fully tabbable and navigable by a keyboard.

## What changes are included in this PR?
- Ensured the `button` remains tabbable and interactive while maintaining its visual design by changing it to a button instead of a div element.

## Are these changes tested?
The changes have been manually tested.

## Are there any user-facing changes?
Yes, the `ThemeToggleButton` is now accessible via keyboard navigation, improving the experience for users relying on assistive technologies. There are no visual or functional changes