### PR TITLE
feat: improve mobile responsiveness across event details, registratio…

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -168,7 +168,7 @@ const EventDetailsPage = () => {
         </div>
       </div>
 
-      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-12">
         <motion.div
           initial={{
             opacity: 0,
@@ -188,14 +188,14 @@ const EventDetailsPage = () => {
             {/* Hero Image */}
             <div className="relative rounded-2xl overflow-hidden mb-8 shadow-xl">
               <img
-                src={event.image}
-                alt={event.title}
-                className="w-full h-96 object-cover"
-              />
+  src={event.image}
+  alt={event.title}
+  className="w-full h-48 sm:h-64 md:h-96 object-cover"
+/>
 
               <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
 
-              <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
+              <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-6 text-white">
                 <div className="flex items-center gap-3 mb-4">
                   <span className="px-3 py-1 bg-indigo-600 rounded-full text-sm font-semibold">
                     {event.type
@@ -219,9 +219,9 @@ const EventDetailsPage = () => {
                   </span>
                 </div>
 
-                <h1 className="text-4xl font-bold">
-                  {event.title}
-                </h1>
+                <h1 className="text-xl sm:text-2xl md:text-4xl font-bold leading-tight">
+  {event.title}
+</h1>
               </div>
             </div>
 

--- a/src/Pages/Home/components/HomeCTA.jsx
+++ b/src/Pages/Home/components/HomeCTA.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 
 export default function CTASection() {
   return (
-    <div className="bg-white dark:bg-black py-12 px-6 lg:px-16">
+    <div className="bg-white dark:bg-black py-8 sm:py-12 px-4 sm:px-6 lg:px-16">
       {/* Main CTA Section */}
       <section className="relative py-16 bg-gray-50 dark:bg-slate-900/50 rounded-lg overflow-hidden border border-gray-200 dark:border-slate-800 shadow-sm">
         {/* CTA Content Wrapper */}
@@ -18,7 +18,7 @@ export default function CTASection() {
           </motion.div>
 
           {/* Main heading */}
-          <motion.h2 className="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white mb-4">
+          <motion.h2 className="text-2xl sm:text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white mb-4">
             Ignite Ideas, Connect Innovators
           </motion.h2>
 

--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -115,19 +115,19 @@ const RegistrationPage = () => {
   }
 
   return (
-    <div className="fixed inset-0 py-16 px-4 bg-gradient-to-br from-indigo-50/50 via-white to-violet-50/50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 transition-colors duration-300 z-[10000] overflow-y-auto flex items-center justify-center">
+    <div className="min-h-screen py-20 px-4 bg-gradient-to-br from-indigo-50/50 via-white to-violet-50/50 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 transition-colors duration-300 overflow-y-auto flex items-start sm:items-center justify-center">
       <motion.div
         initial={{ opacity: 0, y: 30, scale: 0.95 }}
         animate={{ opacity: 1, y: 0, scale: 1 }}
         transition={{ duration: 0.6 }}
-        className="max-w-2xl w-full backdrop-blur-xl bg-white/70 dark:bg-slate-900/70 border border-slate-200/50 dark:border-slate-800/50 shadow-2xl rounded-3xl p-6 sm:p-10 relative overflow-hidden"
+        className="max-w-2xl w-full backdrop-blur-xl bg-white/70 dark:bg-slate-900/70 border border-slate-200/50 dark:border-slate-800/50 shadow-2xl rounded-3xl p-4 sm:p-6 md:p-10 relative overflow-hidden my-4"
       >
         {/* Glow Effects */}
         <div className="absolute top-0 right-0 -mr-20 -mt-20 w-60 h-60 bg-indigo-500/10 rounded-full blur-3xl pointer-events-none"></div>
         <div className="absolute bottom-0 left-0 -ml-20 -mb-20 w-60 h-60 bg-violet-500/10 rounded-full blur-3xl pointer-events-none"></div>
 
         <div className="relative z-10">
-          <h1 className="text-3xl sm:text-4xl font-extrabold mb-2 bg-gradient-to-r from-indigo-600 via-violet-600 to-purple-600 dark:from-indigo-400 dark:via-violet-400 dark:to-purple-400 bg-clip-text text-transparent">
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold mb-2 bg-gradient-to-r from-indigo-600 via-violet-600 to-purple-600 dark:from-indigo-400 dark:via-violet-400 dark:to-purple-400 bg-clip-text text-transparent">
             Register for this Event
           </h1>
           <p className="text-slate-500 dark:text-slate-400 mb-8 text-sm sm:text-base">


### PR DESCRIPTION
Closes #1570

## Rationale for this change
Several pages had layout and spacing issues on smaller screen devices, including oversized hero images, large headings that overflow on mobile, and a fixed positioning bug on the registration page that caused scroll issues.

## What changes are included in this PR?
- EventDetailsPage: responsive hero image height, smaller heading on mobile, reduced padding on small screens
- RegistrationPage: replaced fixed inset-0 with min-h-screen to fix mobile scroll, responsive padding and heading sizes
- HomeCTA: responsive heading size and padding across mobile and tablet breakpoints

## Are these changes tested?
Manually tested using Chrome DevTools device toolbar across mobile (375px), tablet (768px), and desktop (1280px) breakpoints.

## Are there any user-facing changes?
Yes — pages now stack and scale correctly on mobile and tablet devices without layout overflow or scroll issues.