### PR TITLE
docs: correct tech stack documentation to reflect vanilla React front…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # 🤝 Contributing to Eventra 🎉
 
 Thank you for your interest in contributing to **Eventra** — a modern event management platform built for **builders**, **communities**, and **creators**.  
-We’re thrilled to have you on board! 🚀  
+We’re thrilled to have you on board! 🚀
 
 This guide will help you understand how to contribute effectively, maintain high-quality standards, and collaborate seamlessly with our community.
 
@@ -21,7 +21,7 @@ This guide will help you understand how to contribute effectively, maintain high
 
 ---
 
-## 📜 Code of Conduct  
+## 📜 Code of Conduct
 
 At **Eventra**, we believe that collaboration thrives in a respectful, inclusive, and supportive community.  
 Our goal is to ensure that every contributor feels valued and safe while participating in this project.
@@ -29,12 +29,13 @@ Our goal is to ensure that every contributor feels valued and safe while partici
 Before contributing, please take a moment to read our full [**Code of Conduct**](CODE_OF_CONDUCT.md).  
 By participating, you agree to uphold these principles and help us maintain a positive environment for everyone.
 
-**Key principles:**  
-- 💬 **Be respectful:** Treat everyone with kindness and empathy.  
-- 🤝 **Be inclusive:** Embrace diversity and welcome new voices.  
-- 🌱 **Be constructive:** Offer helpful feedback and focus on solutions.  
-- 🛡️ **Be professional:** Avoid harassment, personal attacks, or discriminatory behavior.  
- 
+**Key principles:**
+
+- 💬 **Be respectful:** Treat everyone with kindness and empathy.
+- 🤝 **Be inclusive:** Embrace diversity and welcome new voices.
+- 🌱 **Be constructive:** Offer helpful feedback and focus on solutions.
+- 🛡️ **Be professional:** Avoid harassment, personal attacks, or discriminatory behavior.
+
 Together, we can make **Eventra** a safe and inspiring space for all contributors. ✨
 
 ---
@@ -57,106 +58,91 @@ You can help improve Eventra in several ways:
    ```bash
    git fork https://github.com/SandeepVashishtha/Eventra.git
    cd Eventra
+   ```
 2. Create a Feature Branch
+
 ```bash
 git checkout -b feature/amazing-feature
 ```
+
 3. Make Your Changes
-Follow the code standards and test your changes locally.
+   Follow the code standards and test your changes locally.
 4. Commit Your Changes
+
 ```bash
 git commit -m "feat: add amazing feature"
 ```
+
 5. Push to Your Branch
+
 ```bash
 git push origin feature/amazing-feature
 ```
-6. Open a Pull Request
-Submit a PR with a clear description of your changes.
 
-## 🧩 Code Standards  
+6. Open a Pull Request
+   Submit a PR with a clear description of your changes.
+
+## 🧩 Code Standards
 
 Maintaining consistent coding standards ensures readability, maintainability, and collaboration across **Eventra**.
 
 ---
 
-### ⚙️ Backend Standards  
+### 🎨 Frontend Standards
 
-- Follow **Java 17** conventions and coding guidelines.  
-- Use **Spring Boot** best practices for project structure, dependency injection, and service layers.  
-- Design and maintain **RESTful APIs** with clear endpoints, proper HTTP methods, and status codes.  
-- Keep methods and classes **concise and focused**; avoid large, monolithic services.  
-- Document all new endpoints using **OpenAPI/Swagger** to keep API docs up to date.  
-- Handle exceptions gracefully and log errors appropriately.  
-- Ensure **secure database interactions** and follow best practices for authentication and authorization.  
+- Use **functional components** with **React Hooks** for state and lifecycle management.
+- Follow modern **React best practices**, including component composition and context usage.
+- Keep components **small, reusable, and modular**.
+- Maintain a consistent **UI/UX design**, ensuring accessibility and responsiveness across devices.
+- Store configuration and constants separately (e.g., `src/config`) to maintain clean code.
+- Use **ESLint + Prettier** to enforce consistent code style and formatting.
 
----
-
-### 🎨 Frontend Standards  
-
-- Use **functional components** with **React Hooks** for state and lifecycle management.  
-- Follow modern **React best practices**, including component composition and context usage.  
-- Keep components **small, reusable, and modular**.  
-- Maintain a consistent **UI/UX design**, ensuring accessibility and responsiveness across devices.  
-- Store configuration and constants separately (e.g., `src/config`) to maintain clean code.  
-- Use **ESLint + Prettier** to enforce consistent code style and formatting.  
-
-
-## 🧪 Testing  
+## 🧪 Testing
 
 Proper testing ensures that our features are reliable and maintainable. Please follow these guidelines:
 
-- Write **unit** and **integration tests** for all new features and critical fixes.  
-- Test thoroughly before submitting your PR to ensure everything works as expected.  
-- Use descriptive test names and cover edge cases whenever possible.  
-- Ensure tests pass consistently in both local and CI environments.  
+- Write **unit** and **integration tests** for all new features and critical fixes.
+- Test thoroughly before submitting your PR to ensure everything works as expected.
+- Use descriptive test names and cover edge cases whenever possible.
+- Ensure tests pass consistently in both local and CI environments.
 
 ---
 
-## 📖 Documentation  
+## 📖 Documentation
 
-Good documentation helps other contributors understand and use your code effectively:  
+Good documentation helps other contributors understand and use your code effectively:
 
-- Update the **README** or project documentation for any new features or changes.  
-- Add **inline comments** where necessary to clarify complex logic.  
-- Keep documentation concise, clear, and up to date with code changes.  
+- Update the **README** or project documentation for any new features or changes.
+- Add **inline comments** where necessary to clarify complex logic.
+- Keep documentation concise, clear, and up to date with code changes.
 
 ---
 
-## 🎨 Frontend Guidelines  
+## 🎨 Frontend Guidelines
 
 ### 🛠 Tech Stack
-- **React** 18.2.0  
-- **React Router DOM** for routing  
-- **Framer Motion** for animations  
+
+- **React** 18.2.0
+- **React Router DOM** for routing
+- **Framer Motion** for animations
 
 ### 💻 Code Style
-- Use **ESLint** + **Prettier** for consistent formatting.  
-- Store API configurations in `src/config/api.js`.  
-- Write modular, reusable components with proper naming conventions.  
+
+- Use **ESLint** + **Prettier** for consistent formatting.
+- Store API configurations in `src/config/api.js`.
+- Write modular, reusable components with proper naming conventions.
 
 ### 🌐 Environment
-- Configure environment variables using a `.env` file.  
-- Refer to `.env.example` for required variables and structure.  
+
+- Configure environment variables using a `.env` file.
+- Refer to `.env.example` for required variables and structure.
 
 ---
 
-## ⚙️ Backend Guidelines  
-
-### 🛠 Tech Stack
-- **Java** 17  
-- **Spring Boot** 3.3.1  
-- **Databases:** MySQL for production, H2 for development/testing  
-
-### 💻 Best Practices
-- Follow standard Spring Boot conventions for project structure.  
-- Use proper exception handling and logging.  
-- Ensure secure database connections and avoid exposing sensitive credentials.  
-- Write clean, maintainable code with proper separation of concerns.  
-
-
 ## Commit Message Guidelines
+
 We follow conventional commits:
+
 - feat: – New feature
 - fix: – Bug fix
 - docs: – Documentation only changes
@@ -165,65 +151,64 @@ We follow conventional commits:
 - test: – Adding or updating tests
 - chore: – Maintenance tasks
 
-### 💡 Examples of Commit Messages  
+### 💡 Examples of Commit Messages
 
 Here are some practical examples following our **Conventional Commits** guidelines:
 
-- `feat: add leaderboard component` – Introduces a new feature.  
-- `fix: resolve API CORS issue` – Fixes a bug in the API handling.  
-- `docs: update contributing guidelines` – Updates documentation without affecting code.  
-- `style: format dashboard layout using Prettier` – Adjusts code style or formatting.  
-- `refactor: simplify event creation logic` – Refactors code without adding features or fixing bugs.  
-- `test: add integration tests for event routes` – Adds or updates tests.  
-- `chore: update dependencies and clean up scripts` – Routine maintenance tasks.  
+- `feat: add leaderboard component` – Introduces a new feature.
+- `fix: resolve API CORS issue` – Fixes a bug in the API handling.
+- `docs: update contributing guidelines` – Updates documentation without affecting code.
+- `style: format dashboard layout using Prettier` – Adjusts code style or formatting.
+- `refactor: simplify event creation logic` – Refactors code without adding features or fixing bugs.
+- `test: add integration tests for event routes` – Adds or updates tests.
+- `chore: update dependencies and clean up scripts` – Routine maintenance tasks.
 
 > ✅ Using these clear and descriptive messages keeps the git history readable and makes collaboration easier.
 
-
-## 🚀 Pull Request Process  
+## 🚀 Pull Request Process
 
 Submitting a pull request (PR) is how you share your awesome work with the **Eventra** community!  
 To make the review process smooth and efficient, please follow these steps:
 
-1. **Sync your branch**  
-   - Ensure your feature or fix branch is up to date with the latest `main` branch.  
+1. **Sync your branch**
+   - Ensure your feature or fix branch is up to date with the latest `main` branch.
    - Resolve any merge conflicts before opening your PR.
 
 2. **Describe your changes clearly**  
-   In your PR description, please include:  
-   - 🧩 **Problem Solved:** What issue or feature does this address?  
-   - 💡 **Approach:** How did you solve it? Mention tools, libraries, or patterns used.  
-   - 🔗 **Related Issues:** Reference any related issues (e.g., `Closes #123`).  
+   In your PR description, please include:
+   - 🧩 **Problem Solved:** What issue or feature does this address?
+   - 💡 **Approach:** How did you solve it? Mention tools, libraries, or patterns used.
+   - 🔗 **Related Issues:** Reference any related issues (e.g., `Closes #123`).
    - 🧪 **Testing:** Describe how you tested your changes and include screenshots if applicable.
 
-3. **Run all tests and checks**  
-   - Ensure that all unit, integration, and lint tests pass.  
+3. **Run all tests and checks**
+   - Ensure that all unit, integration, and lint tests pass.
    - If new functionality is added, write appropriate tests.
 
-4. **Follow coding conventions**  
+4. **Follow coding conventions**
    - Use consistent formatting, naming, and structure as defined in our [Code Standards](#-code-standards).
 
-5. **Request a review**  
-   - Assign at least one maintainer or tag a reviewer in your PR.  
-   - Be open to feedback and make revisions as needed.  
+5. **Request a review**
+   - Assign at least one maintainer or tag a reviewer in your PR.
+   - Be open to feedback and make revisions as needed.
 
-6. **Wait for approval & merge**  
-   - Once approved, your PR will be merged by a maintainer. 🎉  
+6. **Wait for approval & merge**
+   - Once approved, your PR will be merged by a maintainer. 🎉
 
 ---
 
-## 💬 Getting Help  
+## 💬 Getting Help
 
-Need assistance or want to discuss ideas? We’re here to help!  
+Need assistance or want to discuss ideas? We’re here to help!
 
-- 🐞 **Issues:** Report bugs or request features.  
+- 🐞 **Issues:** Report bugs or request features.
 - 💭 **Discussions:** Share ideas, ask questions, or connect with contributors.
 - 📧 **Contact Maintainers:** For sensitive matters, reach out privately through the contact listed in the repository.
 
 ---
 
-## 🎉 Final Note  
+## 🎉 Final Note
 
 Thank you for contributing to **Eventra**!  
 Your time, ideas, and code make this project better for everyone.  
-Together, we’re building a **modern, open, and collaborative event management platform** for the community. 🚀💙  
+Together, we’re building a **modern, open, and collaborative event management platform** for the community. 🚀💙

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 Eventra is a comprehensive, open-source platform designed to empower organizers to create, manage, and track events seamlessly. Built with a modern tech stack featuring a React frontend and Spring Boot backend, Eventra provides a full suite of tools for running successful events, from initial creation to post-event analytics.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Java](https://img.shields.io/badge/Java-17-orange.svg)](https://openjdk.java.net/projects/jdk/17/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.3.1-green.svg)](https://spring.io/projects/spring-boot)
 [![React](https://img.shields.io/badge/React-18.2.0-blue.svg)](https://reactjs.org/)
 
 ---
@@ -47,7 +45,6 @@ This repository contains the React frontend application for Eventra. The backend
 - **Swagger**: [https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/swagger-ui/index.html](https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/swagger-ui/index.html)
 - Capacity and registration availability endpoints are documented in Swagger UI.
 
-
 ## Project Insights
 
 <table align="center">
@@ -78,12 +75,14 @@ This repository contains the React frontend application for Eventra. The backend
 ## Features
 
 ### Core Functionality
+
 - **Event Creation & Management**: Easily create and customize events with rich details.
 - **User Authentication**: Secure JWT-based authentication with role-based access control.
 - **Admin & User Dashboards**: Personalized dashboards for seamless management and tracking.
 - **Real-time Analytics**: Track event performance and attendee engagement.
 
 ### Platform Features
+
 - **Hackathon Hub**: Specialized features for managing hackathons.
 - **Project Gallery**: Showcase community projects and foster collaboration.
 - **Community Leaderboards**: Gamify participation and recognize top contributors.
@@ -92,22 +91,24 @@ This repository contains the React frontend application for Eventra. The backend
 
 ## Tech Stack
 
-| Frontend | Backend | DevOps & Infrastructure |
-| :--- | :--- | :--- |
-| **React 18.2** | **Spring Boot 3.3.1** | **Git & GitHub** for Version Control |
-| **React Router** for Routing | **Java 17** | **Vercel** for Frontend Hosting |
-| **Framer Motion** for Animations | **Spring Security & JWT** | **Maven** for Build Automation |
-| **Tailwind CSS** (or CSS) for Styling | **MySQL & H2** Databases | **OpenAPI 3.0** for API Docs |
-| **Create React App** | **Spring Data JPA** | **Azure App Service** for Backend Hosting |
+## Tech Stack
 
-> **Note:** This repository mainly contains the frontend implementation. Backend APIs and services are maintained separately in the [Eventra-Backend](https://github.com/SandeepVashishtha/Eventra-Backend) repository.
+| Frontend                         | DevOps & Infrastructure              |
+| :------------------------------- | :----------------------------------- |
+| **React 18.2**                   | **Git & GitHub** for Version Control |
+| **React Router** for Routing     | **Vercel** for Frontend Hosting      |
+| **Framer Motion** for Animations | **npm** for Package Management       |
+| **Tailwind CSS** for Styling     |                                      |
+| **Create React App**             |                                      |
 
+> **Note:** This repository strictly contains the frontend React application. The backend APIs, databases (MySQL/H2), and Java/Spring Boot services are maintained separately in the [Eventra-Backend](https://github.com/SandeepVashishtha/Eventra-Backend) repository.
 
 ## Getting Started
 
 Follow these steps to set up and run the frontend application on your local machine.
 
 ### Prerequisites
+
 - **Node.js**: Version 16.x or higher
 - **npm**: (usually comes with Node.js)
 - **Git**
@@ -115,28 +116,28 @@ Follow these steps to set up and run the frontend application on your local mach
 ### Installation & Setup
 
 1.  **Clone the Repository:**
+
     ```bash
     git clone https://github.com/SandeepVashishtha/Eventra.git
     cd Eventra
     ```
 
 2.  **Install Dependencies:**
+
     ```bash
     npm install
     ```
 
 3.  **Configure Environment Variables:**
-  Set up your local `.env` file as described in the [Environment Variables](#environment-variables) section. The backend server runs on port `8080` by default.
+    Set up your local `.env` file as described in the [Environment Variables](#environment-variables) section. The backend server runs on port `8080` by default.
 
-  > **Note:** For the backend setup instructions, please refer to the [backend repository's README](https://github.com/SandeepVashishtha/Eventra-Backend).
+> **Note:** For the backend setup instructions, please refer to the [backend repository's README](https://github.com/SandeepVashishtha/Eventra-Backend).
 
 4.  **Run the Development Server:**
     ```bash
     npm start
     ```
     The application will be available at `http://localhost:3000`.
-
-
 
 ## Environment Variables
 
@@ -199,6 +200,7 @@ This project is configured for easy deployment on **Vercel**.
 We welcome contributions from the community! To get started, please follow these guidelines.
 
 ### Development Workflow
+
 1.  **Fork** the repository.
 2.  **Create a new branch** for your feature or bug fix:
     ```bash
@@ -215,6 +217,7 @@ We welcome contributions from the community! To get started, please follow these
 5.  **Open a Pull Request** to the `master` branch of the original repository.
 
 ### Issue Assignment Policy
+
 - To ensure active development, issues are **automatically unassigned after 7 days** of inactivity.
 - To keep your assignment, please **open a draft Pull Request** within the 7-day period to show progress.
 - For more details, see our [Auto-unassign Documentation](.github/AUTO_UNASSIGN.md).
@@ -222,7 +225,6 @@ We welcome contributions from the community! To get started, please follow these
 ## License
 
 This project is licensed under the **Apache License 2.0**. See the [LICENSE](LICENSE) file for details.
-
 
 ## Star History
 
@@ -245,6 +247,7 @@ A huge thank you to everyone who has contributed to Eventra! Your efforts make t
 </p>
 
 ### Maintainers
+
 <table>
 <tr>
 <td align="center">
@@ -271,6 +274,7 @@ A huge thank you to everyone who has contributed to Eventra! Your efforts make t
 </table>
 
 ---
+
 ## Environment Variables Setup
 
 Create a `.env` file in the project root by copying `.env.example`:
@@ -303,5 +307,3 @@ REACT_APP_GITHUB_TOKEN=your_github_token
 The `.env.example` file contains all required environment variable names needed to run the project locally.
 
 Built with care by the Eventra Team
-
-


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1702

## Rationale for this change

The project documentation previously listed backend technologies (Java 17, Spring Boot, MySQL, Maven) within this repository's tech stack and contribution guidelines. Because this repository strictly contains the React frontend application (with the backend maintained separately), this caused severe onboarding confusion for new contributors who thought they needed to install Java/Maven environments to run the UI locally. This PR aligns the documentation with the actual React codebase.

## What changes are included in this PR?

- **`README.md`:** - Removed Java, Spring Boot, Spring Security, MySQL, Maven, and Azure from the "Tech Stack" table.
  - Replaced "Maven" with "npm" in the DevOps column.
  - Strengthened the disclaimer note to explicitly direct users to the `Eventra-Backend` repository for backend APIs.
- **`CONTRIBUTING.md`:** - Removed the "Backend Standards" section.
  - Removed the "Backend Guidelines" section.
  - Removed dead links to backend sections in the Table of Contents.

## Are these changes tested?

Yes. These are documentation-only changes. I have visually verified the markdown rendering to ensure tables and formatting remain unbroken.

## Are there any user-facing changes?

No codebase functionality has been changed. This strictly improves the onboarding and local setup experience for new open-source contributors.