### PR TITLE
fix(auth): normalize roles and recompute scopes on session restore

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -57,13 +57,34 @@ export const AuthProvider = ({ children }) => {
       if (isTokenValid(storedToken)) {
         setToken(storedToken);
         try {
-          setUser(JSON.parse(storedUser));
+          const parsedUser = JSON.parse(storedUser);
+
+          // Normalize roles on restore so server aliases like EVENT_MANAGER
+          // are always mapped to their canonical equivalent (ORGANIZER).
+          // This prevents ORGANIZER users from being blocked by role guards
+          // after a page reload.
+          const normalizedRoles = (parsedUser?.roles ?? []).map((role) => {
+            const upper = String(role).toUpperCase();
+            return upper === "EVENT_MANAGER" ? ROLES.ORGANIZER : upper;
+          });
+          parsedUser.roles = normalizedRoles;
+
+          // Recompute scopes from the normalized roles instead of trusting
+          // whatever is stored in localStorage. A user could otherwise elevate
+          // their own scopes by editing the "user" key in localStorage.
+          parsedUser.scopes = normalizedRoles.includes(ROLES.ADMIN)
+            ? ["admin:all", "event:write", "event:read", "hackathon:write", "hackathon:read"]
+            : normalizedRoles.includes(ROLES.ORGANIZER)
+              ? ["event:write", "event:read", "hackathon:write", "hackathon:read"]
+              : ["event:read", "hackathon:read"];
+
+          setUser(parsedUser);
         } catch {
-          // Corrupted user data in localStorage — clear everything.
+          // Corrupted user data in localStorage -- clear everything.
           clearSession();
         }
       } else {
-        // Token is expired or invalid — clean up stale session data.
+        // Token is expired or invalid -- clean up stale session data.
         clearSession();
       }
     }


### PR DESCRIPTION
Fixes #2017
Fixes #2019

## Problems

### #2017 - EVENT_MANAGER role blocks ORGANIZER users after reload

On page reload, the stored user object was parsed from localStorage and set directly into React state without normalizing the roles array. The \`normalizeRoles\` function that maps \`EVENT_MANAGER -> ORGANIZER\` was only called during login via \`extractSession\`. After a reload, \`user.roles\` could still contain \`EVENT_MANAGER\`, causing \`ProtectedRoute\` guards that check for \`ROLES.ORGANIZER\` to fail. Organizer users were effectively locked out of their routes after any page reload.

### #2019 - Client-side scope elevation via localStorage tampering

Scopes were restored directly from the stored user object in localStorage. Any user could open browser devtools, edit the \`user\` key to include \`["admin:all"]\`, reload the page, and pass all scope-based route guards on the client side.

## Fix

In the session-restore \`useEffect\`, after parsing the stored user:

1. Normalize roles: map any \`EVENT_MANAGER\` alias to \`ROLES.ORGANIZER\` (same logic as \`normalizeRoles\`, applied inline to avoid closure ordering concerns)
2. Recompute scopes from the normalized roles, discarding whatever was stored in localStorage

```js
const normalizedRoles = (parsedUser?.roles ?? []).map((role) => {
  const upper = String(role).toUpperCase();
  return upper === "EVENT_MANAGER" ? ROLES.ORGANIZER : upper;
});
parsedUser.roles = normalizedRoles;
parsedUser.scopes = normalizedRoles.includes(ROLES.ADMIN)
  ? ["admin:all", "event:write", "event:read", "hackathon:write", "hackathon:read"]
  : normalizedRoles.includes(ROLES.ORGANIZER)
    ? ["event:write", "event:read", "hackathon:write", "hackathon:read"]
    : ["event:read", "hackathon:read"];
```

## Test plan

- [ ] Log in as an ORGANIZER user, reload the page -- organizer routes are still accessible
- [ ] Log in as a user whose token contains EVENT_MANAGER role, reload -- organizer routes are accessible
- [ ] Edit localStorage user scopes to add "admin:all", reload -- admin routes are still blocked for non-admins
- [ ] Log in as ADMIN, reload -- admin routes remain accessible