### PR TITLE
Feat/show-back-to-top-button-on-mobile

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useLocation } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronUp } from "lucide-react";
+import { scrollToTop as lenisScrollToTop, getScrollPosition } from "../utils/lenisUtils";
 
 export default function ScrollToTopButton() {
   const { pathname } = useLocation();
@@ -25,12 +26,12 @@ export default function ScrollToTopButton() {
   // Optimized scroll handling
   const handleScroll = useCallback(() => {
     requestAnimationFrame(() => {
-      const scrollTop = window.scrollY;
+      const scrollTop = getScrollPosition();
       const docHeight =
         document.documentElement.scrollHeight -
         document.documentElement.clientHeight;
 
-      const progress = (scrollTop / docHeight) * 100;
+      const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
 
       setVisible(scrollTop > 300);
       setScrollProgress(progress);
@@ -58,10 +59,15 @@ export default function ScrollToTopButton() {
       "(prefers-reduced-motion: reduce)"
     ).matches;
 
-    window.scrollTo({
-      top: 0,
-      behavior: prefersReducedMotion ? "auto" : "smooth",
-    });
+    if (window.lenis) {
+      // Use Lenis helper to respect smooth scrolling engine
+      lenisScrollToTop({ duration: prefersReducedMotion ? 0 : 1.2 });
+    } else {
+      window.scrollTo({
+        top: 0,
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+      });
+    }
   };
 
   const positionClass = isChatbotOpen
@@ -71,64 +77,100 @@ export default function ScrollToTopButton() {
   return (
     <AnimatePresence>
       {visible && (
-        <motion.button
-          onClick={scrollToTop}
-          initial={{ opacity: 0, scale: 0.7, y: 30 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.7, y: 30 }}
-          transition={{ duration: 0.25 }}
-          whileHover={{ scale: 1.1 }}
-          whileTap={{ scale: 0.95 }}
-          aria-label="Scroll back to top"
-          title="Back to Top"
-          className={`
-            fixed ${positionClass}
-            z-[9998]
-            w-14 h-14
-            rounded-full
-            bg-white dark:bg-zinc-900
-            border border-black/10 dark:border-white/10
-            shadow-xl
-            backdrop-blur-md
-            flex items-center justify-center
-            text-black dark:text-white
-            focus:outline-none
-            focus:ring-2
-            focus:ring-blue-500
-            transition-all
-          `}
-        >
-          {/* Progress Ring */}
-          <svg
-            className="absolute inset-0 w-full h-full -rotate-90"
-            viewBox="0 0 100 100"
+        <>
+          {/* Desktop / large screens button */}
+          <motion.button
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.7, y: 30 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.7, y: 30 }}
+            transition={{ duration: 0.25 }}
+            whileHover={{ scale: 1.1 }}
+            whileTap={{ scale: 0.95 }}
+            aria-label="Scroll back to top"
+            title="Back to Top"
+            className={
+              `hidden md:flex fixed ${positionClass} z-[9998] w-14 h-14 rounded-full bg-white dark:bg-zinc-900 border border-black/10 dark:border-white/10 shadow-xl backdrop-blur-md flex items-center justify-center text-black dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all`
+            }
           >
-            <circle
-              cx="50"
-              cy="50"
-              r="46"
-              stroke="currentColor"
-              strokeWidth="4"
-              fill="none"
-              className="opacity-20"
-            />
+            {/* Progress Ring */}
+            <svg
+              className="absolute inset-0 w-full h-full -rotate-90"
+              viewBox="0 0 100 100"
+            >
+              <circle
+                cx="50"
+                cy="50"
+                r="46"
+                stroke="currentColor"
+                strokeWidth="4"
+                fill="none"
+                className="opacity-20"
+              />
 
-            <circle
-              cx="50"
-              cy="50"
-              r="46"
-              stroke="currentColor"
-              strokeWidth="4"
-              fill="none"
-              strokeDasharray={289}
-              strokeDashoffset={289 - (289 * scrollProgress) / 100}
-              strokeLinecap="round"
-              className="transition-all duration-150"
-            />
-          </svg>
+              <circle
+                cx="50"
+                cy="50"
+                r="46"
+                stroke="currentColor"
+                strokeWidth="4"
+                fill="none"
+                strokeDasharray={289}
+                strokeDashoffset={289 - (289 * scrollProgress) / 100}
+                strokeLinecap="round"
+                className="transition-all duration-150"
+              />
+            </svg>
 
-          <ChevronUp className="w-6 h-6 relative z-10" />
-        </motion.button>
+            <ChevronUp className="w-6 h-6 relative z-10" />
+          </motion.button>
+
+          {/* Mobile-specific button (visible on small screens) */}
+          <motion.button
+            onClick={scrollToTop}
+            initial={{ opacity: 0, scale: 0.7, y: 30 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.7, y: 30 }}
+            transition={{ duration: 0.25 }}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            aria-label="Scroll back to top"
+            title="Back to Top"
+            className={
+              `md:hidden fixed ${isChatbotOpen ? 'bottom-24 left-6' : 'bottom-6 right-4'} z-[9998] w-12 h-12 rounded-full bg-white dark:bg-zinc-900 border border-black/10 dark:border-white/10 shadow-xl backdrop-blur-md flex items-center justify-center text-black dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all`
+            }
+          >
+            <svg
+              className="absolute inset-0 w-full h-full -rotate-90"
+              viewBox="0 0 100 100"
+            >
+              <circle
+                cx="50"
+                cy="50"
+                r="46"
+                stroke="currentColor"
+                strokeWidth="4"
+                fill="none"
+                className="opacity-20"
+              />
+
+              <circle
+                cx="50"
+                cy="50"
+                r="46"
+                stroke="currentColor"
+                strokeWidth="4"
+                fill="none"
+                strokeDasharray={289}
+                strokeDashoffset={289 - (289 * scrollProgress) / 100}
+                strokeLinecap="round"
+                className="transition-all duration-150"
+              />
+            </svg>
+
+            <ChevronUp className="w-5 h-5 relative z-10" />
+          </motion.button>
+        </>
       )}
     </AnimatePresence>
   );


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1671 

## Rationale for this change

This change ensures the back-to-top experience works consistently across all screen sizes. The button already exists on desktop, but mobile users had no visible control to quickly return to the top of long pages, which hurts usability on content-heavy screens. Adding the mobile variant preserves the same scroll-to-top behavior and progress indicator while keeping the UI responsive and accessible on smaller devices.

## What changes are included in this PR?

This PR adds a mobile-visible back-to-top button so users on small screens get the same quick scroll-to-top action that desktop users already had. It keeps the existing desktop button behavior and styling, reuses the same smooth-scroll functionality, and makes the action work with the current Lenis scrolling setup.

## Are these changes tested?

The change was validated locally by starting the app and checking that the back-to-top component still renders and works with the existing scroll behavior. No new automated tests were added because this is a small UI-only update

## Are there any user-facing changes?

Yes. Mobile users now get the same back-to-top button experience that desktop users already had. The button appears on small screens, keeps the same scroll-to-top behavior, and uses the same progress-ring visual treatment, so the UI is more consistent and easier to navigate on phones.