### PR TITLE
fix: sanitize CSV cell values to prevent formula injection

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -1,0 +1,59 @@
+export const exportAttendeesToCSV = (
+  attendees,
+  filename = "event-attendees.csv"
+) => {
+  if (!attendees || attendees.length === 0) {
+    return;
+  }
+
+  const headers = [
+    "Name",
+    "Email",
+    "Registration Date",
+    "Ticket Type",
+  ];
+
+  const sanitizeCsvCell = (value) => {
+    const str = String(value ?? "");
+    if (/^[=+\-@\t\r]/.test(str)) {
+      return "'" + str;
+    }
+    return str;
+  };
+
+  const rows = attendees.map((attendee) => [
+    sanitizeCsvCell(attendee.name || ""),
+    sanitizeCsvCell(attendee.email || ""),
+    sanitizeCsvCell(attendee.registrationDate || ""),
+    sanitizeCsvCell(attendee.ticketType || "General"),
+  ]);
+
+  const csvContent = [headers, ...rows]
+    .map((row) =>
+      row.map((field) => `"${field}"`).join(",")
+    )
+    .join("\n");
+
+  const blob = new Blob([csvContent], {
+    type: "text/csv;charset=utf-8;",
+  });
+
+  const url =
+    window.URL.createObjectURL(blob);
+
+  const link =
+    document.createElement("a");
+
+  link.href = url;
+
+  link.setAttribute(
+    "download",
+    filename
+  );
+
+  document.body.appendChild(link);
+
+  link.click();
+
+  document.body.removeChild(link);
+};


### PR DESCRIPTION
## What does this PR do?

This PR fixes the CSV formula injection vulnerability during attendee list exports.

## Why is this change needed?

Currently, user-submitted fields starting with `=`, `+`, `-`, or `@` are written directly into exported CSV cells.
This causes spreadsheet applications (Excel, Google Sheets) to interpret these values as formulas, creating security risks (arbitrary formula execution).

## What changes were made?

* Added a `sanitizeCsvCell` utility in `src/utils/exportCsv.js` to escape formula-prefixing characters with a single quote.
* Wrapped all mapped attendee fields with the sanitation utility.

## How to test

1. Export a list of attendees where a name or email starts with `=1+1`.
2. Open the CSV file in Excel or Google Sheets.
3. Observe that it renders as literal text `'=1+1` instead of executing a formula.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes