### PR TITLE
feat: add skeleton loaders for events, hackathons, and project cards

### DIFF
--- a/SKELETON_LOADERS.md
+++ b/SKELETON_LOADERS.md
@@ -1,0 +1,42 @@
+# Skeleton Loaders Implementation
+
+**Issue:** [#839 - Add skeleton loaders for events, hackathons, and project cards](https://github.com/SandeepVashishtha/Eventra/issues/839)
+
+## Changes Made
+
+### 1. New File: `src/components/common/SkeletonLoaders.jsx`
+Created a reusable skeleton components file with three skeleton variants that closely match the actual card layouts:
+
+- **`EventCardSkeleton`** — Matches `EventCard` layout: header (icon + title + badge), image area, description lines, 2x2 info grid (location/time/type/date), and two CTA buttons.
+- **`HackathonCardSkeleton`** — Matches `HackathonCard` layout: status/difficulty/prize badges, title + description, organizer, date/location/time block, tech stack tags, stats grid (participants/teams/submissions), winner section, and action buttons.
+- **`ProjectCardSkeleton`** — Matches `ProjectCard` layout: header (icon + title + status), 16:9 image area, description, category + difficulty tags, author avatar + stats counters, tech stack tags, and GitHub/Live Demo buttons.
+
+All skeletons use Tailwind's `animate-pulse` with a subtle shimmer gradient (`bg-gradient-to-r` with `bg-[length:200%_100%]`) for a smooth loading effect. Dark mode is fully supported via `dark:` variants.
+
+### 2. Modified: `src/Pages/Events/EventsPage.js`
+- Added `isLoading` state (default: `true`)
+- Added simulated async data loading with an 800ms delay (via `setTimeout`)
+- Replaced instant synchronous `setEvents(mockEvents)` with async loading pattern
+- While `isLoading` is `true`, renders 6 `EventCardSkeleton` placeholders in the grid
+- This page previously had **no loading state at all** — cards appeared instantly with no feedback
+
+### 3. Modified: `src/Pages/Hackathons/HackathonPage.js`
+- Replaced the inline basic `SkeletonCard` (a single div with minimal structure) with the imported `HackathonCardSkeleton` that matches the actual `HackathonCard` layout section-by-section
+- Removed ~20 lines of inline skeleton code
+
+### 4. Modified: `src/Pages/Projects/ProjectsPage.js`
+- Replaced the inline `SkeletonCard` with the imported `ProjectCardSkeleton` that matches `ProjectCard` layout
+- Removed ~32 lines of inline skeleton code
+
+## Key Features
+- **Layout-matched**: Each skeleton mirrors its corresponding card's DOM structure for minimal layout shift
+- **Shimmer effect**: Smooth animated gradient instead of plain gray blocks
+- **Dark mode**: All skeletons use `dark:` variants for dark theme support
+- **Reusable**: Components exported from a single file, easy to maintain and extend
+- **Non-intrusive**: Loading state only shows during initial data fetch; once data loads, real cards render seamlessly
+
+## How to Test
+1. Run the app: `npm start`
+2. Navigate to **Events**, **Hackathons**, and **Projects** pages
+3. You should see shimmer skeleton cards for ~0.8s (Events) / ~1s (Hackathons) / ~0.5s (Projects) before the actual cards appear
+4. Skeletons should closely resemble the card layouts and fully support dark mode

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -43,17 +43,10 @@ const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
   );
 };
 
-// -----------------------------
-// Main Events Page Component
-// -----------------------------
 const EventsPage = () => {
-  // tate to store all events (raw data from mock file)
   const [events, setEvents] = useState([]);
-  // State for filter type (all, upcoming, past, conference, workshop)
   const [filterType, setFilterType] = useState("all");
-  // State for switching between grid view and list view
   const [viewMode, setViewMode] = useState("grid");
-  // State for storing user’s search query (from search bar)
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredEvents, setFilteredEvents] = useState([]);
   const [sortType, setSortType] = useState("Newest");
@@ -71,12 +64,9 @@ const EventsPage = () => {
   // Fuse.js setup
   const fuse = new Fuse(events, {
     keys: ["title", "description", "location", "tags", "type"],
-    threshold: 0.35, // adjust for fuzziness
+    threshold: 0.35,
   });
 
-  // -----------------------------
-  // Search handler function
-  // -----------------------------
   const handleSearch = (query = "") => {
     setSearchQuery(query);
 
@@ -85,7 +75,6 @@ const EventsPage = () => {
       results = fuse.search(query).map((res) => res.item);
     }
 
-    // Apply filterType after fuzzy results
     const final = results.filter((event) => {
       return (
         filterType === "all" ||
@@ -98,12 +87,10 @@ const EventsPage = () => {
     setFilteredEvents(final);
   };
 
-  // Recalculate when filterType or events change
   useEffect(() => {
     handleSearch(searchQuery);
   }, [events, filterType]);
 
-  // Sort handler
   const handleSortChange = (type) => {
     setSortType(type);
     let sorted = [...filteredEvents];
@@ -115,7 +102,6 @@ const EventsPage = () => {
     setFilteredEvents(sorted);
   };
 
-  // Ensure sorting is applied when filter/search changes
   useEffect(() => {
     handleSortChange(sortType);
     // eslint-disable-next-line
@@ -125,13 +111,8 @@ const EventsPage = () => {
     cardSectionRef.current?.scrollIntoView({ behaviour: "smooth" });
   };
 
-  // -----------------------------
-  // JSX Render
-  // -----------------------------
   return (
-    // UPDATED: Main page background
     <div className="flex flex-col min-h-screen bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 overflow-x-hidden">
-      {/* Hero section will be updated in the next step */}
       <EventHero
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
@@ -140,16 +121,13 @@ const EventsPage = () => {
         scrollToCard={scrollToCard}
       />
 
-      {/* Main content wrapper */}
       <div
         ref={cardSectionRef}
         className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12"
       >
-        {/* Filters + Sort + Toggle View Section */}
         <div
           className="mb-8 sm:mb-10 flex flex-col gap-4"
         >
-          {/* Filter Buttons */}
           <div className="flex flex-wrap gap-2 sm:gap-3 items-center justify-center sm:justify-start">
             {[
               { key: "all", label: "All" },
@@ -189,7 +167,6 @@ const EventsPage = () => {
               />
             </div>
 
-            {/* Toggle View Buttons (Grid / List) */}
             <div
               className="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg p-1 shadow-sm"
             >
@@ -223,8 +200,6 @@ const EventsPage = () => {
 
         {renderCardSection(isLoading, filteredEvents, viewMode, filterType)}
       </div>
-
-      {/* These components will be updated in the next steps */}
 
       <EventCTA />
 

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -1,13 +1,13 @@
-// Importing necessary React hooks and libraries
 import { useState, useEffect, useRef } from "react";
-import mockEvents from "./eventsMockData.json"; // mock data file
-import EventHero from "./EventHero"; // Hero section with search
-import EventCard from "./EventCard"; // Card for displaying event details
-import { Grid, List } from "lucide-react"; // icons for toggle view
-import FeedbackButton from "../../components/FeedbackButton"; // Feedback button component
+import mockEvents from "./eventsMockData.json";
+import EventHero from "./EventHero";
+import EventCard from "./EventCard";
+import { Grid, List } from "lucide-react";
+import FeedbackButton from "../../components/FeedbackButton";
 import EventCTA from "./EventCTA";
 import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
+import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
 // -----------------------------
 // Main Events Page Component
 // -----------------------------
@@ -20,16 +20,17 @@ const EventsPage = () => {
   const [viewMode, setViewMode] = useState("grid");
   // State for storing user’s search query (from search bar)
   const [searchQuery, setSearchQuery] = useState("");
-  // State for storing the filtered + searched list of events
   const [filteredEvents, setFilteredEvents] = useState([]);
-  // Sort type state
   const [sortType, setSortType] = useState("Newest");
+  const [isLoading, setIsLoading] = useState(true);
   const cardSectionRef = useRef();
-  // -----------------------------
-  // Load events from mock JSON when component mounts
-  // -----------------------------
+
   useEffect(() => {
-    setEvents(mockEvents); // Setting mock data as events
+    const timer = setTimeout(() => {
+      setEvents(mockEvents);
+      setIsLoading(false);
+    }, 800);
+    return () => clearTimeout(timer);
   }, []);
 
   // Fuse.js setup
@@ -186,7 +187,13 @@ const EventsPage = () => {
         </div>
 
         {/* Event Cards Section */}
-        {filteredEvents.length > 0 ? (
+        {isLoading ? (
+          <div className="grid gap-8 grid-cols-1 sm:grid-cols-1 lg:grid-cols-3">
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <EventCardSkeleton key={`skeleton-${i}`} />
+            ))}
+          </div>
+        ) : filteredEvents.length > 0 ? (
           <div
             key={filterType + viewMode}
             className={`grid gap-8 ${

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -8,6 +8,41 @@ import EventCTA from "./EventCTA";
 import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
 import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
+
+const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
+  if (isLoading) {
+    return (
+      <div className="grid gap-8 grid-cols-1 sm:grid-cols-1 lg:grid-cols-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <EventCardSkeleton key={`skeleton-${i}`} />
+        ))}
+      </div>
+    );
+  }
+
+  if (filteredEvents.length === 0) {
+    return (
+      <div className="relative overflow-hidden rounded-3xl p-10 text-center border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-[0_10px_25px_rgba(0,0,0,0.05)] dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)]">
+      </div>
+    );
+  }
+
+  return (
+    <div
+      key={filterType + viewMode}
+      className={`grid gap-8 ${
+        viewMode === "grid"
+          ? "grid-cols-1 sm:grid-cols-1 lg:grid-cols-3"
+          : "grid-cols-1 max-w-4xl mx-auto"
+      }`}
+    >
+      {filteredEvents.map((event) => (
+        <EventCard key={event.id} event={event} />
+      ))}
+    </div>
+  );
+};
+
 // -----------------------------
 // Main Events Page Component
 // -----------------------------
@@ -186,30 +221,7 @@ const EventsPage = () => {
           </div>
         </div>
 
-        {/* Event Cards Section */}
-        {isLoading ? (
-          <div className="grid gap-8 grid-cols-1 sm:grid-cols-1 lg:grid-cols-3">
-            {[1, 2, 3, 4, 5, 6].map((i) => (
-              <EventCardSkeleton key={`skeleton-${i}`} />
-            ))}
-          </div>
-        ) : filteredEvents.length > 0 ? (
-          <div
-            key={filterType + viewMode}
-            className={`grid gap-8 ${
-              viewMode === "grid"
-                ? "grid-cols-1 sm:grid-cols-1 lg:grid-cols-3"
-                : "grid-cols-1 max-w-4xl mx-auto"
-            }`}
-          >
-            {filteredEvents.map((event) => (
-              <EventCard key={event.id} event={event} />
-            ))}
-          </div>
-        ) : (
-          <div className="relative overflow-hidden rounded-3xl p-10 text-center border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-[0_10px_25px_rgba(0,0,0,0.05)] dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)]">
-          </div>
-        )}
+        {renderCardSection(isLoading, filteredEvents, viewMode, filterType)}
       </div>
 
       {/* These components will be updated in the next steps */}

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -9,26 +9,7 @@ import { FiCode, FiRotateCw, FiCompass, FiChevronDown, FiX } from "react-icons/f
 import HackathonCTA from "./HackathonCTA";
 import Fuse from "fuse.js";
 import { createPortal } from "react-dom";
-
-// UPDATED: Skeleton Loader for dark mode
-const SkeletonCard = () => (
-  <div className="bg-white dark:bg-gray-800 rounded-xl overflow-hidden shadow-md animate-pulse">
-    <div className="p-6">
-      <div className="flex justify-between items-start mb-4">
-        <div className="h-6 w-24 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
-        <div className="h-6 w-20 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
-      </div>
-      <div className="h-6 w-3/4 bg-gray-200 dark:bg-gray-700 rounded mb-4"></div>
-      <div className="h-4 w-full bg-gray-100 dark:bg-gray-600 rounded mb-2"></div>
-      <div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded mb-4"></div>
-      <div className="space-y-3 mb-4">
-        <div className="h-4 w-3/4 bg-gray-100 dark:bg-gray-600 rounded"></div>
-        <div className="h-4 w-1/2 bg-gray-100 dark:bg-gray-600 rounded"></div>
-      </div>
-      <div className="h-10 w-full bg-gray-200 dark:bg-gray-700 rounded-lg"></div>
-    </div>
-  </div>
-);
+import { HackathonCardSkeleton } from "../../components/common/SkeletonLoaders";
 
 // NEW: Tag component for selected tags in search bar
 const Tag = ({ tag, onRemove }) => (
@@ -609,7 +590,7 @@ useEffect(() => {
           {isLoading ? (
             <div className="grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3, 4, 5, 6].map((i) => (
-                <SkeletonCard key={`skeleton-${i}`} />
+                <HackathonCardSkeleton key={`skeleton-${i}`} />
               ))}
             </div>
           ) : filteredHackathons.length > 0 ? (

--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -9,37 +9,8 @@ import FeedbackButton from "../../components/FeedbackButton"; // Feedback floati
 import { useNavigate } from "react-router-dom"; // Navigation hook from React Router
 import { Link } from "react-router-dom"; // Link component for routing
 import ProjectCTA from "./ProjectCTA";
-// Import mock data directly (assuming it's named mockProjectsData.json in the same folder as ProjectsPage.js)
 import mockProjects from "./mockProjectsData.json"; 
-
-// Skeleton loader for project cards while data is loading
-const SkeletonCard = () => (
-  <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden animate-pulse">
-    <div className="h-40 bg-gray-100 dark:bg-gray-700"></div>
-    <div className="p-6">
-      <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-3/4 mb-4"></div>
-      <div className="h-4 bg-gray-100 dark:bg-gray-600 rounded w-full mb-2"></div>
-      <div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded w-5/6 mb-4"></div>
-      <div className="flex flex-wrap gap-2 mb-4">
-        <div className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-16"></div>
-        <div className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-24"></div>
-      </div>
-      <div className="flex items-center justify-between mb-4">
-        <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700"></div>
-        <div className="h-4 bg-gray-100 dark:bg-gray-600 rounded w-1/3"></div>
-      </div>
-      <div className="flex flex-wrap gap-2 mb-4">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-16"></div>
-        ))}
-      </div>
-      <div className="flex items-center justify-between mt-4">
-        <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded-lg w-1/3"></div>
-        <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded-lg w-1/3"></div>
-      </div>
-    </div>
-  </div>
-);
+import { ProjectCardSkeleton } from "../../components/common/SkeletonLoaders";
 
 // Main ProjectGallery component
 const ProjectGallery = () => {
@@ -315,7 +286,7 @@ const ProjectGallery = () => {
             // Show skeleton loaders while fetching
             <div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3, 4, 5, 6].map((i) => (
-                <SkeletonCard key={`skeleton-${i}`} />
+                <ProjectCardSkeleton key={`skeleton-${i}`} />
               ))}
             </div>
           ) : error ? (

--- a/src/components/common/SkeletonLoaders.jsx
+++ b/src/components/common/SkeletonLoaders.jsx
@@ -7,24 +7,20 @@ const SkeletonBlock = ({ className = "" }) => (
 
 export const EventCardSkeleton = () => (
   <div className="group relative bg-white dark:bg-gray-900 rounded-3xl shadow-xl flex flex-col overflow-hidden">
-    {/* Header */}
     <div className="flex items-center px-8 py-6 gap-4 border-b border-gray-200/60 dark:border-gray-700/50">
       <SkeletonBlock className="w-12 h-12 rounded-2xl" />
       <SkeletonBlock className="h-6 flex-1" />
       <SkeletonBlock className="h-6 w-24 rounded-full" />
     </div>
 
-    {/* Image */}
     <SkeletonBlock className="h-64 w-full" />
 
-    {/* Description */}
     <div className="px-8 py-6 border-b border-gray-200/60 dark:border-gray-700/50">
       <SkeletonBlock className="h-4 w-full mb-2" />
       <SkeletonBlock className="h-4 w-5/6 mb-2" />
       <SkeletonBlock className="h-4 w-2/3" />
     </div>
 
-    {/* Info Grid */}
     <div className="px-8 py-6 grid grid-cols-2 gap-6">
       {[...Array(4)].map((_, i) => (
         <div key={i} className="flex items-center gap-3">
@@ -34,7 +30,6 @@ export const EventCardSkeleton = () => (
       ))}
     </div>
 
-    {/* CTA Buttons */}
     <div className="px-8 py-6 flex gap-4">
       <SkeletonBlock className="h-12 flex-1 rounded-2xl" />
       <SkeletonBlock className="h-12 flex-1 rounded-2xl" />
@@ -45,7 +40,6 @@ export const EventCardSkeleton = () => (
 export const HackathonCardSkeleton = () => (
   <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-blue-200 dark:border-gray-700 overflow-hidden">
     <div className="p-6 flex flex-col gap-5">
-      {/* Status, Difficulty, Prize */}
       <div className="flex justify-between items-center">
         <div className="flex gap-2">
           <SkeletonBlock className="h-6 w-20 rounded-full" />
@@ -56,7 +50,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Title & Description */}
       <div>
         <SkeletonBlock className="h-6 w-3/4 mb-2" />
         <SkeletonBlock className="h-4 w-full mb-1" />
@@ -65,7 +58,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Organizer */}
       <div className="flex items-center gap-2">
         <SkeletonBlock className="w-4 h-4 rounded" />
         <SkeletonBlock className="h-4 w-32" />
@@ -73,7 +65,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Date & Location */}
       <div className="flex flex-col gap-3">
         {[...Array(3)].map((_, i) => (
           <div key={i} className="flex items-center gap-2">
@@ -85,7 +76,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Tech Stack */}
       <div>
         <SkeletonBlock className="h-4 w-24 mb-2" />
         <div className="flex flex-wrap gap-2">
@@ -97,7 +87,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Stats */}
       <div className="grid grid-cols-3 gap-4">
         {[...Array(3)].map((_, i) => (
           <div key={i} className="text-center">
@@ -110,7 +99,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Winner */}
       <div className="flex items-center gap-2 p-3 rounded-lg">
         <SkeletonBlock className="w-5 h-5 rounded" />
         <SkeletonBlock className="h-4 w-20" />
@@ -119,7 +107,6 @@ export const HackathonCardSkeleton = () => (
 
       <SkeletonBlock className="h-px w-full" />
 
-      {/* Buttons */}
       <div className="grid grid-cols-2 gap-3">
         <SkeletonBlock className="h-10 rounded-lg" />
         <SkeletonBlock className="h-10 rounded-lg" />
@@ -130,30 +117,25 @@ export const HackathonCardSkeleton = () => (
 
 export const ProjectCardSkeleton = () => (
   <div className="bg-white dark:bg-indigo-950 rounded-xl shadow-md border border-blue-200 dark:border-gray-700 overflow-hidden flex flex-col">
-    {/* Header */}
     <div className="flex items-center justify-between px-5 py-4 border-b border-gray-300 dark:border-gray-700">
       <SkeletonBlock className="w-10 h-10 rounded-full" />
       <SkeletonBlock className="h-5 flex-1 mx-3" />
       <SkeletonBlock className="h-5 w-16 rounded-full" />
     </div>
 
-    {/* Image */}
     <SkeletonBlock className="w-full aspect-[16/9]" />
 
-    {/* Description */}
     <div className="px-5 pt-4 pb-6 border-b border-gray-300 dark:border-gray-700">
       <SkeletonBlock className="h-4 w-full mb-2" />
       <SkeletonBlock className="h-4 w-5/6 mb-2" />
       <SkeletonBlock className="h-4 w-3/4" />
     </div>
 
-    {/* Category & Difficulty */}
     <div className="px-5 py-3 flex gap-2 border-b border-gray-300 dark:border-gray-700">
       <SkeletonBlock className="h-6 w-20 rounded-full" />
       <SkeletonBlock className="h-6 w-24 rounded-full" />
     </div>
 
-    {/* Author + Stats */}
     <div className="px-5 py-4 flex justify-between items-center border-b border-gray-300 dark:border-gray-700">
       <div className="flex items-center gap-3">
         <SkeletonBlock className="w-8 h-8 rounded-full" />
@@ -166,14 +148,12 @@ export const ProjectCardSkeleton = () => (
       </div>
     </div>
 
-    {/* Tech Stack */}
     <div className="px-5 py-4 flex flex-wrap gap-2 border-b border-gray-300 dark:border-gray-700">
       {[...Array(4)].map((_, i) => (
         <SkeletonBlock key={i} className="h-6 w-16 rounded-full" />
       ))}
     </div>
 
-    {/* Buttons */}
     <div className="px-5 py-4 flex gap-3 mt-auto">
       <SkeletonBlock className="h-10 flex-1 rounded-lg" />
       <SkeletonBlock className="h-10 flex-1 rounded-lg" />

--- a/src/components/common/SkeletonLoaders.jsx
+++ b/src/components/common/SkeletonLoaders.jsx
@@ -1,0 +1,182 @@
+const shimmer =
+  "animate-pulse bg-gradient-to-r from-gray-200 via-gray-100 to-gray-200 dark:from-gray-700 dark:via-gray-600 dark:to-gray-700 bg-[length:200%_100%]";
+
+const SkeletonBlock = ({ className = "" }) => (
+  <div className={`${shimmer} rounded ${className}`} />
+);
+
+export const EventCardSkeleton = () => (
+  <div className="group relative bg-white dark:bg-gray-900 rounded-3xl shadow-xl flex flex-col overflow-hidden">
+    {/* Header */}
+    <div className="flex items-center px-8 py-6 gap-4 border-b border-gray-200/60 dark:border-gray-700/50">
+      <SkeletonBlock className="w-12 h-12 rounded-2xl" />
+      <SkeletonBlock className="h-6 flex-1" />
+      <SkeletonBlock className="h-6 w-24 rounded-full" />
+    </div>
+
+    {/* Image */}
+    <SkeletonBlock className="h-64 w-full" />
+
+    {/* Description */}
+    <div className="px-8 py-6 border-b border-gray-200/60 dark:border-gray-700/50">
+      <SkeletonBlock className="h-4 w-full mb-2" />
+      <SkeletonBlock className="h-4 w-5/6 mb-2" />
+      <SkeletonBlock className="h-4 w-2/3" />
+    </div>
+
+    {/* Info Grid */}
+    <div className="px-8 py-6 grid grid-cols-2 gap-6">
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <SkeletonBlock className="w-8 h-8 rounded-lg" />
+          <SkeletonBlock className="h-4 flex-1" />
+        </div>
+      ))}
+    </div>
+
+    {/* CTA Buttons */}
+    <div className="px-8 py-6 flex gap-4">
+      <SkeletonBlock className="h-12 flex-1 rounded-2xl" />
+      <SkeletonBlock className="h-12 flex-1 rounded-2xl" />
+    </div>
+  </div>
+);
+
+export const HackathonCardSkeleton = () => (
+  <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-blue-200 dark:border-gray-700 overflow-hidden">
+    <div className="p-6 flex flex-col gap-5">
+      {/* Status, Difficulty, Prize */}
+      <div className="flex justify-between items-center">
+        <div className="flex gap-2">
+          <SkeletonBlock className="h-6 w-20 rounded-full" />
+          <SkeletonBlock className="h-6 w-24 rounded-full" />
+        </div>
+        <SkeletonBlock className="h-6 w-16 rounded-full" />
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Title & Description */}
+      <div>
+        <SkeletonBlock className="h-6 w-3/4 mb-2" />
+        <SkeletonBlock className="h-4 w-full mb-1" />
+        <SkeletonBlock className="h-4 w-5/6" />
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Organizer */}
+      <div className="flex items-center gap-2">
+        <SkeletonBlock className="w-4 h-4 rounded" />
+        <SkeletonBlock className="h-4 w-32" />
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Date & Location */}
+      <div className="flex flex-col gap-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <SkeletonBlock className="w-4 h-4 rounded" />
+            <SkeletonBlock className="h-4 w-40" />
+          </div>
+        ))}
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Tech Stack */}
+      <div>
+        <SkeletonBlock className="h-4 w-24 mb-2" />
+        <div className="flex flex-wrap gap-2">
+          {[...Array(4)].map((_, i) => (
+            <SkeletonBlock key={i} className="h-6 w-16 rounded-full" />
+          ))}
+        </div>
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-4">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="text-center">
+            <SkeletonBlock className="w-5 h-5 rounded mx-auto mb-1" />
+            <SkeletonBlock className="h-5 w-8 mx-auto mb-1" />
+            <SkeletonBlock className="h-3 w-16 mx-auto" />
+          </div>
+        ))}
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Winner */}
+      <div className="flex items-center gap-2 p-3 rounded-lg">
+        <SkeletonBlock className="w-5 h-5 rounded" />
+        <SkeletonBlock className="h-4 w-20" />
+        <SkeletonBlock className="h-4 w-24" />
+      </div>
+
+      <SkeletonBlock className="h-px w-full" />
+
+      {/* Buttons */}
+      <div className="grid grid-cols-2 gap-3">
+        <SkeletonBlock className="h-10 rounded-lg" />
+        <SkeletonBlock className="h-10 rounded-lg" />
+      </div>
+    </div>
+  </div>
+);
+
+export const ProjectCardSkeleton = () => (
+  <div className="bg-white dark:bg-indigo-950 rounded-xl shadow-md border border-blue-200 dark:border-gray-700 overflow-hidden flex flex-col">
+    {/* Header */}
+    <div className="flex items-center justify-between px-5 py-4 border-b border-gray-300 dark:border-gray-700">
+      <SkeletonBlock className="w-10 h-10 rounded-full" />
+      <SkeletonBlock className="h-5 flex-1 mx-3" />
+      <SkeletonBlock className="h-5 w-16 rounded-full" />
+    </div>
+
+    {/* Image */}
+    <SkeletonBlock className="w-full aspect-[16/9]" />
+
+    {/* Description */}
+    <div className="px-5 pt-4 pb-6 border-b border-gray-300 dark:border-gray-700">
+      <SkeletonBlock className="h-4 w-full mb-2" />
+      <SkeletonBlock className="h-4 w-5/6 mb-2" />
+      <SkeletonBlock className="h-4 w-3/4" />
+    </div>
+
+    {/* Category & Difficulty */}
+    <div className="px-5 py-3 flex gap-2 border-b border-gray-300 dark:border-gray-700">
+      <SkeletonBlock className="h-6 w-20 rounded-full" />
+      <SkeletonBlock className="h-6 w-24 rounded-full" />
+    </div>
+
+    {/* Author + Stats */}
+    <div className="px-5 py-4 flex justify-between items-center border-b border-gray-300 dark:border-gray-700">
+      <div className="flex items-center gap-3">
+        <SkeletonBlock className="w-8 h-8 rounded-full" />
+        <SkeletonBlock className="h-4 w-20" />
+      </div>
+      <div className="flex gap-2">
+        {[...Array(4)].map((_, i) => (
+          <SkeletonBlock key={i} className="h-6 w-12 rounded-md" />
+        ))}
+      </div>
+    </div>
+
+    {/* Tech Stack */}
+    <div className="px-5 py-4 flex flex-wrap gap-2 border-b border-gray-300 dark:border-gray-700">
+      {[...Array(4)].map((_, i) => (
+        <SkeletonBlock key={i} className="h-6 w-16 rounded-full" />
+      ))}
+    </div>
+
+    {/* Buttons */}
+    <div className="px-5 py-4 flex gap-3 mt-auto">
+      <SkeletonBlock className="h-10 flex-1 rounded-lg" />
+      <SkeletonBlock className="h-10 flex-1 rounded-lg" />
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Problem Solved
Pages feel blank while data loads on slow networks. The Events page had no loading state at all. Hackathons and Projects had basic inline skeleton cards that didn't match their card layouts.

## Approach
Created `src/components/common/SkeletonLoaders.jsx` with three layout-matching skeleton components (`EventCardSkeleton`, `HackathonCardSkeleton`, `ProjectCardSkeleton`) using Tailwind's `animate-pulse` with a shimmer gradient.

## Testing
- Navigate to /events, /hackathons, and /projects pages
- Skeleton cards appear momentarily while data loads
- Dark mode is fully supported
- No layout shift when real cards replace skeletons