### PR TITLE
fix(#2453): restrict forwarded query params to an explicit allowlist in github-proxy

### DIFF
--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -4,6 +4,10 @@ const SAFE_GITHUB_PATH_PATTERNS = [
   /^\/users\/[^/?#]+$/,
 ];
 
+// Only these query parameters are forwarded to the GitHub API.
+// All other caller-supplied parameters are silently dropped.
+const ALLOWED_QUERY_PARAMS = new Set(["per_page", "page", "state", "sort", "direction"]);
+
 const normalizePath = (path) => {
   const rawPath = Array.isArray(path) ? path[0] : path;
   if (!rawPath || typeof rawPath !== "string") {
@@ -37,6 +41,7 @@ export default async function handler(req, res) {
 
   const url = new URL(normalizedPath, "https://api.github.com");
   Object.entries(queryParams).forEach(([key, value]) => {
+    if (!ALLOWED_QUERY_PARAMS.has(key)) return;
     if (Array.isArray(value)) {
       value.forEach((item) => url.searchParams.append(key, item));
     } else if (value !== undefined) {


### PR DESCRIPTION
## Summary

Fixes #2453

`api/github-proxy.js` spread all caller-supplied query parameters (except `path`) directly onto the outbound GitHub API URL. An attacker could inject arbitrary parameters such as `access_token`, `client_id`, `client_secret`, or `scope` into the upstream request. Depending on the GitHub API endpoint and OAuth app config, this could leak secrets via redirect, bypass pagination, or poison cached responses.

**Change:** Introduce `ALLOWED_QUERY_PARAMS` (a `Set`) containing only the safe pagination/filter params: `per_page`, `page`, `state`, `sort`, `direction`. Any caller-supplied key not in this set is dropped before the URL is constructed. The path allowlist (`SAFE_GITHUB_PATH_PATTERNS`) is unchanged.

## Test plan

- [ ] `?per_page=10&page=2` is forwarded correctly to GitHub
- [ ] `?access_token=foo` is dropped and does not appear in the upstream URL
- [ ] `?client_secret=bar` is silently ignored
- [ ] Contributors and pulls endpoints continue to return paginated data
- [ ] Invalid path still returns 400

Could you please add the appropriate GSSoC/difficulty labels to this PR? It would help with contribution tracking. Thank you!