### PR TITLE
fix(ui): keep fluid cursor behind content when zoomed

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { BrowserRouter as Router } from "react-router-dom";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import "./App.css";
 
 // --------------- LAYOUT
@@ -45,22 +45,24 @@ function App() {
       <NotificationProvider />
       <AuthProvider>
         <Router>
-          <div className="App">
-            <Navbar
-              cursorEnabled={cursorEnabled}
-              toggleCursor={toggleCursor}
-            />
-
-            <main className="min-h-screen bg-white dark:bg-black ">
-              <AppRoutes />
-            </main>
-
-            <ScrollToTop />
-            <Chatbot />
-            <FeedbackButton />
-            <Footer />
-
+          <div className="App relative">
             <FluidCursor enabled={cursorEnabled} />
+
+            <div className="relative z-10">
+              <Navbar
+                cursorEnabled={cursorEnabled}
+                toggleCursor={toggleCursor}
+              />
+
+              <main className="min-h-screen bg-white dark:bg-black ">
+                <AppRoutes />
+              </main>
+
+              <ScrollToTop />
+              <Chatbot />
+              <FeedbackButton />
+              <Footer />
+            </div>
           </div>
         </Router>
       </AuthProvider>

--- a/src/jhalak/FluidCursor.js
+++ b/src/jhalak/FluidCursor.js
@@ -1,10 +1,14 @@
 'use client';
 import React, { useEffect, useRef } from 'react';
 
-const FluidCursor = () => {
+const FluidCursor = ({ enabled = true }) => {
   const canvasRef = useRef(null);
 
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
     const canvas = canvasRef.current;
     if (!canvas) return;
 
@@ -854,10 +858,14 @@ const FluidCursor = () => {
       dye.swap();
     }
 
+    function getBrowserZoomScale() {
+      return window.visualViewport?.scale ?? 1;
+    }
+
     function correctRadius(radius) {
       let aspectRatio = canvas.width / canvas.height;
       if (aspectRatio > 1) radius *= aspectRatio;
-      return radius;
+      return radius / getBrowserZoomScale();
     }
 
     function hashCode(s) {
@@ -1007,7 +1015,16 @@ const FluidCursor = () => {
 
     update();
 
+    const handleViewportChange = () => {
+      resizeCanvas();
+    };
+
+    window.visualViewport?.addEventListener('resize', handleViewportChange);
+    window.visualViewport?.addEventListener('scroll', handleViewportChange);
+
     return () => {
+      window.visualViewport?.removeEventListener('resize', handleViewportChange);
+      window.visualViewport?.removeEventListener('scroll', handleViewportChange);
       window.removeEventListener('mousedown', handleMouseDown);
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('touchstart', handleTouchStart);
@@ -1017,11 +1034,15 @@ const FluidCursor = () => {
         cancelAnimationFrame(animationFrameId);
       }
     };
-  }, []);
+  }, [enabled]);
+
+  if (!enabled) {
+    return null;
+  }
 
   return (
-    <div className='fixed top-0 left-0 z-[9999] pointer-events-none'>
-      <canvas ref={canvasRef} id='fluid' className='w-screen h-screen' />
+    <div className="fixed inset-0 z-0 pointer-events-none" aria-hidden="true">
+      <canvas ref={canvasRef} id="fluid" className="h-full w-full" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Place `FluidCursor` at `z-0` and wrap page chrome in `relative z-10` so FAQ/Contact/footer stay above the effect
- Scale splat radius by `visualViewport.scale` so the trail does not balloon when browser zoom > 90%
- Honor the `enabled` prop (skip WebGL when off)

Closes #849

## Test plan

- [ ] Zoom Chrome to 110%+ and hover FAQ/Contact in footer — links remain readable and clickable
- [ ] Toggle fluid cursor off — effect removed
- [ ] Normal zoom — cursor effect still visible behind content