### PR TITLE
 Feat: Implement Background Offline Sync Queue for Event Registrations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,12 @@ import { AuthProvider } from "./context/AuthContext";
 import { MyEventsProvider } from "./context/MyEventsContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { useModelContext } from "./hooks/useModelContext";
+import useOfflineSync from "./hooks/useOfflineSync";
+
+const OfflineSyncManager = () => {
+  useOfflineSync();
+  return null;
+};
 
 
 function App() {
@@ -48,6 +54,7 @@ function App() {
       <AuthProvider>
         <MyEventsProvider>
         <NotificationProvider />
+        <OfflineSyncManager />
         <Router>
           <div className="App">
             <Navbar

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -146,14 +146,32 @@ const EventRegistration = () => {
       }
     } catch (error) {
       console.error("Registration error:", error);
-      // ── Offline / no-backend fallback: still save locally so the feature
-      //    is usable while the real API is not yet wired up.
+      
+      // ── Offline Sync Queue Fallback ──
+      const payload = {
+        ...formData,
+        eventId: parseInt(eventId),
+        userId: user?.id || null,
+      };
+      
+      const QUEUE_KEY = 'eventra_offline_queue';
+      let queue = [];
+      try {
+        const queueStr = localStorage.getItem(QUEUE_KEY);
+        if (queueStr) queue = JSON.parse(queueStr);
+      } catch (e) {
+        queue = [];
+      }
+      
+      queue.push({ eventId: parseInt(eventId), payload });
+      localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+
       setRegistered(true);
       addRegistration(event, formData);
-      toast.success("Registration saved locally!");
+      toast.warning("Network error. Registration queued and will sync when you are online.", { autoClose: 4000 });
       setTimeout(() => {
-        navigate(`/events`);
-      }, 2000);
+        navigate(`/events/${eventId}`);
+      }, 3000);
     } finally {
       setSubmitting(false);
     }

--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { useAuth } from '../context/AuthContext';
+import { API_ENDPOINTS } from '../config/api';
+
+const QUEUE_KEY = 'eventra_offline_queue';
+
+const useOfflineSync = () => {
+  const { token } = useAuth();
+
+  useEffect(() => {
+    const handleOnline = async () => {
+      const queueStr = localStorage.getItem(QUEUE_KEY);
+      if (!queueStr) return;
+
+      let queue = [];
+      try {
+        queue = JSON.parse(queueStr);
+      } catch (e) {
+        localStorage.removeItem(QUEUE_KEY);
+        return;
+      }
+
+      if (queue.length === 0) return;
+
+      // Notify user sync is starting
+      toast.info(`Syncing ${queue.length} offline registration(s)...`, { autoClose: 2000 });
+
+      const failedQueue = [];
+      let successCount = 0;
+
+      for (const item of queue) {
+        try {
+          const response = await fetch(API_ENDPOINTS.EVENTS.REGISTER(item.eventId), {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(token && { Authorization: `Bearer ${token}` }),
+            },
+            body: JSON.stringify(item.payload),
+          });
+
+          if (response.ok) {
+            successCount++;
+          } else {
+            // If the server rejected it (e.g. 400 Bad Request), we still drop it from the queue
+            // to avoid infinite retry loops on invalid data.
+            console.error('Registration rejected by server:', await response.text());
+          }
+        } catch (error) {
+          // Network error again, keep in queue
+          failedQueue.push(item);
+        }
+      }
+
+      if (failedQueue.length > 0) {
+        localStorage.setItem(QUEUE_KEY, JSON.stringify(failedQueue));
+        if (successCount > 0) {
+          toast.warning(`Synced ${successCount} registration(s). ${failedQueue.length} remain queued.`);
+        }
+      } else {
+        localStorage.removeItem(QUEUE_KEY);
+        if (successCount > 0) {
+          toast.success('Offline registrations synced successfully!');
+        }
+      }
+    };
+
+    window.addEventListener('online', handleOnline);
+
+    // Also run once on mount in case they came online before the app loaded
+    if (navigator.onLine) {
+      handleOnline();
+    }
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+    };
+  }, [token]);
+};
+
+export default useOfflineSync;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1203 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Previously, if an event registration API call failed due to a network error, the `EventRegistration.js` component would catch the error, save the data strictly to local memory, and tell the user they were successfully registered. However, because there was no sync mechanism, this data was never sent to the backend when the network reconnected, resulting in permanent data loss for Event Organizers.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
I have implemented a robust, enterprise-grade offline sync mechanism.
1. **`useOfflineSync` Custom Hook**: Created a new headless hook that listens to the browser's native `navigator.onLine` events. When the browser regains internet access, this hook silently wakes up, pulls the `eventra_offline_queue` from `localStorage`, and `POST`s all pending registrations to the backend. It removes successful entries from the queue to prevent double-submission.

2. **Global Integration (`App.js`)**: Mounted the headless `<OfflineSyncManager />` inside the `<AuthProvider>` at the root of the app. This guarantees that background sync will trigger no matter what page the user is navigating when their Wi-Fi reconnects, and provides the sync hook with access to the authenticated user's token.

3. **Queue Ingestion (`EventRegistration.js`)**: Rewrote the fallback `catch` block. It now actively packages the `formData` payload and pushes it to the `localStorage` queue. It also displays a highly accurate warning toast: *"Network error. Registration queued and will sync when you are online."*


## Are these changes tested?
**YES**
- **Offline Simulation:** Disabled network via Chrome DevTools, submitted a registration, and verified it correctly aborted the API request and appended the payload to `localStorage`.

- **Background Sync:** Re-enabled the network and verified the `window.ononline` event triggered the queue processing.

- **Queue Cleanup:** Confirmed that successful API `POST` responses correctly cleared the processed items from `localStorage`.

- Verified error toasts and success toasts trigger appropriately based on sync status.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Yes, now the user data is saved even after the connection is lost. 
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->