### PR TITLE
fix(security): remove CSP unsafe-inline from script-src and document …

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -1,75 +1,170 @@
 /**
  * secureStorage.js
- * Note: Client-side encryption has been removed as it provided no actual
- * XSS protection. Tokens and user data are temporarily stored in plain localStorage
- * pending a migration to backend HttpOnly cookies.
  *
- * syncSecureStorage is maintained as a plain-text pass-through wrapper to prevent
- * breaking existing imports and runtime code throughout the application.
+ * CURRENT STATE  ─ localStorage (transitional)
+ * ─────────────────────────────────────────────
+ * Tokens and user data are temporarily stored in plain localStorage while
+ * the codebase migrates to HttpOnly cookies (see MIGRATION PLAN below).
+ *
+ * WHY localStorage IS A SECURITY RISK
+ * ────────────────────────────────────
+ * Any JavaScript running on the page — including injected XSS payloads or
+ * compromised npm packages — can read localStorage without restriction:
+ *
+ *   localStorage.getItem("token")  // ← any script can do this
+ *
+ * This makes stored JWTs vulnerable to theft even if the rest of the
+ * application is otherwise secure.
+ *
+ * MIGRATION PLAN  ─ HttpOnly Cookies
+ * ────────────────────────────────────
+ * HttpOnly cookies are completely inaccessible to JavaScript. The browser
+ * sends them automatically with every same-origin and credentialed request.
+ *
+ * Required backend changes:
+ *   1. On login success: Set-Cookie: token=<jwt>; HttpOnly; Secure; SameSite=Strict
+ *   2. Expose a POST /api/auth/logout endpoint that clears the cookie server-side.
+ *   3. All protected endpoints read the token from the cookie, not the header.
+ *
+ * Required frontend changes (once backend supports cookies):
+ *   1. Remove setToken / getToken / removeToken calls from AuthContext.
+ *   2. Remove the manual Authorization header injection in config/api.js.
+ *   3. Ensure Axios keeps withCredentials: true (already set).
+ *   4. Remove all localStorage.setItem("token", ...) calls.
+ *
+ * NOTE: Client-side encryption was intentionally removed — it provided no
+ * real XSS protection because the encryption key was also stored in
+ * localStorage, making the entire scheme bypassable with a single read.
+ *
+ * syncSecureStorage is kept as a plain-text pass-through wrapper to prevent
+ * breaking existing imports throughout the application during the transition.
+ *
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
  */
 
+// ─── Token helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Persists the Eventra JWT to localStorage.
+ *
+ * TODO: Remove once the backend sets the token via an HttpOnly cookie.
+ * Until then, this is the only storage mechanism available on the frontend.
+ *
+ * @param {string} token - The Eventra-issued JWT returned by the backend
+ */
 export const setToken = (token) => {
   try {
-    localStorage.setItem("token", token);
+    localStorage.setItem('token', token);
   } catch (error) {
-    console.error('Error setting token:', error);
+    console.error('[secureStorage] Error setting token:', error);
   }
 };
 
+/**
+ * Retrieves the stored JWT from localStorage.
+ *
+ * TODO: Remove once the backend manages the token via an HttpOnly cookie
+ * (at which point the browser sends the cookie automatically).
+ *
+ * @returns {string|null} The stored JWT, or null if not present
+ */
 export const getToken = () => {
   try {
-    return localStorage.getItem("token");
+    return localStorage.getItem('token');
   } catch (error) {
-    console.error('Error getting token:', error);
+    console.error('[secureStorage] Error getting token:', error);
     return null;
   }
 };
 
+/**
+ * Removes the stored JWT from localStorage on logout.
+ *
+ * Also clears any legacy encryption-key artefacts that may still be present
+ * in old browser sessions from the previous (insecure) encrypted-storage
+ * implementation.
+ *
+ * TODO: Replace with a call to POST /api/auth/logout once the backend
+ * manages the session via HttpOnly cookies.
+ */
 export const removeToken = () => {
   try {
-    localStorage.removeItem("token");
+    localStorage.removeItem('token');
 
-    // CRITICAL: Clean up the old vulnerability!
-    // Wipe the exposed key out of the browser cache if it exists from an old session.
-    localStorage.removeItem("ENCRYPTION_KEY_KEY");
+    // Wipe the legacy key-in-storage artefact if it exists from an old session.
+    // The old implementation stored the encryption key in localStorage, which
+    // made the "encryption" trivially bypassable — it has been removed.
+    localStorage.removeItem('ENCRYPTION_KEY_KEY');
   } catch (error) {
-    console.error('Error removing token:', error);
+    console.error('[secureStorage] Error removing token:', error);
   }
 };
 
+// ─── Generic key–value storage wrapper ───────────────────────────────────────
+
+/**
+ * syncSecureStorage
+ *
+ * A pass-through wrapper around localStorage that maintains API compatibility
+ * with the old encrypted-storage implementation. It is kept to avoid breaking
+ * the many existing call sites throughout the application.
+ *
+ * This wrapper does NOT provide encryption or additional security.
+ * Do not store sensitive values (passwords, PII) through this interface.
+ */
 export const syncSecureStorage = {
+  /**
+   * Stores a string value under the given key.
+   * @param {string} key
+   * @param {string} value
+   * @returns {boolean} true on success, false on failure
+   */
   setItem: (key, value) => {
     try {
       localStorage.setItem(key, value);
       return true;
     } catch (error) {
-      console.error('syncSecureStorage.setItem failed:', error);
+      console.error('[secureStorage] setItem failed:', error);
       return false;
     }
   },
 
+  /**
+   * Retrieves the value stored under the given key.
+   * @param {string} key
+   * @returns {string|null}
+   */
   getItem: (key) => {
     try {
       return localStorage.getItem(key);
     } catch (error) {
-      console.error('syncSecureStorage.getItem failed:', error);
+      console.error('[secureStorage] getItem failed:', error);
       return null;
     }
   },
 
+  /**
+   * Removes the value stored under the given key.
+   * @param {string} key
+   */
   removeItem: (key) => {
     try {
       localStorage.removeItem(key);
     } catch (error) {
-      console.error('syncSecureStorage.removeItem failed:', error);
+      console.error('[secureStorage] removeItem failed:', error);
     }
   },
 
+  /**
+   * Clears all localStorage data for the current origin.
+   * Use with caution — this removes ALL keys, not just Eventra's.
+   */
   clear: () => {
     try {
       localStorage.clear();
     } catch (error) {
-      console.error('syncSecureStorage.clear failed:', error);
+      console.error('[secureStorage] clear failed:', error);
     }
-  }
+  },
 };

--- a/vercel.json
+++ b/vercel.json
@@ -48,7 +48,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com"
+          "value": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com"
         }
       ]
     },


### PR DESCRIPTION
## 🛠️ GSSoC 2026 Pull Request: Bug Fix & Security Patch

### 📝 Description / Rationale

Two related security issues addressed in this patch:

**Issue 1 — CSP `unsafe-inline` in `script-src`:**
The Content-Security-Policy header in `vercel.json` included `'unsafe-inline'`
in `script-src`. This allows any inline `<script>` tag or `javascript:` URI
to execute, which is the primary XSS vector. Combined with JWT tokens stored
in plain `localStorage`, a successful XSS payload can steal the auth token
in a single line: `localStorage.getItem('token')`.

**Issue 2 — JWT stored in `localStorage`:**
`secureStorage.js` stored the auth JWT in plain `localStorage` with no
migration path documented. The file acknowledged the risk but provided no
roadmap for contributors to resolve it. The full fix (HttpOnly cookies)
requires backend support and is tracked as a follow-on task; this PR lays
the complete frontend groundwork and documentation.

Closes #2228

---

### 💡 Proposed Technical Changes

- **Target Files:**
  - `vercel.json`
  - `src/utils/secureStorage.js`

- **Logic Implemented:**

  **`vercel.json` — CSP fix:**
  - Removed `'unsafe-inline'` from `script-src`. External script hosts
    (`accounts.google.com`, `cdn.jsdelivr.net`) remain explicitly
    whitelisted so Google Sign-In continues to work.
  - `style-src` retains `'unsafe-inline'` temporarily — React's runtime
    CSS injection requires it; a nonce-based approach is a separate task.

  **`src/utils/secureStorage.js` — migration groundwork:**
  - Added comprehensive JSDoc explaining exactly why `localStorage` is a
    security risk for JWT storage.
  - Added a step-by-step **HttpOnly cookie migration plan** as inline
    comments covering both the required backend changes (`Set-Cookie` with
    `HttpOnly; Secure; SameSite=Strict`) and the required frontend changes
    (remove `setToken`/`getToken`, remove manual `Authorization` header).
  - Added `TODO` markers on `setToken`, `getToken`, and `removeToken` so
    IDEs and linters surface these as pending migration items.
  - Added `@see` links to the OWASP Authentication and HTML5 Security
    Cheat Sheets for reference.
  - Added `[secureStorage]` prefix to all `console.error` calls for
    easier log filtering in production.
  - Documented why client-side encryption was removed (the key was stored
    in `localStorage` alongside the ciphertext — trivially bypassable).

- **Safeguards Added:**
  - All existing function signatures and exports are preserved — zero
    breaking changes to any call site.
  - Google Sign-In button continues to work (google.com whitelisted in CSP).
  - No runtime behaviour changes — this is a CSP header change + documentation
    improvement; the actual HttpOnly migration is a follow-on backend task.

---

### 🧪 Local Quality Assurance & Verification

- [x] Verified code compilation and dynamic asset rendering locally.
- [x] Tested layout boundaries across responsive mobile, tablet, and desktop viewports.
- [x] Verified that this change introduces zero breaking mutations to adjacent components.
- [x] Confirmed Google Sign-In still works after removing `unsafe-inline`
      from `script-src` (Google's script is whitelisted by domain).
- [x] Confirmed all existing `secureStorage` call sites compile without errors.
- [x] Confirmed `vercel.json` is valid JSON with no syntax errors.
- [x] Confirmed the CSP change only affects `script-src` — all other
      directives (`style-src`, `img-src`, `connect-src`, etc.) are unchanged.

Closes #2228
CC: @gssoc-maintainer

Signed-off-by: Mihir
