### PR TITLE
feat: implement relative time formatting for dates and timestamps (#1…

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -2,6 +2,7 @@ import { useEffect, useState, memo } from "react";
 import { getUserTimezone } from "../../utils/timezoneUtils";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
+import { getSmartDateLabel } from "../../utils/relativeTime";
 import {
   Bookmark,
   BookmarkCheck,
@@ -302,16 +303,13 @@ const EventCard = ({ event }) => {
           <Calendar size={14} className="text-indigo-500 flex-shrink-0 mt-0.5" />
           <div className="flex flex-col">
             <span className="truncate">
-              {new Date(event.date).toLocaleDateString(
-                "en-US",
-                {
-                  weekday: "short",
-                  day: "numeric",
-                  month: "short",
-                  year: "numeric",
-                }
-              )}
-            </span>
+  {getSmartDateLabel(event.date, event.time)}
+</span>
+<span className="text-[11px] text-gray-500 dark:text-gray-400">
+  {new Date(event.date).toLocaleDateString("en-US", {
+    weekday: "short", day: "numeric", month: "short", year: "numeric",
+  })}
+</span>
             <span className="text-[11px] text-gray-500 dark:text-gray-400">
               Localized Event Time
             </span>

--- a/src/components/Layout/NotificationBell.jsx
+++ b/src/components/Layout/NotificationBell.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNotification } from '../../context/NotificationContext';
-
+import { getRelativeTime } from '../../utils/relativeTime';
 export default function NotificationBell() {
   const { notifications, unreadCount, markAsRead } = useNotification();
   const [isOpen, setIsOpen] = useState(false);
@@ -41,9 +41,9 @@ export default function NotificationBell() {
                   className={`p-3 border-b border-gray-50 cursor-pointer transition-colors ${!notif.isRead ? 'bg-blue-50/60 hover:bg-blue-50' : 'hover:bg-gray-50'}`}
                 >
                   <p className={`text-sm text-gray-800 ${!notif.isRead ? 'font-medium' : ''}`}>{notif.message}</p>
-                  <span className="text-xs text-gray-400 block mt-1">
-                    {new Date(notif.timestamp).toLocaleDateString()}
-                  </span>
+                  <span className="text-xs text-gray-400 block mt-1" title={new Date(notif.timestamp).toLocaleDateString()}>
+  {getRelativeTime(notif.timestamp) || new Date(notif.timestamp).toLocaleDateString()}
+</span>
                 </div>
               ))
             )}

--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -1,4 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion";
+import { getSmartDateLabel } from "../../utils/relativeTime";
 import {
   Calendar, Trophy, FolderOpen, Users, Settings,
   Clock, MapPin, Zap, Activity, Bell, ChevronRight,
@@ -308,7 +309,7 @@ export default function UserDashboard() {
                       <div key={ev.id} className="ud-list-item">
                         <div>
                           <p className="ud-list-title">{ev.title}</p>
-                          <p className="ud-list-meta"><Calendar size={12} /> {ev.date} · <MapPin size={12} /> {ev.location}</p>
+                          <p className="ud-list-meta"><Calendar size={12} /> {getSmartDateLabel(ev.date)} · <MapPin size={12} /> {ev.location}</p>
                         </div>
                         {/* ✅ StatusBadge replaces ud-badge span */}
                         <StatusBadge status={ev.participationType} />
@@ -330,7 +331,7 @@ export default function UserDashboard() {
                       <div key={h.id} className="ud-list-item">
                         <div>
                           <p className="ud-list-title">{h.title}</p>
-                          <p className="ud-list-meta"><Calendar size={12} /> {h.date} · <MapPin size={12} /> {h.location}</p>
+                          <p className="ud-list-meta"><Calendar size={12} /> {getSmartDateLabel(h.date)} · <MapPin size={12} /> {h.location}</p>
                         </div>
                         <StatusBadge status={h.participationType} />
                       </div>
@@ -488,7 +489,7 @@ export default function UserDashboard() {
                         <tr key={item.id}>
                           <td><span className="ud-table-type">{TYPE_ICON[item.type]}{item.type}</span></td>
                           <td className="ud-table-title" title={item.title}>{item.title}</td>
-                          <td>{item.date || "—"}</td>
+                          <td title={item.date || ""}>{item.date ? getSmartDateLabel(item.date) : "—"}</td>
                           <td title={item.location || item.lastUpdate || "—"}>{item.location || item.lastUpdate || "—"}</td>
                           <td>
                             <StatusBadge status={item.projectStatus !== "-" ? item.projectStatus : item.status} />

--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -1,0 +1,45 @@
+export function getRelativeTime(dateInput) {
+  const now = new Date();
+  const date = new Date(dateInput);
+
+  if (isNaN(date)) return null;
+
+  const diffMs = date - now;
+  const diffSec = Math.round(diffMs / 1000);
+  const diffMin = Math.round(diffSec / 60);
+  const diffHour = Math.round(diffMin / 60);
+  const diffDay = Math.round(diffHour / 24);
+
+  if (diffMs < 0) {
+    if (Math.abs(diffSec) < 60) return "Just ended";
+    if (Math.abs(diffMin) < 60) return `${Math.abs(diffMin)} minute${Math.abs(diffMin) !== 1 ? "s" : ""} ago`;
+    if (Math.abs(diffHour) < 24) return `${Math.abs(diffHour)} hour${Math.abs(diffHour) !== 1 ? "s" : ""} ago`;
+    if (Math.abs(diffDay) === 1) return "Yesterday";
+    if (Math.abs(diffDay) < 30) return `${Math.abs(diffDay)} days ago`;
+    return null;
+  }
+
+  if (diffSec < 60) return "Starting soon";
+  if (diffMin < 60) return `In ${diffMin} minute${diffMin !== 1 ? "s" : ""}`;
+  if (diffHour < 24) return `In ${diffHour} hour${diffHour !== 1 ? "s" : ""}`;
+  if (diffDay === 1) return "Tomorrow";
+  if (diffDay < 7) return `In ${diffDay} days`;
+  if (diffDay < 30) return `In ${Math.floor(diffDay / 7)} week${Math.floor(diffDay / 7) !== 1 ? "s" : ""}`;
+
+  return null;
+}
+
+export function getSmartDateLabel(dateInput, timeInput = "") {
+  const relative = getRelativeTime(
+    timeInput ? `${dateInput} ${timeInput}` : dateInput
+  );
+
+  if (relative) return relative;
+
+  return new Date(dateInput).toLocaleDateString("en-US", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}


### PR DESCRIPTION
Closes #1946

## Changes Made

- Created `src/utils/relativeTime.js` with two utility functions:
  - `getRelativeTime()` — converts timestamps to human-readable strings like "2 hours ago", "Tomorrow", "In 3 days"
  - `getSmartDateLabel()` — returns relative time when recent, falls back to formatted date for far future/past

## Files Updated

- `src/Pages/Events/EventCard.js` — event date now shows relative time with exact date as subtitle
- `src/components/Layout/NotificationBell.jsx` — notification timestamps now show relative time with exact date on hover
- `src/components/user/UserDashboard.js` — upcoming events, hackathons and registrations table all use relative time

## Examples
- "Tomorrow", "In 3 days", "In 2 weeks"
- "2 hours ago", "Yesterday", "5 days ago"
- Falls back to "Mon, 15 Jun 2025" for older/far future dates