### PR TITLE
bug: fix double edit profile option from dashboard

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -265,9 +265,9 @@ const UserProfileDropdown = ({
       {user?.profilePicture ? (
         <img src={user.profilePicture} alt="Profile" className="w-8 h-8 rounded-full object-cover ring-2 ring-primary/20" onError={(e) => (e.currentTarget.style.display = "none")} />
       ) : (
-        <div className="w-8 h-8 rounded-full dark:bg-white/20 bg-gray-300 flex items-center justify-center">
-          <UserIcon className="w-4 h-4 text-gray-600 dark:text-white" />
-        </div>
+       <div className="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center text-white font-semibold text-sm">
+        {primaryLine?.charAt(0).toUpperCase()}
+      </div>
       )}
     </button>
     <AnimatePresence>

--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -214,11 +214,6 @@ export default function UserDashboard() {
               </AnimatePresence>
             </div>
 
-            <Link to="/profile" className="ud-icon-btn">
-              <div className="ud-avatar">
-                {firstName.charAt(0).toUpperCase()}
-              </div>
-            </Link>
           </div>
         </header>
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #968 

## What changes are included in this PR?

* Removed the duplicate "Edit Profile" option from the User Dashboard to reduce redundancy.
* Improved the styling of the Navbar user profile section for a cleaner and more consistent user interface.
* Enhanced the overall navigation experience and visual hierarchy of profile-related actions.

## Are these changes tested?
Yes

## Program Contribution

This PR is submitted under the GSSoC contribution period.


<img width="1898" height="718" alt="image" src="https://github.com/user-attachments/assets/fea4fd47-a360-47a2-883a-07559469c129" />
