### PR TITLE
fix(theme): improve dark mode text contrast on key pages

### DIFF
--- a/src/Pages/About/DocumentationPage.js
+++ b/src/Pages/About/DocumentationPage.js
@@ -51,7 +51,7 @@ export default function DocumentationPage() {
       question: "What platforms does Eventra support?",
       answer:
         "Eventra is accessible on Web and Mobile platforms, ensuring you can check events anytime, anywhere.",
-      icon: <FiSmartphone className="w-6 h-6 text-black" />,
+      icon: <FiSmartphone className="w-6 h-6 text-gray-900 dark:text-gray-100" />,
     },
     {
       question: "How can I suggest an event or report an issue?",
@@ -63,7 +63,7 @@ export default function DocumentationPage() {
       question: "Can I create my own events on Eventra?",
       answer:
         "Yes! Eventra allows registered users to create and manage their own events, hackathons, or project showcases directly from the platform.",
-      icon: <FiPlusCircle className="w-6 h-6 text-black" />,
+      icon: <FiPlusCircle className="w-6 h-6 text-gray-900 dark:text-gray-100" />,
     },
     {
       question: "How do I stay updated about upcoming events?",
@@ -87,7 +87,7 @@ export default function DocumentationPage() {
 
   // UPDATED: Code block styles for dark mode
   const codeBlockClass =
-    "bg-gray-100 p-6 rounded-xl overflow-x-auto shadow text-black text-lg font-mono";
+    "bg-gray-100 dark:bg-gray-900 p-6 rounded-xl overflow-x-auto shadow text-gray-900 dark:text-gray-100 text-lg font-mono border border-gray-200 dark:border-gray-700";
   const [openIndex, setOpenIndex] = useState(null);
 
   const toggleFAQ = (index) => {
@@ -95,7 +95,7 @@ export default function DocumentationPage() {
   };
   return (
     // UPDATED: Main page background and text color
-    <div className="pastel-grid-bg min-h-screen bg-gray-100 text-black px-6 py-12 space-y-12">
+    <div className="pastel-grid-bg min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-6 py-12 space-y-12">
       {/* Header */}
       <header className="text-center max-w-4xl mx-auto">
         <motion.h1
@@ -105,7 +105,7 @@ export default function DocumentationPage() {
           data-aos="fade-down"
           data-aos-once="true"
           // UPDATED: Header text colors
-          className="text-5xl font-extrabold text-black mb-4"
+          className="text-5xl font-extrabold text-gray-900 dark:text-gray-100 mb-4"
           style={{ fontFamily: '"Anton", sans-serif' }}
         >
           Eventra Documentation
@@ -113,7 +113,7 @@ export default function DocumentationPage() {
         <motion.p
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="text-black text-xl"
+          className="text-gray-900 dark:text-gray-100 text-xl"
         >
           Modern Event Management Platform for Builders & Communities
         </motion.p>
@@ -122,7 +122,7 @@ export default function DocumentationPage() {
       {/* Features Section */}
       <motion.section
         // UPDATED: Card background
-        className="relative max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md overflow-hidden"
+        className="relative max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md overflow-hidden"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -133,11 +133,11 @@ export default function DocumentationPage() {
       >
         <div className="relative z-10">
         {/* UPDATED: Title icon and text colors */}
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiBookOpen className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">Features</h2>
         </div>
-        <div className="grid md:grid-cols-2 gap-6 text-black">
+        <div className="grid md:grid-cols-2 gap-6 text-gray-900 dark:text-gray-100">
           <div className="space-y-2">
             <h3 className="font-semibold text-xl">Core Features</h3>
             <ul className="list-disc list-inside space-y-1">
@@ -176,7 +176,7 @@ export default function DocumentationPage() {
       {/* Tech Stack Section */}
       <motion.section
         // UPDATED: Card background
-        className="max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md"
+        className="max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -186,11 +186,11 @@ export default function DocumentationPage() {
         data-aos-delay="100"
       >
         {/* UPDATED: Title icon and text colors */}
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiCpu className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">Tech Stack</h2>
         </div>
-        <div className="grid md:grid-cols-2 gap-6 text-black text-lg">
+        <div className="grid md:grid-cols-2 gap-6 text-gray-900 dark:text-gray-100 text-lg">
           <div>
             <h3 className="text-2xl font-semibold mb-3">Backend</h3>
             <ul className="list-disc list-inside space-y-1">
@@ -216,7 +216,7 @@ export default function DocumentationPage() {
       {/* Architecture Section */}
       <motion.section
         // UPDATED: Card background
-        className="max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md"
+        className="max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -226,7 +226,7 @@ export default function DocumentationPage() {
         data-aos-delay="200"
       >
         {/* UPDATED: Title icon and text colors */}
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiLayers className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">Architecture</h2>
         </div>
@@ -327,7 +327,7 @@ export default function DocumentationPage() {
       {/* Quick Start Section */}
       <motion.section
         // UPDATED: Card background
-        className="max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md"
+        className="max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -337,11 +337,11 @@ export default function DocumentationPage() {
         data-aos-delay="300"
       >
         {/* UPDATED: Title icon and text colors */}
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiPlay className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">Quick Start</h2>
         </div>
-        <p className="text-black text-lg mb-3">
+        <p className="text-gray-900 dark:text-gray-100 text-lg mb-3">
           <strong>Prerequisites:</strong> Node.js 16+, npm/yarn, Git
         </p>
         <pre className={codeBlockClass}>
@@ -354,7 +354,7 @@ npm start`}
 
       {/* Deployment Section */}
       <motion.section
-        className="max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md"
+        className="max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -363,11 +363,11 @@ npm start`}
         data-aos="fade-up"
         data-aos-delay="400"
       >
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiGitBranch className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">Deployment</h2>
         </div>
-        <ul className="list-disc list-inside text-black text-lg space-y-1">
+        <ul className="list-disc list-inside text-gray-900 dark:text-gray-100 text-lg space-y-1">
           <li>Frontend: Hosted on Vercel</li>
           <li>Backend: Spring Boot deployment on Azure or preferred host</li>
         </ul>
@@ -375,7 +375,7 @@ npm start`}
 
       {/* License Section */}
       <motion.section
-        className="max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md"
+        className="max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -384,18 +384,18 @@ npm start`}
         data-aos="fade-up"
         data-aos-delay="500"
       >
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiCode className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">License</h2>
         </div>
-        <p className="text-black text-lg">
+        <p className="text-gray-900 dark:text-gray-100 text-lg">
           Apache License 2.0 - see the LICENSE file for details.
         </p>
       </motion.section>
 
       {/* Contributing Section */}
       <motion.section
-        className="max-w-5xl mx-auto bg-white p-8 rounded-2xl shadow-md"
+        className="max-w-5xl mx-auto bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-md"
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true }}
@@ -404,21 +404,21 @@ npm start`}
         data-aos="fade-up"
         data-aos-delay="600"
       >
-        <div className="flex items-center mb-6 text-black">
+        <div className="flex items-center mb-6 text-gray-900 dark:text-gray-100">
           <FiUsers className="mr-3 text-3xl" />
           <h2 className="text-3xl font-bold">Contributing</h2>
         </div>
-        <ol className="list-decimal list-inside space-y-2 text-black text-lg">
+        <ol className="list-decimal list-inside space-y-2 text-gray-900 dark:text-gray-100 text-lg">
           <li>Fork the repository</li>
           <li>
             Create a feature branch:{" "}
-            <code className="bg-gray-100 px-2 py-1 rounded">
+            <code className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
               git checkout -b feature/your-feature
             </code>
           </li>
           <li>
             Commit changes:{" "}
-            <code className="bg-gray-100 px-2 py-1 rounded">
+            <code className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded">
               git commit -m "Add feature"
             </code>
           </li>
@@ -428,19 +428,19 @@ npm start`}
 
       {/* FAQ Section */}
       <section 
-        className="max-w-5xl mx-auto p-6 bg-gray-50 rounded-2xl shadow-lg"
+        className="max-w-5xl mx-auto p-6 bg-gray-50 dark:bg-gray-800/60 rounded-2xl shadow-lg"
         // AOS Implementation
         data-aos="fade-up"
         data-aos-delay="700"
       >
-        <h2 className="text-3xl font-bold mb-10 text-center text-black">
+        <h2 className="text-3xl font-bold mb-10 text-center text-gray-900 dark:text-gray-100">
           Frequently Asked Questions
         </h2>
         <div className="space-y-6">
           {faqs.map((faq, index) => (
             <div
               key={index}
-              className="bg-white rounded-xl shadow p-4 cursor-pointer hover:shadow-lg transition-shadow duration-200"
+              className="bg-white dark:bg-gray-800 rounded-xl shadow p-4 cursor-pointer hover:shadow-lg transition-shadow duration-200"
               onClick={() => toggleFAQ(index)}
               data-aos="zoom-in-up"
               data-aos-delay={750 + index * 50}
@@ -448,14 +448,14 @@ npm start`}
               <div className="flex justify-between items-center">
                 <div className="flex items-center space-x-6">
                   {faq.icon}
-                  <h3 className="text-lg font-semibold text-black">
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                     {faq.question}
                   </h3>
                 </div>
                 {openIndex === index ? (
-                  <ChevronUp className="w-5 h-5 text-black" />
+                  <ChevronUp className="w-5 h-5 text-gray-900 dark:text-gray-100" />
                 ) : (
-                  <ChevronDown className="w-5 h-5 text-black" />
+                  <ChevronDown className="w-5 h-5 text-gray-900 dark:text-gray-100" />
                 )}
               </div>
               <AnimatePresence>
@@ -465,7 +465,7 @@ npm start`}
                     animate={{ opacity: 1, height: "auto" }}
                     exit={{ opacity: 0, height: 0 }}
                     transition={{ duration: 0.3 }}
-                    className="mt-2 text-black whitespace-pre-line"
+                    className="mt-2 text-gray-900 dark:text-gray-100 whitespace-pre-line"
                   >
                     {faq.answer}
                   </motion.div>
@@ -478,19 +478,19 @@ npm start`}
 
       {/* UPDATED: Footer text, border, and link colors */}
       <footer 
-        className="text-center text-black mt-24 border-t border-gray-300 pt-8 pb-6"
+        className="text-center text-gray-900 dark:text-gray-100 mt-24 border-t border-gray-300 dark:border-gray-700 pt-8 pb-6"
         data-aos="fade-up"
         data-aos-offset="50"
       >
-        <p className="text-black text-lg font-medium">
-          Built with <span className="text-black">❤️</span> by the Eventra
+        <p className="text-gray-900 dark:text-gray-100 text-lg font-medium">
+          Built with <span className="text-gray-900 dark:text-gray-100">❤️</span> by the Eventra
           Team.
         </p>
-        <p className="mt-2 text-black text-base">
+        <p className="mt-2 text-gray-900 dark:text-gray-100 text-base">
           Visit{" "}
           <a
             href="https://eventra-psi.vercel.app/"
-            className="text-black font-semibold underline hover:text-zinc-700 transition-colors"
+            className="text-gray-900 dark:text-gray-100 font-semibold underline hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
           >
             Live Demo
           </a>

--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -198,8 +198,8 @@ export default function ModernAbout() {
             data-aos-delay="300"
           >
             {/* UPDATED: Card text */}
-            <h3 className="text-black text-2xl font-bold mb-2">100+</h3>
-            <p className="text-black text-sm">Events Managed</p>
+            <h3 className="text-black dark:text-white text-2xl font-bold mb-2">100+</h3>
+            <p className="text-black dark:text-gray-300 text-sm">Events Managed</p>
           </motion.div>
           {stats.map((s) => (
             <motion.div key={s.label} variants={scaleIn} whileHover={prefersReducedMotion ? {} : { scale: 1.05, y: -4 }} transition={{ type: "spring", stiffness: 300, damping: 20 }} className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-2xl shadow-lg shadow-blue-100 dark:shadow-indigo-900/50 p-4 sm:p-5 cursor-default">

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -152,7 +152,7 @@ const EventRegistration = () => {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-900">
-        <Loader2 className="w-8 h-8 animate-spin text-black" />
+        <Loader2 className="w-8 h-8 animate-spin text-black dark:text-white" />
       </div>
     );
   }

--- a/src/Pages/HelpCenter.js
+++ b/src/Pages/HelpCenter.js
@@ -544,7 +544,7 @@ const HelpCenter = () => {
 
               <div className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                 <span
-                  className="text-xs font-bold text-black"
+                  className="text-xs font-bold text-black dark:text-white"
                 >
                   {String(idx + 1).padStart(2, "0")}
                 </span>

--- a/src/Pages/Privacy.js
+++ b/src/Pages/Privacy.js
@@ -227,13 +227,13 @@ export const Privacy = () => {
           variants={container}
           initial="hidden"
           animate={controls}
-          className="bg-white rounded-2xl p-8 text-center relative overflow-hidden shadow-md border border-gray-200"
+          className="bg-white dark:bg-gray-800 rounded-2xl p-8 text-center relative overflow-hidden shadow-md border border-gray-200 dark:border-gray-700"
         >
           <div className="relative z-10">
-            <h3 className="text-2xl font-bold text-black mb-4">
+            <h3 className="text-2xl font-bold text-black dark:text-white mb-4">
               Have Questions?
             </h3>
-            <p className="text-black mb-6">
+            <p className="text-black dark:text-gray-200 mb-6">
               If you have any questions or concerns about this policy, we're
               here to help.
             </p>

--- a/src/Pages/Projects/SubmitProject.js
+++ b/src/Pages/Projects/SubmitProject.js
@@ -467,8 +467,8 @@ const SubmitProject = () => {
             data-aos="zoom-in"
             data-aos-delay={1500 + index * 100}
           >
-            <stat.icon className="w-10 h-10 text-black mb-3" />
-            <h3 className="text-3xl font-bold text-black">
+            <stat.icon className="w-10 h-10 text-black dark:text-white mb-3" />
+            <h3 className="text-3xl font-bold text-black dark:text-white">
               {stat.number}
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mt-2">
@@ -501,7 +501,7 @@ const SubmitProject = () => {
             href="#"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            className="inline-flex items-center justify-center gap-2 bg-white text-black px-8 py-3 rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-300"
+            className="inline-flex items-center justify-center gap-2 bg-white dark:bg-gray-800 text-black dark:text-white px-8 py-3 rounded-xl shadow-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-300"
           >
             <ArrowUpTrayIcon className="w-5 h-5" /> Submit Another Project
           </motion.a>
@@ -509,7 +509,7 @@ const SubmitProject = () => {
             href="/projects"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
-            className="inline-flex items-center justify-center gap-2 bg-white text-black px-8 py-3 rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-300"
+            className="inline-flex items-center justify-center gap-2 bg-white dark:bg-gray-800 text-black dark:text-white px-8 py-3 rounded-xl shadow-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-300"
           >
             <ClipboardDocumentCheckIcon className="w-5 h-5" />
             Explore Projects

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -323,7 +323,7 @@ const Footer = () => {
               data-aos-delay="0"
             >
               <h2
-                className="text-2xl sm:text-3xl font-bold text-black"
+                className="text-2xl sm:text-3xl font-bold text-black dark:text-white"
                 style={{ fontFamily: "Anton, sans-serif" }}
               >
                 Eventra


### PR DESCRIPTION
## Summary

- **DocumentationPage**: page background, section cards, code blocks, FAQ, and footer links now use `dark:` text/background classes
- **Privacy**: contact CTA card readable in dark mode
- **Footer / HelpCenter / SubmitProject / EventRegistration**: remaining hardcoded `text-black` without dark variants

Closes #954

## Test plan

- [ ] Toggle dark mode on `/documentation` — body text and cards readable
- [ ] Privacy page contact section readable in dark mode
- [ ] About hero stats card (100+ Events) readable in dark mode