### PR TITLE
Clear Chatbot reply timeout on close

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo, useState } from "react";
+import { useCallback, useEffect, useRef, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
@@ -96,6 +96,14 @@ export default function Chatbot() {
   const [draft, setDraft] = useState("");
   const [isTyping, setIsTyping] = useState(false);
   const [messages, setMessages] = useLocalStorage("eventra_chatbot_history", INITIAL_MESSAGES);
+  const replyTimerRef = useRef(null);
+
+  const clearReplyTimer = useCallback(() => {
+    if (replyTimerRef.current) {
+      clearTimeout(replyTimerRef.current);
+      replyTimerRef.current = null;
+    }
+  }, []);
 
   // Expiration check on mount (2 hours threshold)
   useEffect(() => {
@@ -106,6 +114,12 @@ export default function Chatbot() {
     }
     localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());
   }, []);
+
+  useEffect(() => {
+    return () => {
+      clearReplyTimer();
+    };
+  }, [clearReplyTimer]);
 
   // Sync last active timestamp when messages change
   useEffect(() => {
@@ -146,13 +160,15 @@ export default function Chatbot() {
     setIsTyping(true);
 
     // Simulated network/AI response latency
-    setTimeout(() => {
+    clearReplyTimer();
+    replyTimerRef.current = setTimeout(() => {
       const reply = getAssistantReply(cleanMessage);
       setMessages((prev) => [
         ...prev,
         { role: "assistant", content: reply.answer, actions: reply.actions }
       ]);
       setIsTyping(false);
+      replyTimerRef.current = null;
     }, 850);
   };
 
@@ -162,6 +178,8 @@ export default function Chatbot() {
   };
 
   const handleClose = () => {
+    clearReplyTimer();
+    setIsTyping(false);
     setIsOpen(false);
     setIsMinimized(false);
   };


### PR DESCRIPTION
Closes #2299 

## Description
Fixes a Chatbot lifecycle bug where the delayed assistant reply timeout could fire after the chatbot was closed or the component unmounted.

The pending reply timer is now stored in a ref and cleared when the chatbot closes or unmounts, preventing stale state updates and React warnings.

## Changes
- Added `replyTimerRef` to store the simulated reply timeout
- Added a shared timeout cleanup helper
- Clears pending reply timeout before scheduling a new one
- Clears pending timeout on chatbot close
- Clears pending timeout during component unmount cleanup
- Resets `isTyping` when the chatbot is closed

## Testing
- Verified the branch merges cleanly with latest `upstream/master`
- `npm run test:unit` could not complete locally because `fuse.js` is missing
