### PR TITLE
fix: use functional updater in updateSelectedElement to prevent stale closure (#2244)

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -286,23 +286,27 @@ const FloorPlanDesigner = ({ eventId = "default" }) => {
   };
 
   const updateSelectedElement = (key, value) => {
-    setElements(elements.map(el => {
-      if (el.id === selectedId) {
-        let updated = { ...el, [key]: value };
-        // Reset assigned attendees if seats decrease
-        if (key === "seatsCount") {
-          const freshAssigned = {};
-          Object.keys(el.assignedAttendees).forEach(k => {
-            if (parseInt(k) < value) {
-              freshAssigned[k] = el.assignedAttendees[k];
-            }
-          });
-          updated.assignedAttendees = freshAssigned;
+    const updates = typeof key === "object" ? key : { [key]: value };
+    setElements((prevElements) =>
+      prevElements.map((el) => {
+        if (el.id === selectedId) {
+          let updated = { ...el, ...updates };
+          // Reset assigned attendees if seats decrease
+          if ("seatsCount" in updates) {
+            const seatsCountVal = updates.seatsCount;
+            const freshAssigned = {};
+            Object.keys(el.assignedAttendees).forEach((k) => {
+              if (parseInt(k) < seatsCountVal) {
+                freshAssigned[k] = el.assignedAttendees[k];
+              }
+            });
+            updated.assignedAttendees = freshAssigned;
+          }
+          return updated;
         }
-        return updated;
-      }
-      return el;
-    }));
+        return el;
+      })
+    );
   };
 
   const handleSeatAssign = (seatIndex, attendeeName) => {


### PR DESCRIPTION
Fixes #2244

## What type of PR is this?
- [x] 🐛 Bug fix

## Description
Resizing round tables caused width and height to not 
update correctly together. Second resize update was 
overwriting the first due to stale closure.

## Root Cause
`updateSelectedElement` read `elements` directly from 
closure. Sequential calls in the same render tick both 
read the same stale snapshot, so the second update 
overwrote the first instead of building on it.

## Changes Made
- Refactored `updateSelectedElement` to use React 
  functional updater form `setElements(prevElements => ...)`
- Added support for passing an object of updates directly
  instead of single key/value — enables atomic batch updates
- Seat assignment reset logic preserved and updated to 
  work with the new object-based updates pattern

## Testing
- [x] Tested round table resizing locally
- [x] Width and height update correctly together
- [x] Seat assignment reset still works on seatsCount change

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Code follows project style
- [x] No console errors/warnings