### PR TITLE
fix: improve FAQ icon spacing on mobile view

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -173,10 +173,10 @@ const FAQPage = () => {
             >
               <button
                 onClick={() => toggleFAQ(faq.id)}
-                className="w-full p-6 text-left flex items-center justify-between outline-none focus:outline-none focus:ring-0 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
+                className="w-full p-4 sm:p-6 text-left flex items-center justify-between outline-none focus:outline-none focus:ring-0 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-200"
               >
-                <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900 rounded-xl flex items-center justify-center">
+                <div className="flex items-start sm:items-center space-x-3 sm:space-x-4 pr-2">
+                  <div className="w-10 h-10 sm:w-12 sm:h-12 bg-indigo-100 dark:bg-indigo-900 rounded-xl flex items-center justify-center flex-shrink-0">
                     <span className="text-black dark:text-white">
                       {faq.icon}
                     </span>


### PR DESCRIPTION
## Description

Improved FAQ card spacing and responsiveness for mobile devices.

## Changes Made

* Added responsive spacing between FAQ icon and content
* Improved icon sizing on smaller screens
* Reduced mobile padding for better layout balance
* Enhanced alignment for mobile responsiveness

## Related Issue

Fixes #947

<img width="559" height="830" alt="Screenshot (441)" src="https://github.com/user-attachments/assets/425a6bdc-6537-4852-b134-f4e1ec145318" />

