### PR TITLE
fix(routes): protect sensitive routes with ProtectedRoute guard — clo…

### DIFF
--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -2,78 +2,182 @@ import React, { lazy } from 'react';
 import { Route } from 'react-router-dom';
 import PageLayout from '../Layout/PageLayout';
 
-const MockApiResponse = lazy(() => import("../MockApiResponse"));
+// Auth guard — redirects unauthenticated users to /login
+import ProtectedRoute from '../auth/ProtectedRoute';
 
-const HomePage = lazy(() => import("../../Pages/Home/HomePage"));
-const EventDetails = lazy(() => import("../../Pages/Events/EventDetails"));
-const EventRegistration = lazy(() => import("../../Pages/Events/EventRegistration"));
-const BookmarkedEvents = lazy(() => import("../../Pages/Events/BookmarkedEvents"));
-const RemindersPage = lazy(() => import("../../Pages/Events/RemindersPage"));
-const HackathonLifecycle = lazy(() => import("../../Pages/Hackathons/HackathonLifecycle"));
-const Contributors = lazy(() => import("../Contributors"));
-const CommunityEvent = lazy(() => import("../CommunityEvent"));
-const LeaderBoard = lazy(() => import("../../Pages/Leaderboard/Leaderboard"));
-const ContributorGuide = lazy(() => import("../../Pages/Leaderboard/ContributorGuide"));
-const AboutPage = lazy(() => import("../../Pages/About/AboutPage"));
-const FAQPage = lazy(() => import("../../Pages/FAQ/FAQPage"));
-const Terms = lazy(() => import("../../Pages/Terms"));
-const Privacy = lazy(() =>
-  import("../../Pages/Privacy").then((module) => ({
-    default: module.Privacy,
-  }))
+// ─── Lazy-loaded page components ─────────────────────────────────────────────
+// All components are loaded on-demand to keep the initial bundle small.
+const MockApiResponse     = lazy(() => import('../MockApiResponse'));
+const HomePage            = lazy(() => import('../../Pages/Home/HomePage'));
+const EventDetails        = lazy(() => import('../../Pages/Events/EventDetails'));
+const EventRegistration   = lazy(() => import('../../Pages/Events/EventRegistration'));
+const HackathonLifecycle  = lazy(() => import('../../Pages/Hackathons/HackathonLifecycle'));
+const Contributors        = lazy(() => import('../Contributors'));
+const CommunityEvent      = lazy(() => import('../CommunityEvent'));
+const LeaderBoard         = lazy(() => import('../../Pages/Leaderboard/Leaderboard'));
+const ContributorGuide    = lazy(() => import('../../Pages/Leaderboard/ContributorGuide'));
+const AboutPage           = lazy(() => import('../../Pages/About/AboutPage'));
+const FAQPage             = lazy(() => import('../../Pages/FAQ/FAQPage'));
+const Terms               = lazy(() => import('../../Pages/Terms'));
+const Privacy             = lazy(() =>
+  import('../../Pages/Privacy').then((module) => ({ default: module.Privacy }))
 );
-const ApiDocs = lazy(() => import("../../Pages/ApiDocs"));
-const HelpCenter = lazy(() => import("../../Pages/HelpCenter"));
-const ContactUs = lazy(() => import("../../Pages/Contact/ContactUs"));
-const FeedbackPage = lazy(() => import("../../Pages/Feedback/FeedbackPage"));
-const FloorPlanDesignerPage = lazy(() => import("../../Pages/Events/FloorPlanDesignerPage"));
-const DocumentationPage = lazy(() => import("../../Pages/About/DocumentationPage"));
-const SubmitProject = lazy(() => import("../../Pages/Projects/SubmitProject"));
+const ApiDocs             = lazy(() => import('../../Pages/ApiDocs'));
+const HelpCenter          = lazy(() => import('../../Pages/HelpCenter'));
+const ContactUs           = lazy(() => import('../../Pages/Contact/ContactUs'));
+const FeedbackPage        = lazy(() => import('../../Pages/Feedback/FeedbackPage'));
+const DocumentationPage   = lazy(() => import('../../Pages/About/DocumentationPage'));
+const EventsPage          = lazy(() => import('../../Pages/Events/EventsPage'));
+const HackathonPage       = lazy(() => import('../../Pages/Hackathons/HackathonPage'));
+const HackathonDetailsPage = lazy(() => import('../../Pages/Hackathons/HackathonDetailsPage'));
+const ProjectsPage        = lazy(() => import('../../Pages/Projects/ProjectsPage'));
+const MyCalendar          = lazy(() => import('../../Pages/Calendar/MyCalendar'));
 
-const EventsPage = lazy(() => import("../../Pages/Events/EventsPage"));
-const HackathonPage = lazy(() => import("../../Pages/Hackathons/HackathonPage"));
-const HackathonDetailsPage = lazy(() => import("../../Pages/Hackathons/HackathonDetailsPage"));
-const ProjectsPage = lazy(() => import("../../Pages/Projects/ProjectsPage"));
-const EventAnalyticsDashboard = lazy(() => import("../../Pages/Events/EventAnalyticsDashboard"));
-const MyCalendar = lazy(() => import("../../Pages/Calendar/MyCalendar"));
+// ─── Auth-required page components ───────────────────────────────────────────
+// These are imported separately to make the intent explicit: they MUST be
+// wrapped with <ProtectedRoute> — do not move them to the public list above.
+const BookmarkedEvents       = lazy(() => import('../../Pages/Events/BookmarkedEvents'));
+const RemindersPage          = lazy(() => import('../../Pages/Events/RemindersPage'));
+const EventAnalyticsDashboard = lazy(() => import('../../Pages/Events/EventAnalyticsDashboard'));
+const FloorPlanDesignerPage  = lazy(() => import('../../Pages/Events/FloorPlanDesignerPage'));
+const SubmitProject          = lazy(() => import('../../Pages/Projects/SubmitProject'));
 
+/**
+ * getPublicRoutes
+ *
+ * Returns the array of <Route> elements that make up the application's
+ * publicly accessible URL surface.
+ *
+ * SECURITY RULE
+ * -------------
+ * Routes that expose user-specific data (bookmarks, reminders, calendar,
+ * personal analytics) or allow writing data on behalf of a user
+ * (submit-project, floor-plan editor) MUST be wrapped with <ProtectedRoute>.
+ * ProtectedRoute redirects unauthenticated visitors to /login and restores
+ * them to the intended page after sign-in via React Router's `state.from`.
+ *
+ * Do NOT add authenticated-only pages to the bare public route list; use
+ * ProtectedRoutes.js for that, or wrap individually here as shown below.
+ */
 export const getPublicRoutes = () => [
-  <Route key="/" path="/" element={<HomePage />} />,
-  <Route key="/events" path="/events" element={<EventsPage />} />,
-  <Route key="/calendar" path="/calendar" element={<MyCalendar />} />,
-  <Route key="/bookmarks" path="/bookmarks" element={<BookmarkedEvents />} />,
-  <Route key="/reminders" path="/reminders" element={<RemindersPage />} />,
-  <Route key="/event-details" path="/events/:eventId" element={<EventDetails />} />,
-  <Route key="/register" path="/events/:eventId/register" element={<EventRegistration />} />,
-  <Route key="/hackathons" path="/hackathons" element={<HackathonPage />} />,
+  // ── Fully public routes (no login required) ────────────────────────────────
+  <Route key="/"         path="/"         element={<HomePage />} />,
+  <Route key="/events"   path="/events"   element={<EventsPage />} />,
+  <Route key="/event-details"  path="/events/:eventId"          element={<EventDetails />} />,
+  <Route key="/register"       path="/events/:eventId/register" element={<EventRegistration />} />,
+  <Route key="/hackathons"        path="/hackathons"              element={<HackathonPage />} />,
   <Route key="/hackathon-details" path="/hackathons/:hackathonId" element={<HackathonDetailsPage />} />,
   <Route key="/hackathons-lifecycle" path="/hackathons/:id/lifecycle" element={<HackathonLifecycle />} />,
   <Route key="/projects" path="/projects" element={<ProjectsPage />} />,
-  <Route key="/api/hackathons" path="/api/hackathons" element={<MockApiResponse />} />,
-  <Route key="/api/projects" path="/api/projects" element={<MockApiResponse />} />,
+
+  // Mock API endpoints (demo/documentation purposes)
+  <Route key="/api/hackathons"  path="/api/hackathons"  element={<MockApiResponse />} />,
+  <Route key="/api/projects"   path="/api/projects"    element={<MockApiResponse />} />,
   <Route key="/api/contributors" path="/api/contributors" element={<MockApiResponse />} />,
   <Route key="/api/leaderboard" path="/api/leaderboard" element={<MockApiResponse />} />,
+
+  // ── Auth-protected routes (login required) ─────────────────────────────────
+  // Each of these routes exposes personal data or allows data mutations that
+  // require a verified user identity. ProtectedRoute checks the session token
+  // and redirects to /login if the user is not authenticated.
+
+  // /bookmarks — shows the signed-in user's personal saved events list
+  <Route
+    key="/bookmarks"
+    path="/bookmarks"
+    element={
+      <ProtectedRoute>
+        <BookmarkedEvents />
+      </ProtectedRoute>
+    }
+  />,
+
+  // /reminders — shows the signed-in user's personal event reminders
+  <Route
+    key="/reminders"
+    path="/reminders"
+    element={
+      <ProtectedRoute>
+        <RemindersPage />
+      </ProtectedRoute>
+    }
+  />,
+
+  // /calendar — personal calendar tied to the user's registered events
+  <Route
+    key="/calendar"
+    path="/calendar"
+    element={
+      <ProtectedRoute>
+        <MyCalendar />
+      </ProtectedRoute>
+    }
+  />,
+
+  // ── PageLayout-wrapped routes ──────────────────────────────────────────────
   <Route key="page-layout" element={<PageLayout />}>
-    <Route key="/contributors" path="/contributors" element={<Contributors />} />
+    <Route key="/contributors"   path="/contributors"   element={<Contributors />} />
     <Route key="/communityEvent" path="/communityEvent" element={<CommunityEvent />} />
     <Route key="/community-event" path="/community-event" element={<CommunityEvent />} />
-    <Route key="/leaderBoard" path="/leaderBoard" element={<LeaderBoard />} />
-    <Route key="/leaderboard" path="/leaderboard" element={<LeaderBoard />} />
-    <Route key="/contributorguide" path="/contributorguide" element={<ContributorGuide />} />
+    <Route key="/leaderBoard"    path="/leaderBoard"    element={<LeaderBoard />} />
+    <Route key="/leaderboard"    path="/leaderboard"    element={<LeaderBoard />} />
+    <Route key="/contributorguide"  path="/contributorguide"  element={<ContributorGuide />} />
     <Route key="/contributor-guide" path="/contributor-guide" element={<ContributorGuide />} />
-    <Route key="/about" path="/about" element={<AboutPage />} />
-    <Route key="/about-fallback" path="/about/*" element={<AboutPage />} />
-    <Route key="/faq" path="/faq" element={<FAQPage />} />
-    <Route key="/terms" path="/terms" element={<Terms />} />
-    <Route key="/privacy" path="/privacy" element={<Privacy />} />
-    <Route key="/apiDocs" path="/apiDocs" element={<ApiDocs />} />
-    <Route key="/api-docs" path="/api-docs" element={<ApiDocs />} />
-    <Route key="/helpcenter" path="/helpcenter" element={<HelpCenter />} />
-    <Route key="/contact" path="/contact" element={<ContactUs />} />
-    <Route key="/feedback" path="/feedback" element={<FeedbackPage />} />
-    <Route key="/analytics" path="/analytics" element={<EventAnalyticsDashboard />} />
-    <Route key="/events/:eventId/floor-plan" path="/events/:eventId/floor-plan" element={<FloorPlanDesignerPage />} />
-    <Route key="/documentation" path="/documentation" element={<DocumentationPage />} />
-    <Route key="/submit-project" path="/submit-project" element={<SubmitProject />} />
-  </Route>
+    <Route key="/about"          path="/about"          element={<AboutPage />} />
+    <Route key="/about-fallback" path="/about/*"        element={<AboutPage />} />
+    <Route key="/faq"            path="/faq"            element={<FAQPage />} />
+    <Route key="/terms"          path="/terms"          element={<Terms />} />
+    <Route key="/privacy"        path="/privacy"        element={<Privacy />} />
+    <Route key="/apiDocs"        path="/apiDocs"        element={<ApiDocs />} />
+    <Route key="/api-docs"       path="/api-docs"       element={<ApiDocs />} />
+    <Route key="/helpcenter"     path="/helpcenter"     element={<HelpCenter />} />
+    <Route key="/contact"        path="/contact"        element={<ContactUs />} />
+    <Route key="/feedback"       path="/feedback"       element={<FeedbackPage />} />
+    <Route key="/documentation"  path="/documentation"  element={<DocumentationPage />} />
+
+    {/*
+      /analytics — exposes organisation-level event analytics data.
+      Requires authentication so that only registered users can view
+      aggregate participant and event metrics.
+    */}
+    <Route
+      key="/analytics"
+      path="/analytics"
+      element={
+        <ProtectedRoute>
+          <EventAnalyticsDashboard />
+        </ProtectedRoute>
+      }
+    />
+
+    {/*
+      /events/:eventId/floor-plan — venue floor plan designer.
+      Requires authentication; only event organisers should be able
+      to view or edit a floor plan layout.
+    */}
+    <Route
+      key="/events/:eventId/floor-plan"
+      path="/events/:eventId/floor-plan"
+      element={
+        <ProtectedRoute>
+          <FloorPlanDesignerPage />
+        </ProtectedRoute>
+      }
+    />
+
+    {/*
+      /submit-project — allows users to submit projects to hackathons.
+      Requires authentication so submissions are linked to a verified
+      user account and cannot be made anonymously.
+    */}
+    <Route
+      key="/submit-project"
+      path="/submit-project"
+      element={
+        <ProtectedRoute>
+          <SubmitProject />
+        </ProtectedRoute>
+      }
+    />
+  </Route>,
 ];


### PR DESCRIPTION
## 🛠️ GSSoC 2026 Pull Request: Bug Fix & Security Patch

### 📝 Description / Rationale

Five sensitive routes in `PublicRoutes.js` had no authentication guard,
allowing any unauthenticated visitor to access personal user data and
write-capable pages directly by typing the URL. This patch wraps all
affected routes with `<ProtectedRoute>` so unauthenticated users are
redirected to `/login` and returned to their intended destination after
sign-in.

Routes fixed:
- `/bookmarks` — personal saved events list
- `/reminders` — personal event reminders
- `/calendar` — personal calendar tied to user registrations
- `/analytics` — organisation-level event analytics
- `/submit-project` — writes project data (must require login)
- `/events/:id/floor-plan` — venue floor plan editor (must require login)

Closes #2225

---

### 💡 Proposed Technical Changes

- **Target File:** `src/components/routes/PublicRoutes.js`

- **Logic Implemented:**
  - Imported `ProtectedRoute` from `../auth/ProtectedRoute`.
  - Wrapped all six sensitive routes individually with `<ProtectedRoute>`.
    Unauthenticated users are redirected to `/login`; after sign-in they
    are returned to their originally requested page via React Router
    `state.from`.
  - Added a `SECURITY RULE` comment block to the file explaining the
    distinction between public and auth-required routes so future
    contributors do not accidentally add sensitive pages to the public list.
  - Moved all auth-required lazy imports into a clearly labelled section
    (`Auth-required page components`) separate from the public imports.
  - Added `/calendar` to the protected list — it displays data tied to the
    signed-in user's event registrations and must not be publicly accessible.

- **Safeguards Added:**
  - All six wrapped routes use the existing `ProtectedRoute` component which
    is already tested and used by `/dashboard`, `/admin`, and `/create-event`.
  - No new dependencies introduced.
  - Adjacent public routes (`/events`, `/hackathons`, `/projects`, etc.)
    are untouched and remain fully accessible without login.

---

### 🧪 Local Quality Assurance & Verification

- [x] Verified code compilation and dynamic asset rendering locally.
- [x] Tested layout boundaries across responsive mobile, tablet, and desktop viewports.
- [x] Verified that this change introduces zero breaking mutations to adjacent components.
- [x] Confirmed unauthenticated access to `/bookmarks`, `/reminders`,
      `/analytics`, `/submit-project`, `/calendar`, and `/events/:id/floor-plan`
      now redirects to `/login`.
- [x] Confirmed that logged-in users can still access all six routes normally.
- [x] Confirmed all other public routes (`/`, `/events`, `/faq`, etc.)
      remain unaffected.

Closes #2225
CC: @gssoc-maintainer

Signed-off-by: Mihir
