### PR TITLE
refactor: extract shared offline queue utility to eliminate duplicate…

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -19,6 +19,7 @@ import { useSessionRecovery } from "../../context/SessionRecoveryContext";
 import { API_ENDPOINTS } from "../../config/api";
 import { toast } from "react-toastify";
 import mockEvents from "./eventsMockData.json";
+import { pushToQueue } from "../../utils/offlineQueue";
 
 const EventRegistration = () => {
   const { eventId } = useParams();
@@ -185,17 +186,7 @@ const EventRegistration = () => {
         userId: user?.id || null,
       };
       
-      const QUEUE_KEY = 'eventra_offline_queue';
-      let queue = [];
-      try {
-        const queueStr = localStorage.getItem(QUEUE_KEY);
-        if (queueStr) queue = JSON.parse(queueStr);
-      } catch (e) {
-        queue = [];
-      }
-      
-      queue.push({ eventId: parseInt(eventId), payload });
-      localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+      pushToQueue({ eventId: parseInt(eventId), payload });
 
       setRegistered(true);
       addRegistration(event, formData);

--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -2,8 +2,7 @@ import { useEffect, useRef } from 'react';
 import { toast } from 'react-toastify';
 import { useAuth } from '../context/AuthContext';
 import { API_ENDPOINTS } from '../config/api';
-
-const QUEUE_KEY = 'eventra_offline_queue';
+import { getQueue, setQueue, clearQueue } from '../utils/offlineQueue';
 const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 1_000; // 1s → 2s → 4s per item
 
@@ -65,17 +64,7 @@ const useOfflineSync = () => {
       // Prevent concurrent sync runs (e.g. if the user rapidly toggles network)
       if (isSyncing.current) return;
 
-      const queueStr = localStorage.getItem(QUEUE_KEY);
-      if (!queueStr) return;
-
-      let queue = [];
-      try {
-        queue = JSON.parse(queueStr);
-      } catch {
-        localStorage.removeItem(QUEUE_KEY);
-        return;
-      }
-
+      const queue = getQueue();
       if (queue.length === 0) return;
 
       isSyncing.current = true;
@@ -112,12 +101,12 @@ const useOfflineSync = () => {
       }
 
       if (failedQueue.length > 0) {
-        localStorage.setItem(QUEUE_KEY, JSON.stringify(failedQueue));
+        setQueue(failedQueue);
         toast.warning(
           `Synced ${successCount} registration(s). ${failedQueue.length} still queued (will retry).`
         );
       } else {
-        localStorage.removeItem(QUEUE_KEY);
+        clearQueue();
         if (successCount > 0) {
           toast.success('All offline registrations synced successfully!');
         }

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------
+// Shared Offline Queue Utility
+// ---------------------------------------------------------------------------
+// Single source of truth for the offline registration queue stored in
+// localStorage. Both EventRegistration (producer) and useOfflineSync
+// (consumer) import from here instead of defining their own logic.
+
+const QUEUE_KEY = 'eventra_offline_queue';
+
+/**
+ * Read the current offline queue from localStorage.
+ * Returns an empty array if the key is missing or the JSON is malformed.
+ *
+ * @returns {Array} The current queue entries.
+ */
+export const getQueue = () => {
+  try {
+    const raw = localStorage.getItem(QUEUE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Append a single item to the offline queue.
+ *
+ * @param {object} item - The queue entry to store (e.g. { eventId, payload }).
+ */
+export const pushToQueue = (item) => {
+  const queue = getQueue();
+  queue.push(item);
+  localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+};
+
+/**
+ * Overwrite the queue with a new array (used after partial sync to keep
+ * only the items that failed).
+ *
+ * @param {Array} queue - The replacement queue.
+ */
+export const setQueue = (queue) => {
+  if (queue.length === 0) {
+    localStorage.removeItem(QUEUE_KEY);
+  } else {
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  }
+};
+
+/**
+ * Remove the offline queue entirely from localStorage.
+ */
+export const clearQueue = () => {
+  localStorage.removeItem(QUEUE_KEY);
+};


### PR DESCRIPTION
Closes #1315 
## Summary

Extracts the duplicated offline queue management logic from `EventRegistration.js` and `useOfflineSync.js` into a shared `src/utils/offlineQueue.js` utility — single source of truth for the queue key, reads, writes, and clears.

## Problem

Both files independently defined `QUEUE_KEY = 'eventra_offline_queue'` and implemented their own `localStorage.getItem` → `JSON.parse` → `JSON.stringify` → `localStorage.setItem` logic. If the key was renamed in one file but not the other, the offline sync pipeline would silently break.

## Changes

3 files changed (1 new, 2 modified).

### [NEW] `src/utils/offlineQueue.js`
Shared utility with 4 functions:
| Function | Purpose |
|----------|---------|
| `getQueue()` | Read queue from localStorage (safe JSON parse) |
| `pushToQueue(item)` | Append an item to the queue |
| `setQueue(queue)` | Replace the queue (or remove if empty) |
| `clearQueue()` | Remove the queue entirely |

### [MODIFIED] `src/Pages/Events/EventRegistration.js`
- Removed 11 lines of inline localStorage queue logic
- Replaced with single `pushToQueue({ eventId, payload })` call
- Added `import { pushToQueue } from '../../utils/offlineQueue'`

### [MODIFIED] `src/hooks/useOfflineSync.js`
- Removed duplicated `QUEUE_KEY` constant
- Replaced `localStorage.getItem` + `JSON.parse` with `getQueue()`
- Replaced `localStorage.setItem` + `JSON.stringify` with `setQueue(failedQueue)`
- Replaced `localStorage.removeItem` with `clearQueue()`
- Added `import { getQueue, setQueue, clearQueue } from '../utils/offlineQueue'`

## What's Preserved

- ✅ Queue entry format — identical `{ eventId, payload }` shape
- ✅ Offline → online sync flow — same behavior
- ✅ Exponential backoff retry in useOfflineSync — untouched
- ✅ Toast notifications — unchanged
- ✅ Session recovery integration — unchanged

## Verification

- [x] `npm run build` compiles successfully
- [x] No new warnings
- [x] Queue format is backward-compatible with existing localStorage data
- [x] No functional regressions in offline sync or event registration
