### PR TITLE
fix: remove duplicate feedback buttons

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -1,7 +1,6 @@
 import { useRef, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import EventHero from "./EventHero";
-import FeedbackButton from "../../components/FeedbackButton";
 import EventCTA from "./EventCTA";
 import EventCardSection from "./EventCardSection";
 import EventFiltersToolbar from "./EventFiltersToolbar";
@@ -123,7 +122,6 @@ const EventsPage = () => {
       </div>
 
       <EventCTA />
-      <FeedbackButton />
       <BackToTopButton />
     </div>
   );

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -4,7 +4,6 @@ import { Link } from "react-router-dom";
 import mockHackathons from "./hackathonMockData.json";
 import HackathonHero from "./HackathonHero";
 import HackathonCard from "./HackathonCard";
-import FeedbackButton from "../../components/FeedbackButton";
 import { FiCode, FiRotateCw, FiCompass, FiChevronDown, FiX } from "react-icons/fi";
 import HackathonCTA from "./HackathonCTA";
 import Fuse from "fuse.js";
@@ -734,9 +733,6 @@ const HackathonHub = () => {
         </AnimatePresence>
       </div>
       <HackathonCTA></HackathonCTA>
-
-      {/* Feedback Button */}
-      <FeedbackButton />
       <BackToTopButton />
     </div>
   );

--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -4,7 +4,6 @@ import { FiAlertCircle, FiChevronDown, FiSearch, FiX } from "react-icons/fi";
 
 import ProjectHero from "./ProjectHero";
 import ProjectCard from "./ProjectCard";
-import FeedbackButton from "../../components/FeedbackButton";
 import ProjectCTA from "./ProjectCTA";
 
 import mockProjects from "./mockProjectsData.json";
@@ -477,8 +476,6 @@ const ProjectGallery = () => {
       </div>
 
       <ProjectCTA />
-
-      <FeedbackButton />
     </div>
   );
 };


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1953

## Rationale for this change

`FeedbackButton` is already rendered globally in `src/App.js`, but several individual pages also rendered their own instances. This could lead to duplicate floating feedback buttons.

## What changes are included in this PR?

- Removed page-level `FeedbackButton` usage from Events page
- Removed page-level `FeedbackButton` usage from Projects page
- Removed page-level `FeedbackButton` usage from Hackathons page
- Kept the global `FeedbackButton` rendering in `src/App.js`

## Are these changes tested?

I verified with `rg FeedbackButton src` that only the global render and component definition remain. I also ran `git diff --check`. A full local build was not run because dependencies are not installed in this checkout.

## Are there any user-facing changes?

Yes. Pages that previously rendered duplicate feedback buttons should now show only the single global feedback button.

> Hey maintainers, I made this contribution under GSSoC26