### PR TITLE
Security: Expand Permissions-Policy headers to restrict modern browse…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -44,7 +44,7 @@
         },
         {
           "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=()"
+          "value": "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=(), payment=(), usb=(), bluetooth=()"
         },
         {
           "key": "Content-Security-Policy",


### PR DESCRIPTION
## Description
This PR enforces a modern, strict `Permissions-Policy` HTTP header in the `vercel.json` configuration file. It restricts access to sensitive browser APIs (like geolocation, camera, microphone, and newer APIs like browsing-topics) to enhance the application's privacy and security posture.

Fixes #2360

## Changes Made
- Expanded the `Permissions-Policy` header in `vercel.json` to include modern web restrictions.