### PR TITLE
Feat: autofocus added to search bar of events page

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -79,6 +79,7 @@ export default function EventHero({
           <ModernSearchInput
             value={searchQuery}
             onChange={(e) => handleSearch(e.target.value)}
+            autoFocus
             placeholder="Search events by name, location, or tags..."
           />
 

--- a/src/components/common/ModernSearchInput.js
+++ b/src/components/common/ModernSearchInput.js
@@ -11,6 +11,7 @@ const ModernSearchInput = ({
   onChange,
   placeholder = "Search...",
   onFocus,
+  autoFocus,
   onBlur,
   onKeyDown,
   containerClassName = "",
@@ -70,6 +71,7 @@ const ModernSearchInput = ({
             value={value}
             onChange={onChange}
             onFocus={handleFocus}
+            autoFocus={autoFocus}
             onBlur={handleBlur}
             onKeyDown={onKeyDown}
           />


### PR DESCRIPTION
## Which issue does this PR close?
issue #1195 .

- Closes #1195.

## Rationale for this change

The search input on the Events page did not automatically focus when the page loaded, requiring users to manually click the search bar before typing. This update improves accessibility and user experience by enabling autofocus functionality for the search input component.

## What changes are included in this PR?

 Added `autoFocus` prop support to the reusable `ModernSearchInput` component.
 Forwarded the `autoFocus` prop to the underlying `<input />` element.
 Enabled autofocus on the Events page search bar inside `EventHero`.
 Improved usability by allowing users to start typing immediately after page load.

## Are these changes tested?

Yes.

Verified that the cursor automatically focuses on the search bar when the Events page loads.
Confirmed that existing search functionality continues to work correctly.
Tested that no UI or functionality regressions were introduced.

## Are there any user-facing changes?

Yes.

Users can now immediately type in the Events page search bar without manually clicking the input field.