### PR TITLE
fix: remove duplicate self-closing NotificationProvider in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -110,7 +110,6 @@ function App() {
       <NotificationProvider>
         <MyEventsProvider>
           <SessionRecoveryProvider>
-            <NotificationProvider />
             <ReminderChecker />
             <NotificationToastContainer />
             <OfflineSyncManager />


### PR DESCRIPTION
Hey there! Noticed that `<NotificationProvider>` was being rendered twice in `App.js`. Once wrapping the entire tree (correct), and again inside as a self-closing void element under `<SessionRecoveryProvider>`. This creates nested empty contexts, causing stale/empty states when consuming notifications, and duplicating polling intervals.
  
  Removed the redundant inner self-closing tag. Ran a production build, verified that everything compiles cleanly and works perfectly.
  
  Closes #1881.