### PR TITLE
fix messenger share app id fallback

### DIFF
--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -107,6 +107,10 @@ const ShareMenu = ({
       setTimeout(() => setCopied(false), 2000);
       return;
     }
+
+    if (!url) {
+      return;
+    }
     
     // Open URL in a new window for social platforms
     window.open(url, '_blank', 'noopener,noreferrer');

--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -10,7 +10,7 @@
  * @param {string} shareData.description - The description of the content
  * @param {string} shareData.url - The URL to the content
  * @param {string} shareData.hashtags - Comma-separated list of hashtags (no # symbol)
- * @param {string} platform - The platform to share on ('email', 'twitter', 'facebook', 'linkedin', 'whatsapp', 'telegram')
+ * @param {string} platform - The platform to share on ('email', 'twitter', 'facebook', 'messenger', 'linkedin', 'whatsapp', 'telegram')
  * @returns {string} The sharing URL for the specified platform
  */
 export const generateSharingUrl = (shareData, platform) => {
@@ -35,11 +35,7 @@ export const generateSharingUrl = (shareData, platform) => {
       const appId = process.env.REACT_APP_FACEBOOK_APP_ID;
 
       if (!appId) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'REACT_APP_FACEBOOK_APP_ID is not set - Messenger sharing disabled'
-        );
-        return url;
+        return '';
       }
 
       return `https://www.facebook.com/dialog/send?link=${encodedUrl}&app_id=${appId}&redirect_uri=${encodedUrl}`;


### PR DESCRIPTION
Closes #2335 

## Summary
- Remove fallback behavior for Messenger sharing when `REACT_APP_FACEBOOK_APP_ID` is missing
- Return an empty share URL for Messenger without a configured Facebook App ID
- Guard the share menu from opening empty share URLs

## Why
Messenger sharing should not silently fall back to a committed App ID or a misleading URL. The required `REACT_APP_FACEBOOK_APP_ID` remains documented in `.env.example`.

## Testing
- Verified no hardcoded Facebook App ID remains under `src`
- Ran a direct module check confirming Messenger returns an empty string when `REACT_APP_FACEBOOK_APP_ID` is unset