### PR TITLE
Fix: Persistent Scroll Position on Route Navigation Across Pages (#875)

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,11 +1,18 @@
 import { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { FaCaretUp } from "react-icons/fa";
 import { ChevronUp } from "lucide-react";
 
 export default function ScrollToTopButton() {
+  const { pathname } = useLocation();
   const [visible, setVisible] = useState(false);
   const [isChatbotOpen, setIsChatbotOpen] = useState(false);
+
+  // Automatically scroll to top whenever the route changes
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [pathname]);
 
   useEffect(() => {
     const handleScroll = () => setVisible(window.scrollY > 50);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #875 .

## Rationale for this change
This PR resolves the persistent scroll position bug encountered during route transitions, ensuring a consistent and expected navigation experience across the application.

Previously, navigating between routes (e.g., from Events to Projects) did not automatically reset the window's scroll position. If a user navigated from the middle or bottom of a page, the newly opened page would start from that same scroll depth instead of the top.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
Instead of duplicating `window.scrollTo` logic across individual page components, this PR introduces a solution within the existing `ScrollToTop` component. By using `react-router-dom`'s `useLocation()` hook, the application now automatically and smoothly scrolls to the top of the window on any route change.

- Modified `src/components/ScrollToTop.js` to include `useLocation`.
- Added a `useEffect` dependency on `pathname` to trigger `window.scrollTo({ top: 0, behavior: "smooth" })` globally.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, the changes have been tested locally.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
**Yes.** 
- **Before:** When navigating from the middle or bottom of one page to another, the new page would load at that same scroll depth instead of starting from the top.
- **After:** Every time a user clicks a link to navigate to a new route, the window will automatically and smoothly scroll back to the top of the page.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->