### PR TITLE
Remove redundant API dev flag alias

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -19,7 +19,7 @@ const normalizeApiBaseUrl = (value = "") => {
   }
 };
 
-const isDevelopment = process.env.NODE_ENV === "development";
+const isDev = process.env.NODE_ENV === "development";
 
 const resolveEnvApiBaseUrl = () => {
   return normalizeApiBaseUrl(process.env.REACT_APP_API_URL || "http://localhost:8080");
@@ -53,7 +53,6 @@ const REQUEST_TIMEOUT_MS = 15_000;
 const RETRYABLE_STATUS_CODES = [502, 503, 504];
 const MAX_RETRIES = 1;
 const RETRY_DELAY_MS = 1_000;
-const isDev = isDevelopment;
 
 // ---------------------------------------------------------------------------
 // Normalized API Error


### PR DESCRIPTION
Closes #2305 

## Description
Removes redundant development environment flag indirection in `src/config/api.js`.

The file previously declared both `isDevelopment` and `isDev` for the same boolean. It now uses a single `isDev` constant consistently in the API interceptors.

## Changes
- Renamed the environment check constant to `isDev`
- Removed the redundant `isDev = isDevelopment` alias
- Preserved existing interceptor behavior

## Testing
- Verified `isDevelopment` no longer exists
- Verified `isDev` is used consistently
- Confirmed the branch merges cleanly with `upstream/master`

## GSSoC
Please assign this PR under GSSoC'26.