### PR TITLE
fix: replace href="#" placeholder links in Features, HostHackathon, and SubmitProject

### DIFF
--- a/src/Pages/About/Features.js
+++ b/src/Pages/About/Features.js
@@ -156,13 +156,13 @@ export default function Features() {
                     <FaArrowRight className="ml-2 w-4 h-4 transform group-hover:translate-x-1 transition-transform duration-200" />
                   </Link>
                 ) : (
-                  <a
-                    href="#"
-                    className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-medium text-sm flex items-center group"
+                  <span
+                    className="text-indigo-400 dark:text-indigo-600 font-medium text-sm flex items-center cursor-not-allowed opacity-60"
+                    title="Coming soon"
                   >
-                    {feature.cta}
-                    <FaArrowRight className="ml-2 w-4 h-4 transform group-hover:translate-x-1 transition-transform duration-200" />
-                  </a>
+                      {feature.cta}
+                      <FaArrowRight className="ml-2 w-4 h-4" />
+                  </span>
                 )}
               </div>
             </motion.div>

--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -488,14 +488,14 @@ const HostHackathon = () => {
           today!
         </p>
         <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-6">
-          <motion.a
-            href="#"
+          <motion.button
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             className="inline-block bg-white text-black px-8 py-3 rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-300"
           >
             Explore Hosting Options
-          </motion.a>
+          </motion.button>
 
           <motion.a
             href="/hackathons"

--- a/src/Pages/Projects/SubmitProject.js
+++ b/src/Pages/Projects/SubmitProject.js
@@ -496,14 +496,15 @@ const SubmitProject = () => {
           progress easily.
         </p>
         <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-6">
-          <motion.a
-            href="#"
+          <motion.button
+            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             className="inline-flex items-center justify-center gap-2 bg-white text-black px-8 py-3 rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-300"
           >
             <ArrowUpTrayIcon className="w-5 h-5" /> Submit Another Project
-          </motion.a>
+          </motion.button>
+          
           <motion.a
             href="/projects"
             whileHover={{ scale: 1.05 }}


### PR DESCRIPTION
Fixes #1387

## Changes Made
- Features.js: Replaced href="#" anchor tags with disabled span elements (coming soon)
- HostHackathon.js: Replaced href="#" with a button that scrolls to top of form
- SubmitProject.js: Replaced href="#" with a button that scrolls to top of form

## Type of Change
- Bug fix (non-functional placeholder links)