### PR TITLE
feat: Add dynamic Clear Filters button to EventsPage

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -167,6 +167,20 @@ const EventsPage = () => {
                 {filter.label}
               </button>
             ))}
+            
+            {/* Clear Filters Button */}
+            {(filterType !== "all" || sortType !== "Newest" || searchQuery !== "") && (
+              <button
+                onClick={() => {
+                  setFilterType("all");
+                  setSortType("Newest");
+                  setSearchQuery("");
+                }}
+                className="px-3 sm:px-4 py-2 text-xs sm:text-sm rounded-full transition bg-red-50 text-red-600 border border-red-200 hover:bg-red-100 dark:bg-red-900/30 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/50 font-semibold"
+              >
+                Clear Filters
+              </button>
+            )}
           </div>
 
           {/* Sort Dropdown and View Toggle */}


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1309 .

## Rationale for this change
On the main /events page, when a user applies a search query, changes the sort dropdown, or selects a specific category tab (like "Conferences" or "Upcoming"), there was previously no immediate way to reset everything back to the default state. The user was forced to manually clear the search bar, reset the dropdown, and re-click "All" to reset the view. This creates friction. Adding a simple, visual "Clear Filters" button significantly improves the UX by allowing users to reset their search state in a single click.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
-Updated EventsPage.js to include a dynamic hasActiveFilters logic check.
-Added a Clear Filters button next to the filter tabs that conditionally renders only when a search query is active, a non-default tab is selected, or a custom sort is applied.
-Bound an onClick handler to the button that instantly resets searchQuery, filterType, and sortType to their default states.
-Styled the button using existing Tailwind CSS utility classes to perfectly match the application's light/dark mode aesthetics.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes.

1.Verified locally that selecting a specific category (e.g., "Upcoming") and searching for an event successfully triggers the new button to appear.
2.Verified that clicking the "Clear Filters" button instantly clears the search state, resets the dropdowns, and re-renders the full event grid view without errors.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Yes, a new user-facing "Clear Filters" button now conditionally appears on the Events Discover page. It is fully styled and responsive. No documentation updates are required as the UI is self-explanatory.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->