### PR TITLE
Fix: handle empty data gracefully in analytics dashboard

### DIFF
--- a/src/Pages/Events/EventAnalyticsDashboard.js
+++ b/src/Pages/Events/EventAnalyticsDashboard.js
@@ -34,8 +34,11 @@ const TABS = ['overview', 'registrations', 'demographics', 'feedback'];
 
 const totalRegistrations = eventsData.reduce((sum, e) => sum + e.attendees, 0);
 const totalCapacity = eventsData.reduce((sum, e) => sum + e.maxAttendees, 0);
-const fillRate = Math.round((totalRegistrations / totalCapacity) * 100);
-const avgRating = (feedbackData.reduce((s, f) => s + f.rating, 0) / feedbackData.length).toFixed(1);
+const fillRate = totalCapacity > 0 ? Math.round((totalRegistrations / totalCapacity) * 100) : 0;
+const avgRating = feedbackData.length > 0
+  ? (feedbackData.reduce((s, f) => s + f.rating, 0) / feedbackData.length).toFixed(1)
+  : "0.0";
+
 
 const getTopEvents = () =>
   [...eventsData].sort((a, b) => b.attendees - a.attendees).slice(0, 6)


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #936 

## Rationale for this change

The `EventAnalyticsDashboard` currently lacks safety checks when calculating metrics like **Fill Rate** and **Average Rating**. If an organizer has no event data or feedback (empty arrays), the component performs division by zero. This results in `NaN` values being rendered directly in the UI, which creates a broken user experience for new accounts. This PR introduces defensive checks to ensure these metrics fall back gracefully to `0` or `0.0`.

## What changes are included in this PR?

- Added a ternary conditional check in `EventAnalyticsDashboard.js` to verify `totalCapacity > 0` before calculating `fillRate`.
- Added a ternary conditional check to verify `feedbackData.length > 0` before calculating `avgRating`.
- Ensured metrics fall back to `0` (for percentages) and `"0.0"` (for ratings) when no data is present.

## Are these changes tested?

Yes, these changes were tested manually by:
1. Clearing the `eventsMockData.json` file to simulate an account with no events.
2. Clearing the `feedbackData` array in `EventAnalyticsDashboard.js` to simulate an account with no feedback.
3. Verifying that the dashboard now displays `0%` and `⭐ 0.0` instead of `NaN` values.
4. Verifying that the dashboard still calculates and displays values correctly when data is present.

## Are there any user-facing changes?

Yes. Users with no event or feedback history will now see clean "0" values in their analytics KPI cards instead of "NaN" errors.

## Screenshots
### Before Fix (Showing NaN errors)

<img width="1919" height="909" alt="Screenshot 2026-05-15 114320" src="https://github.com/user-attachments/assets/4304dcc3-5ae6-4ae2-afa9-cd404677dc90" />

### After Fix (Showing safe fallback values)
<img width="1919" height="913" alt="Screenshot 2026-05-15 114625" src="https://github.com/user-attachments/assets/d39dc5d7-508d-4f95-860e-720ca5dfb2fe" />


---
*Note: I am participating in **GSSoC 2026**.  This PR is for my assigned issue. Thank you!*
