### PR TITLE
fix(events): derive upcoming/past filters from event date-time

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -9,6 +9,7 @@ import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
 import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
+import { matchesEventTimingFilter } from "../../utils/eventTiming";
 
 const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
   if (isLoading) {
@@ -77,14 +78,7 @@ const EventsPage = () => {
       results = fuse.search(query).map((res) => res.item);
     }
 
-    const final = results.filter((event) => {
-      return (
-        filterType === "all" ||
-        (filterType === "upcoming" && event.status === "upcoming") ||
-        (filterType === "past" && event.status === "past") ||
-        event.type === filterType
-      );
-    });
+    const final = results.filter((event) => matchesEventTimingFilter(event, filterType));
 
     setFilteredEvents(final);
   };

--- a/src/Pages/Events/eventPaginationUtils.js
+++ b/src/Pages/Events/eventPaginationUtils.js
@@ -1,3 +1,5 @@
+import { matchesEventTimingFilter } from "../../utils/eventTiming";
+
 export const DEFAULT_EVENTS_PER_PAGE = 6;
 export const EVENTS_PER_PAGE_OPTIONS = [6, 9, 12];
 
@@ -33,14 +35,7 @@ export const getVisiblePaginationPages = (currentPage, totalPages, siblingCount 
 };
 
 export const filterEventsByType = (events, filterType) => {
-  return events.filter((event) => {
-    return (
-      filterType === "all" ||
-      (filterType === "upcoming" && event.status === "upcoming") ||
-      (filterType === "past" && event.status === "past") ||
-      event.type === filterType
-    );
-  });
+  return events.filter((event) => matchesEventTimingFilter(event, filterType));
 };
 
 export const sortEventsByDate = (events, sortType) => {

--- a/src/utils/eventTiming.js
+++ b/src/utils/eventTiming.js
@@ -1,0 +1,55 @@
+const TIME_PATTERN = /^(\d{1,2}):(\d{2})\s*(AM|PM)$/i;
+
+export const parseEventDateTime = (event) => {
+  if (!event?.date) {
+    return null;
+  }
+
+  const time = event.time?.trim();
+  if (time) {
+    const match = time.match(TIME_PATTERN);
+    if (match) {
+      let hours = Number(match[1]);
+      const minutes = Number(match[2]);
+      const meridiem = match[3].toUpperCase();
+
+      if (meridiem === "PM" && hours < 12) {
+        hours += 12;
+      } else if (meridiem === "AM" && hours === 12) {
+        hours = 0;
+      }
+
+      const [year, month, day] = event.date.split("-").map(Number);
+      return new Date(year, month - 1, day, hours, minutes, 0, 0);
+    }
+
+    const parsed = new Date(`${event.date} ${time}`);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  const [year, month, day] = event.date.split("-").map(Number);
+  return new Date(year, month - 1, day, 23, 59, 59, 999);
+};
+
+export const getEventTimingStatus = (event, referenceDate = new Date()) => {
+  const eventDateTime = parseEventDateTime(event);
+  if (!eventDateTime) {
+    return event?.status === "past" ? "past" : "upcoming";
+  }
+
+  return eventDateTime >= referenceDate ? "upcoming" : "past";
+};
+
+export const matchesEventTimingFilter = (event, filterType) => {
+  if (filterType === "all") {
+    return true;
+  }
+
+  if (filterType === "upcoming" || filterType === "past") {
+    return getEventTimingStatus(event) === filterType;
+  }
+
+  return event.type === filterType;
+};

--- a/src/utils/eventTiming.test.js
+++ b/src/utils/eventTiming.test.js
@@ -1,0 +1,48 @@
+import {
+  getEventTimingStatus,
+  matchesEventTimingFilter,
+  parseEventDateTime,
+} from "./eventTiming";
+
+describe("eventTiming", () => {
+  const referenceDate = new Date(2026, 4, 17, 12, 0, 0);
+
+  it("parses 12-hour event times", () => {
+    const parsed = parseEventDateTime({
+      date: "2026-06-01",
+      time: "10:30 AM",
+    });
+
+    expect(parsed.getFullYear()).toBe(2026);
+    expect(parsed.getMonth()).toBe(5);
+    expect(parsed.getDate()).toBe(1);
+    expect(parsed.getHours()).toBe(10);
+    expect(parsed.getMinutes()).toBe(30);
+  });
+
+  it("derives upcoming status from a future date-time", () => {
+    const status = getEventTimingStatus(
+      { date: "2026-12-10", time: "9:00 AM", status: "past" },
+      referenceDate
+    );
+
+    expect(status).toBe("upcoming");
+  });
+
+  it("derives past status from an elapsed date-time", () => {
+    const status = getEventTimingStatus(
+      { date: "2026-01-01", time: "9:00 AM", status: "upcoming" },
+      referenceDate
+    );
+
+    expect(status).toBe("past");
+  });
+
+  it("filters events by derived timing instead of hardcoded status", () => {
+    const event = { date: "2026-12-10", time: "9:00 AM", status: "past", type: "summit" };
+
+    expect(matchesEventTimingFilter(event, "upcoming")).toBe(true);
+    expect(matchesEventTimingFilter(event, "past")).toBe(false);
+    expect(matchesEventTimingFilter(event, "summit")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Event list filtering no longer relies on hardcoded `status` labels. Upcoming/past tabs now compare each event's date and time against the current moment.

## Changes

- Added `src/utils/eventTiming.js` with date-time parsing and `getEventTimingStatus` / `matchesEventTimingFilter` helpers
- Wired dynamic filtering into `EventsPage` search/filter flow and `eventPaginationUtils.filterEventsByType`
- Added unit tests covering stale status labels (e.g. future event marked `past`)

Fixes #1105

## Test plan

- [ ] `npm test -- --watchAll=false src/utils/eventTiming.test.js` passes
- [ ] On `/events`, filter **Upcoming** — future-dated events appear even if mock `status` is `past`
- [ ] Filter **Past** — elapsed events appear even if mock `status` is `upcoming`