### PR TITLE
Fix/contributors search crash

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -190,11 +190,11 @@ const Contributors = () => {
   // Filter contributors based on search term
   const filteredContributors = contributors.filter(
     (c) =>
-      c.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      c.login?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      c.role?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      c.location?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      c.company?.toLowerCase().includes(searchTerm.toLowerCase()),
+      (c.name || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (c.login || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (c.role || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (c.location || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (c.company || "").toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
   // UPDATED: Loading skeleton grid


### PR DESCRIPTION
Closes #2284 

Description
This PR resolves a crashing bug (Unhandled TypeError) on the Contributors page caused by the search filter attempting to call .toLowerCase() on nullable fields (c.location and c.company) when querying profiles directly from the GitHub API.

Many GitHub profiles do not have a public location or company set. Previously, typing a search term would crash the page if a profile had null for these values.

Changes Made
Added a fallback empty string (c.location || "") and (c.company || "") before calling .toLowerCase() inside the filteredContributors callback in src/components/Contributors.js.
Applied the same safe fallback to all fields (name, login, role) for consistency and to prevent future regressions.

All checks were performed.