### PR TITLE
feat: add pagination for event listings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -722,6 +723,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz",
       "integrity": "sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
       },
@@ -1605,6 +1607,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
       "integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-module-imports": "^7.28.6",
@@ -4341,6 +4344,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -4394,6 +4398,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4763,6 +4768,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4861,6 +4867,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5784,6 +5791,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7765,6 +7773,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10729,6 +10738,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -11712,6 +11722,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -13116,6 +13127,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14250,6 +14262,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14618,6 +14631,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14752,6 +14766,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14794,13 +14809,15 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14824,6 +14841,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15065,7 +15083,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15434,6 +15453,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15679,6 +15699,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16769,6 +16790,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16853,23 +16875,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {
@@ -17260,6 +17265,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17368,6 +17374,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17713,6 +17720,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17784,6 +17792,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -18196,6 +18205,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "react-scripts build",
     "build:fast": "set \"GENERATE_SOURCEMAP=false\" && set \"DISABLE_ESLINT_PLUGIN=true\" && set \"NODE_OPTIONS=--no-deprecation --max-old-space-size=4096\" && react-scripts build",
     "test": "react-scripts test",
+    "test:pagination": "node --no-warnings tests/eventPaginationUtils.test.mjs",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/Pages/Events/EventCardSection.js
+++ b/src/Pages/Events/EventCardSection.js
@@ -1,0 +1,44 @@
+import EventCard from "./EventCard";
+import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
+
+const EventCardSection = ({ isLoading, events, viewMode, filterType }) => {
+  if (isLoading) {
+    return (
+      <div className="grid gap-8 grid-cols-1 sm:grid-cols-1 lg:grid-cols-3">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <EventCardSkeleton key={`skeleton-${i}`} />
+        ))}
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="relative overflow-hidden rounded-3xl p-10 text-center border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-[0_10px_25px_rgba(0,0,0,0.05)] dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)]">
+        <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+          No events found
+        </h3>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          Try changing your search or filters.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      key={filterType + viewMode}
+      className={`grid gap-8 ${
+        viewMode === "grid"
+          ? "grid-cols-1 sm:grid-cols-1 lg:grid-cols-3"
+          : "grid-cols-1 max-w-4xl mx-auto"
+      }`}
+    >
+      {events.map((event) => (
+        <EventCard key={event.id} event={event} />
+      ))}
+    </div>
+  );
+};
+
+export default EventCardSection;

--- a/src/Pages/Events/EventFiltersToolbar.js
+++ b/src/Pages/Events/EventFiltersToolbar.js
@@ -1,0 +1,103 @@
+import { Grid, List } from "lucide-react";
+import StyledDropdown from "../../components/StyledDropdown";
+
+const EVENT_FILTERS = [
+  { key: "all", label: "All" },
+  { key: "upcoming", label: "Upcoming" },
+  { key: "past", label: "Past" },
+  { key: "conference", label: "Conferences" },
+  { key: "workshop", label: "Workshops" },
+];
+
+const FilterButton = ({ filter, filterType, onFilterChange }) => {
+  const isActive = filterType === filter.key;
+
+  return (
+    <button
+      onClick={() => onFilterChange(filter.key)}
+      className={`px-3 sm:px-4 py-2 text-xs sm:text-sm rounded-full transition ${
+        isActive
+          ? "bg-black text-white"
+          : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:bg-indigo-50 dark:hover:bg-gray-700"
+      }`}
+      aria-pressed={isActive}
+    >
+      {filter.label}
+    </button>
+  );
+};
+
+const ViewModeButton = ({ mode, activeMode, onViewModeChange, icon: Icon }) => {
+  const isActive = activeMode === mode;
+
+  return (
+    <button
+      onClick={() => onViewModeChange(mode)}
+      className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
+        isActive
+          ? "bg-black text-white shadow-md"
+          : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+      }`}
+      aria-label={`${mode === "grid" ? "Grid" : "List"} view`}
+      aria-pressed={isActive}
+    >
+      <Icon size={16} />
+    </button>
+  );
+};
+
+const EventFiltersToolbar = ({
+  filterType,
+  onFilterChange,
+  sortType,
+  onSortChange,
+  viewMode,
+  onViewModeChange,
+}) => {
+  return (
+    <div className="mb-8 sm:mb-10 flex flex-col gap-4">
+      <div className="flex flex-wrap gap-2 sm:gap-3 items-center justify-center sm:justify-start">
+        {EVENT_FILTERS.map((filter) => (
+          <FilterButton
+            key={filter.key}
+            filter={filter}
+            filterType={filterType}
+            onFilterChange={onFilterChange}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4">
+        <div className="w-full sm:w-auto">
+          <label htmlFor="sort-events" className="sr-only">
+            Sort events
+          </label>
+          <StyledDropdown
+            label=""
+            value={sortType === "" ? "" : sortType}
+            onChange={onSortChange}
+            options={["Newest", "Upcoming"]}
+            placeholder="Sort by Date"
+          />
+        </div>
+
+        <div className="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg p-1 shadow-sm">
+          <ViewModeButton
+            mode="grid"
+            activeMode={viewMode}
+            onViewModeChange={onViewModeChange}
+            icon={Grid}
+          />
+          <ViewModeButton
+            mode="list"
+            activeMode={viewMode}
+            onViewModeChange={onViewModeChange}
+            icon={List}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EventFiltersToolbar;

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -1,124 +1,22 @@
-import { useState, useEffect, useMemo, useRef } from "react";
-import mockEvents from "./eventsMockData.json";
+import { useRef } from "react";
 import EventHero from "./EventHero";
-import EventCard from "./EventCard";
-import { Grid, List } from "lucide-react";
 import FeedbackButton from "../../components/FeedbackButton";
 import EventCTA from "./EventCTA";
-import Fuse from "fuse.js";
-import StyledDropdown from "../../components/StyledDropdown";
-import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
+import EventCardSection from "./EventCardSection";
+import EventFiltersToolbar from "./EventFiltersToolbar";
 import PaginationControls from "./PaginationControls";
-import {
-  DEFAULT_EVENTS_PER_PAGE,
-  clampPage,
-  filterEventsByType,
-  getPaginatedEvents,
-  getTotalPages,
-  sortEventsByDate,
-} from "./eventPaginationUtils";
-
-const renderCardSection = (isLoading, eventsToShow, viewMode, filterType) => {
-  if (isLoading) {
-    return (
-      <div className="grid gap-8 grid-cols-1 sm:grid-cols-1 lg:grid-cols-3">
-        {[1, 2, 3, 4, 5, 6].map((i) => (
-          <EventCardSkeleton key={`skeleton-${i}`} />
-        ))}
-      </div>
-    );
-  }
-
-  if (eventsToShow.length === 0) {
-    return (
-      <div className="relative overflow-hidden rounded-3xl p-10 text-center border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-[0_10px_25px_rgba(0,0,0,0.05)] dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)]">
-        <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-          No events found
-        </h3>
-        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          Try changing your search or filters.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      key={filterType + viewMode}
-      className={`grid gap-8 ${
-        viewMode === "grid"
-          ? "grid-cols-1 sm:grid-cols-1 lg:grid-cols-3"
-          : "grid-cols-1 max-w-4xl mx-auto"
-      }`}
-    >
-      {eventsToShow.map((event) => (
-        <EventCard key={event.id} event={event} />
-      ))}
-    </div>
-  );
-};
+import useEventListing from "./useEventListing";
 
 const EventsPage = () => {
-  const [events, setEvents] = useState([]);
-  const [filterType, setFilterType] = useState("all");
-  const [viewMode, setViewMode] = useState("grid");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [sortType, setSortType] = useState("Newest");
-  const [isLoading, setIsLoading] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [eventsPerPage, setEventsPerPage] = useState(DEFAULT_EVENTS_PER_PAGE);
   const cardSectionRef = useRef();
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setEvents(mockEvents);
-      setIsLoading(false);
-    }, 800);
-    return () => clearTimeout(timer);
-  }, []);
-
-  const filteredEvents = useMemo(() => {
-    const fuse = new Fuse(events, {
-      keys: ["title", "description", "location", "tags", "type"],
-      threshold: 0.35,
-    });
-
-    const searchResults = searchQuery.trim()
-      ? fuse.search(searchQuery).map((res) => res.item)
-      : events;
-
-    return sortEventsByDate(
-      filterEventsByType(searchResults, filterType),
-      sortType
-    );
-  }, [events, filterType, searchQuery, sortType]);
-
-  const totalPages = getTotalPages(filteredEvents.length, eventsPerPage);
-  const paginatedEvents = useMemo(() => {
-    return getPaginatedEvents(filteredEvents, currentPage, eventsPerPage);
-  }, [currentPage, eventsPerPage, filteredEvents]);
+  const listing = useEventListing();
 
   const handleSearch = (query = "") => {
-    setSearchQuery(query);
+    listing.setSearchQuery(query);
   };
-
-  const handleSortChange = (type) => {
-    setSortType(type);
-  };
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [eventsPerPage, filterType, searchQuery, sortType]);
-
-  useEffect(() => {
-    if (currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [currentPage, totalPages]);
 
   const handlePageChange = (page) => {
-    const nextPage = clampPage(page, totalPages);
-    setCurrentPage(nextPage);
+    listing.setSafePage(page);
     cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
@@ -129,9 +27,9 @@ const EventsPage = () => {
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 overflow-x-hidden">
       <EventHero
-        searchQuery={searchQuery}
-        setSearchQuery={setSearchQuery}
-        filteredEvents={filteredEvents}
+        searchQuery={listing.searchQuery}
+        setSearchQuery={listing.setSearchQuery}
+        filteredEvents={listing.filteredEvents}
         handleSearch={handleSearch}
         scrollToCard={scrollToCard}
       />
@@ -140,89 +38,30 @@ const EventsPage = () => {
         ref={cardSectionRef}
         className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12"
       >
-        <div
-          className="mb-8 sm:mb-10 flex flex-col gap-4"
-        >
-          <div className="flex flex-wrap gap-2 sm:gap-3 items-center justify-center sm:justify-start">
-            {[
-              { key: "all", label: "All" },
-              { key: "upcoming", label: "Upcoming" },
-              { key: "past", label: "Past" },
-              { key: "conference", label: "Conferences" },
-              { key: "workshop", label: "Workshops" },
-            ].map((filter) => (
-              <button
-                key={filter.key}
-                onClick={() => setFilterType(filter.key)}
-                className={`px-3 sm:px-4 py-2 text-xs sm:text-sm rounded-full transition ${
-                  filterType === filter.key
-                    ? "bg-black text-white"
-                    : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700 hover:bg-indigo-50 dark:hover:bg-gray-700"
-                }`}
-                aria-pressed={filterType === filter.key}
-              >
-                {filter.label}
-              </button>
-            ))}
-          </div>
+        <EventFiltersToolbar
+          filterType={listing.filterType}
+          onFilterChange={listing.setFilterType}
+          sortType={listing.sortType}
+          onSortChange={listing.setSortType}
+          viewMode={listing.viewMode}
+          onViewModeChange={listing.setViewMode}
+        />
 
-          {/* Sort Dropdown and View Toggle */}
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4">
-            {/* Sort Dropdown */}
-            <div className="w-full sm:w-auto">
-              <label htmlFor="sort-events" className="sr-only">
-                Sort events
-              </label>
-              <StyledDropdown
-                label=""
-                value={sortType === "" ? "" : sortType}
-                onChange={handleSortChange}
-                options={["Newest", "Upcoming"]}
-                placeholder="Sort by Date"
-              />
-            </div>
+        <EventCardSection
+          isLoading={listing.isLoading}
+          events={listing.paginatedEvents}
+          viewMode={listing.viewMode}
+          filterType={listing.filterType}
+        />
 
-            <div
-              className="flex items-center space-x-2 bg-white dark:bg-gray-800 rounded-lg p-1 shadow-sm"
-            >
-              <button
-                onClick={() => setViewMode("grid")}
-                className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
-                  viewMode === "grid"
-                    ? "bg-black text-white shadow-md"
-                    : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                }`}
-                aria-label="Grid view"
-                aria-pressed={viewMode === "grid"}
-              >
-                <Grid size={16} />
-              </button>
-              <button
-                onClick={() => setViewMode("list")}
-                className={`p-2 rounded-md transition-all duration-200 flex items-center justify-center ${
-                  viewMode === "list"
-                    ? "bg-black text-white shadow-md"
-                    : "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700"
-                }`}
-                aria-label="List view"
-                aria-pressed={viewMode === "list"}
-              >
-                <List size={16} />
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {renderCardSection(isLoading, paginatedEvents, viewMode, filterType)}
-
-        {!isLoading && (
+        {!listing.isLoading && (
           <PaginationControls
-            currentPage={currentPage}
-            eventsPerPage={eventsPerPage}
-            totalEvents={filteredEvents.length}
-            totalPages={totalPages}
+            currentPage={listing.currentPage}
+            eventsPerPage={listing.eventsPerPage}
+            totalEvents={listing.filteredEvents.length}
+            totalPages={listing.totalPages}
             onPageChange={handlePageChange}
-            onPageSizeChange={setEventsPerPage}
+            onPageSizeChange={listing.setEventsPerPage}
           />
         )}
       </div>

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -2,20 +2,19 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import mockEvents from "./eventsMockData.json";
 import EventHero from "./EventHero";
 import EventCard from "./EventCard";
-import { ChevronLeft, ChevronRight, Grid, List } from "lucide-react";
+import { Grid, List } from "lucide-react";
 import FeedbackButton from "../../components/FeedbackButton";
 import EventCTA from "./EventCTA";
 import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
 import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
+import PaginationControls from "./PaginationControls";
 import {
   DEFAULT_EVENTS_PER_PAGE,
-  EVENTS_PER_PAGE_OPTIONS,
   clampPage,
   filterEventsByType,
   getPaginatedEvents,
   getTotalPages,
-  getVisiblePaginationPages,
   sortEventsByDate,
 } from "./eventPaginationUtils";
 
@@ -59,125 +58,6 @@ const renderCardSection = (isLoading, eventsToShow, viewMode, filterType) => {
   );
 };
 
-const PaginationControls = ({
-  currentPage,
-  eventsPerPage,
-  totalEvents,
-  totalPages,
-  onPageChange,
-  onPageSizeChange,
-}) => {
-  if (totalEvents === 0) {
-    return null;
-  }
-
-  const startEvent = (currentPage - 1) * eventsPerPage + 1;
-  const endEvent = Math.min(currentPage * eventsPerPage, totalEvents);
-  const { firstVisiblePage, lastVisiblePage, pages: visiblePages } =
-    getVisiblePaginationPages(currentPage, totalPages);
-
-  return (
-    <div className="mt-10 flex flex-col gap-4 border-t border-gray-200 pt-6 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
-      <p className="text-sm text-gray-600 dark:text-gray-400">
-        Showing {startEvent}-{endEvent} of {totalEvents} events
-      </p>
-
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <label
-          htmlFor="events-per-page"
-          className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
-        >
-          Per page
-          <select
-            id="events-per-page"
-            value={eventsPerPage}
-            onChange={(event) => onPageSizeChange(Number(event.target.value))}
-            className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
-          >
-            {EVENTS_PER_PAGE_OPTIONS.map((option) => (
-              <option key={option} value={option}>
-                {option}
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <nav className="flex items-center gap-2" aria-label="Event pagination">
-          <button
-            type="button"
-            onClick={() => onPageChange(currentPage - 1)}
-            disabled={currentPage === 1}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-            aria-label="Previous page"
-          >
-            <ChevronLeft size={18} />
-          </button>
-
-          {firstVisiblePage > 1 && (
-            <>
-              <button
-                type="button"
-                onClick={() => onPageChange(1)}
-                className="h-10 min-w-10 rounded-lg border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-              >
-                1
-              </button>
-              {firstVisiblePage > 2 && (
-                <span className="px-1 text-sm text-gray-500 dark:text-gray-400">
-                  ...
-                </span>
-              )}
-            </>
-          )}
-
-          {visiblePages.map((page) => (
-            <button
-              type="button"
-              key={page}
-              onClick={() => onPageChange(page)}
-              className={`h-10 min-w-10 rounded-lg px-3 text-sm font-medium transition ${
-                page === currentPage
-                  ? "bg-black text-white"
-                  : "border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-              }`}
-              aria-current={page === currentPage ? "page" : undefined}
-            >
-              {page}
-            </button>
-          ))}
-
-          {lastVisiblePage < totalPages && (
-            <>
-              {lastVisiblePage < totalPages - 1 && (
-                <span className="px-1 text-sm text-gray-500 dark:text-gray-400">
-                  ...
-                </span>
-              )}
-              <button
-                type="button"
-                onClick={() => onPageChange(totalPages)}
-                className="h-10 min-w-10 rounded-lg border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-              >
-                {totalPages}
-              </button>
-            </>
-          )}
-
-          <button
-            type="button"
-            onClick={() => onPageChange(currentPage + 1)}
-            disabled={currentPage === totalPages}
-            className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-            aria-label="Next page"
-          >
-            <ChevronRight size={18} />
-          </button>
-        </nav>
-      </div>
-    </div>
-  );
-};
-
 const EventsPage = () => {
   const [events, setEvents] = useState([]);
   const [filterType, setFilterType] = useState("all");
@@ -207,7 +87,10 @@ const EventsPage = () => {
       ? fuse.search(searchQuery).map((res) => res.item)
       : events;
 
-    return sortEventsByDate(filterEventsByType(searchResults, filterType), sortType);
+    return sortEventsByDate(
+      filterEventsByType(searchResults, filterType),
+      sortType
+    );
   }, [events, filterType, searchQuery, sortType]);
 
   const totalPages = getTotalPages(filteredEvents.length, eventsPerPage);
@@ -267,7 +150,7 @@ const EventsPage = () => {
               { key: "past", label: "Past" },
               { key: "conference", label: "Conferences" },
               { key: "workshop", label: "Workshops" },
-            ].map((filter, index) => (
+            ].map((filter) => (
               <button
                 key={filter.key}
                 onClick={() => setFilterType(filter.key)}

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -1,15 +1,25 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import mockEvents from "./eventsMockData.json";
 import EventHero from "./EventHero";
 import EventCard from "./EventCard";
-import { Grid, List } from "lucide-react";
+import { ChevronLeft, ChevronRight, Grid, List } from "lucide-react";
 import FeedbackButton from "../../components/FeedbackButton";
 import EventCTA from "./EventCTA";
 import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
 import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
+import {
+  DEFAULT_EVENTS_PER_PAGE,
+  EVENTS_PER_PAGE_OPTIONS,
+  clampPage,
+  filterEventsByType,
+  getPaginatedEvents,
+  getTotalPages,
+  getVisiblePaginationPages,
+  sortEventsByDate,
+} from "./eventPaginationUtils";
 
-const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
+const renderCardSection = (isLoading, eventsToShow, viewMode, filterType) => {
   if (isLoading) {
     return (
       <div className="grid gap-8 grid-cols-1 sm:grid-cols-1 lg:grid-cols-3">
@@ -20,9 +30,15 @@ const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
     );
   }
 
-  if (filteredEvents.length === 0) {
+  if (eventsToShow.length === 0) {
     return (
       <div className="relative overflow-hidden rounded-3xl p-10 text-center border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-[0_10px_25px_rgba(0,0,0,0.05)] dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)]">
+        <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+          No events found
+        </h3>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          Try changing your search or filters.
+        </p>
       </div>
     );
   }
@@ -36,9 +52,128 @@ const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
           : "grid-cols-1 max-w-4xl mx-auto"
       }`}
     >
-      {filteredEvents.map((event) => (
+      {eventsToShow.map((event) => (
         <EventCard key={event.id} event={event} />
       ))}
+    </div>
+  );
+};
+
+const PaginationControls = ({
+  currentPage,
+  eventsPerPage,
+  totalEvents,
+  totalPages,
+  onPageChange,
+  onPageSizeChange,
+}) => {
+  if (totalEvents === 0) {
+    return null;
+  }
+
+  const startEvent = (currentPage - 1) * eventsPerPage + 1;
+  const endEvent = Math.min(currentPage * eventsPerPage, totalEvents);
+  const { firstVisiblePage, lastVisiblePage, pages: visiblePages } =
+    getVisiblePaginationPages(currentPage, totalPages);
+
+  return (
+    <div className="mt-10 flex flex-col gap-4 border-t border-gray-200 pt-6 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Showing {startEvent}-{endEvent} of {totalEvents} events
+      </p>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <label
+          htmlFor="events-per-page"
+          className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
+        >
+          Per page
+          <select
+            id="events-per-page"
+            value={eventsPerPage}
+            onChange={(event) => onPageSizeChange(Number(event.target.value))}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+          >
+            {EVENTS_PER_PAGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <nav className="flex items-center gap-2" aria-label="Event pagination">
+          <button
+            type="button"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            aria-label="Previous page"
+          >
+            <ChevronLeft size={18} />
+          </button>
+
+          {firstVisiblePage > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={() => onPageChange(1)}
+                className="h-10 min-w-10 rounded-lg border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                1
+              </button>
+              {firstVisiblePage > 2 && (
+                <span className="px-1 text-sm text-gray-500 dark:text-gray-400">
+                  ...
+                </span>
+              )}
+            </>
+          )}
+
+          {visiblePages.map((page) => (
+            <button
+              type="button"
+              key={page}
+              onClick={() => onPageChange(page)}
+              className={`h-10 min-w-10 rounded-lg px-3 text-sm font-medium transition ${
+                page === currentPage
+                  ? "bg-black text-white"
+                  : "border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+              }`}
+              aria-current={page === currentPage ? "page" : undefined}
+            >
+              {page}
+            </button>
+          ))}
+
+          {lastVisiblePage < totalPages && (
+            <>
+              {lastVisiblePage < totalPages - 1 && (
+                <span className="px-1 text-sm text-gray-500 dark:text-gray-400">
+                  ...
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => onPageChange(totalPages)}
+                className="h-10 min-w-10 rounded-lg border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+              >
+                {totalPages}
+              </button>
+            </>
+          )}
+
+          <button
+            type="button"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            aria-label="Next page"
+          >
+            <ChevronRight size={18} />
+          </button>
+        </nav>
+      </div>
     </div>
   );
 };
@@ -48,9 +183,10 @@ const EventsPage = () => {
   const [filterType, setFilterType] = useState("all");
   const [viewMode, setViewMode] = useState("grid");
   const [searchQuery, setSearchQuery] = useState("");
-  const [filteredEvents, setFilteredEvents] = useState([]);
   const [sortType, setSortType] = useState("Newest");
   const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [eventsPerPage, setEventsPerPage] = useState(DEFAULT_EVENTS_PER_PAGE);
   const cardSectionRef = useRef();
 
   useEffect(() => {
@@ -61,54 +197,50 @@ const EventsPage = () => {
     return () => clearTimeout(timer);
   }, []);
 
-  // Fuse.js setup
-  const fuse = new Fuse(events, {
-    keys: ["title", "description", "location", "tags", "type"],
-    threshold: 0.35,
-  });
+  const filteredEvents = useMemo(() => {
+    const fuse = new Fuse(events, {
+      keys: ["title", "description", "location", "tags", "type"],
+      threshold: 0.35,
+    });
+
+    const searchResults = searchQuery.trim()
+      ? fuse.search(searchQuery).map((res) => res.item)
+      : events;
+
+    return sortEventsByDate(filterEventsByType(searchResults, filterType), sortType);
+  }, [events, filterType, searchQuery, sortType]);
+
+  const totalPages = getTotalPages(filteredEvents.length, eventsPerPage);
+  const paginatedEvents = useMemo(() => {
+    return getPaginatedEvents(filteredEvents, currentPage, eventsPerPage);
+  }, [currentPage, eventsPerPage, filteredEvents]);
 
   const handleSearch = (query = "") => {
     setSearchQuery(query);
-
-    let results = events;
-    if (query.trim()) {
-      results = fuse.search(query).map((res) => res.item);
-    }
-
-    const final = results.filter((event) => {
-      return (
-        filterType === "all" ||
-        (filterType === "upcoming" && event.status === "upcoming") ||
-        (filterType === "past" && event.status === "past") ||
-        event.type === filterType
-      );
-    });
-
-    setFilteredEvents(final);
   };
-
-  useEffect(() => {
-    handleSearch(searchQuery);
-  }, [events, filterType]);
 
   const handleSortChange = (type) => {
     setSortType(type);
-    let sorted = [...filteredEvents];
-    if (type === "Newest") {
-      sorted.sort((a, b) => new Date(b.date) - new Date(a.date));
-    } else if (type === "upcoming") {
-      sorted.sort((a, b) => new Date(a.date) - new Date(b.date));
-    }
-    setFilteredEvents(sorted);
   };
 
   useEffect(() => {
-    handleSortChange(sortType);
-    // eslint-disable-next-line
-  }, [filterType, searchQuery]);
+    setCurrentPage(1);
+  }, [eventsPerPage, filterType, searchQuery, sortType]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const handlePageChange = (page) => {
+    const nextPage = clampPage(page, totalPages);
+    setCurrentPage(nextPage);
+    cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
 
   const scrollToCard = () => {
-    cardSectionRef.current?.scrollIntoView({ behaviour: "smooth" });
+    cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (
@@ -198,7 +330,18 @@ const EventsPage = () => {
           </div>
         </div>
 
-        {renderCardSection(isLoading, filteredEvents, viewMode, filterType)}
+        {renderCardSection(isLoading, paginatedEvents, viewMode, filterType)}
+
+        {!isLoading && (
+          <PaginationControls
+            currentPage={currentPage}
+            eventsPerPage={eventsPerPage}
+            totalEvents={filteredEvents.length}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+            onPageSizeChange={setEventsPerPage}
+          />
+        )}
       </div>
 
       <EventCTA />

--- a/src/Pages/Events/PaginationControls.js
+++ b/src/Pages/Events/PaginationControls.js
@@ -1,0 +1,160 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  EVENTS_PER_PAGE_OPTIONS,
+  getVisiblePaginationPages,
+} from "./eventPaginationUtils";
+
+const PageButton = ({ children, isActive = false, onClick, ariaLabel }) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`h-10 min-w-10 rounded-lg px-3 text-sm font-medium transition ${
+        isActive
+          ? "bg-black text-white"
+          : "border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+      }`}
+      aria-current={isActive ? "page" : undefined}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  );
+};
+
+const PageGap = () => {
+  return (
+    <span className="px-1 text-sm text-gray-500 dark:text-gray-400">...</span>
+  );
+};
+
+const ArrowButton = ({ direction, disabled, onClick }) => {
+  const Icon = direction === "previous" ? ChevronLeft : ChevronRight;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+      aria-label={`${direction === "previous" ? "Previous" : "Next"} page`}
+    >
+      <Icon size={18} />
+    </button>
+  );
+};
+
+const PageSizeSelector = ({ eventsPerPage, onPageSizeChange }) => {
+  return (
+    <label
+      htmlFor="events-per-page"
+      className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400"
+    >
+      Per page
+      <select
+        id="events-per-page"
+        value={eventsPerPage}
+        onChange={(event) => onPageSizeChange(Number(event.target.value))}
+        className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-black focus:outline-none focus:ring-2 focus:ring-black/10 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+      >
+        {EVENTS_PER_PAGE_OPTIONS.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+const PageNumberControls = ({ currentPage, totalPages, onPageChange }) => {
+  const { firstVisiblePage, lastVisiblePage, pages } =
+    getVisiblePaginationPages(currentPage, totalPages);
+
+  return (
+    <>
+      {firstVisiblePage > 1 && (
+        <>
+          <PageButton onClick={() => onPageChange(1)} ariaLabel="Go to page 1">
+            1
+          </PageButton>
+          {firstVisiblePage > 2 && <PageGap />}
+        </>
+      )}
+
+      {pages.map((page) => (
+        <PageButton
+          key={page}
+          isActive={page === currentPage}
+          onClick={() => onPageChange(page)}
+          ariaLabel={`Go to page ${page}`}
+        >
+          {page}
+        </PageButton>
+      ))}
+
+      {lastVisiblePage < totalPages && (
+        <>
+          {lastVisiblePage < totalPages - 1 && <PageGap />}
+          <PageButton
+            onClick={() => onPageChange(totalPages)}
+            ariaLabel={`Go to page ${totalPages}`}
+          >
+            {totalPages}
+          </PageButton>
+        </>
+      )}
+    </>
+  );
+};
+
+const PaginationControls = ({
+  currentPage,
+  eventsPerPage,
+  totalEvents,
+  totalPages,
+  onPageChange,
+  onPageSizeChange,
+}) => {
+  if (totalEvents === 0) {
+    return null;
+  }
+
+  const startEvent = (currentPage - 1) * eventsPerPage + 1;
+  const endEvent = Math.min(currentPage * eventsPerPage, totalEvents);
+
+  return (
+    <div className="mt-10 flex flex-col gap-4 border-t border-gray-200 pt-6 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Showing {startEvent}-{endEvent} of {totalEvents} events
+      </p>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <PageSizeSelector
+          eventsPerPage={eventsPerPage}
+          onPageSizeChange={onPageSizeChange}
+        />
+
+        <nav className="flex items-center gap-2" aria-label="Event pagination">
+          <ArrowButton
+            direction="previous"
+            onClick={() => onPageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          />
+          <PageNumberControls
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={onPageChange}
+          />
+          <ArrowButton
+            direction="next"
+            onClick={() => onPageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+          />
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+export default PaginationControls;

--- a/src/Pages/Events/eventPaginationUtils.js
+++ b/src/Pages/Events/eventPaginationUtils.js
@@ -1,0 +1,56 @@
+export const DEFAULT_EVENTS_PER_PAGE = 6;
+export const EVENTS_PER_PAGE_OPTIONS = [6, 9, 12];
+
+export const getTotalPages = (totalEvents, eventsPerPage) => {
+  if (totalEvents <= 0) {
+    return 1;
+  }
+
+  return Math.ceil(totalEvents / eventsPerPage);
+};
+
+export const clampPage = (page, totalPages) => {
+  return Math.min(Math.max(page, 1), totalPages);
+};
+
+export const getPaginatedEvents = (events, currentPage, eventsPerPage) => {
+  const startIndex = (currentPage - 1) * eventsPerPage;
+  return events.slice(startIndex, startIndex + eventsPerPage);
+};
+
+export const getVisiblePaginationPages = (currentPage, totalPages, siblingCount = 2) => {
+  const firstVisiblePage = Math.max(1, currentPage - siblingCount);
+  const lastVisiblePage = Math.min(totalPages, currentPage + siblingCount);
+
+  return {
+    firstVisiblePage,
+    lastVisiblePage,
+    pages: Array.from(
+      { length: lastVisiblePage - firstVisiblePage + 1 },
+      (_, index) => firstVisiblePage + index
+    ),
+  };
+};
+
+export const filterEventsByType = (events, filterType) => {
+  return events.filter((event) => {
+    return (
+      filterType === "all" ||
+      (filterType === "upcoming" && event.status === "upcoming") ||
+      (filterType === "past" && event.status === "past") ||
+      event.type === filterType
+    );
+  });
+};
+
+export const sortEventsByDate = (events, sortType) => {
+  const sorted = [...events];
+
+  if (sortType === "Newest") {
+    sorted.sort((a, b) => new Date(b.date) - new Date(a.date));
+  } else if (sortType === "Upcoming") {
+    sorted.sort((a, b) => new Date(a.date) - new Date(b.date));
+  }
+
+  return sorted;
+};

--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from "react";
+import Fuse from "fuse.js";
+import mockEvents from "./eventsMockData.json";
+import {
+  DEFAULT_EVENTS_PER_PAGE,
+  clampPage,
+  filterEventsByType,
+  getPaginatedEvents,
+  getTotalPages,
+  sortEventsByDate,
+} from "./eventPaginationUtils";
+
+const getSearchResults = (events, searchQuery) => {
+  if (!searchQuery.trim()) {
+    return events;
+  }
+
+  const fuse = new Fuse(events, {
+    keys: ["title", "description", "location", "tags", "type"],
+    threshold: 0.35,
+  });
+
+  return fuse.search(searchQuery).map((res) => res.item);
+};
+
+const useEventListing = () => {
+  const [events, setEvents] = useState([]);
+  const [filterType, setFilterType] = useState("all");
+  const [viewMode, setViewMode] = useState("grid");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortType, setSortType] = useState("Newest");
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [eventsPerPage, setEventsPerPage] = useState(DEFAULT_EVENTS_PER_PAGE);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setEvents(mockEvents);
+      setIsLoading(false);
+    }, 800);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  const filteredEvents = useMemo(() => {
+    const searchResults = getSearchResults(events, searchQuery);
+    const filtered = filterEventsByType(searchResults, filterType);
+    return sortEventsByDate(filtered, sortType);
+  }, [events, filterType, searchQuery, sortType]);
+
+  const totalPages = getTotalPages(filteredEvents.length, eventsPerPage);
+  const paginatedEvents = useMemo(() => {
+    return getPaginatedEvents(filteredEvents, currentPage, eventsPerPage);
+  }, [currentPage, eventsPerPage, filteredEvents]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [eventsPerPage, filterType, searchQuery, sortType]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const setSafePage = (page) => {
+    setCurrentPage(clampPage(page, totalPages));
+  };
+
+  return {
+    currentPage,
+    eventsPerPage,
+    filteredEvents,
+    filterType,
+    isLoading,
+    paginatedEvents,
+    searchQuery,
+    sortType,
+    totalPages,
+    viewMode,
+    setEventsPerPage,
+    setFilterType,
+    setSafePage,
+    setSearchQuery,
+    setSortType,
+    setViewMode,
+  };
+};
+
+export default useEventListing;

--- a/tests/eventPaginationUtils.test.mjs
+++ b/tests/eventPaginationUtils.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_EVENTS_PER_PAGE,
+  EVENTS_PER_PAGE_OPTIONS,
+  clampPage,
+  filterEventsByType,
+  getPaginatedEvents,
+  getTotalPages,
+  getVisiblePaginationPages,
+  sortEventsByDate,
+} from "../src/Pages/Events/eventPaginationUtils.js";
+
+const sampleEvents = [
+  {
+    id: 1,
+    title: "React Workshop",
+    status: "upcoming",
+    type: "workshop",
+    date: "2026-06-10",
+  },
+  {
+    id: 2,
+    title: "AI Conference",
+    status: "upcoming",
+    type: "conference",
+    date: "2026-05-01",
+  },
+  {
+    id: 3,
+    title: "Past Meetup",
+    status: "past",
+    type: "meetup",
+    date: "2025-09-15",
+  },
+  {
+    id: 4,
+    title: "Cloud Workshop",
+    status: "past",
+    type: "workshop",
+    date: "2025-02-20",
+  },
+];
+
+const makeEvents = (count) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    title: `Event ${index + 1}`,
+    status: index % 2 === 0 ? "upcoming" : "past",
+    type: index % 3 === 0 ? "conference" : "workshop",
+    date: `2026-01-${String((index % 28) + 1).padStart(2, "0")}`,
+  }));
+
+assert.equal(DEFAULT_EVENTS_PER_PAGE, 6);
+assert.deepEqual(EVENTS_PER_PAGE_OPTIONS, [6, 9, 12]);
+
+assert.equal(getTotalPages(0, 6), 1, "empty lists still expose one safe page");
+assert.equal(getTotalPages(6, 6), 1, "exact page size fits on one page");
+assert.equal(getTotalPages(7, 6), 2, "overflow creates another page");
+assert.equal(getTotalPages(120, 12), 10, "large lists scale by page size");
+
+assert.equal(clampPage(-2, 5), 1, "negative pages clamp to first page");
+assert.equal(clampPage(0, 5), 1, "page zero clamps to first page");
+assert.equal(clampPage(3, 5), 3, "valid pages pass through");
+assert.equal(clampPage(8, 5), 5, "over-large pages clamp to last page");
+
+const thirteenEvents = makeEvents(13);
+assert.deepEqual(
+  getPaginatedEvents(thirteenEvents, 1, 6).map((event) => event.id),
+  [1, 2, 3, 4, 5, 6],
+  "first page returns the first batch only"
+);
+assert.deepEqual(
+  getPaginatedEvents(thirteenEvents, 2, 6).map((event) => event.id),
+  [7, 8, 9, 10, 11, 12],
+  "middle page returns the next batch"
+);
+assert.deepEqual(
+  getPaginatedEvents(thirteenEvents, 3, 6).map((event) => event.id),
+  [13],
+  "last page returns a partial batch without over-reading"
+);
+assert.deepEqual(
+  getPaginatedEvents(thirteenEvents, 2, 9).map((event) => event.id),
+  [10, 11, 12, 13],
+  "changing page size updates the slice window"
+);
+
+assert.deepEqual(
+  getVisiblePaginationPages(1, 10),
+  { firstVisiblePage: 1, lastVisiblePage: 3, pages: [1, 2, 3] },
+  "pagination window is compact at the beginning"
+);
+assert.deepEqual(
+  getVisiblePaginationPages(5, 10),
+  { firstVisiblePage: 3, lastVisiblePage: 7, pages: [3, 4, 5, 6, 7] },
+  "pagination window stays compact in the middle"
+);
+assert.deepEqual(
+  getVisiblePaginationPages(10, 10),
+  { firstVisiblePage: 8, lastVisiblePage: 10, pages: [8, 9, 10] },
+  "pagination window is compact at the end"
+);
+assert.deepEqual(
+  getVisiblePaginationPages(1, 1),
+  { firstVisiblePage: 1, lastVisiblePage: 1, pages: [1] },
+  "single-page lists render one active page"
+);
+
+assert.deepEqual(
+  filterEventsByType(sampleEvents, "all").map((event) => event.id),
+  [1, 2, 3, 4],
+  "all filter preserves all events"
+);
+assert.deepEqual(
+  filterEventsByType(sampleEvents, "upcoming").map((event) => event.id),
+  [1, 2],
+  "upcoming filter uses status"
+);
+assert.deepEqual(
+  filterEventsByType(sampleEvents, "past").map((event) => event.id),
+  [3, 4],
+  "past filter uses status"
+);
+assert.deepEqual(
+  filterEventsByType(sampleEvents, "workshop").map((event) => event.id),
+  [1, 4],
+  "type filters still work with pagination"
+);
+assert.deepEqual(
+  filterEventsByType(sampleEvents, "webinar").map((event) => event.id),
+  [],
+  "unknown filters safely return an empty list"
+);
+
+assert.deepEqual(
+  sortEventsByDate(sampleEvents, "Newest").map((event) => event.id),
+  [1, 2, 3, 4],
+  "newest sort puts latest dates first"
+);
+assert.deepEqual(
+  sortEventsByDate(sampleEvents, "Upcoming").map((event) => event.id),
+  [4, 3, 2, 1],
+  "upcoming sort puts earliest dates first"
+);
+assert.deepEqual(
+  sampleEvents.map((event) => event.id),
+  [1, 2, 3, 4],
+  "sorting does not mutate the source array"
+);
+
+const filteredSorted = sortEventsByDate(
+  filterEventsByType(sampleEvents, "workshop"),
+  "Upcoming"
+);
+assert.deepEqual(
+  getPaginatedEvents(filteredSorted, 1, 1).map((event) => event.id),
+  [4],
+  "filter, sort, and pagination compose correctly"
+);
+
+console.log("event pagination edge cases passed");


### PR DESCRIPTION
## Which issue does this PR close?

Closes #861

## Rationale for this change

Large event lists were rendered all at once, which can hurt performance and make browsing slower as the number of events grows.

## What changes were made?

- Added pagination controls for event listings.
- Added Previous/Next buttons and compact page number controls.
- Added a per-page selector for 6, 9, and 12 events.
- Reset pagination when search, filters, sort, or page size changes.
- Extracted pagination/filter/sort helper logic into a utility file.
- Added edge-case tests for pagination behavior.

## Testing

- Ran `npm run test:pagination`
- Ran `npm run build`
- Manually verified `/events`
- Checked page navigation, Previous/Next states, page-size changes, and search/filter reset behavior
