### PR TITLE
feat: add achievements navigation links to navbar and dashboard

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -308,6 +308,9 @@ const UserProfileDropdown = ({
             <Link to="/dashboard" onClick={() => setShowProfileDropdown(false)} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors ${location.pathname === "/dashboard" ? "bg-black/5 dark:bg-white/10 text-black dark:text-white" : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"}`}>
               <LayoutDashboard className="w-4 h-4" />Dashboard
             </Link>
+            <Link to="/dashboard/achievements" onClick={() => setShowProfileDropdown(false)} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors ${location.pathname === "/dashboard/achievements" ? "bg-black/5 dark:bg-white/10 text-black dark:text-white" : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"}`}>
+              <Trophy className="w-4 h-4" />Achievements
+            </Link>
             <Link to="/profile" onClick={() => setShowProfileDropdown(false)} className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors ${location.pathname === "/profile" ? "bg-black/5 dark:bg-white/10 text-black dark:text-white" : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"}`}>
               <UserCog className="w-4 h-4" />Edit Profile
             </Link>
@@ -342,6 +345,9 @@ const MobileUserSection = ({
     </div>
     <Link to="/dashboard" onClick={closeAllMenus} className={`flex items-center gap-3 w-full px-4 py-2.5 rounded-lg transition-colors text-base font-medium ${location.pathname === "/dashboard" ? "bg-black/10 dark:bg-white/15 border border-black/10 dark:border-white/20 text-black dark:text-white" : "text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/10"}`}>
       <LayoutDashboard className="w-5 h-5" />Dashboard
+    </Link>
+    <Link to="/dashboard/achievements" onClick={closeAllMenus} className={`flex items-center gap-3 w-full px-4 py-2.5 rounded-lg transition-colors text-base font-medium ${location.pathname === "/dashboard/achievements" ? "bg-black/10 dark:bg-white/15 border border-black/10 dark:border-white/20 text-black dark:text-white" : "text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/10"}`}>
+      <Trophy className="w-5 h-5" />Achievements
     </Link>
     <Link to="/profile" onClick={closeAllMenus} className={`flex items-center gap-3 w-full px-4 py-3 rounded-lg transition-colors text-lg font-medium ${location.pathname === "/profile" ? "bg-black/10 dark:bg-white/15 border border-black/10 dark:border-white/20 text-black dark:text-white" : "text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/10"}`}>
       <UserCog className="w-5 h-5" />Edit Profile

--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -156,6 +156,10 @@ export default function UserDashboard() {
               )}
             </button>
           ))}
+          <Link to="/dashboard/achievements" className="ud-nav-item">
+            <Trophy size={18} />
+            <span>Achievements</span>
+          </Link>
         </nav>
 
         <div className="ud-sidebar-bottom">


### PR DESCRIPTION
### Description
closes #1496 
This PR resolves the missing navigation pathways to the Achievements page (`/dashboard/achievements`). Links have been integrated into the key layout and dashboard navigation components to improve accessibility across both desktop and mobile viewports.

### Changes Made
- **Navbar (Desktop & Mobile)**:
  - Added an **Achievements** option with a `Trophy` icon from `lucide-react` to the desktop user profile dropdown (`UserProfileDropdown`).
  - Added an **Achievements** link with a `Trophy` icon to the mobile navigation drawer (`MobileUserSection`).
- **User Dashboard Sidebar**:
  - Appended an **Achievements** navigation option with a `Trophy` icon directly to the dashboard's main sidebar menu (`ud-nav`).

### Verification & Testing
- Verified successful compilation via `npm run build:fast`.
- Confirmed all new navigation buttons route correctly to `/dashboard/achievements`.
- Checked responsiveness and visual alignment of the menu items in both dark and light modes.
