### PR TITLE
fix: improve subtitle text contrast in dark mode on Events 

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -25,7 +25,7 @@ export default function EventHero({
           Discover <span className="text-blue-600 dark:text-blue-500">Events</span>
         </h1>
 
-        <p className="mt-4 text-sm sm:text-base md:text-lg text-gray-500 dark:text-gray-400 max-w-2xl mx-auto px-4 sm:px-0">
+        <p className="mt-4 text-sm sm:text-base md:text-lg text-gray-500 dark:text-white max-w-2xl mx-auto px-4 sm:px-0">
           Discover exciting events, compete with talented participants, learn
           new skills, and <span className="font-semibold text-gray-900 dark:text-white">win rewards</span>.
         </p>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1490 

## Rationale for this change

In dark mode, the subtitle text on the Events  section — "Discover exciting events, compete with talented participants, learn new skills, and win rewards" — was almost completely invisible. It was using `dark:text-gray-400` which blended into the dark gradient background, making it unreadable. This is a clear accessibility issue that affects all users visiting the Events page in dark mode.

## What changes are included in this PR?

- Updated the subtitle text color in `src/Pages/Events/EventHero.js` from `dark:text-gray-400` to `dark:text-white` to ensure proper contrast against the dark background.

## Are these changes tested?

- Yes, tested manually by switching to dark mode on the Events page and confirming the subtitle text is now clearly visible and readable.

## Are there any user-facing changes?

- Yes, the subtitle text in the Events section is now clearly readable in dark mode. No breaking changes to any public APIs.