### PR TITLE
CI/add unit test script

### DIFF
--- a/.github/workflows/ci-quality-pipeline.yml
+++ b/.github/workflows/ci-quality-pipeline.yml
@@ -32,6 +32,9 @@ jobs:
         env:
           CI: true
 
+      - name: Run utility unit tests
+        run: npm run test:unit
+
       - name: Production build verification
         run: CI=false npm run build
         env:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -41,3 +41,6 @@ jobs:
         run: npm run test -- --watchAll=false --passWithNoTests
         env:
           CI: true
+
+      - name: Run Utility Unit Tests
+        run: npm run test:unit

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "react-scripts build",
     "build:fast": "cross-env GENERATE_SOURCEMAP=false DISABLE_ESLINT_PLUGIN=true NODE_OPTIONS=\"--no-deprecation --max-old-space-size=4096\" react-scripts build",
     "test": "react-scripts test",
+    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs",
     "eject": "react-scripts eject",
     "lint": "eslint src --ext .js,.jsx --max-warnings=-1",
     "lint:fix": "eslint src --ext .js,.jsx --fix",


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1916

## Rationale for this change

The repository already has utility tests under the `tests/` directory, but there was no dedicated npm script to run them directly. Adding a separate script improves contributor experience and makes these utility tests easier to run locally and in CI.

## What changes are included in this PR?

- Added a new `test:unit` script in `package.json`
- Wired `npm run test:unit` into the CI quality workflow
- Wired `npm run test:unit` into the frontend CI workflow
- Kept the existing Jest/CRA test command unchanged

## Are these changes tested?

I attempted to run:

```bash
npm run test:unit