### PR TITLE
feature: Avatar is reflecting on navbar

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -154,6 +154,7 @@ const performSave = () => {
   const resolvedForm = {
     ...form,
     fullName: form.fullName || `${user?.firstName || ""} ${user?.lastName || ""}`.trim(),
+    profilePicture: form.avatarBase64 || form.profilePicture || "",
   };
   const validation = validate(resolvedForm);
   setErrors(validation);
@@ -168,10 +169,8 @@ const performSave = () => {
     setLoading(false);
     setSuccessMessage("Profile updated successfully");
     setConfirmOpen(false);
-
-    // ✅ Persist updates to both context and localStorage
-    setUser(form);
-    localStorage.setItem("user", JSON.stringify(form));
+    setUser(resolvedForm);                              
+    localStorage.setItem("user", JSON.stringify(resolvedForm)); 
 
     // ✅ Navigate away after a short delay to let user see success message
     setTimeout(() => {


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #998 
<img width="1890" height="783" alt="Screenshot 2026-05-19 195621" src="https://github.com/user-attachments/assets/3ec95d3e-ee59-4b31-939a-0676f5444820" />


### Problem
After uploading a new avatar on the Edit Profile page, the Navbar profile icon continued showing the default avatar/initial instead of the newly uploaded image.

### Root Cause
`EditProfile.js` was saving the avatar under `avatarBase64` but `Navbar.js` reads from `user.profilePicture`. Due to this field name mismatch, the Navbar never received the updated avatar even after saving.

### Fix
In `EditProfile.js`, mapped `avatarBase64` → `profilePicture` inside `resolvedForm` before saving to context and localStorage:


### Files Changed
- `src/Pages/EditProfile.js`


### Notes
- No existing functionality is affected — the fix is purely additive
- All other form fields (`username`, `bio`, `skills`, `github`, etc.) remain unchanged
- `avatarBase64` continues to work normally on the Edit Profile page itself