### PR TITLE
feat: improve empty search states

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -8,9 +8,10 @@ import EventCTA from "./EventCTA";
 import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
 import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
+import SearchEmptyState from "../../components/common/SearchEmptyState";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 
-const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
+const renderCardSection = (isLoading, filteredEvents, viewMode, filterType, searchQuery, onClearSearch) => {
   if (isLoading) {
     return (
       <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
@@ -24,6 +25,14 @@ const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
   if (filteredEvents.length === 0) {
     return (
       <div className="relative overflow-hidden rounded-3xl p-10 text-center border border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-[0_10px_25px_rgba(0,0,0,0.05)] dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)]">
+        <SearchEmptyState
+          query={searchQuery}
+          itemLabel="events"
+          browseLabel="Browse All Events"
+          browsePath="/events"
+          onClear={onClearSearch}
+          popularTags={["AI", "Blockchain", "Web", "DevOps", "React", "UX"]}
+        />
       </div>
     );
   }
@@ -128,6 +137,13 @@ const EventsPage = () => {
     cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 
+  const clearSearchAndFilters = () => {
+    setSearchQuery("");
+    setFilterType("all");
+    setSortType("Newest");
+    handleSearch("");
+  };
+
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:to-black text-gray-900 dark:text-gray-100 overflow-x-hidden">
       <EventHero
@@ -215,7 +231,14 @@ const EventsPage = () => {
           </div>
         </div>
 
-        {renderCardSection(isLoading, filteredEvents, viewMode, filterType)}
+        {renderCardSection(
+          isLoading,
+          filteredEvents,
+          viewMode,
+          filterType,
+          searchQuery,
+          clearSearchAndFilters
+        )}
       </div>
 
       <EventCTA />

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -39,8 +39,6 @@ import HackathonCard from "./HackathonCard";
 import FeedbackButton from "../../components/FeedbackButton";
 import {
   FiCode,
-  FiRotateCw,
-  FiCompass,
   FiChevronDown,
   FiX,
 } from "react-icons/fi";
@@ -48,6 +46,7 @@ import HackathonCTA from "./HackathonCTA";
 import Fuse from "fuse.js";
 import { createPortal } from "react-dom";
 import { HackathonCardSkeleton } from "../../components/common/SkeletonLoaders";
+import SearchEmptyState from "../../components/common/SearchEmptyState";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 // NEW: Tag component for selected tags in search bar
@@ -771,37 +770,14 @@ const HackathonHub = () => {
                   No Hackathons Found
                 </h3>
 
-                <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-                  {searchQuery ||
-                  filters.difficulty ||
-                  filters.prize ||
-                  filters.location ||
-                  selectedTags.length > 0
-                    ? "No hackathons match your current filters. Try adjusting your search or filters."
-                    : "Check back later for exciting new hackathons!"}
-                </p>
-
-                <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                  <motion.button
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={resetFilters}
-                    className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-lg text-white bg-black hover:bg-zinc-800 shadow-lg transition-all"
-                  >
-                    <FiRotateCw className="w-4 h-4" />
-                    Reset Filters
-                  </motion.button>
-
-                  <motion.button
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={() => { }}
-                    className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-lg text-black dark:text-white border border-black/15 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 shadow-md transition-all"
-                  >
-                    Explore Hackathons
-                    <FiCompass className="w-4 h-4" />
-                  </motion.button>
-                </div>
+                <SearchEmptyState
+                  query={searchQuery}
+                  itemLabel="hackathons"
+                  browseLabel="Browse All Hackathons"
+                  browsePath="/hackathons"
+                  onClear={resetFilters}
+                  popularTags={availableTags}
+                />
               </div>
             </motion.div>
           )}

--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -10,6 +10,7 @@ import ProjectCTA from "./ProjectCTA";
 import mockProjects from "./mockProjectsData.json";
 
 import ModernSearchInput from "../../components/common/ModernSearchInput";
+import SearchEmptyState from "../../components/common/SearchEmptyState";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 // Skeleton loader for project cards while data is loading
@@ -467,45 +468,18 @@ const ProjectGallery = () => {
                 >
                   <FiSearch className="h-10 w-10 text-black dark:text-white" />
                 </motion.div>
-
-                {/* UPDATED: Text colors */}
-                <h3 className="mt-6 text-2xl font-bold text-gray-900 dark:text-gray-100 tracking-tight">
-                  No Projects Found
-                </h3>
-                <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-                  {searchQuery || selectedCategories.length > 0
-                    ? "We couldn’t find any projects with your filters. Try exploring all projects!"
-                    : "Looks like there are no projects yet. Stay tuned for exciting updates!"}
-                </p>
-
-                {/* Action Buttons */}
-                <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                  <motion.button
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={() => {
-                      setSelectedCategories([]);
-                      setSearchQuery("");
-                      setSortBy("recent");
-                    }}
-                    className="px-6 py-2.5 text-sm font-medium rounded-lg text-white bg-black hover:bg-zinc-800 shadow-lg transition-all"
-                  >
-                    Clear Filters
-                  </motion.button>
-
-                  <motion.button
-                    whileHover={{ scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    onClick={() => {
-                      setSelectedCategories([]);
-                      setSearchQuery("");
-                      setSortBy("recent");
-                    }}
-                    className="px-6 py-2.5 text-sm font-medium rounded-lg text-black dark:text-white border border-black/15 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 shadow-md transition-all"
-                  >
-                    Explore Projects
-                  </motion.button>
-                </div>
+                <SearchEmptyState
+                  query={searchQuery}
+                  itemLabel="projects"
+                  browseLabel="Browse All Projects"
+                  browsePath="/projects"
+                  onClear={() => {
+                    setSelectedCategories([]);
+                    setSearchQuery("");
+                    setSortBy("recent");
+                  }}
+                  popularTags={categories.filter((category) => category !== "all")}
+                />
               </div>
             </motion.div>
           )}
@@ -522,3 +496,4 @@ const ProjectGallery = () => {
 };
 
 export default ProjectGallery;
+

--- a/src/components/common/SearchEmptyState.jsx
+++ b/src/components/common/SearchEmptyState.jsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Search, X } from "lucide-react";
+
+const DEFAULT_SUGGESTIONS = [
+  "Check your spelling",
+  "Use fewer keywords",
+  "Try a broader topic",
+];
+
+const SEARCH_LINKS = [
+  { label: "Events", to: "/events" },
+  { label: "Hackathons", to: "/hackathons" },
+  { label: "Projects", to: "/projects" },
+];
+
+const SearchEmptyState = ({
+  query,
+  itemLabel,
+  browseLabel,
+  browsePath,
+  onClear,
+  suggestions = DEFAULT_SUGGESTIONS,
+  popularTags = [],
+}) => {
+  const hasQuery = Boolean(query?.trim());
+
+  return (
+    <div className="relative z-10 mx-auto max-w-2xl text-center">
+      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 dark:bg-indigo-950/60 dark:text-indigo-300">
+        <Search size={30} />
+      </div>
+
+      <h3 className="mt-6 text-2xl font-bold text-gray-900 dark:text-gray-100">
+        {hasQuery ? `No results found for "${query}"` : `No ${itemLabel} found`}
+      </h3>
+      <p className="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">
+        Try one of these quick actions to keep exploring Eventra.
+      </p>
+
+      <ul className="mt-5 grid gap-2 text-left text-sm text-gray-700 dark:text-gray-300 sm:grid-cols-3">
+        {suggestions.map((suggestion) => (
+          <li
+            key={suggestion}
+            className="rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-900/70"
+          >
+            {suggestion}
+          </li>
+        ))}
+      </ul>
+
+      {popularTags.length > 0 && (
+        <div className="mt-5 flex flex-wrap justify-center gap-2">
+          {popularTags.slice(0, 6).map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm ring-1 ring-gray-200 dark:bg-gray-900 dark:text-gray-200 dark:ring-gray-700"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
+        <button
+          type="button"
+          onClick={onClear}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-black px-5 py-2.5 text-sm font-medium text-white transition hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-zinc-200"
+        >
+          <X size={16} />
+          Clear Search
+        </button>
+        <Link
+          to={browsePath}
+          onClick={onClear}
+          className="inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium text-gray-900 transition hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+        >
+          {browseLabel}
+        </Link>
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <span>Search across</span>
+        {SEARCH_LINKS.map((link) => (
+          <Link
+            key={link.to}
+            to={hasQuery ? `${link.to}?search=${encodeURIComponent(query)}` : link.to}
+            className="font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
+          >
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SearchEmptyState;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1157

## Rationale for this change

When a search returned no results, users only saw a basic empty state such as `0 events found` or `No projects found`. This left users without clear next steps. The new empty state helps users recover by suggesting search improvements and quick navigation actions.

## What changes are included in this PR?

- Added a reusable `SearchEmptyState` component.
- Added helpful suggestions like checking spelling, using fewer keywords, and trying broader topics.
- Added quick actions to clear search and browse all results.
- Added cross-navigation links for Events, Hackathons, and Projects.
- Updated empty states on Events, Hackathons, and Projects pages.

## Are these changes tested?

Yes.

- Ran `npm.cmd run build` successfully.
- Manually verified empty search states using:
  - `/events?search=zzzznotfound1157`
  - `/hackathons?search=zzzznotfound1157`
  - `/projects?search=zzzznotfound1157`

## Are there any user-facing changes?

Yes. Users now see a more helpful empty search state with suggestions and quick actions when no matching events, hackathons, or projects are found.