### PR TITLE
fix: add aria attributes to form inputs for screen readers

### DIFF
--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -226,11 +226,14 @@ const RegistrationPage = () => {
                     errors.fullName ? "border-rose-500 ring-rose-500/20" : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 dark:focus:border-indigo-400"
                   } p-3.5 rounded-2xl text-slate-800 dark:text-white outline-none focus:ring-4 focus:ring-indigo-500/10 dark:focus:ring-indigo-400/10 transition-all duration-300`}
                   required
+                  aria-invalid={!!errors.fullName}
+                  aria-describedby={errors.fullName ? "fullName-error" : undefined}
                 />
               </div>
               <AnimatePresence>
                 {errors.fullName && (
                   <motion.div
+                    id="fullName-error"
                     initial={{ opacity: 0, y: -8 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -8 }}
@@ -261,10 +264,13 @@ const RegistrationPage = () => {
                   errors.email ? "border-rose-500 ring-rose-500/20" : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 dark:focus:border-indigo-400"
                 } p-3.5 rounded-2xl text-slate-800 dark:text-white outline-none focus:ring-4 focus:ring-indigo-500/10 dark:focus:ring-indigo-400/10 transition-all duration-300`}
                 required
+                aria-invalid={!!errors.email}
+                aria-describedby={errors.email ? "email-error" : undefined}
               />
               <AnimatePresence>
                 {errors.email && (
                   <motion.div
+                    id="email-error"
                     initial={{ opacity: 0, y: -8 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -8 }}
@@ -295,10 +301,13 @@ const RegistrationPage = () => {
                   errors.phone ? "border-rose-500 ring-rose-500/20" : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 dark:focus:border-indigo-400"
                 } p-3.5 rounded-2xl text-slate-800 dark:text-white outline-none focus:ring-4 focus:ring-indigo-500/10 dark:focus:ring-indigo-400/10 transition-all duration-300`}
                 required
+                aria-invalid={!!errors.phone}
+                aria-describedby={errors.phone ? "phone-error" : undefined}
               />
               <AnimatePresence>
                 {errors.phone && (
                   <motion.div
+                    id="phone-error"
                     initial={{ opacity: 0, y: -8 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -8 }}


### PR DESCRIPTION
# Pull Request: Fix Missing ARIA Attributes on Form Error States

## Description
This PR addresses issue #2215 by adding dynamic `aria-invalid` and `aria-describedby` attributes to the form inputs in `RegistrationPage.jsx`.

### Changes Made:
- **`src/Pages/RegistrationPage.jsx`**:
  - Added `aria-invalid={!!errors.fieldName}` to the Full Name, Email, and Phone number inputs.
  - Added `aria-describedby` to link these inputs to their corresponding error message containers.
  - Assigned unique `id`s (`fullName-error`, `email-error`, `phone-error`) to the `motion.div` containers that display the validation error messages.

## Why this is important:
- **Accessibility Improvements**: Screen readers will now automatically announce when a form field is invalid.
- **Contextual Feedback**: Assistive technologies will properly associate and read aloud the specific error message linked to the input field, improving the experience for visually impaired users.

## Testing:
- Ran the unit test suite (`npm run test:unit`) and ESLint (`npm run lint`), verifying that these modifications introduce no new regressions.