### PR TITLE
Fixed cta by removing duplicate send feedback button

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -75,18 +75,18 @@ const EventsPage = () => {
           onSearchChange={listing.setSearchQuery}
         />
 
-{!listing.loadError && (
-  <EventCardSection
-    isLoading={listing.isLoading}
-    events={listing.paginatedEvents}
-    viewMode={listing.viewMode}
-    filterType={listing.filterType}
-    onClearFilters={() => {
-      listing.setSearchQuery("");
-      listing.setFilterType("all");
-    }}
-  />
-)}
+        {!listing.loadError && (
+          <EventCardSection
+            isLoading={listing.isLoading}
+            events={listing.paginatedEvents}
+            viewMode={listing.viewMode}
+            filterType={listing.filterType}
+            onClearFilters={() => {
+              listing.setSearchQuery("");
+              listing.setFilterType("all");
+            }}
+          />
+        )}
         {!listing.isLoading && !listing.loadError && (
           <PaginationControls
             currentPage={listing.currentPage}
@@ -100,7 +100,6 @@ const EventsPage = () => {
       </div>
 
       <EventCTA />
-      <FeedbackButton />
     </div>
   );
 };


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #1757 

# Rationale for this change

An extra instance of the `<FeedbackButton/>` component was explicitly rendered inside the `EventsPage` layout. Because a global, floating feedback button is already handled elsewhere in the layout lifecycle, this additional instance broke the layout flow, causing a duplicate button to incorrectly render relative to the DOM flow right beneath the `EventCTA` section.

## What changes are included in this PR?

* **Removed Duplicate Component:** Deleted the rogue `<FeedbackButton/>` component from the bottom layout block of `EventsPage.jsx`.


## Are these changes tested?

* **Manual Verification:** Verified locally that the layout error is resolved. The floating feedback button at the page/footer level behaves correctly, while the out-of-place static button directly below the Event CTA container is gone. 

## Are there any user-facing changes?

Yes. Users will no longer see duplicate feedback icons overlapping or stacking awkwardly at the bottom of the Events page layout. The visual pollution is cleared, matching the expected UI design.
## Before:
<img width="1900" height="651" alt="Screenshot 2026-05-24 160426" src="https://github.com/user-attachments/assets/0484251e-f979-4852-9e2d-580755cc4e8b" />

## After:
<img width="1899" height="741" alt="image" src="https://github.com/user-attachments/assets/51bd05aa-f287-447c-930a-23e6b172f1f7" />
