### PR TITLE
fix: disable registration for ended events

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -1,7 +1,10 @@
 import React from "react";
 import { Link, useParams } from "react-router-dom";
 import { Calendar, MapPin, Clock, Tag } from "lucide-react";
-import { getEventStatus } from "../../utils/eventUtils";
+import {
+  getEventStatus,
+  isEventRegistrationClosed,
+} from "../../utils/eventUtils";
 import { isEventBookmarked } from "../../utils/bookmarkUtils";
 import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
@@ -37,6 +40,7 @@ const EventDetails = () => {
   }
 
   const canSetReminder = isEventBookmarked(event.id) || isRegistered(event.id);
+  const isRegistrationClosed = isEventRegistrationClosed(event.status);
 
   return (
     <div className="min-h-screen bg-white dark:bg-slate-950 text-gray-900 dark:text-gray-100 py-16 px-4 sm:px-6 lg:px-8">
@@ -57,20 +61,27 @@ const EventDetails = () => {
           </div>
 
           <div className="flex flex-wrap gap-3">
-  {event.status === "past" ? (
-    <CertificateDownload
-      eventName={event.title}
-      eventDate={event.date}
-      eventType={event.type}
-    />
-  ) : (
-    <Link
-      to={`/events/${event.id}/register`}
-      className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 transition"
-    >
-      Register Now
-    </Link>
-  )}
+            {isRegistrationClosed ? (
+              <>
+                <span className="inline-flex items-center justify-center rounded-full bg-gray-200 px-6 py-3 text-sm font-semibold text-gray-600 shadow-sm cursor-not-allowed dark:bg-gray-800 dark:text-gray-300">
+                  Event Ended
+                </span>
+                {event.status === "past" && (
+                  <CertificateDownload
+                    eventName={event.title}
+                    eventDate={event.date}
+                    eventType={event.type}
+                  />
+                )}
+              </>
+            ) : (
+              <Link
+                to={`/events/${event.id}/register`}
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white shadow hover:bg-slate-800 transition"
+              >
+                Register Now
+              </Link>
+            )}
 
   {/* Copy Link Button */}
   <CopyLinkButton />

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -60,6 +60,15 @@ export const getEventStatus = (event) => {
   return explicitStatus || "upcoming";
 };
 
+export const isEventRegistrationClosed = (eventOrStatus) => {
+  const status =
+    typeof eventOrStatus === "string"
+      ? mapStatusKey(eventOrStatus)
+      : getEventStatus(eventOrStatus);
+
+  return status === "past" || status === "ended";
+};
+
 export const normalizeEvent = (event) => ({
   ...event,
   status: getEventStatus(event),

--- a/src/utils/eventUtils.test.js
+++ b/src/utils/eventUtils.test.js
@@ -1,0 +1,24 @@
+import { getEventStatus, isEventRegistrationClosed } from "./eventUtils";
+
+describe("event status utilities", () => {
+  it("closes registration for computed past events", () => {
+    const pastEvent = {
+      date: "2024-01-01",
+      time: "10:00",
+      status: "upcoming",
+    };
+
+    expect(getEventStatus(pastEvent)).toBe("past");
+    expect(isEventRegistrationClosed(pastEvent)).toBe(true);
+  });
+
+  it("closes registration for explicit ended statuses", () => {
+    expect(getEventStatus({ status: "ended", date: "2099-01-01" })).toBe("ended");
+    expect(isEventRegistrationClosed("event ended")).toBe(true);
+  });
+
+  it("keeps registration open for upcoming and live events", () => {
+    expect(isEventRegistrationClosed("upcoming")).toBe(false);
+    expect(isEventRegistrationClosed("live")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1815.

## Rationale for this change

The event details page was still showing the `Register Now` CTA for events whose computed status was `past` or explicitly `ended`. This allowed users to navigate to the registration flow for events that should no longer accept registrations.

## What changes are included in this PR?

- Added a reusable `isEventRegistrationClosed` helper in `src/utils/eventUtils.js`.
- Updated the active event details page CTA logic to use computed event status before rendering registration.
- Replaced the registration link with a disabled `Event Ended` state for `past` and `ended` events.
- Added focused tests for registration-closed behavior across computed past, explicit ended, and open statuses.

## Are these changes tested?

Yes.

- `npm.cmd test -- --watchAll=false src/utils/eventUtils.test.js`
- `npm.cmd run test:unit`
- `npx.cmd eslint src/Pages/Events/EventDetails.js src/utils/eventUtils.js src/utils/eventUtils.test.js --max-warnings=0`

Note: Full `npm.cmd run lint` is currently blocked by an unrelated upstream parse error in `src/Pages/Hackathons/HackathonCard.js:35`, where `timer` is declared twice.

## Are there any user-facing changes?

Yes. Past or ended event details pages now show a disabled `Event Ended` state instead of the `Register Now` button.