### PR TITLE
Fix #2231: Allow single-character last names and improve validation

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -83,13 +83,13 @@ const Signup = () => {
     }
 
     if (e.target.name === "lastName") {
-      if (!e.target.value.trim())
+      if (!e.target.value.trim()) {
         setLastNameError("Last name is required");
-      else if (e.target.value.length < 2)
-        setLastNameError("At least 2 characters");
-      else if (e.target.value.length > 50)
+      } else if (e.target.value.trim().length > 50) {
         setLastNameError("Less than 50 characters");
-      else setLastNameError("");
+      } else {
+        setLastNameError("");  
+      } 
     }
 
     if (error) setError("");


### PR DESCRIPTION
## What this fixes

Closes #2231

## Changes made

* Updated last name validation to allow single-character inputs
* Added trimming to prevent whitespace-only values
* Ensured validation still restricts empty and overly long inputs

## How I tested it

✅ Tested with single-character last name ("S") — accepted
✅ Tested with normal last name ("Sharma") — accepted
✅ Tested with empty and whitespace-only input — rejected

## Notes

This improves inclusivity for naming conventions where single-character last names are common.
