### PR TITLE
fix: improve visibility and contrast of community section subtitle

### DIFF
--- a/src/components/CommunityEvent.js
+++ b/src/components/CommunityEvent.js
@@ -111,7 +111,7 @@ const CommunityEvent = () => {
           <h1 className="text-5xl font-extrabold text-indigo-900 dark:text-gray-100 mb-4">
             Community Events
           </h1>
-          <p className="text-base text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
+          <p className="text-base text-white dark:text-white max-w-2xl mx-auto">
             "Explore meetups, hackathons, webinars, and global conferences where
             developers collaborate, innovate, and grow together."
           </p>
@@ -134,7 +134,9 @@ const CommunityEvent = () => {
                   {event.icon}
                 </div>
                 {/* UPDATED: Text color */}
-                <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">{event.title}</h2>
+                <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+                  {event.title}
+                </h2>
               </div>
 
               {/* Event Info */}
@@ -145,7 +147,9 @@ const CommunityEvent = () => {
               <p className="text-sm text-gray-600 dark:text-gray-400">
                 <strong>Location:</strong> {event.location}
               </p>
-              <p className="mt-4 text-gray-700 dark:text-gray-300">{event.description}</p>
+              <p className="mt-4 text-gray-700 dark:text-gray-300">
+                {event.description}
+              </p>
 
               {/* Learn More Button is fine for both themes */}
               <motion.button

--- a/src/components/CommunityEvent.js
+++ b/src/components/CommunityEvent.js
@@ -111,7 +111,7 @@ const CommunityEvent = () => {
           <h1 className="text-5xl font-extrabold text-indigo-900 dark:text-gray-100 mb-4">
             Community Events
           </h1>
-          <p className="text-base text-white dark:text-white max-w-2xl mx-auto">
+          <p className="text-base text-gray-700 dark:text-white max-w-2xl mx-auto">
             "Explore meetups, hackathons, webinars, and global conferences where
             developers collaborate, innovate, and grow together."
           </p>


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1546 

## Rationale for this change

During a recent discussion regarding the Projects Page, I identified that subtitle text elements on light gradient backgrounds suffered from low visibility and poor contrast. While another contributor implemented the contrast fix on the Projects section, this exact same readability issue was present on the Community Events section.

## What changes are included in this PR?

Updated Subtitle Text Classes: Changed the styling classes on the Community Events paragraph text from a low-contrast light gray to a high-contrast, white.

## Are these changes tested?

Because this is a purely aesthetic, frontend-only user interface adjustment, no new automated unit tests or integration tests were written.

However, the changes have been locally verified:

[x] Manually tested the layout locally on a development server using npm start across different window resizes to ensure it renders correctly.


## Are there any user-facing changes?

Yes, there is a minor visual improvement. The text under the "Community Events" heading is now fully visible against the background gradient without needing to highlight it.

No functional workflows, user interactions, or public APIs were modified.
<img width="1085" height="379" alt="Screenshot 2026-05-23 133924" src="https://github.com/user-attachments/assets/233c0dc5-09ff-4ad8-ad21-d3c41363d2d7" />
<img width="980" height="259" alt="Screenshot 2026-05-23 140716" src="https://github.com/user-attachments/assets/7337879f-13b4-4f87-80e4-d2d6c376787e" />
