### PR TITLE
Fix runtime crash in useKeyboardShortcuts caused by undefined key events

### DIFF
--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -18,22 +18,27 @@ const useKeyboardShortcuts = ({
 
       if (isTyping) return;
 
+      // Safe normalized key
+      const key = String(e?.key || "").toLowerCase();
+
+      if (!key) return;
+
       // Open modal
-      if (e.shiftKey && e.key === "?") {
+      if (e.shiftKey && key === "?") {
         e.preventDefault();
-        onOpenHelp();
+        onOpenHelp?.();
         return;
       }
 
       // Close modal
-      if (e.key === "Escape") {
+      if (key === "escape") {
         e.preventDefault();
-        onCloseHelp();
+        onCloseHelp?.();
         keyBuffer.current = [];
         return;
       }
 
-      keyBuffer.current.push(e.key.toLowerCase());
+      keyBuffer.current.push(key);
 
       if (keyBuffer.current.length > 2) {
         keyBuffer.current.shift();


### PR DESCRIPTION
## Description

### 🎯 Purpose of this Pull Request
Fixes a runtime crash occurring inside the `useKeyboardShortcuts` hook when certain keyboard events contain an undefined `key` value.

### 🔗 Related Issue
Fixes #2365 

### 🛠️ Changes Made
- Added safe normalization for `e.key`
- Prevented unsafe `.toLowerCase()` calls on undefined values
- Added fallback handling for invalid keyboard events
- Improved keyboard shortcut stability across browsers and input methods

### 🧪 Testing Done
- Verified keyboard shortcuts still work correctly:
  - `gh`
  - `gl`
  - `gs`
  - `Shift + ?`
  - `Escape`
- Confirmed application no longer crashes on malformed keyboard events
- Verified no ESLint or runtime errors remain