### PR TITLE
routing: remove duplicate auth wildcard route to avoid NotFound page conflict

### DIFF
--- a/src/components/routes/ProtectedRoutes.js
+++ b/src/components/routes/ProtectedRoutes.js
@@ -99,5 +99,5 @@ export const getAuthRoutes = () => [
   <Route key="/signup" path="/signup" element={<AuthPage />} />,
   <Route key="/unauthorized" path="/unauthorized" element={<Unauthorized />} />,
   <Route key="/password-reset" path="/password-reset" element={<PasswordReset />} />,
-  <Route key="/*" path="/*" element={<NotFound />} />,
+  // <Route key="/*" path="/*" element={<NotFound />} />,
 ];


### PR DESCRIPTION
Hey maintainers,

Currently, both `ProtectedRoutes.js` (inside `getAuthRoutes`) and `AppRoutes.js` render competing catch-all wildcard routes matching different NotFound components (`NotFound` vs `NotFoundPage`). This causes competing evaluations inside the React Router hierarchy.

This PR removes the nested auth wildcard route so that unmatched paths are cleanly caught and resolved by the unified top-level `NotFoundPage` in `AppRoutes.js`.

Fixes #1888