### PR TITLE
Fix: Remove duplicate static import of RegistrationPage (#1961)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,6 @@ import KeyboardShortcutsModal from "./components/common/KeyboardShortcutsModal";
 import ThemeCustomizerDrawer from "./components/common/ThemeCustomizerDrawer";
 import SessionRecovery from "./components/SessionRecovery";
 
-import RegistrationPage from "./Pages/RegistrationPage";
 
 import NotificationToastContainer from "./components/common/NotificationProvider";
 import { NotificationProvider } from "./context/NotificationContext";


### PR DESCRIPTION
## Description
This Pull Request resolves issue #1961 where `RegistrationPage` was being imported both statically and as a lazy-loaded component in `src/App.js`. This duplicate declaration caused a naming collision (`SyntaxError: Identifier 'RegistrationPage' has already been declared`) and broke the intended performance benefits of lazy loading.

## Changes Made
- Removed the static import `import RegistrationPage from "./Pages/RegistrationPage";` at the top of `src/App.js`.
- Retained the existing `lazy()` import to ensure the application correctly code-splits the Registration component for better performance.

## Related Issue
Fixes #1961