### PR TITLE
Feat/ticket generator

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -152,10 +152,6 @@ const EventDetailsPage = () => {
                 alt={`${event.title} event banner`}
                 className="w-full h-96 object-cover"
               />
-  src={event.image}
-  alt={event.title}
-  className="w-full h-48 sm:h-64 md:h-96 object-cover"
-/>
 
               <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
 
@@ -186,9 +182,6 @@ const EventDetailsPage = () => {
                 <h1 id="event-details-title" className="text-4xl font-bold">
                   {event.title}
                 </h1>
-                <h1 className="text-xl sm:text-2xl md:text-4xl font-bold leading-tight">
-  {event.title}
-</h1>
               </div>
             </div>
 
@@ -203,9 +196,7 @@ const EventDetailsPage = () => {
               </p>
             </section>
           </section>
-            </div>
-          </div>
-        {/* Sidebar */}
+          {/* Sidebar */}
           <div className="lg:col-span-1 flex flex-col gap-6">
             {/* Countdown Timer */}
             {!isPastEvent && (

--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -3,7 +3,7 @@ import { useNotification } from '../context/NotificationContext';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import QuestCenter from '../components/gamification/QuestCenter';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast } from 'react-hot-toast';
+import { toast } from 'react-toastify';
 import {
   Award,
   Zap,

--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -877,8 +877,7 @@ const FloorPlanDesigner = ({ eventId = "default" }) => {
               <div className="fp-sidebar-section">
                 <div className="flex items-center justify-between mb-4">
                   <div className="fp-section-title">Element Details</div>
-                  <button 
-                    <button
+                  <button
                     onClick={handleDeleteSelected}
                     aria-label="Delete selected floor plan element"
                     className="p-1.5 text-red-400 hover:bg-red-500/10 border border-red-500/20 hover:border-red-500/40 rounded-lg transition-colors cursor-pointer"

--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -309,7 +309,7 @@ const EventTicket = ({ event, user, onClose }) => {
                       })} 
                       size={90} 
                       bgColor="transparent" 
-                      fgColor="currentColor"
+                      fgColor="#ffffff"
                       className="ud-ticket-qr"
                     />
                   </div>

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -81,7 +81,7 @@ const EmptyState = () => {
   );
 };
 
-const EventCard = ({ event, index, onRemoveRegistration, showCancel }) => {
+const EventCard = ({ event, index, onRemoveRegistration, showCancel, onViewTicket }) => {
   const prefersReducedMotion = useReducedMotion();
   const fadeUpVariants = fadeUp(prefersReducedMotion);
   const status = getEventStatus(event);
@@ -176,21 +176,31 @@ const EventCard = ({ event, index, onRemoveRegistration, showCancel }) => {
 
       <div className="px-6 py-4 flex gap-3 bg-gradient-to-r from-gray-50/30 to-white/60 dark:from-gray-800/30 dark:to-gray-900/60 border-t border-gray-200/60 dark:border-gray-700/50 mt-auto">
         {showCancel ? (
-          <button
-            className="group/btn flex-1"
-            onClick={() => onRemoveRegistration?.(event?.id, event?.title)}
-          >
-            <div className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-slate-950 via-slate-900 to-indigo-950 hover:from-slate-900 hover:via-slate-800 hover:to-indigo-900 text-white px-5 py-2.5 text-sm font-bold shadow-lg hover:shadow-xl transition-all duration-300 w-full relative overflow-hidden">
-              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-slate-900 to-transparent -translate-x-full group-hover/btn:translate-x-full transition-transform duration-700" />
-              <Trash2 size={13} className="relative" />
-              <span className="relative">Cancel</span>
-            </div>
-          </button>
+          <>
+            <button
+              className="group/btn flex-1"
+              onClick={() => onRemoveRegistration?.(event?.id, event?.title)}
+            >
+              <div className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-slate-950 via-slate-900 to-indigo-950 hover:from-slate-900 hover:via-slate-800 hover:to-indigo-900 text-white px-3 py-2 text-xs sm:px-5 sm:py-2.5 sm:text-sm font-bold shadow-lg hover:shadow-xl transition-all duration-300 w-full relative overflow-hidden cursor-pointer">
+                <Trash2 size={13} className="relative" />
+                <span className="relative">Cancel</span>
+              </div>
+            </button>
+            <button
+              className="group/btn flex-1"
+              onClick={() => onViewTicket?.(event)}
+            >
+              <div className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-650 to-pink-600 hover:from-indigo-700 hover:to-pink-700 text-white px-3 py-2 text-xs sm:px-5 sm:py-2.5 sm:text-sm font-bold shadow-lg hover:shadow-xl transition-all duration-300 w-full relative overflow-hidden cursor-pointer">
+                <Ticket size={13} className="relative" />
+                <span className="relative">Ticket</span>
+              </div>
+            </button>
+          </>
         ) : (
           <div className="flex-1" />
         )}
         <Link to={`/events/${event?.id}`} className="group/btn flex-1">
-          <div className="inline-flex items-center justify-center gap-2 rounded-2xl border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-5 py-2.5 text-sm font-bold hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-indigo-400 dark:hover:border-indigo-500 transition-all duration-300 w-full">
+          <div className="inline-flex items-center justify-center gap-2 rounded-2xl border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-3 py-2 text-xs sm:px-5 sm:py-2.5 sm:text-sm font-bold hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-indigo-400 dark:hover:border-indigo-500 transition-all duration-300 w-full">
             <span>{showCancel ? "View Details" : "Open Event"}</span>
           </div>
         </Link>
@@ -199,7 +209,7 @@ const EventCard = ({ event, index, onRemoveRegistration, showCancel }) => {
   );
 };
 
-const EventsTab = ({ hostedEvents = [] }) => {
+const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   const prefersReducedMotion = useReducedMotion();
   const fadeUpVariants = fadeUp(prefersReducedMotion);
   const staggerVariants = stagger(prefersReducedMotion);
@@ -440,6 +450,7 @@ const EventsTab = ({ hostedEvents = [] }) => {
                     index={index}
                     onRemoveRegistration={handleCancelClick}
                     showCancel
+                    onViewTicket={onViewTicket}
                   />
                 ))}
               </motion.div>

--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -370,6 +370,7 @@ export default function UserDashboard() {
           {activeTab === "events" && (
             <EventsTab
               hostedEvents={MOCK_DATA.filter((d) => d.type === "Event" && d.participationType === "Hosted")}
+              onViewTicket={setSelectedTicketEvent}
             />
           )}
 
@@ -472,7 +473,7 @@ export default function UserDashboard() {
                           <td>
                             <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
                               <StatusBadge status={item.participationType} />
-                              {item.type === "Event" && item.participationType === "Registered" && (
+                              {(item.type === "Event" || item.type === "Hackathon") && item.participationType === "Registered" && (
                                 <button
                                   onClick={() => setSelectedTicketEvent(item)}
                                   className="ud-btn-ticket"


### PR DESCRIPTION
## 🎟️ feat: Dynamic Ticket Generator, visual exporting, and User Achievements Fix
Closes #2396 
### Problem
1. Registered users couldn't access their event tickets from the main **Events** tab under the dashboard, only from the general registrations grid.
2. The "View Ticket" button was only active for general `Event` entries, preventing registered `Hackathon` users from accessing the custom holographic `HACKATHON PASS` ticket themes.
3. High-resolution canvas ticket downloads via `html2canvas` occasionally failed to render the SVG QR code due to its dependency on the CSS `currentColor` variable.
4. Badge sharing inside the **Progression Studio** triggered a runtime `TypeError` (`toast.info is not a function`) due to an invalid/deprecated `react-hot-toast` import.
5. Duplicate elements, broken image attributes, and mismatched closing `</div>` tags inside `EventDetailsPage.js` prevented the build step from compiling successfully.

### Proposed Changes
- **EventsTab Integration**: Added a "Ticket" button to all registered event card footers inside the EventsTab list.
- **Holographic Hackathon passes**: Enabled the View Ticket button for registered Hackathon objects under the registrations grid.
- **QR Code Canvas Compatibility**: Standardized the fill color of the `react-qr-code` SVG component to `#ffffff` to guarantee flawless vector rendering under `html2canvas`.
- **Achievements Toast Fix**: Swapped out the `react-hot-toast` import with the unified `react-toastify` library inside `UserAchievements.jsx` to prevent copy-to-clipboard runtime crashes.
- **Event Details Cleanup**: Resolved HTML duplication and rendering-blocking syntax errors in `EventDetailsPage.js`.
