### PR TITLE
fix: prevent custom cursor button from overlapping nav items when zoomed (#849)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16501,23 +16501,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -299,7 +299,7 @@ import {
           </Link>
 
           {/* Centered nav links */}
-          <div className="hidden lg:flex absolute left-[48%] transform -translate-x-1/2 space-x-5 z-10">
+          <div className="hidden lg:flex flex-1 justify-center space-x-3 z-10">
             {navItems.map((item) => {
               const isActive = item.href
                 ? location.pathname === item.href
@@ -379,15 +379,18 @@ import {
             {/* Cursor Toggle Button */}
            <button
   onClick={toggleCursor}
-  className="flex items-center gap-1 px-2 py-1 mr-3
-  text-s font-normal
+  title={cursorEnabled ? "Turn Cursor OFF" : "Turn Cursor ON"}
+  className="flex items-center gap-1 px-2 py-1 ml-4 mr-2
+  text-xs font-normal
   bg-black text-white
   rounded-md
   hover:bg-zinc-800
-  transition-all"
+  transition-all
+  relative z-50
+  shrink-0
+  whitespace-nowrap"
 >
   <MousePointer className="w-4 h-4" />
-
   {cursorEnabled
     ? "OFF"
     : "ON"}

--- a/src/jhalak/FluidCursor.js
+++ b/src/jhalak/FluidCursor.js
@@ -960,16 +960,16 @@ const FluidCursor = () => {
 
     const handleMouseDown = (e) => {
       let pointer = pointers[0];
-      let posX = scaleByPixelRatio(e.clientX);
-      let posY = scaleByPixelRatio(e.clientY);
+      let posX = e.clientX * (canvas.width / canvas.clientWidth);
+      let posY = e.clientY * (canvas.height / canvas.clientHeight);
       updatePointerDownData(pointer, -1, posX, posY);
       clickSplat(pointer);
     };
 
     const handleMouseMove = (e) => {
       let pointer = pointers[0];
-      let posX = scaleByPixelRatio(e.clientX);
-      let posY = scaleByPixelRatio(e.clientY);
+      let posX = e.clientX * (canvas.width / canvas.clientWidth);
+      let posY = e.clientY * (canvas.height / canvas.clientHeight);
       let color = pointer.color;
       updatePointerMoveData(pointer, posX, posY, color);
     };


### PR DESCRIPTION
#849

## Problem
When increasing browser zoom level to 90% or higher, the custom cursor toggle button enlarged and overlapped the FAQ and Contact nav items.

## Root Cause
The nav links were using `absolute left-[48%]` positioning which caused overlap with the right-side button group at higher zoom levels.

## Changes Made

### Navbar.js
- Changed nav links from `absolute` positioning to `flex-1 justify-center` for proper flow layout
- Added `shrink-0` and `whitespace-nowrap` to cursor toggle button to prevent it from collapsing
- Reduced nav item spacing from `space-x-5` to `space-x-3` for better fit at higher zoom

### FluidCursor.js
- Fixed mouse position calculation to use canvas-relative coordinates instead of `scaleByPixelRatio`, preventing cursor drift when browser is zoomed

## Testing
- Tested at 100% zoom - no overlap
- Tested at 125% zoom - no overlap
- All nav items remain accessible