### PR TITLE
fix: prevent leaderboard crash on GitHub API error responses

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -96,7 +96,7 @@ const EventsPage = () => {
     let sorted = [...filteredEvents];
     if (type === "Newest") {
       sorted.sort((a, b) => new Date(b.date) - new Date(a.date));
-    } else if (type === "upcoming") {
+    } else if (type === "Upcoming" || type === "upcoming") {
       sorted.sort((a, b) => new Date(a.date) - new Date(b.date));
     }
     setFilteredEvents(sorted);
@@ -108,7 +108,7 @@ const EventsPage = () => {
   }, [filterType, searchQuery]);
 
   const scrollToCard = () => {
-    cardSectionRef.current?.scrollIntoView({ behaviour: "smooth" });
+    cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
   return (

--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -107,9 +107,17 @@ export default function LeaderBoard() {
           `https://api.github.com/repos/${GITHUB_REPO}/pulls?state=closed&per_page=100&page=${page}`,
           { headers: TOKEN ? { Authorization: `token ${TOKEN}` } : {} }
         );
+
+        if (!res.ok) {
+          console.warn(`GitHub API request failed with status: ${res.status}`);
+          hasMore = false;
+          break;
+        }
+
         const prs = await res.json();
-        // If no PRs returned, stop paginating
-        if (prs.length === 0) {
+        
+        // Ensure standard array shape to avoid runtime TypeError crash
+        if (!Array.isArray(prs) || prs.length === 0) {
           hasMore = false;
           break;
         }

--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -150,7 +150,7 @@ const ProjectGallery = () => {
     });
 
   const scrollToCard = () => {
-    cardSectionRef.current?.scrollIntoView({ behaviour: 'smooth' })
+    cardSectionRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
 
   return (


### PR DESCRIPTION
## Summary

Prevents leaderboard crashes when the GitHub API returns rate-limited or invalid responses.

This PR adds defensive response validation and graceful fallback handling to avoid runtime failures caused by unexpected API payloads.

Fixes #1052