### PR TITLE
feat: Add event materials/resources download for past events #1349

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -3,6 +3,7 @@ import { Calendar, MapPin, Clock, Tag } from "lucide-react";
 import { getEventStatus } from "../../utils/eventUtils";
 import mockEvents from "./eventsMockData.json";
 import CertificateDownload from "../../components/CertificateDownload";
+import EventMaterials from "../../components/common/EventMaterials";
 
 const EventDetails = () => {
   const { eventId } = useParams();
@@ -17,12 +18,9 @@ const EventDetails = () => {
         <div className="mx-auto max-w-3xl rounded-3xl bg-white dark:bg-gray-900 shadow-xl p-10 text-center">
           <h1 className="text-5xl font-extrabold mb-4">Event Not Found</h1>
           <p className="text-gray-600 dark:text-gray-300 mb-8">
-            We could not find the event you were looking for. It may have been removed or the URL is incorrect.
+            We could not find the event you were looking for.
           </p>
-          <Link
-            to="/events"
-            className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-6 py-3 text-white font-semibold shadow hover:bg-indigo-700 transition"
-          >
+          <Link to="/events" className="inline-flex items-center justify-center rounded-full bg-indigo-600 px-6 py-3 text-white font-semibold shadow hover:bg-indigo-700 transition">
             Browse Events
           </Link>
         </div>
@@ -33,6 +31,8 @@ const EventDetails = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-100 dark:from-gray-950 dark:via-gray-900 dark:to-black text-gray-900 dark:text-gray-100 py-16 px-4 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl space-y-8">
+
+        {/* Header */}
         <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <p className="inline-flex rounded-full bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200 px-4 py-1 text-sm font-semibold uppercase tracking-[0.2em]">
@@ -47,20 +47,20 @@ const EventDetails = () => {
           </div>
 
           <div className="flex flex-wrap gap-3">
-  {event.status === 'past' ? (
-    <CertificateDownload
-      eventName={event.title}
-      eventDate={event.date}
-      eventType={event.type}
-    />
-  ) : (
-    <Link
-      to={`/events/${event.id}/register`}
-      className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 transition"
-    >
-      Register Now
-    </Link>
-  )}
+            {event.status === 'past' ? (
+              <CertificateDownload
+                eventName={event.title}
+                eventDate={event.date}
+                eventType={event.type}
+              />
+            ) : (
+              <Link
+                to={`/events/${event.id}/register`}
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 transition"
+              >
+                Register Now
+              </Link>
+            )}
             <Link
               to="/events"
               className="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-800 shadow-sm hover:bg-gray-50 transition dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
@@ -70,14 +70,16 @@ const EventDetails = () => {
           </div>
         </div>
 
+        {/* Main Grid */}
         <div className="grid gap-8 lg:grid-cols-[1.25fr_0.75fr] items-start">
+
+          {/* Left - Image and Details */}
           <div className="space-y-6 rounded-3xl bg-white p-8 shadow-xl dark:bg-gray-900">
             <img
               src={event.image}
               alt={event.title}
               className="w-full rounded-3xl object-cover shadow-lg h-96"
             />
-
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="flex items-center gap-3 rounded-3xl bg-slate-50 p-5 dark:bg-gray-800">
                 <Calendar className="h-5 w-5 text-indigo-600" />
@@ -108,8 +110,35 @@ const EventDetails = () => {
                 </div>
               </div>
             </div>
+
+{event.status === 'past' && (
+  <EventMaterials materials={event.materials || [
+    {
+      "id": 1,
+      "title": `${event.title} - Presentation Slides`,
+      "type": "ppt",
+      "size": "3.2 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    },
+    {
+      "id": 2,
+      "title": `${event.title} - Session Notes`,
+      "type": "pdf",
+      "size": "1.5 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    },
+    {
+      "id": 3,
+      "title": `${event.title} - Resource Guide`,
+      "type": "doc",
+      "size": "0.8 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    }
+  ]} />
+)}
           </div>
 
+          {/* Right - Sidebar */}
           <aside className="space-y-6 rounded-3xl bg-white p-8 shadow-xl dark:bg-gray-900">
             <div className="space-y-4">
               <h2 className="text-xl font-semibold">Event Details</h2>
@@ -119,7 +148,6 @@ const EventDetails = () => {
                 <p><span className="font-semibold">Tags:</span> {event.tags.join(", ")}</p>
               </div>
             </div>
-
             <div className="rounded-3xl bg-slate-50 p-5 dark:bg-gray-800">
               <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">Summary</h3>
               <p className="mt-3 text-gray-700 dark:text-gray-300 text-sm leading-6">
@@ -127,6 +155,7 @@ const EventDetails = () => {
               </p>
             </div>
           </aside>
+
         </div>
       </div>
     </div>

--- a/src/Pages/Events/eventsMockData.json
+++ b/src/Pages/Events/eventsMockData.json
@@ -28,19 +28,42 @@
     "tags": ["AI", "ML", "Python"]
   },
   {
-    "id": 3,
-    "title": "DevOps Summit 2026",
-    "date": "2026-12-10",
-    "time": "9:00 AM",
-    "location": "New York, NY",
-    "type": "summit",
-    "status": "past",
-    "description": "Comprehensive summit on modern DevOps practices and cloud technologies.",
-    "attendees": 400,
-    "maxAttendees": 400,
-    "image": "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=400&h=200&fit=crop",
-    "tags": ["DevOps", "Cloud", "Infrastructure"]
-  },
+  "id": 3,
+  "title": "DevOps Summit 2026",
+  "date": "2026-12-10",
+  "time": "9:00 AM",
+  "location": "New York, NY",
+  "type": "summit",
+  "status": "past",
+  "description": "Comprehensive summit on modern DevOps practices and cloud technologies.",
+  "attendees": 400,
+  "maxAttendees": 400,
+  "image": "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=400&h=200&fit=crop",
+  "tags": ["DevOps", "Cloud", "Infrastructure"],
+  "materials": [
+    {
+      "id": 1,
+      "title": "DevOps Best Practices 2026",
+      "type": "pdf",
+      "size": "2.4 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    },
+    {
+      "id": 2,
+      "title": "Cloud Infrastructure slides",
+      "type": "ppt",
+      "size": "5.1 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    },
+    {
+      "id": 3,
+      "title": "CI/CD Pipeline Workshop Notes",
+      "type": "doc",
+      "size": "1.2 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    }
+  ]
+},
   {
     "id": 4,
     "title": "Blockchain Intensive",
@@ -112,19 +135,35 @@
     "tags": ["Data Science", "AI", "Hackathon"]
   },
   {
-    "id": 9,
-    "title": "Android Development Workshop",
-    "date": "2026-11-15",
-    "time": "1:30 PM",
-    "location": "Online",
-    "type": "workshop",
-    "status": "past",
-    "description": "Learn to build cross-platform mobile apps with React Native and Flutter.",
-    "attendees": 95,
-    "maxAttendees": 100,
-    "image": "https://images.unsplash.com/photo-1555774698-0b77e0d5fac6?w=400&h=200&fit=crop",
-    "tags": ["Mobile", "React Native", "Flutter"]
-  },
+  "id": 9,
+  "title": "Android Development Workshop",
+  "date": "2026-11-15",
+  "time": "1:30 PM",
+  "location": "Online",
+  "type": "workshop",
+  "status": "past",
+  "description": "Learn to build cross-platform mobile apps with React Native and Flutter.",
+  "attendees": 95,
+  "maxAttendees": 100,
+  "image": "https://images.unsplash.com/photo-1555774698-0b77e0d5fac6?w=400&h=200&fit=crop",
+  "tags": ["Mobile", "React Native", "Flutter"],
+  "materials": [
+    {
+      "id": 1,
+      "title": "React Native Setup Guide",
+      "type": "pdf",
+      "size": "1.8 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    },
+    {
+      "id": 2,
+      "title": "Flutter Basics Slides",
+      "type": "ppt",
+      "size": "3.2 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    }
+  ]
+},
   {
     "id": 10,
     "title": "Tech Leadership Summit",
@@ -168,19 +207,35 @@
     "tags": ["AI", "Healthcare", "Innovation"]
   },
   {
-    "id": 13,
-    "title": "Web3 & DeFi Workshop",
-    "date": "2026-10-05",
-    "time": "2:00 PM",
-    "location": "Miami, FL",
-    "type": "workshop",
-    "status": "past",
-    "description": "Hands-on workshop on building decentralized applications and DeFi protocols.",
-    "attendees": 75,
-    "maxAttendees": 80,
-    "image": "https://images.unsplash.com/photo-1639762681057-408e52192e55?w=400&h=200&fit=crop",
-    "tags": ["Web3", "DeFi", "Blockchain"]
-  },
+  "id": 13,
+  "title": "Web3 & DeFi Workshop",
+  "date": "2026-10-05",
+  "time": "2:00 PM",
+  "location": "Miami, FL",
+  "type": "workshop",
+  "status": "past",
+  "description": "Hands-on workshop on building decentralized applications and DeFi protocols.",
+  "attendees": 75,
+  "maxAttendees": 80,
+  "image": "https://images.unsplash.com/photo-1639762681057-408e52192e55?w=400&h=200&fit=crop",
+  "tags": ["Web3", "DeFi", "Blockchain"],
+  "materials": [
+    {
+      "id": 1,
+      "title": "Introduction to Web3",
+      "type": "pdf",
+      "size": "2.1 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    },
+    {
+      "id": 2,
+      "title": "DeFi Protocols Explained",
+      "type": "ppt",
+      "size": "4.5 MB",
+      "url": "https://www.w3.org/WAI/WCAG21/Techniques/pdf/PDF1"
+    }
+  ]
+},
   {
     "id": 14,
     "title": "DevOps Days",

--- a/src/components/common/EventMaterials.jsx
+++ b/src/components/common/EventMaterials.jsx
@@ -1,0 +1,58 @@
+const EventMaterials = ({ materials }) => {
+  if (!materials || materials.length === 0) return null;
+
+  const getIcon = (type) => {
+    if (type === 'pdf') return '📄';
+    if (type === 'ppt') return '📊';
+    if (type === 'doc') return '📝';
+    if (type === 'video') return '🎥';
+    return '📎';
+  };
+
+  const getColor = (type) => {
+    if (type === 'pdf') return 'text-red-500 bg-red-50 dark:bg-red-900/20';
+    if (type === 'ppt') return 'text-orange-500 bg-orange-50 dark:bg-orange-900/20';
+    if (type === 'doc') return 'text-blue-500 bg-blue-50 dark:bg-blue-900/20';
+    return 'text-gray-500 bg-gray-50 dark:bg-gray-900/20';
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700 mt-8">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg">
+          <span className="text-2xl">📚</span>
+        </div>
+        <div>
+          <h3 className="text-xl font-bold text-gray-900 dark:text-white">Event Resources</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Download materials from this event</p>
+        </div>
+      </div>
+      <div className="space-y-3">
+        {materials.map((material) => (
+          <div key={material.id} className="flex items-center justify-between p-4 rounded-xl border border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-all duration-200">
+            <div className="flex items-center gap-4">
+              <div className={`p-2 rounded-lg text-xl ${getColor(material.type)}`}>
+                {getIcon(material.type)}
+              </div>
+              <div>
+                <p className="font-semibold text-gray-900 dark:text-white text-sm">{material.title}</p>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className={`text-xs font-bold uppercase px-2 py-0.5 rounded-full ${getColor(material.type)}`}>{material.type}</span>
+                  <span className="text-xs text-gray-400">{material.size}</span>
+                </div>
+              </div>
+            </div>
+            <a href={material.url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-lg transition-colors duration-200">
+              ⬇️ Download
+            </a>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mt-4 text-center">
+        Materials shared by event organizers • For attendees only
+      </p>
+    </div>
+  );
+};
+
+export default EventMaterials;


### PR DESCRIPTION
## Which issue does this PR close?
--Closes #1349
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->



## Rationale for this change
After an event ends, attendees had no way to access 
or download event materials from the platform. 
This feature adds an Event Resources section on 
past event detail pages so attendees can download 
presentations, notes and guides shared by organizers.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- Created new EventMaterials component with download buttons
- Added materials field to past events in eventsMockData.json
- Materials section appears only on past/ended events
- Shows PPT, PDF, DOC files with icons, file size and download button
- For past events without specific materials, fallback default 
  materials are shown automatically

Note: Currently using placeholder/dummy PDF URLs in mock data 
since this is a frontend implementation. In production, real 
event material URLs would be uploaded by organizers through 
the backend and stored in the database.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, manually tested on localhost:3000
- Verified Event Resources section appears on all past events
- Verified Download button works and opens file
- Verified section does NOT appear on upcoming events
- Tested on DevOps Summit, Android Workshop, Web3 Workshop

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?
Yes. A new "Event Resources" section now appears on past 
event detail pages, allowing attendees to download 
event materials like presentations, session notes 
and resource guides.hop

<img width="1909" height="843" alt="image" src="https://github.com/user-attachments/assets/e8b21c33-33cf-47aa-a227-174333346bbf" />


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->