### PR TITLE
fix(form): remove duplicate additionalInfo textarea with conflicting …

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -824,39 +824,7 @@ const EventRegistration = () => {
                     </span>
                   </div>
               </div>
-             {/* Additional Info */}
-<div>
-  <label
-    htmlFor="additionalInfo"
-    className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
-  >
-    Additional Information (Optional)
-  </label>
 
-  <textarea
-    id="additionalInfo"
-    name="additionalInfo"
-    value={formData.additionalInfo}
-    onChange={handleChange}
-    rows="4"
-    maxLength={500}
-    className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-indigo-500 outline-none transition-all resize-none"
-    placeholder="Any special requirements or questions?"
-  />
-
-  {/* Character Counter */}
-  <div className="mt-2 flex justify-end">
-    <span
-      className={`text-sm font-medium transition-colors ${
-        formData.additionalInfo.length >= 400
-          ? "text-red-500"
-          : "text-gray-500 dark:text-gray-400"
-      }`}
-    >
-      {formData.additionalInfo.length} / 500 characters
-    </span>
-  </div>
-</div>
 
               {/* Submit Button */}
               <div className="flex gap-4">


### PR DESCRIPTION
## 🛠️ GSSoC 2026 Pull Request: Bug Fix & Accessibility Patch

### 📝 Description / Rationale

`EventRegistration.js` rendered **two separate `<textarea>` elements**
both with `id="additionalInfo"` and `name="additionalInfo"`. Duplicate
HTML IDs are invalid per the HTML spec and break all accessibility tools,
automated tests, and label associations. The two textareas also had
**different `maxLength` values** (`MAX_NOTES_CHARS` vs `500`), letting
users bypass the intended character limit by typing in the second one.

---

### 💡 Proposed Technical Changes

- **Target File:** `src/Pages/Events/EventRegistration.js`

- **Logic Implemented:**
  - Removed the duplicate second `<textarea>` block (lines 827–859).
  - The canonical first instance (lines 801–826) is retained as the
    single source of truth because it:
    - Uses `MAX_NOTES_CHARS` — a named constant — for a centrally
      controlled and consistent character limit.
    - Has the animated pulse counter that warns users as they approach
      the limit.
    - Is correctly indented inside the form's grid layout.

- **Safeguards Added:**
  - The `htmlFor="additionalInfo"` label now resolves to exactly one
    element — correct, accessible behaviour.
  - `MAX_NOTES_CHARS` is the single character limit in the form.
    The hardcoded `500` fallback that allowed users to bypass the limit
    is removed.
  - All `onChange`, `value`, and `onBlur` bindings remain on the
    retained textarea — no form data loss.

---

### 🧪 Local Quality Assurance & Verification

- [x] Verified code compilation and dynamic asset rendering locally.
- [x] Tested layout boundaries across responsive mobile, tablet, and desktop viewports.
- [x] Verified that this change introduces zero breaking mutations to adjacent components.
- [x] Confirmed `document.querySelectorAll('#additionalInfo')` returns
      exactly 1 element after the fix.
- [x] Confirmed the character counter and `maxLength` enforcement work
      correctly on the retained textarea.
- [x] Confirmed screen reader label association is correct (one label →
      one input).

Closes #2321 
CC: @gssoc-maintainer

Signed-off-by: Mihir
