### PR TITLE
fix: ContactUs add null check for formRef before DOM manipulation

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -174,10 +174,14 @@ const ContactUs = () => {
 
     if (!validateForm()) {
       // Shake animation for invalid form
-      formRef.current.classList.add("animate-shake");
-      setTimeout(() => {
-        formRef.current.classList.remove("animate-shake");
-      }, 500);
+      if (formRef.current) {
+        formRef.current.classList.add("animate-shake");
+        setTimeout(() => {
+          if (formRef.current) {
+            formRef.current.classList.remove("animate-shake");
+          }
+        }, 500);
+      }
       return;
     }
 


### PR DESCRIPTION
### Title

fix: ContactUs add null check for formRef before DOM manipulation

### Which issue does this PR close?

- Closes #1610 

### Rationale for this change

The ContactUs component currently manipulates `formRef.current.classList` without ensuring the ref is available, which can lead to null reference errors when the component unmounts before animation cleanup.

### What changes are included in this PR?

- Added null checks before accessing `formRef.current` in `src/Pages/Contact/ContactUs.js`
- Wrapped shake animation add/remove logic in safe checks
- Prevented potential crashes during rapid component unmounts

### Are these changes tested?

- Manually verified that the form no longer throws an error when the component unmounts during invalid submission animation
- No automated tests were added for this change

### Are there any user-facing changes?

- Yes. Contact form submission validations remain the same, but animation handling is now safer and more robust.

### Labels to Add

- level:intermediate
- type:bug
- gssoc26:approved