### PR TITLE
fix: add missing useDocumentTitle to RegistrationPage

### DIFF
--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -2,8 +2,10 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { FiUser, FiMail, FiPhone, FiBriefcase, FiAward, FiMessageSquare, FiCheckCircle, FiAlertCircle } from "react-icons/fi";
+import useDocumentTitle from "../hooks/useDocumentTitle";
 
 const RegistrationPage = () => {
+  useDocumentTitle("Eventra | Registration");
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     fullName: "",


### PR DESCRIPTION
## Summary

Adds the shared `useDocumentTitle` hook to `RegistrationPage.jsx` — the last remaining routable page missing a descriptive `document.title`.

Closes #1317 
## Problem

`src/Pages/RegistrationPage.jsx` did not set `document.title`, causing the browser tab to show a stale or generic title when navigating to the registration page.

## Changes

1 file changed, 2 insertions.

| File | Change |
|------|--------|
| `src/Pages/RegistrationPage.jsx` | Added `import useDocumentTitle` and `useDocumentTitle("Eventra | Registration")` |

## Why This Matters

- **SEO:** Search engines rely on `document.title` for indexing
- **Accessibility:** Screen readers announce the page title on navigation
- **UX:** Users with multiple tabs can distinguish pages
- **Consistency:** All other pages already use the `"Eventra | <Page Name>"` convention

## Verification

- [x] `npm run build` compiles successfully
- [x] No new warnings introduced
- [x] Follows existing naming convention
- [x] Minimal patch — 2 lines added, zero unrelated changes
