### PR TITLE
fix: prevent chatbot from overflowing viewport on mobile devices

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -215,7 +215,7 @@ export default function Chatbot() {
       className="
         fixed bottom-6 right-6 z-[100]
         flex flex-col                        /* KEY FIX: flex column layout */
-        w-[calc(100vw-2rem)] max-w-sm
+        w-[calc(100vw-2rem)] max-w-sm sm:max-w-sm
         rounded-2xl
         border border-slate-200 dark:border-slate-700
         bg-white dark:bg-slate-900
@@ -223,7 +223,7 @@ export default function Chatbot() {
 
         /* KEY FIX: constrain total height to viewport so it never overflows.
            bottom-6 = 1.5rem offset from bottom, so we subtract that + a little breathing room. */
-        max-h-[calc(100vh-5rem)]
+        max-h-[calc(100dvh-2rem)] sm:max-h-[calc(100vh-5rem)]
       "
     >
       {/* ── Header — always visible, never scrolls away ── */}


### PR DESCRIPTION
Fixes #1461

## Problem
On mobile, the chatbot popup expanded to cover the full screen 
blocking all page content.

## Fix
Replaced 100vh with 100dvh for mobile to correctly account for 
browser UI bars (address bar, bottom nav) on mobile devices.

## Files Changed
- src/components/Chatbot.jsx