### PR TITLE
fix: add mock responses for api docs endpoints

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -98,12 +98,16 @@ const ApiDocs = () => {
           API Documentation
         </motion.h1>
         <p className="text-black dark:text-white max-w-2xl mx-auto text-lg">
-          Use our RESTful APIs to interact with{" "}
+          Explore mock REST API responses for{" "}
           <span className="text-black dark:text-white">Hackathons</span>,{" "}
           <span className="text-black dark:text-white">Projects</span>,{" "}
           <span className="text-black dark:text-white">Contributors</span>, and{" "}
           <span className="text-black dark:text-white">Leaderboards</span>{" "}
-          programmatically.
+          in this frontend demo.
+        </p>
+        <p className="mt-4 text-sm text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+          These documented endpoints return sample JSON-style data in the demo app.
+          Connect a backend service before using them as production APIs.
         </p>
       </section>
 

--- a/src/components/MockApiResponse.js
+++ b/src/components/MockApiResponse.js
@@ -1,0 +1,96 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+
+const mockResponses = {
+  "/api/hackathons": {
+    status: 200,
+    source: "mock",
+    data: [
+      {
+        id: 1,
+        title: "CodeFest 2025",
+        startDate: "2025-09-20",
+        endDate: "2025-09-25",
+        participants: 150,
+      },
+    ],
+  },
+  "/api/projects": {
+    status: 200,
+    source: "mock",
+    data: [
+      {
+        id: 42,
+        title: "AI-Powered Chatbot",
+        author: "Jane Doe",
+        votes: 120,
+      },
+    ],
+  },
+  "/api/contributors": {
+    status: 200,
+    source: "mock",
+    data: [
+      {
+        id: 7,
+        username: "dev_ankita",
+        points: 230,
+        rank: 2,
+      },
+    ],
+  },
+  "/api/leaderboard": {
+    status: 200,
+    source: "mock",
+    data: [
+      {
+        rank: 1,
+        username: "coder123",
+        points: 500,
+      },
+    ],
+  },
+};
+
+const MockApiResponse = () => {
+  const location = useLocation();
+  const response = mockResponses[location.pathname] || {
+    status: 404,
+    source: "mock",
+    error: "Endpoint not found",
+  };
+
+  const payload = {
+    ...response,
+    endpoint: `${location.pathname}${location.search}`,
+    message:
+      "This frontend demo returns mock API documentation data. Connect a backend service for live API responses.",
+  };
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-16 text-slate-100">
+      <section className="mx-auto max-w-4xl">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-emerald-300">
+              Mock API Response
+            </p>
+            <h1 className="mt-2 text-3xl font-bold">{payload.endpoint}</h1>
+          </div>
+          <Link
+            to="/apiDocs"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:bg-slate-800"
+          >
+            Back to API Docs
+          </Link>
+        </div>
+
+        <pre className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-900 p-5 text-left text-sm leading-6 text-emerald-100 shadow-xl">
+          <code>{JSON.stringify(payload, null, 2)}</code>
+        </pre>
+      </section>
+    </main>
+  );
+};
+
+export default MockApiResponse;

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -23,6 +23,7 @@ import FeedbackPage from "../../Pages/Feedback/FeedbackPage";
 import EventAnalyticsDashboard from "../../Pages/Events/EventAnalyticsDashboard";
 import DocumentationPage from "../../Pages/About/DocumentationPage";
 import SubmitProject from "../../Pages/Projects/SubmitProject";
+import MockApiResponse from "../MockApiResponse";
 
 export const getPublicRoutes = () => [
   <Route key="/" path="/" element={<HomePage />} />,
@@ -30,6 +31,10 @@ export const getPublicRoutes = () => [
   <Route key="/register" path="/events/:eventId/register" element={<EventRegistration />} />,
   <Route key="/hackathons" path="/hackathons" element={<HackathonPage />} />,
   <Route key="/projects" path="/projects" element={<ProjectsPage />} />,
+  <Route key="/api/hackathons" path="/api/hackathons" element={<MockApiResponse />} />,
+  <Route key="/api/projects" path="/api/projects" element={<MockApiResponse />} />,
+  <Route key="/api/contributors" path="/api/contributors" element={<MockApiResponse />} />,
+  <Route key="/api/leaderboard" path="/api/leaderboard" element={<MockApiResponse />} />,
   <Route key="page-layout" element={<PageLayout />}>
     <Route key="/contributors" path="/contributors" element={<Contributors />} />
     <Route key="/communityEvent" path="/communityEvent" element={<CommunityEvent />} />


### PR DESCRIPTION
Closes #1123

## Changes
- Added frontend mock API response routes for the documented API endpoints.
- Registered routes for `/api/hackathons`, `/api/projects`, `/api/contributors`, and `/api/leaderboard`.
- Ensured query-string examples like `/api/projects?hackathonId=1` and `/api/leaderboard?limit=10` open correctly.
- Added a JSON-style mock response page instead of showing blank pages.
- Updated API Docs copy to clarify that these are demo/mock endpoints until a backend service is connected.

## Testing
- Ran `npm run build`
- Opened `/apiDocs`
- Opened `/api/hackathons`
- Opened `/api/projects?hackathonId=1`
- Opened `/api/contributors`
- Opened `/api/leaderboard?limit=10`
- Verified each documented endpoint shows a mock JSON-style response instead of a blank page