### PR TITLE
feat: add sticky navbar and scroll progress bar

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,6 +1,7 @@
 import React, {
   useRef,
   useState,
+  useEffect,
 } from "react";
 
 import { Link } from "react-router-dom";
@@ -11,7 +12,6 @@ import {
 } from "lucide-react";
 
 import { useAuth } from "../../context/AuthContext";
-
 import { useTheme } from "../../context/ThemeContext";
 
 import DesktopNavbar from "./DesktopNavbar";
@@ -24,25 +24,27 @@ const Navbar = ({
   cursorEnabled,
   toggleCursor,
 }) => {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] =
-    useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [scrollProgress, setScrollProgress] = useState(0);
 
   const navRef = useRef(null);
 
-  const {
-    user,
-    isAuthenticated,
-    logout,
-  } = useAuth();
+  const { user, isAuthenticated, logout } = useAuth();
+  const { isDarkMode, toggleTheme } = useTheme();
 
-  const {
-    isDarkMode,
-    toggleTheme,
-  } = useTheme();
+  useBodyScrollLock(isMobileMenuOpen);
 
-  useBodyScrollLock(
-    isMobileMenuOpen
-  );
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+      setScrollProgress(progress);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   return (
     <>
@@ -50,59 +52,21 @@ const Navbar = ({
         ref={navRef}
         className="fixed top-0 left-0 w-full h-20 bg-white dark:bg-gray-900 border-b border-border z-[200] transition-all duration-300"
       >
-        <div
-          className="
-            h-full
-            px-6
-            flex
-            items-center
-            justify-between
-          "
-        >
+        <div className="h-full px-6 flex items-center justify-between">
           {/* Logo */}
           <Link to="/">
-            <div
-              className="
-                flex
-                items-center
-                justify-center
-                gap-2
-              "
-            >
+            <div className="flex items-center justify-center gap-2">
               <img
                 src="/Eventra.png"
                 alt="Eventra Logo"
-                className="
-                  h-8
-                  w-8
-                  rounded-xl
-                  object-contain
-                  bg-gray-200
-                  dark:bg-transparent
-                  p-1
-                "
+                className="h-8 w-8 rounded-xl object-contain bg-gray-200 dark:bg-transparent p-1"
               />
-
-              <h1
-                className="
-                  text-xl
-                  font-bold
-                  text-text
-                "
-              >
-                Eventra
-              </h1>
+              <h1 className="text-xl font-bold text-text">Eventra</h1>
             </div>
           </Link>
 
           {/* Right Side */}
-          <div
-            className="
-              flex
-              items-center
-              gap-4
-            "
-          >
+          <div className="flex items-center gap-4">
             <DesktopNavbar
               isAuthenticated={isAuthenticated()}
               user={user}
@@ -113,76 +77,36 @@ const Navbar = ({
             <button
               onClick={toggleTheme}
               aria-label="Toggle Theme"
-              className="
-                theme-toggle
-
-                relative
-
-                flex
-                items-center
-                justify-center
-
-                w-11
-                h-11
-
-                rounded-full
-
-                bg-gray-200
-                dark:bg-gray-800
-
-                text-black
-                dark:text-white
-
-                shadow-md
-
-                hover:scale-110
-                hover:shadow-lg
-
-                transition-all
-                duration-300
-
-                focus:outline-none
-                focus:ring-2
-                focus:ring-blue-500
-              "
+              className="theme-toggle relative flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 dark:bg-gray-800 text-black dark:text-white shadow-md hover:scale-110 hover:shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
-              <div
-                className="
-                  transition-transform
-                  duration-500
-                "
-              >
-                {isDarkMode ? (
-                  <Sun size={20} />
-                ) : (
-                  <Moon size={20} />
-                )}
+              <div className="transition-transform duration-500">
+                {isDarkMode ? <Sun size={20} /> : <Moon size={20} />}
               </div>
             </button>
 
             {/* Cursor Toggle */}
             <CursorToggle
-              cursorEnabled={
-                cursorEnabled
-              }
-              toggleCursor={
-                toggleCursor
-              }
+              cursorEnabled={cursorEnabled}
+              toggleCursor={toggleCursor}
             />
 
             {/* Mobile Navbar */}
             <MobileNavbar
-              isOpen={
-                isMobileMenuOpen
-              }
-              setIsOpen={
-                setIsMobileMenuOpen
-              }
+              isOpen={isMobileMenuOpen}
+              setIsOpen={setIsMobileMenuOpen}
               isAuthenticated={isAuthenticated()}
               user={user}
               logout={logout}
             />
           </div>
+        </div>
+
+        {/* Scroll Progress Bar */}
+        <div className="absolute bottom-0 left-0 w-full h-1 bg-transparent">
+          <div
+            className="h-full bg-blue-500 transition-all duration-100 ease-out"
+            style={{ width: `${scrollProgress}%` }}
+          />
         </div>
       </nav>
     </>


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #1584 

## Rationale for this change
Users lose track of navigation on longer pages like event details since there was no visual indicator of scroll progress.

## What changes are included in this PR?
- Added `useEffect` hook with a `scroll` event listener in `Navbar.jsx`
- Added scroll progress state that calculates: `scrollTop / (documentHeight - windowHeight) * 100`
- Added a progress bar UI at the bottom of the navbar that fills dynamically based on scroll percentage
- Cleanup of event listener on component unmount

## Are these changes tested?
Manually tested on long pages — the progress bar fills correctly as the user scrolls and resets on scroll back to top.

## Are there any user-facing changes?
Yes — a blue scroll progress bar is now visible at the bottom of the navbar on all pages.