### PR TITLE
perf: implement route-based lazy loading for heavy modules

### DIFF
--- a/src/components/routes/ProtectedRoutes.js
+++ b/src/components/routes/ProtectedRoutes.js
@@ -1,12 +1,10 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { Route } from 'react-router-dom';
 
 // --------------- COMPONENTS
 import ProtectedRoute from "../auth/ProtectedRoute";
 import EventCreation from "../common/EventCreation";
-import AdminDashboard from "../admin/AdminDashboard";
 import HostHackathon from "../../Pages/Hackathons/HostHackathon";
-import Dashboard from "../Dashboard";
 import EditProfile from "../user/EditProfile";
 import Settings from "../../Pages/Settings";
 import Login from "../auth/Login";
@@ -14,6 +12,9 @@ import Signup from "../auth/Signup";
 import Unauthorized from "../auth/Unauthorized";
 import PasswordReset from "../auth/PasswordReset";
 import NotFound from "../NotFound";
+
+const AdminDashboard = lazy(() => import("../admin/AdminDashboard"));
+const Dashboard = lazy(() => import("../Dashboard"));
 
 export const getProtectedRoutes = () => [
   <Route

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -1,14 +1,11 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { Route } from 'react-router-dom';
 import PageLayout from '../Layout/PageLayout';
 
 // --------------- PAGES
 import HomePage from "../../Pages/Home/HomePage";
-import EventsPage from "../../Pages/Events/EventsPage";
 import EventDetails from "../../Pages/Events/EventDetails";
 import EventRegistration from "../../Pages/Events/EventRegistration";
-import HackathonPage from "../../Pages/Hackathons/HackathonPage";
-import ProjectsPage from "../../Pages/Projects/ProjectsPage";
 import Contributors from "../Contributors";
 import CommunityEvent from "../CommunityEvent";
 import LeaderBoard from "../../Pages/Leaderboard/Leaderboard";
@@ -21,11 +18,15 @@ import ApiDocs from "../../Pages/ApiDocs";
 import HelpCenter from "../../Pages/HelpCenter";
 import ContactUs from "../../Pages/Contact/ContactUs";
 import FeedbackPage from "../../Pages/Feedback/FeedbackPage";
-import EventAnalyticsDashboard from "../../Pages/Events/EventAnalyticsDashboard";
 import FloorPlanDesignerPage from "../../Pages/Events/FloorPlanDesignerPage";
 import DocumentationPage from "../../Pages/About/DocumentationPage";
 import SubmitProject from "../../Pages/Projects/SubmitProject";
 import MockApiResponse from "../MockApiResponse";
+
+const EventsPage = lazy(() => import("../../Pages/Events/EventsPage"));
+const HackathonPage = lazy(() => import("../../Pages/Hackathons/HackathonPage"));
+const ProjectsPage = lazy(() => import("../../Pages/Projects/ProjectsPage"));
+const EventAnalyticsDashboard = lazy(() => import("../../Pages/Events/EventAnalyticsDashboard"));
 
 export const getPublicRoutes = () => [
   <Route key="/" path="/" element={<HomePage />} />,


### PR DESCRIPTION
## 📝 Description

This PR implements route-based lazy loading for heavy route-level modules to improve initial bundle performance and reduce unnecessary code loading during initial application startup.

### Which issue does this PR close?
Closes #1321

---

## 🎯 Rationale for this change

Several heavy route modules were statically imported, causing dashboard/admin-related code to be bundled during the initial load even when users only visited lightweight pages.

This PR improves performance by dynamically loading only high-impact route modules when they are actually visited.

---

## 🚀 Changes included in this PR

### Lazy-loaded heavy route modules

#### Public Routes
- `EventsPage`
- `EventAnalyticsDashboard`
- `HackathonPage`
- `ProjectsPage`

#### Protected Routes
- `AdminDashboard`
- `Dashboard` (User Dashboard)

### Implementation Details
- Replaced static imports with `React.lazy()`
- Reused the existing global `Suspense` boundary
- Preserved current routing behavior
- Kept lightweight routes intentionally static to avoid unnecessary chunk fragmentation

---

## ✅ Testing

Tested manually in local development.

### Verified:
- Application builds successfully
- Route navigation works correctly
- Protected route behavior remains intact
- Heavy modules load correctly when navigated to
- No regressions in mobile responsiveness or layout

No UI or routing logic outside the scope of this issue was modified.