### PR TITLE
perf: resolve api request flooding via client-side batching in markAllAsRead (#1851)

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -119,15 +119,26 @@ export const NotificationProvider = ({ children }) => {
 
       try {
         setUnreadCount(0);
-        await Promise.allSettled(
-          unread.map((n) => {
-            const endpoint = endpointGetter(n.id);
-            if (!endpoint || typeof endpoint !== "string" || endpoint.includes("undefined")) {
-              return Promise.reject("Invalid endpoint");
-            }
-            return apiUtils.put(endpoint, {});
-          })
-        );
+
+        // Helper to slice the unread notifications into smaller batch sizes
+        const BATCH_SIZE = 5;
+        const chunks = [];
+        for (let i = 0; i < unread.length; i += BATCH_SIZE) {
+          chunks.push(unread.slice(i, i + BATCH_SIZE));
+        }
+
+        // Process each chunk sequentially to respect browser connection limits
+        for (const chunk of chunks) {
+          await Promise.allSettled(
+            chunk.map((n) => {
+              const endpoint = endpointGetter(n.id);
+              if (!endpoint || typeof endpoint !== "string" || endpoint.includes("undefined")) {
+                return Promise.reject("Invalid endpoint");
+              }
+              return apiUtils.put(endpoint, {});
+            })
+          );
+        }
       } catch (error) {
         console.error('Error marking all notifications as read:', error);
         // Re-fetch to restore accurate state on server failure
@@ -135,7 +146,7 @@ export const NotificationProvider = ({ children }) => {
       }
     }, 0);
   }, [token, fetchNotifications]);
-
+  
   // ── Initial fetch + polling ───────────────────────────────────────────────
   useEffect(() => {
     if (!token) {


### PR DESCRIPTION

## Which issue does this PR close?

- Closes #1851 

## Rationale for this change

The previous implementation of `markAllAsRead` mapped over all unread notifications and fired independent, concurrent HTTP PUT requests simultaneously via `Promise.allSettled`. For users with a large backlog of unread items (30–50+), this instantly triggered a severe network stampede. 

Because browsers restrict concurrent connections to the same domain (typically a limit of 6), the excess requests stalled in the network queue. This caused visible UI lag, delayed other critical app requests, and risked mimicking a minor DDoS attack against the backend database pool. This PR optimizes the client-side execution path to respect browser connection bottlenecks.

## What changes are included in this PR?

- **Batching Utility Logic:** Updated the asynchronous execution block inside the `setTimeout` of `markAllAsRead` within `NotificationContext.js`.
- **Sequential Chunk Processing:** Added logic to segment the `unread` notifications array into smaller slices of 5 (`BATCH_SIZE = 5`).
- **Throttled Execution:** Swapped out the single massive promise array for a sequential `for...of` loop. It now processes one batch of 5 concurrent requests at a time, waiting for them to settle before moving to the next chunk.

## Are these changes tested?

Yes, tested manually via local development setup:
1. Seeded the local notifications state with a large volume of unread notifications (~30 items).
2. Triggered `markAllAsRead` while monitoring the Chrome DevTools Network tab.
3. Verified that requests are sent out cleanly in controlled waves of 5 without hitting the "Stalled" or "Queued" connection limits that were present in the baseline build.


## Are there any user-facing changes?

No structural changes to the user interface or features. The visual outcome remains identical (all notifications turn to a read state immediately via the optimistic state update). The only impact is a noticeable performance enhancement—the application remains fully responsive, and background API tasks are no longer choked when a user bulk-clears notifications.

Closes #1851