### PR TITLE
fix(auth): login/logout toasts auto-dismiss and close (#1079)

### DIFF
--- a/src/components/Layout/Navbar/hooks/useNavbarState.js
+++ b/src/components/Layout/Navbar/hooks/useNavbarState.js
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../../../context/AuthContext";
-import { toast } from "react-toastify";
+import { showAuthToast } from "../../../../utils/toast";
 
 const useNavbarState = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -103,12 +103,7 @@ const useNavbarState = () => {
 
     logout();
 
-    toast.success("You have been logged out successfully.", {
-      className: "custom-toast",
-      autoClose: 3000,
-    });
-
-    navigate("/");
+    showAuthToast("You have been logged out successfully.", () => navigate("/"));
   };
 
   const handleCancelLogout = () => {

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -3,7 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useAuth } from '../../context/AuthContext';
 import GoogleSignInButton from '../GoogleSignInButton';
-import { toast } from 'react-toastify';
+import { toast } from "react-toastify";
+import { showAuthToast } from "../../utils/toast";
 
 const Login = () => {
   const [formData, setFormData] = useState({ usernameOrEmail: "", password: "" });
@@ -46,9 +47,10 @@ const Login = () => {
     try {
       const ok = await login(formData.usernameOrEmail, formData.password);
       if (ok) {
-  toast.success('Login successful! Redirecting to dashboard...');
-  navigate('/dashboard', { replace: true });
-}
+        showAuthToast("Login successful! Redirecting to dashboard...", () =>
+          navigate("/dashboard", { replace: true })
+        );
+      }
     } catch (err) {
       console.error("Login error:", err);
       setError({ general: err.message || "Invalid email or password" });

--- a/src/components/common/NotificationProvider.js
+++ b/src/components/common/NotificationProvider.js
@@ -9,11 +9,14 @@ const NotificationProvider = () => {
       hideProgressBar={false}
       newestOnTop
       closeOnClick
+      closeButton
       rtl={false}
       pauseOnFocusLoss
       draggable
       pauseOnHover
       theme="colored"
+      limit={3}
+      style={{ zIndex: 10050 }}
     />
   );
 };

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,1 +1,13 @@
-// Deprecated: use react-toastify instead
+import { toast } from "react-toastify";
+
+const AUTH_TOAST_ID = "auth-feedback";
+
+/** Auth flows: dismiss stale toasts, show one toast, navigate after it closes. */
+export function showAuthToast(message, onAfterClose) {
+  toast.dismiss(AUTH_TOAST_ID);
+  toast.success(message, {
+    toastId: AUTH_TOAST_ID,
+    autoClose: 2500,
+    onClose: onAfterClose,
+  });
+}


### PR DESCRIPTION
## Summary
- Add `showAuthToast` helper with stable `toastId` and navigation deferred to `onClose`.
- Login and logout no longer navigate immediately while the toast is still mounting.
- Raise `ToastContainer` z-index and enable explicit close button.

Fixes #1079

## Test plan
- [ ] Login: toast auto-closes ~2.5s, × dismisses, then lands on dashboard
- [ ] Logout: same on home route