### PR TITLE
fix: resolve hackathon filter state handling

### DIFF
--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -11,15 +11,18 @@ import {
   ShareIcon,
 } from "@heroicons/react/24/outline";
 
-import { addHackathonToGoogleCalendar } from "../../utils/calendarUtils";
 import ShareMenu from "../../components/common/ShareMenu";
+import { addHackathonToGoogleCalendar } from "../../utils/calendarUtils";
 import { generateEventSharingData } from "../../utils/shareUtils";
 
-// ─── Countdown Hook ───────────────────────────────────────────────────────────
 const useCountdown = (targetDate) => {
   const calculateTimeLeft = useCallback(() => {
     const difference = new Date(targetDate) - new Date();
-    if (difference <= 0) return null;
+
+    if (!targetDate || difference <= 0) {
+      return null;
+    }
+
     return {
       days: Math.floor(difference / (1000 * 60 * 60 * 24)),
       hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
@@ -28,24 +31,26 @@ const useCountdown = (targetDate) => {
   }, [targetDate]);
 
   const [timeLeft, setTimeLeft] = useState(calculateTimeLeft());
+
   useEffect(() => {
+    setTimeLeft(calculateTimeLeft());
+
     const timer = setInterval(() => {
       setTimeLeft(calculateTimeLeft());
     }, 1000);
-    const timer = setInterval(() => setTimeLeft(calculateTimeLeft()), 1000);
+
     return () => clearInterval(timer);
   }, [calculateTimeLeft]);
 
   return timeLeft;
 };
 
-// ─── Countdown Timer ──────────────────────────────────────────────────────────
 const CountdownTimer = ({ targetDate, label }) => {
   const timeLeft = useCountdown(targetDate);
 
   if (!timeLeft) {
     return (
-      <span className="text-red-500 font-semibold text-xs tracking-wide">
+      <span className="text-xs font-semibold text-red-500 dark:text-red-400">
         Deadline passed
       </span>
     );
@@ -55,105 +60,91 @@ const CountdownTimer = ({ targetDate, label }) => {
 
   return (
     <div
-      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md border ${
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${
         isUrgent
-          ? "bg-red-50 dark:bg-red-950/20 border-red-100 dark:border-red-900/30 text-red-600 dark:text-red-400"
-          : "bg-blue-50 dark:bg-blue-950/20 border-blue-100 dark:border-blue-900/30 text-blue-600 dark:text-blue-400"
+          ? "border-red-200 bg-red-50 text-red-600 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400"
+          : "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-300"
       }`}
     >
-      <ClockIcon className={`w-3.5 h-3.5 shrink-0 ${isUrgent ? "animate-pulse" : ""}`} />
-      <span className="text-[11px] font-medium opacity-80">{label}:</span>
-      <div className="flex items-center gap-0.5 font-mono text-[11px] font-bold">
-        {timeLeft.days > 0 && <span>{timeLeft.days}d</span>}
-        <span>{String(timeLeft.hours).padStart(2, "0")}h</span>
-        <span>{String(timeLeft.minutes).padStart(2, "0")}m</span>
-    return <span className="text-red-500 dark:text-red-400 font-semibold text-xs">Deadline passed</span>;
-  }
-
-  const isUrgent = timeLeft.days < 3;
-  const isVerySoon = timeLeft.days === 0;
-  const chipClass = isUrgent
-    ? "bg-red-50 border-red-200 text-red-600 dark:bg-red-500/20 dark:text-red-400 dark:border-red-500/30 border"
-    : "bg-indigo-50 border-indigo-200 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-300 dark:border-indigo-500/30 border";
-
-  return (
-    <div className={`flex items-center gap-2 ${isUrgent ? "text-red-500 dark:text-red-400" : "text-indigo-600 dark:text-indigo-400"}`}>
-      <ClockIcon className={`w-4 h-4 flex-shrink-0 ${isUrgent ? "animate-pulse" : ""}`} />
-      <span className="text-xs font-medium text-slate-500 dark:text-slate-400">{label}:</span>
-      <div className="flex items-center gap-1 font-mono text-xs font-bold">
-        {timeLeft.days > 0 && (
-          <span className={`px-1.5 py-0.5 rounded ${chipClass}`}>{timeLeft.days}d</span>
-        )}
-        <span className={`px-1.5 py-0.5 rounded ${chipClass}`}>
-          {String(timeLeft.hours).padStart(2, "0")}h
-        </span>
-        <span className={`px-1.5 py-0.5 rounded ${chipClass}`}>
-          {String(timeLeft.minutes).padStart(2, "0")}m
-        </span>
-        {isVerySoon && (
-          <span className="px-1.5 py-0.5 rounded bg-red-50 border-red-200 text-red-600 dark:bg-red-500/20 dark:text-red-400 dark:border-red-500/30 border">
-            {String(timeLeft.seconds).padStart(2, "0")}s
-          </span>
-        )}
-      </div>
+      <ClockIcon className={`h-3.5 w-3.5 ${isUrgent ? "animate-pulse" : ""}`} />
+      <span>{label}</span>
+      <span className="font-mono">
+        {timeLeft.days > 0 ? `${timeLeft.days}d ` : ""}
+        {String(timeLeft.hours).padStart(2, "0")}h{" "}
+        {String(timeLeft.minutes).padStart(2, "0")}m
+      </span>
     </div>
   );
 };
 
-// ─── Urgency Badge ────────────────────────────────────────────────────────────
 const UrgencyBadge = ({ startDate, endDate, status }) => {
   const timeLeft = useCountdown(status === "upcoming" ? startDate : endDate);
-  if (status === "completed" || !timeLeft) return null;
 
-  if (timeLeft.days < 1) {
-    return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded bg-red-500 text-white text-[10px] font-bold uppercase tracking-wider animate-pulse">
-        🔥 Closing Today
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-red-50 border-red-200 text-red-600 dark:bg-red-500/20 dark:text-red-400 dark:border-red-500/40 border text-xs font-bold animate-pulse">
-        🔥 Closing Today!
-      </span>
-    );
+  if (status === "completed" || !timeLeft || timeLeft.days >= 3) {
+    return null;
   }
-  if (timeLeft.days < 3) {
-    return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded bg-amber-500 text-white text-[10px] font-bold uppercase tracking-wider">
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-orange-50 border-orange-200 text-orange-600 dark:bg-orange-500/20 dark:text-orange-400 dark:border-orange-500/40 border text-xs font-bold">
-        ⚡ Closing Soon
-      </span>
-    );
-  }
-  return null;
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+        timeLeft.days < 1
+          ? "border-red-200 bg-red-50 text-red-600 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-400"
+          : "border-orange-200 bg-orange-50 text-orange-600 dark:border-orange-500/40 dark:bg-orange-500/10 dark:text-orange-400"
+      }`}
+    >
+      {timeLeft.days < 1 ? "Closing today" : "Closing soon"}
+    </span>
+  );
 };
 
-// ─── Status helpers ───────────────────────────────────────────────────────────
 const computeStatus = (startDate, endDate) => {
   const now = new Date();
   const start = new Date(startDate);
   const end = new Date(endDate);
-  if (end < now) return "completed";
-  if (start <= now && now <= end) return "live";
+
+  if (end < now) {
+    return "completed";
+  }
+
+  if (start <= now && now <= end) {
+    return "live";
+  }
+
   return "upcoming";
 };
 
 const statusStyles = {
   live: {
-    badge: "bg-red-50 border-red-200 text-red-700 dark:bg-red-500/20 dark:text-red-400 dark:border-red-500/40 border",
+    badge:
+      "border-red-200 bg-red-50 text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-400",
     dot: "bg-red-500 animate-pulse",
     topBar: "from-red-500 via-orange-500 to-red-500",
   },
   upcoming: {
-    badge: "bg-blue-50 border-blue-200 text-blue-700 dark:bg-blue-500/20 dark:text-blue-400 dark:border-blue-500/40 border",
+    badge:
+      "border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-400",
     dot: "bg-blue-500",
     topBar: "from-blue-500 via-indigo-500 to-violet-500",
   },
   completed: {
-    badge: "bg-emerald-50 border-emerald-200 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-400 dark:border-emerald-500/40 border",
+    badge:
+      "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-400",
     dot: "bg-emerald-500",
     topBar: "from-emerald-500 via-teal-500 to-emerald-500",
   },
 };
 
-// ─── Main Card ────────────────────────────────────────────────────────────────
+const formatDateRange = (startDate, endDate) => {
+  const dateOptions = { month: "short", day: "numeric" };
+  const start = new Date(startDate).toLocaleDateString("en-US", dateOptions);
+  const end = new Date(endDate).toLocaleDateString("en-US", {
+    ...dateOptions,
+    year: "numeric",
+  });
+
+  return `${start} - ${end}`;
+};
+
 const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
   const navigate = useNavigate();
   const normalizedHackathon = {
@@ -164,406 +155,171 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
     organizer: hackathon?.organizer || "Eventra Community",
     location: hackathon?.location || "Location TBA",
     prize: hackathon?.prize || "Prize TBA",
-    techStack: Array.isArray(hackathon?.techStack) && hackathon.techStack.length > 0 ? hackathon.techStack : ["General"],
+    techStack:
+      Array.isArray(hackathon?.techStack) && hackathon.techStack.length > 0
+        ? hackathon.techStack
+        : ["General"],
     participants: hackathon?.participants ?? 0,
     teams: hackathon?.teams ?? 0,
     submissions: hackathon?.submissions ?? 0,
     winner: hackathon?.winner || "",
   };
 
-  const status = computeStatus(normalizedHackathon.startDate, normalizedHackathon.endDate);
-    techStack:
-      Array.isArray(hackathon?.techStack) && hackathon.techStack.length > 0
-        ? hackathon.techStack
-        : ["General"],
-    rules:
-      Array.isArray(hackathon?.rules) && hackathon.rules.length > 0
-        ? hackathon.rules
-        : ["Rules will be shared before the hackathon starts."],
-  };
-
-  // FIX 3: Use computed status everywhere instead of hackathon.status
-
-  const status = computeStatus(hackathon.startDate, hackathon.endDate);
-  const style = statusStyles[status];
-  const safeTechStack = hackathon?.techStack || [];
-  const safeRules = hackathon?.rules || [];
-  
-  const stats = {
-    participants: normalizedHackathon.participants,
-    teams: normalizedHackathon.teams,
-    submissions: normalizedHackathon.submissions,
-  };
-
-  const hackathonSharingData = generateEventSharingData({
+  const status =
+    normalizedHackathon.startDate && normalizedHackathon.endDate
+      ? computeStatus(normalizedHackathon.startDate, normalizedHackathon.endDate)
+      : normalizedHackathon.status || "upcoming";
+  const style = statusStyles[status] || statusStyles.upcoming;
+  const sharingData = generateEventSharingData({
     ...normalizedHackathon,
-    title: normalizedHackathon.title,
-    description: normalizedHackathon.description,
     date: normalizedHackathon.startDate,
-    id: normalizedHackathon.id,
   });
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 15 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3 }}
-      viewport={{ once: true, amount: 0.1 }}
-      whileHover={{ y: -4 }}
-      className={`
-        w-full max-w-sm h-full
-        bg-white dark:bg-gray-900
-        rounded-xl shadow-sm hover:shadow-md
-        transition-all duration-200
-        border border-gray-200/80 dark:border-gray-800
-        relative flex flex-col overflow-hidden
-        ${isFeatured ? "ring-2 ring-blue-500 dark:ring-blue-400" : ""}
-      `}
+      initial={{ opacity: 0, y: 50, scale: 0.95 }}
+      whileInView={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.45, ease: "easeOut" }}
+      viewport={{ once: true, amount: 0.2 }}
+      whileHover={{ y: -5, scale: 1.01 }}
+      className={`relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all duration-300 hover:border-indigo-300 hover:shadow-md dark:border-white/10 dark:bg-slate-900 dark:shadow-[0_4px_24px_rgba(0,0,0,0.35)] ${
+        isFeatured ? "ring-2 ring-indigo-400/50 dark:ring-indigo-500/40" : ""
+      }`}
       {...props}
     >
-      {/* Structural Accent Top line */}
-      <div className={`h-1 w-full ${
-        status === 'live' ? 'bg-red-500' : status === 'upcoming' ? 'bg-blue-500' : 'bg-emerald-500'
-      }`} />
+      <div className={`h-[3px] w-full bg-gradient-to-r ${style.topBar}`} />
 
-      {/* Main Container */}
-      <div className="p-5 flex flex-col flex-1 gap-4">
-        
-        {/* Top Badges Header row */}
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-1.5">
-            <span className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider ${
-              status === "live" ? "bg-red-50 text-red-700 dark:bg-red-950/40 dark:text-red-400" :
-              status === "upcoming" ? "bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-400" :
-              "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400"
-            }`}>
-              {status}
+      <div className="flex flex-1 flex-col gap-4 p-5">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${style.badge}`}
+            >
+              <span className={`h-1.5 w-1.5 rounded-full ${style.dot}`} />
+              {status.charAt(0).toUpperCase() + status.slice(1)}
             </span>
-            <span className="px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 text-[10px] font-bold uppercase tracking-wider">
+            <span className="rounded-full border border-slate-200 bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700 dark:border-white/10 dark:bg-slate-700/60 dark:text-slate-300">
               {normalizedHackathon.difficulty}
             </span>
-            <UrgencyBadge startDate={normalizedHackathon.startDate} endDate={normalizedHackathon.endDate} status={status} />
+            <UrgencyBadge
+              startDate={normalizedHackathon.startDate}
+              endDate={normalizedHackathon.endDate}
+              status={status}
+            />
           </div>
 
-          <ShareMenu shareData={hackathonSharingData} position="bottom-right">
-            <button className="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
-              <ShareIcon className="w-4 h-4 text-gray-400 hover:text-gray-600" />
+          <ShareMenu shareData={sharingData} position="bottom-right">
+            <button
+              type="button"
+              className="rounded-full border border-slate-200 bg-slate-50 p-2 transition-all hover:bg-slate-100 dark:border-white/10 dark:bg-white/5 dark:hover:bg-white/10"
+              aria-label={`Share ${normalizedHackathon.title}`}
+            >
+              <ShareIcon className="h-3.5 w-3.5 text-slate-500 dark:text-slate-400" />
             </button>
           </ShareMenu>
         </div>
 
-        {/* Title & Creator Core Space */}
-        <div>
-          <h3 className="text-lg font-bold text-gray-900 dark:text-white line-clamp-1 mb-0.5">
-            {normalizedHackathon.title}
-          </h3>
-          <div className="flex items-center text-gray-500 dark:text-gray-400 text-xs gap-1">
-            <BuildingLibraryIcon className="w-3.5 h-3.5 shrink-0 text-gray-400" />
-            <span className="truncate font-medium">{normalizedHackathon.organizer}</span>
-          </div>
-        </div>
-
-        {/* Primary High-Priority Data Split View Block */}
-        <div className="grid grid-cols-2 gap-2 bg-gray-50 dark:bg-gray-800/40 p-2.5 rounded-lg border border-gray-100 dark:border-gray-800/60">
-          <div>
-            <div className="text-[10px] uppercase font-bold tracking-wider text-gray-400 dark:text-gray-500 mb-0.5">Prize Pool</div>
-            <div className="text-sm font-extrabold text-gray-900 dark:text-white truncate">
-              {normalizedHackathon.prize}
-            </div>
-
-      initial={{ opacity: 0, y: 50, scale: 0.95 }}
-      whileInView={{ opacity: 1, y: 0, scale: 1 }}
-      transition={{ duration: 0.55, ease: "easeOut" }}
-      viewport={{ once: true, amount: 0.2 }}
-      whileHover={{ y: -5, scale: 1.015 }}
-      className={`
-        h-full relative flex flex-col
-        rounded-2xl
-        border border-slate-200 dark:border-white/10
-        bg-white dark:bg-slate-900
-        shadow-sm hover:shadow-md dark:shadow-[0_4px_24px_rgba(0,0,0,0.4)]
-        dark:hover:shadow-[0_8px_40px_rgba(99,102,241,0.18)]
-        hover:border-indigo-300 dark:hover:border-indigo-500/30
-        transition-all duration-300
-        ${isFeatured ? "ring-2 ring-indigo-400/50 dark:ring-indigo-500/40" : ""}
-      `}
-      {...props}
-    >
-      {/* ── Gradient top border line (no overflow-hidden needed) ── */}
-      <div
-        className={`rounded-t-2xl h-[3px] w-full bg-gradient-to-r flex-shrink-0 ${style.topBar}`}
-      />
-
-      {/* ── Main Content ────────────────────────────────────────── */}
-      <div className="p-5 flex flex-col gap-4 flex-1">
-
-        {/* ── ROW 1: Status + Featured badge + Share ── */}
-        <div className="flex items-start justify-between gap-2">
-          {/* Left: status badges */}
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold ${style.badge}`}>
-              <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${style.dot}`} />
-              {status.charAt(0).toUpperCase() + status.slice(1)}
-            </span>
-
-            <span className="px-2.5 py-1 rounded-full bg-slate-100 dark:bg-slate-700/60 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-white/10 text-xs font-medium">
-              {normalizedHackathon.difficulty}
-            </span>
-
-            <UrgencyBadge startDate={normalizedHackathon.startDate} endDate={normalizedHackathon.endDate} status={status} />
-          </div>
-
-          {/* Right: Share button only */}
-          <ShareMenu
-            shareData={hackathonSharingData}
-            position="bottom-right"
-            menuClassName="!z-[999] shadow-2xl"
-          >
-            <motion.div
-              className="flex-shrink-0 bg-slate-50 dark:bg-white/5 rounded-full p-2 cursor-pointer hover:bg-slate-100 dark:hover:bg-white/10 border border-slate-200 dark:border-white/10 transition-all"
-              whileHover={{ scale: 1.1 }}
-              transition={{ type: "spring", stiffness: 400, damping: 10 }}
-            >
-              <ShareIcon className="w-3.5 h-3.5 text-slate-500 dark:text-slate-400" />
-            </motion.div>
-          </ShareMenu>
-        </div>
-
-        {/* ── ROW 2: Featured badge (full-width, only shown if featured) ── */}
         {isFeatured && (
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 bg-gradient-to-r from-indigo-50 to-violet-50 dark:from-indigo-600/30 dark:to-violet-600/30 border border-indigo-200 dark:border-indigo-500/40 text-indigo-700 dark:text-indigo-300 text-[10px] font-bold uppercase tracking-wider px-3 py-1 rounded-full">
-              ✦ Featured
-            </span>
-          </div>
+          <span className="w-fit rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-[10px] font-bold uppercase tracking-wider text-indigo-700 dark:border-indigo-500/40 dark:bg-indigo-600/20 dark:text-indigo-300">
+            Featured
+          </span>
         )}
 
-        {/* ── ROW 3: Prize chip ── */}
-        <div className="flex items-center">
-          <span className="inline-flex items-center gap-1.5 bg-amber-50 border border-amber-200 text-amber-700 dark:bg-amber-500/10 dark:border-amber-500/30 dark:text-amber-300 text-xs font-bold px-3 py-1.5 rounded-full">
-            🏆 {normalizedHackathon.prize}
-          </span>
-        </div>
+        <span className="w-fit rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-bold text-amber-700 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300">
+          Prize: {normalizedHackathon.prize}
+        </span>
 
         <div className="border-t border-slate-100 dark:border-white/5" />
 
-        {/* ── Title + Description ── */}
         <div className="min-h-[72px]">
-          <h3 className="text-base font-bold text-slate-900 dark:text-white mb-1.5 leading-snug">
+          <h3 className="mb-1.5 text-base font-bold leading-snug text-slate-900 dark:text-white">
             {normalizedHackathon.title}
           </h3>
-          <p className="text-slate-600 dark:text-slate-400 text-sm line-clamp-2 leading-relaxed">
+          <p className="line-clamp-2 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
             {normalizedHackathon.description}
           </p>
         </div>
 
-        <div className="border-t border-slate-100 dark:border-white/5" />
-
-        {/* ── Organizer ── */}
-        <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400 text-sm">
-          <BuildingLibraryIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 flex-shrink-0" />
-          <span className="truncate">{normalizedHackathon.organizer}</span>
-        </div>
-
-        <div className="border-t border-slate-100 dark:border-white/5" />
-
-        {/* ── Date, Location, Countdown ── */}
-        <div className="flex flex-col gap-2.5 text-slate-600 dark:text-slate-400 text-sm">
+        <div className="space-y-2.5 text-sm text-slate-600 dark:text-slate-400">
           <div className="flex items-center gap-2">
-            <CalendarIcon className="w-4 h-4 text-sky-500 dark:text-sky-400 flex-shrink-0" />
+            <BuildingLibraryIcon className="h-4 w-4 flex-shrink-0 text-indigo-600 dark:text-indigo-400" />
+            <span className="truncate">{normalizedHackathon.organizer}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <CalendarIcon className="h-4 w-4 flex-shrink-0 text-sky-500 dark:text-sky-400" />
             <span>
-              {new Date(normalizedHackathon.startDate).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-              })}
-              {" – "}
-              {new Date(normalizedHackathon.endDate).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })}
+              {normalizedHackathon.startDate && normalizedHackathon.endDate
+                ? formatDateRange(
+                    normalizedHackathon.startDate,
+                    normalizedHackathon.endDate,
+                  )
+                : "Dates TBA"}
             </span>
           </div>
-          <div className="border-l border-gray-200 dark:border-gray-700 pl-3">
-            <div className="text-[10px] uppercase font-bold tracking-wider text-gray-400 dark:text-gray-500 mb-0.5">Format</div>
-            <div className="flex items-center gap-1 text-sm font-bold text-gray-800 dark:text-gray-200">
-              <MapPinIcon className="w-3.5 h-3.5 text-emerald-500 shrink-0" />
-              <span className="truncate">{normalizedHackathon.location}</span>
-            </div>
+          <div className="flex items-center gap-2">
+            <MapPinIcon className="h-4 w-4 flex-shrink-0 text-emerald-500 dark:text-emerald-400" />
+            <span className="truncate">{normalizedHackathon.location}</span>
           </div>
         </div>
 
-        {/* Description Text */}
-        <p className="text-gray-600 dark:text-gray-400 text-xs leading-relaxed line-clamp-2">
-          {normalizedHackathon.description}
-        </p>
+        {status === "upcoming" && normalizedHackathon.startDate && (
+          <CountdownTimer targetDate={normalizedHackathon.startDate} label="Starts in" />
+        )}
+        {status === "live" && normalizedHackathon.endDate && (
+          <CountdownTimer targetDate={normalizedHackathon.endDate} label="Ends in" />
+        )}
 
-        {/* Timeline Row Group */}
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pt-1 border-t border-gray-100 dark:border-gray-800/60">
-          <div className="flex items-center gap-1.5 text-xs font-semibold text-gray-600 dark:text-gray-400">
-            <CalendarIcon className="w-4 h-4 text-gray-400 shrink-0" />
-            <span>
-              {new Date(hackathon.startDate).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-              {" - "}
-              {new Date(hackathon.endDate).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
-            </span>
-          </div>
-
-          {status === "upcoming" && hackathon.startDate && (
-            <CountdownTimer targetDate={hackathon.startDate} label="Starts in" />
-          )}
-          {status === "live" && hackathon.endDate && (
-            <CountdownTimer targetDate={hackathon.endDate} label="Ends in" />
-          )}
-        </div>
-
-        {/* Minimal Stack Badge Tags */}
-        <div className="flex flex-wrap gap-1">
-          {(hackathon.techStack || []).slice(0, 3).map((tech, index) => (
-            <span key={index} className="px-2 py-0.5 bg-gray-50/50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 text-gray-500 dark:text-gray-400 text-[10px] font-medium rounded">
+        <div className="flex flex-wrap gap-2">
+          {normalizedHackathon.techStack.slice(0, 4).map((tech) => (
+            <span
+              key={tech}
+              className="rounded-full border border-indigo-200 bg-indigo-50 px-2.5 py-0.5 text-xs font-medium text-indigo-700 dark:border-indigo-500/20 dark:bg-indigo-500/10 dark:text-indigo-300"
+            >
               {tech}
             </span>
           ))}
-          {(hackathon.techStack || []).length > 3 && (
-            <span className="px-1.5 py-0.5 text-gray-400 text-[10px] font-medium">
-              +{hackathon.techStack.length - 3}
+          {normalizedHackathon.techStack.length > 4 && (
+            <span className="px-1.5 py-0.5 text-xs font-medium text-slate-400">
+              +{normalizedHackathon.techStack.length - 4}
             </span>
           )}
         </div>
 
-        {/* Engagement Stats Stripe */}
-        <div className="flex items-center justify-between py-2 px-1 bg-gray-50/40 dark:bg-gray-800/20 rounded-md border border-gray-100/40 dark:border-gray-800/30 text-center">
-          <div className="flex-1">
-            <div className="text-xs font-bold text-gray-800 dark:text-gray-200">{normalizedHackathon.participants || "0"}</div>
-            <div className="text-[9px] text-gray-400 uppercase font-bold tracking-wider">Joiners</div>
-          </div>
-          <div className="w-px h-6 bg-gray-200 dark:bg-gray-800" />
-          <div className="flex-1">
-            <div className="text-xs font-bold text-gray-800 dark:text-gray-200">{normalizedHackathon.teams || "0"}</div>
-            <div className="text-[9px] text-gray-400 uppercase font-bold tracking-wider">Teams</div>
-          </div>
-          <div className="w-px h-6 bg-gray-200 dark:bg-gray-800" />
-          <div className="flex-1">
-            <div className="text-xs font-bold text-gray-800 dark:text-gray-200">{normalizedHackathon.submissions || "0"}</div>
-            <div className="text-[9px] text-gray-400 uppercase font-bold tracking-wider">Builds</div>
-          </div>
-        </div>
-
-        {/* Completed Winner Banner */}
-        {status === "completed" && (
-          <div className="flex items-center gap-1.5 bg-amber-50/40 dark:bg-amber-950/10 px-2.5 py-1.5 rounded-lg border border-amber-100/50 dark:border-amber-900/30 text-xs">
-            <TrophyIcon className="w-3.5 h-3.5 text-amber-500 shrink-0" />
-            <span className="font-bold text-amber-800 dark:text-amber-400">Winner:</span>
-            <span className="text-gray-600 dark:text-gray-300 truncate font-medium">{normalizedHackathon.winner || "TBA"}</span>
-          </div>
-        )}
-
-        {/* Smart Button/Action Area */}
-        <div className="mt-auto pt-1">
-          {status === "live" ? (
-            <div className="flex items-center gap-2">
-              <button className="flex-1 py-2 bg-blue-600 hover:bg-blue-700 text-white text-xs font-bold rounded-lg transition-colors">
-                Join Now
-              </button>
-              <button className="px-3 py-2 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 text-xs font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">
-          <div className="flex items-center gap-2">
-            <MapPinIcon className="w-4 h-4 text-emerald-500 dark:text-emerald-400 flex-shrink-0" />
-            <span>{normalizedHackathon.location}</span>
-          </div>
-
-          {status === "upcoming" && normalizedHackathon.startDate && (
-            <CountdownTimer targetDate={normalizedHackathon.startDate} label="Starts in" />
-          )}
-          {status === "live" && normalizedHackathon.endDate && (
-            <CountdownTimer targetDate={normalizedHackathon.endDate} label="Ends in" />
-          )}
-        </div>
-
-        <div className="border-t border-slate-100 dark:border-white/5" />
-
-        {/* ── Tech Stack ── */}
-        <div>
-          <h4 className="text-[10px] font-bold uppercase tracking-widest text-slate-500 mb-2">
-            Tech Stack
-          </h4>
-
-          <div className="flex flex-wrap gap-2">
-
-            {safeTechStack.map((tech, index) => (
-              <span
-                key={index}
-                className="px-2.5 py-0.5 rounded-full bg-indigo-50 border border-indigo-200 text-indigo-700 dark:bg-indigo-500/10 dark:border-indigo-500/20 dark:text-indigo-300 text-xs font-medium"
-              >
-                {tech}
-              </span>
-            ))}
-          </div>
-        </div>
-
-        <div className="border-t border-slate-100 dark:border-white/5" />
-
-        {/* ── Rules ── */}
-        <div>
-          <h4 className="text-[10px] font-bold uppercase tracking-widest text-slate-500 mb-2 flex items-center gap-1.5">
-            <DocumentTextIcon className="w-3.5 h-3.5 text-blue-500 dark:text-blue-400" />
-            Rules
-          </h4>
-
-          <ul className="list-disc list-inside text-xs line-clamp-3 min-h-[60px]">
-          
-            {safeRules.map((rule, index) => (
-
-              <li key={index}>{rule}</li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="border-t border-slate-100 dark:border-white/5" />
-
-        {/* ── Stats Row ── */}
-        <div className="grid grid-cols-3 gap-2 rounded-xl bg-slate-50 border border-slate-100 dark:bg-white/5 dark:border-white/10 p-3">
+        <div className="grid grid-cols-3 gap-2 rounded-xl border border-slate-100 bg-slate-50 p-3 text-center dark:border-white/10 dark:bg-white/5">
           {[
-            { icon: UserGroupIcon, value: stats.participants, label: "Participants", color: "text-rose-500 dark:text-rose-400" },
-            { icon: UserGroupIcon, value: stats.teams, label: "Teams", color: "text-emerald-500 dark:text-emerald-400" },
-            { icon: UserGroupIcon, value: stats.submissions, label: "Submissions", color: "text-blue-600 dark:text-blue-400" },
-          ].map(({ icon: Icon, value, label, color }) => (
-            <div key={label} className="text-center">
-              <Icon className={`w-4 h-4 ${color} mx-auto mb-1`} />
-              <div className={`text-base font-bold ${color}`}>{value || "–"}</div>
-              <div className="text-[10px] text-slate-500 font-medium">{label}</div>
+            { value: normalizedHackathon.participants, label: "Participants" },
+            { value: normalizedHackathon.teams, label: "Teams" },
+            { value: normalizedHackathon.submissions, label: "Submissions" },
+          ].map(({ value, label }) => (
+            <div key={label}>
+              <UserGroupIcon className="mx-auto mb-1 h-4 w-4 text-indigo-500" />
+              <div className="text-base font-bold text-slate-900 dark:text-slate-100">
+                {value || 0}
+              </div>
+              <div className="text-[10px] font-medium text-slate-500">{label}</div>
             </div>
           ))}
         </div>
 
-        <div className="border-t border-slate-100 dark:border-white/5" />
+        {status === "completed" && (
+          <div className="flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs dark:border-amber-500/20 dark:bg-amber-500/10">
+            <TrophyIcon className="h-4 w-4 flex-shrink-0 text-amber-500" />
+            <span className="font-semibold text-slate-600 dark:text-slate-400">
+              Winner:
+            </span>
+            <span className="truncate text-slate-700 dark:text-slate-300">
+              {normalizedHackathon.winner || "Announced soon"}
+            </span>
+          </div>
+        )}
 
-        {/* ── Winner ── */}
-        <div className="flex items-center gap-2 bg-amber-50 border border-amber-200 dark:bg-amber-500/10 dark:border-amber-500/20 p-3 rounded-xl">
-          <TrophyIcon className="w-4 h-4 text-amber-500 dark:text-amber-400 flex-shrink-0" />
-          <span className="text-xs font-semibold text-slate-600 dark:text-slate-400">Winner:</span>
-          <span className="text-xs text-slate-700 dark:text-slate-300 truncate">
-            {status === "completed" && normalizedHackathon.winner ? normalizedHackathon.winner : "Announced soon"}
-          </span>
-        </div>
-
-        {/* ── Action Buttons ── */}
-        <div className="mt-auto pt-1">
-          {status === "live" ? (
-            <div className="grid grid-cols-2 gap-3">
-              <button className="px-4 py-2.5 bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 text-white text-sm font-semibold rounded-xl shadow-md hover:shadow-lg dark:shadow-[0_0_16px_rgba(99,102,241,0.3)] dark:hover:shadow-[0_0_24px_rgba(99,102,241,0.5)] transition-all">
-                Join Now
-              </button>
-              <button className="px-4 py-2.5 bg-white border border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-indigo-300 hover:text-indigo-700 shadow-sm dark:bg-white/5 dark:hover:bg-white/10 dark:border-white/10 dark:text-slate-300 dark:hover:text-white dark:shadow-none text-sm font-semibold rounded-xl transition-all">
-              Submit
-              </button>
-            </div>
-          ) : status === "upcoming" ? (
-            <div className="flex items-center gap-2">
+        <div className="mt-auto grid grid-cols-2 gap-3 pt-1">
+          {status === "upcoming" ? (
+            <>
               <button
-                onClick={() => navigate(`/register/${hackathon.id}`)}
-                className="flex-1 py-2 bg-gray-900 hover:bg-black dark:bg-gray-100 dark:hover:bg-white dark:text-gray-900 text-white text-xs font-bold rounded-lg transition-colors"
+                type="button"
                 onClick={() => navigate(`/register/${normalizedHackathon.id}`)}
-                className="px-4 py-2.5 bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 text-white text-sm font-semibold rounded-xl shadow-md hover:shadow-lg dark:shadow-[0_0_16px_rgba(99,102,241,0.3)] dark:hover:shadow-[0_0_24px_rgba(99,102,241,0.5)] transition-all"
+                className="rounded-xl bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
               >
                 Register
               </button>
@@ -571,34 +327,28 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
                 href={addHackathonToGoogleCalendar(normalizedHackathon)}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-2.5 py-2 border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 text-xs rounded-lg text-center hover:bg-gray-50 dark:hover:bg-gray-800"
+                className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-center text-sm font-semibold text-slate-700 shadow-sm transition-all hover:border-indigo-300 hover:bg-slate-50 hover:text-indigo-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
               >
-                Remind Me
+                Reminder
               </a>
-            </div>
+            </>
           ) : (
-            <button className="w-full py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200 text-xs font-bold rounded-lg transition-colors">
-              View Results
-            </button>
-                className="block"
+            <>
+              <button
+                type="button"
+                className="rounded-xl bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
               >
-                <button className="w-full px-4 py-2.5 bg-white border border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-indigo-300 hover:text-indigo-700 shadow-sm dark:bg-white/5 dark:hover:bg-white/10 dark:border-white/10 dark:text-slate-300 dark:hover:text-white dark:shadow-none text-sm font-semibold rounded-xl transition-all">
-                  Reminder
-                </button>
-              </a>
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 gap-3">
-              <button className="px-4 py-2.5 bg-gradient-to-r from-emerald-600 to-teal-600 text-white text-sm font-semibold rounded-xl shadow-md hover:shadow-lg dark:shadow-[0_0_16px_rgba(16,185,129,0.2)] dark:hover:shadow-[0_0_24px_rgba(16,185,129,0.4)] transition-all">
-                View Results
+                {status === "live" ? "Join Now" : "View Results"}
               </button>
-              <button className="px-4 py-2.5 bg-white border border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-indigo-300 hover:text-indigo-700 shadow-sm dark:bg-white/5 dark:hover:bg-white/10 dark:border-white/10 dark:text-slate-300 dark:hover:text-white dark:shadow-none text-sm font-semibold rounded-xl transition-all">
-                Resources
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition-all hover:border-indigo-300 hover:bg-slate-50 hover:text-indigo-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-white"
+              >
+                {status === "live" ? "Submit" : "Resources"}
               </button>
-            </div>
+            </>
           )}
         </div>
-
       </div>
     </motion.div>
   );

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -8,10 +8,10 @@ import { FiCode, FiRotateCw, FiCompass, FiChevronDown, FiX } from "react-icons/f
 import HackathonCTA from "./HackathonCTA";
 import Fuse from "fuse.js";
 import { createPortal } from "react-dom";
-import { HackathonCardSkeleton } from "../../components/common/SkeletonLoaders";
 import BackToTopButton from "../../components/common/BackToTopButton";
 import PageLoader from "../../components/common/PageLoader";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
+import { filterHackathons } from "./hackathonFilterUtils.mjs";
 
 // NEW: Tag component for selected tags in search bar
 const Tag = ({ tag, onRemove }) => (
@@ -153,39 +153,11 @@ const HackathonHub = () => {
     ? fuse.search(searchQuery).map((result) => result.item)
     : hackathons;
 
-  // UPDATED: Filter hackathons based on selected tags
-  const filteredHackathons = searchedHackathons
-    .filter((hackathon) => {
-      if (activeTab === "all") return true;
-      return hackathon.status === activeTab;
-    })
-    .filter((hackathon) => {
-      if (filters.difficulty && hackathon.difficulty !== filters.difficulty) {
-        return false;
-      }
-      if (
-        filters.prize &&
-        !hackathon.prize.toLowerCase().includes(filters.prize.toLowerCase())
-      ) {
-        return false;
-      }
-      if (
-        filters.location &&
-        !hackathon.location
-          .toLowerCase()
-          .includes(filters.location.toLowerCase())
-      ) {
-        return false;
-      }
-
-      // NEW: Filter by selected tags
-      if (selectedTags.length > 0) {
-        const hackathonTags = hackathon.techStack || [];
-        return selectedTags.some((tag) => hackathonTags.includes(tag));
-      }
-
-      return true;
-    });
+  const filteredHackathons = filterHackathons(searchedHackathons, {
+    activeTab,
+    filters,
+    selectedTags,
+  });
 
   const featuredHackathons = [...hackathons]
     .filter((h) => h.featured)

--- a/src/Pages/Hackathons/hackathonFilterUtils.mjs
+++ b/src/Pages/Hackathons/hackathonFilterUtils.mjs
@@ -1,0 +1,81 @@
+export const normalizeFilterValue = (value) => {
+  if (Array.isArray(value)) {
+    return normalizeFilterValue(value[0]);
+  }
+
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value).trim();
+};
+
+const parsePrizeAmount = (prize) => {
+  const amount = Number.parseInt(String(prize || "").replace(/[^\d]/g, ""), 10);
+  return Number.isFinite(amount) ? amount : null;
+};
+
+export const matchesPrizeRange = (prize, prizeFilter) => {
+  const selectedPrize = normalizeFilterValue(prizeFilter);
+
+  if (!selectedPrize) {
+    return true;
+  }
+
+  const prizeAmount = parsePrizeAmount(prize);
+
+  if (prizeAmount === null) {
+    return false;
+  }
+
+  if (selectedPrize === "Under $1,000") {
+    return prizeAmount < 1000;
+  }
+
+  if (selectedPrize === "$1,000 - $5,000") {
+    return prizeAmount >= 1000 && prizeAmount <= 5000;
+  }
+
+  if (selectedPrize === "$5,000+") {
+    return prizeAmount >= 5000;
+  }
+
+  return String(prize || "").toLowerCase().includes(selectedPrize.toLowerCase());
+};
+
+export const filterHackathons = (
+  hackathons,
+  { activeTab = "all", filters = {}, selectedTags = [] } = {},
+) => {
+  const difficulty = normalizeFilterValue(filters.difficulty);
+  const prize = normalizeFilterValue(filters.prize);
+  const location = normalizeFilterValue(filters.location).toLowerCase();
+
+  return hackathons.filter((hackathon) => {
+    if (activeTab !== "all" && hackathon.status !== activeTab) {
+      return false;
+    }
+
+    if (difficulty && hackathon.difficulty !== difficulty) {
+      return false;
+    }
+
+    if (!matchesPrizeRange(hackathon.prize, prize)) {
+      return false;
+    }
+
+    if (
+      location &&
+      !String(hackathon.location || "").toLowerCase().includes(location)
+    ) {
+      return false;
+    }
+
+    if (selectedTags.length > 0) {
+      const hackathonTags = hackathon.techStack || [];
+      return selectedTags.some((tag) => hackathonTags.includes(tag));
+    }
+
+    return true;
+  });
+};

--- a/tests/hackathonFilterUtils.test.mjs
+++ b/tests/hackathonFilterUtils.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import {
+  filterHackathons,
+  matchesPrizeRange,
+  normalizeFilterValue,
+} from "../src/Pages/Hackathons/hackathonFilterUtils.mjs";
+
+const require = createRequire(import.meta.url);
+const hackathons = require("../src/Pages/Hackathons/hackathonMockData.json");
+
+assert.equal(normalizeFilterValue(["Advanced"]), "Advanced");
+assert.equal(normalizeFilterValue(" Beginner "), "Beginner");
+assert.equal(normalizeFilterValue([]), "");
+
+assert.equal(matchesPrizeRange("$750", "Under $1,000"), true);
+assert.equal(matchesPrizeRange("$1,000", "Under $1,000"), false);
+assert.equal(matchesPrizeRange("$1,000", "$1,000 - $5,000"), true);
+assert.equal(matchesPrizeRange("$5,000", "$1,000 - $5,000"), true);
+assert.equal(matchesPrizeRange("$50,000", "$5,000+"), true);
+assert.equal(matchesPrizeRange("Prize TBA", "$5,000+"), false);
+
+assert.deepEqual(
+  filterHackathons(hackathons, {
+    filters: { difficulty: ["Advanced"] },
+  }).map((hackathon) => hackathon.difficulty),
+  ["Advanced", "Advanced"],
+  "legacy array difficulty filters still match hackathons",
+);
+
+assert.deepEqual(
+  filterHackathons(hackathons, {
+    filters: { prize: "$5,000+" },
+  }).map((hackathon) => hackathon.title),
+  hackathons.map((hackathon) => hackathon.title),
+  "$5,000+ prize filter includes all seeded hackathons above the threshold",
+);
+
+assert.deepEqual(
+  filterHackathons(hackathons, {
+    filters: { location: ["new york"] },
+  }).map((hackathon) => hackathon.location),
+  ["New York, NY", "New York, NY"],
+  "legacy array location filters are normalized and matched case-insensitively",
+);
+
+assert.deepEqual(
+  filterHackathons(hackathons, {
+    activeTab: "live",
+    filters: {
+      difficulty: "Intermediate",
+      prize: "$5,000+",
+      location: "Los Angeles",
+    },
+    selectedTags: ["Unity"],
+  }).map((hackathon) => hackathon.title),
+  ["Virtual Reality Hackathon"],
+  "tab, dropdown, and technology filters compose correctly",
+);
+
+if (process.env.NODE_ENV === "development") {
+  console.log("hackathon filter utilities passed");
+}


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1812.

## Rationale for this change

Hackathon filters could return incorrect or empty results because filter values were not handled consistently. The dropdown state could be treated as either strings or one-item arrays, while the filtering logic expected direct string comparisons. Prize range filtering also used string matching, which caused valid hackathons like `$50,000` to be excluded when selecting `$5,000+`.

## What changes are included in this PR?

- Added reusable hackathon filter utility functions.
- Normalized filter values so both string values and legacy array values are handled safely.
- Updated difficulty, prize range, location, tab, and technology tag filtering to compose correctly.
- Added numeric prize range matching for `Under $1,000`, `$1,000 - $5,000`, and `$5,000+`.
- Added focused tests for hackathon filter behavior.
- Fixed corrupted duplicate JSX/timer logic in `HackathonCard.js` that was blocking production builds.

## Are these changes tested?

Yes.

Tested with:

```bash
node tests/hackathonFilterUtils.test.mjs
node tests/routeSearchUtils.test.mjs
node tests/eventPaginationUtils.test.mjs
npm.cmd run build