### PR TITLE
fix: address homepage search review feedback

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -114,9 +114,16 @@ const EventsPage = () => {
   };
 
   useEffect(() => {
-    handleSortChange(sortType);
-    // eslint-disable-next-line
-  }, [filterType, searchQuery]);
+    setFilteredEvents((currentEvents) => {
+      const sorted = [...currentEvents];
+      if (sortType === "Newest") {
+        sorted.sort((a, b) => new Date(b.date) - new Date(a.date));
+      } else if (sortType === "Upcoming" || sortType === "upcoming") {
+        sorted.sort((a, b) => new Date(a.date) - new Date(b.date));
+      }
+      return sorted;
+    });
+  }, [filterType, searchQuery, sortType]);
 
   const scrollToCard = () => {
     cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -44,22 +44,28 @@ const Hero = () => {
   }, [controls]);
 
   // Global search functionality
+  const createSearchItem = (item, type, searchType) => ({
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    location: item.location,
+    tags: item.tags,
+    techStack: item.techStack,
+    category: item.category,
+    author: item.author,
+    organizer: item.organizer,
+    type,
+    searchType,
+  });
+
   const allData = [
-    ...eventsData.map((item) => ({
-      ...item,
-      type: "event",
-      searchType: "Events",
-    })),
-    ...hackathonsData.map((item) => ({
-      ...item,
-      type: "hackathon",
-      searchType: "Hackathons",
-    })),
-    ...projectsData.map((item) => ({
-      ...item,
-      type: "project",
-      searchType: "Projects",
-    })),
+    ...eventsData.map((item) => createSearchItem(item, "event", "Events")),
+    ...hackathonsData.map((item) =>
+      createSearchItem(item, "hackathon", "Hackathons")
+    ),
+    ...projectsData.map((item) =>
+      createSearchItem(item, "project", "Projects")
+    ),
   ];
 
   const fuse = new Fuse(allData, {
@@ -283,7 +289,9 @@ const Hero = () => {
                                 className="flex items-center gap-3 p-3 rounded-2xl 
                                  hover:bg-gray-50 
                                  cursor-pointer transition-colors group text-left no-underline"
-                                aria-label={`Open ${result.item.title} in ${result.item.searchType}`}
+                                aria-label={`Open ${result.item.title} in ${
+                                  result.item.searchType || result.item.type || "page"
+                                }`}
                               >
                                 <div
                                   className="flex-shrink-0 p-2 bg-blue-100 rounded-xl text-blue-600 


### PR DESCRIPTION
Closes #1120

## Changes
- Addressed the review feedback on homepage search result data preparation.
- Replaced direct spreading of full mock data objects in `Hero.js` with an explicit `createSearchItem` helper.
- The helper now copies only the fields needed for homepage search and Fuse matching, such as `id`, `title`, `description`, `location`, `tags`, `techStack`, `category`, `author`, and `organizer`.
- This keeps the search result objects lightweight and avoids attaching search-specific fields like `type` and `searchType` to the original mock data shape.
- Updated the search result `aria-label` to safely fall back when `searchType` is unavailable.
- The label now uses `searchType || type || "page"` so it still remains accessible if future API data does not include `searchType`.
- Addressed the Events page sorting effect feedback.
- Removed the `eslint-disable-next-line` comment from the sort effect in `EventsPage.js`.
- Added `sortType` into the effect dependency behavior and kept sorting stable using a functional `setFilteredEvents` update.
- This keeps the sorting logic cleaner and avoids suppressing lint warnings.

## Review Comments Addressed
- For the `allData` search array in `Hero.js`, the reviewer suggested avoiding direct object spreading and copying only required fields. This has been updated with `createSearchItem`.
- For the search result `aria-label`, the reviewer suggested adding a fallback when `searchType` is missing. This now falls back to `type` and then `"page"`.
- For the `EventsPage.js` sort effect, the reviewer suggested removing the lint suppression and including `sortType` in the dependencies. The effect now handles sorting without the suppression comment.

## Testing
- Ran `npm run build`
- Verified the homepage search result review changes in `Hero.js`
- Verified the Events page sorting effect cleanup in `EventsPage.js`
- Confirmed the build completes successfully with only existing unrelated warnings