### PR TITLE
fix: prevent undefined author prefill

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build": "react-scripts build",
     "build:fast": "cross-env GENERATE_SOURCEMAP=false DISABLE_ESLINT_PLUGIN=true NODE_OPTIONS=\"--no-deprecation --max-old-space-size=4096\" react-scripts build",
     "test": "react-scripts test",
-    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs",
+    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs && node tests/userNameUtils.test.mjs",
     "eject": "react-scripts eject",
     "lint": "eslint src --ext .js,.jsx --max-warnings=-1",
     "lint:fix": "eslint src --ext .js,.jsx --fix",

--- a/src/components/common/ProjectSubmission.js
+++ b/src/components/common/ProjectSubmission.js
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { FiGithub, FiExternalLink, FiPlus, FiX } from "react-icons/fi";
 import { useAuth } from "../../context/AuthContext";
 import { API_ENDPOINTS, apiUtils } from "../../config/api";
+import { getUserFullName } from "../../utils/userNameUtils.mjs";
 import "./ProjectSubmission.css";
 
 const ProjectSubmission = ({ onClose, onSubmit }) => {
@@ -10,7 +11,7 @@ const ProjectSubmission = ({ onClose, onSubmit }) => {
   const [formData, setFormData] = useState({
     title: "",
     description: "",
-    author: user?.firstName + " " + user?.lastName || "",
+    author: getUserFullName(user),
     category: "",
     techStack: [],
     githubUrl: "",

--- a/src/utils/userNameUtils.mjs
+++ b/src/utils/userNameUtils.mjs
@@ -1,0 +1,5 @@
+export const getUserFullName = (user) =>
+  [user?.firstName, user?.lastName]
+    .map((name) => (typeof name === "string" ? name.trim() : ""))
+    .filter(Boolean)
+    .join(" ");

--- a/tests/userNameUtils.test.mjs
+++ b/tests/userNameUtils.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { getUserFullName } from "../src/utils/userNameUtils.mjs";
+
+assert.equal(getUserFullName(null), "", "missing user returns a blank name");
+
+assert.equal(
+  getUserFullName({}),
+  "",
+  "missing first and last names return a blank name"
+);
+
+assert.equal(
+  getUserFullName({ firstName: "Ada" }),
+  "Ada",
+  "first name can be used on its own"
+);
+
+assert.equal(
+  getUserFullName({ lastName: "Lovelace" }),
+  "Lovelace",
+  "last name can be used on its own"
+);
+
+assert.equal(
+  getUserFullName({ firstName: " Ada ", lastName: " Lovelace " }),
+  "Ada Lovelace",
+  "complete names are trimmed and joined"
+);


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #1819.

## Rationale for this change

The project submission modal could prefill the Author field with `undefined undefined` when the logged-in user did not have `firstName` or `lastName` values. This happened because the previous string concatenation converted missing values into text before applying the fallback.

## What changes are included in this PR?

- Added a reusable `getUserFullName` helper to safely build a user's display name from available name parts.
- Updated the project submission modal to use the safe helper for the Author field prefill.
- Added unit tests for missing, partial, trimmed, and complete user names.
- Included the new test in the existing `test:unit` script.

## Are these changes tested?

Yes.

- `npm.cmd run test:unit` passed.
- `npx.cmd eslint src\components\common\ProjectSubmission.js src\utils\userNameUtils.mjs --max-warnings=0` passed.

Note: full project lint/build are currently blocked by an existing unrelated syntax error in `src\Pages\Hackathons\HackathonCard.js`: `Identifier 'timer' has already been declared`.

## Are there any user-facing changes?

Yes. The Author field in the project submission modal will now be blank when no valid user name is available, or will use the available first/last name safely without showing `undefined`.