### PR TITLE
git push origin fix/sidebar-footer-hidden

### DIFF
--- a/src/components/user/UserDashboard.css
+++ b/src/components/user/UserDashboard.css
@@ -38,7 +38,7 @@
   position: sticky;
   top: 0;
   flex-shrink: 0;
-  overflow-y: auto;
+  overflow: hidden;   /* ← changed */
 }
 
 /* removed dark mode override (handled by CSS variables) */
@@ -70,6 +70,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--ud-space-xxs);
+  overflow-y: auto;   /* ← add this line */
+  min-height: 0;      /* ← add this line (required for flex scroll to work) */
 }
 
 .ud-nav-item {


### PR DESCRIPTION
Fixes #890

## Problem
Profile and Logout options at the bottom of the sidebar were partially 
hidden on medium-height displays because the entire sidebar had 
overflow-y: auto, causing the footer to scroll out of view.

## Solution
- Changed `overflow-y: auto` to `overflow: hidden` on `.ud-sidebar`
- Added `overflow-y: auto` and `min-height: 0` to `.ud-nav` so only 
  the nav section scrolls independently
- Profile and Logout footer is now always pinned and visible

## Testing
Tested at viewport heights of 600px, 700px, 768px — footer always visible.