### PR TITLE
fix: retry projects fetch without reload

### DIFF
--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { FiAlertCircle, FiChevronDown, FiSearch, FiX } from "react-icons/fi";
 
@@ -44,8 +44,7 @@ const ProjectGallery = () => {
     }
   };
 
-  useEffect(() => {
-    const fetchProjects = async () => {
+  const fetchProjects = useCallback(async () => {
       try {
         setIsLoading(true);
         setError("");
@@ -97,10 +96,11 @@ const ProjectGallery = () => {
       } finally {
         setIsLoading(false);
       }
-    };
-
-    fetchProjects();
   }, []);
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
   const filteredAndSortedProjects = projects
     .filter((project) => {
@@ -393,8 +393,10 @@ const ProjectGallery = () => {
               </p>
 
               <button
-                onClick={() => window.location.reload()}
-                className="mt-6 px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white"
+                type="button"
+                onClick={fetchProjects}
+                disabled={isLoading}
+                className="mt-6 px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 Try Again
               </button>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1955

## Rationale for this change

The Projects page retry button was reloading the entire application using `window.location.reload()`. This is heavier than necessary and can lose client-side state.

## What changes are included in this PR?

- Reused the existing project fetch logic through a `useCallback`
- Updated the Try Again button to retry the project fetch in-place
- Removed the full-page reload behavior

## Are these changes tested?

I verified that `window.location.reload()` is no longer used and ran `git diff --check`. A full local build was not run because dependencies are not installed in this checkout.

## Are there any user-facing changes?

Yes. When project loading fails, clicking Try Again now retries loading projects without refreshing the entire page.


> Hey maintainers, I made this contribution under **GSSoC26**