### PR TITLE
Validate GitHub proxy paths

### DIFF
--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -1,3 +1,27 @@
+const SAFE_GITHUB_PATH_PATTERNS = [
+  /^\/repos\/[^/?#]+\/[^/?#]+\/contributors$/,
+  /^\/repos\/[^/?#]+\/[^/?#]+\/pulls$/,
+  /^\/users\/[^/?#]+$/,
+];
+
+const normalizePath = (path) => {
+  const rawPath = Array.isArray(path) ? path[0] : path;
+  if (!rawPath || typeof rawPath !== "string") {
+    return "";
+  }
+
+  return rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+};
+
+const isSafeGitHubPath = (path) => {
+  if (path.includes("..") || path.includes("@") || path.includes("://")) {
+    return false;
+  }
+
+  const { pathname } = new URL(path, "https://api.github.com");
+  return SAFE_GITHUB_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
+};
+
 export default async function handler(req, res) {
   const { path, ...queryParams } = req.query;
 
@@ -5,13 +29,25 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Missing path parameter" });
   }
 
-  const queryString = new URLSearchParams(queryParams).toString();
-  const url = `https://api.github.com${path.startsWith('/') ? path : `/${path}`}${queryString ? `?${queryString}` : ""}`;
+  const normalizedPath = normalizePath(path);
+
+  if (!normalizedPath || !isSafeGitHubPath(normalizedPath)) {
+    return res.status(400).json({ error: "Invalid GitHub API path" });
+  }
+
+  const url = new URL(normalizedPath, "https://api.github.com");
+  Object.entries(queryParams).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((item) => url.searchParams.append(key, item));
+    } else if (value !== undefined) {
+      url.searchParams.append(key, value);
+    }
+  });
 
   const token = process.env.GITHUB_TOKEN || process.env.REACT_APP_GITHUB_TOKEN;
 
   try {
-    const fetchRes = await fetch(url, {
+    const fetchRes = await fetch(url.toString(), {
       headers: {
         Accept: "application/vnd.github.v3+json",
         ...(token ? { Authorization: `token ${token}` } : {}),

--- a/tests/githubProxy.test.mjs
+++ b/tests/githubProxy.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import handler from "../api/github-proxy.js";
+
+const createResponse = () => {
+  const response = {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.body = body;
+      return this;
+    },
+  };
+
+  return response;
+};
+
+const blockedPaths = [
+  "@evil.example.com/steal",
+  "/repos/owner/repo/../secret",
+  "/repos/owner/repo/issues",
+  "https://evil.example.com/steal",
+];
+
+let fetchCalls = [];
+globalThis.fetch = async (url, options) => {
+  fetchCalls.push({ url, options });
+  return {
+    status: 200,
+    json: async () => ({ ok: true }),
+  };
+};
+
+process.env.GITHUB_TOKEN = "test-token";
+
+for (const path of blockedPaths) {
+  const response = createResponse();
+  await handler({ query: { path } }, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(fetchCalls.length, 0);
+}
+
+const contributorsResponse = createResponse();
+await handler(
+  { query: { path: "/repos/Eventra/Eventra/contributors?per_page=100", page: "2" } },
+  contributorsResponse
+);
+
+assert.equal(contributorsResponse.statusCode, 200);
+assert.equal(fetchCalls.length, 1);
+assert.equal(
+  fetchCalls[0].url,
+  "https://api.github.com/repos/Eventra/Eventra/contributors?per_page=100&page=2"
+);
+assert.equal(fetchCalls[0].options.headers.Authorization, "token test-token");
+
+const usersResponse = createResponse();
+await handler({ query: { path: "/users/octocat" } }, usersResponse);
+
+assert.equal(usersResponse.statusCode, 200);
+assert.equal(fetchCalls.length, 2);
+assert.equal(fetchCalls[1].url, "https://api.github.com/users/octocat");


### PR DESCRIPTION
Closes #2309 

## Description
Hardens `api/github-proxy.js` against unsafe GitHub API path values.

The proxy now validates the requested path before building the GitHub API URL or attaching the configured GitHub token. Invalid paths are rejected with a `400 Bad Request`.

## Changes
- Added allowlisted GitHub API path patterns
- Allows only current supported proxy routes:
  - `/repos/{owner}/{repo}/contributors`
  - `/repos/{owner}/{repo}/pulls`
  - `/users/{username}`
- Rejects paths containing `..`, `@`, or `://`
- Builds the upstream request with the `URL` API instead of string interpolation
- Added regression tests for malicious and valid proxy paths

## Testing
- Passed: `node tests/githubProxy.test.mjs`
- Confirmed the branch merges cleanly with `upstream/master`
- `npm run test:unit` could not complete locally because `fuse.js` is missing

## GSSoC
Please assign this PR under GSSoC'26.