### PR TITLE
fix: improve mobile touch target sizes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,9 @@
   --fw-semibold: 600;
   --fw-bold: 700;
   --fw-extrabold: 800;
+
+  --touch-target-min: 44px;
+  --touch-target-gap: 0.75rem;
 }
 
 /* Fix #599: Changed from body.dark to .dark
@@ -181,6 +184,91 @@ code {
   .container { padding: 0 16px; }
   .section-padding { padding: 60px 0; }
   .btn-primary, .btn-secondary { padding: 10px 24px; font-size: 0.875rem; }
+}
+
+/* Issue #862: keep mobile and coarse-pointer controls comfortable to tap. */
+@media (max-width: 768px), (hover: none) and (pointer: coarse) {
+  :where(
+    button,
+    [role="button"],
+    input[type="button"],
+    input[type="reset"],
+    input[type="submit"],
+    select,
+    summary
+  ) {
+    min-height: var(--touch-target-min);
+    min-width: var(--touch-target-min);
+    touch-action: manipulation;
+  }
+
+  :where(
+    a[href].btn-primary,
+    a[href].btn-secondary,
+    a[href].btn-outline,
+    a[href].cta-button,
+    a[href].button,
+    a[href][class*="rounded"],
+    nav a[href],
+    .mobile-nav-link
+  ) {
+    min-height: var(--touch-target-min);
+    touch-action: manipulation;
+  }
+
+  :where(
+    button[class*="p-1"],
+    button[class*="p-2"],
+    a[href][class*="p-1"],
+    a[href][class*="p-2"]
+  ) {
+    padding: 0.75rem;
+  }
+
+  :where(
+    button[class*="py-1"],
+    a[href][class*="py-1"]
+  ) {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+  }
+
+  :where(
+    button[class*="py-2"],
+    a[href][class*="py-2"]
+  ) {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+  }
+
+  :where(
+    .share-button-pop,
+    .social-link,
+    .theme-toggle,
+    .profile-button,
+    .mobile-menu-button,
+    .ud-search-clear
+  ) {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+    min-height: var(--touch-target-min);
+    min-width: var(--touch-target-min);
+  }
+
+  :where(
+    .filter-controls,
+    .view-controls,
+    .event-actions,
+    .hackathon-actions,
+    .project-actions,
+    .cta-actions,
+    .mobile-auth,
+    .navbar-auth,
+    .social-links
+  ) {
+    gap: max(var(--touch-target-gap), 0.75rem);
+  }
 }
 
 /* Remove input clear buttons */


### PR DESCRIPTION
Closes #862

## Problem Solved
Some buttons, links, icon controls, and grouped interactive elements had small tap areas on mobile devices, which could make them harder to use and increase accidental taps.

## Approach
Added a shared mobile/coarse-pointer CSS layer in `src/index.css` to improve touch accessibility across the app without changing the desktop layout.

## Changes
- Added reusable touch target variables for minimum tap size and spacing.
- Ensured common interactive elements such as buttons, selects, role-based buttons, summaries, nav links, and button-like links have a comfortable minimum touch target on mobile/coarse-pointer devices.
- Increased padding for compact controls using small Tailwind-style padding classes like `p-1`, `p-2`, `py-1`, and `py-2`.
- Added minimum tap sizes for icon-style controls such as share buttons, social links, theme toggle, profile button, mobile menu button, and dashboard clear button.
- Improved spacing between grouped controls such as filters, view toggles, event actions, hackathon actions, project actions, CTA buttons, mobile auth buttons, navbar auth controls, and social links.
- Added `touch-action: manipulation` to improve mobile tap responsiveness.

## Testing
- Ran `npm run build` successfully.
- Verified the mobile navigation drawer in responsive mode.
- Checked that drawer links, close button, Sign In, Get Started, Dark mode, and Cursor controls are easier to tap.
- Manually verified that the Cursor button still works even near the floating chatbot button.
- Checked mobile interactive controls for improved spacing and no obvious layout breakage.
