### PR TITLE
fix: add descriptive text to links for SEO

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -101,13 +101,8 @@ const ApiDocs = () => {
           Use our RESTful APIs to interact with{" "}
           <span className="text-black dark:text-white">Hackathons</span>,{" "}
           <span className="text-black dark:text-white">Projects</span>,{" "}
-          <span className="text-black dark:text-white">
-            Contributors
-          </span>
-          , and{" "}
-          <span className="text-black dark:text-white">
-            Leaderboards
-          </span>{" "}
+          <span className="text-black dark:text-white">Contributors</span>, and{" "}
+          <span className="text-black dark:text-white">Leaderboards</span>{" "}
           programmatically.
         </p>
       </section>
@@ -121,18 +116,10 @@ const ApiDocs = () => {
           <table className="w-full border-collapse">
             <thead className="bg-gray-50 dark:bg-[#1c1c1c]">
               <tr>
-                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">
-                  API
-                </th>
-                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">
-                  Method
-                </th>
-                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">
-                  Endpoint
-                </th>
-                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">
-                  Description
-                </th>
+                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">API</th>
+                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">Method</th>
+                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">Endpoint</th>
+                <th className="p-4 text-left bg-gray-50 dark:bg-[#1c1c1c]">Description</th>
               </tr>
             </thead>
             <tbody className="bg-gray-50 dark:bg-[#000000]">
@@ -153,9 +140,7 @@ const ApiDocs = () => {
                   <td className="p-4 font-mono text-sm text-gray-600 dark:text-gray-300">
                     {ep.url}
                   </td>
-                  <td className="p-4 text-gray-500 dark:text-gray-400">
-                    {ep.desc}
-                  </td>
+                  <td className="p-4 text-gray-500 dark:text-gray-400">{ep.desc}</td>
                 </tr>
               ))}
             </tbody>
@@ -180,12 +165,10 @@ const ApiDocs = () => {
                 <h3 className="text-xl font-semibold">{ep.title}</h3>
               </div>
               <p className="text-gray-600 dark:text-gray-400 mb-3">{ep.desc}</p>
-
               <h4 className="font-semibold mb-2">Example Request</h4>
               <pre className="bg-gray-100 dark:bg-black text-black dark:text-white text-sm rounded-lg p-3 overflow-x-auto">
                 <code>{ep.example}</code>
               </pre>
-
               <h4 className="font-semibold mt-4 mb-2">Example Response</h4>
               <pre className="bg-gray-100 dark:bg-black text-black dark:text-white text-sm rounded-lg p-3 overflow-x-auto">
                 <code>{ep.response}</code>
@@ -207,38 +190,22 @@ const ApiDocs = () => {
             <table className="w-full border-collapse">
               <thead className="bg-gray-50 dark:bg-[#222]">
                 <tr>
-                  <th className="p-3 text-left bg-gray-50 dark:bg-[#000]">
-                    Code
-                  </th>
-                  <th className="p-3 text-left bg-gray-50 dark:bg-[#000]">
-                    Description
-                  </th>
+                  <th className="p-3 text-left bg-gray-50 dark:bg-[#000]">Code</th>
+                  <th className="p-3 text-left bg-gray-50 dark:bg-[#000]">Description</th>
                 </tr>
               </thead>
               <tbody className="bg-gray-50 dark:bg-[#151515]">
                 <tr className="border-t border-gray-200 dark:border-gray-800">
-                  <td className="p-3 text-black dark:text-white font-bold">
-                    400
-                  </td>
-                  <td className="p-3">
-                    Bad Request (missing or invalid parameters)
-                  </td>
+                  <td className="p-3 text-black dark:text-white font-bold">400</td>
+                  <td className="p-3">Bad Request (missing or invalid parameters)</td>
                 </tr>
                 <tr className="border-t border-gray-200 dark:border-gray-800">
-                  <td className="p-3 text-black dark:text-white font-bold">
-                    404
-                  </td>
-                  <td className="p-3">
-                    Not Found (endpoint or resource not available)
-                  </td>
+                  <td className="p-3 text-black dark:text-white font-bold">404</td>
+                  <td className="p-3">Not Found (endpoint or resource not available)</td>
                 </tr>
                 <tr className="border-t border-gray-200 dark:border-gray-800">
-                  <td className="p-3 text-black dark:text-white font-bold">
-                    500
-                  </td>
-                  <td className="p-3">
-                    Server Error (something went wrong on our side)
-                  </td>
+                  <td className="p-3 text-black dark:text-white font-bold">500</td>
+                  <td className="p-3">Server Error (something went wrong on our side)</td>
                 </tr>
               </tbody>
             </table>
@@ -254,26 +221,18 @@ const ApiDocs = () => {
             <h3 className="text-xl font-semibold">Authentication</h3>
           </div>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            All requests to protected endpoints require an API key. Pass your
-            key in the{" "}
-            <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">
-              Authorization
-            </code>{" "}
-            header as a Bearer token. API keys are unique to each user and
-            should be kept secret.
+            All requests to protected endpoints require an API key. Pass your key in the{" "}
+            <code className="bg-gray-200 dark:bg-gray-800 px-1 rounded">Authorization</code>{" "}
+            header as a Bearer token. API keys are unique to each user and should be kept secret.
           </p>
           <pre className="bg-indigo-50 dark:bg-black text-black dark:text-white text-sm rounded-lg p-3 overflow-x-auto mb-4">
             <code>{`fetch("/api/contributors", {
   headers: { Authorization: "Bearer YOUR_API_KEY" }
 })`}</code>
           </pre>
-          <p className="text-gray-900 dark:text-gray-400 mb-3">
-            Best practices:
-          </p>
+          <p className="text-gray-900 dark:text-gray-400 mb-3">Best practices:</p>
           <ul className="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2">
-            <li>
-              Never expose your API key in client-side code or public repos.
-            </li>
+            <li>Never expose your API key in client-side code or public repos.</li>
             <li>Rotate keys periodically for security.</li>
             <li>Restrict keys to specific domains or IPs when possible.</li>
           </ul>
@@ -288,32 +247,24 @@ const ApiDocs = () => {
             <h3 className="text-xl font-semibold">Rate Limiting</h3>
           </div>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            To ensure fair usage, all requests are subject to rate limits. Each
-            API key allows <b>100 requests per minute</b>. Rate limit
-            information is included in response headers:
+            To ensure fair usage, all requests are subject to rate limits. Each API key allows{" "}
+            <b>100 requests per minute</b>. Rate limit information is included in response headers:
           </p>
           <pre className="bg-indigo-50 dark:bg-black text-black dark:text-white text-sm rounded-lg p-3 overflow-x-auto mb-4">
             <code>{`X-RateLimit-Limit: 100
 X-RateLimit-Remaining: 57
 X-RateLimit-Reset: 1695037200`}</code>
           </pre>
-          <p className="text-gray-900 dark:text-gray-400 mb-3">
-            Handling rate limits:
-          </p>
+          <p className="text-gray-900 dark:text-gray-400 mb-3">Handling rate limits:</p>
           <ul className="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2">
             <li>
-              Check the <code>X-RateLimit-Remaining</code> header to avoid
-              hitting the cap.
+              Check the <code>X-RateLimit-Remaining</code> header to avoid hitting the cap.
             </li>
             <li>
-              If you receive a <code>429 Too Many Requests</code> error, wait
-              until the <code>X-RateLimit-Reset</code> timestamp before
-              retrying.
+              If you receive a <code>429 Too Many Requests</code> error, wait until the{" "}
+              <code>X-RateLimit-Reset</code> timestamp before retrying.
             </li>
-            <li>
-              Use exponential backoff or queue requests in high-volume
-              scenarios.
-            </li>
+            <li>Use exponential backoff or queue requests in high-volume scenarios.</li>
           </ul>
         </div>
       </section>
@@ -326,8 +277,8 @@ X-RateLimit-Reset: 1695037200`}</code>
             <h3 className="text-xl font-semibold">Pagination & Filtering</h3>
           </div>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            Many endpoints return large datasets. To optimize responses, use
-            query parameters for pagination, sorting, and filtering.
+            Many endpoints return large datasets. To optimize responses, use query parameters for
+            pagination, sorting, and filtering.
           </p>
           <pre className="bg-indigo-50 dark:bg-black text-black dark:text-white text-sm rounded-lg p-3 overflow-x-auto mb-4">
             <code>{`GET /api/projects?page=2&limit=5&sort=votes&filter=ai`}</code>
@@ -344,22 +295,12 @@ X-RateLimit-Reset: 1695037200`}</code>
   ]
 }`}</code>
           </pre>
-          <p className="text-gray-900 dark:text-gray-400 mb-3">
-            Supported parameters:
-          </p>
+          <p className="text-gray-900 dark:text-gray-400 mb-3">Supported parameters:</p>
           <ul className="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2">
-            <li>
-              <b>page</b> – The page number (default: 1)
-            </li>
-            <li>
-              <b>limit</b> – Number of results per page (default: 10)
-            </li>
-            <li>
-              <b>sort</b> – Field to sort by (e.g., votes, date)
-            </li>
-            <li>
-              <b>filter</b> – Keyword filter (e.g., ai, web, cloud)
-            </li>
+            <li><b>page</b> – The page number (default: 1)</li>
+            <li><b>limit</b> – Number of results per page (default: 10)</li>
+            <li><b>sort</b> – Field to sort by (e.g., votes, date)</li>
+            <li><b>filter</b> – Keyword filter (e.g., ai, web, cloud)</li>
           </ul>
         </div>
       </section>
@@ -372,26 +313,24 @@ X-RateLimit-Reset: 1695037200`}</code>
             <h3 className="text-xl font-semibold">API Explorer</h3>
           </div>
           <p className="text-gray-600 dark:text-gray-400 mb-4">
-            Experiment with our endpoints using interactive tools. These
-            explorers make testing and learning the API simple and fast.
+            Experiment with our endpoints using interactive tools. These explorers make testing and
+            learning the API simple and fast.
           </p>
           <ul className="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 mb-4">
             <li>
+              {/* ✅ FIX: descriptive text now inside <a> tag */}
               <a href="/swagger" className="text-black hover:underline">
-                Swagger UI
-              </a>{" "}
-              – browse and execute endpoints in your browser.
+                Swagger UI – browse and execute endpoints in your browser
+              </a>
             </li>
             <li>
+              {/* ✅ FIX: descriptive text now inside <a> tag */}
               <a href="/postman.json" className="text-black hover:underline">
-                Postman Collection
-              </a>{" "}
-              – import into Postman and test quickly.
+                Postman Collection – import into Postman and test quickly
+              </a>
             </li>
           </ul>
-          <p className="text-gray-900 dark:text-gray-400">
-            Example setup in Postman:
-          </p>
+          <p className="text-gray-900 dark:text-gray-400">Example setup in Postman:</p>
           <pre className="bg-indigo-50 dark:bg-black text-black dark:text-white text-sm rounded-lg p-3 overflow-x-auto">
             <code>{`1. Import postman.json into Postman
 2. Set environment variable: API_KEY = your key


### PR DESCRIPTION
## Changes
- Fixed anchor tags in `src/Pages/ApiDocs.js` that had no descriptive text
- Moved link text inside `<a>` tags for Swagger UI and Postman Collection links

## Lighthouse Issue Fixed
- Links do not have descriptive text (1 link found) →Fixed

## Related Issue
Closes #868