### PR TITLE
feat: implement interactive REST API playground and sandbox console in docs 

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -1,4 +1,4 @@
-
+import React, { useState } from "react";
 import { motion } from "framer-motion";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import useReducedMotion from "../hooks/useReducedMotion.js";
@@ -8,6 +8,11 @@ import {
   BookOpen,
   Users,
   Trophy,
+  Play,
+  RefreshCw,
+  Terminal,
+  Settings,
+  ShieldAlert,
 } from "lucide-react";
 
 const endpoints = [
@@ -86,6 +91,120 @@ example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
 const ApiDocs = () => {
   const prefersReducedMotion = useReducedMotion();
   useDocumentTitle("Eventra | API Docs");
+
+  const [selectedEndpoint, setSelectedEndpoint] = useState("/api/hackathons");
+  const [params, setParams] = useState({
+    limit: "5",
+    status: "all",
+    hackathonId: "1",
+    sortBy: "recent",
+    authHeader: "Bearer evt_dev_test_token",
+    role: "all",
+    page: "1",
+  });
+  const [terminalOutput, setTerminalOutput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleParamChange = (name, val) => {
+    setParams(prev => ({ ...prev, [name]: val }));
+  };
+
+  const executeMockRequest = () => {
+    setIsLoading(true);
+    setTerminalOutput("");
+    
+    setTimeout(() => {
+      let data = [];
+      const headers = {
+        Status: "200 OK",
+        "Content-Type": "application/json",
+        "X-Powered-By": "Eventra Mock API Sandbox Engine",
+        "Cache-Control": "no-cache",
+      };
+      
+      switch (selectedEndpoint) {
+        case "/api/hackathons": {
+          const limitVal = parseInt(params.limit) || 5;
+          const statusVal = params.status || "all";
+          const allHackathons = [
+            { id: 1, title: "CodeFest 2025", startDate: "2025-09-20", endDate: "2025-09-25", participants: 150, status: "completed" },
+            { id: 2, title: "AI Innovation Challenge", startDate: "2026-06-15", endDate: "2026-06-18", participants: 420, status: "active" },
+            { id: 3, title: "Global Open Source Sprint", startDate: "2026-08-01", endDate: "2026-08-10", participants: 750, status: "active" },
+            { id: 4, title: "Web3 Protocol Buildathon", startDate: "2026-11-10", endDate: "2026-11-15", participants: 280, status: "active" },
+            { id: 5, title: "Cyber Shield Security CTF", startDate: "2025-12-05", endDate: "2025-12-07", participants: 190, status: "completed" },
+          ];
+          let filtered = allHackathons;
+          if (statusVal !== "all") {
+            filtered = allHackathons.filter(h => h.status === statusVal);
+          }
+          data = filtered.slice(0, limitVal);
+          break;
+        }
+        case "/api/projects": {
+          const hackathonId = params.hackathonId || "1";
+          const sortBy = params.sortBy || "recent";
+          const allProjects = [
+            { id: 42, title: "AI-Powered Chatbot", author: "Jane Doe", votes: 120, hackathonId: "1", date: "2025-09-24" },
+            { id: 43, title: "Decentralized File Storage", author: "Bob Smith", votes: 95, hackathonId: "2", date: "2026-06-17" },
+            { id: 44, title: "Open Source Contributor Board", author: "Alice Johnson", votes: 240, hackathonId: "1", date: "2025-09-25" },
+            { id: 45, title: "Zero Knowledge Proof Verification", author: "Charlie Brown", votes: 180, hackathonId: "2", date: "2026-06-16" },
+          ];
+          let filtered = allProjects.filter(p => p.hackathonId === hackathonId);
+          if (sortBy === "votes") {
+            filtered.sort((a, b) => b.votes - a.votes);
+          }
+          data = filtered;
+          break;
+        }
+        case "/api/contributors": {
+          const authHeader = params.authHeader || "";
+          if (!authHeader.startsWith("Bearer ")) {
+            headers.Status = "401 Unauthorized";
+            data = { error: "Missing or invalid bearer token in Authorization headers." };
+            break;
+          }
+          const role = params.role || "all";
+          const allContributors = [
+            { id: 7, username: "dev_ankita", points: 230, rank: 2, role: "maintainer" },
+            { id: 8, username: "coder123", points: 500, rank: 1, role: "contributor" },
+            { id: 9, username: "alex_builds", points: 180, rank: 3, role: "contributor" },
+            { id: 10, username: "sara_security", points: 150, rank: 4, role: "maintainer" },
+          ];
+          let filtered = allContributors;
+          if (role !== "all") {
+            filtered = allContributors.filter(c => c.role === role);
+          }
+          data = filtered;
+          break;
+        }
+        case "/api/leaderboard": {
+          const limitVal = parseInt(params.limit) || 10;
+          const pageVal = parseInt(params.page) || 1;
+          const allLeaderboard = [
+            { rank: 1, username: "coder123", points: 500 },
+            { rank: 2, username: "dev_ankita", points: 230 },
+            { rank: 3, username: "alex_builds", points: 180 },
+            { rank: 4, username: "sara_security", points: 150 },
+            { rank: 5, username: "john_doe", points: 120 },
+            { rank: 6, username: "jane_doe", points: 110 },
+          ];
+          const start = (pageVal - 1) * limitVal;
+          data = allLeaderboard.slice(start, start + limitVal);
+          break;
+        }
+        default:
+          break;
+      }
+      
+      const responseStr = JSON.stringify(data, null, 2);
+      const headersStr = Object.entries(headers)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join("\n");
+      
+      setTerminalOutput(`${headersStr}\n\n${responseStr}`);
+      setIsLoading(false);
+    }, 700);
+  };
 
   return (
     <div className="pastel-grid-bg min-h-screen bg-white dark:bg-[#121212] text-gray-900 dark:text-gray-100 px-6 py-16">
@@ -211,7 +330,7 @@ const ApiDocs = () => {
       </section>
 
       {/* Error Codes */}
-      <section className="max-w-6xl mx-auto mb-16">
+      <section className="max-w-6xl mx-auto mb-20">
         <h2 className="text-3xl font-semibold mb-8 text-center">
           Error Codes
         </h2>
@@ -264,6 +383,209 @@ const ApiDocs = () => {
                 </tr>
               </tbody>
             </table>
+          </div>
+        </div>
+      </section>
+
+      {/* INTERACTIVE API PLAYGROUND SANDBOX */}
+      <section className="max-w-6xl mx-auto mb-16">
+        <h2 className="text-3xl font-semibold mb-8 text-center">
+          Interactive API Playground
+        </h2>
+
+        <div className="bg-slate-900 border border-slate-800 rounded-3xl p-6 md:p-8 shadow-xl text-slate-100 grid grid-cols-1 lg:grid-cols-[340px_1fr] gap-8">
+          
+          {/* Playground config panel */}
+          <div className="space-y-6">
+            <div className="flex items-center gap-2 text-indigo-400 font-bold uppercase tracking-wider text-xs">
+              <Settings className="w-4 h-4" />
+              <span>Query Configurator</span>
+            </div>
+
+            {/* Select Endpoint */}
+            <div>
+              <label className="block text-xs font-bold text-slate-400 uppercase mb-2">Target Endpoint</label>
+              <select
+                value={selectedEndpoint}
+                onChange={(e) => setSelectedEndpoint(e.target.value)}
+                className="w-full bg-slate-950 border border-slate-800 rounded-xl px-4 py-2.5 text-sm outline-none text-white focus:border-indigo-500"
+              >
+                <option value="/api/hackathons">GET /api/hackathons</option>
+                <option value="/api/projects">GET /api/projects</option>
+                <option value="/api/contributors">GET /api/contributors</option>
+                <option value="/api/leaderboard">GET /api/leaderboard</option>
+              </select>
+            </div>
+
+            {/* Config inputs based on Endpoint */}
+            <div className="p-4 bg-slate-950/50 border border-slate-800/80 rounded-2xl space-y-4">
+              <span className="block text-[10px] font-black text-slate-500 uppercase tracking-widest leading-none">Parameters</span>
+              
+              {selectedEndpoint === "/api/hackathons" && (
+                <div className="space-y-4 animate-fadeIn">
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Limit (Count)</label>
+                    <input
+                      type="number"
+                      value={params.limit}
+                      onChange={(e) => handleParamChange("limit", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Status</label>
+                    <select
+                      value={params.status}
+                      onChange={(e) => handleParamChange("status", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    >
+                      <option value="all">All</option>
+                      <option value="active">Active</option>
+                      <option value="completed">Completed</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+
+              {selectedEndpoint === "/api/projects" && (
+                <div className="space-y-4 animate-fadeIn">
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Hackathon ID</label>
+                    <input
+                      type="text"
+                      value={params.hackathonId}
+                      onChange={(e) => handleParamChange("hackathonId", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Sort By</label>
+                    <select
+                      value={params.sortBy}
+                      onChange={(e) => handleParamChange("sortBy", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    >
+                      <option value="recent">Recent</option>
+                      <option value="votes">Votes</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+
+              {selectedEndpoint === "/api/contributors" && (
+                <div className="space-y-4 animate-fadeIn">
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Authorization Header</label>
+                    <input
+                      type="text"
+                      value={params.authHeader}
+                      onChange={(e) => handleParamChange("authHeader", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                      placeholder="Bearer token"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Role Filter</label>
+                    <select
+                      value={params.role}
+                      onChange={(e) => handleParamChange("role", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    >
+                      <option value="all">All</option>
+                      <option value="maintainer">Maintainer</option>
+                      <option value="contributor">Contributor</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+
+              {selectedEndpoint === "/api/leaderboard" && (
+                <div className="space-y-4 animate-fadeIn">
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Limit</label>
+                    <input
+                      type="number"
+                      value={params.limit}
+                      onChange={(e) => handleParamChange("limit", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1">Page</label>
+                    <input
+                      type="number"
+                      value={params.page}
+                      onChange={(e) => handleParamChange("page", e.target.value)}
+                      className="w-full bg-slate-950 border border-slate-800 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-indigo-500"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <button
+              onClick={executeMockRequest}
+              disabled={isLoading}
+              className="w-full py-3 px-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-xs font-black uppercase tracking-wider transition-all flex items-center justify-center gap-2 cursor-pointer shadow-md disabled:opacity-50"
+            >
+              {isLoading ? (
+                <>
+                  <RefreshCw className="w-4 h-4 animate-spin" />
+                  <span>Executing Request...</span>
+                </>
+              ) : (
+                <>
+                  <Play className="w-4 h-4" />
+                  <span>Execute Request</span>
+                </>
+              )}
+            </button>
+          </div>
+
+          {/* Playground terminal sandbox */}
+          <div className="flex flex-col h-[340px] md:h-auto min-h-[380px] bg-slate-950 border border-slate-800 rounded-2xl overflow-hidden">
+            {/* Console Address Bar */}
+            <div className="flex items-center gap-3 px-4 py-3 bg-slate-900 border-b border-slate-850">
+              <div className="flex items-center gap-1.5 shrink-0">
+                <span className="w-2.5 h-2.5 rounded-full bg-rose-500" />
+                <span className="w-2.5 h-2.5 rounded-full bg-amber-500" />
+                <span className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
+              </div>
+
+              <div className="flex-1 flex items-center gap-2 px-3 py-1 bg-slate-950 border border-slate-850 rounded-lg text-[10px] font-mono text-slate-400 select-all overflow-x-auto whitespace-nowrap scrollbar-none">
+                <span className="text-emerald-500 font-bold uppercase shrink-0">GET</span>
+                <span>http://localhost:3000{selectedEndpoint}</span>
+                {selectedEndpoint === "/api/hackathons" && (
+                  <span className="text-indigo-400 shrink-0">?limit={params.limit}&status={params.status}</span>
+                )}
+                {selectedEndpoint === "/api/projects" && (
+                  <span className="text-indigo-400 shrink-0">?hackathonId={params.hackathonId}&sortBy={params.sortBy}</span>
+                )}
+                {selectedEndpoint === "/api/contributors" && (
+                  <span className="text-indigo-400 shrink-0">?role={params.role}</span>
+                )}
+                {selectedEndpoint === "/api/leaderboard" && (
+                  <span className="text-indigo-400 shrink-0">?limit={params.limit}&page={params.page}</span>
+                )}
+              </div>
+            </div>
+
+            {/* Output terminal */}
+            <div className="flex-1 p-4 font-mono text-xs overflow-y-auto leading-relaxed select-text scrollbar-thin scrollbar-thumb-slate-800 scrollbar-track-transparent">
+              {isLoading ? (
+                <div className="flex flex-col items-center justify-center h-full text-slate-500 gap-2">
+                  <RefreshCw className="w-6 h-6 animate-spin text-indigo-400" />
+                  <span>Connecting to mock sandbox database...</span>
+                </div>
+              ) : terminalOutput ? (
+                <pre className="text-emerald-400 whitespace-pre-wrap">{terminalOutput}</pre>
+              ) : (
+                <div className="flex flex-col items-center justify-center h-full text-slate-600 gap-2 text-center max-w-sm mx-auto">
+                  <Terminal className="w-8 h-8 text-slate-800" />
+                  <p className="text-[11px]">Terminal idle. Configure your query parameters and click "Execute Request" to display payload console details.</p>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## 💻 feat: Interactive REST API Playground and Live Sandbox Console
Closes #2311 
### Problem
The API Docs page (`src/Pages/ApiDocs.js`) was entirely static. Users had to look at hardcoded JSON mock responses and request snippets, without the ability to dynamically test the endpoints or see how query variables alter payload objects.

### Proposed Changes
- **Query Configurator Control Panel**: Injected custom controls (limit count, status dropdown, hackathon ID, sorting criteria) that render adaptively based on the selected endpoint.
- **Header Authentication Sandbox**: Added an `Authorization` header input field for the `/api/contributors` endpoint. Emulates authentication checks: returns a real `401 Unauthorized` response block if the Bearer token formatting is missing or invalid.
- **Latency & Loader Terminal Console**: Styled a dark CLI-styled console showing custom response headers (`Status: 200 OK`, `X-Powered-By`, etc.) and formatted JSON response bodies with simulation loading spinners.

### Modified Files
| File Path | Action | Description |
|---|---|---|
| `src/Pages/ApiDocs.js` | **MODIFIED** | Implemented query states, sandbox runner methods, configurator fields, and emulator terminal. |
