### PR TITLE
Add custom 404 Not Found page with fallback route

### DIFF
--- a/src/Pages/NotFoundPage.jsx
+++ b/src/Pages/NotFoundPage.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+
+const NotFoundPage = () => {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-white dark:bg-gray-900 text-center px-6">
+      
+      <motion.h1
+        initial={{ opacity: 0, scale: 0.5 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.6 }}
+        className="text-7xl md:text-9xl font-bold text-black dark:text-white"
+      >
+        404
+      </motion.h1>
+
+      <motion.h2
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.6 }}
+        className="mt-4 text-2xl md:text-4xl font-semibold text-gray-800 dark:text-gray-200"
+      >
+        Page Not Found
+      </motion.h2>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.4, duration: 0.6 }}
+        className="mt-4 text-gray-600 dark:text-gray-400 max-w-md"
+      >
+        Sorry, the page you are looking for does not exist
+        or has been moved.
+      </motion.p>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.6, duration: 0.6 }}
+      >
+        <Link
+          to="/"
+          className="
+            inline-block
+            mt-8
+            px-6
+            py-3
+            rounded-lg
+            bg-black
+            text-white
+            dark:bg-white
+            dark:text-black
+            font-medium
+            hover:scale-105
+            transition-transform
+            duration-300
+          "
+        >
+          Go Back Home
+        </Link>
+      </motion.div>
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -1,16 +1,31 @@
-import React from 'react';
-import { Route, Routes } from 'react-router-dom';
-import { getPublicRoutes } from './routes/PublicRoutes';
-import { getProtectedRoutes, getAuthRoutes } from './routes/ProtectedRoutes';
-import ProtectedRoute from './auth/ProtectedRoute';
-import UserAchievements from '../Pages/UserAchievements';
+import React from "react";
+import { Route, Routes } from "react-router-dom";
+
+import { getPublicRoutes } from "./routes/PublicRoutes";
+import {
+  getProtectedRoutes,
+  getAuthRoutes,
+} from "./routes/ProtectedRoutes";
+
+import ProtectedRoute from "./auth/ProtectedRoute";
+
+import UserAchievements from "../Pages/UserAchievements";
+
+import NotFoundPage from "../Pages/NotFoundPage";
 
 const AppRoutes = () => {
   return (
     <Routes>
+      {/* Public Routes */}
       {getPublicRoutes()}
+
+      {/* Protected Routes */}
       {getProtectedRoutes()}
+
+      {/* Auth Routes */}
       {getAuthRoutes()}
+
+      {/* Achievements Route */}
       <Route
         path="/dashboard/achievements"
         element={
@@ -18,6 +33,12 @@ const AppRoutes = () => {
             <UserAchievements />
           </ProtectedRoute>
         }
+      />
+
+      {/* 404 Route */}
+      <Route
+        path="*"
+        element={<NotFoundPage />}
       />
     </Routes>
   );


### PR DESCRIPTION
## Description

This PR adds a custom 404 - Not Found page to improve user experience when navigating to invalid or undefined routes.

### Changes Made

* Created `NotFoundPage.jsx` inside `src/pages/`
* Added a catch-all fallback route:

```jsx
<Route path="*" element={<NotFoundPage />} />
```

* Added navigation button to return users to the homepage
* Improved handling for unmatched routes
* Added responsive and theme-compatible UI

### Result

Users visiting invalid routes such as:

* `/abc`
* `/random-page`
* `/unknown-route`

will now see a proper 404 page instead of a blank screen.

### Tech Stack

* React Router DOM
* Tailwind CSS
* Framer Motion

### Related Issue

Fixes #1384 
