### PR TITLE
fix(theme): sync ThemeContext with documentElement dark class

### DIFF
--- a/src/components/common/ThemeToggleButton.js
+++ b/src/components/common/ThemeToggleButton.js
@@ -1,39 +1,27 @@
-import { useEffect, useState } from "react";
 import { FiSun, FiMoon } from "react-icons/fi";
 
-const ThemeToggleButton = () => {
-  const [darkMode, setDarkMode] = useState(
-    () => localStorage.getItem("theme") === "dark"
-  );
+import { useTheme } from "../../context/ThemeContext";
 
-  useEffect(() => {
-    const root = document.documentElement;
-    if (darkMode) {
-      root.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      root.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-  }, [darkMode]);
+const ThemeToggleButton = () => {
+  const { isDarkMode, toggleTheme } = useTheme();
 
   return (
     <button
+      type="button"
       className="flex items-center cursor-pointer select-none"
-      onClick={() => setDarkMode((prev) => !prev)}
+      onClick={toggleTheme}
+      aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
     >
-      <div
-        className={`w-12 h-6 rounded-full p-1 bg-gray-300 dark:bg-gray-700 relative`} // reduced size
-      >
+      <div className="w-12 h-6 rounded-full p-1 bg-gray-300 dark:bg-gray-700 relative">
         <div
           className={`w-5 h-5 bg-white rounded-full shadow-lg flex items-center justify-center
             transform transition-all duration-300 ease-in-out absolute top-0.5
-            ${darkMode ? "translate-x-6" : "translate-x-0"}`} // adjusted translation
+            ${isDarkMode ? "translate-x-6" : "translate-x-0"}`}
         >
-          {darkMode ? (
-            <FiSun className="text-yellow-500 text-sm" /> // smaller icon
+          {isDarkMode ? (
+            <FiSun className="text-yellow-500 text-sm" />
           ) : (
-            <FiMoon className="text-gray-700 text-sm" /> // smaller icon
+            <FiMoon className="text-gray-700 text-sm" />
           )}
         </div>
       </div>

--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -1,32 +1,64 @@
-import { createContext, useContext,useEffect,useState} from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 export const ThemeContext = createContext();
 
-export const ThemeProvider = ({ children }) => {
+const THEME_STORAGE_KEY = 'theme';
 
-  const [isDarkMode, setIsDarkMode] = useState(() => {
-    return localStorage.getItem('theme') === 'dark';
-  });
+const readStoredDarkPreference = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === 'dark') {
+    return true;
+  }
+  if (stored === 'light') {
+    return false;
+  }
+
+  return (
+    document.documentElement.classList.contains('dark')
+    || document.body.classList.contains('dark')
+  );
+};
+
+const applyThemeToDocument = (isDarkMode) => {
+  const root = document.documentElement;
+
+  if (isDarkMode) {
+    root.classList.add('dark');
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+  } else {
+    root.classList.remove('dark');
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
+  }
+
+  document.body.classList.remove('dark');
+};
+
+export const ThemeProvider = ({ children }) => {
+  const [isDarkMode, setIsDarkMode] = useState(readStoredDarkPreference);
 
   useEffect(() => {
-   const body = document.body; 
-    if (isDarkMode) {
-      body.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-    } else {
-      body.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
-    }
+    applyThemeToDocument(isDarkMode);
   }, [isDarkMode]);
 
   const toggleTheme = () => {
-    setIsDarkMode(prev => !prev);
+    setIsDarkMode((prev) => !prev);
   };
 
   return (
-    <ThemeContext.Provider value={{ theme: isDarkMode ? 'dark' : 'light', toggleTheme, isDarkMode }}>
+    <ThemeContext.Provider
+      value={{
+        theme: isDarkMode ? 'dark' : 'light',
+        toggleTheme,
+        isDarkMode,
+      }}
+    >
       {children}
     </ThemeContext.Provider>
   );
 };
+
 export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary

- Apply the `dark` class on `document.documentElement` (aligned with Tailwind and `index.css`)
- Initialize theme state from `localStorage` and any legacy `html`/`body` class
- Route `ThemeToggleButton` through `useTheme()` so UI and context stay in sync

Closes #856

## Test plan

- [ ] Toggle theme from navbar; `useTheme().theme` matches visible mode
- [ ] Reload with `localStorage.theme === 'dark'`; context and UI stay dark
- [ ] If `ThemeToggleButton` is used, toggle updates context (not local state only)