### PR TITLE
fix: restrict cursor smoke effect to background areas only

### DIFF
--- a/src/jhalak/FluidCursor.js
+++ b/src/jhalak/FluidCursor.js
@@ -957,7 +957,7 @@ const FluidCursor = () => {
       if (aspectRatio > 1) delta /= aspectRatio;
       return delta;
     }
-
+/*
     const handleMouseDown = (e) => {
       let pointer = pointers[0];
       let posX = scaleByPixelRatio(e.clientX);
@@ -971,6 +971,36 @@ const FluidCursor = () => {
       let posX = scaleByPixelRatio(e.clientX);
       let posY = scaleByPixelRatio(e.clientY);
       let color = pointer.color;
+      updatePointerMoveData(pointer, posX, posY, color);
+    };
+*/
+    const handleMouseDown = (e) => {
+      const blockedElement = e.target.closest(
+        "button, a, input, textarea, select, nav, form, .card-with-floating-elements, [class*='card'], [class*='Card'], [class*='modal'], [class*='popup'], [class*='rounded'], [class*='shadow']"
+      );
+
+      if (blockedElement) return;
+
+      let pointer = pointers[0];
+      let posX = scaleByPixelRatio(e.clientX);
+      let posY = scaleByPixelRatio(e.clientY);
+
+      updatePointerDownData(pointer, -1, posX, posY);
+      clickSplat(pointer);
+    };
+
+    const handleMouseMove = (e) => {
+      const blockedElement = e.target.closest(
+        "button, a, input, textarea, select, nav, form, .card-with-floating-elements, [class*='card'], [class*='Card'], [class*='modal'], [class*='popup'], [class*='rounded'], [class*='shadow']"
+      );
+
+      if (blockedElement) return;
+
+      let pointer = pointers[0];
+      let posX = scaleByPixelRatio(e.clientX);
+      let posY = scaleByPixelRatio(e.clientY);
+      let color = pointer.color;
+
       updatePointerMoveData(pointer, posX, posY, color);
     };
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #853 

## Rationale for this change

The cursor smoke effect was appearing over interactive and content-heavy UI sections such as hackathon cards, stats cards, buttons, forms, and other elevated containers. This reduced readability and negatively affected the user experience.
before:
<img width="737" height="462" alt="Screenshot 2026-05-12 202814" src="https://github.com/user-attachments/assets/d4f9e195-0f05-4228-8443-314da65c4b1d" />

This PR improves the cursor effect behavior by restricting smoke rendering on foreground UI components while preserving the visual effect in background areas.
After:
<img width="1027" height="566" alt="Screenshot 2026-05-15 151621" src="https://github.com/user-attachments/assets/fdf864ec-fc92-4b1c-962d-ed9323b1e531" />

## What changes are included in this PR?

-Added filtering logic to prevent smoke effects from rendering over:
    -buttons
    -forms
    -navigation elements
    -cards and elevated UI containers
-Preserved smoke effects in non-interactive/background areas
-Maintained existing animation behavior without affecting responsiveness or layout

## Are these changes tested?
Yes.
Tested locally using:
npm run dev

Verified:
-smoke effect remains visible in background areas
-cards and content sections remain smoke-free
-buttons and forms work correctly
-no layout or responsiveness issues introduced

## Are there any user-facing changes?
Yes.
Users will now experience:
-cleaner UI visibility
-reduced visual distraction on cards/content
-improved readability and interaction experience while retaining the cursor smoke effect in background areas