### PR TITLE
[Bug]Removed the extra hamburger icon and fixed the mobile navbar UI

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -13,7 +13,7 @@ import useDocumentTitle from "../../hooks/useDocumentTitle";
 const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
   if (isLoading) {
     return (
-      <div className="grid gap-6 grid-cols-1 md:grid-cols-3">
+      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {[1, 2, 3, 4, 5, 6].map((i) => (
           <EventCardSkeleton key={`skeleton-${i}`} />
         ))}
@@ -32,10 +32,10 @@ const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
     <div
       key={filterType + viewMode}
       className={`grid gap-6 ${
-        viewMode === "grid"
-          ? "grid-cols-1 md:grid-cols-3"
-          : "grid-cols-1 max-w-4xl mx-auto"
-      }`}
+  viewMode === "grid"
+    ? "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+    : "grid-cols-1 max-w-4xl mx-auto"
+}`}
     >
       {filteredEvents.map((event) => (
         <EventCard key={event.id} event={event} />
@@ -170,9 +170,9 @@ const EventsPage = () => {
           </div>
 
           {/* Sort Dropdown and View Toggle */}
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4">
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 sm:gap-4">
             {/* Sort Dropdown */}
-            <div className="w-full sm:w-auto">
+            <div className="w-full sm:w-48">
               <label htmlFor="sort-events" className="sr-only">
                 Sort events
               </label>

--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -171,7 +171,7 @@ const Hero = () => {
   ];
 
   return (
-    <section className="relative overflow-hidden bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 py-16 sm:py-20 md:py-24">
+    <section className="relative overflow-hidden bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-gray-900 pb-16 sm:pb-20 md:pb-24 pt-6 sm:pt-10">
       {/* Floating pastel shapes */}
       {shapes.map((shape, i) => (
         <motion.div

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -16,7 +16,6 @@ const WhatsHappening = () => {
   const [direction, setDirection] = useState(1);
   const [isAutoPlaying, setIsAutoPlaying] = useState(true);
 
-  // Combine and format events and hackathons data
   const formatEventsData = (events) => {
     return events
       .filter((event) => new Date(event.date) >= new Date())
@@ -66,19 +65,18 @@ const WhatsHappening = () => {
       }));
   };
 
-  // Combine all events and hackathons
   const upcomingEvents = [
     ...formatEventsData(eventsData),
     ...formatHackathonsData(hackathonsData),
-  ].sort((a, b) => new Date(a.date) - new Date(b.date)); // Sort by date
+  ].sort((a, b) => new Date(a.date) - new Date(b.date));
 
-  // UPDATED: Added dark mode classes for all statuses
   const statusColors = {
     "Registration Open":
       "bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300",
     "Coming Soon":
       "bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300",
-    "Live Now": "bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300",
+    "Live Now":
+      "bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300",
     "Live Event":
       "bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-300",
     Planning:
@@ -90,11 +88,11 @@ const WhatsHappening = () => {
   useEffect(() => {
     const updateCardsPerView = () => {
       if (window.innerWidth < 640) {
-        setCardsPerView(1); // Mobile
+        setCardsPerView(1);
       } else if (window.innerWidth < 1024) {
-        setCardsPerView(2); // Tablet
+        setCardsPerView(2);
       } else {
-        setCardsPerView(3); // Desktop
+        setCardsPerView(3);
       }
     };
 
@@ -133,24 +131,16 @@ const WhatsHappening = () => {
 
   useEffect(() => {
     if (isAutoPlaying) return;
-
     const timeout = setTimeout(() => {
       setIsAutoPlaying(true);
     }, 10000);
-
     return () => clearTimeout(timeout);
   }, [isAutoPlaying]);
 
   const cardVariants = {
-    enter: (dir) => ({
-      opacity: 0,
-      x: dir > 0 ? 300 : -300,
-    }),
+    enter: (dir) => ({ opacity: 0, x: dir > 0 ? 300 : -300 }),
     center: { opacity: 1, x: 0 },
-    exit: (dir) => ({
-      opacity: 0,
-      x: dir > 0 ? -300 : 300,
-    }),
+    exit: (dir) => ({ opacity: 0, x: dir > 0 ? -300 : 300 }),
   };
 
   const activeDotIndex =
@@ -158,16 +148,15 @@ const WhatsHappening = () => {
     Math.ceil(upcomingEvents.length / cardsPerView);
 
   return (
-    // UPDATED: Section background
     <section
       ref={ref}
       className="py-12 sm:py-16 bg-gradient-to-t from-sky-50 via-pink-50 to-amber-50 dark:from-gray-900 dark:via-gray-800 dark:to-black"
-      // AOS Implementation
       data-aos="fade-up"
       data-aos-duration="1000"
       data-aos-offset="150"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+
         {/* Heading */}
         <motion.div
           className="text-center mb-8 sm:mb-12"
@@ -175,7 +164,6 @@ const WhatsHappening = () => {
           animate={inView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6 }}
         >
-          {/* UPDATED: Text colors */}
           <h2 className="text-2xl sm:text-3xl font-extrabold text-black dark:text-gray-100">
             What's Happening Now
           </h2>
@@ -187,69 +175,52 @@ const WhatsHappening = () => {
 
         {/* Carousel */}
         <div className="relative w-full max-w-7xl mx-auto">
-          {/* Auto-play indicator */}
-          <div className="absolute top-4 right-4 z-20">
+
+          {/* FIX 1: Auto-play button — moved closer to edge on mobile */}
+          <div className="absolute top-2 right-2 sm:top-4 sm:right-4 z-20">
             <button
               onClick={() => setIsAutoPlaying(!isAutoPlaying)}
               className="p-2 rounded-full bg-white/20 dark:bg-gray-700/90 shadow-lg hover:bg-white dark:hover:bg-gray-700 transition-colors"
               title={isAutoPlaying ? "Pause auto-play" : "Resume auto-play"}
             >
               {isAutoPlaying ? (
-                <svg
-                  className="w-4 h-4 text-gray-600 dark:text-gray-300"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
+                <svg className="w-4 h-4 text-gray-600 dark:text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M6 4h2v12H6V4zm6 0h2v12h-2V4z" />
                 </svg>
               ) : (
-                <svg
-                  className="w-4 h-4 text-gray-600 dark:text-gray-300"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
+                <svg className="w-4 h-4 text-gray-600 dark:text-gray-300" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M6.3 4.1l8.4 5.4c.4.3.4.8 0 1l-8.4 5.4c-.5.3-1.1-.1-1.1-.6V4.7c0-.5.6-.9 1.1-.6z" />
                 </svg>
               )}
             </button>
           </div>
 
-          {/* Navigation Buttons */}
+          {/* FIX 2: Nav buttons flush to edge on mobile */}
           <button
             onClick={prevSlide}
-            className="absolute left-2 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white dark:bg-gray-700 shadow-lg hover:bg-gray-100 dark:hover:bg-gray-600 z-10 text-gray-700 dark:text-gray-200 transition-all hover:scale-105"
+            className="absolute left-0 sm:left-2 top-1/2 -translate-y-1/2 p-2 sm:p-3 rounded-full bg-white dark:bg-gray-700 shadow-lg hover:bg-gray-100 dark:hover:bg-gray-600 z-10 text-gray-700 dark:text-gray-200 transition-all hover:scale-105"
           >
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fillRule="evenodd"
-                d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                clipRule="evenodd"
-              />
+            <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
             </svg>
           </button>
 
           <button
             onClick={() => {
               setDirection(1);
-              setCurrent(
-                (prev) => (prev + cardsPerView) % upcomingEvents.length
-              );
+              setCurrent((prev) => (prev + cardsPerView) % upcomingEvents.length);
               setIsAutoPlaying(false);
             }}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-3 rounded-full bg-white dark:bg-gray-700 shadow-lg hover:bg-gray-100 dark:hover:bg-gray-600 z-10 text-gray-700 dark:text-gray-200 transition-all hover:scale-105"
+            className="absolute right-0 sm:right-2 top-1/2 -translate-y-1/2 p-2 sm:p-3 rounded-full bg-white dark:bg-gray-700 shadow-lg hover:bg-gray-100 dark:hover:bg-gray-600 z-10 text-gray-700 dark:text-gray-200 transition-all hover:scale-105"
           >
-            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fillRule="evenodd"
-                d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                clipRule="evenodd"
-              />
+            <svg className="w-4 h-4 sm:w-5 sm:h-5" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
             </svg>
           </button>
 
-          {/* Cards Container */}
+          {/* FIX 3: px-16 → px-8 sm:px-16 — was crushing cards on mobile */}
           <div
-            className="overflow-hidden px-16 py-5 pointer-events-none"
+            className="overflow-hidden px-8 sm:px-16 py-5 pointer-events-none"
             onMouseEnter={() => setIsAutoPlaying(false)}
             onMouseLeave={() => setIsAutoPlaying(true)}
           >
@@ -271,31 +242,24 @@ const WhatsHappening = () => {
                     prevSlide();
                   } else if (info.offset.x < -100) {
                     setDirection(1);
-                    setCurrent(
-                      (prev) => (prev + cardsPerView) % upcomingEvents.length
-                    );
+                    setCurrent((prev) => (prev + cardsPerView) % upcomingEvents.length);
                     setIsAutoPlaying(false);
                   }
                 }}
               >
-                {/* Show 3 cards at a time */}
                 {upcomingEvents
                   .slice(current, current + cardsPerView)
                   .concat(
                     current + cardsPerView > upcomingEvents.length
-                      ? upcomingEvents.slice(
-                          0,
-                          (current + cardsPerView) % upcomingEvents.length
-                        )
+                      ? upcomingEvents.slice(0, (current + cardsPerView) % upcomingEvents.length)
                       : []
                   )
                   .slice(0, cardsPerView)
                   .map((event) => (
+                    // FIX 4: min-h-[360px] → min-h-[300px] sm:min-h-[360px]
                     <div
                       key={event.id}
-
-                      className="flex flex-col rounded-xl overflow-hidden shadow-md hover:shadow-lg transition-all duration-300 bg-white dark:bg-black/60 transform hover:scale-105 min-h-[360px] ring-2 ring-sky-200 dark:ring-sky-700/60"
-
+                      className="flex flex-col rounded-xl overflow-hidden shadow-md hover:shadow-lg transition-all duration-300 bg-white dark:bg-black/60 transform hover:scale-105 min-h-[300px] sm:min-h-[360px] ring-2 ring-sky-200 dark:ring-sky-700/60"
                     >
                       <div className="p-4 sm:p-6 flex-1 flex flex-col">
                         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 sm:mb-4 gap-2 sm:gap-0">
@@ -319,28 +283,18 @@ const WhatsHappening = () => {
                           {event.description}
                         </p>
 
-                        {/* Additional info for hackathons */}
                         {event.prize && (
                           <div className="flex items-center text-xs sm:text-sm text-rose-500 dark:text-rose-300 mb-2">
-                            <svg
-                              className="w-4 h-4 mr-1.5"
-                              fill="currentColor"
-                              viewBox="0 0 20 20"
-                            >
-                              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                            <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
+                              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 00.951-.69l1.07-3.292z" />
                             </svg>
                             {event.prize}
                           </div>
                         )}
 
-                        {/* Participants/Attendees info */}
                         {(event.participants || event.attendees) && (
                           <div className="flex items-center text-xs sm:text-sm text-blue-600 dark:text-blue-400 mb-2">
-                            <svg
-                              className="w-4 h-4 mr-1.5"
-                              fill="currentColor"
-                              viewBox="0 0 20 20"
-                            >
+                            <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
                               <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
                             </svg>
                             {event.participants
@@ -356,12 +310,7 @@ const WhatsHappening = () => {
                             viewBox="0 0 24 24"
                             stroke="currentColor"
                           >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                            />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                           </svg>
                           {event.date}
                         </div>
@@ -375,30 +324,12 @@ const WhatsHappening = () => {
                               ? "bg-black text-white hover:bg-sky-100 hover:text-black"
                               : "bg-black text-white hover:bg-emerald-100 hover:text-black"
                           }`}
-                          target={
-                            event.link.startsWith("http") ? "_blank" : "_self"
-                          }
-                          rel={
-                            event.link.startsWith("http")
-                              ? "noopener noreferrer"
-                              : ""
-                          }
+                          target={event.link.startsWith("http") ? "_blank" : "_self"}
+                          rel={event.link.startsWith("http") ? "noopener noreferrer" : ""}
                         >
                           {event.featured ? "Join Now" : "Learn More"}
-                          <svg
-                            className="ml-1 sm:ml-2 -mr-1 w-3 h-3 sm:w-4 sm:h-4"
-                            fill="currentColor"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              fillRule="evenodd"
-                              d="M10.293 5.293a1 1 0 011.414 0l4 
-                            4a1 1 0 010 1.414l-4 4a1 1 
-                            0 01-1.414-1.414L12.586 11H5a1 
-                            1 0 110-2h7.586l-2.293-2.293a1 
-                            1 0 010-1.414z"
-                              clipRule="evenodd"
-                            />
+                          <svg className="ml-1 sm:ml-2 -mr-1 w-3 h-3 sm:w-4 sm:h-4" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M10.293 5.293a1 1 0 011.414 0l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414-1.414L12.586 11H5a1 1 0 110-2h7.586l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
                           </svg>
                         </a>
                       </div>
@@ -409,7 +340,7 @@ const WhatsHappening = () => {
           </div>
         </div>
 
-        {/* Dots with progress indicator - Updated for 3-card pagination */}
+        {/* FIX 5: Dots — increased mobile tap target from w-3 to w-5 */}
         <div className="flex justify-center items-center mt-4 space-x-1 sm:space-x-2">
           {Array.from(
             { length: Math.ceil(upcomingEvents.length / cardsPerView) },
@@ -424,20 +355,17 @@ const WhatsHappening = () => {
                 className="relative group"
               >
                 <div
-                  className={`w-3 h-2.5 sm:w-8 sm:h-2.5 rounded-full transition-colors duration-300 ${
+                  className={`w-5 h-2.5 sm:w-8 sm:h-2.5 rounded-full transition-colors duration-300 ${
                     activeDotIndex === index
                       ? "bg-gradient-to-r from-sky-300 via-emerald-300 to-rose-300 dark:from-sky-500 dark:via-emerald-500 dark:to-rose-500"
                       : "bg-gray-300 dark:bg-gray-600 group-hover:bg-sky-200 dark:group-hover:bg-sky-500"
                   }`}
                 />
-                {/* Auto-play progress indicator for current slide group */}
                 {activeDotIndex === index && isAutoPlaying && (
                   <div className="absolute inset-0 rounded-full border-2 border-sky-300 dark:border-sky-400">
                     <div
                       className="w-full h-full rounded-full bg-sky-200/20 dark:bg-sky-400/20"
-                      style={{
-                        animation: "progress 2.5s linear infinite",
-                      }}
+                      style={{ animation: "progress 2.5s linear infinite" }}
                     />
                   </div>
                 )}
@@ -445,6 +373,7 @@ const WhatsHappening = () => {
             )
           )}
         </div>
+
       </div>
     </section>
   );

--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -1,7 +1,11 @@
 import React from "react";
 import NavbarLinks from "./NavbarLinks";
-
-const MobileDrawer = ({ isOpen, closeMenu }) => {
+import { Link } from "react-router-dom";
+import { LogIn, UserPlus } from "lucide-react";
+import {  useLocation } from "react-router-dom";
+const MobileDrawer = ({ isOpen, closeMenu, isAuthenticated, user, logout }) => {
+    const location = useLocation();
+  const isActive = (path) => location.pathname === path;
   return (
     <div
       className={`fixed top-0 right-0 h-screen w-[85%] bg-white dark:bg-gray-900 z-50 transition-transform duration-300 ${
@@ -9,16 +13,63 @@ const MobileDrawer = ({ isOpen, closeMenu }) => {
       }`}
     >
       <div className="p-4 flex justify-between items-center border-b">
-        <h2 className="text-2xl font-bold">Eventra</h2>
-
+        <div className="flex items-center gap-2">
+          <img src="/Eventra.png" alt="Eventra Logo" className="h-8 w-8 rounded-xl object-contain" />
+          <h2 className="text-2xl font-bold">Eventra</h2>
+        </div>
         <button onClick={closeMenu}>X</button>
       </div>
 
       <div className="p-4">
+        
         <NavbarLinks vertical={true} onClick={closeMenu} />
+
+        
+        {isAuthenticated ? (
+  <>
+    <div className="flex items-center gap-3 py-3 px-1 text-gray-500 text-base">
+      <span>{user?.name}</span>
+    </div>
+    <button
+      onClick={() => { logout(); closeMenu(); }}
+      className="flex items-center gap-3 py-3 px-1 w-full text-left text-base text-gray-600 dark:text-gray-300 hover:text-red-500 transition-colors"
+    >
+      Logout
+    </button>
+  </>
+) : (
+  <div className="flex flex-col gap-4 mt-4">
+  <>
+
+   <Link
+  to="/login"
+  onClick={closeMenu}
+  className={`flex items-center gap-1.5 py-2 text-sm font-medium transition-all duration-200 pl-3 border-l-2 w-full ${
+    isActive("/login")
+      ? "text-black dark:text-white border-black dark:border-white font-semibold"
+      : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white border-transparent"
+  }`}
+>
+      <LogIn className="w-5 h-5" />
+      Login
+    </Link>
+    <Link
+  to="/signup"
+  onClick={closeMenu}
+  className={`flex items-center gap-1.5 py-2 text-sm font-medium transition-all duration-200 pl-3 border-l-2 w-full ${
+    isActive("/signup")
+      ? "text-black dark:text-white border-black dark:border-white font-semibold"
+      : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white border-transparent"
+  }`}
+>
+      <UserPlus className="w-5 h-5" />
+      Sign Up
+    </Link>
+  </>
+  </div>
+)}
       </div>
     </div>
   );
 };
-
 export default MobileDrawer;

--- a/src/components/navbar/MobileNavbar.jsx
+++ b/src/components/navbar/MobileNavbar.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import MobileDrawer from "./MobileDrawer";
 
-const MobileNavbar = ({ isOpen, setIsOpen }) => {
+const MobileNavbar = ({ isOpen, setIsOpen, isAuthenticated, user, logout }) => {
   return (
     <>
       <button
@@ -14,6 +14,9 @@ const MobileNavbar = ({ isOpen, setIsOpen }) => {
       <MobileDrawer
         isOpen={isOpen}
         closeMenu={() => setIsOpen(false)}
+        isAuthenticated={isAuthenticated}
+        user={user}
+        logout={logout}
       />
     </>
   );

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -19,8 +19,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
   useBodyScrollLock(isMobileMenuOpen);
 
-  const navHeight = useNavbarHeight(navRef);
-
+  
   return (
     <>
       <nav
@@ -28,53 +27,34 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
         className="fixed top-0 left-0 w-full h-20 bg-white dark:bg-gray-900 border-b border-border z-50 transition-all duration-300"
       >
         <div className="h-full px-6 flex items-center justify-between">
-
-          {/* Logo */}
           <Link to="/">
             <div className="flex items-center justify-center gap-2">
-              <img
-                src="/Eventra.png"
-                alt="Eventra Logo"
-                className="h-8 w-8 rounded-xl object-contain"
-              />
-              <h1 className="text-xl font-bold text-text">
-                Eventra
-              </h1>
+              <img src="/Eventra.png" alt="Eventra Logo" className="h-11 w-11 rounded-xl object-contain" />
+              <h1 className="text-3xl font-bold text-text">Eventra</h1>
             </div>
           </Link>
 
-          {/* Right Side */}
-          <div className="flex items-center gap-2">
-
-            {/* Desktop Navbar */}
-            <DesktopNavbar
-              isAuthenticated={isAuthenticated()}
-              user={user}
-              logout={logout}
-            />
-            {/* Dark Mode Toggle */}
+          <div className="flex items-center gap-4">
+            <DesktopNavbar isAuthenticated={isAuthenticated()} user={user} logout={logout} />
             <button
               onClick={toggleTheme}
               className="w-10 h-10 flex items-center justify-center rounded-lg border border-border bg-card-bg text-text transition-all duration-300 hover:scale-105"
             >
               <img src={isDarkMode ? "/sun.svg" : "/moon.svg"} alt="" />
             </button>
-            {/* Curson Toggle */}
-            <CursorToggle
-              cursorEnabled={cursorEnabled}
-              toggleCursor={toggleCursor}
-            />
-
-            {/* Mobile Navbar */}
+            <CursorToggle cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
             <MobileNavbar
               isOpen={isMobileMenuOpen}
               setIsOpen={setIsMobileMenuOpen}
+              isAuthenticated={isAuthenticated()}
+              user={user}
+              logout={logout}
             />
           </div>
         </div>
       </nav>
 
-      <div style={{ height: navHeight }} />
+      
     </>
   );
 };


### PR DESCRIPTION

## Which issue does this PR close?
The Mobile View had an extra Hamburger Icon and  the authentication wasn't wired through the mobile navbar

## Rationale for this change

The mobile navbar had two issues: a duplicate hamburger icon caused by `MobileNavbar` being rendered twice in `Navbar.jsx`, and the mobile drawer had no way to show login/signup links because auth props were never passed down the component tree. The authentication logic already existed — it just needed to be wired through.

## What changes are included in this PR?

- Removed the duplicate hamburger (☰) icon that was rendering twice in the mobile navbar
- Passed `isAuthenticated`, `user`, and `logout` props from `Navbar` → `MobileNavbar` → `MobileDrawer` so the auth state is correctly reflected in the mobile drawer
- Added Login and Sign Up links in the mobile drawer with matching icon and active-state styling from `NavbarLinks`


## Are these changes tested?

Manually tested on mobile viewport. Verified that:
- Only one hamburger icon appears in the navbar
- Login and Sign Up links appear in the drawer when the user is not authenticated
- User name and Logout button appear when authenticated
- Active route indicator (left border) works correctly on Login and Sign Up links

##Screenshots:


<img width="447" height="891" alt="nice1" src="https://github.com/user-attachments/assets/aa1715ec-c790-4dc0-b6d5-ee0087ad26f9" />
<img width="342" height="846" alt="nice2" src="https://github.com/user-attachments/assets/c99f5822-294c-4703-a618-444fcb18d387" />

## Are there any user-facing changes?

Yes — mobile users can now access Login and Sign Up from the navigation drawer.


- Closes  #1162 