### PR TITLE
fix: remove duplicate static import of RegistrationPage to resolve solve #1959

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,8 +13,6 @@ import KeyboardShortcutsModal from "./components/common/KeyboardShortcutsModal";
 import ThemeCustomizerDrawer from "./components/common/ThemeCustomizerDrawer";
 import SessionRecovery from "./components/SessionRecovery";
 
-import RegistrationPage from "./Pages/RegistrationPage";
-
 import NotificationToastContainer from "./components/common/NotificationProvider";
 import { NotificationProvider } from "./context/NotificationContext";
 import { AuthProvider } from "./context/AuthContext";


### PR DESCRIPTION
closes #1959 
## Description
This PR resolves a variable re-declaration conflict in `App.js` to fix build warnings and ensure the registration page benefits from proper lazy-loading.

### Problem
The `RegistrationPage` component was imported twice in the same scope: once as a static import at the top of the file, and once as a lazy-loaded component below. This duplicate declaration using the same name triggers variable redeclaration compilation errors in strict bundler environments and completely overrides the performance benefits of React code-splitting for this route.

### Solution
Removed the static import of `RegistrationPage` at the top of the file. This allows the lazy declaration to remain the single, canonical definition for the component, resolving the redeclaration conflict and enabling successful lazy-loading when navigating to the registration route.

### Verification Done
- Confirmed that the duplicate declaration compiler warning is resolved.
- Verified that the application compiles successfully and routes to the registration page cleanly.