### PR TITLE
Chore: Implement markdownlint configuration to standardize documentation

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,12 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD029": {
+    "style": "ordered"
+  }
+}


### PR DESCRIPTION
## 🚀 Description
This PR introduces a `.markdownlint.json` configuration file at the root directory to establish standard markdown formatting rules (e.g., no trailing spaces, consistent heading levels). This helps all contributors write better, standardized documentation.

Fixes #2425

## 🛠️ Type of change
- [x] New feature (non-breaking change which adds functionality)

## 📋 Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas