### PR TITLE
feat: persist Create Event form drafts using localStorage

### DIFF
--- a/src/components/common/EventCreation.js
+++ b/src/components/common/EventCreation.js
@@ -32,6 +32,8 @@ import {
   Plus,
 } from "lucide-react";
 
+const DRAFT_KEY = "eventra_create_event_draft";
+
 const EventCreation = () => {
   const [currentStep, setCurrentStep] = useState("form");
   const [loading, setLoading] = useState(false);
@@ -403,6 +405,16 @@ const EventCreation = () => {
   };
 
   useEffect(() => {
+    const saved = localStorage.getItem(DRAFT_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        setFormData(prev => ({ ...prev, ...parsed, banner: null, bannerPreview: null }));
+      } catch (e) {}
+    }
+  }, []);
+  
+  useEffect(() => {
     if (successMessage || generalError) {
       const timer = setTimeout(() => {
         setSuccessMessage("");
@@ -412,6 +424,11 @@ const EventCreation = () => {
     }
   }, [successMessage, generalError]);
 
+  useEffect(() => {
+    const { banner, bannerPreview, ...saveable } = formData;
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(saveable));
+  }, [formData]);
+  
   const resetForm = () => {
     setFormData({
       title: "",
@@ -446,6 +463,7 @@ const EventCreation = () => {
       bannerPreview: null,
     });
     setErrors({});
+    localStorage.removeItem(DRAFT_KEY);
     setNewTag("");
     setCurrentStep("form");
   };


### PR DESCRIPTION
## Purpose / Description

Users can accidentally lose entered form data after refreshing or closing the tab. This PR adds localStorage-based draft persistence to the Create Event form so data is never lost.

## Fixes

* Closes #858

## Approach

* Added a `DRAFT_KEY` constant outside the component
* Added a `useEffect` to restore saved draft on component mount
* Added a `useEffect` to save form state to localStorage on every change (skipping `banner` and `bannerPreview` since File objects can't be serialized)
* Added `localStorage.removeItem(DRAFT_KEY)` in `resetForm()` to clear the draft after successful submission

## How Has This Been Tested?

* Filled out the form, refreshed the page, confirmed all fields were restored
* Submitted the form successfully, confirmed draft was cleared from localStorage