### PR TITLE
fix: guard offline sync against missing or expired auth token

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 import { useAuth } from '../context/AuthContext';
 import { API_ENDPOINTS, apiUtils } from '../config/api';
 import { getQueue, setQueue, clearQueue } from '../utils/offlineQueue';
+import { isTokenValid } from '../utils/tokenUtils';
 
 const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 1_000;
@@ -42,6 +43,10 @@ const useOfflineSync = () => {
 
     const handleOnline = async () => {
       if (isSyncing.current) {
+        return;
+      }
+
+      if (!token || !isTokenValid(token)) {
         return;
       }
 


### PR DESCRIPTION
## Problem

`useOfflineSync` fires API calls for every queued registration the moment the browser comes back online. There was no check on whether a valid auth token actually exists at that point.

If the user had logged out or their token expired while offline, all queued items would be replayed with no `Authorization` header (or with an expired token), causing a wave of 401 errors with no user-facing explanation.

## Fix

Added an early-return guard in `handleOnline` that bails out before touching the queue when:
- `token` is falsy (user is not logged in), or
- `isTokenValid(token)` returns false (token has expired)

```js
if (!token || !isTokenValid(token)) {
  return;
}
```

The existing `useEffect` already re-runs whenever `token` changes, so a fresh login after coming back online will naturally re-trigger `handleOnline` with a valid token and process the queue at that point.

## Testing

1. Queue a registration while offline (disable network in DevTools).
2. Log out (clears token).
3. Re-enable network -- sync should NOT fire (no API calls, no errors).
4. Log back in -- sync fires and processes the queue correctly.

Closes #2018