### PR TITLE
fix: improve FAQ icon spacing on mobile view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16855,23 +16855,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",

--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -175,8 +175,8 @@ const FAQPage = () => {
                 onClick={() => toggleFAQ(faq.id)}
                 className="w-full p-6 text-left flex items-center justify-between outline-none focus:outline-none focus:ring-0 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
               >
-                <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900 rounded-xl flex items-center justify-center">
+                <div className="flex items-center space-x-3 sm:space-x-4 pr-2">
+                  <div className="w-12 h-12 flex-shrink-0 bg-indigo-100 dark:bg-indigo-900 rounded-xl flex items-center justify-center">
                     <span className="text-black dark:text-white">
                       {faq.icon}
                     </span>


### PR DESCRIPTION
## Description

This PR fixes the FAQ icon spacing issue in mobile view. The icons were appearing too close to the card edges, which made the spacing look uneven on smaller screens.

## Problem Solved

* Improved spacing and alignment of FAQ icons on mobile devices
* Prevented icon shrinking on smaller screen sizes
* Enhanced overall responsiveness and UI consistency

## Changes Made

* Updated flex alignment and spacing classes in the FAQ layout
* Added `flex-shrink-0` to maintain proper icon sizing
* Improved responsive spacing for better mobile appearance

## Approach

Refined the FAQ card layout styles in `FAQPage.js` using responsive Tailwind utility classes without affecting the desktop layout.

## Testing

* Tested locally in responsive/mobile view
* Verified alignment across different mobile screen sizes
* Confirmed no UI issues on desktop view

## Screenshots

### Before

<img width="470" height="932" alt="image" src="https://github.com/user-attachments/assets/8d82b92f-88a4-42ff-9f74-9ff9b177c9bd" />

### After

<img width="454" height="916" alt="image" src="https://github.com/user-attachments/assets/163bd63e-2b8b-4fa5-9b73-74b388daa81d" />


Closes #947
