### PR TITLE
fix: add missing useDocumentTitle to all pages for consistent browser…

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { motion } from "framer-motion";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 import {
   Server,
   AlertCircle,
@@ -84,6 +85,7 @@ const endpoints = [
 ];
 
 const ApiDocs = () => {
+  useDocumentTitle("Eventra | API Docs");
   return (
     <div className="pastel-grid-bg min-h-screen bg-white dark:bg-[#121212] text-gray-900 dark:text-gray-100 px-6 py-16">
       {/* Hero Section */}

--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import {
   Sparkles,
   Calendar,
@@ -10,18 +10,7 @@ import {
   Globe,
 } from "lucide-react";
 import FAQCTA from "./FaqCTA";
-
-function useDocumentTitle(title) {
-  useEffect(() => {
-    const previousTitle = document.title;
-
-    document.title = title;
-
-    return () => {
-      document.title = previousTitle;
-    };
-  }, [title]);
-}
+import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 const faqs = [
   {

--- a/src/Pages/HelpCenter.js
+++ b/src/Pages/HelpCenter.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { motion, useAnimation } from "framer-motion";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 import { FiChevronDown, FiChevronUp } from "react-icons/fi";
 import {
   Search,
@@ -152,6 +153,7 @@ const faqs = [
 ];
 
 const HelpCenter = () => {
+  useDocumentTitle("Eventra | Help Center");
   const [expandedFAQ, setExpandedFAQ] = useState(null);
   const controls = useAnimation();
 

--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -9,6 +9,7 @@ import {
 import confetti from "canvas-confetti";
 import GSSoCContribution from "./GSSoCContribution";
 import StyledDropdown from "../../components/StyledDropdown";
+import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 // Repository constant — update if the leaderboard should point to another repo
 const GITHUB_REPO = "SandeepVashishtha/Eventra";
@@ -36,6 +37,7 @@ const calculatePrPoints = (labels) => {
 };
 
 export default function LeaderBoard() {
+  useDocumentTitle("Eventra | Leaderboard");
   // Local state: contributors list and UI state
   const [contributors, setContributors] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/src/Pages/Privacy.js
+++ b/src/Pages/Privacy.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { motion, useAnimation } from "framer-motion";
 import { Link } from "react-router-dom";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 import {
   FaLock,
   FaUserShield,
@@ -13,6 +14,7 @@ import {
 } from "react-icons/fa";
 
 export const Privacy = () => {
+  useDocumentTitle("Eventra | Privacy Policy");
   const controls = useAnimation();
   const [openSections, setOpenSections] = useState({});
 

--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
+import useDocumentTitle from '../hooks/useDocumentTitle';
 
 const RegistrationPage = () => {
+  useDocumentTitle("Eventra | Registration");
   const [formData, setFormData] = useState({
     fullName: '',
     email: '',

--- a/src/Pages/Settings.js
+++ b/src/Pages/Settings.js
@@ -3,8 +3,10 @@ import { Link } from "react-router-dom";
 import { useTheme } from "../context/ThemeContext";
 import { Sun, Moon, MousePointer, Bell, ShieldCheck, ArrowRight } from "lucide-react";
 import useLocalStorage from "../hooks/useLocalStorage";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 const Settings = () => {
+  useDocumentTitle("Eventra | Settings");
   const { isDarkMode, toggleTheme } = useTheme();
 
   // Replace scattered localStorage.getItem / setItem calls with the hook

--- a/src/Pages/Terms.js
+++ b/src/Pages/Terms.js
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 export const Terms = () => {
+  useDocumentTitle("Eventra | Terms of Service");
   const [openDropdown, setOpenDropdown] = useState(null);
 
   const toggleDropdown = (section) => {

--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react';
 import { useNotification } from '../context/NotificationContext';
+import useDocumentTitle from '../hooks/useDocumentTitle';
 
 export default function UserAchievements() {
+  useDocumentTitle("Eventra | Achievements");
   const { achievements, fetchAchievements } = useNotification();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Adds the shared `useDocumentTitle` hook to all 8 pages that were missing it, and replaces the duplicate local implementation in `FAQPage.js` with the shared hook. Every routable page now sets a descriptive `document.title` following the existing `"Eventra | <Page Name>"` convention.
Closes #1301 
## Problem

- 8 pages did not call `useDocumentTitle`, causing the browser tab to show stale or generic titles during navigation
- `FAQPage.js` defined its own local copy of the hook instead of importing the shared one from `src/hooks/useDocumentTitle.js`
- Poor SEO — search engines rely on `document.title` for indexing
- Poor accessibility — screen readers announce page title on navigation
- Poor UX — users with multiple tabs couldn't distinguish pages

## Changes

9 files changed, 18 insertions, 13 deletions.

### Pages that received `useDocumentTitle`

| File | Title Set |
|------|-----------|
| `src/Pages/ApiDocs.js` | `Eventra | API Docs` |
| `src/Pages/Privacy.js` | `Eventra | Privacy Policy` |
| `src/Pages/Terms.js` | `Eventra | Terms of Service` |
| `src/Pages/Settings.js` | `Eventra | Settings` |
| `src/Pages/HelpCenter.js` | `Eventra | Help Center` |
| `src/Pages/RegistrationPage.jsx` | `Eventra | Registration` |
| `src/Pages/UserAchievements.jsx` | `Eventra | Achievements` |
| `src/Pages/Leaderboard/Leaderboard.jsx` | `Eventra | Leaderboard` |

### Duplicate hook removed

| File | Change |
|------|--------|
| `src/Pages/FAQ/FAQPage.js` | Replaced 11-line local `useDocumentTitle` function with `import` from `src/hooks/useDocumentTitle.js` |

## What's NOT Changed

- The shared hook at `src/hooks/useDocumentTitle.js` — untouched
- Pages that already used the hook correctly (Home, Events, Projects, Feedback, Contact, About, etc.)
- No visual or functional changes to any page

## Verification

- [x] `npm run build` compiles successfully
- [x] No new warnings introduced (existing Signup.js/ThemeContext.js warnings are pre-existing upstream)
- [x] All pages follow the `"Eventra | <Page Name>"` convention
- [x] No duplicate `useDocumentTitle` definitions remain
