### PR TITLE
fix csv blob url cleanup

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -60,7 +60,13 @@ export const exportAttendeesToCSV = (
 
   document.body.appendChild(link);
 
-  link.click();
+  try {
+    link.click();
+  } finally {
+    document.body.removeChild(link);
 
-  document.body.removeChild(link);
+    setTimeout(() => {
+      window.URL.revokeObjectURL(url);
+    }, 100);
+  }
 };

--- a/tests/exportCsv.test.mjs
+++ b/tests/exportCsv.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 
 let blobContent = "";
 let clicked = false;
+let revokedUrl = "";
 
 globalThis.Blob = class {
   constructor(parts) {
@@ -14,7 +15,14 @@ globalThis.window = {
     createObjectURL() {
       return "blob:csv";
     },
+    revokeObjectURL(url) {
+      revokedUrl = url;
+    },
   },
+};
+
+globalThis.setTimeout = (callback) => {
+  callback();
 };
 
 globalThis.document = {
@@ -53,6 +61,7 @@ exportAttendeesToCSV([
 ]);
 
 assert.equal(clicked, true);
+assert.equal(revokedUrl, "blob:csv");
 assert.ok(blobContent.includes(`"'=HYPERLINK(""http://evil.com"",""click"")"`));
 assert.ok(blobContent.includes(`"'+user""quote@example.com"`));
 assert.ok(blobContent.includes(`"'-2026-05-26"`));


### PR DESCRIPTION
Closes #2323 

## Summary
- Revoke generated CSV Blob object URLs after triggering attendee CSV downloads
- Keep DOM cleanup in a `finally` block so the temporary download link is removed reliably
- Add test coverage to verify the Blob URL is revoked

## Why
Repeated CSV exports previously created object URLs via `URL.createObjectURL()` without releasing them. This retained Blob references until page unload and could accumulate memory during long sessions.

## Testing
- `node tests/exportCsv.test.mjs`

Note: `npm run test:unit` could not complete locally because `fuse.js` is missing from `node_modules`.