### PR TITLE
fix: move toast position to prevent overlap with header actions

### DIFF
--- a/src/components/common/NotificationProvider.js
+++ b/src/components/common/NotificationProvider.js
@@ -4,7 +4,7 @@ import "react-toastify/dist/ReactToastify.css";
 const NotificationProvider = () => {
   return (
     <ToastContainer
-      position="top-right"
+      position="bottom-right"
       autoClose={3000}
       hideProgressBar={false}
       newestOnTop
@@ -16,7 +16,10 @@ const NotificationProvider = () => {
       pauseOnHover
       theme="colored"
       limit={3}
-      style={{ zIndex: 10050 }}
+      style={{ 
+        zIndex: 10050,
+        marginBottom: '1rem'
+      }}
     />
   );
 };


### PR DESCRIPTION
Closes #889

### Description
Toast notification was positioned top-right, directly overlapping the notification bell and profile avatar in the navbar. On smaller screens this blocked user interaction with header elements until the toast disappeared.

### What I did
- Changed toast position from top-right to bottom-right in NotificationProvider.js
- Added bottom margin for better spacing on mobile

### Type of Change
- [x] Bug fix

### Checklist
- [x] My changes follow the project's contribution guidelines
- [x] I have linked the related issue
- [x] No unrelated files changed