### PR TITLE
fix(hackathons): prevent negative or zero participant limit 

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -125,6 +125,11 @@ const HostHackathon = () => {
         "Description must be at least 20 characters long!";
     }
 
+    // Participant Limit validation
+    if (data.participantLimit && Number(data.participantLimit) < 1) {
+      newErrors.participantLimit = "Participant limit must be at least 1!";
+    }
+
     return newErrors;
   };
 


### PR DESCRIPTION
## 🚀 Description
Fixed a frontend validation loophole where users could submit a hackathon with negative or zero participant limits.

**The Bug:**
The `HostHackathon.js` component performs rigorous client-side validation for most fields (name lengths, valid emails, date chronology). However, it completely lacked validation for the `participantLimit` field. Because the HTML `<input type="number">` did not enforce a minimum value natively, users could manually type `-500` or `0`, completely bypassing restrictions and sending malformed numeric data to the state/backend.

**Changes Made:**
* Modified `src/Pages/Hackathons/HostHackathon.js`.
* Added explicit validation inside the `validateForm` function to ensure that if `data.participantLimit` is provided, it is numerically `>= 1`.
* If the limit is negative or zero, it sets a specific error blocking the submission and focusing the user on the field.

**Impact:**
This fix maintains data integrity for hackathon limits and prevents bugs on the UI where "negative" spots remaining could be displayed, ensuring organizers set valid capacity limits.

Fixes #2443 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
