### PR TITLE
Fix mobile drawer overflow

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -417,42 +417,50 @@ const MobileDrawer = ({ isOpen, drawerRef, openDropdown, setOpenDropdown, closeA
   const { user, isAuthenticated } = useAuth();
 
   return (
-    <div
-      id="mobile-drawer"
-      ref={drawerRef}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-      className={`fixed top-0 right-0 h-dvh overflow-y-auto w-[88vw] max-w-sm shadow-2xl z-50 flex flex-col transform transition-transform duration-300 ease-in-out bg-white backdrop-blur-lg dark:bg-gray-900/95 ${isOpen ? "translate-x-0" : "translate-x-full"}`}
-      role="dialog"
-      aria-modal={isOpen}
-    >
-      <MobileDrawerHeader closeBtnRef={closeBtnRef} closeAllMenus={closeAllMenus} />
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          id="mobile-drawer"
+          ref={drawerRef}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          className="fixed top-0 right-0 h-dvh overflow-y-auto w-[88vw] max-w-sm shadow-2xl z-50 flex flex-col bg-white backdrop-blur-lg dark:bg-gray-900/95"
+          role="dialog"
+          aria-modal="true"
+          initial={{ x: "100%" }}
+          animate={{ x: 0 }}
+          exit={{ x: "100%" }}
+          transition={{ duration: 0.3, ease: "easeInOut" }}
+        >
+          <MobileDrawerHeader closeBtnRef={closeBtnRef} closeAllMenus={closeAllMenus} />
 
-      <div className="flex-grow p-3.5 sm:p-4 space-y-2 overflow-y-auto">
-        <NavList 
-          location={location} 
-          openDropdown={openDropdown} 
-          onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)} 
-          onLinkClick={closeAllMenus} 
-          isMobile={true} 
-        />
-      </div>
+          <div className="flex-grow p-3.5 sm:p-4 space-y-2 overflow-y-auto">
+            <NavList 
+              location={location} 
+              openDropdown={openDropdown} 
+              onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)} 
+              onLinkClick={closeAllMenus} 
+              isMobile={true} 
+            />
+          </div>
 
-      <MobileDrawerFooter 
-        isAuthenticated={isAuthenticated} 
-        user={user} 
-        primaryLine={primaryLine} 
-        secondaryLine={secondaryLine} 
-        closeAllMenus={closeAllMenus} 
-        location={location} 
-        handleLogoutClick={handleLogoutClick} 
-        isDarkMode={isDarkMode} 
-        toggleTheme={toggleTheme} 
-        cursorEnabled={cursorEnabled} 
-        toggleCursor={toggleCursor} 
-      />
-    </div>
+          <MobileDrawerFooter 
+            isAuthenticated={isAuthenticated} 
+            user={user} 
+            primaryLine={primaryLine} 
+            secondaryLine={secondaryLine} 
+            closeAllMenus={closeAllMenus} 
+            location={location} 
+            handleLogoutClick={handleLogoutClick} 
+            isDarkMode={isDarkMode} 
+            toggleTheme={toggleTheme} 
+            cursorEnabled={cursorEnabled} 
+            toggleCursor={toggleCursor} 
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 };
 const Navbar = ({ cursorEnabled, toggleCursor }) => {
@@ -606,7 +614,8 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
               ref={toggleBtnRef} 
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)} 
               aria-expanded={isMobileMenuOpen} 
-              aria-label="Open navigation" 
+              aria-controls="mobile-drawer"
+              aria-label={isMobileMenuOpen ? "Close navigation" : "Open navigation"} 
               className="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/10"
             >
               <svg className="h-5 w-5 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -633,6 +642,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
         primaryLine={primaryLine}
         secondaryLine={secondaryLine}
       />
+
 
       {/* Confirmation Modal */}
       <ConfirmationModal


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1274

## Rationale for this change

The closed mobile navigation drawer was still mounted off-screen with `translate-x-full`. On mobile viewports, that could keep drawer content in the page/accessibility tree and contribute to horizontal overflow before the menu was opened.

## What changes are included in this PR?

- Render the mobile drawer only while it is open.
- Keep the slide-in/slide-out animation using `AnimatePresence` and `motion.div`.
- Remove the closed off-canvas drawer from the DOM so it cannot affect layout or accessibility.
- Add `aria-controls="mobile-drawer"` to the hamburger button.
- Update the hamburger accessible label between “Open navigation” and “Close navigation”.

## Are these changes tested?

- Verified the changed drawer behavior locally.
- Ran `npm run build:fast`, but the build is currently blocked by an unrelated upstream syntax error in `src/Pages/ApiDocs.js:41`.

## Are there any user-facing changes?

Yes. On mobile, the closed navigation drawer should no longer cause horizontal scrolling or expose hidden drawer links before the hamburger menu is opened.