### PR TITLE
fix: use ISO 8601 date format to prevent NaN on Safari and iOS (#2241)

### DIFF
--- a/src/components/common/CountdownTimer.jsx
+++ b/src/components/common/CountdownTimer.jsx
@@ -3,7 +3,7 @@ import { Clock } from "lucide-react";
 
 const calculateTimeLeft = (deadline) => {
   const diff = new Date(deadline) - new Date();
-  if (diff <= 0) return null;
+  if (isNaN(diff) || diff <= 0) return null;
   return {
     days: Math.floor(diff / (1000 * 60 * 60 * 24)),
     hours: Math.floor((diff / (1000 * 60 * 60)) % 24),
@@ -16,7 +16,7 @@ const pad = (n) => String(n).padStart(2, "0");
 
 // Compact version for EventCard
 export const CountdownBadge = ({ date, time }) => {
-  const deadline = useMemo(() => new Date(`${date} ${time}`), [date, time]);
+  const deadline = useMemo(() => new Date(`${date}T${time}`), [date, time]);
   const [timeLeft, setTimeLeft] = useState(() => calculateTimeLeft(deadline));
 
   useEffect(() => {
@@ -44,7 +44,7 @@ export const CountdownBadge = ({ date, time }) => {
 
 // Large version for EventDetailsPage
 const CountdownTimer = ({ date, time }) => {
-  const deadline = useMemo(() => new Date(`${date} ${time}`), [date, time]);
+  const deadline = useMemo(() => new Date(`${date}T${time}`), [date, time]);
   const [timeLeft, setTimeLeft] = useState(() => calculateTimeLeft(deadline));
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #2241

## What type of PR is this?
- [x] 🐛 Bug fix

## Description
Countdown timers showed "NaNd NaNh NaNm NaNs" on 
Safari and iOS because `new Date("2024-01-01 10:00")` 
with space separator is non-standard and returns 
Invalid Date in WebKit browsers.

## Root Cause
`new Date(\`${date} ${time}\`)` — space separator 
is not part of ISO 8601 standard. Safari strictly 
requires `T` separator between date and time.

## Changes Made
- Replaced space with `T` separator in both 
  `CountdownBadge` and `CountdownTimer` components
- Added `isNaN(diff)` guard in `calculateTimeLeft` 
  to safely handle invalid dates
- Fix applies to both compact and large timer variants

## Testing
- [x] Tested locally
- [x] Tested on Safari
- [x] Tested on iOS

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Code follows project style
- [x] No console errors/warnings