### PR TITLE
feat(dx): add cross-platform git merge driver registration for package-lock.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto-resolve conflicts in package-lock.json using the custom merge driver
+package-lock.json merge=ours-then-install

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "build": "react-scripts build",
     "build:fast": "set \"GENERATE_SOURCEMAP=false\" && set \"DISABLE_ESLINT_PLUGIN=true\" && set \"NODE_OPTIONS=--no-deprecation --max-old-space-size=4096\" && react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "prepare": "node scripts/setup-git-config.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/setup-git-config.js
+++ b/scripts/setup-git-config.js
@@ -1,0 +1,34 @@
+// scripts/setup-git-config.js
+//
+// Registers the custom `ours-then-install` merge driver for package-lock.json.
+// This driver:
+//   1. Accepts the incoming (theirs) version of the lockfile — avoiding
+//      hundreds of conflict markers — then
+//   2. Runs `npm install` to reconcile the result so node_modules stays consistent.
+//
+// This script is called automatically by the `prepare` hook in package.json
+// and is fully cross-platform (Windows, macOS, Linux).
+
+const { execSync } = require("child_process");
+
+console.log("🔧  Registering package-lock.json merge driver...");
+
+try {
+  // 1. Register the name of the driver
+  execSync(
+    'git config merge.ours-then-install.name "Accept incoming lockfile, then run npm install"',
+    { stdio: "inherit" }
+  );
+
+  // 2. Register the driver command (%O = base, %A = ours, %B = theirs)
+  // Git always wraps this command in a sh-like context internally, so 'cp' works on all platforms.
+  execSync(
+    'git config merge.ours-then-install.driver "cp %B %A && npm install"',
+    { stdio: "inherit" }
+  );
+
+  console.log("✅  Done. Git will now resolve package-lock.json conflicts automatically.");
+} catch (error) {
+  console.error("❌  Failed to register git merge driver:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
### 🚀 Pull Request Overview
This PR adds a highly useful Developer Experience (DX) feature to automatically resolve git conflicts in `package-lock.json` using a custom cross-platform git merge driver.

### 🛠️ Changes Implemented
1. **`.gitattributes`:** Configured the root git attributes to bind `package-lock.json` to a custom `ours-then-install` merge driver.
2. **`scripts/setup-git-config.js`:** Created a robust, cross-platform Node.js script using Node's `child_process` API to register the merge driver command (`git config merge.ours-then-install.driver "cp %B %A && npm install"`).
3. **`package.json`:** Added the `"prepare": "node scripts/setup-git-config.js"` hook so the driver is registered automatically when contributors run `npm install`.

This is fully compatible with Windows (CMD/PowerShell), macOS, and Linux.

### 🔗 Linked Issues
* Closes #1118
