### PR TITLE
fix: make homepage search results clickable

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -46,10 +46,11 @@ const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
 
 const EventsPage = () => {
   useDocumentTitle("Eventra | Events")
+  const initialSearchQuery = new URLSearchParams(window.location.search).get("search") || "";
   const [events, setEvents] = useState([]);
   const [filterType, setFilterType] = useState("all");
   const [viewMode, setViewMode] = useState("grid");
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const [filteredEvents, setFilteredEvents] = useState([]);
   const [sortType, setSortType] = useState("Newest");
   const [isLoading, setIsLoading] = useState(true);
@@ -92,6 +93,14 @@ const EventsPage = () => {
   useEffect(() => {
     handleSearch(searchQuery);
   }, [events, filterType]);
+
+  useEffect(() => {
+    if (!isLoading && initialSearchQuery) {
+      setTimeout(() => {
+        cardSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 100);
+    }
+  }, [isLoading, initialSearchQuery]);
 
   const handleSortChange = (type) => {
     setSortType(type);

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -70,9 +70,10 @@ const Tag = ({ tag, onRemove }) => (
 
 const HackathonHub = () => {
   useDocumentTitle("Eventra | Hackathon Hub")
+  const initialSearchQuery = new URLSearchParams(window.location.search).get("search") || "";
   const [hackathons, setHackathons] = useState([]);
   const [activeTab, setActiveTab] = useState("all");
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const [isLoading, setIsLoading] = useState(true);
   const [isScrollVisible, setIsScrollVisible] = useState(false);
   const [filters, setFilters] = useState({
@@ -99,6 +100,15 @@ const HackathonHub = () => {
 
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(() => {
+    if (!isLoading && initialSearchQuery) {
+      setTimeout(() => {
+        cardsSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 100);
+    }
+  }, [isLoading, initialSearchQuery]);
+
   // UPDATED: Extract available tags from hackathons - ADDED BLOCKCHAIN TAGS
   useEffect(() => {
     if (hackathons.length > 0) {

--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -1,8 +1,8 @@
 import { motion, useAnimation, AnimatePresence, MotionConfig } from "framer-motion";
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Fuse from "fuse.js";
-import { Search, X, Calendar, Trophy, Code, ExternalLink } from "lucide-react";
+import { Search, Calendar, Trophy, Code, ExternalLink } from "lucide-react";
 
 // Import mock data
 import eventsData from "../../Events/eventsMockData.json";
@@ -12,9 +12,10 @@ import RespawningText from "../../../jhalak/RespawningText";
 import ModernSearchInput from "../../../components/common/ModernSearchInput";
 import useDocumentTitle from "../../../hooks/useDocumentTitle";
 
+const MotionLink = motion(Link);
+
 const Hero = () => {
   useDocumentTitle("Eventra | Home")
-  const navigate = useNavigate();
   const phrases = [
     "Amazing Tech Events",
     "Exciting Hackathons Today",
@@ -26,7 +27,6 @@ const Hero = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState([]);
   const [showResults, setShowResults] = useState(false);
-  const [isFocused, setIsFocused] = useState(false);
 
   // Change phrase every 3 seconds
   useEffect(() => {
@@ -90,16 +90,18 @@ const Hero = () => {
     }
   };
 
-  const handleResultClick = (result, type) => {
+  const clearSearch = () => {
     setShowResults(false);
     setSearchQuery("");
-    if (type === "event") {
-      navigate("/events");
-    } else if (type === "hackathon") {
-      navigate("/hackathons");
-    } else if (type === "project") {
-      navigate("/projects");
-    }
+  };
+
+  const getResultHref = (item) => {
+    const query = encodeURIComponent(item.title || searchQuery);
+
+    if (item.type === "event") return `/events?search=${query}`;
+    if (item.type === "hackathon") return `/hackathons?search=${query}`;
+    if (item.type === "project") return `/projects?search=${query}`;
+    return "/";
   };
 
   const getResultIcon = (type) => {
@@ -271,17 +273,17 @@ const Hero = () => {
                           </div>
                           <div className="space-y-2">
                             {searchResults.map((result, index) => (
-                              <motion.div
+                              <MotionLink
                                 key={`${result.item.type}-${result.item.id}`}
+                                to={getResultHref(result.item)}
                                 initial={{ opacity: 0, x: -20 }}
                                 animate={{ opacity: 1, x: 0 }}
                                 transition={{ delay: index * 0.05 }}
-                                onClick={() =>
-                                  handleResultClick(result.item, result.item.type)
-                                }
+                                onClick={clearSearch}
                                 className="flex items-center gap-3 p-3 rounded-2xl 
                                  hover:bg-gray-50 
-                                 cursor-pointer transition-colors group"
+                                 cursor-pointer transition-colors group text-left no-underline"
+                                aria-label={`Open ${result.item.title} in ${result.item.searchType}`}
                               >
                                 <div
                                   className="flex-shrink-0 p-2 bg-blue-100 rounded-xl text-blue-600 
@@ -308,7 +310,7 @@ const Hero = () => {
                                 <ExternalLink
                                   className="w-4 h-4 text-gray-400 group-hover:text-blue-500 transition-colors"
                                 />
-                              </motion.div>
+                              </MotionLink>
                             ))}
                           </div>
                         </>

--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -45,12 +45,13 @@ const SkeletonCard = () => (
 // Main ProjectGallery component
 const ProjectGallery = () => {
   useDocumentTitle("Eventra | Projects")
+  const initialSearchQuery = new URLSearchParams(window.location.search).get("search") || "";
   // State variables
   const [projects, setProjects] = useState([]); // Stores all fetched projects
   const [isLoading, setIsLoading] = useState(true); // Loading state
   const [filterCategory, setFilterCategory] = useState("all"); // Current category filter
   const [sortBy, setSortBy] = useState("recent"); // Sorting option
-  const [searchQuery, setSearchQuery] = useState(""); // Search input
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery); // Search input
   const [categories, setCategories] = useState(["all"]); // Categories available
   const [error, setError] = useState(""); // Error message
   const [categoryOpen, setCategoryOpen] = useState(false); // Category dropdown state
@@ -111,6 +112,14 @@ const ProjectGallery = () => {
 
     fetchProjects(); // Trigger data fetch
   }, []);
+
+  useEffect(() => {
+    if (!isLoading && initialSearchQuery) {
+      setTimeout(() => {
+        cardSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 100);
+    }
+  }, [isLoading, initialSearchQuery]);
 
   // Filter, search, and sort projects dynamically
   const filteredAndSortedProjects = projects


### PR DESCRIPTION
Closes #1120

## Changes
- Converted homepage search result items into clickable navigation links.
- Added navigation for event, hackathon, and project search results.
- Passed the selected result title through the URL search query.
- Updated Events, Hackathons, and Projects pages to read the search query from the URL.
- Automatically scrolls to the filtered result section after opening a clicked search result.

## Testing
- Ran `npm run build`
- Searched `cloud` from the homepage search bar.
- Clicked `Cloud Native Conference` from the search results.
- Verified it navigates to `/events?search=Cloud%20Native%20Conference`.
- Verified the Events page opens with the selected event filtered and visible.
- Verified the page scrolls down to the result card section.