### PR TITLE
docs: add EVENTS and PROJECTS API endpoint definitions to API_DOCUMEN…

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -140,6 +140,99 @@ Authenticates the user and returns a JWT token.
 
 # Event APIs
 
+## Create Event
+
+| Method | Endpoint |
+|--------|----------|
+| POST | `/api/events` |
+
+Creates a new event. Requires JWT authentication.
+
+### Request Headers
+
+```bash
+Authorization: Bearer YOUR_JWT_TOKEN
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "title": "Tech Conference 2026",
+  "description": "Annual developer meetup featuring talks and workshops",
+  "location": "Mumbai",
+  "eventDate": "2026-08-15T10:00:00",
+  "public": true
+}
+```
+
+### Successful Response (201)
+
+```json
+{
+  "id": 1,
+  "title": "Tech Conference 2026",
+  "description": "Annual developer meetup featuring talks and workshops",
+  "location": "Mumbai",
+  "eventDate": "2026-08-15T10:00:00",
+  "public": true
+}
+```
+
+### Error Response (401)
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Full authentication is required to access this resource",
+  "path": "/api/events",
+  "timestamp": "2026-05-19T12:20:31"
+}
+```
+
+---
+
+## List Events
+
+| Method | Endpoint |
+|--------|----------|
+| GET | `/api/events` |
+
+Returns a list of all available events. No authentication required.
+
+### Example Request
+
+```bash
+GET /api/events
+```
+
+### Successful Response (200)
+
+```json
+[
+  {
+    "id": 1,
+    "title": "Tech Conference 2026",
+    "description": "Annual developer meetup featuring talks and workshops",
+    "location": "Mumbai",
+    "eventDate": "2026-08-15T10:00:00",
+    "public": true
+  },
+  {
+    "id": 2,
+    "title": "Open Source Hackathon",
+    "description": "48-hour hackathon for open source projects",
+    "location": "Bangalore",
+    "eventDate": "2026-09-20T09:00:00",
+    "public": true
+  }
+]
+```
+
+---
+
 ## Get Public Event By ID
 
 | Method | Endpoint |
@@ -154,7 +247,7 @@ Returns a public event if available.
 GET /api/events/1
 ```
 
-### Successful Response
+### Successful Response (200)
 
 ```json
 {
@@ -165,6 +258,198 @@ GET /api/events/1
   "eventDate": "2026-05-19T18:30:00",
   "public": true
 }
+```
+
+### Error Response (404)
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "Event not found or is not public with id: 888",
+  "path": "/api/events/888",
+  "timestamp": "2026-05-19T12:20:31"
+}
+```
+
+---
+
+## Register for Event
+
+| Method | Endpoint |
+|--------|----------|
+| POST | `/api/events/{id}/register` |
+
+Registers the authenticated user for a specific event. Requires JWT authentication.
+
+### Request Headers
+
+```bash
+Authorization: Bearer YOUR_JWT_TOKEN
+Content-Type: application/json
+```
+
+### Example Request
+
+```bash
+POST /api/events/1/register
+```
+
+### Successful Response (200)
+
+```json
+{
+  "message": "Successfully registered for event",
+  "eventId": 1,
+  "userId": 1
+}
+```
+
+### Error Response (404)
+
+```json
+{
+  "status": 404,
+  "error": "Not Found",
+  "message": "Event not found with id: 999",
+  "path": "/api/events/999/register",
+  "timestamp": "2026-05-19T12:20:31"
+}
+```
+
+### Error Response (401)
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Full authentication is required to access this resource",
+  "path": "/api/events/1/register",
+  "timestamp": "2026-05-19T12:20:31"
+}
+```
+
+---
+
+# Project APIs
+
+## Submit Project
+
+| Method | Endpoint |
+|--------|----------|
+| POST | `/api/projects` |
+
+Submits a new project. Requires JWT authentication.
+
+### Request Headers
+
+```bash
+Authorization: Bearer YOUR_JWT_TOKEN
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "title": "Eventra Mobile App",
+  "description": "A cross-platform mobile application for event management",
+  "category": "Mobile Development",
+  "repositoryUrl": "https://github.com/example/eventra-mobile"
+}
+```
+
+### Successful Response (201)
+
+```json
+{
+  "id": 1,
+  "title": "Eventra Mobile App",
+  "description": "A cross-platform mobile application for event management",
+  "category": "Mobile Development",
+  "repositoryUrl": "https://github.com/example/eventra-mobile",
+  "submittedBy": "john@example.com"
+}
+```
+
+### Error Response (401)
+
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Full authentication is required to access this resource",
+  "path": "/api/projects",
+  "timestamp": "2026-05-19T12:20:31"
+}
+```
+
+---
+
+## List Projects
+
+| Method | Endpoint |
+|--------|----------|
+| GET | `/api/projects` |
+
+Returns a list of all submitted projects. No authentication required.
+
+### Example Request
+
+```bash
+GET /api/projects
+```
+
+### Successful Response (200)
+
+```json
+[
+  {
+    "id": 1,
+    "title": "Eventra Mobile App",
+    "description": "A cross-platform mobile application for event management",
+    "category": "Mobile Development",
+    "repositoryUrl": "https://github.com/example/eventra-mobile",
+    "submittedBy": "john@example.com"
+  },
+  {
+    "id": 2,
+    "title": "Eventra CLI Tool",
+    "description": "Command-line tool for managing Eventra events",
+    "category": "Developer Tools",
+    "repositoryUrl": "https://github.com/example/eventra-cli",
+    "submittedBy": "jane@example.com"
+  }
+]
+```
+
+---
+
+## Get Project Categories
+
+| Method | Endpoint |
+|--------|----------|
+| GET | `/api/projects/categories` |
+
+Returns a list of available project categories. No authentication required.
+
+### Example Request
+
+```bash
+GET /api/projects/categories
+```
+
+### Successful Response (200)
+
+```json
+[
+  "Mobile Development",
+  "Web Development",
+  "Developer Tools",
+  "Machine Learning",
+  "DevOps",
+  "Design"
+]
 ```
 
 ---


### PR DESCRIPTION

Add 6 missing backend endpoint definitions identified from PR #1221:

- POST /api/events (Create Event)
- GET /api/events (List Events)
- POST /api/events/{id}/register (Register for Event)
- POST /api/projects (Submit Project)
- GET /api/projects (List Projects)
- GET /api/projects/categories (Get Project Categories)

Each endpoint includes path/method, summary, request body schema, success/error response structures, and JWT auth requirements. Enhances existing GET /api/events/{id} with 404 error response. Follows the existing documentation format exactly.



- Closes #1222.
