### PR TITLE
[FIX]: remove hardcoded Facebook App ID fallback from Messenger sharing

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -31,8 +31,19 @@ export const generateSharingUrl = (shareData, platform) => {
     case 'facebook':
       return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
       
-    case 'messenger':
-      return `https://www.facebook.com/dialog/send?link=${encodedUrl}&app_id=${process.env.REACT_APP_FACEBOOK_APP_ID || '1061800788374065'}&redirect_uri=${encodedUrl}`;
+    case 'messenger': {
+      const appId = process.env.REACT_APP_FACEBOOK_APP_ID;
+
+      if (!appId) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'REACT_APP_FACEBOOK_APP_ID is not set - Messenger sharing disabled'
+        );
+        return url;
+      }
+
+      return `https://www.facebook.com/dialog/send?link=${encodedUrl}&app_id=${appId}&redirect_uri=${encodedUrl}`;
+    }
       
     case 'linkedin':
       return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}&title=${encodedTitle}&summary=${encodedDescription}`;
@@ -119,6 +130,7 @@ export const copyToClipboard = async (text) => {
       return successful;
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.error('Failed to copy text: ', err);
     return false;
   }


### PR DESCRIPTION
## 🛠️ GSSoC 2026 Pull Request: Security Fix for Messenger Sharing

### 📝 Description / Rationale
This PR fixes a security issue where the Facebook Messenger sharing functionality used a hardcoded fallback Facebook App ID inside the frontend source code. Since frontend bundles are publicly accessible, exposing a production App ID in source code can lead to misuse for spoofed or phishing Messenger share links.

The fix removes the hardcoded fallback and ensures the application relies only on environment variables for configuration.

### 💡 Proposed Technical Changes
- **Target File:** `src/utils/shareUtils.js`
- **Logic Implemented:**
  - Removed the hardcoded Facebook App ID fallback
  - Messenger sharing now uses only:
    ```js
    process.env.REACT_APP_FACEBOOK_APP_ID
    ```
  - Added graceful handling when the environment variable is missing
  - Prevented insecure Messenger URL generation without a valid App ID
- **Safeguards Added:**
  - Added warning logging for missing environment configuration
  - Preserved existing functionality for all other share platforms
  - Avoided introducing breaking changes to the sharing utility

### 🧪 Local Quality Assurance & Verification
- [x] Verified Messenger sharing logic manually.
- [x] Ran ESLint validation on the modified file.
- [x] Confirmed no hardcoded App ID remains in the implementation.
- [x] Verified no unrelated files were modified.

### 🔒 Security Impact
This change prevents accidental exposure of production Facebook App credentials in:
- Git history
- Compiled frontend bundles
- Browser DevTools/network inspection

Closes #2258 
CC: @SandeepVashishtha  

Signed-off-by: @Yashrajsinh-Kanchva