### PR TITLE
fix: solve mobile drawer cut-off links by enabling vertical scrolling

### DIFF
--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -36,7 +36,7 @@ const MobileDrawer = ({
         </button>
       </div>
 
-      <div className="p-4 overflow-x-auto space-y-6">
+      <div className="p-4 overflow-y-auto h-[calc(100vh-72px)] pb-12 space-y-6">
         <NavbarLinks vertical={true} onClick={closeMenu} />
 
         {isAuthenticated ? (


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1329

## Rationale for this change

In `MobileDrawer.jsx`, the navigation links container was styled with `overflow-x-auto` but lacked any vertical layout or scroll limits:
`<div className="p-4 overflow-x-auto space-y-6">`

When a user is authenticated (revealing "Dashboard", "Edit Profile", and "Logout" buttons) or accessing the menu on shorter mobile devices, the total height of the navigation links easily exceeds the viewport height. Because the drawer had no vertical scrollable container, the bottom action links were completely cut off and inaccessible.

## What changes are included in this PR?

- Replaced `overflow-x-auto` with `overflow-y-auto` on the mobile drawer content list.
- Constrained the inner container height using `h-[calc(100vh-72px)] pb-12` so that vertical overflow is contained within the drawer height boundaries, triggering vertical scrollbars smoothly.

## Are these changes tested?

Yes, these changes were tested locally:
1. Shrank the viewport width to mobile sizes and limited viewport heights.
2. Toggled user authentication states.
3. Confirmed that the mobile drawer correctly renders all elements and allows smooth vertical scrolling to access "Logout" and profile options.

## Are there any user-facing changes?

Yes. Users on mobile devices can now scroll vertically inside the side navigation drawer menu to access all available platform links.
### 🏷️ Proposed Labels
`gssoc:approved` `quality:exceptional` `level:intermediate` `type:bug`



