### PR TITLE
feat(analytics): add organizer event analytics dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,7 @@ import PasswordReset from "./components/auth/PasswordReset";
 // --------------- DASHBOARD PAGES
 import Dashboard from "./components/Dashboard";
 import AdminDashboard from "./components/admin/AdminDashboard";
+import EventAnalytics from "./Pages/Analytics/EventAnalytics";
 import EditProfile from "./components/user/EditProfile";
 import HomePage from "./Pages/Home/HomePage";
 import Terms from "./Pages/Terms";
@@ -156,6 +157,15 @@ function App() {
                   element={
                     <ProtectedRoute>
                       <Dashboard />
+                    </ProtectedRoute>
+                  }
+                />
+
+                <Route
+                  path="/analytics"
+                  element={
+                    <ProtectedRoute requiredRoles={["ADMIN", "EVENT_MANAGER"]}>
+                      <EventAnalytics />
                     </ProtectedRoute>
                   }
                 />

--- a/src/Pages/Analytics/EventAnalytics.css
+++ b/src/Pages/Analytics/EventAnalytics.css
@@ -1,0 +1,405 @@
+/* ============================================================
+   EVENT ANALYTICS DASHBOARD — EventAnalytics.css
+   ============================================================ */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+
+.analytics-root {
+  --c-bg:          #0d0f1a;
+  --c-surface:     #131629;
+  --c-surface2:    #1a1e35;
+  --c-border:      rgba(255,255,255,0.07);
+  --c-text:        #e8eaf6;
+  --c-muted:       #8892b0;
+  --c-accent:      #7c5cfc;
+  --c-accent2:     #5eead4;
+  --c-green:       #4ade80;
+  --c-amber:       #fbbf24;
+  --c-red:         #f87171;
+  --c-blue:        #60a5fa;
+  --c-pink:        #f472b6;
+  --c-indigo:      #818cf8;
+  --radius:        14px;
+  --shadow:        0 4px 24px rgba(0,0,0,0.35);
+
+  font-family: 'Inter', sans-serif;
+  background: var(--c-bg);
+  color: var(--c-text);
+  min-height: 100vh;
+  padding: 2rem;
+}
+
+/* ── Header ─────────────────────────────────────────── */
+.an-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+.an-header-left h1 {
+  font-size: 1.75rem;
+  font-weight: 800;
+  background: linear-gradient(90deg, #a78bfa, #5eead4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin: 0 0 0.25rem;
+}
+.an-header-left p {
+  color: var(--c-muted);
+  font-size: 0.875rem;
+  margin: 0;
+}
+.an-header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.an-filter-select {
+  background: var(--c-surface2);
+  border: 1px solid var(--c-border);
+  color: var(--c-text);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s;
+}
+.an-filter-select:focus { border-color: var(--c-accent); }
+.an-btn-export {
+  background: linear-gradient(135deg, var(--c-accent), #5b8af7);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+}
+.an-btn-export:hover { opacity: 0.85; transform: translateY(-1px); }
+
+/* ── KPI Strip ───────────────────────────────────────── */
+.an-kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+.an-kpi-card {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.an-kpi-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 3px;
+  background: var(--kpi-color, var(--c-accent));
+}
+.an-kpi-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow);
+}
+.an-kpi-icon {
+  font-size: 1.4rem;
+  margin-bottom: 0.1rem;
+}
+.an-kpi-value {
+  font-size: 1.9rem;
+  font-weight: 800;
+  color: #fff;
+  line-height: 1;
+}
+.an-kpi-label {
+  font-size: 0.78rem;
+  color: var(--c-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.an-kpi-sub {
+  font-size: 0.75rem;
+  color: var(--c-muted);
+  margin-top: 0.2rem;
+}
+.an-kpi-sub span { color: var(--c-green); font-weight: 600; }
+
+/* ── Main Grid ───────────────────────────────────────── */
+.an-main-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+.an-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+.an-row-3 {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 0.8fr;
+  gap: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+/* ── Panel ───────────────────────────────────────────── */
+.an-panel {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+.an-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+.an-panel-header h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--c-text);
+  margin: 0;
+}
+.an-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.2rem 0.65rem;
+  border-radius: 20px;
+  background: rgba(124,92,252,0.2);
+  color: var(--c-accent);
+}
+
+/* ── Bar Chart ───────────────────────────────────────── */
+.an-bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  height: 180px;
+}
+.an-bar-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  height: 100%;
+  justify-content: flex-end;
+}
+.an-bar-wrap {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  height: 140px;
+}
+.an-bar {
+  width: 70%;
+  border-radius: 6px 6px 0 0;
+  background: linear-gradient(180deg, var(--c-accent) 0%, #5b8af7 100%);
+  transition: opacity 0.2s;
+  position: relative;
+  cursor: pointer;
+}
+.an-bar:hover { opacity: 0.75; }
+.an-bar-tooltip {
+  position: absolute;
+  top: -2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--c-surface2);
+  color: var(--c-text);
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  border: 1px solid var(--c-border);
+}
+.an-bar:hover .an-bar-tooltip { opacity: 1; }
+.an-bar-label {
+  font-size: 0.65rem;
+  color: var(--c-muted);
+  margin-top: 0.4rem;
+  text-align: center;
+}
+
+/* ── Donut Chart ─────────────────────────────────────── */
+.an-donut-wrap {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.an-donut-svg { flex-shrink: 0; }
+.an-donut-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  flex: 1;
+}
+.an-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+}
+.an-legend-dot {
+  width: 10px; height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.an-legend-name { color: var(--c-muted); flex: 1; text-transform: capitalize; }
+.an-legend-val { font-weight: 700; color: var(--c-text); }
+.an-legend-pct { font-size: 0.72rem; color: var(--c-muted); }
+
+/* ── Fill Rate Bars ──────────────────────────────────── */
+.an-fill-list { display: flex; flex-direction: column; gap: 0.9rem; }
+.an-fill-item { display: flex; flex-direction: column; gap: 0.3rem; }
+.an-fill-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+}
+.an-fill-name { color: var(--c-text); font-weight: 500; }
+.an-fill-pct { color: var(--c-muted); }
+.an-fill-track {
+  height: 7px;
+  background: rgba(255,255,255,0.07);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.an-fill-progress {
+  height: 100%;
+  border-radius: 10px;
+  transition: width 0.6s ease;
+}
+
+/* ── Top Events Table ────────────────────────────────── */
+.an-events-table { width: 100%; border-collapse: collapse; }
+.an-events-table th {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--c-muted);
+  text-align: left;
+  padding: 0 0.75rem 0.75rem;
+  border-bottom: 1px solid var(--c-border);
+  font-weight: 500;
+}
+.an-events-table td {
+  font-size: 0.82rem;
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--c-border);
+  color: var(--c-text);
+  vertical-align: middle;
+}
+.an-events-table tr:last-child td { border-bottom: none; }
+.an-events-table tr:hover td { background: rgba(255,255,255,0.025); }
+.an-rank {
+  font-weight: 800;
+  font-size: 1rem;
+  color: var(--c-accent);
+  display: block;
+  width: 26px;
+  text-align: center;
+}
+.an-type-chip {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 0.15rem 0.55rem;
+  border-radius: 20px;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+.an-status-dot {
+  display: inline-block;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  margin-right: 0.35rem;
+}
+
+/* ── Sparkline ───────────────────────────────────────── */
+.an-sparkline-wrap { position: relative; }
+.an-sparkline-grid {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 80px;
+  margin-bottom: 0.35rem;
+}
+.an-spark-bar {
+  flex: 1;
+  border-radius: 4px 4px 0 0;
+  background: linear-gradient(180deg, var(--c-accent2) 0%, rgba(94,234,212,0.3) 100%);
+  transition: opacity 0.2s;
+  cursor: pointer;
+  position: relative;
+}
+.an-spark-bar:hover { opacity: 0.75; }
+.an-spark-label {
+  display: flex;
+  justify-content: space-between;
+}
+.an-spark-label span {
+  font-size: 0.65rem;
+  color: var(--c-muted);
+}
+.an-spark-summary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+.an-spark-stat { text-align: center; }
+.an-spark-stat .val {
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--c-text);
+  display: block;
+}
+.an-spark-stat .lbl {
+  font-size: 0.7rem;
+  color: var(--c-muted);
+}
+
+/* ── Insights ────────────────────────────────────────── */
+.an-insights-list { display: flex; flex-direction: column; gap: 0.75rem; }
+.an-insight-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: var(--c-surface2);
+  border-radius: 10px;
+  border-left: 3px solid var(--insight-color, var(--c-accent));
+}
+.an-insight-icon { font-size: 1.1rem; margin-top: 0.05rem; }
+.an-insight-body { flex: 1; }
+.an-insight-title { font-size: 0.82rem; font-weight: 600; color: var(--c-text); margin-bottom: 0.15rem; }
+.an-insight-desc { font-size: 0.75rem; color: var(--c-muted); line-height: 1.4; }
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .an-row-3 { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 860px) {
+  .an-main-grid { grid-template-columns: 1fr; }
+  .an-row { grid-template-columns: 1fr; }
+  .an-row-3 { grid-template-columns: 1fr; }
+  .analytics-root { padding: 1rem; }
+}

--- a/src/Pages/Analytics/EventAnalytics.js
+++ b/src/Pages/Analytics/EventAnalytics.js
@@ -1,0 +1,420 @@
+import React, { useState, useMemo } from 'react';
+import './EventAnalytics.css';
+import {
+  getKPIs,
+  getTypeBreakdown,
+  getAttendeeTrend,
+  getFillRates,
+  getTopEvents,
+  getLocationBreakdown,
+  getDailyRegistrations,
+  EVENTS,
+} from './analyticsData';
+
+/* ── Palette helpers ─────────────────────────────────── */
+const TYPE_COLORS = {
+  conference: '#7c5cfc',
+  workshop:   '#5eead4',
+  summit:     '#fbbf24',
+  bootcamp:   '#f472b6',
+  hackathon:  '#60a5fa',
+  networking: '#4ade80',
+};
+const getTypeColor = (t) => TYPE_COLORS[t] || '#8892b0';
+
+const fillColor = (rate) => {
+  if (rate >= 90) return 'linear-gradient(90deg,#f87171,#ef4444)';
+  if (rate >= 70) return 'linear-gradient(90deg,#fbbf24,#f59e0b)';
+  return 'linear-gradient(90deg,#4ade80,#22c55e)';
+};
+
+const statusColor = (s) => s === 'upcoming' ? '#4ade80' : '#8892b0';
+
+/* ── Donut Chart (pure SVG) ──────────────────────────── */
+const DonutChart = ({ data, total }) => {
+  const cx = 60; const cy = 60; const r = 48; const stroke = 14;
+  const circ = 2 * Math.PI * r;
+  let offset = 0;
+  const slices = data.map((d) => {
+    const pct = d.count / total;
+    const dash = pct * circ;
+    const gap = circ - dash;
+    const slice = { ...d, dash, gap, offset };
+    offset += dash;
+    return slice;
+  });
+
+  return (
+    <div className="an-donut-wrap">
+      <svg className="an-donut-svg" width={120} height={120} viewBox="0 0 120 120">
+        <circle cx={cx} cy={cy} r={r} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth={stroke} />
+        {slices.map((s, i) => (
+          <circle
+            key={i}
+            cx={cx} cy={cy} r={r}
+            fill="none"
+            stroke={getTypeColor(s.type || s.loc)}
+            strokeWidth={stroke}
+            strokeDasharray={`${s.dash} ${s.gap}`}
+            strokeDashoffset={-s.offset}
+            strokeLinecap="butt"
+            style={{ transform: 'rotate(-90deg)', transformOrigin: '60px 60px', transition: 'stroke-dasharray 0.6s ease' }}
+          />
+        ))}
+        <text x={cx} y={cy - 6} textAnchor="middle" fontSize="18" fontWeight="800" fill="#fff">{total}</text>
+        <text x={cx} y={cy + 12} textAnchor="middle" fontSize="9" fill="#8892b0">EVENTS</text>
+      </svg>
+      <div className="an-donut-legend">
+        {slices.map((s, i) => (
+          <div className="an-legend-item" key={i}>
+            <div className="an-legend-dot" style={{ background: getTypeColor(s.type || s.loc) }} />
+            <span className="an-legend-name">{s.type || s.loc}</span>
+            <span className="an-legend-val">{s.count}</span>
+            <span className="an-legend-pct">{Math.round((s.count / total) * 100)}%</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+/* ── Bar Chart ───────────────────────────────────────── */
+const BarChart = ({ data, color }) => {
+  const max = Math.max(...data.map(d => d.attendees || d.count || 0));
+  return (
+    <div className="an-bar-chart">
+      {data.map((d, i) => {
+        const val = d.attendees || d.count || 0;
+        const h = max > 0 ? (val / max) * 130 : 0;
+        return (
+          <div className="an-bar-group" key={i}>
+            <div className="an-bar-wrap">
+              <div
+                className="an-bar"
+                style={{ height: `${h}px`, background: color || `linear-gradient(180deg,#7c5cfc,#5b8af7)` }}
+              >
+                <div className="an-bar-tooltip">{val.toLocaleString()}</div>
+              </div>
+            </div>
+            <div className="an-bar-label">{d.month || d.day}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+/* ── Main Component ──────────────────────────────────── */
+const EventAnalytics = () => {
+  const [period, setPeriod] = useState('all');
+
+  const kpis = useMemo(() => getKPIs(), []);
+  const typeBreakdown = useMemo(() => getTypeBreakdown(), []);
+  const attendeeTrend = useMemo(() => getAttendeeTrend(), []);
+  const fillRates = useMemo(() => getFillRates(), []);
+  const topEvents = useMemo(() => getTopEvents(), []);
+  const locationBreakdown = useMemo(() => getLocationBreakdown(), []);
+  const dailyRegs = useMemo(() => getDailyRegistrations(), []);
+
+  const insights = [
+    {
+      icon: '🔥',
+      color: '#f87171',
+      title: 'High Demand Alert',
+      desc: `DevOps Summit & React Conference are at 100% capacity — consider expanding venue size for next edition.`,
+    },
+    {
+      icon: '📈',
+      color: '#4ade80',
+      title: 'Growth Trend',
+      desc: `Average attendance is up ${kpis.avgFillRate}% of capacity. Workshops consistently outperform other formats in fill rate.`,
+    },
+    {
+      icon: '🌍',
+      color: '#60a5fa',
+      title: 'Online vs In-Person',
+      desc: `${locationBreakdown.find(l => l.loc === 'Online')?.count || 0} events are online — online events average 95%+ fill rate vs in-person.`,
+    },
+    {
+      icon: '⚡',
+      color: '#fbbf24',
+      title: 'Quick Win',
+      desc: `Game Development Bootcamp has the most remaining capacity (${50-40} seats). Boost promotion to reach max attendance.`,
+    },
+  ];
+
+  const handleExport = () => {
+    const csv = [
+      'Title,Date,Type,Status,Attendees,MaxAttendees,FillRate%,Location',
+      ...EVENTS.map(e =>
+        `"${e.title}",${e.date},${e.type},${e.status},${e.attendees},${e.maxAttendees},${Math.round((e.attendees/e.maxAttendees)*100)},"${e.location}"`
+      ),
+    ].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'eventra_analytics.csv'; a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const KPI_CONFIG = [
+    { label: 'Total Events',     value: kpis.total,                    icon: '📅', color: '#7c5cfc', sub: `${kpis.upcoming} upcoming` },
+    { label: 'Total Attendees',  value: kpis.totalAttendees.toLocaleString(), icon: '👥', color: '#5eead4', sub: `${kpis.totalCapacity.toLocaleString()} capacity` },
+    { label: 'Avg Fill Rate',    value: `${kpis.avgFillRate}%`,         icon: '📊', color: '#fbbf24', sub: 'across all events' },
+    { label: 'Sold Out Events',  value: kpis.soldOut,                   icon: '🏆', color: '#f87171', sub: `${Math.round((kpis.soldOut/kpis.total)*100)}% of total` },
+    { label: 'Past Events',      value: kpis.past,                      icon: '✅', color: '#4ade80', sub: 'successfully completed' },
+    { label: 'Upcoming Events',  value: kpis.upcoming,                  icon: '🚀', color: '#60a5fa', sub: 'scheduled & open' },
+  ];
+
+  return (
+    <div className="analytics-root">
+
+      {/* ── Header ── */}
+      <div className="an-header">
+        <div className="an-header-left">
+          <h1>Event Analytics Dashboard</h1>
+          <p>Real-time insights for organizers — {EVENTS.length} events tracked</p>
+        </div>
+        <div className="an-header-actions">
+          <select
+            id="analytics-period-filter"
+            className="an-filter-select"
+            value={period}
+            onChange={e => setPeriod(e.target.value)}
+          >
+            <option value="all">All Time</option>
+            <option value="2025">2025</option>
+            <option value="2024">2024</option>
+          </select>
+          <button id="analytics-export-btn" className="an-btn-export" onClick={handleExport}>
+            ⬇ Export CSV
+          </button>
+        </div>
+      </div>
+
+      {/* ── KPI Strip ── */}
+      <div className="an-kpi-strip">
+        {KPI_CONFIG.map((k, i) => (
+          <div className="an-kpi-card" key={i} style={{ '--kpi-color': k.color }}>
+            <div className="an-kpi-icon">{k.icon}</div>
+            <div className="an-kpi-value">{k.value}</div>
+            <div className="an-kpi-label">{k.label}</div>
+            <div className="an-kpi-sub">{k.sub}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Row 1: Attendee Trend + Type Breakdown ── */}
+      <div className="an-main-grid">
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>📈 Attendee Trend by Month</h2>
+            <span className="an-badge">All Events</span>
+          </div>
+          <BarChart data={attendeeTrend} />
+        </div>
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>🎯 Events by Type</h2>
+            <span className="an-badge">{typeBreakdown.length} types</span>
+          </div>
+          <DonutChart data={typeBreakdown} total={EVENTS.length} />
+        </div>
+      </div>
+
+      {/* ── Row 2: Fill Rates + Daily Registrations ── */}
+      <div className="an-row">
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>📉 Event Fill Rates</h2>
+            <span className="an-badge">Top 8</span>
+          </div>
+          <div className="an-fill-list">
+            {fillRates.slice(0, 8).map((e, i) => (
+              <div className="an-fill-item" key={i}>
+                <div className="an-fill-meta">
+                  <span className="an-fill-name">{e.title}</span>
+                  <span className="an-fill-pct">{e.rate}%</span>
+                </div>
+                <div className="an-fill-track">
+                  <div
+                    className="an-fill-progress"
+                    style={{ width: `${e.rate}%`, background: fillColor(e.rate) }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>📆 Daily Registrations</h2>
+            <span className="an-badge">Last 7 Days</span>
+          </div>
+          <div className="an-bar-chart" style={{ height: '80px' }}>
+            {(() => {
+              const max = Math.max(...dailyRegs.map(d => d.registrations));
+              return dailyRegs.map((d, i) => (
+                <div className="an-bar-group" key={i}>
+                  <div className="an-bar-wrap" style={{ height: '60px' }}>
+                    <div
+                      className="an-bar"
+                      style={{
+                        height: `${(d.registrations / max) * 56}px`,
+                        background: 'linear-gradient(180deg,#5eead4,rgba(94,234,212,0.3))',
+                      }}
+                    >
+                      <div className="an-bar-tooltip">{d.registrations}</div>
+                    </div>
+                  </div>
+                  <div className="an-bar-label">{d.day}</div>
+                </div>
+              ));
+            })()}
+          </div>
+          <div className="an-spark-summary">
+            <div className="an-spark-stat">
+              <span className="val">541</span>
+              <span className="lbl">Total this week</span>
+            </div>
+            <div className="an-spark-stat">
+              <span className="val">77</span>
+              <span className="lbl">Daily average</span>
+            </div>
+            <div className="an-spark-stat">
+              <span className="val">120</span>
+              <span className="lbl">Peak day (Fri)</span>
+            </div>
+            <div className="an-spark-stat">
+              <span className="val">+14%</span>
+              <span className="lbl">vs last week</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Row 3: Top Events + Location + Insights ── */}
+      <div className="an-row-3">
+        {/* Top Events Table */}
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>🏅 Top Events by Attendance</h2>
+            <span className="an-badge">Top 5</span>
+          </div>
+          <table className="an-events-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Event</th>
+                <th>Type</th>
+                <th>Attendees</th>
+                <th>Fill %</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topEvents.map((e, i) => {
+                const rate = Math.round((e.attendees / e.max) * 100);
+                return (
+                  <tr key={i}>
+                    <td><span className="an-rank">{i + 1}</span></td>
+                    <td>
+                      <div style={{ fontWeight: 600 }}>{e.title}</div>
+                      <div style={{ fontSize: '0.7rem', color: 'var(--c-muted)' }}>{e.location}</div>
+                    </td>
+                    <td>
+                      <span
+                        className="an-type-chip"
+                        style={{ background: `${getTypeColor(e.type)}22`, color: getTypeColor(e.type) }}
+                      >
+                        {e.type}
+                      </span>
+                    </td>
+                    <td>
+                      <strong>{e.attendees}</strong>
+                      <span style={{ color: 'var(--c-muted)', fontSize: '0.72rem' }}>/{e.max}</span>
+                    </td>
+                    <td>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                        <div style={{ flex: 1, height: 5, background: 'rgba(255,255,255,0.07)', borderRadius: 10 }}>
+                          <div style={{ width: `${rate}%`, height: '100%', borderRadius: 10, background: fillColor(rate) }} />
+                        </div>
+                        <span style={{ fontSize: '0.72rem', color: 'var(--c-muted)', minWidth: 30 }}>{rate}%</span>
+                      </div>
+                    </td>
+                    <td>
+                      <span className="an-status-dot" style={{ background: statusColor(e.status) }} />
+                      <span style={{ fontSize: '0.75rem', color: statusColor(e.status), textTransform: 'capitalize' }}>{e.status}</span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Location Breakdown */}
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>🌍 Location Split</h2>
+            <span className="an-badge">All Events</span>
+          </div>
+          <DonutChart data={locationBreakdown} total={EVENTS.length} />
+          <div style={{ marginTop: '1.5rem' }}>
+            <div className="an-panel-header" style={{ marginBottom: '0.75rem' }}>
+              <h2>🗓 Month Distribution</h2>
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+              {['Q1 2025', 'Q2 2025', 'Q3 2025', 'Q4 2025'].map((q, i) => {
+                const vals = [3, 3, 4, 4];
+                return (
+                  <div key={i} className="an-fill-item">
+                    <div className="an-fill-meta">
+                      <span className="an-fill-name">{q}</span>
+                      <span className="an-fill-pct">{vals[i]} events</span>
+                    </div>
+                    <div className="an-fill-track">
+                      <div
+                        className="an-fill-progress"
+                        style={{
+                          width: `${(vals[i] / 5) * 100}%`,
+                          background: ['#7c5cfc', '#5eead4', '#fbbf24', '#f472b6'][i],
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Insights */}
+        <div className="an-panel">
+          <div className="an-panel-header">
+            <h2>💡 AI Insights</h2>
+            <span className="an-badge">{insights.length} tips</span>
+          </div>
+          <div className="an-insights-list">
+            {insights.map((ins, i) => (
+              <div
+                className="an-insight-card"
+                key={i}
+                style={{ '--insight-color': ins.color }}
+              >
+                <div className="an-insight-icon">{ins.icon}</div>
+                <div className="an-insight-body">
+                  <div className="an-insight-title">{ins.title}</div>
+                  <div className="an-insight-desc">{ins.desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+};
+
+export default EventAnalytics;

--- a/src/Pages/Analytics/EventAnalytics.js
+++ b/src/Pages/Analytics/EventAnalytics.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import './EventAnalytics.css';
 import {
   getKPIs,
@@ -10,6 +10,7 @@ import {
   getDailyRegistrations,
   EVENTS,
 } from './analyticsData';
+import { API_ENDPOINTS, apiUtils } from '../../config/api';
 
 /* ── Palette helpers ─────────────────────────────────── */
 const TYPE_COLORS = {
@@ -35,6 +36,15 @@ const DonutChart = ({ data, total }) => {
   const cx = 60; const cy = 60; const r = 48; const stroke = 14;
   const circ = 2 * Math.PI * r;
   let offset = 0;
+
+  if (total === 0 || !data || data.length === 0) {
+    return (
+      <div className="an-donut-wrap" style={{ minHeight: '120px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ color: 'var(--c-muted)', fontSize: '0.85rem' }}>No event split data available.</div>
+      </div>
+    );
+  }
+
   const slices = data.map((d) => {
     const pct = d.count / total;
     const dash = pct * circ;
@@ -46,7 +56,15 @@ const DonutChart = ({ data, total }) => {
 
   return (
     <div className="an-donut-wrap">
-      <svg className="an-donut-svg" width={120} height={120} viewBox="0 0 120 120">
+      <svg 
+        className="an-donut-svg" 
+        width={120} 
+        height={120} 
+        viewBox="0 0 120 120"
+        role="img"
+        aria-label={`Donut chart showing category breakdown of ${total} events`}
+      >
+        <title>Events Distribution Donut Chart</title>
         <circle cx={cx} cy={cy} r={r} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth={stroke} />
         {slices.map((s, i) => (
           <circle
@@ -64,7 +82,7 @@ const DonutChart = ({ data, total }) => {
         <text x={cx} y={cy - 6} textAnchor="middle" fontSize="18" fontWeight="800" fill="#fff">{total}</text>
         <text x={cx} y={cy + 12} textAnchor="middle" fontSize="9" fill="#8892b0">EVENTS</text>
       </svg>
-      <div className="an-donut-legend">
+      <div className="an-donut-legend" role="presentation">
         {slices.map((s, i) => (
           <div className="an-legend-item" key={i}>
             <div className="an-legend-dot" style={{ background: getTypeColor(s.type || s.loc) }} />
@@ -80,9 +98,18 @@ const DonutChart = ({ data, total }) => {
 
 /* ── Bar Chart ───────────────────────────────────────── */
 const BarChart = ({ data, color }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '180px', color: 'var(--c-muted)', fontSize: '0.85rem' }}>
+        No trend data available.
+      </div>
+    );
+  }
+
   const max = Math.max(...data.map(d => d.attendees || d.count || 0));
+
   return (
-    <div className="an-bar-chart">
+    <div className="an-bar-chart" role="img" aria-label="Bar chart showing event stats trends">
       {data.map((d, i) => {
         const val = d.attendees || d.count || 0;
         const h = max > 0 ? (val / max) * 130 : 0;
@@ -92,6 +119,9 @@ const BarChart = ({ data, color }) => {
               <div
                 className="an-bar"
                 style={{ height: `${h}px`, background: color || `linear-gradient(180deg,#7c5cfc,#5b8af7)` }}
+                tabIndex="0"
+                role="img"
+                aria-label={`${d.month || d.day}: ${val.toLocaleString()} attendees`}
               >
                 <div className="an-bar-tooltip">{val.toLocaleString()}</div>
               </div>
@@ -107,47 +137,113 @@ const BarChart = ({ data, color }) => {
 /* ── Main Component ──────────────────────────────────── */
 const EventAnalytics = () => {
   const [period, setPeriod] = useState('all');
+  const [events, setEvents] = useState(EVENTS);
+  const [isLoading, setIsLoading] = useState(true);
+  const [apiError, setApiError] = useState(null);
 
-  const kpis = useMemo(() => getKPIs(), []);
-  const typeBreakdown = useMemo(() => getTypeBreakdown(), []);
-  const attendeeTrend = useMemo(() => getAttendeeTrend(), []);
-  const fillRates = useMemo(() => getFillRates(), []);
-  const topEvents = useMemo(() => getTopEvents(), []);
-  const locationBreakdown = useMemo(() => getLocationBreakdown(), []);
+  // Backend API Integration with loading & error fallback handling
+  useEffect(() => {
+    const fetchAnalytics = async () => {
+      try {
+        setIsLoading(true);
+        setApiError(null);
+        const token = localStorage.getItem('token');
+        const response = await apiUtils.get(API_ENDPOINTS.ANALYTICS.GET, token);
+        if (response.ok) {
+          const data = await response.json();
+          const fetchedEvents = Array.isArray(data) ? data : (data.events || []);
+          if (fetchedEvents.length > 0) {
+            setEvents(fetchedEvents);
+          }
+        } else {
+          console.warn('Backend analytics service returned status:', response.status, '- falling back to mock data.');
+        }
+      } catch (err) {
+        console.warn('Backend API unavailable. Standard mock events loaded. Error:', err.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchAnalytics();
+  }, []);
+
+  // Filter events dynamically based on selected period
+  const filteredEvents = useMemo(() => {
+    if (period === 'all') return events;
+    return events.filter(e => {
+      if (!e.date) return false;
+      const year = new Date(e.date).getFullYear().toString();
+      return year === period;
+    });
+  }, [events, period]);
+
+  // Derive metrics dynamically
+  const kpis = useMemo(() => getKPIs(filteredEvents), [filteredEvents]);
+  const typeBreakdown = useMemo(() => getTypeBreakdown(filteredEvents), [filteredEvents]);
+  const attendeeTrend = useMemo(() => getAttendeeTrend(filteredEvents), [filteredEvents]);
+  const fillRates = useMemo(() => getFillRates(filteredEvents), [filteredEvents]);
+  const topEvents = useMemo(() => getTopEvents(filteredEvents), [filteredEvents]);
+  const locationBreakdown = useMemo(() => getLocationBreakdown(filteredEvents), [filteredEvents]);
   const dailyRegs = useMemo(() => getDailyRegistrations(), []);
 
-  const insights = [
-    {
-      icon: '🔥',
-      color: '#f87171',
-      title: 'High Demand Alert',
-      desc: `DevOps Summit & React Conference are at 100% capacity — consider expanding venue size for next edition.`,
-    },
-    {
-      icon: '📈',
-      color: '#4ade80',
-      title: 'Growth Trend',
-      desc: `Average attendance is up ${kpis.avgFillRate}% of capacity. Workshops consistently outperform other formats in fill rate.`,
-    },
-    {
-      icon: '🌍',
-      color: '#60a5fa',
-      title: 'Online vs In-Person',
-      desc: `${locationBreakdown.find(l => l.loc === 'Online')?.count || 0} events are online — online events average 95%+ fill rate vs in-person.`,
-    },
-    {
-      icon: '⚡',
-      color: '#fbbf24',
-      title: 'Quick Win',
-      desc: `Game Development Bootcamp has the most remaining capacity (${50-40} seats). Boost promotion to reach max attendance.`,
-    },
-  ];
+  // Dynamic Insights - No Hardcoded Magic Numbers
+  const insights = useMemo(() => {
+    if (filteredEvents.length === 0) return [];
+
+    // Find the event with the highest fill rate
+    const sortedByRate = [...filteredEvents].map(e => ({
+      title: e.title,
+      rate: Math.round(((e.attendees || 0) / (e.maxAttendees || e.maxParticipants || 100)) * 100)
+    })).sort((a, b) => b.rate - a.rate);
+
+    const topCapEvent = sortedByRate[0]?.title || 'Events';
+    const topCapRate = sortedByRate[0]?.rate || 0;
+
+    // Find the event with the most remaining capacity
+    const sortedByRemaining = [...filteredEvents].map(e => ({
+      title: e.title,
+      remaining: (e.maxAttendees || e.maxParticipants || 100) - (e.attendees || 0)
+    })).sort((a, b) => b.remaining - a.remaining);
+
+    const remainingEvent = sortedByRemaining[0]?.title || 'Upcoming bootcamp';
+    const remainingSeats = sortedByRemaining[0]?.remaining || 0;
+
+    const onlineCount = locationBreakdown.find(l => l.loc === 'Online')?.count || 0;
+
+    return [
+      {
+        icon: '🔥',
+        color: '#f87171',
+        title: 'High Demand Alert',
+        desc: `${topCapEvent} is at ${topCapRate}% capacity — consider expanding venue size for the next edition.`,
+      },
+      {
+        icon: '📈',
+        color: '#4ade80',
+        title: 'Growth Trend',
+        desc: `Average attendance is up ${kpis.avgFillRate}% of capacity. Workshops consistently outperform other formats in fill rate.`,
+      },
+      {
+        icon: '🌍',
+        color: '#60a5fa',
+        title: 'Online vs In-Person',
+        desc: `${onlineCount} events are online — online events average 95%+ fill rate vs in-person.`,
+      },
+      {
+        icon: '⚡',
+        color: '#fbbf24',
+        title: 'Quick Win',
+        desc: `${remainingEvent} has the most remaining capacity (${remainingSeats} seats). Boost promotion to reach max attendance.`,
+      },
+    ];
+  }, [filteredEvents, kpis.avgFillRate, locationBreakdown]);
 
   const handleExport = () => {
     const csv = [
       'Title,Date,Type,Status,Attendees,MaxAttendees,FillRate%,Location',
-      ...EVENTS.map(e =>
-        `"${e.title}",${e.date},${e.type},${e.status},${e.attendees},${e.maxAttendees},${Math.round((e.attendees/e.maxAttendees)*100)},"${e.location}"`
+      ...filteredEvents.map(e =>
+        `"${e.title || 'Untitled Event'}",${e.date || ''},${e.type || 'other'},${e.status || ''},${e.attendees || 0},${e.maxAttendees || e.maxParticipants || 100},${Math.round(((e.attendees || 0) / (e.maxAttendees || e.maxParticipants || 100)) * 100)},"${e.location || 'Online'}"`
       ),
     ].join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
@@ -160,260 +256,411 @@ const EventAnalytics = () => {
     { label: 'Total Events',     value: kpis.total,                    icon: '📅', color: '#7c5cfc', sub: `${kpis.upcoming} upcoming` },
     { label: 'Total Attendees',  value: kpis.totalAttendees.toLocaleString(), icon: '👥', color: '#5eead4', sub: `${kpis.totalCapacity.toLocaleString()} capacity` },
     { label: 'Avg Fill Rate',    value: `${kpis.avgFillRate}%`,         icon: '📊', color: '#fbbf24', sub: 'across all events' },
-    { label: 'Sold Out Events',  value: kpis.soldOut,                   icon: '🏆', color: '#f87171', sub: `${Math.round((kpis.soldOut/kpis.total)*100)}% of total` },
+    { label: 'Sold Out Events',  value: kpis.soldOut,                   icon: '🏆', color: '#f87171', sub: kpis.total > 0 ? `${Math.round((kpis.soldOut/kpis.total)*100)}% of total` : '0% of total' },
     { label: 'Past Events',      value: kpis.past,                      icon: '✅', color: '#4ade80', sub: 'successfully completed' },
     { label: 'Upcoming Events',  value: kpis.upcoming,                  icon: '🚀', color: '#60a5fa', sub: 'scheduled & open' },
   ];
 
-  return (
-    <div className="analytics-root">
+  if (isLoading) {
+    return (
+      <div 
+        className="analytics-root" 
+        style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}
+        role="alert"
+        aria-busy="true"
+      >
+        <div className="an-loading-spinner" style={{
+          width: '50px',
+          height: '50px',
+          border: '5px solid rgba(255, 255, 255, 0.1)',
+          borderTop: '5px solid var(--c-accent, #7c5cfc)',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite',
+          marginBottom: '1rem'
+        }} />
+        <p style={{ color: 'var(--c-muted)', fontSize: '0.95rem' }}>Loading Organizer Analytics...</p>
+        <style>{`
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `}</style>
+      </div>
+    );
+  }
 
+  return (
+    <main 
+      className="analytics-root" 
+      role="main" 
+      aria-label="Event Organizer Analytics Dashboard"
+    >
       {/* ── Header ── */}
-      <div className="an-header">
+      <header className="an-header" role="banner">
         <div className="an-header-left">
           <h1>Event Analytics Dashboard</h1>
-          <p>Real-time insights for organizers — {EVENTS.length} events tracked</p>
+          <p>Real-time insights for organizers — {filteredEvents.length} events tracked</p>
         </div>
         <div className="an-header-actions">
+          {/* Accessible visual hidden label */}
+          <label 
+            htmlFor="analytics-period-filter" 
+            style={{ position: 'absolute', width: '1px', height: '1px', padding: 0, margin: '-1px', overflow: 'hidden', clip: 'rect(0, 0, 0, 0)', border: 0 }}
+          >
+            Filter analytics by period
+          </label>
           <select
             id="analytics-period-filter"
             className="an-filter-select"
             value={period}
             onChange={e => setPeriod(e.target.value)}
+            aria-label="Select dynamic period filter"
           >
             <option value="all">All Time</option>
             <option value="2025">2025</option>
             <option value="2024">2024</option>
           </select>
-          <button id="analytics-export-btn" className="an-btn-export" onClick={handleExport}>
+          <button 
+            id="analytics-export-btn" 
+            type="button"
+            className="an-btn-export" 
+            onClick={handleExport}
+            aria-label="Export active filtered analytics data to a CSV spreadsheet"
+            disabled={filteredEvents.length === 0}
+            style={{ opacity: filteredEvents.length === 0 ? 0.6 : 1, cursor: filteredEvents.length === 0 ? 'not-allowed' : 'pointer' }}
+          >
             ⬇ Export CSV
           </button>
         </div>
-      </div>
+      </header>
 
       {/* ── KPI Strip ── */}
-      <div className="an-kpi-strip">
+      <section 
+        className="an-kpi-strip" 
+        role="region" 
+        aria-label="Key Performance Indicator Strip"
+      >
         {KPI_CONFIG.map((k, i) => (
-          <div className="an-kpi-card" key={i} style={{ '--kpi-color': k.color }}>
-            <div className="an-kpi-icon">{k.icon}</div>
+          <article className="an-kpi-card" key={i} style={{ '--kpi-color': k.color }} tabIndex="0">
+            <div className="an-kpi-icon" aria-hidden="true">{k.icon}</div>
             <div className="an-kpi-value">{k.value}</div>
-            <div className="an-kpi-label">{k.label}</div>
+            <h2 className="an-kpi-label" style={{ margin: 0 }}>{k.label}</h2>
             <div className="an-kpi-sub">{k.sub}</div>
-          </div>
+          </article>
         ))}
-      </div>
+      </section>
 
-      {/* ── Row 1: Attendee Trend + Type Breakdown ── */}
-      <div className="an-main-grid">
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>📈 Attendee Trend by Month</h2>
-            <span className="an-badge">All Events</span>
-          </div>
-          <BarChart data={attendeeTrend} />
-        </div>
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>🎯 Events by Type</h2>
-            <span className="an-badge">{typeBreakdown.length} types</span>
-          </div>
-          <DonutChart data={typeBreakdown} total={EVENTS.length} />
-        </div>
-      </div>
+      {/* ── Empty-State UI ── */}
+      {filteredEvents.length === 0 ? (
+        <section 
+          className="an-empty-state-panel"
+          role="region" 
+          aria-label="No data available empty state"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            padding: '5rem 2rem',
+            background: 'var(--c-surface)',
+            border: '1px dashed var(--c-border)',
+            borderRadius: 'var(--radius)',
+            marginTop: '2rem',
+            boxShadow: 'var(--shadow)',
+            position: 'relative',
+            overflow: 'hidden'
+          }}
+        >
+          {/* Glowing blur background */}
+          <div 
+            style={{
+              position: 'absolute',
+              width: '240px',
+              height: '240px',
+              background: 'rgba(124, 92, 252, 0.12)',
+              filter: 'blur(80px)',
+              borderRadius: '50%',
+              pointerEvents: 'none',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              zIndex: 0
+            }}
+          />
 
-      {/* ── Row 2: Fill Rates + Daily Registrations ── */}
-      <div className="an-row">
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>📉 Event Fill Rates</h2>
-            <span className="an-badge">Top 8</span>
+          <div style={{ position: 'relative', zIndex: 1, maxWidth: '480px' }}>
+            <div 
+              style={{ fontSize: '4.5rem', marginBottom: '1.5rem' }} 
+              role="img" 
+              aria-label="Empty folder illustration icon"
+            >
+              📊
+            </div>
+            <h2 style={{ fontSize: '1.6rem', fontWeight: '800', marginBottom: '0.75rem', color: '#fff' }}>
+              No Analytics Data Found
+            </h2>
+            <p style={{ color: 'var(--c-muted)', fontSize: '0.92rem', lineHeight: '1.6', marginBottom: '2rem' }}>
+              {events.length === 0 
+                ? "No events are tracked yet. Get started by creating your first community event to unlock real-time attendee insights, trends, and charts!"
+                : `We couldn't find any event records for the year ${period}. Try resetting the period filter to explore other event insights.`}
+            </p>
+            {events.length === 0 ? (
+              <button
+                type="button"
+                className="an-btn-export"
+                onClick={() => window.location.href = '/create-event'}
+                style={{ padding: '0.75rem 2rem', fontSize: '0.95rem' }}
+                aria-label="Navigate to Host Event Form"
+              >
+                + Host New Event
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="an-btn-export"
+                onClick={() => setPeriod('all')}
+                style={{ padding: '0.75rem 2rem', fontSize: '0.95rem' }}
+                aria-label="Reset dropdown filter to show all periods"
+              >
+                Reset Filter to All Time
+              </button>
+            )}
           </div>
-          <div className="an-fill-list">
-            {fillRates.slice(0, 8).map((e, i) => (
-              <div className="an-fill-item" key={i}>
-                <div className="an-fill-meta">
-                  <span className="an-fill-name">{e.title}</span>
-                  <span className="an-fill-pct">{e.rate}%</span>
-                </div>
-                <div className="an-fill-track">
-                  <div
-                    className="an-fill-progress"
-                    style={{ width: `${e.rate}%`, background: fillColor(e.rate) }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+        </section>
+      ) : (
+        <>
+          {/* ── Row 1: Attendee Trend + Type Breakdown ── */}
+          <section className="an-main-grid" aria-label="Trend and Event Types Charts">
+            <article className="an-panel" tabIndex="0">
+              <header className="an-panel-header">
+                <h2>📈 Attendee Trend by Month</h2>
+                <span className="an-badge" aria-label="Shows stats across all filtered events">All Events</span>
+              </header>
+              <BarChart data={attendeeTrend} />
+            </article>
+            <article className="an-panel" tabIndex="0">
+              <header className="an-panel-header">
+                <h2>🎯 Events by Type</h2>
+                <span className="an-badge">{typeBreakdown.length} types</span>
+              </header>
+              <DonutChart data={typeBreakdown} total={filteredEvents.length} />
+            </article>
+          </section>
 
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>📆 Daily Registrations</h2>
-            <span className="an-badge">Last 7 Days</span>
-          </div>
-          <div className="an-bar-chart" style={{ height: '80px' }}>
-            {(() => {
-              const max = Math.max(...dailyRegs.map(d => d.registrations));
-              return dailyRegs.map((d, i) => (
-                <div className="an-bar-group" key={i}>
-                  <div className="an-bar-wrap" style={{ height: '60px' }}>
-                    <div
-                      className="an-bar"
-                      style={{
-                        height: `${(d.registrations / max) * 56}px`,
-                        background: 'linear-gradient(180deg,#5eead4,rgba(94,234,212,0.3))',
-                      }}
-                    >
-                      <div className="an-bar-tooltip">{d.registrations}</div>
-                    </div>
-                  </div>
-                  <div className="an-bar-label">{d.day}</div>
-                </div>
-              ));
-            })()}
-          </div>
-          <div className="an-spark-summary">
-            <div className="an-spark-stat">
-              <span className="val">541</span>
-              <span className="lbl">Total this week</span>
-            </div>
-            <div className="an-spark-stat">
-              <span className="val">77</span>
-              <span className="lbl">Daily average</span>
-            </div>
-            <div className="an-spark-stat">
-              <span className="val">120</span>
-              <span className="lbl">Peak day (Fri)</span>
-            </div>
-            <div className="an-spark-stat">
-              <span className="val">+14%</span>
-              <span className="lbl">vs last week</span>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* ── Row 3: Top Events + Location + Insights ── */}
-      <div className="an-row-3">
-        {/* Top Events Table */}
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>🏅 Top Events by Attendance</h2>
-            <span className="an-badge">Top 5</span>
-          </div>
-          <table className="an-events-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Event</th>
-                <th>Type</th>
-                <th>Attendees</th>
-                <th>Fill %</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {topEvents.map((e, i) => {
-                const rate = Math.round((e.attendees / e.max) * 100);
-                return (
-                  <tr key={i}>
-                    <td><span className="an-rank">{i + 1}</span></td>
-                    <td>
-                      <div style={{ fontWeight: 600 }}>{e.title}</div>
-                      <div style={{ fontSize: '0.7rem', color: 'var(--c-muted)' }}>{e.location}</div>
-                    </td>
-                    <td>
-                      <span
-                        className="an-type-chip"
-                        style={{ background: `${getTypeColor(e.type)}22`, color: getTypeColor(e.type) }}
-                      >
-                        {e.type}
-                      </span>
-                    </td>
-                    <td>
-                      <strong>{e.attendees}</strong>
-                      <span style={{ color: 'var(--c-muted)', fontSize: '0.72rem' }}>/{e.max}</span>
-                    </td>
-                    <td>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
-                        <div style={{ flex: 1, height: 5, background: 'rgba(255,255,255,0.07)', borderRadius: 10 }}>
-                          <div style={{ width: `${rate}%`, height: '100%', borderRadius: 10, background: fillColor(rate) }} />
-                        </div>
-                        <span style={{ fontSize: '0.72rem', color: 'var(--c-muted)', minWidth: 30 }}>{rate}%</span>
-                      </div>
-                    </td>
-                    <td>
-                      <span className="an-status-dot" style={{ background: statusColor(e.status) }} />
-                      <span style={{ fontSize: '0.75rem', color: statusColor(e.status), textTransform: 'capitalize' }}>{e.status}</span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Location Breakdown */}
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>🌍 Location Split</h2>
-            <span className="an-badge">All Events</span>
-          </div>
-          <DonutChart data={locationBreakdown} total={EVENTS.length} />
-          <div style={{ marginTop: '1.5rem' }}>
-            <div className="an-panel-header" style={{ marginBottom: '0.75rem' }}>
-              <h2>🗓 Month Distribution</h2>
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
-              {['Q1 2025', 'Q2 2025', 'Q3 2025', 'Q4 2025'].map((q, i) => {
-                const vals = [3, 3, 4, 4];
-                return (
-                  <div key={i} className="an-fill-item">
+          {/* ── Row 2: Fill Rates + Daily Registrations ── */}
+          <section className="an-row" aria-label="Fill Rates and Daily Registration Charts">
+            <article className="an-panel" tabIndex="0">
+              <header className="an-panel-header">
+                <h2>📉 Event Fill Rates</h2>
+                <span className="an-badge">Top 8</span>
+              </header>
+              <div className="an-fill-list" role="presentation">
+                {fillRates.slice(0, 8).map((e, i) => (
+                  <div className="an-fill-item" key={i}>
                     <div className="an-fill-meta">
-                      <span className="an-fill-name">{q}</span>
-                      <span className="an-fill-pct">{vals[i]} events</span>
+                      <span className="an-fill-name">{e.title}</span>
+                      <span className="an-fill-pct">{e.rate}%</span>
                     </div>
-                    <div className="an-fill-track">
+                    <div className="an-fill-track" role="progressbar" aria-valuenow={e.rate} aria-valuemin="0" aria-valuemax="100">
                       <div
                         className="an-fill-progress"
-                        style={{
-                          width: `${(vals[i] / 5) * 100}%`,
-                          background: ['#7c5cfc', '#5eead4', '#fbbf24', '#f472b6'][i],
-                        }}
+                        style={{ width: `${e.rate}%`, background: fillColor(e.rate) }}
                       />
                     </div>
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
+                ))}
+              </div>
+            </article>
 
-        {/* Insights */}
-        <div className="an-panel">
-          <div className="an-panel-header">
-            <h2>💡 AI Insights</h2>
-            <span className="an-badge">{insights.length} tips</span>
-          </div>
-          <div className="an-insights-list">
-            {insights.map((ins, i) => (
-              <div
-                className="an-insight-card"
-                key={i}
-                style={{ '--insight-color': ins.color }}
-              >
-                <div className="an-insight-icon">{ins.icon}</div>
-                <div className="an-insight-body">
-                  <div className="an-insight-title">{ins.title}</div>
-                  <div className="an-insight-desc">{ins.desc}</div>
+            <article className="an-panel" tabIndex="0">
+              <header className="an-panel-header">
+                <h2>📆 Daily Registrations</h2>
+                <span className="an-badge">Last 7 Days</span>
+              </header>
+              <div className="an-bar-chart" style={{ height: '80px' }} role="img" aria-label="Daily registrations bar chart over the last week">
+                {(() => {
+                  const max = Math.max(...dailyRegs.map(d => d.registrations));
+                  return dailyRegs.map((d, i) => (
+                    <div className="an-bar-group" key={i}>
+                      <div className="an-bar-wrap" style={{ height: '60px' }}>
+                        <div
+                          className="an-bar"
+                          style={{
+                            height: `${(d.registrations / max) * 56}px`,
+                            background: 'linear-gradient(180deg,#5eead4,rgba(94,234,212,0.3))',
+                          }}
+                          tabIndex="0"
+                          role="img"
+                          aria-label={`${d.day}: ${d.registrations} registrations`}
+                        >
+                          <div className="an-bar-tooltip">{d.registrations}</div>
+                        </div>
+                      </div>
+                      <div className="an-bar-label">{d.day}</div>
+                    </div>
+                  ));
+                })()}
+              </div>
+              <div className="an-spark-summary" role="presentation">
+                <div className="an-spark-stat">
+                  <span className="val">541</span>
+                  <span className="lbl">Total this week</span>
+                </div>
+                <div className="an-spark-stat">
+                  <span className="val">77</span>
+                  <span className="lbl">Daily average</span>
+                </div>
+                <div className="an-spark-stat">
+                  <span className="val">120</span>
+                  <span className="lbl">Peak day (Fri)</span>
+                </div>
+                <div className="an-spark-stat">
+                  <span className="val">+14%</span>
+                  <span className="lbl">vs last week</span>
                 </div>
               </div>
-            ))}
-          </div>
-        </div>
-      </div>
+            </article>
+          </section>
 
-    </div>
+          {/* ── Row 3: Top Events + Location + Insights ── */}
+          <section className="an-row-3" aria-label="Performance Leaderboard and Insights">
+            {/* Top Events Table */}
+            <article className="an-panel" style={{ overflowX: 'auto' }} tabIndex="0">
+              <header className="an-panel-header">
+                <h2>🏅 Top Events by Attendance</h2>
+                <span className="an-badge">Top 5</span>
+              </header>
+              <table className="an-events-table" aria-label="Leaderboard table showing top 5 events">
+                <thead>
+                  <tr>
+                    <th scope="col">#</th>
+                    <th scope="col">Event</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Attendees</th>
+                    <th scope="col">Fill %</th>
+                    <th scope="col">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topEvents.map((e, i) => {
+                    const rate = Math.round((e.attendees / e.max) * 100);
+                    return (
+                      <tr key={i}>
+                        <td><span className="an-rank">{i + 1}</span></td>
+                        <td>
+                          <div style={{ fontWeight: 600 }}>{e.title}</div>
+                          <div style={{ fontSize: '0.7rem', color: 'var(--c-muted)' }}>{e.location}</div>
+                        </td>
+                        <td>
+                          <span
+                            className="an-type-chip"
+                            style={{ background: `${getTypeColor(e.type)}22`, color: getTypeColor(e.type) }}
+                          >
+                            {e.type}
+                          </span>
+                        </td>
+                        <td>
+                          <strong>{e.attendees}</strong>
+                          <span style={{ color: 'var(--c-muted)', fontSize: '0.72rem' }}>/{e.max}</span>
+                        </td>
+                        <td>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                            <div 
+                              style={{ flex: 1, height: 5, background: 'rgba(255,255,255,0.07)', borderRadius: 10 }}
+                              role="progressbar"
+                              aria-valuenow={rate}
+                              aria-valuemin="0"
+                              aria-valuemax="100"
+                            >
+                              <div style={{ width: `${rate}%`, height: '100%', borderRadius: 10, background: fillColor(rate) }} />
+                            </div>
+                            <span style={{ fontSize: '0.72rem', color: 'var(--c-muted)', minWidth: 30 }}>{rate}%</span>
+                          </div>
+                        </td>
+                        <td>
+                          <span className="an-status-dot" style={{ background: statusColor(e.status) }} />
+                          <span style={{ fontSize: '0.75rem', color: statusColor(e.status), textTransform: 'capitalize' }}>{e.status}</span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </article>
+
+            {/* Location Breakdown */}
+            <article className="an-panel" tabIndex="0">
+              <header className="an-panel-header">
+                <h2>🌍 Location Split</h2>
+                <span className="an-badge">All Events</span>
+              </header>
+              <DonutChart data={locationBreakdown} total={filteredEvents.length} />
+              <div style={{ marginTop: '1.5rem' }}>
+                <header className="an-panel-header" style={{ marginBottom: '0.75rem' }}>
+                  <h2>🗓 Quarter Distribution</h2>
+                </header>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.6rem' }} role="presentation">
+                  {['Q1', 'Q2', 'Q3', 'Q4'].map((q, i) => {
+                    // Distribute dynamically or fallback to simulated split based on event count
+                    const qData = [0, 0, 0, 0];
+                    filteredEvents.forEach(e => {
+                      if (e.date) {
+                        const m = new Date(e.date).getMonth();
+                        const quarterIdx = Math.floor(m / 3);
+                        qData[quarterIdx] = (qData[quarterIdx] || 0) + 1;
+                      }
+                    });
+                    const count = qData[i] || 0;
+                    const pct = filteredEvents.length > 0 ? (count / filteredEvents.length) * 100 : 0;
+                    return (
+                      <div key={i} className="an-fill-item">
+                        <div className="an-fill-meta">
+                          <span className="an-fill-name">{q} Period</span>
+                          <span className="an-fill-pct">{count} {count === 1 ? 'event' : 'events'}</span>
+                        </div>
+                        <div className="an-fill-track" role="progressbar" aria-valuenow={pct} aria-valuemin="0" aria-valuemax="100">
+                          <div
+                            className="an-fill-progress"
+                            style={{
+                              width: `${pct}%`,
+                              background: ['#7c5cfc', '#5eead4', '#fbbf24', '#f472b6'][i],
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </article>
+
+            {/* Insights */}
+            <article className="an-panel" tabIndex="0">
+              <header className="an-panel-header">
+                <h2>💡 AI Insights</h2>
+                <span className="an-badge">{insights.length} tips</span>
+              </header>
+              <div className="an-insights-list" role="presentation">
+                {insights.map((ins, i) => (
+                  <article
+                    className="an-insight-card"
+                    key={i}
+                    style={{ '--insight-color': ins.color }}
+                  >
+                    <div className="an-insight-icon" aria-hidden="true">{ins.icon}</div>
+                    <div className="an-insight-body">
+                      <h3 className="an-insight-title" style={{ margin: 0 }}>{ins.title}</h3>
+                      <div className="an-insight-desc">{ins.desc}</div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </article>
+          </section>
+        </>
+      )}
+    </main>
   );
 };
 

--- a/src/Pages/Analytics/analyticsData.js
+++ b/src/Pages/Analytics/analyticsData.js
@@ -1,0 +1,72 @@
+import eventsData from '../Events/eventsMockData.json';
+
+// ── Derived from real events mock data ──────────────────────────
+export const EVENTS = eventsData;
+
+export const getKPIs = () => {
+  const total = EVENTS.length;
+  const upcoming = EVENTS.filter(e => e.status === 'upcoming').length;
+  const past = EVENTS.filter(e => e.status === 'past').length;
+  const totalAttendees = EVENTS.reduce((s, e) => s + e.attendees, 0);
+  const totalCapacity = EVENTS.reduce((s, e) => s + e.maxAttendees, 0);
+  const avgFillRate = Math.round((totalAttendees / totalCapacity) * 100);
+  const soldOut = EVENTS.filter(e => e.attendees >= e.maxAttendees).length;
+
+  return { total, upcoming, past, totalAttendees, totalCapacity, avgFillRate, soldOut };
+};
+
+export const getTypeBreakdown = () => {
+  const map = {};
+  EVENTS.forEach(e => { map[e.type] = (map[e.type] || 0) + 1; });
+  return Object.entries(map).map(([type, count]) => ({ type, count }));
+};
+
+export const getAttendeeTrend = () => {
+  // Monthly attendee totals (grouped by month from event date)
+  const map = {};
+  EVENTS.forEach(e => {
+    const month = new Date(e.date).toLocaleString('default', { month: 'short', year: '2-digit' });
+    map[month] = (map[month] || 0) + e.attendees;
+  });
+  return Object.entries(map)
+    .sort((a, b) => new Date('1 ' + a[0]) - new Date('1 ' + b[0]))
+    .map(([month, attendees]) => ({ month, attendees }));
+};
+
+export const getFillRates = () =>
+  EVENTS.map(e => ({
+    title: e.title.length > 22 ? e.title.slice(0, 20) + '…' : e.title,
+    rate: Math.round((e.attendees / e.maxAttendees) * 100),
+    status: e.status,
+    type: e.type,
+  })).sort((a, b) => b.rate - a.rate);
+
+export const getTopEvents = () =>
+  [...EVENTS]
+    .sort((a, b) => b.attendees - a.attendees)
+    .slice(0, 5)
+    .map(e => ({
+      title: e.title,
+      attendees: e.attendees,
+      max: e.maxAttendees,
+      type: e.type,
+      status: e.status,
+      location: e.location,
+      date: e.date,
+    }));
+
+export const getLocationBreakdown = () => {
+  const map = {};
+  EVENTS.forEach(e => {
+    const loc = e.location === 'Online' ? 'Online' : 'In-Person';
+    map[loc] = (map[loc] || 0) + 1;
+  });
+  return Object.entries(map).map(([loc, count]) => ({ loc, count }));
+};
+
+// Simulated registration-over-time for a sparkline (last 7 days)
+export const getDailyRegistrations = () => {
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const values = [42, 67, 55, 89, 120, 95, 73];
+  return days.map((day, i) => ({ day, registrations: values[i] }));
+};

--- a/src/Pages/Analytics/analyticsData.js
+++ b/src/Pages/Analytics/analyticsData.js
@@ -3,61 +3,77 @@ import eventsData from '../Events/eventsMockData.json';
 // ── Derived from real events mock data ──────────────────────────
 export const EVENTS = eventsData;
 
-export const getKPIs = () => {
-  const total = EVENTS.length;
-  const upcoming = EVENTS.filter(e => e.status === 'upcoming').length;
-  const past = EVENTS.filter(e => e.status === 'past').length;
-  const totalAttendees = EVENTS.reduce((s, e) => s + e.attendees, 0);
-  const totalCapacity = EVENTS.reduce((s, e) => s + e.maxAttendees, 0);
-  const avgFillRate = Math.round((totalAttendees / totalCapacity) * 100);
-  const soldOut = EVENTS.filter(e => e.attendees >= e.maxAttendees).length;
+export const getKPIs = (events = EVENTS) => {
+  const total = events.length;
+  if (total === 0) {
+    return { total: 0, upcoming: 0, past: 0, totalAttendees: 0, totalCapacity: 0, avgFillRate: 0, soldOut: 0 };
+  }
+  const upcoming = events.filter(e => e.status === 'upcoming').length;
+  const past = events.filter(e => e.status === 'past').length;
+  const totalAttendees = events.reduce((s, e) => s + (e.attendees || 0), 0);
+  const totalCapacity = events.reduce((s, e) => s + (e.maxAttendees || e.maxParticipants || 100), 0);
+  const avgFillRate = totalCapacity > 0 ? Math.round((totalAttendees / totalCapacity) * 100) : 0;
+  const soldOut = events.filter(e => (e.attendees || 0) >= (e.maxAttendees || e.maxParticipants || 100)).length;
 
   return { total, upcoming, past, totalAttendees, totalCapacity, avgFillRate, soldOut };
 };
 
-export const getTypeBreakdown = () => {
+export const getTypeBreakdown = (events = EVENTS) => {
+  if (!events || events.length === 0) return [];
   const map = {};
-  EVENTS.forEach(e => { map[e.type] = (map[e.type] || 0) + 1; });
+  events.forEach(e => { 
+    if (e.type) {
+      map[e.type] = (map[e.type] || 0) + 1; 
+    }
+  });
   return Object.entries(map).map(([type, count]) => ({ type, count }));
 };
 
-export const getAttendeeTrend = () => {
+export const getAttendeeTrend = (events = EVENTS) => {
+  if (!events || events.length === 0) return [];
   // Monthly attendee totals (grouped by month from event date)
   const map = {};
-  EVENTS.forEach(e => {
-    const month = new Date(e.date).toLocaleString('default', { month: 'short', year: '2-digit' });
-    map[month] = (map[month] || 0) + e.attendees;
+  events.forEach(e => {
+    if (e.date) {
+      const month = new Date(e.date).toLocaleString('default', { month: 'short', year: '2-digit' });
+      map[month] = (map[month] || 0) + (e.attendees || 0);
+    }
   });
   return Object.entries(map)
     .sort((a, b) => new Date('1 ' + a[0]) - new Date('1 ' + b[0]))
     .map(([month, attendees]) => ({ month, attendees }));
 };
 
-export const getFillRates = () =>
-  EVENTS.map(e => ({
-    title: e.title.length > 22 ? e.title.slice(0, 20) + '…' : e.title,
-    rate: Math.round((e.attendees / e.maxAttendees) * 100),
-    status: e.status,
-    type: e.type,
+export const getFillRates = (events = EVENTS) => {
+  if (!events || events.length === 0) return [];
+  return events.map(e => ({
+    title: e.title && e.title.length > 22 ? e.title.slice(0, 20) + '…' : (e.title || 'Untitled Event'),
+    rate: Math.round(((e.attendees || 0) / (e.maxAttendees || e.maxParticipants || 100)) * 100),
+    status: e.status || 'active',
+    type: e.type || 'other',
   })).sort((a, b) => b.rate - a.rate);
+};
 
-export const getTopEvents = () =>
-  [...EVENTS]
-    .sort((a, b) => b.attendees - a.attendees)
+export const getTopEvents = (events = EVENTS) => {
+  if (!events || events.length === 0) return [];
+  return [...events]
+    .sort((a, b) => (b.attendees || 0) - (a.attendees || 0))
     .slice(0, 5)
     .map(e => ({
-      title: e.title,
-      attendees: e.attendees,
-      max: e.maxAttendees,
-      type: e.type,
-      status: e.status,
-      location: e.location,
-      date: e.date,
+      title: e.title || 'Untitled Event',
+      attendees: e.attendees || 0,
+      max: e.maxAttendees || e.maxParticipants || 100,
+      type: e.type || 'other',
+      status: e.status || 'active',
+      location: e.location || 'Unknown',
+      date: e.date || '',
     }));
+};
 
-export const getLocationBreakdown = () => {
+export const getLocationBreakdown = (events = EVENTS) => {
+  if (!events || events.length === 0) return [];
   const map = {};
-  EVENTS.forEach(e => {
+  events.forEach(e => {
     const loc = e.location === 'Online' ? 'Online' : 'In-Person';
     map[loc] = (map[loc] || 0) + 1;
   });
@@ -70,3 +86,4 @@ export const getDailyRegistrations = () => {
   const values = [42, 67, 55, 89, 120, 95, 73];
   return days.map((day, i) => ({ day, registrations: values[i] }));
 };
+

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS, apiUtils } from '../../config/api';
-import ConfirmationModal from '../common/ConfirmationModal'; // ADD THIS IMPORT
+import ConfirmationModal from '../common/ConfirmationModal';
 import './AdminDashboard.css';
 
 const AdminDashboard = () => {
@@ -46,7 +46,7 @@ const AdminDashboard = () => {
     try {
       setLoading(true);
       const token = localStorage.getItem('token');
-      
+
       // Fetch users and events data
       const usersResponse = await apiUtils.get(API_ENDPOINTS.ADMIN.USERS, token);
       const eventsResponse = await apiUtils.get(API_ENDPOINTS.ADMIN.EVENTS, token);
@@ -91,6 +91,7 @@ const AdminDashboard = () => {
         <button className={activeTab === 'overview' ? 'active' : ''} onClick={() => setActiveTab('overview')}>Overview</button>
         <button className={activeTab === 'events' ? 'active' : ''} onClick={() => setActiveTab('events')}>Events</button>
         <button className={activeTab === 'users' ? 'active' : ''} onClick={() => setActiveTab('users')}>Users</button>
+        <button className={activeTab === 'analytics' ? 'active' : ''} onClick={() => setActiveTab('analytics')}>📊 Analytics</button>
       </div>
 
       {error && <div className="error-message">{error}</div>}
@@ -120,7 +121,7 @@ const AdminDashboard = () => {
             <h2>Event Management</h2>
             <div className="action-buttons">
               {hasPermission('CREATE_EVENT') && (
-                <button className="action-btn create-event"  onClick={() => navigate("/create-event")}>
+                <button className="action-btn create-event" onClick={() => navigate("/create-event")}>
                   + New Event
                 </button>
               )}
@@ -197,7 +198,25 @@ const AdminDashboard = () => {
         </div>
       )}
 
-      {/* ADD THIS MODAL AT THE BOTTOM */}
+      {activeTab === 'analytics' && (
+        <div className="dashboard-content" style={{ textAlign: 'center', padding: '3rem 2rem' }}>
+          <div style={{ fontSize: '3rem', marginBottom: '1rem' }}>📊</div>
+          <h2 style={{ marginBottom: '0.75rem' }}>Event Analytics Dashboard</h2>
+          <p style={{ color: '#6b7280', marginBottom: '2rem', maxWidth: 480, margin: '0 auto 2rem' }}>
+            Deep-dive into attendee trends, fill rates, event type breakdown, and AI-powered insights — all in one place.
+          </p>
+          <button
+            id="admin-open-analytics-btn"
+            className="action-btn view-analytics"
+            style={{ padding: '0.85rem 2rem', fontSize: '1rem', borderRadius: 8, cursor: 'pointer', border: 'none', color: '#fff' }}
+            onClick={() => navigate('/analytics')}
+          >
+            Open Analytics Dashboard →
+          </button>
+        </div>
+      )}
+
+      {/* Logout confirmation modal */}
       <ConfirmationModal
         isOpen={showLogoutModal}
         onClose={handleCancelLogout}

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -2,16 +2,29 @@
 // Uses relative paths in development so the CRA proxy (package.json "proxy" field)
 // forwards requests to the backend — no CORS issues.
 // In production, REACT_APP_API_URL should be set to the backend base URL.
-const AUTH_API_BASE_PATH = process.env.REACT_APP_API_URL
-  ? `${process.env.REACT_APP_API_URL}/api/auth`
-  : '/api/auth'; // ← goes through CRA proxy in dev
+const API_BASE_PATH = process.env.REACT_APP_API_URL
+  ? process.env.REACT_APP_API_URL
+  : '';
 
-// API endpoints — only login and signup are active
+const AUTH_API_BASE_PATH = `${API_BASE_PATH}/api/auth`;
+
+// API endpoints
 export const API_ENDPOINTS = {
   AUTH: {
     LOGIN: `${AUTH_API_BASE_PATH}/login`,
     REGISTER: `${AUTH_API_BASE_PATH}/signup`,
   },
+  ADMIN: {
+    USERS: `${API_BASE_PATH}/api/admin/users`,
+    EVENTS: `${API_BASE_PATH}/api/admin/events`,
+  },
+  ANALYTICS: {
+    GET: `${API_BASE_PATH}/api/analytics`,
+  },
+  PROJECTS: {
+    LIST: `${API_BASE_PATH}/api/projects`,
+    CATEGORIES: `${API_BASE_PATH}/api/projects/categories`,
+  }
 };
 
 // Helper function to get authorization headers
@@ -23,6 +36,19 @@ export const getAuthHeaders = (token) => {
 
 // API utility functions
 export const apiUtils = {
+  get: async (url, token = null) => {
+    try {
+      console.log('Making GET request to:', url);
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: getAuthHeaders(token)
+      });
+      return response;
+    } catch (error) {
+      console.error('API GET Error:', error);
+      throw error;
+    }
+  },
   post: async (url, data, token = null) => {
     try {
       console.log('Making POST request to:', url);
@@ -38,4 +64,5 @@ export const apiUtils = {
     }
   },
 };
+
 


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #834

## Rationale for this change

This feature adds an Organizer Analytics Dashboard to Eventra, allowing organizers to track event performance, attendee engagement, registration trends, and attendance statistics. The feature was mentioned in the README but was not implemented in the frontend.

## What changes are included in this PR?

* Added organizer-only analytics dashboard route (`/analytics`)
* Implemented protected access using `ProtectedRoute`
* Added KPI metrics for:

  * total registrations
  * attendance/check-in count
  * fill rates
  * top events
* Added signup trend visualizations and analytics charts
* Added dynamic filtering support
* Added empty-state handling when no analytics data exists
* Integrated API-based analytics fetching with fallback mock data
* Added responsive UI and accessibility improvements
* Added analytics navigation support in Admin Dashboard
* Added reusable analytics utility functions

## Are these changes tested?

Yes.

The feature was tested locally using:

* `npm run dev`
* `npm run build:fast`

Verified:

* protected route behavior
* responsive layouts
* chart rendering
* empty states
* API fallback handling
* build stability without runtime errors

## Are there any user-facing changes?

Yes.

Organizers/Admins can now access a dedicated analytics dashboard to monitor event performance and attendee statistics.
