### PR TITLE
fix: persist notification and privacy settings to localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "lucide-react": "^0.542.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^5.5.0",
+        "react-icons": "^5.6.0",
         "react-intersection-observer": "^9.4.1",
         "react-router-dom": "^6.8.0",
         "react-scripts": "^5.0.1",
@@ -16307,23 +16307,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^5.5.0",
+    "react-icons": "^5.6.0",
     "react-intersection-observer": "^9.4.1",
     "react-router-dom": "^6.8.0",
     "react-scripts": "^5.0.1",

--- a/src/Pages/Settings.js
+++ b/src/Pages/Settings.js
@@ -6,8 +6,12 @@ import { Sun, Moon, MousePointer, Bell, ShieldCheck, ArrowRight } from "lucide-r
 const Settings = () => {
   const { isDarkMode, toggleTheme } = useTheme();
   const [cursorEnabled, setCursorEnabled] = useState(true);
-  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
-  const [privacyMode, setPrivacyMode] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(
+    () => localStorage.getItem("notifications") !== "false"
+  );
+  const [privacyMode, setPrivacyMode] = useState(
+    () => localStorage.getItem("privacyMode") === "true"
+  );
 
   useEffect(() => {
     const storedCursor = localStorage.getItem("cursor");
@@ -78,7 +82,11 @@ const Settings = () => {
             <div className="space-y-3">
               <button
                 type="button"
-                onClick={() => setNotificationsEnabled((prev) => !prev)}
+                onClick={() => {
+                const next = !notificationsEnabled;
+                setNotificationsEnabled(next);
+                localStorage.setItem("notifications", next.toString());
+              }}
                 className="w-full inline-flex items-center justify-between rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-950 px-4 py-3 text-left text-sm font-medium text-slate-800 dark:text-slate-100 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-slate-900 transition"
               >
                 <span className="flex items-center gap-3">
@@ -104,7 +112,11 @@ const Settings = () => {
             <div className="space-y-3">
               <button
                 type="button"
-                onClick={() => setPrivacyMode((prev) => !prev)}
+                onClick={() => {
+                const next = !privacyMode;
+                setPrivacyMode(next);
+                localStorage.setItem("privacyMode", next.toString());
+              }}
                 className="w-full inline-flex items-center justify-between rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-950 px-4 py-3 text-left text-sm font-medium text-slate-800 dark:text-slate-100 hover:border-indigo-400 hover:bg-indigo-50 dark:hover:bg-slate-900 transition"
               >
                 <span className="flex items-center gap-3">


### PR DESCRIPTION
Closes #1126

The Notification and Privacy toggles in the Settings page were resetting to their default values on every page refresh. Users 
had no way to persist their preferences between sessions, making the settings feel broken and unreliable.

- Notification toggle now reads initial state from localStorage
- Notification toggle now saves state to localStorage on change
- Privacy Mode toggle now reads initial state from localStorage
- Privacy Mode toggle now saves state to localStorage on change
- Applied the same localStorage pattern already used by the 
  existing Fluid Cursor toggle in the same file

Manually tested:
1. Go to Settings page
2. Toggle Notifications to disabled
3. Toggle Privacy Mode to enabled
4. Refresh the page
5. Both settings correctly persist ✅

Yes - users can now save their notification and privacy preferences and they will persist across page refreshes and browser sessions.