### PR TITLE
fix: re-fetch event capacity before submit and strip PII from offline queue

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -290,10 +290,25 @@ const EventRegistration = () => {
       return;
     }
 
-    // Atomic capacity check - re-check immediately before submission
-    if (event.attendees >= event.maxAttendees) {
-      toast.error("This event has reached maximum capacity.");
-      return;
+    // Re-fetch the event to get the latest attendee count before checking capacity.
+    // Using the stale value from initial page load creates a race window where
+    // two users can both pass the check and both register past the limit.
+    try {
+      const freshRes = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
+      if (freshRes.ok) {
+        const freshEvent = await freshRes.json();
+        if (freshEvent.attendees >= freshEvent.maxAttendees) {
+          toast.error("This event has reached maximum capacity.");
+          return;
+        }
+      }
+    } catch {
+      // If the re-fetch fails, fall back to the cached value so the user
+      // can still attempt registration rather than being silently blocked.
+      if (event.attendees >= event.maxAttendees) {
+        toast.error("This event has reached maximum capacity.");
+        return;
+      }
     }
 
     // Check for scheduling conflicts
@@ -345,12 +360,13 @@ const EventRegistration = () => {
       console.error("Registration error:", error);
       
       // ── Offline Sync Queue Fallback ──
+      // Only persist the identifiers needed to retry the request -- never
+      // store PII (name, email, phone) in localStorage.
       const payload = {
-        ...formData,
         eventId: parseInt(eventId),
         userId: user?.id || null,
       };
-      
+
       pushToQueue({ eventId: parseInt(eventId), payload });
 
       setRegistered(true);


### PR DESCRIPTION
## Problems

### #2015 - Stale capacity check (TOCTOU race)

`handleSubmit` reads `event.attendees` and `event.maxAttendees` from the React state set at page load. If multiple users open the last available spot at the same time, they all see the same stale count, all pass the check, and all complete registration -- exceeding the event limit.

### #1538 - PII stored in localStorage via offline queue

When a registration fails (network error), the fallback spreads the entire `formData` object into the queue payload before calling `pushToQueue`. This writes the user's full name, email address, and phone number to `localStorage` where it persists indefinitely, survives browser sessions, and can be read by any script on the page.

## Fixes

**#2015 - Fresh capacity check:**

Re-fetch the event from `EVENTS.DETAIL(eventId)` immediately before the capacity gate:

```js
const freshRes = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
if (freshRes.ok) {
  const freshEvent = await freshRes.json();
  if (freshEvent.attendees >= freshEvent.maxAttendees) {
    toast.error("This event has reached maximum capacity.");
    return;
  }
}
```

If the re-fetch itself fails (network down, etc.) the code falls back to the cached value rather than silently blocking the user.

**#1538 - PII-free queue payload:**

```js
// Before
const payload = { ...formData, eventId: parseInt(eventId), userId: user?.id || null };

// After
const payload = { eventId: parseInt(eventId), userId: user?.id || null };
```

Only the identifiers needed to retry the request are queued. The server can re-read the user's profile from the authenticated session when the sync runs.

## Testing

**#2015:** Open the same event registration page in two tabs simultaneously. Fill both forms. Submit both quickly. Only one should succeed; the second should see the capacity error.

**#1538:** With DevTools Network offline, submit a registration form. Open `localStorage` in Application tab and inspect the offline queue key. Confirm no `fullName`, `email`, or `phone` fields appear in the stored payload.

Closes #2015
Closes #1538