### PR TITLE
Fix Telegram footer social link

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -78,7 +78,7 @@ const socialLinks = [
   },
   {
     name: "Telegram",
-    href: "https://www.telegram.com/",
+    href: "https://t.me/eventra",
     icon: (
       <FaTelegram
         className="size-10 p-2 rounded-full text-black dark:text-white bg-white dark:bg-gray-800 shadow-sm hover:shadow-lg transition-all duration-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-110 hover:-translate-y-1"


### PR DESCRIPTION
Fixes #1272

Updated the footer Telegram social link from `https://www.telegram.com/` to `https://t.me/eventra`.

Tested:
- Verified the footer link in `src/components/Layout/Footer.js`