### PR TITLE
Accessibility/shared dropdown keyboard

### DIFF
--- a/src/components/StyledDropdown.js
+++ b/src/components/StyledDropdown.js
@@ -11,6 +11,7 @@ const Dropdown = ({
 }) => {
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef(null);
+  const listboxId = `dropdown-${label || placeholder}`.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -27,6 +28,22 @@ const Dropdown = ({
     setOpen(false);
   };
 
+  const handleTriggerKeyDown = (event) => {
+    if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const handleOptionKeyDown = (event, opt) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleSelect(opt);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
   return (
     <div className="relative w-full sm:w-64" ref={dropdownRef}>
       {label && (
@@ -34,9 +51,14 @@ const Dropdown = ({
           {label}
         </label>
       )}
-      <div
-        className="flex items-center justify-between px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm bg-white dark:bg-gray-800 cursor-pointer hover:ring-2 hover:ring-indigo-500 transition-all"
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-xl shadow-sm bg-white dark:bg-gray-800 cursor-pointer hover:ring-2 hover:ring-indigo-500 transition-all"
         onClick={() => setOpen((prev) => !prev)}
+        onKeyDown={handleTriggerKeyDown}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
       >
         <span
           className={`text-sm ${
@@ -46,12 +68,20 @@ const Dropdown = ({
         >
           {value || placeholder}
         </span>
-        <FiChevronDown className="text-gray-400 dark:text-gray-500" />
-      </div>
+        <FiChevronDown
+          className={`text-gray-400 dark:text-gray-500 transition-transform ${
+            open ? "rotate-180" : ""
+          }`}
+          aria-hidden="true"
+        />
+      </button>
 
       <AnimatePresence>
         {open && (
           <motion.ul
+            id={listboxId}
+            role="listbox"
+            aria-label={label || placeholder}
             className="absolute mt-2 w-full z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg"
             initial={{ opacity: 0, y: -5 }}
             animate={{ opacity: 1, y: 0 }}
@@ -61,14 +91,21 @@ const Dropdown = ({
             {[placeholder, ...options].map((opt) => (
               <li
                 key={opt}
-                onClick={() => handleSelect(opt)}
-                className={`px-4 py-2 text-sm cursor-pointer hover:bg-indigo-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-100 ${
-                  value === opt
-                    ? "font-semibold bg-indigo-100 dark:bg-indigo-900"
-                    : ""
-                }`}
+                role="option"
+                aria-selected={value === opt || (!value && opt === placeholder)}
               >
-                {opt}
+                <button
+                  type="button"
+                  onClick={() => handleSelect(opt)}
+                  onKeyDown={(event) => handleOptionKeyDown(event, opt)}
+                  className={`w-full px-4 py-2 text-left text-sm cursor-pointer hover:bg-indigo-50 dark:hover:bg-gray-700 focus:bg-indigo-50 dark:focus:bg-gray-700 focus:outline-none text-gray-700 dark:text-gray-100 ${
+                    value === opt
+                      ? "font-semibold bg-indigo-100 dark:bg-indigo-900"
+                      : ""
+                  }`}
+                >
+                  {opt}
+                </button>
               </li>
             ))}
           </motion.ul>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1941

## Rationale for this change

The shared dropdown used a clickable `div` trigger and clickable list items, which made the component less accessible for keyboard and assistive-technology users.

## What changes are included in this PR?

- Replaced the dropdown trigger with a native button
- Added ARIA attributes for expanded state and listbox relationship
- Added listbox and option semantics
- Added keyboard support for Enter, Space, and Escape
- Preserved the existing component API and visual styling

## Are these changes tested?

I reviewed the updated dropdown markup and ran `git diff --check`. A full local build was not run because dependencies are not installed in this checkout.

## Are there any user-facing changes?

Yes. The shared dropdown is now easier to operate with a keyboard while keeping the existing visual design.

> Hey maintainers, I made this contribution under GSSoC26!