### PR TITLE
fix: improve dark mode text visibility in WhatsHappening section (#1695)

### DIFF
--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -175,10 +175,10 @@ border-t border-gray-100 dark:border-slate-800/80"
           animate={inView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6 }}
         >
-          <h2 className="text-2xl sm:text-3xl font-extrabold text-black dark:text-gray-900">
+          <h2 className="text-2xl sm:text-3xl font-extrabold text-black dark:text-white">
             What's Happening Now
           </h2>
-          <p className="mt-2 sm:mt-3 max-w-xl mx-auto text-sm sm:text-lg text-black dark:text-gray-800">
+          <p className="mt-2 sm:mt-3 max-w-xl mx-auto text-sm sm:text-lg text-black dark:text-gray-300">
             Stay updated with {upcomingEvents.length} upcoming events, community
             programs, and opportunities to contribute to Eventra
           </p>


### PR DESCRIPTION
## Fix: Dark Mode Text Visibility in "What's Happening Now" Section

- Closes #1695

## Rationale for this change

In dark mode, the `"What's Happening Now"` section heading and subtitle were using Tailwind classes `dark:text-gray-900` and `dark:text-gray-800` — both of which are near-black colors. On a dark background (`dark:from-slate-950 dark:via-slate-900 dark:to-black`), these colors become essentially invisible, severely impacting readability and accessibility, especially on lower-brightness displays and smaller screens.

## What changes are included in this PR?

- Changed `<h2>` heading class from `dark:text-gray-900` → `dark:text-white` for maximum contrast on dark backgrounds
- Changed `<p>` subtitle class from `dark:text-gray-800` → `dark:text-gray-300` for readable, softer contrast on dark backgrounds

Both changes are limited to `WhatsHappening.js` and do not affect light mode behavior.

## Are these changes tested?

These changes are visual/CSS in nature and can be verified by toggling dark mode on the Home page and checking the `"What's Happening Now"` section. No unit tests are required as this is a pure styling fix. The fix meets WCAG AA contrast ratio requirements (`dark:text-white` gives a 21:1 ratio, `dark:text-gray-300` gives ~10:1 on the dark background).

## Are there any user-facing changes?

Yes — users using dark mode will now be able to clearly read the section heading **"What's Happening Now"** and its subtitle, which were previously near-invisible. No breaking changes to any APIs or component interfaces.

<img width="1382" height="679" alt="image" src="https://github.com/user-attachments/assets/3f0ad425-ba5c-4495-a453-ae188b178830" />


