### PR TITLE
Fix profile menu #1077

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -33,8 +33,8 @@ const Login = () => {
   };
 
   useEffect(() => {
-  if (isAuthenticated()) navigate('/dashboard', { replace: true });
-}, []); // eslint-disable-line react-hooks/exhaustive-deps'/dashboard', { replace: true });
+    if (isAuthenticated()) navigate('/dashboard', { replace: true });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
   
 
   const handleSubmit = async (e) => {

--- a/src/components/navbar/ProfileMenu.jsx
+++ b/src/components/navbar/ProfileMenu.jsx
@@ -1,43 +1,90 @@
-import React from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import {
   LayoutDashboard,
   LogOut,
   User,
+  Settings
 } from "lucide-react";
 
 const ProfileMenu = ({ user, logout }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
   return (
-    <div className="relative">
-      <button>
+    <div className="relative" ref={menuRef}>
+      <button 
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-center rounded-full transition-transform hover:scale-105 focus:outline-none"
+      >
         {user?.profilePicture ? (
           <img loading="lazy"
             src={user.profilePicture}
             alt="profile"
-            className="w-10 h-10 rounded-full"
+            className="w-10 h-10 rounded-full object-cover border-2 border-transparent hover:border-blue-500 transition-colors"
           />
         ) : (
-          <User />
+          <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 flex items-center justify-center hover:border-blue-500 transition-colors">
+            <User className="text-gray-600 dark:text-gray-300 w-5 h-5" />
+          </div>
         )}
       </button>
 
-      <div className="absolute right-0 mt-3 bg-white dark:bg-gray-900 rounded-lg shadow-xl w-56 p-2">
-        <Link
-          to="/dashboard"
-          className="flex items-center gap-2 px-3 py-2"
-        >
-          <LayoutDashboard />
-          Dashboard
-        </Link>
+      {isOpen && (
+        <div className="absolute right-0 mt-3 bg-white dark:bg-gray-900 rounded-xl shadow-2xl w-56 p-2 z-50 border border-gray-100 dark:border-gray-800">
+          <div className="px-3 py-2 mb-2 border-b border-gray-100 dark:border-gray-800">
+            <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+              {user?.name || user?.username || 'User'}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {user?.email || 'Logged in'}
+            </p>
+          </div>
 
-        <button
-          onClick={logout}
-          className="flex items-center gap-2 px-3 py-2 w-full"
-        >
-          <LogOut />
-          Logout
-        </button>
-      </div>
+          <Link
+            to="/dashboard"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          >
+            <LayoutDashboard className="w-4 h-4" />
+            Dashboard
+          </Link>
+
+          <Link
+            to="/settings"
+            onClick={() => setIsOpen(false)}
+            className="flex items-center gap-3 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors mt-1"
+          >
+            <Settings className="w-4 h-4" />
+            Edit Profile
+          </Link>
+
+          <div className="h-px bg-gray-100 dark:bg-gray-800 my-2"></div>
+
+          <button
+            onClick={() => {
+              setIsOpen(false);
+              logout();
+            }}
+            className="flex items-center gap-3 px-3 py-2 w-full text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+          >
+            <LogOut className="w-4 h-4" />
+            Logout
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../../context/AuthContext";
+import { useNavigate } from "react-router-dom";
 
 import {
   User as UserIcon,
@@ -78,7 +79,7 @@ const allSkillSuggestions = [
   /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-._~:/?#[\]@!$&'()*+,;=]*)?$/i;
 
 const EditProfile = () => {
-
+   const navigate = useNavigate();
    const { user, setUser } = useAuth();
   const [form, setForm] = useState(user || initialFormState);
   const [errors, setErrors] = useState({});
@@ -171,6 +172,11 @@ const performSave = () => {
     // ✅ Persist updates to both context and localStorage
     setUser(form);
     localStorage.setItem("user", JSON.stringify(form));
+
+    // ✅ Navigate away after a short delay to let user see success message
+    setTimeout(() => {
+      navigate("/dashboard");
+    }, 1000);
 
   }, 1500);
 };


### PR DESCRIPTION
Which issue does this PR close?
Closes #1077 
Rationale for this change
The profile dropdown menu was previously always visible in the top right corner, breaking the UI layout and taking up unnecessary screen space. Furthermore, after editing user profiles, there was no auto-redirect back to the dashboard, creating a jarring user experience. Finally, a minor ESLint error in the authentication flow was causing build warnings. This PR addresses all of these UX and quality-of-life issues.

What changes are included in this PR?
Profile Menu Overhaul: Updated ProfileMenu.jsx so the dropdown is hidden by default and only toggles on click. Added a global click-outside event listener to dismiss the menu automatically. Added a new "Edit Profile" link.
Edit Profile Redirection: Modified EditProfile.js to automatically redirect users back to /dashboard 1 second after successfully saving their profile changes.
Syntax/Linting Fixes: Resolved a typo inside an eslint-disable-line comment in Login.js that was causing react-hooks/exhaustive-deps build warnings.
Are these changes tested?
Yes. Manual testing was performed locally. Verified that:

The profile menu properly opens/closes on click and click-outside.
Saving the edit profile form correctly triggers the success message and routing.
App compiles without ESLint warnings.
Are there any user-facing changes?
Yes. The profile dropdown behavior is now standard (click-to-toggle) and contains an additional "Edit Profile" option. Users are also now automatically routed back to their dashboard upon saving profile modifications.