### PR TITLE
Fix/hosthackathon email validation

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -94,9 +94,9 @@ const HostHackathon = () => {
       newErrors.location = "Location must be at least 3 characters long!";
     }
 
-    // ✅ Email validation — works even for incomplete email
+    // ✅ Email validation — stricter regex to prevent invalid TLDs
     if (data.email) {
-      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/;
       if (!emailRegex.test(data.email.trim())) {
         newErrors.email = "Please enter a valid email address!";
       }

--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -16,11 +16,8 @@ import {
   LinkIcon,
   CalendarDaysIcon,
   DocumentTextIcon,
-  ComputerDesktopIcon
+  ComputerDesktopIcon,
 } from "@heroicons/react/24/solid";
-
-
-
 
 const HostHackathon = () => {
   const [errors, setErrors] = useState({});
@@ -168,7 +165,7 @@ const HostHackathon = () => {
 
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
-  
+
   const formFields = [
     {
       label: "Hackathon Name",
@@ -220,7 +217,6 @@ const HostHackathon = () => {
       icon: LinkIcon,
     },
   ];
-
 
   return (
     <div className="min-h-screen bg-white dark:bg-slate-950 flex flex-col items-center justify-center py-12 px-4 sm:px-6 lg:px-8 pt-20">


### PR DESCRIPTION
### Title

fix: HostHackathon improve email validation regex to reject invalid TLDs

### Which issue does this PR close?

- Closes #1607

### Rationale for this change

The HostHackathon email validation currently accepts invalid email domain extensions such as single-character TLDs, which can allow malformed contact information into submissions.

### What changes are included in this PR?

- Updated the email validation regex in `src/Pages/Hackathons/HostHackathon.js`
- Replaced the loose pattern with a stricter regex requiring at least two alphabetic TLD characters
- Prevented invalid emails like `a@b.c` from passing validation

### Are these changes tested?

- Manually validated emails with short and valid TLDs
- No automated tests were added for this regex update

### Are there any user-facing changes?

- Yes. HostHackathon form validation is stricter and rejects invalid email formats more accurately.

### Labels to Add

- level:intermediate
- type:bug
- gssoc26:approved
