### PR TITLE
fix(navbar): stack mobile hamburger menu items vertically

### DIFF
--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -9,13 +9,13 @@ const MobileDrawer = ({ isOpen, closeMenu }) => {
       }`}
     >
       <div className="p-4 flex justify-between items-center border-b">
-        <h2 className="text-2xl font-bold">Eventra</h2>
+        <h2 className="text-2xl font-bold text-black dark:text-white">Eventra</h2>
 
         <button onClick={closeMenu}>X</button>
       </div>
 
       <div className="p-4">
-        <NavbarLinks />
+        <NavbarLinks variant="mobile" onNavigate={closeMenu} />
       </div>
     </div>
   );

--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -2,11 +2,18 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { NAV_ITEMS } from "./constants/navItems";
 
-const NavbarLinks = () => {
+const NavbarLinks = ({ variant = "desktop", onNavigate }) => {
   const location = useLocation();
+  const isMobile = variant === "mobile";
 
   return (
-    <div className="flex items-center gap-5">
+    <div
+      className={
+        isMobile
+          ? "flex w-full flex-col items-stretch gap-1"
+          : "flex items-center gap-5"
+      }
+    >
       {NAV_ITEMS.map((item) => {
         const active = location.pathname === item.href;
 
@@ -14,11 +21,14 @@ const NavbarLinks = () => {
           <Link
             key={item.name}
             to={item.href || "#"}
-            className={`text-sm font-medium transition-colors whitespace-nowrap ${
+            onClick={onNavigate}
+            className={`text-sm font-medium transition-colors ${
+              isMobile ? "block w-full rounded-lg px-3 py-3" : "whitespace-nowrap"
+            } ${
               active
                 ? "text-black dark:text-white"
                 : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white"
-            }`}
+            } ${isMobile && active ? "bg-gray-100 dark:bg-gray-800" : ""}`}
           >
             {item.name}
           </Link>


### PR DESCRIPTION
## Summary

Fixes the mobile drawer showing navigation links in a horizontal row.

## Changes

- Add `variant="mobile"` to `NavbarLinks` with column layout and full-width items
- Close the drawer after selecting a link via `onNavigate`
- Improve drawer title contrast in dark mode

Fixes #1099