### PR TITLE
feat: add lowercase public route aliases

### DIFF
--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -58,14 +58,18 @@ export const getPublicRoutes = () => [
   <Route key="page-layout" element={<PageLayout />}>
     <Route key="/contributors" path="/contributors" element={<Contributors />} />
     <Route key="/communityEvent" path="/communityEvent" element={<CommunityEvent />} />
+    <Route key="/community-event" path="/community-event" element={<CommunityEvent />} />
     <Route key="/leaderBoard" path="/leaderBoard" element={<LeaderBoard />} />
+    <Route key="/leaderboard" path="/leaderboard" element={<LeaderBoard />} />
     <Route key="/contributorguide" path="/contributorguide" element={<ContributorGuide />} />
+    <Route key="/contributor-guide" path="/contributor-guide" element={<ContributorGuide />} />
     <Route key="/about" path="/about" element={<AboutPage />} />
     <Route key="/about-fallback" path="/about/*" element={<AboutPage />} />
     <Route key="/faq" path="/faq" element={<FAQPage />} />
     <Route key="/terms" path="/terms" element={<Terms />} />
     <Route key="/privacy" path="/privacy" element={<Privacy />} />
     <Route key="/apiDocs" path="/apiDocs" element={<ApiDocs />} />
+    <Route key="/api-docs" path="/api-docs" element={<ApiDocs />} />
     <Route key="/helpcenter" path="/helpcenter" element={<HelpCenter />} />
     <Route key="/contact" path="/contact" element={<ContactUs />} />
     <Route key="/feedback" path="/feedback" element={<FeedbackPage />} />


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1935

## Rationale for this change

Some public routes use inconsistent casing or concatenated names, making them harder to guess, share, and document.

## What changes are included in this PR?

- Added `/community-event` as an alias for `/communityEvent`
- Added `/leaderboard` as an alias for `/leaderBoard`
- Added `/contributor-guide` as an alias for `/contributorguide`
- Added `/api-docs` as an alias for `/apiDocs`
- Preserved all existing routes for backward compatibility

## Are these changes tested?

I verified the route definitions and ran `git diff --check`. A full local build was not run because dependencies are not installed in this checkout.

## Are there any user-facing changes?

Yes. Users can now access the affected public pages through more consistent lowercase/kebab-case URLs, while the old URLs continue to work.

> Hey maintainers, I made this contribution under GSSoC26