### PR TITLE
fix: resolve shadowed scroll callback and unused scrollProgress state…solve #1962

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -10,7 +10,6 @@ export default function ScrollToTopButton() {
   const { pathname } = useLocation();
 
   const [visible, setVisible] = useState(false);
-  const [scrollProgress, setScrollProgress] = useState(0);
   const [isChatbotOpen, setIsChatbotOpen] = useState(false);
 
   // Auto scroll to top on route change
@@ -26,23 +25,11 @@ export default function ScrollToTopButton() {
   const handleScroll = useCallback(() => {
     requestAnimationFrame(() => {
       const scrollTop = getScrollPosition();
-      const docHeight =
-        document.documentElement.scrollHeight -
-        document.documentElement.clientHeight;
-
-      const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
-
-      setVisible(scrollTop > 300);
-      setScrollProgress(progress);
+      setVisible(scrollTop > 50);
     });
   }, []);
 
   useEffect(() => {
-    const handleScroll = () => {
-      const scrollY = window.lenis ? window.lenis.scroll : window.scrollY;
-      setVisible(scrollY > 50);
-    };
-    
     handleScroll();
     
     if (window.lenis) {


### PR DESCRIPTION
closes #1962 

## Description
This PR resolves a performance issue and cleans up redundant, dead code in the `ScrollToTopButton` component.

### Problem
1. **Variable Shadowing**: An optimized scroll listener was defined using `useCallback` and `requestAnimationFrame`. However, a duplicate local function named `handleScroll` was declared inside the `useEffect` hook. This shadowed the optimized listener, rendering it completely dead code and bypassing the performance benefits of `requestAnimationFrame` debouncing.
2. **Unused State**: The component maintained a `scrollProgress` state which was updated on every scroll event but never actually read or rendered in the component, causing unnecessary re-renders of the button on scroll.

### Solution
1. Removed the unused `scrollProgress` state and its calculations.
2. Cleaned up the shadowed function definition inside the `useEffect` hook.
3. Updated the main optimized `handleScroll` callback to use the standard threshold of 50px, ensuring proper performance-optimized scroll handling via `requestAnimationFrame`.

### Verification Done
- Verified that the scroll-to-top button appears properly after scrolling past the 50px threshold.
- Verified that clicking the button scrolls the page back to the top smoothly.