### PR TITLE
fix: About page feature cards invisible in dark mode

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -228,7 +228,7 @@ function MissionSection({ anim, prefersReducedMotion }) {
                 variants={staggerItem}
                 whileHover={prefersReducedMotion ? {} : { y: -4, scale: 1.02 }}
                 transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                className="rounded-2xl border p-5 cursor-default bg-gradient-to-b from-white via-white to-slate-50 border-slate-100 shadow-xl shadow-slate-100/70 dark:bg-gray-800/50 transition-transform duration-300"
+                className="rounded-2xl border p-5 cursor-default bg-gradient-to-b from-white via-white to-slate-50 dark:from-gray-800 dark:via-gray-800 dark:to-gray-900 border-slate-100 dark:border-gray-700 shadow-xl shadow-slate-100/70 dark:shadow-none transition-transform duration-300"
               >
                 <h4 className="font-bold text-sm text-black dark:text-white mb-2">{v.title}</h4>
                 <p className="text-xs text-gray-500 dark:text-gray-400 leading-relaxed">{v.desc}</p>


### PR DESCRIPTION
## 🐛 Bug Fix

Closes #1636 

## Problem
The 2×2 feature cards (Open Source, Community First, Innovation, 
Accessibility) under "Our Mission & Vision" on the `/about` page 
were invisible in dark mode.

## Root Cause
The cards used `bg-gradient-to-b from-white via-white to-slate-50` 
but had no dark mode gradient stop overrides. Tailwind's `dark:bg-*` 
sets background-color but CSS gradients take precedence, so the card 
background remained white in dark mode making text invisible.

## Fix
Added dark mode gradient overrides to `ModernAbout.js`:
- `dark:from-gray-800 dark:via-gray-800 dark:to-gray-900`
- `dark:border-gray-700`
- `dark:shadow-none`

##Screenshot
- Previous
<img width="1915" height="997" alt="Screenshot 2026-05-23 180210" src="https://github.com/user-attachments/assets/6e483236-dd0d-4847-95a6-010220e7491a" />

- Current
<img width="1905" height="915" alt="Screenshot 2026-05-24 204055" src="https://github.com/user-attachments/assets/d93a5d8a-c1f0-4c76-a23c-60be6f27d8b4" />



## Files Changed
- `src/Pages/About/ModernAbout.js`