### PR TITLE
fix: resolve infinite render loop in isAuthenticated (#1392)

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -66,6 +66,25 @@ export const AuthProvider = ({ children }) => {
     return () => setOnUnauthorizedHandler(null);
   }, [clearSession]);
 
+  // --- Periodic Token Expiry Check ---
+  // Check token validity in the background so we don't mutate state during a render.
+  useEffect(() => {
+    if (!token) return;
+
+    const checkTokenExpiry = () => {
+      if (!isTokenValid(token)) {
+        clearSession(); // Safe here because useEffect runs AFTER rendering finishes
+      }
+    };
+
+    // Check immediately when the component mounts or token changes
+    checkTokenExpiry();
+
+    // Check periodically every 15 seconds to catch mid-session expiry
+    const interval = setInterval(checkTokenExpiry, 15000);
+    return () => clearInterval(interval);
+  }, [token, clearSession]);
+
   const persistSession = (sessionToken, sessionUser) => {
     setToken(sessionToken);
     setUser(sessionUser);
@@ -131,16 +150,15 @@ const login = async (usernameOrEmail, password) => {
     clearSession();
   };
 
-  const isAuthenticated = useCallback(() => {
+ const isAuthenticated = useCallback(() => {
     // Also verify the current token hasn't expired since it was stored.
     if (!user || !token) return false;
     if (!isTokenValid(token)) {
-      // Token expired mid-session — clean up immediately.
-      clearSession();
+      // Token expired mid-session — safely return false without mutating state
       return false;
     }
     return true;
-  }, [user, token, clearSession]);
+  }, [user, token]);
 
   const hasRole = (roleName) => {
     return user?.roles?.includes(roleName) || false;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1392

## Rationale for this change

The `isAuthenticated` helper function was executing a side effect (`clearSession()`) directly during its execution. Because components frequently invoke `isAuthenticated()` inside JSX or render paths to handle conditional UI blocks, this side effect triggered a React state mutation mid-render. 

This violates React's component lifecycle rules, causing explicit state-update console warnings and forcing the application into an infinite re-render loop that breaks the UI when a session expires.

## What changes are included in this PR?

- **Made `isAuthenticated` a pure helper:** Removed the `clearSession()` side-effect call from the function block inside `src/context/AuthContext.js`. It now strictly evaluates the current user and token validity status, returning a clean boolean value without mutating state.
- **Added Safe Background Session Cleanup:** Introduced a separate, dedicated `useEffect` hook that monitors token expiration in the background. It checks the token immediately upon mounting/shifting and runs a periodic check every 15 seconds, executing `clearSession()` completely outside of the active rendering phase.

## Are these changes tested?

Yes, manually verified that:
1. Calling `isAuthenticated()` inside conditional rendering paths no longer throws React state mutation warnings.
2. The infinite re-render loop condition is entirely resolved.
3. Expired sessions are still automatically caught and cleared safely in the background via the new effect hook without affecting the render loop.

## Are there any user-facing changes?

No structural user-facing behavior changes. The application will continue to automatically clear sessions and sign out users whose tokens expire mid-session, but it will now do so smoothly without crashing or freezing the user interface.