### PR TITLE
fix: replace native alert with toast notification in EventCard

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -11,6 +11,7 @@ import {
   Gift,
   Share2,
 } from "lucide-react";
+import { toast } from "react-toastify";
 import { addEventToGoogleCalendar } from "../../utils/calendarUtils";
 import ShareMenu from "../../components/common/ShareMenu";
 import { generateEventSharingData } from "../../utils/shareUtils";
@@ -46,10 +47,15 @@ const EventCard = ({ event }) => {
     navigator.clipboard
       .writeText(shareUrl)
       .then(() => {
-        alert("Event link copied to clipboard!");
+        toast.success("Event link copied to clipboard!", {
+          autoClose: 2000,
+        });
       })
       .catch((err) => {
         console.error("Failed to copy: ", err);
+        toast.error("Could not copy link. Please try again.", {
+          autoClose: 2500,
+        });
       });
   };
 


### PR DESCRIPTION
## Related Issue
Closes #1268 

## Problem
In `src/Pages/Events/EventCard.js` (line ~47), the copy-link button uses the native browser `alert()` popup to confirm that the event link was copied. This is jarring, blocks the UI, and looks inconsistent with the rest of the app which already uses `react-toastify` for notifications.

Additionally, the error case in the `.catch()` block was completely silent — only logging to the console, leaving the user with no feedback if copying failed.

## Fix
- Imported `toast` from `react-toastify` (already a project dependency and used in many other files like `AdminDashboard.js`, `Login.js`, etc.).
- Replaced `alert("Event link copied to clipboard!")` with `toast.success("Event link copied to clipboard!", { autoClose: 2000 })`.
- Added a `toast.error("Could not copy link. Please try again.", { autoClose: 2500 })` inside the `.catch()` block so the user gets feedback even when copying fails (e.g. permissions denied / older browsers).

This matches the existing notification pattern used throughout the project — no new dependencies, no new config, just consistent UX.

## Files Changed
- `src/Pages/Events/EventCard.js`

## Testing
- Clicked the copy-link button on an event card → toast success appears, link is copied to clipboard ✅
- Verified the toast auto-dismisses after 2 seconds ✅
- Verified no console errors ✅
- Verified the rest of the card (share menu, calendar link, register button) still works ✅

## Checklist
- [x] My code follows the existing style of the project
- [x] I have tested my changes locally
- [x] No new dependencies were added
- [x] The PR is focused on a single concern
- [x] Both success and error cases now give user feedback

---

Submitted as part of **GSSoC '25**.