### PR TITLE
fix: clear recovery timeout on manual reset to prevent unexpected page reloads (#2247)

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -83,6 +83,11 @@ class GlobalErrorBoundary extends React.Component {
 
   // Retry Rendering
   handleReset() {
+    if (this.recoveryTimeout) {
+      clearTimeout(this.recoveryTimeout);
+      this.recoveryTimeout = null;
+    }
+
     if (
       this.state.retryCount >=
       3


### PR DESCRIPTION
Fixes #2247

## What type of PR is this?
- [x] 🐛 Bug fix

## Description
Users were experiencing sudden unexpected page reloads 
during active sessions. Clicking "Try Again" manually 
did not stop the background auto-recovery timeout, 
causing it to fire anyway and eventually force a reload.

## Root Cause
`handleReset()` never cleared `this.recoveryTimeout` 
before executing. The 10-second auto-recovery timeout 
continued running in the background after manual reset. 
After 3 accumulated retries, `window.location.reload()` 
was forced unexpectedly mid-session.

## Changes Made
- Added `clearTimeout(this.recoveryTimeout)` at the 
  very start of `handleReset()`
- Set `this.recoveryTimeout = null` after clearing
- Manual "Try Again" now cancels any pending 
  auto-recovery timeout immediately

## Testing
- [x] Tested locally
- [x] Manual reset no longer triggers background reload
- [x] Auto-recovery still works when no manual reset

## Checklist
- [x] No hardcoded secrets or credentials
- [x] Code follows project style
- [x] No console errors/warnings