### PR TITLE
fix: cross-browser date parsing crash/inaccuracy in Safari and iOS WebKit (closes #2069)

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -55,8 +55,7 @@ const EventCard = ({ event }) => {
   const hasConflict = conflictCheck.hasConflict;
   const isUserRegistered = isRegistered(event.id);
 
-  const eventDateTime = new Date(`${event.date} ${event.time}`);
-  const isPastEvent = eventDateTime < new Date();
+  const isPastEvent = getEventStatus(event) === "past" || getEventStatus(event) === "ended";
 
   const eventSharingData = generateEventSharingData({
     ...event,

--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -6,6 +6,7 @@ import CountdownTimer from "../../components/common/CountdownTimer";
 import { Calendar, MapPin, Clock, Users, Tag, ArrowLeft } from "lucide-react";
 
 import eventsMockData from "./eventsMockData.json";
+import { getEventStatus } from "../../utils/eventUtils";
 
 // Removed unused imports: addEventToGoogleCalendar, ShareMenu, CertificateDownload, generateEventSharingData
 
@@ -103,12 +104,8 @@ const EventDetailsPage = () => {
     );
   }
 
-  const eventDateTime = new Date(
-    `${event.date} ${event.time}`
-  );
-
   const isPastEvent =
-    eventDateTime < new Date();
+    getEventStatus(event) === "past" || getEventStatus(event) === "ended";
 
   // Removed unused derived values and handlers to satisfy linting rules
 

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -374,7 +374,7 @@ const EventRegistration = () => {
     );
   }
 
-  const isPastEvent = new Date(`${event.date} ${event.time}`) < new Date();
+  const isPastEvent = getEventStatus(event) === "past" || getEventStatus(event) === "ended";
   const isEventFull = event.attendees >= event.maxAttendees;
 
   if (isPastEvent || isEventFull) {

--- a/src/Pages/Events/RemindersPage.js
+++ b/src/Pages/Events/RemindersPage.js
@@ -8,14 +8,20 @@ import {
   subscribeToReminderChanges,
 } from "../../utils/reminderUtils";
 
-const formatEventDate = (event) =>
-  new Date(`${event.date} ${event.time || "12:00 AM"}`).toLocaleString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+import { parseEventDateTimeLocal } from "../../utils/timezoneUtils";
+
+const formatEventDate = (event) => {
+  const parsed = parseEventDateTimeLocal(event.date, event.time);
+  return parsed
+    ? parsed.toLocaleString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : "";
+};
 
 const formatTriggerDate = (triggerAt) =>
   new Date(triggerAt).toLocaleString("en-US", {

--- a/src/utils/reminderUtils.js
+++ b/src/utils/reminderUtils.js
@@ -1,3 +1,5 @@
+import { parseEventDateTimeLocal } from "./timezoneUtils";
+
 export const REMINDERS_STORAGE_KEY = "eventra_event_reminders";
 export const REMINDERS_CHANGED_EVENT = "eventraRemindersChanged";
 
@@ -14,8 +16,7 @@ export const getReminderId = (eventId, timing) =>
 
 export const getEventDateTime = (event) => {
   if (!event?.date) return null;
-  const parsed = new Date(`${event.date} ${event.time || "12:00 AM"}`);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+  return parseEventDateTimeLocal(event.date, event.time);
 };
 
 export const isPastEvent = (event) => {

--- a/src/utils/timezoneUtils.js
+++ b/src/utils/timezoneUtils.js
@@ -172,3 +172,23 @@ export const parseEventToUTC = (dateStr, timeStr, timezone) => {
     return new Date(year, month - 1, day, hours, minutes).getTime();
   }
 };
+
+/**
+ * Parse an event's local date + time string into a native Date object in local time.
+ * Safe for cross-browser parsing (e.g. Safari / iOS WebKit).
+ *
+ * @param {string} dateStr
+ * @param {string} [timeStr]
+ * @returns {Date|null}
+ */
+export const parseEventDateTimeLocal = (dateStr, timeStr) => {
+  const normalizedDate = normalizeDateString(dateStr);
+  const parsedTime = parseTimeString(timeStr || "12:00 AM");
+
+  if (!normalizedDate || !parsedTime) return null;
+
+  const [year, month, day] = normalizedDate.split('-').map(Number);
+  const { hours, minutes } = parsedTime;
+
+  return new Date(year, month - 1, day, hours, minutes);
+};


### PR DESCRIPTION
## Summary

Fixes #2069

### Problem

Multiple components used `new Date(`${event.date} ${event.time}`)` to construct date objects for past-event checks. The concatenated format (`"2026-03-15 10:00 AM"`) is **non-standard** and returns `Invalid Date` on **Safari** and **iOS WebKit**. This caused:

- `isPastEvent` always evaluating to `false` on Safari
- Past events incorrectly shown as active/upcoming
- Users able to register for past events on Safari

### Fix

Replaced all occurrences of the non-standard `new Date(date + time)` pattern with cross-browser safe alternatives:

**Components using `getEventStatus()` (for past/ended boolean checks):**
- `EventCard.js` — past event CTA rendering
- `EventDetailsPage.js` — past event badge and registration gate
- `EventRegistration.js` — registration form validation

**Utilities using `parseEventDateTimeLocal()` (where an actual Date object is needed):**
- `RemindersPage.js` — event date display formatting
- `reminderUtils.js` — reminder trigger time calculation

### New Utility

Added `parseEventDateTimeLocal(dateStr, timeStr)` to `timezoneUtils.js` — manually parses date and 12h/24h time strings into individual components, then constructs a Date object using `new Date(year, month, day, hours, minutes)` which works identically on all browsers.

### Testing

- Production build passes successfully
- All 6 modified files compile without errors
