### PR TITLE
Remove duplicate API endpoint aliases

### DIFF
--- a/src/Pages/Calendar/useCalendarEvents.js
+++ b/src/Pages/Calendar/useCalendarEvents.js
@@ -19,7 +19,7 @@ const useCalendarEvents = () => {
     setLoadError("");
 
     try {
-      const response = await apiUtils.get(API_ENDPOINTS.EVENTS.ALL);
+      const response = await apiUtils.get(API_ENDPOINTS.EVENTS.LIST);
       const apiEvents = Array.isArray(response.data) ? response.data : [];
       setEvents(normalizeEvents(apiEvents));
     } catch (error) {

--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -65,7 +65,7 @@ const useEventListing = () => {
     setLoadError("");
 
     try {
-      const response = await apiUtils.get(API_ENDPOINTS.EVENTS.ALL);
+      const response = await apiUtils.get(API_ENDPOINTS.EVENTS.LIST);
       const apiEvents = Array.isArray(response.data) ? response.data : [];
       setEvents(apiEvents.map((event) => ({ ...event, status: getEventStatus(event) })));
     } catch (error) {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -212,20 +212,17 @@ export const API_ENDPOINTS = {
   },
   EVENTS: {
     CREATE: buildApiUrl("/api/events/create"),
-    ALL: buildApiUrl("/api/events"),
     LIST: buildApiUrl("/api/events"),
     DETAIL: (id) => buildApiUrl(`/api/events/${id}`),
     REGISTER: (id) => buildApiUrl(`/api/events/${id}/register`),
   },
   PROJECTS: {
-    ALL: buildApiUrl("/api/projects"),
     LIST: buildApiUrl("/api/projects"),
     DETAIL: (id) => buildApiUrl(`/api/projects/${id}`),
     CATEGORIES: buildApiUrl("/api/projects/categories"),
     SUBMIT: buildApiUrl("/api/projects"),
   },
   NOTIFICATIONS: {
-    ALL: buildApiUrl("/api/notifications"),
     BASE: buildApiUrl("/api/notifications"),
     READ: (id) => (id ? buildApiUrl(`/api/notifications/${id}/read`) : ""),
     READ_ALL: buildApiUrl("/api/notifications/read-all"),


### PR DESCRIPTION
## Description
Removes duplicate API endpoint aliases from `src/config/api.js` to make endpoint usage more consistent and easier to grep.

Collection endpoints now use the canonical `LIST` name, while notifications keep `BASE`.

## Changes
- Removed `API_ENDPOINTS.EVENTS.ALL`
- Removed `API_ENDPOINTS.PROJECTS.ALL`
- Removed `API_ENDPOINTS.NOTIFICATIONS.ALL`
- Updated event list call sites from `EVENTS.ALL` to `EVENTS.LIST`

## Testing
- Verified no stale `EVENTS.ALL`, `PROJECTS.ALL`, or `NOTIFICATIONS.ALL` usages remain
- Confirmed the branch merges cleanly with `upstream/master`
- `npm run test:unit` could not complete locally because `fuse.js` is missing

Closes #2291 