### PR TITLE
fix: make 404 page heading visible in light mode

### DIFF
--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -99,7 +99,7 @@ const NotFoundPage = () => {
         <motion.h2
           variants={itemVariants}
           // UPDATED: Text colors
-          className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold leading-tight px-4 text-white"
+                    className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold leading-tight px-4 text-gray-900 dark:text-white"
         >
           Lost in the <span className="text-indigo-600 dark:text-blue-400">Eventra</span> Space
         </motion.h2>


### PR DESCRIPTION
## Related Issue
Closes #1264 

## Problem
The main heading on the 404 Not Found page (`src/components/NotFound.js`, line 102) uses `text-white` with no light mode override. In light mode, the white text renders on a light background, making the heading "Lost in the Eventra Space" completely invisible to users.

## Fix
Changed the class from `text-white` to `text-gray-900 dark:text-white` so the heading is dark in light mode and white in dark mode.

**Before:**
`className="... text-white"` → heading invisible in light mode ❌

**After:**
`className="... text-gray-900 dark:text-white"` → heading clearly visible in both themes ✅

This matches the existing pattern already used on the subtitle directly below it (`text-gray-600 dark:text-white/80`), keeping the styling consistent across the component.

## Files Changed
- `src/components/NotFound.js` (1 line)

## Testing
- Verified the heading is now clearly visible in light mode ✅
- Verified the heading still renders correctly in dark mode ✅
- No other styling affected ✅

## Checklist
- [x] My code follows the existing style of the project
- [x] I have tested my changes locally in both themes
- [x] No new dependencies were added
- [x] The PR is focused on a single concern

---

Submitted as part of **GSSoC '25**.