### PR TITLE
fix: make floor plan designer responsive on mobile viewports

### DIFF
--- a/src/components/events/FloorPlanDesigner.css
+++ b/src/components/events/FloorPlanDesigner.css
@@ -30,7 +30,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 24px;
-  border-b: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(13, 13, 23, 0.6);
   backdrop-filter: blur(10px);
 }
@@ -604,3 +604,96 @@
 .light-theme .fp-stat-label {
   color: #64748b;
 }
+
+/* Responsive configurations for mobile and tablet viewports */
+@media (max-width: 768px) {
+  .fp-container {
+    height: auto;
+    min-height: calc(100vh - 80px);
+    overflow-y: auto;
+  }
+
+  .fp-topbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 14px;
+    padding: 16px;
+  }
+
+  .fp-topbar-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .fp-workspace {
+    flex-direction: column;
+    height: auto;
+    overflow-y: visible;
+  }
+
+  .fp-sidebar,
+  .fp-sidebar-right {
+    width: 100% !important;
+    height: auto;
+    border: none;
+  }
+
+  .fp-sidebar-left {
+    order: 2; /* Move toolbox below the canvas on mobile */
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  :global(.light) .fp-sidebar-left,
+  .light-theme .fp-sidebar-left {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .fp-sidebar-right {
+    order: 3; /* Move details inspector to the bottom */
+  }
+
+  .fp-canvas-wrapper {
+    order: 1; /* Bring canvas to the top for quick visibility */
+    width: 100%;
+    height: 480px;
+    min-height: 400px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  :global(.light) .fp-canvas-wrapper,
+  .light-theme .fp-canvas-wrapper {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .fp-canvas-svg {
+    max-width: 95%;
+    max-height: 95%;
+  }
+
+  .fp-tool-grid {
+    grid-template-columns: repeat(3, 1fr); /* Fit 3 items per row on mobile to save vertical space */
+    gap: 8px;
+  }
+
+  .fp-tool-item {
+    padding: 12px 8px;
+  }
+
+  .fp-controls-floating {
+    bottom: 12px;
+    left: 12px;
+    gap: 4px;
+    padding: 4px;
+  }
+
+  .fp-control-btn {
+    width: 32px;
+    height: 32px;
+  }
+
+  .fp-zoom-display {
+    min-width: 40px;
+    font-size: 0.7rem;
+  }
+}
+


### PR DESCRIPTION
### Description
closes #1491 
This PR addresses layout rendering issues in the Floor Plan Designer on mobile and smaller viewports. It implements responsive CSS rules to prevent workspace collapsing and ensures the tool layout adapts correctly to smaller viewport widths.

### Changes Made
- **CSS Bug Fix**: Corrected a layout border property in `.fp-topbar` to use standard `border-bottom` instead of `border-b` which was causing rendering issues.
- **Mobile Responsive Layout (Media Queries <768px)**:
  - Stacked sidebar panels (`.fp-sidebar`, `.fp-sidebar-right`) vertically to fit mobile screen widths.
  - Placed the workspace canvas (`.fp-canvas-wrapper`) at the top of the layout stack (`order: 1`) and set a minimum height of `400px` to prevent collapsing on smaller screens.
  - Re-structured the object library toolbox grid (`.fp-tool-grid`) to a 3-column layout to conserve vertical space.
  - Scaled down floating zoom/pan controls (`.fp-controls-floating`) to align cleanly with the smaller viewport dimensions.

### Verification & Testing
- Verified successful compilation via `npm run build:fast`.
- Confirmed layout responsiveness and canvas alignment locally on simulated mobile viewports.
