### PR TITLE
fix: replace silent console.log with proper error handling in navigator.share()

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -440,7 +440,11 @@ const EventRegistration = () => {
           title: event.title,
           text: shareText,
           url: shareUrl,
-        }).catch((err) => console.log(err));
+        }).catch((err) => {
+          if (err.name !== "AbortError") {
+            toast.error("Unable to share event. Try copying the link instead.");
+          }
+        });
       } else {
         navigator.clipboard.writeText(shareUrl).then(() => {
           toast.success("Event link copied to clipboard!");


### PR DESCRIPTION
## Summary

In `EventRegistration.js`, the `navigator.share()` promise rejection is caught with a silent `console.log`:

```js
}).catch((err) => console.log(err));
```

When sharing fails (e.g. user cancels the share dialog, or the share API encounters an error), the error is silently swallowed with only a console log. Users receive no feedback.

## Changes

- Replaced `console.log(err)` with a conditional check:
  - If the user simply cancelled the share dialog (`AbortError`), no toast is shown (expected behavior)
  - For genuine share failures, a `toast.error()` is shown so users know the share action failed

## Testing

- Verified clean compilation with `npm run build` (zero errors)