### PR TITLE
fix: implement robust time validation to prevent non-padded HH:MM comparison bug

### DIFF
--- a/src/components/common/EventCreation.js
+++ b/src/components/common/EventCreation.js
@@ -153,8 +153,13 @@ const [showRestoreModal, setShowRestoreModal] = useState(false);
       !formData.isMultiDay
     ) {
       // Convert time strings (HH:MM format) to minutes for proper comparison
-      const startMinutes = parseInt(formData.startTime.replace(":", ""));
-      const endMinutes = parseInt(formData.endTime.replace(":", ""));
+      const parseTimeToMinutes = (timeStr) => {
+        if (!timeStr) return 0;
+        const [hours, minutes] = timeStr.split(":").map(Number);
+        return (hours || 0) * 60 + (minutes || 0);
+      };
+      const startMinutes = parseTimeToMinutes(formData.startTime);
+      const endMinutes = parseTimeToMinutes(formData.endTime);
       if (startMinutes >= endMinutes) {
         newErrors.endTime = "End time must be after start time";
       }


### PR DESCRIPTION
Hey maintainers,

Currently, start/end time comparisons in event validation use direct `parseInt(timeStr.replace(':', ''))` checks. If the browser or environment returns non-padded values like `9:5` instead of `09:05`, this can lead to incorrect comparisons (e.g. comparing 95 to 1000).

This PR introduces a robust time-to-minutes parser (`parseTimeToMinutes`) that correctly parses and compares start/end times regardless of zero-padding.

Fixes #1891