### PR TITLE
docs: clarify mock server side-effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,20 +363,18 @@ SSE_MOCK_PORT=4005 ALLOWED_ORIGIN=http://localhost:3000 SSE_DEBUG=true node sse-
 ```
 
 ### 3. Configure the React Application
-Update `.env.local` to point to the mock server base URL:
-```env
-REACT_APP_API_URL=http://localhost:4001
-```
-*(Make sure to match the port number if a custom `SSE_MOCK_PORT` was configured.)*
 Update `.env.local` to point to the mock server. You have two options:
 - **Option A (Recommended)**: Set `REACT_APP_SSE_URL` to route only real-time connections to the mock server, keeping the rest of the application pointing to the real API:
   ```env
   REACT_APP_SSE_URL=http://localhost:4001
   ```
-- **Option B**: Set the general `REACT_APP_API_URL` to point to the mock server port (this routes all endpoints through port 4001):
+- **Option B (Not Recommended)**: Set the general `REACT_APP_API_URL` to point to the mock server port (this routes all endpoints through port 4001):
   ```env
   REACT_APP_API_URL=http://localhost:4001
   ```
+  > [!WARNING]
+  > **Side-effects of Option B:** Setting the general `REACT_APP_API_URL` to the mock server port will break standard REST API calls (like fetching events, logging in, etc.) because the mock server does not proxy these requests. Use Option A for standard local development to prevent breaking your local environment.
+
 
 ---
 


### PR DESCRIPTION
# Pull Request: Clarify Local Mock Server Setup

## Description
This PR updates the `README.md` to address issue #2217, clarifying the mock server setup options to prevent contributors from inadvertently breaking their local environment during standard development.

### Changes Made:
- Removed a duplicate and contradictory instruction block instructing users to set `REACT_APP_API_URL` before introducing the options.
- Labeled Option B as "(Not Recommended)".
- Added a `> [!WARNING]` block explaining that Option B routes all endpoints (including REST APIs for standard data fetching/authentication) through the mock server port. Since the mock server does not proxy these standard API endpoints, standard calls will break.

## Why this is important:
- New contributors testing real-time leaderboard features will be explicitly guided to use Option A (`REACT_APP_SSE_URL`) to avoid local environment breakages.