### PR TITLE
fix(a11y): accessible navbar controls and shared Button

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,26 @@
+const variantClasses = {
+  primary:
+    'inline-flex items-center justify-center gap-2 rounded-lg bg-black px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-white dark:text-black dark:hover:bg-zinc-200 dark:focus-visible:ring-offset-gray-900',
+  secondary:
+    'inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-800 transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-offset-gray-900',
+  ghost:
+    'inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:text-gray-200 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900',
+};
+
+const Button = ({
+  variant = 'primary',
+  type = 'button',
+  className = '',
+  children,
+  ...props
+}) => (
+  <button
+    type={type}
+    className={`${variantClasses[variant] ?? variantClasses.primary} ${className}`.trim()}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+export default Button;

--- a/src/components/navbar/AuthButtons.jsx
+++ b/src/components/navbar/AuthButtons.jsx
@@ -6,14 +6,14 @@ const AuthButtons = () => {
     <div className="flex items-center gap-3">
       <Link
         to="/login"
-        className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-black dark:text-gray-300 dark:hover:text-white transition-colors whitespace-nowrap"
+        className="rounded-lg px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:text-gray-300 dark:hover:text-white dark:focus-visible:ring-offset-gray-900 whitespace-nowrap"
       >
         Sign In
       </Link>
 
       <Link
         to="/signup"
-        className="px-4 py-2 bg-black text-white rounded-lg text-sm font-semibold hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-zinc-200 transition-colors whitespace-nowrap"
+        className="rounded-lg px-4 py-2 bg-black text-sm font-semibold text-white transition-colors hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:bg-white dark:text-black dark:hover:bg-zinc-200 dark:focus-visible:ring-offset-gray-900 whitespace-nowrap"
       >
         Get Started
       </Link>

--- a/src/components/navbar/CursorToggle.jsx
+++ b/src/components/navbar/CursorToggle.jsx
@@ -1,15 +1,17 @@
-import React from "react";
-import { MousePointer } from "lucide-react";
+import { MousePointer } from 'lucide-react';
 
-const CursorToggle = ({ cursorEnabled, toggleCursor }) => {
-  return (
-    <button
-      onClick={toggleCursor}
-      className="px-3 py-2 rounded-lg bg-black text-white dark:bg-white dark:text-black"
-    >
-      <MousePointer />
-    </button>
-  );
-};
+import Button from '../common/Button';
+
+const CursorToggle = ({ cursorEnabled, toggleCursor }) => (
+  <Button
+    variant="primary"
+    onClick={toggleCursor}
+    aria-label={cursorEnabled ? 'Turn fluid cursor off' : 'Turn fluid cursor on'}
+    aria-pressed={cursorEnabled}
+    title={cursorEnabled ? 'Turn fluid cursor off' : 'Turn fluid cursor on'}
+  >
+    <MousePointer aria-hidden="true" />
+  </Button>
+);
 
 export default CursorToggle;

--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -1,22 +1,34 @@
-import React from "react";
-import NavbarLinks from "./NavbarLinks";
+import NavbarLinks from './NavbarLinks';
 
 const MobileDrawer = ({ isOpen, closeMenu }) => {
+  if (!isOpen) {
+    return null;
+  }
+
   return (
     <div
-      className={`fixed top-0 right-0 h-screen w-[85%] bg-white dark:bg-gray-900 z-50 transition-transform duration-300 ${
-        isOpen ? "translate-x-0" : "translate-x-full"
-      }`}
+      id="mobile-navigation-drawer"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Navigation menu"
+      className="fixed top-0 right-0 z-50 h-screen w-[85%] translate-x-0 bg-white shadow-xl transition-transform duration-300 dark:bg-gray-900"
     >
-      <div className="p-4 flex justify-between items-center border-b">
-        <h2 className="text-2xl font-bold">Eventra</h2>
+      <div className="flex items-center justify-between border-b p-4 dark:border-gray-700">
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Eventra</h2>
 
-        <button onClick={closeMenu}>X</button>
+        <button
+          type="button"
+          className="rounded-lg px-3 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:text-gray-200 dark:hover:bg-gray-800"
+          onClick={closeMenu}
+          aria-label="Close navigation menu"
+        >
+          Close
+        </button>
       </div>
 
-      <div className="p-4">
+      <nav className="p-4" aria-label="Mobile">
         <NavbarLinks />
-      </div>
+      </nav>
     </div>
   );
 };

--- a/src/components/navbar/MobileNavbar.jsx
+++ b/src/components/navbar/MobileNavbar.jsx
@@ -1,22 +1,23 @@
-import React from "react";
-import MobileDrawer from "./MobileDrawer";
+import MobileDrawer from './MobileDrawer';
 
-const MobileNavbar = ({ isOpen, setIsOpen }) => {
-  return (
-    <>
-      <button
-        onClick={() => setIsOpen(true)}
-        className="lg:hidden"
-      >
-        ☰
-      </button>
+const MobileNavbar = ({ isOpen, setIsOpen }) => (
+  <>
+    <button
+      type="button"
+      className="rounded-lg p-2 text-2xl leading-none text-gray-800 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-900 lg:hidden"
+      onClick={() => setIsOpen(true)}
+      aria-label="Open navigation menu"
+      aria-expanded={isOpen}
+      aria-controls="mobile-navigation-drawer"
+    >
+      <span aria-hidden="true">☰</span>
+    </button>
 
-      <MobileDrawer
-        isOpen={isOpen}
-        closeMenu={() => setIsOpen(false)}
-      />
-    </>
-  );
-};
+    <MobileDrawer
+      isOpen={isOpen}
+      closeMenu={() => setIsOpen(false)}
+    />
+  </>
+);
 
 export default MobileNavbar;

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -25,6 +25,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
     <>
       <nav
         ref={navRef}
+        aria-label="Main navigation"
         className="fixed top-0 left-0 w-full h-20 bg-white dark:bg-gray-900 border-b z-50"
       >
         <div className="h-full px-6 flex items-center justify-between">

--- a/src/components/navbar/ThemeToggle.jsx
+++ b/src/components/navbar/ThemeToggle.jsx
@@ -1,15 +1,17 @@
-import React from "react";
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun } from 'lucide-react';
 
-const ThemeToggle = ({ isDarkMode, toggleTheme }) => {
-  return (
-    <button
-      onClick={toggleTheme}
-      className="px-3 py-2 rounded-lg bg-black text-white dark:bg-white dark:text-black"
-    >
-      {isDarkMode ? <Sun /> : <Moon />}
-    </button>
-  );
-};
+import Button from '../common/Button';
+
+const ThemeToggle = ({ isDarkMode, toggleTheme }) => (
+  <Button
+    variant="primary"
+    onClick={toggleTheme}
+    aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+    aria-pressed={isDarkMode}
+    title={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+  >
+    {isDarkMode ? <Sun aria-hidden="true" /> : <Moon aria-hidden="true" />}
+  </Button>
+);
 
 export default ThemeToggle;


### PR DESCRIPTION
## Summary

- Add `Button` component with `primary` / `secondary` / `ghost` variants and consistent `focus-visible` rings (toward #842)
- Theme and cursor toggles: `aria-label`, `aria-pressed`, decorative icons marked `aria-hidden`
- Mobile menu: `aria-expanded`, `aria-controls`, drawer uses `role="dialog"` + `aria-modal`
- Main `<nav>` and auth links: labels and keyboard focus styles

Closes #843

## Test plan

- [ ] Tab through navbar on desktop — visible focus rings on toggles and auth links
- [ ] Screen reader: theme/cursor toggles announce state
- [ ] Mobile: open/close menu; drawer is announced as dialog; close button works