### PR TITLE
fix: stabilize markAllAsRead dependency array to prevent context re-r…

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -73,27 +73,37 @@ export const NotificationProvider = ({ children }) => {
 
   /** Mark ALL notifications as read in one shot */
   const markAllAsRead = useCallback(async () => {
-    if (!token || notifications.length === 0) return;
+    if (!token) return;
 
-    const unread = notifications.filter((n) => !n.isRead);
-    if (unread.length === 0) return;
+    // Use a functional wrapper block to get access to current state safely without a dependency array trigger
+    let unread = [];
+    
+    setNotifications((prev) => {
+      unread = prev.filter((n) => !n.isRead);
+      if (unread.length === 0) return prev;
+      
+      // Return optimistically updated array
+      return prev.map((n) => ({ ...n, isRead: true }));
+    });
 
-    try {
-      // Optimistic UI update first
-      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-      setUnreadCount(0);
+    // If there were no unread items captured, stop execution early
+    setTimeout(async () => {
+      if (unread.length === 0) return;
 
-      await Promise.allSettled(
-        unread.map((n) =>
-          apiUtils.put(API_ENDPOINTS.NOTIFICATIONS.READ(n.id), {}, token)
-        )
-      );
-    } catch (error) {
-      console.error('Error marking all notifications as read:', error);
-      // Re-fetch to restore accurate state
-      fetchNotifications();
-    }
-  }, [token, notifications, fetchNotifications]);
+      try {
+        setUnreadCount(0);
+        await Promise.allSettled(
+          unread.map((n) =>
+            apiUtils.put(API_ENDPOINTS.NOTIFICATIONS.READ(n.id), {}, token)
+          )
+        );
+      } catch (error) {
+        console.error('Error marking all notifications as read:', error);
+        // Re-fetch to restore accurate state on server failure
+        fetchNotifications();
+      }
+    }, 0);
+  }, [token, fetchNotifications]);
 
   // ── Initial fetch + polling ───────────────────────────────────────────────
   useEffect(() => {


### PR DESCRIPTION
## Description
This PR resolves an infinite re-render loop and unnecessary component updates caused by a mutable dependency reference inside the `NotificationContext`.

While `fetchNotifications` and `fetchAchievements` were memoized, the `markAllAsRead` handler included the raw `notifications` array directly inside its `useCallback` dependency array. Consequently, any changes to notifications recreated the reference of `markAllAsRead`, causing an unstable context value object and triggering recursive re-renders for all consuming components. 

This issue has been resolved by utilizing functional state updates (`setNotifications(prev => ...)`), completely decoupling the state array from the hook dependencies.

## Related Issue
Fixes #1594

## Changes Made
- **File Modified:** `src/context/NotificationContext.js`
- Refactored `markAllAsRead` to access current state inside a functional `setNotifications` update block.
- Removed `notifications` from the `useCallback` dependency array of `markAllAsRead`, stabilizing the hook reference entirely.
- Isolated async API operations outside the rendering execution chain safely using a `setTimeout` closure block.

## How to Test
1. Log in to the application and trigger multiple unread notifications.
2. Navigate to a view that uses the `useNotification` context hook.
3. Open React DevTools $\rightarrow$ Profiler tab, or execute `markAllAsRead()`.
4. Observe that notifications update to read seamlessly, and consumer components re-render exactly once rather than triggering a cascading render loop.

## Checklist
- [x] My code follows the code style of this project.
- [x] Unstable dependencies inside React hooks have been removed or refactored.
- [x] The core functionality has been tested and verified with zero build errors.