### PR TITLE
fix: add aria-label to password toggle button

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -230,6 +230,7 @@ text-gray-900 dark:text-white"
                     <button
                       type="button"
                       onClick={() => setShowPassword((s) => !s)}
+                      aria-label={showPassword ? "Hide password" : "Show password"}
                       className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 transition-colors"
                     >
                       {showPassword ? (


### PR DESCRIPTION
## Description
Added missing aria-label attributes to improve accessibility and screen reader support for icon-only buttons.

## Changes Made
- Added aria-label to password visibility toggle button
- Improved accessibility for authentication UI
- Enhanced screen reader compatibility

## Issue Fixed
Icon-only buttons were missing descriptive aria-label attributes, reducing accessibility for assistive technologies.