### PR TITLE
Add skeleton loaders for dashboard pages

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -1,5 +1,5 @@
 import StatusBadge from "../common/StatusBadge";
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
@@ -9,6 +9,11 @@ import {
   Trash2, Edit2, CheckCircle, AlertCircle,
   TrendingUp
 } from 'lucide-react';
+import {
+  AdminListCardSkeleton,
+  AdminStatCardSkeleton,
+  AdminTableSkeleton,
+} from '../common/SkeletonLoaders';
 import './AdminDashboard.css';
 import { toast } from 'react-toastify';
 
@@ -83,8 +88,14 @@ const AdminDashboard = () => {
   const [searchUser,  setSearchUser]  = useState('');
   const [searchEvent, setSearchEvent] = useState('');
   const [confirmModal, setConfirmModal] = useState({ open: false, type: '', id: null });
+  const [loading, setLoading] = useState(true);
 
   const firstName = user?.firstName || user?.username || 'Admin';
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setLoading(false), 700);
+    return () => window.clearTimeout(timer);
+  }, []);
 
   /* Stats */
   const totalUsers  = users.length;
@@ -191,7 +202,9 @@ const AdminDashboard = () => {
 
                 {/* Stat Cards */}
                 <motion.div variants={stagger} className="ad-stats-grid">
-                  {[
+                  {loading
+                    ? [...Array(4)].map((_, i) => <AdminStatCardSkeleton key={i} />)
+                    : [
                     { label: 'Total Users',     value: totalUsers,        sub: `${activeUsers} active`,      icon: <Users size={20} />,    color: '#6366f1' },
                     { label: 'Total Events',    value: totalEvents,       sub: `${upcoming} upcoming`,       icon: <Calendar size={20} />, color: '#ec4899' },
                     { label: 'Participants',    value: totalParticipants, sub: 'across all events',          icon: <TrendingUp size={20}/>, color: '#10b981' },
@@ -210,6 +223,13 @@ const AdminDashboard = () => {
 
                 {/* Recent Users + Recent Events */}
                 <div className="ad-two-col">
+                  {loading ? (
+                    <>
+                      <AdminListCardSkeleton />
+                      <AdminListCardSkeleton />
+                    </>
+                  ) : (
+                  <>
                   <motion.section custom={1} variants={fadeUp} className="ad-card">
                     <div className="ad-card-head">
                       <span className="ad-card-icon" style={{ background: '#6366f118', color: '#6366f1' }}><Users size={15} /></span>
@@ -245,6 +265,8 @@ const AdminDashboard = () => {
                       </div>
                     ))}
                   </motion.section>
+                  </>
+                  )}
                 </div>
               </motion.div>
             )}
@@ -266,6 +288,9 @@ const AdminDashboard = () => {
                 </div>
 
                 <div className="ad-table-wrap">
+                  {loading ? (
+                    <AdminTableSkeleton rows={5} />
+                  ) : (
                   <table className="ad-table">
                     <thead>
                       <tr>
@@ -314,6 +339,7 @@ const AdminDashboard = () => {
                         ))}
                     </tbody>
                   </table>
+                  )}
                 </div>
               </motion.div>
             )}
@@ -335,6 +361,9 @@ const AdminDashboard = () => {
                 </div>
 
                 <div className="ad-table-wrap">
+                  {loading ? (
+                    <AdminTableSkeleton rows={5} />
+                  ) : (
                   <table className="ad-table">
                     <thead>
                       <tr>
@@ -378,6 +407,7 @@ const AdminDashboard = () => {
                         ))}
                     </tbody>
                   </table>
+                  )}
                 </div>
               </motion.div>
             )}
@@ -386,7 +416,9 @@ const AdminDashboard = () => {
             {activeTab === 'analytics' && (
               <motion.div key="analytics" initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }} className="ad-section">
                 <motion.div variants={stagger} initial="hidden" animate="visible" className="ad-stats-grid">
-                  {[
+                  {loading
+                    ? [...Array(4)].map((_, i) => <AdminStatCardSkeleton key={i} />)
+                    : [
                     { label: 'Total Users',        value: totalUsers,        sub: `${activeUsers} active · ${totalUsers - activeUsers} inactive`,    color: '#6366f1', icon: <Users size={20} /> },
                     { label: 'Events Hosted',       value: totalEvents,       sub: `${upcoming} upcoming · ${totalEvents - upcoming} completed`,      color: '#ec4899', icon: <Calendar size={20} /> },
                     { label: 'Total Participants',  value: totalParticipants, sub: 'across all events',                                              color: '#10b981', icon: <TrendingUp size={20} /> },

--- a/src/components/common/SkeletonLoaders.jsx
+++ b/src/components/common/SkeletonLoaders.jsx
@@ -160,3 +160,133 @@ export const ProjectCardSkeleton = () => (
     </div>
   </div>
 );
+
+export const DashboardStatCardSkeleton = () => (
+  <div className="ud-stat-card">
+    <SkeletonBlock className="ud-stat-icon h-11 w-11 rounded-xl" />
+    <div className="ud-stat-info flex-1">
+      <SkeletonBlock className="h-3 w-20 mb-2" />
+      <SkeletonBlock className="h-8 w-14 mb-2" />
+      <SkeletonBlock className="h-3 w-32" />
+    </div>
+  </div>
+);
+
+export const DashboardQuickActionSkeleton = () => (
+  <div className="ud-quick-card">
+    <SkeletonBlock className="ud-quick-icon h-10 w-10 rounded-xl" />
+    <SkeletonBlock className="h-4 w-20" />
+  </div>
+);
+
+export const DashboardListCardSkeleton = () => (
+  <div className="ud-card">
+    <div className="ud-card-head">
+      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+      <SkeletonBlock className="h-5 w-32" />
+    </div>
+    {[...Array(3)].map((_, i) => (
+      <div key={i} className="ud-list-item">
+        <div className="flex-1">
+          <SkeletonBlock className="h-4 w-3/4 mb-2" />
+          <SkeletonBlock className="h-3 w-1/2" />
+        </div>
+        <SkeletonBlock className="h-6 w-16 rounded-full" />
+      </div>
+    ))}
+  </div>
+);
+
+export const DashboardItemCardSkeleton = () => (
+  <div className="ud-item-card">
+    <div className="ud-item-top">
+      <SkeletonBlock className="h-6 w-20 rounded-full" />
+      <SkeletonBlock className="h-6 w-16 rounded-full" />
+    </div>
+    <SkeletonBlock className="h-5 w-4/5 mb-3" />
+    <SkeletonBlock className="h-4 w-full mb-2" />
+    <SkeletonBlock className="h-4 w-2/3 mb-4" />
+    <SkeletonBlock className="h-6 w-24 rounded-full" />
+  </div>
+);
+
+export const DashboardProfileSkeleton = () => (
+  <div>
+    <SkeletonBlock className="h-4 w-28 mb-2" />
+    <SkeletonBlock className="h-8 w-40" />
+  </div>
+);
+
+export const DashboardSectionTitleSkeleton = () => (
+  <SkeletonBlock className="h-6 w-40 mb-4" />
+);
+
+export const AdminStatCardSkeleton = () => (
+  <div className="ad-stat-card">
+    <SkeletonBlock className="ad-stat-icon h-10 w-10 rounded-xl" />
+    <div className="flex-1">
+      <SkeletonBlock className="h-3 w-20 mb-2" />
+      <SkeletonBlock className="h-7 w-12 mb-1" />
+      <SkeletonBlock className="h-3 w-24" />
+    </div>
+  </div>
+);
+
+export const AdminTableSkeleton = ({ rows = 5 }) => (
+  <div className="ad-table-wrap">
+    <div className="ad-table">
+      {[...Array(rows)].map((_, i) => (
+        <div key={i} className="ad-table-row flex items-center gap-4 px-4 py-3">
+          <SkeletonBlock className="h-4 w-1/4" />
+          <SkeletonBlock className="h-4 w-1/3" />
+          <SkeletonBlock className="h-6 w-16 rounded-full" />
+          <SkeletonBlock className="h-4 w-20" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const AdminListCardSkeleton = () => (
+  <div className="ad-card">
+    <div className="ad-card-head">
+      <SkeletonBlock className="h-8 w-8 rounded-lg" />
+      <SkeletonBlock className="h-5 w-32" />
+    </div>
+    {[...Array(4)].map((_, i) => (
+      <div key={i} className="ad-list-item">
+        <SkeletonBlock className="ad-list-avatar h-8 w-8 rounded-full" />
+        <div className="flex-1">
+          <SkeletonBlock className="h-4 w-3/4 mb-2" />
+          <SkeletonBlock className="h-3 w-1/2" />
+        </div>
+        <SkeletonBlock className="h-6 w-16 rounded-full" />
+      </div>
+    ))}
+  </div>
+);
+
+export const DashboardTableSkeleton = ({ rows = 5 }) => (
+  <div className="ud-table-wrap">
+    <table className="ud-table">
+      <thead>
+        <tr>
+          {["Type", "Title", "Date", "Location", "Status", "Participation"].map(col => (
+            <th key={col}>{col}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {[...Array(rows)].map((_, i) => (
+          <tr key={i}>
+            {[...Array(6)].map((__, j) => (
+              <td key={j}>
+                <SkeletonBlock className="h-4 w-full" />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);

--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -8,6 +8,15 @@ import { Link, useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { useAuth } from "../../context/AuthContext";
 import StatusBadge from "../common/StatusBadge";
+import {
+  DashboardItemCardSkeleton,
+  DashboardListCardSkeleton,
+  DashboardProfileSkeleton,
+  DashboardQuickActionSkeleton,
+  DashboardSectionTitleSkeleton,
+  DashboardStatCardSkeleton,
+  DashboardTableSkeleton,
+} from "../common/SkeletonLoaders";
 import "./UserDashboard.css";
 
 const fadeUp = {
@@ -61,6 +70,7 @@ export default function UserDashboard() {
   const [filterStatus, setFilterStatus] = useState("All");
   const [greeting, setGreeting] = useState("");
   const [notifOpen, setNotifOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const firstName = user?.firstName || user?.username || "there";
 
@@ -69,6 +79,11 @@ export default function UserDashboard() {
     if (h < 12) setGreeting("Good morning");
     else if (h < 17) setGreeting("Good afternoon");
     else setGreeting("Good evening");
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setLoading(false), 700);
+    return () => window.clearTimeout(timer);
   }, []);
 
   const stats = {
@@ -149,10 +164,14 @@ export default function UserDashboard() {
       {/* Main */}
       <main className="ud-main">
         <header className="ud-topbar">
-          <div>
-            <p className="ud-greeting">{greeting},</p>
-            <h1 className="ud-username">{firstName} 👋</h1>
-          </div>
+          {loading ? (
+            <DashboardProfileSkeleton />
+          ) : (
+            <div>
+              <p className="ud-greeting">{greeting},</p>
+              <h1 className="ud-username">{firstName} 👋</h1>
+            </div>
+          )}
 
           <div className="ud-topbar-right">
             <div className="ud-search-wrap">
@@ -199,6 +218,31 @@ export default function UserDashboard() {
           {/* Overview */}
           {activeTab === "overview" && (
             <motion.div key="overview" variants={stagger} initial="hidden" animate="visible" exit={{ opacity: 0 }} className="ud-content">
+              {loading ? (
+                <>
+                  <div className="ud-stats-grid">
+                    {[...Array(4)].map((_, i) => (
+                      <DashboardStatCardSkeleton key={i} />
+                    ))}
+                  </div>
+
+                  <section>
+                    <DashboardSectionTitleSkeleton />
+                    <div className="ud-quick-grid">
+                      {[...Array(6)].map((_, i) => (
+                        <DashboardQuickActionSkeleton key={i} />
+                      ))}
+                    </div>
+                  </section>
+
+                  <div className="ud-three-col">
+                    {[...Array(3)].map((_, i) => (
+                      <DashboardListCardSkeleton key={i} />
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <>
               <motion.div variants={stagger} className="ud-stats-grid">
                 {[
                   { label: "Events", value: stats.eventsTotal, sub: `${stats.eventsCreated} hosted · ${stats.eventsJoined} joined`, icon: <Calendar size={20} />, accent: "#6366f1" },
@@ -300,6 +344,8 @@ export default function UserDashboard() {
                   }
                 </motion.section>
               </div>
+                </>
+              )}
             </motion.div>
           )}
 
@@ -311,7 +357,9 @@ export default function UserDashboard() {
                 <Link to="/events" className="ud-btn-primary"><Plus size={15} /> Explore Events</Link>
               </div>
               <div className="ud-items-grid">
-                {MOCK_DATA.filter(d => d.type === "Event").map((ev, i) => (
+                {loading
+                  ? [...Array(3)].map((_, i) => <DashboardItemCardSkeleton key={i} />)
+                  : MOCK_DATA.filter(d => d.type === "Event").map((ev, i) => (
                   <motion.div key={ev.id} custom={i} variants={fadeUp} initial="hidden" animate="visible" className="ud-item-card">
                     <div className="ud-item-top">
                       <span className="ud-item-type" style={{ background: "#6366f118", color: "#6366f1" }}><Calendar size={13} /> Event</span>
@@ -339,7 +387,9 @@ export default function UserDashboard() {
                 <Link to="/hackathons" className="ud-btn-primary"><Plus size={15} /> Explore Hackathons</Link>
               </div>
               <div className="ud-items-grid">
-                {MOCK_DATA.filter(d => d.type === "Hackathon").map((h, i) => (
+                {loading
+                  ? [...Array(3)].map((_, i) => <DashboardItemCardSkeleton key={i} />)
+                  : MOCK_DATA.filter(d => d.type === "Hackathon").map((h, i) => (
                   <motion.div key={h.id} custom={i} variants={fadeUp} initial="hidden" animate="visible" className="ud-item-card">
                     <div className="ud-item-top">
                       <span className="ud-item-type" style={{ background: "#ec489918", color: "#ec4899" }}><Trophy size={13} /> Hackathon</span>
@@ -367,7 +417,9 @@ export default function UserDashboard() {
                 <Link to="/submit-project" className="ud-btn-primary"><Plus size={15} /> Submit Project</Link>
               </div>
               <div className="ud-items-grid">
-                {MOCK_DATA.filter(d => d.type === "Project").map((p, i) => (
+                {loading
+                  ? [...Array(2)].map((_, i) => <DashboardItemCardSkeleton key={i} />)
+                  : MOCK_DATA.filter(d => d.type === "Project").map((p, i) => (
                   <motion.div key={p.id} custom={i} variants={fadeUp} initial="hidden" animate="visible" className="ud-item-card">
                     <div className="ud-item-top">
                       <span className="ud-item-type" style={{ background: "#8b5cf618", color: "#8b5cf6" }}><FolderOpen size={13} /> Project</span>
@@ -401,6 +453,9 @@ export default function UserDashboard() {
                 </div>
               </div>
 
+              {loading ? (
+                <DashboardTableSkeleton rows={6} />
+              ) : (
               <div className="ud-table-wrap">
                 <table className="ud-table">
                   <thead>
@@ -429,6 +484,7 @@ export default function UserDashboard() {
                   </tbody>
                 </table>
               </div>
+              )}
             </motion.div>
           )}
         </AnimatePresence>


### PR DESCRIPTION
## Summary

Adds shimmer skeleton placeholders to User and Admin dashboard pages while mock/API data loads, improving perceived performance on initial paint.

## Changes

- Extended `SkeletonLoaders.jsx` with dashboard-specific components (`DashboardStatCardSkeleton`, `DashboardItemCardSkeleton`, `AdminStatCardSkeleton`, `AdminTableSkeleton`, etc.)
- **UserDashboard**: 700ms loading state on mount; skeletons for overview stats/quick actions/list cards, plus events/hackathons/projects grids and registrations table
- **AdminDashboard**: matching loading state with skeletons for overview stats, recent lists, users/events tables, and analytics stat cards

Fixes #1068

## Test plan

- [ ] Open `/user-dashboard` — overview shows skeleton cards briefly, then real content
- [ ] Switch tabs (Events, Hackathons, Projects, Registrations) during load — item/table skeletons appear
- [ ] Open admin dashboard — overview stats and recent lists skeleton, then populate
- [ ] Users/Events/Analytics tabs show table/stat skeletons while loading