### PR TITLE
fix: correct POINTS config keys to match normalized GSSoC label format in Leaderboard

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -20,9 +20,9 @@ const LEADERBOARD_CACHE_KEY = "leaderboardData:v2";
 
 // Points mapping for PR labels (keeps scoring logic centralized)
 const POINTS = {
-  level1: 3,
-  level2: 7,
-  level3: 10,
+  gssoclevel1: 3,
+  gssoclevel2: 7,
+  gssoclevel3: 10,
 };
 const DEFAULT_MERGED_PR_POINTS = 1;
 


### PR DESCRIPTION
Closes #1560

## Problem
All contributors received default score of 1 
instead of level-based points on leaderboard.

## Root Cause
normalizeLabel() converts "GSSoC Level1" to 
"gssoclevel1" but POINTS config used keys 
level1, level2, level3 — never matched.

## Fix
Updated POINTS keys to match normalized labels:
- gssoclevel1: 3
- gssoclevel2: 7  
- gssoclevel3: 10

## Files Changed
- src/Pages/Leaderboard/Leaderboard.jsx

@SandeepVashishtha Ready for review! 🚀