### PR TITLE
fix(theme): correct dark mode text on About page and footer

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -198,8 +198,8 @@ export default function ModernAbout() {
             data-aos-delay="300"
           >
             {/* UPDATED: Card text */}
-            <h3 className="text-black text-2xl font-bold mb-2">100+</h3>
-            <p className="text-black text-sm">Events Managed</p>
+            <h3 className="text-2xl font-bold mb-2 text-black dark:text-white">100+</h3>
+            <p className="text-sm text-black dark:text-gray-300">Events Managed</p>
           </motion.div>
           {stats.map((s) => (
             <motion.div key={s.label} variants={scaleIn} whileHover={prefersReducedMotion ? {} : { scale: 1.05, y: -4 }} transition={{ type: "spring", stiffness: 300, damping: 20 }} className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-2xl shadow-lg shadow-blue-100 dark:shadow-indigo-900/50 p-4 sm:p-5 cursor-default">

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -323,7 +323,7 @@ const Footer = () => {
               data-aos-delay="0"
             >
               <h2
-                className="text-2xl sm:text-3xl font-bold text-black"
+                className="text-2xl sm:text-3xl font-bold text-black dark:text-white"
                 style={{ fontFamily: "Anton, sans-serif" }}
               >
                 Eventra


### PR DESCRIPTION
## Summary

Fixes text that stayed light-mode colored on the About page and footer in dark theme.

## Changes

- Add `dark:text-white` / `dark:text-gray-300` to the hero stats card in `ModernAbout.js`
- Add `dark:text-white` to the footer brand heading

Fixes #1100