### PR TITLE
fix: ensure immediate redirect to dashboard after successful login

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -33,8 +33,9 @@ const Login = () => {
   };
 
   useEffect(() => {
-    if (isAuthenticated()) navigate('/dashboard', { replace: true });
-  }, [isAuthenticated, navigate]);
+  if (isAuthenticated()) navigate('/dashboard', { replace: true });
+}, []); // eslint-disable-line react-hooks/exhaustive-deps'/dashboard', { replace: true });
+  
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -45,14 +46,9 @@ const Login = () => {
     try {
       const ok = await login(formData.usernameOrEmail, formData.password);
       if (ok) {
-        // Show success toast
-        toast.success('Login successful! Redirecting to dashboard...');
-        
-        // Redirect after a brief delay to show the toast
-        setTimeout(() => {
-          navigate('/dashboard', { replace: true });
-        }, 1500);
-      }
+  toast.success('Login successful! Redirecting to dashboard...');
+  navigate('/dashboard', { replace: true });
+}
     } catch (err) {
       console.error("Login error:", err);
       setError({ general: err.message || "Invalid email or password" });


### PR DESCRIPTION
Fixes #888

## Problem
After successful login, the toast displayed "Redirecting to dashboard..." 
but users remained on the login page due to a 1500ms setTimeout delay 
before the redirect. The useEffect also had an unstable dependency array 
causing unreliable redirects for already-authenticated users.

## Solution
- Removed `setTimeout` — redirect now happens immediately after login
- Fixed `useEffect` dependency array to `[]` so it only runs on mount,
  reliably redirecting already-authenticated users away from login page

## Testing
- Logged in with valid credentials — redirected to dashboard instantly
- Visiting /login while already logged in redirects to dashboard correctly