### PR TITLE
feat: add real-time search bar to events listing page

### DIFF
--- a/src/Pages/Events/EventFiltersToolbar.js
+++ b/src/Pages/Events/EventFiltersToolbar.js
@@ -1,4 +1,5 @@
-import { Grid, List } from "lucide-react";
+import { Grid, List, Search, X } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
 import StyledDropdown from "../../components/StyledDropdown";
 
 const EVENT_FILTERS = [
@@ -11,7 +12,6 @@ const EVENT_FILTERS = [
 
 const FilterButton = ({ filter, filterType, onFilterChange }) => {
   const isActive = filterType === filter.key;
-
   return (
     <button
       onClick={() => onFilterChange(filter.key)}
@@ -29,7 +29,6 @@ const FilterButton = ({ filter, filterType, onFilterChange }) => {
 
 const ViewModeButton = ({ mode, activeMode, onViewModeChange, icon: Icon }) => {
   const isActive = activeMode === mode;
-
   return (
     <button
       onClick={() => onViewModeChange(mode)}
@@ -53,9 +52,59 @@ const EventFiltersToolbar = ({
   onSortChange,
   viewMode,
   onViewModeChange,
+  searchQuery,
+  onSearchChange,
 }) => {
+  const [localQuery, setLocalQuery] = useState(searchQuery || "");
+  const debounceRef = useRef(null);
+
+  useEffect(() => {
+    setLocalQuery(searchQuery || "");
+  }, [searchQuery]);
+
+  const handleInput = (e) => {
+    const value = e.target.value;
+    setLocalQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      onSearchChange?.(value);
+    }, 300);
+  };
+
+  const handleClear = () => {
+    setLocalQuery("");
+    onSearchChange?.("");
+  };
+
   return (
     <div className="mb-8 sm:mb-10 flex flex-col gap-4">
+
+      {/* Search Bar */}
+      <div className="relative w-full">
+        <Search
+          size={16}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 pointer-events-none"
+        />
+        <input
+          type="text"
+          value={localQuery}
+          onChange={handleInput}
+          placeholder="Search events by title, category, date..."
+          aria-label="Search events"
+          className="w-full pl-9 pr-10 py-2.5 text-sm rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:focus:ring-indigo-500 focus:border-transparent transition-all duration-200 shadow-sm"
+        />
+        {localQuery && (
+          <button
+            onClick={handleClear}
+            aria-label="Clear search"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          >
+            <X size={15} />
+          </button>
+        )}
+      </div>
+
+      {/* Filter Buttons */}
       <div className="flex flex-wrap gap-2 sm:gap-3 items-center justify-center sm:justify-start">
         {EVENT_FILTERS.map((filter) => (
           <FilterButton
@@ -67,6 +116,7 @@ const EventFiltersToolbar = ({
         ))}
       </div>
 
+      {/* Sort + View Mode */}
       <div className="flex flex-col sm:flex-row justify-between items-center gap-3 sm:gap-4">
         <div className="w-full sm:w-auto">
           <label htmlFor="sort-events" className="sr-only">

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -45,6 +45,8 @@ const EventsPage = () => {
           onSortChange={listing.setSortType}
           viewMode={listing.viewMode}
           onViewModeChange={listing.setViewMode}
+          searchQuery={listing.searchQuery}
+          onSearchChange={listing.setSearchQuery}
         />
 
         <EventCardSection
@@ -52,6 +54,10 @@ const EventsPage = () => {
           events={listing.paginatedEvents}
           viewMode={listing.viewMode}
           filterType={listing.filterType}
+          onClearFilters={() => {
+            listing.setSearchQuery("");
+            listing.setFilterType("all");
+          }}
         />
 
         {!listing.isLoading && (


### PR DESCRIPTION
Closes #1574

## Rationale for this change
Users had to scroll through all events manually with no way to search directly on the listing page.

## What changes are included in this PR?
- Added a search bar inside EventFiltersToolbar with real-time filtering
- Debounced input (300ms) for performance
- Search filters by title, category, date, description, and tags using existing fuzzy search logic
- "No events found" UI state with a Clear Filters button that resets both search and filters
- Wired searchQuery and onSearchChange props through EventsPage to EventFiltersToolbar

## Are these changes tested?
Manually tested — real-time filtering works, debounce prevents excessive re-renders, No events found state shows correctly, Clear Filters resets everything.

## Are there any user-facing changes?
Yes — a search bar is now visible directly on the events listing page below the hero section.