### PR TITLE
fix: resolve duplicate button syntax error in FloorPlanDesigner prope…

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -877,8 +877,7 @@ const FloorPlanDesigner = ({ eventId = "default" }) => {
               <div className="fp-sidebar-section">
                 <div className="flex items-center justify-between mb-4">
                   <div className="fp-section-title">Element Details</div>
-                  <button 
-                    <button
+                  <button
                     onClick={handleDeleteSelected}
                     aria-label="Delete selected floor plan element"
                     className="p-1.5 text-red-400 hover:bg-red-500/10 border border-red-500/20 hover:border-red-500/40 rounded-lg transition-colors cursor-pointer"


### PR DESCRIPTION
## 🛠️ fix: FloorPlanDesigner Properties Sidebar JSX Syntax Error
Closes #2395 
### Problem
A duplicate `<button` opening tag inside `src/components/events/FloorPlanDesigner.js` prevented the application from compiling and loading, causing a React build failure.

### Proposed Changes
- Removed the redundant button opening line on line 881.
- Restored code structure to ensure clean component parsing and smooth compilation.

### Modified Files
| File Path | Action | Description |
|---|---|---|
| `src/components/events/FloorPlanDesigner.js` | **MODIFIED** | Cleaned up duplicate button markup in sidebar elements. |
