### PR TITLE
feat: use shared loader for suspense fallback

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import ScrollToTop from "./components/ScrollToTop";
 import FeedbackButton from "./components/FeedbackButton";
 import FluidCursor from "./jhalak/FluidCursor";
 import PageTransition from "./components/common/PageTransition";
+import PageLoader from "./components/common/PageLoader";
 import ReminderChecker from "./components/reminders/ReminderChecker";
 import KeyboardShortcutsModal from "./components/common/KeyboardShortcutsModal";
 import ThemeCustomizerDrawer from "./components/common/ThemeCustomizerDrawer";
@@ -125,13 +126,7 @@ function App() {
                 "
               >
                 <PageTransition>
-                  <Suspense
-                    fallback={
-                      <div className="flex items-center justify-center min-h-screen">
-                        Loading...
-                      </div>
-                    }
-                  >
+                  <Suspense fallback={<PageLoader text="Loading page..." />}>
                     <Routes>
                       <Route path="/register/:id" element={<RegistrationPage />} />
                       <Route path="/*" element={<AppRoutes />} />


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1926

## Rationale for this change

The app-level Suspense fallback was rendering plain `Loading...` text even though the project already has a reusable page loader component.

## What changes are included in this PR?

- Imported the existing `PageLoader` component in `src/App.js`
- Replaced the plain text Suspense fallback with `PageLoader`

## Are these changes tested?

A full local build was not run because dependencies are not installed in this checkout. The change is limited to replacing the Suspense fallback with an existing component.

## Are there any user-facing changes?

Yes. Lazy-loaded routes now show the shared loading UI instead of plain text.