### PR TITLE
Meta: Add FUNDING.yml to enable GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [SandeepVashishtha]


### PR DESCRIPTION
## 🚀 Description
This PR adds a `.github/FUNDING.yml` file to officially enable the GitHub "Sponsor" button on the repository. This allows the project and maintainer to directly accept community support from the repository page.

Fixes #2426

## 🛠️ Type of change
- [x] New feature (non-breaking change which adds functionality)

## 📋 Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas