### PR TITLE
fix: restore isOpen state variable in ModernAbout.js

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -181,7 +181,7 @@ export default function ModernAbout() {
 function MissionSection({ anim, prefersReducedMotion }) {
   const containerRef = useRef(null);
   const isContainerInView = useInView(containerRef, { once: false, amount: 0.2 });
-  const [, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     setIsOpen(isContainerInView);


### PR DESCRIPTION
### Description
This PR fixes the `no-undef` ESLint compilation error on the About page (`/about`) that was inadvertently introduced in #1229. 

In #1229, the `isOpen` state variable was removed from the `useState` destructuring array in `ModernAbout.js` under the assumption that it was unused. However, it is actively required on line 245 to conditionally render and trigger the `<CountUp />` animation.

This PR restores the `isOpen` variable to the destructuring array, ensuring the page compiles successfully and the animation functions as intended.

### Related Issues
- Fixes #1259 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Verification
- [x] Verified `npm start` compiles successfully without the `no-undef` error.
- [x] Verified the "Active Users" `<CountUp />` animation works correctly when scrolled into view on the About page.