### PR TITLE
feat: enhance page transition animations for smoother navigation

### DIFF
--- a/src/components/common/PageTransition.jsx
+++ b/src/components/common/PageTransition.jsx
@@ -2,28 +2,64 @@ import React from "react";
 import { useLocation } from "react-router-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
-const TRANSITION = { duration: 0.22, ease: [0.25, 0.1, 0.25, 1] };
-
-const pageVariants = {
-  initial: { opacity: 0, y: 8 },
-  animate: { opacity: 1, y: 0 },
-  exit: { opacity: 0, y: -6 },
+// Route-type based transition picker
+const getVariants = (pathname) => {
+  if (["/login", "/signup", "/auth"].some((p) => pathname.startsWith(p))) {
+    // Slide up for auth pages
+    return {
+      initial: { opacity: 0, y: 24, scale: 0.98 },
+      animate: { opacity: 1, y: 0, scale: 1 },
+      exit:    { opacity: 0, y: -16, scale: 0.98 },
+    };
+  }
+  if (pathname.startsWith("/events/") || pathname.startsWith("/hackathons/")) {
+    // Slide in from right for detail pages
+    return {
+      initial: { opacity: 0, x: 32 },
+      animate: { opacity: 1, x: 0 },
+      exit:    { opacity: 0, x: -32 },
+    };
+  }
+  if (pathname.startsWith("/dashboard")) {
+    // Fade + slight scale for dashboard
+    return {
+      initial: { opacity: 0, scale: 0.97 },
+      animate: { opacity: 1, scale: 1 },
+      exit:    { opacity: 0, scale: 1.01 },
+    };
+  }
+  // Default: smooth fade + subtle slide
+  return {
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: 1, y: 0 },
+    exit:    { opacity: 0, y: -6 },
+  };
 };
 
 const reducedMotionVariants = {
   initial: { opacity: 0 },
   animate: { opacity: 1 },
-  exit: { opacity: 0 },
+  exit:    { opacity: 0 },
 };
 
-/**
- * Wraps route content with a short fade/slide on pathname change.
- * Respects prefers-reduced-motion (also aligned with MotionConfig in index.js).
- */
+const getTransition = (pathname) => {
+  if (pathname.startsWith("/events/") || pathname.startsWith("/hackathons/")) {
+    return { duration: 0.28, ease: [0.32, 0, 0.67, 0] };
+  }
+  return { duration: 0.22, ease: [0.25, 0.1, 0.25, 1] };
+};
+
 const PageTransition = ({ children }) => {
   const location = useLocation();
   const prefersReducedMotion = useReducedMotion();
-  const variants = prefersReducedMotion ? reducedMotionVariants : pageVariants;
+
+  const variants = prefersReducedMotion
+    ? reducedMotionVariants
+    : getVariants(location.pathname);
+
+  const transition = prefersReducedMotion
+    ? { duration: 0.15 }
+    : getTransition(location.pathname);
 
   return (
     <AnimatePresence mode="wait" initial={false}>
@@ -33,9 +69,13 @@ const PageTransition = ({ children }) => {
         initial="initial"
         animate="animate"
         exit="exit"
-        transition={TRANSITION}
+        transition={transition}
         className="min-h-[inherit] w-full"
-        style={{ willChange: "opacity, transform" }}
+        style={{
+          willChange: "opacity, transform",
+          transform: "translateZ(0)", // GPU acceleration
+          backfaceVisibility: "hidden", // Prevent flicker
+        }}
       >
         {children}
       </motion.div>


### PR DESCRIPTION
Closes #1943 

## Problem
Page transitions were abrupt — only one generic fade/slide animation 
was applied to all routes, reducing frontend smoothness.

## Changes Made
Enhanced `src/components/common/PageTransition.jsx` with:

- Route-aware transitions:
  - Auth pages (`/login`, `/signup`) → slide up effect
  - Detail pages (`/events/:id`, `/hackathons/:id`) → slide in from right
  - Dashboard → fade + subtle scale
  - All other pages → smooth default fade + slide

- Performance optimizations:
  - `translateZ(0)` for GPU acceleration
  - `backfaceVisibility: hidden` to prevent flicker
  - `willChange: opacity, transform` for smoother rendering

- Accessibility:
  - Respects `prefers-reduced-motion` — uses simple opacity fade for users who prefer reduced motion
  - Faster duration (0.15s) for reduced motion users

## Testing
Navigate between different route types to see contextual transitions.