### PR TITLE
fix(api): define missing EVENTS and PROJECTS endpoints to resolve runtime crashes

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -6,11 +6,23 @@ const AUTH_API_BASE_PATH = process.env.REACT_APP_API_URL
   ? `${process.env.REACT_APP_API_URL}/api/auth`
   : '/api/auth'; // ← goes through CRA proxy in dev
 
-// API endpoints — only login and signup are active
+const API_BASE_PATH = process.env.REACT_APP_API_URL || '';
+
+// API endpoints — auth, events, and projects are active
 export const API_ENDPOINTS = {
   AUTH: {
     LOGIN: `${AUTH_API_BASE_PATH}/login`,
     REGISTER: `${AUTH_API_BASE_PATH}/signup`,
+  },
+  EVENTS: {
+    CREATE: `${API_BASE_PATH}/api/events`,
+    REGISTER: (id) => `${API_BASE_PATH}/api/events/${id}/register`,
+    LIST: `${API_BASE_PATH}/api/events`,
+  },
+  PROJECTS: {
+    SUBMIT: `${API_BASE_PATH}/api/projects`,
+    LIST: `${API_BASE_PATH}/api/projects`,
+    CATEGORIES: `${API_BASE_PATH}/api/projects/categories`,
   },
 };
 
@@ -23,6 +35,19 @@ export const getAuthHeaders = (token) => {
 
 // API utility functions
 export const apiUtils = {
+  get: async (url, token = null) => {
+    try {
+      console.log('Making GET request to:', url);
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: getAuthHeaders(token),
+      });
+      return response;
+    } catch (error) {
+      console.error('API GET Error:', error);
+      throw error;
+    }
+  },
   post: async (url, data, token = null) => {
     try {
       console.log('Making POST request to:', url);


### PR DESCRIPTION
## Description
Resolves a critical runtime crash (`TypeError: Cannot read properties of undefined`) that occurs when a user attempts to submit a project, register for an event, or preview/create an event. 

The global `API_ENDPOINTS` object inside `src/config/api.js` only declared the `AUTH` namespace and completely omitted `EVENTS` and `PROJECTS` properties, which were actively accessed by core React pages and components. In addition, the utility function `apiUtils.get` was missing.

Fixes #1204

## Changes Made
- Added the missing `EVENTS` and `PROJECTS` objects to `API_ENDPOINTS` inside `src/config/api.js`.
- Introduced the standard `get` method to the `apiUtils` helper.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Validation and Testing
- Verified that `npm run build` compiles successfully without any compilation errors.
- Verified that all unit tests inside `tests/` pass with zero failures.
- Verified that ESLint syntax checks pass.
