### PR TITLE
fix: replace AUTH.REGISTER with AUTH.SIGNUP to resolve SignUp 404 crash

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -219,7 +219,7 @@ const handleSubmit = async (e) => {
 
   try {
     const response = await apiUtils.post(
-      API_ENDPOINTS.AUTH.REGISTER,
+      API_ENDPOINTS.AUTH.SIGNUP,
       {
         firstName:
           formData.firstName.trim(),


### PR DESCRIPTION
Closes #1558

## 🐛 Problem
New user registration was completely broken — every 
signup attempt crashed with a 404 network error, 
making it impossible for any new user to create 
an account on the platform.

## 🔍 Root Cause
src/components/auth/Signup.js called 
API_ENDPOINTS.AUTH.REGISTER which does not exist 
in api.js. This evaluated to undefined, sending 
the request to /undefined and returning 404.

## ✅ Fix
Replaced API_ENDPOINTS.AUTH.REGISTER with 
API_ENDPOINTS.AUTH.SIGNUP — the correct key 
that exists in the centralized API config.

## 📁 Files Changed
- src/components/auth/Signup.js (Line 221)

## Impact
This was a critical bug — every single new user 
attempting to register on Eventra was blocked. 
Fix is a targeted one-line change with zero 
risk of regression.

## Testing
- [x] Signup request now hits correct endpoint
- [x] No other auth logic modified