### PR TITLE
fix: resolve dark mode text contrast for What's Happening Now section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16527,6 +16527,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16527,23 +16527,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -175,10 +175,10 @@ border-t border-gray-100 dark:border-slate-800/80"
           animate={inView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6 }}
         >
-          <h2 className="text-2xl sm:text-3xl font-extrabold text-black dark:text-gray-900">
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-black dark:text-white">
             What's Happening Now
           </h2>
-          <p className="mt-2 sm:mt-3 max-w-xl mx-auto text-sm sm:text-lg text-black dark:text-gray-800">
+          <p className="mt-2 sm:mt-3 max-w-xl mx-auto text-sm sm:text-lg text-black dark:text-gray-300">
             Stay updated with {upcomingEvents.length} upcoming events, community
             programs, and opportunities to contribute to Eventra
           </p>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1484.

## Rationale for this change

The heading and subtitle in the "What's Happening Now" section were using dark text classes (`text-gray-900` and `text-gray-800`) while the background also transitioned to a dark gradient in Dark Mode. This caused a severe accessibility and contrast failure, making the text unreadable for users.

## What changes are included in this PR?

- Updated the Tailwind CSS classes in the hero section.
- Changed the heading dark mode text color to `dark:text-white`.
- Changed the subtitle dark mode text color to `dark:text-gray-300`.
- This ensures high contrast and readability against the `dark:from-slate-950` background gradient without affecting the light mode styling.

## Are these changes tested?

Yes. I ran the application locally and toggled the theme switch between Light and Dark modes. I verified visually that the text transitions correctly and passes basic contrast legibility in both states. 

*(Note to maintainers: I can provide before/after screenshots if needed!)*

## Are there any user-facing changes?

Yes. This is purely a UI/accessibility fix. Users will now be able to clearly read the "What's Happening Now" section when their theme is set to Dark Mode.