### PR TITLE
fix: improve dashboard layout on large screens to reduce empty whitespace

### DIFF
--- a/src/components/user/UserDashboard.css
+++ b/src/components/user/UserDashboard.css
@@ -1062,3 +1062,17 @@
   .ud-stats-grid { grid-template-columns: 1fr; }
   .ud-quick-grid { grid-template-columns: repeat(2, 1fr); }
 }
+
+/* ── Large screen fix (Issue #891) ── */
+@media (min-width: 1400px) {
+  .ud-content { max-width: 1400px; padding-left: 2.5rem; padding-right: 2.5rem; }
+  .ud-stats-grid { grid-template-columns: repeat(4, 1fr); }
+  .ud-quick-grid { grid-template-columns: repeat(6, 1fr); }
+  .ud-three-col  { grid-template-columns: repeat(3, 1fr); }
+}
+
+@media (max-width: 1400px) and (min-width: 1100px) {
+  .ud-stats-grid { grid-template-columns: repeat(4, 1fr); }
+  .ud-quick-grid { grid-template-columns: repeat(4, 1fr); }
+  .ud-three-col  { grid-template-columns: repeat(3, 1fr); }
+}


### PR DESCRIPTION
Fixes #891

## Problem
On large/widescreen monitors, dashboard cards were stretched with 
excessive empty whitespace on the right side. Cards were concentrated 
toward the left, making the interface feel incomplete.

## Solution
- Added `min-width: 1400px` breakpoint to maintain proper 4-col stats 
  grid and cap content width on very wide screens
- Added mid-range `1100px–1400px` breakpoint so grids scale smoothly
- All grids (stats, quick actions, bottom cards) now fill the screen evenly

## Testing
Tested at full screen (1456px wide):
- All 4 stat cards display in one row
- 6 quick action columns fill the width
- 3 bottom cards evenly spaced with no whitespace gaps