### PR TITLE
perf: add lazy loading to all images across the app

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -122,7 +122,7 @@ const EventCard = ({ event }) => {
 
       {/* Image */}
       <div className="relative h-64 card-content-overflow">
-        <img src={event.image} alt={event.title} className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110" />
+        <img loading="lazy" src={event.image} alt={event.title} className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110" />
         <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:from-black/50 transition-all duration-500"></div>
       </div>
 

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -212,7 +212,7 @@ const EventRegistration = () => {
         <div className="bg-white dark:bg-gray-800 rounded-3xl shadow-xl overflow-hidden">
           {/* Event Header */}
           <div className="relative h-64 overflow-hidden">
-            <img
+            <img loading="lazy"
               src={event.image}
               alt={event.title}
               className="w-full h-full object-cover"

--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -296,7 +296,7 @@ const Contributors = () => {
                   {/* Avatar */}
                   <div className="absolute top-3 mt-3 left-1/2 -translate-x-1/2">
                     <div className="relative">
-                      <img
+                      <img loading="lazy"
                         src={c.avatar_url}
                         alt={c.login}
                         className="w-[65px] h-[65px] rounded-full border-4 border-black shadow-md relative z-10"

--- a/src/Pages/Home/components/Testimonials.js
+++ b/src/Pages/Home/components/Testimonials.js
@@ -158,7 +158,7 @@ shadow-lg
 
               {/* Author section */}
               <div className="flex items-center mt-auto pt-4 border-t border-gray-400 dark:border-gray-700">
-                <img
+                <img loading="lazy"
                   src={testimonial.image}
                   alt={testimonial.author}
                   className="h-14 w-14 rounded-full object-cover border-2 border-white/20 dark:border-gray-600"

--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -390,7 +390,7 @@ export default function LeaderBoard() {
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">
                             <div className="flex-shrink-0 h-10 w-10">
-                              <img
+                              <img loading="lazy"
                                 className="h-10 w-10 rounded-full border-2 border-indigo-200 dark:border-gray-600"
                                 src={c.avatar}
                                 alt={c.username}

--- a/src/Pages/Projects/ProjectCard.js
+++ b/src/Pages/Projects/ProjectCard.js
@@ -92,7 +92,7 @@ const ProjectCard = ({ project, index }) => {
       {/* Image */}
       {/* UPDATED: Image container background and border */}
       <div className="relative aspect-[16/9] bg-gray-100 dark:bg-gray-700 border-b border-gray-300 dark:border-gray-700 overflow-hidden">
-        <img
+        <img loading="lazy"
           src={project.lowResImage || project.image}
           alt={project.title}
           className={`absolute inset-0 w-full h-full object-cover blur-lg scale-105 transition-opacity duration-500 ${
@@ -100,7 +100,7 @@ const ProjectCard = ({ project, index }) => {
           }`}
           aria-hidden="true"
         />
-        <img
+        <img loading="lazy"
           src={project.image}
           alt={project.title}
           loading="lazy"

--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -206,7 +206,7 @@ const Contributors = () => {
               {/* Avatar with Glow */}
               <div className="absolute -top-8 left-1/2 -translate-x-1/2">
                 <div className="relative">
-                  <img
+                  <img loading="lazy"
                     src={c.avatar_url}
                     alt={c.login}
                     className="w-20 h-20 rounded-full border-4 border-black shadow-xl"

--- a/src/components/Layout/Navbar/MobileDrawer.jsx
+++ b/src/components/Layout/Navbar/MobileDrawer.jsx
@@ -107,7 +107,7 @@ const MobileDrawer = ({
             {/* User info */}
             <div className="flex items-center gap-3 px-3 py-2 mb-2">
               {user?.profilePicture ? (
-                <img
+                <img loading="lazy"
                   src={user.profilePicture}
                   alt="Profile"
                   className="w-10 h-10 rounded-full object-cover"

--- a/src/components/Layout/Navbar/ProfileDropdown.jsx
+++ b/src/components/Layout/Navbar/ProfileDropdown.jsx
@@ -27,7 +27,7 @@ const ProfileDropdown = ({
           className="flex items-center gap-2 text-sm font-medium text-black/90 dark:text-white/90 hover:text-black dark:hover:text-white transition-colors"
         >
           {user?.profilePicture ? (
-            <img
+            <img loading="lazy"
               src={user.profilePicture}
               alt="Profile"
               className="w-8 h-8 rounded-full object-cover ring-2 ring-primary/20"
@@ -56,7 +56,7 @@ const ProfileDropdown = ({
               <div className="p-4 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
                 <div className="flex items-center gap-3">
                   {user?.profilePicture ? (
-                    <img
+                    <img loading="lazy"
                       src={user.profilePicture}
                       alt="Profile"
                       className="w-12 h-12 rounded-full object-cover ring-2 ring-purple-500/20"

--- a/src/components/common/EventCreation.js
+++ b/src/components/common/EventCreation.js
@@ -701,7 +701,7 @@ const EventCreation = () => {
                   {/* Preview Section */}
                   {formData.bannerPreview && (
                     <div className="rounded-lg overflow-hidden border border-indigo-200 dark:border-gray-700 shadow-md">
-                      <img
+                      <img loading="lazy"
                         src={formData.bannerPreview}
                         alt="Banner preview"
                         className="w-full h-48 object-cover hover:scale-[1.02] transition-transform duration-300"
@@ -1505,7 +1505,7 @@ const EventCreation = () => {
           <div className="bg-white dark:bg-gray-800 shadow-xl rounded-2xl overflow-hidden border border-indigo-300 dark:border-gray-700">
             {formData.bannerPreview && (
               <div className="w-full h-64 overflow-hidden">
-                <img
+                <img loading="lazy"
                   src={formData.bannerPreview}
                   alt="Event banner"
                   className="w-full h-full object-cover"

--- a/src/components/navbar/ProfileMenu.jsx
+++ b/src/components/navbar/ProfileMenu.jsx
@@ -11,7 +11,7 @@ const ProfileMenu = ({ user, logout }) => {
     <div className="relative">
       <button>
         {user?.profilePicture ? (
-          <img
+          <img loading="lazy"
             src={user.profilePicture}
             alt="profile"
             className="w-10 h-10 rounded-full"

--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -215,7 +215,7 @@ const performSave = () => {
             <div className="relative">
               <div className="h-20 w-20 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 flex items-center justify-center ring-2 ring-indigo-200/60 dark:ring-indigo-900/40">
                 {form.avatarBase64 ? (
-                  <img
+                  <img loading="lazy"
                     src={form.avatarBase64}
                     alt="Avatar preview"
                     className="h-full w-full object-cover"


### PR DESCRIPTION
Fixes #863

## Problem
Large images were loading eagerly on page load, slowing down 
page load times and increasing unnecessary bandwidth usage.

## Solution
Added `loading="lazy"` to all `<img>` tags across 12 files so 
off-screen images are only loaded when the user scrolls near them.

## Files Updated
- src/components/common/EventCreation.js
- src/components/Contributors.js
- src/components/Layout/Navbar/MobileDrawer.jsx
- src/components/Layout/Navbar/ProfileDropdown.jsx
- src/components/navbar/ProfileMenu.jsx
- src/components/user/EditProfile.js
- src/Pages/Events/EventCard.js
- src/Pages/Events/EventRegistration.js
- src/Pages/Home/components/ContributorsCarousel.js
- src/Pages/Home/components/Testimonials.js
- src/Pages/Leaderboard/Leaderboard.jsx
- src/Pages/Projects/ProjectCard.js

## Expected Improvements
- Faster initial page load times
- Better Lighthouse performance scores
- Reduced data usage for users on slow connections