### PR TITLE
feat: add seats availability indicator with progress bar to EventCard

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -171,6 +171,67 @@ const EventCard = ({ event }) => {
         </div>
       </div>
 
+      {/* Seats / Capacity */}
+      {typeof event.maxAttendees === "number" && event.maxAttendees > 0 && (() => {
+        const registered = Number(event.attendees) || 0;
+        const capacity = Number(event.maxAttendees);
+        const isFull = registered >= capacity;
+        const ratio = Math.min(registered / capacity, 1);
+        const percent = Math.round(ratio * 100);
+        const spotsLeft = Math.max(capacity - registered, 0);
+
+        const barColor = isFull
+          ? "bg-red-500"
+          : ratio >= 0.85
+          ? "bg-red-500"
+          : ratio >= 0.6
+          ? "bg-amber-500"
+          : "bg-emerald-500";
+
+        const textColor = isFull
+          ? "text-red-600 dark:text-red-400"
+          : ratio >= 0.85
+          ? "text-red-600 dark:text-red-400"
+          : ratio >= 0.6
+          ? "text-amber-600 dark:text-amber-400"
+          : "text-emerald-600 dark:text-emerald-400";
+
+        return (
+          <div className="px-5 py-3 border-t border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                Seats
+              </span>
+              {isFull ? (
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300">
+                  Full
+                </span>
+              ) : (
+                <span className={`text-xs font-semibold tabular-nums ${textColor}`}>
+                  {spotsLeft} spot{spotsLeft === 1 ? "" : "s"} left
+                </span>
+              )}
+            </div>
+            <div
+              className="w-full h-1.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden"
+              role="progressbar"
+              aria-valuenow={percent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${registered} of ${capacity} seats filled`}
+            >
+              <div
+                className={`h-full ${barColor} transition-all duration-500 ease-out`}
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+            <div className="mt-1 text-[11px] text-gray-500 dark:text-gray-500 tabular-nums">
+              {registered} / {capacity} registered
+            </div>
+          </div>
+        );
+      })()}
+
       {/* CTA */}
       <div className="px-5 py-4 flex gap-3 mt-auto">
         {isPastEvent ? (


### PR DESCRIPTION
## Related Issue
Closes #1267 

## Problem
The EventCard (`src/Pages/Events/EventCard.js`) shows date, location, time and type — but does not show how many seats are left or how many people have already registered. This is critical information for users deciding whether to register for an event.

## Solution
Added a new Seats / Capacity section between the existing Info Grid and the CTA buttons, showing:

- "X spots left" when seats are still available (pluralized correctly — "1 spot" vs "2 spots")
- "Full" badge (red pill) when attendees >= maxAttendees
- Progress bar that fills based on the attendees / maxAttendees ratio, with the color changing as the event fills up:
  - Green — less than 60% filled
  - Amber — 60–85% filled
  - Red — over 85% filled or full
- "X / Y registered" subtext for full context

## Note on Field Names
The issue mentioned `capacity` and `registered` fields, but the existing mock data in `eventsMockData.json` actually uses `maxAttendees` and `attendees`. I used the existing field names to avoid breaking any other parts of the app that already rely on them.

## Graceful Fallback
The entire section is wrapped in a guard:
`{typeof event.maxAttendees === "number" && event.maxAttendees > 0 && (...)}`

So if an event doesn't have `maxAttendees` defined (or it's 0), the section simply won't render — no crashes, no empty UI.

## Accessibility
- Progress bar uses proper ARIA attributes: `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and a descriptive `aria-label`.
- Numbers use `tabular-nums` so digits don't jitter as values change.
- Dark mode fully supported.

## Files Changed
- `src/Pages/Events/EventCard.js` (+61 lines)

## Testing
- Verified seats info appears on all events with `maxAttendees` defined ✅
- Verified "Full" badge appears on DevOps Summit (attendees: 400, maxAttendees: 400) ✅
- Verified "X spots left" text on partially filled events ✅
- Verified progress bar color transitions (green → amber → red) ✅
- Verified pluralization: "1 spot left" vs "180 spots left" ✅
- Verified the section hides cleanly when `maxAttendees` is missing ✅
- Verified dark mode styling ✅
- No console errors or warnings ✅

## Checklist
- [x] My code follows the existing style of the project
- [x] I have tested my changes locally
- [x] No new dependencies were added
- [x] The PR is focused on a single concern
- [x] Accessible (ARIA attributes, tabular-nums, semantic structure)
- [x] Graceful fallback when data is missing

---

Submitted as part of **GSSoC '25**.