### PR TITLE
fix(ui): background cursor effect toggle

### DIFF
--- a/src/components/navbar/CursorToggle.jsx
+++ b/src/components/navbar/CursorToggle.jsx
@@ -4,10 +4,21 @@ import { MousePointer } from "lucide-react";
 const CursorToggle = ({ cursorEnabled, toggleCursor }) => {
   return (
     <button
+      type="button"
       onClick={toggleCursor}
-      className="px-3 py-2 rounded-lg bg-black text-white dark:bg-white dark:text-black"
+      aria-pressed={cursorEnabled}
+      title={
+        cursorEnabled
+          ? "Turn off background cursor effects"
+          : "Turn on background cursor effects"
+      }
+      className={`rounded-lg border px-3 py-2 transition-colors ${
+        cursorEnabled
+          ? "border-indigo-500 bg-indigo-600 text-white shadow-sm"
+          : "border-gray-300 bg-gray-100 text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+      }`}
     >
-      <MousePointer />
+      <MousePointer aria-hidden="true" />
     </button>
   );
 };

--- a/src/jhalak/FluidCursor.js
+++ b/src/jhalak/FluidCursor.js
@@ -1,12 +1,16 @@
 'use client';
 import React, { useEffect, useRef } from 'react';
 
-const FluidCursor = () => {
+const FluidCursor = ({ enabled = true }) => {
   const canvasRef = useRef(null);
 
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
     const canvas = canvasRef.current;
-    if (!canvas) return;
+    if (!canvas) return undefined;
 
     let animationFrameId;
 
@@ -1017,7 +1021,11 @@ const FluidCursor = () => {
         cancelAnimationFrame(animationFrameId);
       }
     };
-  }, []);
+  }, [enabled]);
+
+  if (!enabled) {
+    return null;
+  }
 
   return (
     <div className='fixed top-0 left-0 z-[9999] pointer-events-none'>


### PR DESCRIPTION
## Summary
- `FluidCursor` now respects the `enabled` prop and unmounts when disabled
- Navbar toggle shows on/off styling with `aria-pressed` for accessibility

Fixes #1095