### PR TITLE
docs: add backend API setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ This repository contains the React frontend application for Eventra. The backend
 - **Swagger**: [https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/swagger-ui/index.html](https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/swagger-ui/index.html)
 - Capacity and registration availability endpoints are documented in Swagger UI.
 
+### Backend API Setup Note
+
+The frontend communicates with the Spring Boot backend through `/api` routes. For local full-stack testing, run the backend service separately and configure the frontend API URL accordingly.
+
+Backend repository: https://github.com/SandeepVashishtha/Eventra-Backend
+
 ## Project Insights
 
 <table align="center">


### PR DESCRIPTION
## Related Issue

Related to SandeepVashishtha/Eventra#2106

## Description

Added a small backend API setup note to clarify that the frontend communicates with the Spring Boot backend through `/api` routes and linked the backend repository for local full-stack setup.

Note: This PR also serves as a small documentation/update reference connected to the backend restoration work tracked in SandeepVashishtha/Eventra-Backend#18.

## Type of PR

* [x] Documentation update

## Checklist

* [x] Updated documentation only
* [x] No frontend logic changed
* [x] No breaking changes
