### PR TITLE
fix: Gate debug console logs behind NODE_ENV check to prevent cluttering production logs

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -19,10 +19,22 @@ const ASSETS_TO_CACHE = [
 ];
 
 // Install Service Worker and cache core static assets
+const isLocalhost = Boolean(
+  self.location.hostname === 'localhost' ||
+  self.location.hostname === '[::1]' ||
+  self.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
+);
+
+const log = (...args) => {
+  if (isLocalhost) {
+    console.log(...args);
+  }
+};
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => {
-      console.log('[Service Worker] Caching core static assets');
+      log('[Service Worker] Caching core static assets');
       return cache.addAll(ASSETS_TO_CACHE);
     }).then(() => self.skipWaiting())
   );
@@ -35,7 +47,7 @@ self.addEventListener('activate', (event) => {
       return Promise.all(
         cacheNames.map((cache) => {
           if (cache !== CACHE_NAME) {
-            console.log('[Service Worker] Deleting legacy cache:', cache);
+            log('[Service Worker] Deleting legacy cache:', cache);
             return caches.delete(cache);
           }
         })

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -9,6 +9,14 @@ const isLocalhost = Boolean(
     window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/)
 );
 
+const isDev = process.env.NODE_ENV === 'development';
+
+const log = (...args) => {
+  if (isDev) {
+    console.log(...args);
+  }
+};
+
 export function register(config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
@@ -27,7 +35,7 @@ export function register(config) {
 
         // Add logging to localhost, welcoming developers
         navigator.serviceWorker.ready.then(() => {
-          console.log(
+          log(
             'This web app is being served cache-first by a service worker. To learn more, visit https://cra.link/pwa'
           );
         });
@@ -54,7 +62,7 @@ function registerValidSW(swUrl, config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log(
+              log(
                 'New content is available and will be used when all tabs for this page are closed. See https://cra.link/pwa.'
               );
 
@@ -65,7 +73,7 @@ function registerValidSW(swUrl, config) {
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a "Content is cached for offline use!" message.
-              console.log('Content is cached for offline use.');
+              log('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -105,7 +113,7 @@ function checkValidServiceWorker(swUrl, config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.');
+      log('No internet connection found. App is running in offline mode.');
     });
 }
 

--- a/sse-mock-server.js
+++ b/sse-mock-server.js
@@ -7,6 +7,14 @@ const http = require("http");
 
 const PORT = 4001;
 
+const enableLogs = process.env.NODE_ENV !== "production";
+
+const log = (...args) => {
+  if (enableLogs) {
+    console.log(...args);
+  }
+};
+
 const MOCK_CONTRIBUTORS = [
   { username: "alice", name: "Alice Dev", avatar: "https://avatars.githubusercontent.com/u/1?v=4", profile: "https://github.com/alice", points: 42, prs: 6 },
   { username: "bob", name: "Bob Coder", avatar: "https://avatars.githubusercontent.com/u/2?v=4", profile: "https://github.com/bob", points: 35, prs: 5 },
@@ -44,7 +52,7 @@ const server = http.createServer((req, res) => {
 
   if (req.url === "/stream/leaderboard") {
     sseHeaders(res);
-    console.log("[SSE] leaderboard client connected");
+    log("[SSE] leaderboard client connected");
 
     // Send initial snapshot immediately
     send(res, MOCK_CONTRIBUTORS);
@@ -57,19 +65,19 @@ const server = http.createServer((req, res) => {
         prs: c.prs + (Math.random() > 0.7 ? 1 : 0),
       })).sort((a, b) => b.points - a.points);
       send(res, updated);
-      console.log("[SSE] leaderboard update sent");
+      log("[SSE] leaderboard update sent");
     }, 8000);
 
     req.on("close", () => {
       clearInterval(interval);
-      console.log("[SSE] leaderboard client disconnected");
+      log("[SSE] leaderboard client disconnected");
     });
     return;
   }
 
   if (req.url === "/stream/analytics") {
     sseHeaders(res);
-    console.log("[SSE] analytics client connected");
+    log("[SSE] analytics client connected");
 
     // Push a new check-in every 5 seconds
     const interval = setInterval(() => {
@@ -78,12 +86,12 @@ const server = http.createServer((req, res) => {
       const status = Math.random() > 0.1 ? "Verified" : "Flagged";
       const checkin = { id: `sse-${Date.now()}`, name, event, time: "Just now", status };
       send(res, checkin);
-      console.log(`[SSE] analytics check-in: ${name} → ${status}`);
+      log(`[SSE] analytics check-in: ${name} → ${status}`);
     }, 5000);
 
     req.on("close", () => {
       clearInterval(interval);
-      console.log("[SSE] analytics client disconnected");
+      log("[SSE] analytics client disconnected");
     });
     return;
   }


### PR DESCRIPTION
Resolves #2043

This PR gates the debug console.log statements behind `NODE_ENV === 'development'` (or local environment checks for client/mock server) in order to avoid cluttering logs and potentially leaking sensitive info in production.

### Files modified:
- `public/service-worker.js`
- `src/serviceWorkerRegistration.js`
- `sse-mock-server.js`