### PR TITLE
Chore: Add CODEOWNERS to automate PR review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Global owner (fallback)
+* @SandeepVashishtha
+
+# Specific directories
+/.github/ @SandeepVashishtha
+/src/ @SandeepVashishtha


### PR DESCRIPTION
## 🚀 Objective
This Pull Request introduces a `.github/CODEOWNERS` file to automate repository governance. It ensures that the right maintainers are immediately and automatically pinged for reviews whenever critical code is modified.

## 🔍 Context & Rationale
As open-source repositories scale (especially during events like GSSoC), the influx of Pull Requests can become overwhelming. Without automated routing:
1. **Review Delays:** PRs sit unassigned for days because contributors don't know who to manually request a review from.
2. **Maintainer Burnout:** Core maintainers waste time manually triaging and assigning PRs.
3. **Security Risks:** Critical infrastructural files (like CI/CD pipelines) might get merged by junior reviewers without a senior architect looking at them.

## 🛠️ Changes Implemented
- **Created `CODEOWNERS`:** Placed in the `.github/` directory for native GitHub integration.
- **Global Fallback Routing:** Assigned `@SandeepVashishtha` as the default code owner for the entire repository, guaranteeing that no PR ever slips through the cracks.
- **Strict Directory Enforcement:** Explicitly routed all changes in `src/` and `.github/` to ensure high-priority logic and CI/CD pipelines always receive core maintainer oversight.

## 📈 Expected Impact & Benefits
- **⚡ Lightning-Fast Triage:** Reviewers are assigned the exact second a PR is opened.
- **🔒 Guardrailed Merging:** GitHub can now optionally be configured to *require* an owner's approval before a branch can be merged.
- **✅ Streamlined Operations:** Massive reduction in administrative overhead for the core team.

I am contributing this critical repository management optimization as part of GSSoC '26!