### PR TITLE
fix(offlineSync): prevent local DoS by capping offline queue

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -101,6 +101,9 @@ const useOfflineSync = () => {
           // Still a network error — keep in queue with incremented retry counter
           failedQueue.push({ ...item, retries: retries + 1 });
         }
+
+        // Delay 1 second between processing each item to throttle sync rate
+        await new Promise((resolve) => setTimeout(resolve, 1000));
       }
 
       if (failedQueue.length > 0) {

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -29,6 +29,10 @@ export const getQueue = () => {
  */
 export const pushToQueue = (item) => {
   const queue = getQueue();
+  if (queue.length >= 5) {
+    console.warn('Offline queue limit reached (max 5). Dropping new registration to prevent local DoS.');
+    return;
+  }
   queue.push(item);
   localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
 };


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1633 .

## Rationale for this change
Fixed a critical application-level Denial of Service (DoS) vulnerability in the offline registration queue.

**Details:**
Previously, the `eventra_offline_queue` allowed an unbounded number of items to be pushed into `localStorage`. When the network came back online, the `useOfflineSync` hook would rapidly execute all queued requests in quick succession without a throttle. This could allow a malicious actor to inject thousands of dummy registrations offline and trigger an overwhelming burst of traffic against the backend APIs upon reconnection.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

**Fix:**
1. **Queue Cap:** Implemented a strict hard limit in `pushToQueue` (`offlineQueue.js`). The queue now holds a maximum of 5 offline registration attempts, dropping excess items to prevent memory abuse and payload bloating.
2. **Execution Throttle:** Added a 1-second delay between processing each queue item in `useOfflineSync.js`. This guarantees offline-sync requests are throttled appropriately to maintain API stability and avoid server crashes.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
Yes, all changes are tested locally.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
