### PR TITLE
perf: remove duplicate ThemeProvider wrapping and import in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ import NotificationToastContainer from "./components/common/NotificationProvider
 import { NotificationProvider } from "./context/NotificationContext";
 import { AuthProvider } from "./context/AuthContext";
 import { MyEventsProvider } from "./context/MyEventsContext";
-import { ThemeProvider } from "./context/ThemeContext";
 import { SessionRecoveryProvider } from "./context/SessionRecoveryContext";
 import useOfflineSync from "./hooks/useOfflineSync";
 import useLenis from "./hooks/useLenis";
@@ -77,59 +76,57 @@ function App() {
   }, []);
 
   return (
-    <ThemeProvider>
-      <AuthProvider>
-        <NotificationProvider>
-          <MyEventsProvider>
-            <SessionRecoveryProvider>
-              <NotificationToastContainer />
+    <AuthProvider>
+      <NotificationProvider>
+        <MyEventsProvider>
+          <SessionRecoveryProvider>
+            <NotificationToastContainer />
 
-              <OfflineSyncManager />
+            <OfflineSyncManager />
 
-              <Router>
-              <div className="App">
-                <Navbar
-                  cursorEnabled={cursorEnabled}
-                  toggleCursor={toggleCursor}
-                />
+            <Router>
+            <div className="App">
+              <Navbar
+                cursorEnabled={cursorEnabled}
+                toggleCursor={toggleCursor}
+              />
 
-                <main
-                  className="
-                    relative
-                    z-10
-                    min-h-screen
-                    bg-white
-                    dark:bg-slate-950
-                    text-black
-                    dark:text-white
-                    transition-colors
-                    duration-300
-                  "
-                >
-                  <PageTransition>
-                    <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
-                      <Routes>
-                        <Route path="/register/:id" element={<RegistrationPage />} />
-                        <Route path="*" element={<AppRoutes />} />
-                      </Routes>
-                    </Suspense>
-                  </PageTransition>
-                </main>
+              <main
+                className="
+                  relative
+                  z-10
+                  min-h-screen
+                  bg-white
+                  dark:bg-slate-950
+                  text-black
+                  dark:text-white
+                  transition-colors
+                  duration-300
+                "
+              >
+                <PageTransition>
+                  <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
+                    <Routes>
+                      <Route path="/register/:id" element={<RegistrationPage />} />
+                      <Route path="*" element={<AppRoutes />} />
+                    </Routes>
+                  </Suspense>
+                </PageTransition>
+              </main>
 
-                <ScrollToTop />
-                <Suspense fallback={null}>
-                  <Chatbot />
-                  <Footer />
-                </Suspense>
-                <FeedbackButton />
-                <FluidCursor enabled={cursorEnabled} />
-              </div>
-            </Router>
-            </SessionRecoveryProvider>
-          </MyEventsProvider>
-        </NotificationProvider>
-      </AuthProvider>
-    </ThemeProvider>
+              <ScrollToTop />
+              <Suspense fallback={null}>
+                <Chatbot />
+                <Footer />
+              </Suspense>
+              <FeedbackButton />
+              <FluidCursor enabled={cursorEnabled} />
+            </div>
+          </Router>
+          </SessionRecoveryProvider>
+        </MyEventsProvider>
+      </NotificationProvider>
+    </AuthProvider>
   );
 }
 


### PR DESCRIPTION
Closes #1374

### Description
This PR resolves an architectural and performance issue where `<ThemeProvider>` was mounted twice in the React application tree (once in `src/index.js` and once in `src/App.js`). Having two independent instances of `ThemeContext` led to double execution of theme-related side effects, redundant `localStorage` writes, and unnecessary layout rerender cycles during theme changes.

### Changes Made

#### 1. Removed Duplicate Wrapper & Import in App.js
* Removed the duplicate `<ThemeProvider>` wrapper tags wrapping the internal context providers inside `src/App.js`.
* Cleaned up the unused `ThemeProvider` import statement at the top of the file to maintain a clean codebase.
* Kept the nesting order of all other context providers (`AuthProvider`, `NotificationProvider`, `MyEventsProvider`, `SessionRecoveryProvider`) intact.

#### 2. Retained Global Provider in index.js
* Retained the single, unified `<ThemeProvider>` inside `src/index.js` wrapping the `<App />` root.
* This maintains structural consistency and ensures the entire application tree—including components rendered directly in `<App />`—can access a single source of truth for the active theme.

### Performance Gains
* **Side-Effect Optimization**: Eliminates double listener attachments and redundant class list updates to `document.documentElement` during theme transitions.
* **Storage Synchronization**: Restricts theme write updates to a single `localStorage` operation per toggle.
* **Optimized Rerendering**: Removes duplicate context-update cascades, leading to faster paint times during theme toggles.
