### PR TITLE
fix: submit registration to API and remove misleading email copy

### DIFF
--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { FiUser, FiMail, FiPhone, FiBriefcase, FiAward, FiMessageSquare, FiCheckCircle, FiAlertCircle } from "react-icons/fi";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { toast } from "react-toastify";
+import { API_ENDPOINTS, apiUtils } from "../config/api";
 
 import {
   isAlreadyRegistered,
@@ -12,7 +13,7 @@ import {
 const RegistrationPage = () => {
   useDocumentTitle("Eventra | Registration");
   const navigate = useNavigate();
-  const { eventId = "general" } = useParams();
+  const { id: eventId = "general" } = useParams();
   const [formData, setFormData] = useState({
     fullName: "",
     email: "",
@@ -84,13 +85,23 @@ const RegistrationPage = () => {
         return;
       }
 
+      const res = await apiUtils.post(
+        API_ENDPOINTS.EVENTS.REGISTER(eventId),
+        formData
+      );
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.message || data?.error || "Registration failed. Please try again.");
+      }
+
       saveRegistration(eventId, formData.email);
       setSubmitSuccess(true);
       toast.success("Registration successful!");
     } catch (error) {
       setErrors((prev) => ({
         ...prev,
-        submit: "Something went wrong. Please try again.",
+        submit: error.message || "Something went wrong. Please try again.",
       }));
     } finally {
       setIsSubmitting(false);
@@ -120,7 +131,7 @@ const RegistrationPage = () => {
           </div>
           <h2 className="text-3xl font-bold text-slate-800 dark:text-white mb-3">Registration Successful!</h2>
           <p className="text-slate-600 dark:text-slate-300 mb-8 leading-relaxed">
-            Thank you for registering, <span className="font-semibold">{formData.fullName}</span>. A confirmation email has been sent to <span className="font-semibold">{formData.email}</span> with further details.
+            Thank you for registering, <span className="font-semibold">{formData.fullName}</span>. Your spot has been confirmed. Check your dashboard for event details and updates.
           </p>
           <div className="flex flex-col gap-3">
             <button


### PR DESCRIPTION
## Problems

### #1539 - handleSubmit never calls the backend

`RegistrationPage.handleSubmit` only saved registration data to localStorage via `saveRegistration`. There was no API call, so registrations were never persisted server-side. Users would see a "success" screen while their data sat only in the browser.

Additionally, the route is `/register/:id` but the component destructured `{ eventId }` from `useParams()` -- since the param is named `id`, not `eventId`, the destructure always fell back to `"general"`, making the endpoint `/api/events/general/register` regardless of which event was opened.

### #1537 - Success screen claims an email was sent

The success message read "A confirmation email has been sent to `<email>` with further details." No email is sent anywhere in the codebase. This is misleading and erodes user trust.

## Fixes

**#1539:**
- Fixed param destructure: `const { id: eventId = "general" } = useParams()`
- Added `apiUtils.post(API_ENDPOINTS.EVENTS.REGISTER(eventId), formData)` before the local save
- Non-2xx responses throw with the server's message surfaced in the error banner
- Local `saveRegistration` still runs after a successful API response so the duplicate-check guard continues to work client-side

**#1537:**
- Replaced the false email claim with accurate copy: "Your spot has been confirmed. Check your dashboard for event details and updates."

## Testing

1. Navigate to `/register/<valid-event-id>` while logged in.
2. Fill out the form and submit.
3. Network tab should show `POST /api/events/<id>/register`.
4. Success screen should show the updated message (no email mention).
5. Submitting again should show the "already registered" error from the local guard.

Closes #1539
Closes #1537