### PR TITLE
fix chatbot effect dependencies

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -113,7 +113,7 @@ export default function Chatbot() {
       setMessages(INITIAL_MESSAGES);
     }
     localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());
-  }, []);
+  }, [setMessages]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
Closes #2334 

## Summary
- Add `setMessages` to the Chatbot expiration `useEffect` dependency array
- Align the hook with React exhaustive-deps guidance

## Why
The effect references `setMessages` from `useLocalStorage`, but the dependency array was empty. This could trigger `react-hooks/exhaustive-deps` warnings and risk a stale setter reference.

## Testing
- `git diff --check`

Note: The requested `npx eslint src/components/Chatbot.jsx --rule '{"react-hooks/exhaustive-deps": "warn"}'` could not be completed cleanly because `npx` fetched ESLint 10, which requires `eslint.config.*` and does not read this project’s current `package.json` ESLint config format.