### PR TITLE
fix: resolve auth token localStorage key mismatch and user profile sync

### DIFF
--- a/src/components/common/EventCreation.js
+++ b/src/components/common/EventCreation.js
@@ -5,6 +5,7 @@ import { Download } from "lucide-react";
 import {
   
 } from "../../utils/eventDraftUtils";
+import { syncSecureStorage } from "../../utils/secureStorage";
 
 
 import { exportAttendeesToCSV }
@@ -402,7 +403,7 @@ const [showRestoreModal, setShowRestoreModal] = useState(false);
           })),
       };
 
-      const token = localStorage.getItem("token");
+      const token = syncSecureStorage.getItem("token");
       if (!token) {
         toast.error("Authentication required. Please log in and try again.");
         setCurrentStep("form");

--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../../context/AuthContext";
 import { useNavigate } from "react-router-dom";
+import { syncSecureStorage } from "../../utils/secureStorage";
 
 import {
   User as UserIcon,
@@ -47,7 +48,7 @@ const EditProfile = () => {
   
   // Initialize with fallback progression to prevent undefined fields
   const [form, setForm] = useState(() => {
-    const saved = localStorage.getItem("user");
+    const saved = syncSecureStorage.getItem("user");
     if (saved) return JSON.parse(saved);
     return user ? { ...initialFormState, ...user } : initialFormState;
   });
@@ -61,7 +62,7 @@ const EditProfile = () => {
 
   // Keep state synchronized if the auth context updates lazily
   useEffect(() => {
-    const saved = localStorage.getItem("user");
+    const saved = syncSecureStorage.getItem("user");
     if (!saved && user) {
       setForm((prev) => ({ ...prev, ...user }));
     }
@@ -158,7 +159,7 @@ const EditProfile = () => {
       setSuccessMessage("Profile updated successfully");
       setConfirmOpen(false);
       setUser(resolvedForm);
-      localStorage.setItem("user", JSON.stringify(resolvedForm));
+      syncSecureStorage.setItem("user", JSON.stringify(resolvedForm));
 
       setTimeout(() => {
         navigate("/dashboard");

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { syncSecureStorage } from "../utils/secureStorage";
+
 
 // ---------------------------------------------------------------------------
 // Base API URL
@@ -110,7 +112,7 @@ const normalizeRequestConfig = (configOrToken = {}, maybeToken) => {
       ? configOrToken
       : typeof maybeToken === "string"
         ? maybeToken
-        : localStorage.getItem("token") || "";
+        : syncSecureStorage.getItem("token") || "";
 
   if (token) {
     config.headers = {


### PR DESCRIPTION
Hey guys,

I noticed a couple of authentication and profile state synchronization issues during local testing:
1. `AuthContext.js` saves the session token and user profile under base64 obfuscated keys (e.g. `encrypted_token` and `encrypted_user`) via the `syncSecureStorage` utility.
2. However, the API configuration layer (`api.js`) and event creation flow (`EventCreation.js`) read direct raw `"token"` from plain `localStorage.getItem("token")`. Since this key is empty, authorization headers were never correctly attached to outgoing requests.
3. Similarly, `EditProfile.js` directly accessed/updated plain `"user"` in `localStorage`, leaving it completely disconnected from the context's secure storage.

This PR transitions these direct token and user profile localStorage reads/writes to use the unified `syncSecureStorage` helper. This resolves the auth state restoration mismatch and keeps the user profile in sync!

Fixes #1880