### PR TITLE
Fix success toast to avoid overlap with back to top button

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -16,7 +16,7 @@ const Toast = ({ message, type = "success", onClose }) => {
       initial={{ opacity: 0, y: 50, scale: 0.3 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, scale: 0.5, transition: { duration: 0.2 } }}
-      className={`fixed bottom-4 right-4 max-w-sm w-full shadow-lg rounded-lg pointer-events-auto overflow-hidden ${
+      className={`fixed top-24 right-4 max-w-sm w-full shadow-lg rounded-lg pointer-events-auto overflow-hidden ${
         type === "success" ? "bg-green-500" : "bg-red-500"
       }`}
     >


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #680 .

## Rationale for this change
Previously, the success toast on Contact form submission overlapped with the "Back to top" button.

## What changes are included in this PR?
Moved the success toast to the top right instead of bottom right, to avoid overlap.

## Are these changes tested?
Since this was just UI feature, it was tested manually.

## Are there any user-facing changes?
Yes