### PR TITLE
feat(perf): route-level code splitting with React.lazy

### DIFF
--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -1,16 +1,18 @@
-import React from 'react';
+import { Suspense } from 'react';
 import { Routes } from 'react-router-dom';
+
+import RouteLoadingFallback from './common/RouteLoadingFallback';
 import { getPublicRoutes } from './routes/PublicRoutes';
 import { getProtectedRoutes, getAuthRoutes } from './routes/ProtectedRoutes';
 
-const AppRoutes = () => {
-  return (
+const AppRoutes = () => (
+  <Suspense fallback={<RouteLoadingFallback />}>
     <Routes>
       {getPublicRoutes()}
       {getProtectedRoutes()}
       {getAuthRoutes()}
     </Routes>
-  );
-};
+  </Suspense>
+);
 
 export default AppRoutes;

--- a/src/components/common/RouteLoadingFallback.jsx
+++ b/src/components/common/RouteLoadingFallback.jsx
@@ -1,0 +1,14 @@
+import { EventCardSkeleton } from "./SkeletonLoaders";
+
+const RouteLoadingFallback = () => (
+  <div
+    className="mx-auto flex min-h-[50vh] max-w-4xl items-center justify-center px-4 py-12"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading page"
+  >
+    <EventCardSkeleton />
+  </div>
+);
+
+export default RouteLoadingFallback;

--- a/src/components/routes/ProtectedRoutes.js
+++ b/src/components/routes/ProtectedRoutes.js
@@ -1,26 +1,26 @@
-import React from 'react';
+import { lazy } from 'react';
 import { Route } from 'react-router-dom';
 
-// --------------- COMPONENTS
-import ProtectedRoute from "../auth/ProtectedRoute";
-import EventCreation from "../common/EventCreation";
-import AdminDashboard from "../admin/AdminDashboard";
-import HostHackathon from "../../Pages/Hackathons/HostHackathon";
-import Dashboard from "../Dashboard";
-import EditProfile from "../user/EditProfile";
-import Settings from "../../Pages/Settings";
-import Login from "../auth/Login";
-import Signup from "../auth/Signup";
-import Unauthorized from "../auth/Unauthorized";
-import PasswordReset from "../auth/PasswordReset";
-import NotFound from "../NotFound";
+import ProtectedRoute from '../auth/ProtectedRoute';
+
+const EventCreation = lazy(() => import('../common/EventCreation'));
+const AdminDashboard = lazy(() => import('../admin/AdminDashboard'));
+const HostHackathon = lazy(() => import('../../Pages/Hackathons/HostHackathon'));
+const Dashboard = lazy(() => import('../Dashboard'));
+const EditProfile = lazy(() => import('../user/EditProfile'));
+const Settings = lazy(() => import('../../Pages/Settings'));
+const Login = lazy(() => import('../auth/Login'));
+const Signup = lazy(() => import('../auth/Signup'));
+const Unauthorized = lazy(() => import('../auth/Unauthorized'));
+const PasswordReset = lazy(() => import('../auth/PasswordReset'));
+const NotFound = lazy(() => import('../NotFound'));
 
 export const getProtectedRoutes = () => [
   <Route
     key="/create-event"
     path="/create-event"
     element={
-      <ProtectedRoute requiredPermissions={["CREATE_EVENT"]}>
+      <ProtectedRoute requiredPermissions={['CREATE_EVENT']}>
         <EventCreation />
       </ProtectedRoute>
     }
@@ -29,7 +29,7 @@ export const getProtectedRoutes = () => [
     key="/admin"
     path="/admin"
     element={
-      <ProtectedRoute requiredRoles={["ADMIN"]}>
+      <ProtectedRoute requiredRoles={['ADMIN']}>
         <AdminDashboard />
       </ProtectedRoute>
     }
@@ -38,7 +38,7 @@ export const getProtectedRoutes = () => [
     key="/host-hackathon"
     path="/host-hackathon"
     element={
-      <ProtectedRoute requiredPermissions={["HOST_HACKATHON"]}>
+      <ProtectedRoute requiredPermissions={['HOST_HACKATHON']}>
         <HostHackathon />
       </ProtectedRoute>
     }

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -1,28 +1,32 @@
-import React from 'react';
+import { lazy } from 'react';
 import { Route } from 'react-router-dom';
-import PageLayout from '../Layout/PageLayout';
 
-// --------------- PAGES
-import HomePage from "../../Pages/Home/HomePage";
-import EventsPage from "../../Pages/Events/EventsPage";
-import EventRegistration from "../../Pages/Events/EventRegistration";
-import HackathonPage from "../../Pages/Hackathons/HackathonPage";
-import ProjectsPage from "../../Pages/Projects/ProjectsPage";
-import Contributors from "../Contributors";
-import CommunityEvent from "../CommunityEvent";
-import LeaderBoard from "../../Pages/Leaderboard/Leaderboard";
-import ContributorGuide from "../../Pages/Leaderboard/ContributorGuide";
-import AboutPage from "../../Pages/About/AboutPage";
-import FAQPage from "../../Pages/FAQ/FAQPage";
-import Terms from "../../Pages/Terms";
-import { Privacy } from "../../Pages/Privacy";
-import ApiDocs from "../../Pages/ApiDocs";
-import HelpCenter from "../../Pages/HelpCenter";
-import ContactUs from "../../Pages/Contact/ContactUs";
-import FeedbackPage from "../../Pages/Feedback/FeedbackPage";
-import EventAnalyticsDashboard from "../../Pages/Events/EventAnalyticsDashboard";
-import DocumentationPage from "../../Pages/About/DocumentationPage";
-import SubmitProject from "../../Pages/Projects/SubmitProject";
+import PageLayout from '../Layout/PageLayout';
+import HomePage from '../../Pages/Home/HomePage';
+
+const EventsPage = lazy(() => import('../../Pages/Events/EventsPage'));
+const EventRegistration = lazy(() => import('../../Pages/Events/EventRegistration'));
+const HackathonPage = lazy(() => import('../../Pages/Hackathons/HackathonPage'));
+const ProjectsPage = lazy(() => import('../../Pages/Projects/ProjectsPage'));
+const Contributors = lazy(() => import('../Contributors'));
+const CommunityEvent = lazy(() => import('../CommunityEvent'));
+const LeaderBoard = lazy(() => import('../../Pages/Leaderboard/Leaderboard'));
+const ContributorGuide = lazy(() => import('../../Pages/Leaderboard/ContributorGuide'));
+const AboutPage = lazy(() => import('../../Pages/About/AboutPage'));
+const FAQPage = lazy(() => import('../../Pages/FAQ/FAQPage'));
+const Terms = lazy(() => import('../../Pages/Terms'));
+const Privacy = lazy(() =>
+  import('../../Pages/Privacy').then((module) => ({ default: module.Privacy }))
+);
+const ApiDocs = lazy(() => import('../../Pages/ApiDocs'));
+const HelpCenter = lazy(() => import('../../Pages/HelpCenter'));
+const ContactUs = lazy(() => import('../../Pages/Contact/ContactUs'));
+const FeedbackPage = lazy(() => import('../../Pages/Feedback/FeedbackPage'));
+const EventAnalyticsDashboard = lazy(() =>
+  import('../../Pages/Events/EventAnalyticsDashboard')
+);
+const DocumentationPage = lazy(() => import('../../Pages/About/DocumentationPage'));
+const SubmitProject = lazy(() => import('../../Pages/Projects/SubmitProject'));
 
 export const getPublicRoutes = () => [
   <Route key="/" path="/" element={<HomePage />} />,
@@ -46,5 +50,5 @@ export const getPublicRoutes = () => [
     <Route key="/analytics" path="/analytics" element={<EventAnalyticsDashboard />} />
     <Route key="/documentation" path="/documentation" element={<DocumentationPage />} />
     <Route key="/submit-project" path="/submit-project" element={<SubmitProject />} />
-  </Route>
+  </Route>,
 ];


### PR DESCRIPTION
## Summary

- Lazy-load public, protected, and auth route pages via `React.lazy()` in route modules
- Keep `HomePage` eagerly loaded to preserve first-visit FCP
- Wrap `<Routes>` in `<Suspense>` with `RouteLoadingFallback` (`EventCardSkeleton`)

Closes #942

## Test plan

- [ ] Load `/` — homepage renders without suspense flash on first paint
- [ ] Navigate to `/events`, `/admin`, `/login` — page loads after brief skeleton fallback
- [ ] Production build shows separate async chunks per route (network tab)