### PR TITLE
fix: redirect What's Happening Now buttons to respective detail pages

### DIFF
--- a/src/Pages/Hackathons/HackathonDetailsPage.js
+++ b/src/Pages/Hackathons/HackathonDetailsPage.js
@@ -1,0 +1,211 @@
+import { Link, useParams } from "react-router-dom";
+import { motion } from "framer-motion";
+import { Calendar, MapPin, Award, Users, Trophy, Tag, ArrowLeft } from "lucide-react";
+
+import hackathonsData from "./hackathonMockData.json";
+
+const getHackathonStatus = (hackathon) => {
+  const now = new Date();
+  const startDate = new Date(hackathon.startDate);
+  const endDate = new Date(hackathon.endDate);
+
+  if (endDate < now) return "completed";
+  if (startDate <= now && now <= endDate) return "live";
+  return "upcoming";
+};
+
+const HackathonDetailsPage = () => {
+  const { hackathonId } = useParams();
+  const foundHackathon = hackathonsData.find((item) => String(item.id) === hackathonId);
+
+  if (!foundHackathon) {
+    return (
+      <div className="min-h-screen bg-white dark:bg-slate-950 flex items-center justify-center px-4 py-24">
+        <div className="max-w-xl w-full rounded-3xl bg-white dark:bg-gray-900 shadow-xl border border-gray-200 dark:border-gray-800 p-10 text-center">
+          <h1 className="text-4xl font-extrabold text-gray-900 dark:text-gray-100">
+            Hackathon Not Found
+          </h1>
+          <p className="mt-4 text-gray-600 dark:text-gray-300">
+            The hackathon you selected could not be found.
+          </p>
+          <Link
+            to="/hackathons"
+            className="mt-8 inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 transition"
+          >
+            Back to Hackathons
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const status = getHackathonStatus(foundHackathon);
+  const statusStyles = {
+    live: "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200",
+    upcoming: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200",
+    completed: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200",
+  };
+
+  const prizeValue = Number.parseInt(String(foundHackathon.prize).replace(/[^\d]/g, ""), 10);
+  const isFeatured = Number.isFinite(prizeValue) && prizeValue >= 30000;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-blue-50 via-white to-white dark:from-slate-950 dark:via-slate-950 dark:to-black text-gray-900 dark:text-gray-100">
+      <div className="sticky top-0 z-30 border-b border-gray-200/80 dark:border-gray-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-4">
+          <Link
+            to="/hackathons"
+            className="inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-semibold hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+          >
+            <ArrowLeft size={18} />
+            Back to Hackathons
+          </Link>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.45 }}
+          className="grid gap-8 lg:grid-cols-[1.3fr_0.7fr]"
+        >
+          <section className="space-y-6">
+            <div className="rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-6 sm:p-8">
+              <div className="flex flex-wrap items-center gap-3">
+                <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] ${statusStyles[status]}`}>
+                  {status}
+                </span>
+                <span className="inline-flex items-center rounded-full bg-slate-100 dark:bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-700 dark:text-slate-200">
+                  {foundHackathon.difficulty}
+                </span>
+                {isFeatured && (
+                  <span className="inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900/40 px-3 py-1 text-xs font-semibold text-amber-700 dark:text-amber-200">
+                    Featured
+                  </span>
+                )}
+              </div>
+
+              <h1 className="mt-5 text-4xl sm:text-5xl font-extrabold tracking-tight">
+                {foundHackathon.title}
+              </h1>
+              <p className="mt-4 max-w-3xl text-base sm:text-lg text-gray-600 dark:text-gray-300 leading-7">
+                {foundHackathon.description}
+              </p>
+
+              <div className="mt-8 flex flex-wrap gap-3">
+                <a
+                  href={`https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(foundHackathon.title)}&dates=${foundHackathon.startDate.replaceAll("-", "")}/${foundHackathon.endDate.replaceAll("-", "")}&details=${encodeURIComponent(foundHackathon.description)}&location=${encodeURIComponent(foundHackathon.location)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 transition"
+                >
+                  Add Reminder
+                </a>
+                <Link
+                  to="/hackathons"
+                  className="inline-flex items-center justify-center rounded-full border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-800 shadow-sm hover:bg-gray-50 transition dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+                >
+                  Browse Hackathons
+                </Link>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-3xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 p-5 shadow-sm flex items-start gap-3">
+                <Calendar className="h-5 w-5 text-blue-600 mt-0.5" />
+                <div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Dates</p>
+                  <p className="font-semibold">
+                    {new Date(foundHackathon.startDate).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+                    {" - "}
+                    {new Date(foundHackathon.endDate).toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-3xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 p-5 shadow-sm flex items-start gap-3">
+                <MapPin className="h-5 w-5 text-emerald-600 mt-0.5" />
+                <div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Location</p>
+                  <p className="font-semibold">{foundHackathon.location}</p>
+                </div>
+              </div>
+
+              <div className="rounded-3xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 p-5 shadow-sm flex items-start gap-3">
+                <Award className="h-5 w-5 text-amber-600 mt-0.5" />
+                <div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Prize Pool</p>
+                  <p className="font-semibold">{foundHackathon.prize}</p>
+                </div>
+              </div>
+
+              <div className="rounded-3xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 p-5 shadow-sm flex items-start gap-3">
+                <Users className="h-5 w-5 text-indigo-600 mt-0.5" />
+                <div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Participants</p>
+                  <p className="font-semibold">{foundHackathon.participants}</p>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <aside className="space-y-6">
+            <div className="rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-6 sm:p-8">
+              <h2 className="text-xl font-bold">Overview</h2>
+              <div className="mt-4 space-y-4 text-sm text-gray-600 dark:text-gray-300 leading-6">
+                <p>
+                  <span className="font-semibold text-gray-900 dark:text-gray-100">Organizer:</span>{" "}
+                  {foundHackathon.organizer}
+                </p>
+                <p>
+                  <span className="font-semibold text-gray-900 dark:text-gray-100">Teams:</span>{" "}
+                  {foundHackathon.teams}
+                </p>
+                <p>
+                  <span className="font-semibold text-gray-900 dark:text-gray-100">Submissions:</span>{" "}
+                  {foundHackathon.submissions}
+                </p>
+                <p>
+                  <span className="font-semibold text-gray-900 dark:text-gray-100">Status:</span>{" "}
+                  {status.charAt(0).toUpperCase() + status.slice(1)}
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-6 sm:p-8">
+              <h2 className="text-xl font-bold flex items-center gap-2">
+                <Tag className="h-5 w-5 text-blue-600" />
+                Tech Stack
+              </h2>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {(foundHackathon.techStack || []).map((tech) => (
+                  <span
+                    key={tech}
+                    className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200"
+                  >
+                    {tech}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-3xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-6 sm:p-8">
+              <h2 className="text-xl font-bold flex items-center gap-2">
+                <Trophy className="h-5 w-5 text-amber-600" />
+                Rules
+              </h2>
+              <ul className="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-300 list-disc list-inside">
+                {(foundHackathon.rules || []).map((rule) => (
+                  <li key={rule}>{rule}</li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+        </motion.div>
+      </main>
+    </div>
+  );
+};
+
+export default HackathonDetailsPage;

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -1,5 +1,6 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
 import { useInView } from "react-intersection-observer";
 import { HomeCardSkeleton } from "../../../components/common/SkeletonLoaders";
 
@@ -41,7 +42,7 @@ const WhatsHappening = () => {
         type: event.type.charAt(0).toUpperCase() + event.type.slice(1),
         status:
           event.status === "upcoming" ? "Registration Open" : "Live Event",
-        link: "/events",
+        link: `/events/${event.id}`,
         featured: event.attendees > 200,
         location: event.location,
         attendees: event.attendees,
@@ -66,7 +67,7 @@ const WhatsHappening = () => {
         rawDate: hackathon.startDate,
         type: "Hackathon",
         status: hackathon.status === "live" ? "Live Now" : "Registration Open",
-        link: "/hackathons",
+        link: `/hackathons/${hackathon.id}`,
         featured:
           hackathon.prize &&
           parseInt(hackathon.prize.replace(/[$,]/g, "")) > 30000,
@@ -370,23 +371,13 @@ const WhatsHappening = () => {
                           </div>
 
                           <div className="bg-gray-50 dark:bg-gray-700/50 px-4 sm:px-6 py-3 sm:py-4">
-                            <a
-                              href={event.link}
+                            <Link
+                              to={event.link}
                               className={`w-full inline-flex items-center justify-center px-3 sm:px-4 py-2 sm:py-2.5 border border-transparent rounded-md shadow-sm text-xs sm:text-sm font-medium transition-colors ${
                                 event.featured
                                   ? "bg-black text-white hover:bg-sky-100 hover:text-black"
                                   : "bg-black text-white hover:bg-emerald-100 hover:text-black"
                               }`}
-                              target={
-                                event.link.startsWith("http")
-                                  ? "_blank"
-                                  : "_self"
-                              }
-                              rel={
-                                event.link.startsWith("http")
-                                  ? "noopener noreferrer"
-                                  : ""
-                              }
                             >
                               {event.featured ? "Join Now" : "Learn More"}
                               <svg
@@ -400,7 +391,7 @@ const WhatsHappening = () => {
                                   clipRule="evenodd"
                                 />
                               </svg>
-                            </a>
+                            </Link>
                           </div>
                         </div>
                       ))}

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -26,6 +26,7 @@ import MockApiResponse from "../MockApiResponse";
 
 const EventsPage = lazy(() => import("../../Pages/Events/EventsPage"));
 const HackathonPage = lazy(() => import("../../Pages/Hackathons/HackathonPage"));
+const HackathonDetailsPage = lazy(() => import("../../Pages/Hackathons/HackathonDetailsPage"));
 const ProjectsPage = lazy(() => import("../../Pages/Projects/ProjectsPage"));
 const EventAnalyticsDashboard = lazy(() => import("../../Pages/Events/EventAnalyticsDashboard"));
 
@@ -36,6 +37,7 @@ export const getPublicRoutes = () => [
   <Route key="/event-details" path="/events/:eventId" element={<EventDetails />} />,
   <Route key="/register" path="/events/:eventId/register" element={<EventRegistration />} />,
   <Route key="/hackathons" path="/hackathons" element={<HackathonPage />} />,
+  <Route key="/hackathon-details" path="/hackathons/:hackathonId" element={<HackathonDetailsPage />} />,
   <Route key="/projects" path="/projects" element={<ProjectsPage />} />,
   <Route key="/api/hackathons" path="/api/hackathons" element={<MockApiResponse />} />,
   <Route key="/api/projects" path="/api/projects" element={<MockApiResponse />} />,


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #1468 

## Rationale for this change

The homepage “What’s Happening Now” carousel was sending users to the general Events or Hackathons listing pages instead of the specific item they selected. This added an unnecessary navigation step and did not match the expected user flow from the homepage to a detail page.

## What changes are included in this PR?

* Updated the homepage carousel so event cards link directly to their individual event detail pages.
* Updated the homepage carousel so hackathon cards link directly to their individual hackathon detail pages.
* Added a dedicated hackathon detail page component for rendering selected hackathon information.
* Registered the `/hackathons/:hackathonId` route so hackathon detail URLs resolve correctly.
* Preserved the existing event detail route behavior for `/events/:eventId`.

## Are these changes tested?

* Verified the route configuration for both event and hackathon detail pages.
* Confirmed the homepage card actions now point to the correct detail URLs instead of the list pages.
* Checked the updated route/page files for errors after wiring the new navigation behavior.

## Are there any user-facing changes?

* Yes. Clicking “Learn More” or “Join Now” from the “What’s Happening Now” section now opens the selected event or hackathon detail page directly.
* This removes the extra step of visiting the generic listing page and manually locating the same item again.

## Demo


https://github.com/user-attachments/assets/c5ce0268-92cf-48bc-b469-821932be629a

