### PR TITLE
fix: add lazy/Suspense import and reorder imports in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,20 +1,14 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, lazy, Suspense } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import "./App.css";
 
 // Layout & Components
 import Navbar from "./components/Layout/Navbar";
-// Lazy load heavy components
-const Footer = lazy(() => import("./components/Layout/Footer"));
-const Chatbot = lazy(() => import("./components/Chatbot"));
-const AppRoutes = lazy(() => import("./components/AppRoutes")); // This is Heaviestt
-
 import ScrollToTop from "./components/ScrollToTop";
 import FeedbackButton from "./components/FeedbackButton";
 import FluidCursor from "./jhalak/FluidCursor";
 import PageTransition from "./components/common/PageTransition";
-// Ensure this path matches the exact location of your file
-import RegistrationPage from "./Pages/RegistrationPage"; 
+import RegistrationPage from "./Pages/RegistrationPage";
 
 // Context & Hooks
 import NotificationProvider from "./components/common/NotificationProvider";
@@ -23,6 +17,11 @@ import { MyEventsProvider } from "./context/MyEventsContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import { useModelContext } from "./hooks/useModelContext";
 import useOfflineSync from "./hooks/useOfflineSync";
+
+// Lazy load heavy components
+const Footer = lazy(() => import("./components/Layout/Footer"));
+const Chatbot = lazy(() => import("./components/Chatbot"));
+const AppRoutes = lazy(() => import("./components/AppRoutes"));
 
 const OfflineSyncManager = () => {
   useOfflineSync();
@@ -67,16 +66,20 @@ function App() {
               <Navbar cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
               <main className="relative z-10 min-h-screen bg-white dark:bg-black">
                 <PageTransition>
-                  <Routes>
-                    <Route path="/register/:id" element={<RegistrationPage />} />
-                    <Route path="*" element={<AppRoutes />} />
-                  </Routes>
+                  <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
+                    <Routes>
+                      <Route path="/register/:id" element={<RegistrationPage />} />
+                      <Route path="*" element={<AppRoutes />} />
+                    </Routes>
+                  </Suspense>
                 </PageTransition>
               </main>
               <ScrollToTop />
-              <Chatbot />
+              <Suspense fallback={null}>
+                <Chatbot />
+                <Footer />
+              </Suspense>
               <FeedbackButton />
-              <Footer />
               <FluidCursor enabled={cursorEnabled} />
             </div>
           </Router>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1281

## Rationale for this change

`src/App.js` used `lazy()` to code-split heavy components but never imported 
`lazy` or `Suspense` from React. This caused a compile-breaking ESLint error 
(`no-undef`) that prevented the app from starting at all on a fresh clone. 
Additionally, several `import` statements were placed after the `lazy()` calls, 
violating the `import/first` rule.

## What changes are included in this PR?

- Added `lazy` and `Suspense` to the React import on line 1
- Reordered all `import` statements to the top of the file before any `lazy()` calls
- Wrapped lazy-loaded components (`AppRoutes`, `Chatbot`, `Footer`) inside 
  `<Suspense>` with appropriate fallbacks — these were missing and would have 
  caused a runtime crash when the lazy components loaded

## Are these changes tested?

Manually tested by running `npm install` and `npm start` on a fresh clone. 
The app now compiles and runs successfully at `http://localhost:3000` with 
zero ESLint errors related to this file.

## Are there any user-facing changes?

No visual changes. The app now loads correctly where it previously failed 
to compile entirely. The `<Suspense>` fallback shows a centered "Loading..." 
indicator while lazy components are being fetched, which is standard React 
beh