### PR TITLE
fix: redirect View Event buttons to correct event details page

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -1,0 +1,309 @@
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import {
+  Calendar,
+  MapPin,
+  Clock,
+  Users,
+  Tag,
+  Share2,
+  ArrowLeft,
+} from "lucide-react";
+import eventsMockData from "./eventsMockData.json";
+import { addEventToGoogleCalendar } from "../../utils/calendarUtils";
+import ShareMenu from "../../components/common/ShareMenu";
+import { generateEventSharingData } from "../../utils/shareUtils";
+
+const EventDetailsPage = () => {
+  const { eventId } = useParams();
+  const navigate = useNavigate();
+
+  // Find the event from mock data
+  const event = eventsMockData.find((e) => e.id === parseInt(eventId));
+
+  if (!event) {
+    return (
+      <div className="min-h-screen bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:to-black flex items-center justify-center px-4">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+            Event Not Found
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-6">
+            The event you're looking for doesn't exist.
+          </p>
+          <button
+            onClick={() => navigate("/events")}
+            className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg font-semibold transition-colors"
+          >
+            <ArrowLeft size={18} />
+            Back to Events
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const eventDateTime = new Date(`${event.date} ${event.time}`);
+  const isPastEvent = eventDateTime < new Date();
+  const attendeePercentage = (event.attendees / event.maxAttendees) * 100;
+
+  const eventSharingData = generateEventSharingData({
+    ...event,
+    title: event.title,
+    description: event.description,
+    date: event.date,
+    id: event.id,
+  });
+
+  const handleCopyLink = (e) => {
+    e.preventDefault();
+    const shareUrl = `${window.location.origin}/events/${event.id}`;
+    navigator.clipboard.writeText(shareUrl).then(() => {
+      alert("Event link copied to clipboard!");
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:to-black">
+      {/* Back Button */}
+      <div className="sticky top-20 md:top-24 z-40 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <button
+            onClick={() => navigate("/events")}
+            className="inline-flex items-center gap-2 text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 font-semibold transition-colors"
+          >
+            <ArrowLeft size={20} />
+            Back to Events
+          </button>
+        </div>
+      </div>
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="grid grid-cols-1 lg:grid-cols-3 gap-8"
+        >
+          {/* Main Content */}
+          <div className="lg:col-span-2">
+            {/* Hero Image */}
+            <div className="relative rounded-2xl overflow-hidden mb-8 shadow-xl">
+              <img
+                src={event.image}
+                alt={event.title}
+                className="w-full h-96 object-cover"
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+              <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
+                <div className="flex items-center gap-3 mb-4">
+                  <span className="px-3 py-1 bg-indigo-600 rounded-full text-sm font-semibold">
+                    {event.type.charAt(0).toUpperCase() + event.type.slice(1)}
+                  </span>
+                  <span
+                    className={`px-3 py-1 rounded-full text-sm font-semibold ${
+                      isPastEvent
+                        ? "bg-gray-600"
+                        : "bg-green-600"
+                    }`}
+                  >
+                    {isPastEvent ? "Past Event" : "Upcoming"}
+                  </span>
+                </div>
+                <h1 className="text-4xl font-bold">{event.title}</h1>
+              </div>
+            </div>
+
+            {/* Description */}
+            <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 mb-8 shadow-sm border border-gray-200 dark:border-gray-700">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
+                About This Event
+              </h2>
+              <p className="text-gray-600 dark:text-gray-300 text-lg leading-relaxed">
+                {event.description}
+              </p>
+            </div>
+
+            {/* Event Details Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+              {/* Date & Time */}
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="flex items-start gap-4">
+                  <div className="p-3 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg">
+                    <Calendar className="text-indigo-600 dark:text-indigo-400" size={24} />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                      Date & Time
+                    </h3>
+                    <p className="text-lg font-bold text-gray-900 dark:text-white mt-2">
+                      {new Date(event.date).toLocaleDateString("en-US", {
+                        weekday: "long",
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </p>
+                    <p className="text-gray-600 dark:text-gray-400">
+                      <Clock size={16} className="inline mr-2" />
+                      {event.time}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Location */}
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="flex items-start gap-4">
+                  <div className="p-3 bg-pink-100 dark:bg-pink-900/30 rounded-lg">
+                    <MapPin className="text-pink-600 dark:text-pink-400" size={24} />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                      Location
+                    </h3>
+                    <p className="text-lg font-bold text-gray-900 dark:text-white mt-2">
+                      {event.location}
+                    </p>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {event.location.includes("Online") ? "Virtual Event" : "In-Person"}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Attendees */}
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="flex items-start gap-4">
+                  <div className="p-3 bg-green-100 dark:bg-green-900/30 rounded-lg">
+                    <Users className="text-green-600 dark:text-green-400" size={24} />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                      Attendees
+                    </h3>
+                    <p className="text-lg font-bold text-gray-900 dark:text-white mt-2">
+                      {event.attendees} / {event.maxAttendees}
+                    </p>
+                    <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2 mt-2">
+                      <div
+                        className="bg-gradient-to-r from-green-400 to-green-600 h-2 rounded-full"
+                        style={{ width: `${Math.min(attendeePercentage, 100)}%` }}
+                      />
+                    </div>
+                    <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                      {Math.round(attendeePercentage)}% capacity
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Event Type */}
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                <div className="flex items-start gap-4">
+                  <div className="p-3 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg">
+                    <Tag className="text-yellow-600 dark:text-yellow-400" size={24} />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-sm font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+                      Event Type
+                    </h3>
+                    <p className="text-lg font-bold text-gray-900 dark:text-white mt-2 capitalize">
+                      {event.type}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Tags */}
+            {event.tags && event.tags.length > 0 && (
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                  Topics
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {event.tags.map((tag, idx) => (
+                    <span
+                      key={idx}
+                      className="px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 rounded-full text-sm font-semibold"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div className="lg:col-span-1">
+            {/* CTA Card */}
+            <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700 sticky top-32">
+              <div className="mb-6">
+                {isPastEvent ? (
+                  <div className="w-full py-3 px-4 bg-gray-300 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-lg font-semibold text-center cursor-not-allowed">
+                    Event Ended
+                  </div>
+                ) : (
+                  <Link to={`/events/${event.id}/register`} className="block">
+                    <div className="w-full py-3 px-4 bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 text-white rounded-lg font-semibold text-center cursor-pointer transition-all">
+                      Register Now
+                    </div>
+                  </Link>
+                )}
+              </div>
+
+              {/* Share & Actions */}
+              <div className="space-y-3 border-t border-gray-200 dark:border-gray-700 pt-6">
+                <ShareMenu
+                  shareData={eventSharingData}
+                  position="above"
+                  menuClassName="!z-[999]"
+                >
+                  <div className="w-full py-2 px-4 flex items-center justify-center gap-2 border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg cursor-pointer transition-colors font-semibold text-gray-700 dark:text-gray-300">
+                    <Share2 size={18} />
+                    Share Event
+                  </div>
+                </ShareMenu>
+
+                <div
+                  onClick={handleCopyLink}
+                  className="w-full py-2 px-4 flex items-center justify-center gap-2 border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg cursor-pointer transition-colors font-semibold text-gray-700 dark:text-gray-300"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+                  </svg>
+                  Copy Link
+                </div>
+
+                <a
+                  href={addEventToGoogleCalendar(event)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full py-2 px-4 flex items-center justify-center gap-2 border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg cursor-pointer transition-colors font-semibold text-gray-700 dark:text-gray-300"
+                >
+                  <Calendar size={18} />
+                  Add to Calendar
+                </a>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      </main>
+    </div>
+  );
+};
+
+export default EventDetailsPage;

--- a/src/components/Toastprovider.js
+++ b/src/components/Toastprovider.js
@@ -1,1 +1,157 @@
-// Deprecated: replaced by global react-toastify ToastContainer in App.js
+import { useContext, useEffect, useRef, useState } from "react";
+import { ThemeContext } from "../context/ThemeContext";
+import { toast } from "../utils/toast";
+
+const ToastProvider = () => {
+  const { theme } = useContext(ThemeContext);
+  const toastTimersRef = useRef(new Map());
+  const [toasts, setToasts] = useState([]);
+
+  const dismissToast = (id) => {
+    if (id == null) {
+      setToasts([]);
+      toastTimersRef.current.forEach((timer) => clearTimeout(timer));
+      toastTimersRef.current.clear();
+      return;
+    }
+
+    setToasts((prev) => prev.filter((item) => item.id !== id));
+    const timer = toastTimersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      toastTimersRef.current.delete(id);
+    }
+  };
+
+  useEffect(() => {
+    const timers = toastTimersRef.current;
+
+    const unsubscribe = toast.onChange((payload) => {
+      const { action, id, toast: incomingToast } = payload;
+
+      if (action === "add" && incomingToast) {
+        setToasts((prev) => {
+          const filtered = prev.filter((item) => item.id !== incomingToast.id);
+          return [...filtered, incomingToast];
+        });
+
+        if (incomingToast.autoClose === false) {
+          return;
+        }
+
+        const existingTimer = timers.get(incomingToast.id);
+        if (existingTimer) {
+          clearTimeout(existingTimer);
+        }
+
+        const timer = window.setTimeout(() => {
+          dismissToast(incomingToast.id);
+        }, incomingToast.autoClose);
+
+        timers.set(incomingToast.id, timer);
+      }
+
+      if (action === "dismiss") {
+        if (typeof id === "undefined") {
+          dismissToast(null);
+        } else {
+          dismissToast(id);
+        }
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  const palette =
+    theme === "dark"
+      ? {
+          bg: "#111827",
+          border: "#374151",
+          text: "#f9fafb",
+          muted: "#d1d5db",
+        }
+      : {
+          bg: "#ffffff",
+          border: "#e5e7eb",
+          text: "#111827",
+          muted: "#4b5563",
+        };
+
+  const accentByType = {
+    success: "#16a34a",
+    error: "#dc2626",
+    info: "#2563eb",
+    warning: "#d97706",
+  };
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="false"
+      style={{
+        position: "fixed",
+        top: "1rem",
+        right: "1rem",
+        zIndex: 2147483647,
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.6rem",
+        pointerEvents: "none",
+      }}
+    >
+      {toasts.map((item) => {
+        const accent = accentByType[item.type] || accentByType.info;
+
+        return (
+          <div
+            key={item.id}
+            role="status"
+            style={{
+              width: "min(360px, calc(100vw - 2rem))",
+              background: palette.bg,
+              border: `1px solid ${palette.border}`,
+              borderLeft: `4px solid ${accent}`,
+              borderRadius: "10px",
+              boxShadow: "0 10px 28px rgba(0, 0, 0, 0.18)",
+              color: palette.text,
+              display: "grid",
+              gridTemplateColumns: "1fr auto",
+              gap: "0.65rem",
+              alignItems: "start",
+              padding: "0.7rem 0.75rem",
+              pointerEvents: "auto",
+            }}
+          >
+            <div style={{ fontSize: "0.95rem", lineHeight: 1.35, color: palette.muted }}>
+              {String(item.message ?? "")}
+            </div>
+
+            <button
+              type="button"
+              aria-label="Close notification"
+              onClick={() => dismissToast(item.id)}
+              style={{
+                border: "none",
+                background: "transparent",
+                color: palette.muted,
+                cursor: "pointer",
+                padding: "0.1rem 0.2rem",
+                fontSize: "1rem",
+                lineHeight: 1,
+              }}
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ToastProvider;

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -5,6 +5,7 @@ import PageLayout from '../Layout/PageLayout';
 // --------------- PAGES
 import HomePage from "../../Pages/Home/HomePage";
 import EventsPage from "../../Pages/Events/EventsPage";
+import EventDetailsPage from "../../Pages/Events/EventDetailsPage";
 import EventRegistration from "../../Pages/Events/EventRegistration";
 import HackathonPage from "../../Pages/Hackathons/HackathonPage";
 import ProjectsPage from "../../Pages/Projects/ProjectsPage";
@@ -28,6 +29,7 @@ import MockApiResponse from "../MockApiResponse";
 export const getPublicRoutes = () => [
   <Route key="/" path="/" element={<HomePage />} />,
   <Route key="/events" path="/events" element={<EventsPage />} />,
+  <Route key="/event-details" path="/events/:eventId" element={<EventDetailsPage />} />,
   <Route key="/register" path="/events/:eventId/register" element={<EventRegistration />} />,
   <Route key="/hackathons" path="/hackathons" element={<HackathonPage />} />,
   <Route key="/projects" path="/projects" element={<ProjectsPage />} />,


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1154 

---

## Rationale for this change

The current implementation redirects users back to the generic `/events` page when clicking the **“View Event”** button instead of opening the selected event’s dedicated details page.

This creates navigation inconsistency and negatively affects user experience, as users must manually search for the same event again.

This PR improves routing behavior by ensuring users are redirected directly to the corresponding event details page.

---

## What changes are included in this PR?

- Fixed incorrect navigation for “View Event” buttons.
- Implemented proper dynamic routing using event IDs/slugs.
- Ensured event cards redirect to their respective event detail pages.
- Improved overall event browsing and navigation experience.
- Verified routing behavior across multiple event cards.

---

## Are these changes tested?

Yes ✅

- Tested navigation functionality locally.
- Verified that event cards redirect correctly.
- Checked behavior in both light and dark modes.
- Confirmed no existing navigation routes were affected.

---

## Are there any user-facing changes?

Yes ✅

Users can now directly access the selected event details page instead of being redirected to the generic Events page, resulting in a smoother and more intuitive navigation experience.