### PR TITLE
fix(#2454): add auth guard and real API call to HostHackathon and SubmitProject forms

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 import { toast } from "react-toastify";
-import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
 
 import useReducedMotion from "../../hooks/useReducedMotion.js";
+import { useAuth } from "../../context/AuthContext";
+import { API_ENDPOINTS, apiUtils } from "../../config/api";
 import {
   ArrowRightIcon,
   ChartBarIcon,
@@ -22,7 +24,17 @@ import {
 
 const HostHackathon = () => {
   const prefersReducedMotion = useReducedMotion();
+  const navigate = useNavigate();
+  const { user, token, isAuthenticated } = useAuth();
   const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      toast.error("You must be logged in to host a hackathon.");
+      navigate("/login", { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
   const [formData, setFormData] = useState({
     hackathonName: "",
     organizerName: "",
@@ -129,6 +141,13 @@ const HostHackathon = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+
+    if (!isAuthenticated()) {
+      toast.error("You must be logged in to host a hackathon.");
+      navigate("/login");
+      return;
+    }
+
     const validationErrors = validateForm({ ...formData });
 
     if (Object.keys(validationErrors).length > 0) {
@@ -150,22 +169,39 @@ const HostHackathon = () => {
       return;
     }
 
-    toast.success("Hackathon submitted successfully!");
+    setIsSubmitting(true);
+    try {
+      await apiUtils.post(
+        API_ENDPOINTS.HACKATHONS.HOST,
+        {
+          ...formData,
+          hostUserId: user?.id,
+        },
+        token
+      );
 
-    setFormData({
-      hackathonName: "",
-      organizerName: "",
-      email: "",
-      startDate: "",
-      endDate: "",
-      description: "",
-      location: "",
-      participantLimit: "",
-      prizeDetails: "",
-      website: "",
-    });
+      toast.success("Hackathon submitted successfully! It will be reviewed before going live.");
 
-    window.scrollTo({ top: 0, behavior: "smooth" });
+      setFormData({
+        hackathonName: "",
+        organizerName: "",
+        email: "",
+        startDate: "",
+        endDate: "",
+        description: "",
+        location: "",
+        participantLimit: "",
+        prizeDetails: "",
+        website: "",
+      });
+
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    } catch (err) {
+      const message = err?.data?.message || err?.message || "Submission failed. Please try again.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const formFields = [
@@ -419,9 +455,11 @@ const HostHackathon = () => {
           {/* Submit Button */}
           <button
             type="submit"
-            className="w-full flex items-center justify-center gap-2 bg-black text-white font-semibold p-3 rounded-xl shadow-lg hover:bg-zinc-800 transition-all duration-300"
+            disabled={isSubmitting}
+            className="w-full flex items-center justify-center gap-2 bg-black text-white font-semibold p-3 rounded-xl shadow-lg hover:bg-zinc-800 transition-all duration-300 disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            Submit Hackathon <ArrowRightIcon className="w-5 h-5" />
+            {isSubmitting ? "Submitting..." : "Submit Hackathon"}
+            {!isSubmitting && <ArrowRightIcon className="w-5 h-5" />}
           </button>
         </form>
       </motion.div>

--- a/src/Pages/Projects/SubmitProject.js
+++ b/src/Pages/Projects/SubmitProject.js
@@ -1,6 +1,9 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+import { API_ENDPOINTS, apiUtils } from "../../config/api";
 import {
   ArrowRightIcon,
   LightBulbIcon,
@@ -26,6 +29,17 @@ import {
 } from "@heroicons/react/24/solid";
 
 const SubmitProject = () => {
+  const navigate = useNavigate();
+  const { user, token, isAuthenticated } = useAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      toast.error("You must be logged in to submit a project.");
+      navigate("/login", { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
   const [formData, setFormData] = useState({
     projectName: "",
     teamName: "",
@@ -126,8 +140,15 @@ const SubmitProject = () => {
     return newErrors;
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
+
+    if (!isAuthenticated()) {
+      toast.error("You must be logged in to submit a project.");
+      navigate("/login");
+      return;
+    }
+
     const validationErrors = validateForm(formData);
 
     if (Object.keys(validationErrors).length > 0) {
@@ -135,8 +156,8 @@ const SubmitProject = () => {
       toast.error("Please fix the errors before submitting!");
 
       const fieldsInOrder = [
-        ...formFields.map(field => field.name), 
-        "description", 
+        ...formFields.map(field => field.name),
+        "description",
         "additionalNotes"
       ];
 
@@ -154,25 +175,42 @@ const SubmitProject = () => {
       return;
     }
 
-    toast.success("Project submitted successfully!");
-    setFormData({
-      projectName: "",
-      teamName: "",
-      email: "",
-      githubLink: "",
-      liveDemoLink: "",
-      description: "",
-      projectType: "",
-      techStack: "",
-      projectCategory: "",
-      additionalNotes: "",
-      projectImage: "",
-      submissionCategory: "",
-      teamMembersCount: "",
-      projectDuration: "",
-      targetAudience: "",
-    });
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    setIsSubmitting(true);
+    try {
+      await apiUtils.post(
+        API_ENDPOINTS.PROJECTS.SUBMIT,
+        {
+          ...formData,
+          submittedBy: user?.id,
+        },
+        token
+      );
+
+      toast.success("Project submitted successfully!");
+      setFormData({
+        projectName: "",
+        teamName: "",
+        email: "",
+        githubLink: "",
+        liveDemoLink: "",
+        description: "",
+        projectType: "",
+        techStack: "",
+        projectCategory: "",
+        additionalNotes: "",
+        projectImage: "",
+        submissionCategory: "",
+        teamMembersCount: "",
+        projectDuration: "",
+        targetAudience: "",
+      });
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    } catch (err) {
+      const message = err?.data?.message || err?.message || "Submission failed. Please try again.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
   
   // Define form fields with icons
@@ -435,11 +473,13 @@ const SubmitProject = () => {
           </motion.div>
           <motion.button
             type="submit"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            className="w-full flex items-center justify-center gap-2 text-white font-semibold p-3 rounded-xl shadow-lg transition-all duration-300 bg-black hover:bg-zinc-800"
+            disabled={isSubmitting}
+            whileHover={{ scale: isSubmitting ? 1 : 1.05 }}
+            whileTap={{ scale: isSubmitting ? 1 : 0.95 }}
+            className="w-full flex items-center justify-center gap-2 text-white font-semibold p-3 rounded-xl shadow-lg transition-all duration-300 bg-black hover:bg-zinc-800 disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            Submit Project <ArrowRightIcon className="w-5 h-5" />
+            {isSubmitting ? "Submitting..." : "Submit Project"}
+            {!isSubmitting && <ArrowRightIcon className="w-5 h-5" />}
           </motion.button>
         </form>
       </motion.div>

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -229,6 +229,11 @@ export const API_ENDPOINTS = {
     CATEGORIES: buildApiUrl("/api/projects/categories"),
     SUBMIT: buildApiUrl("/api/projects"),
   },
+  HACKATHONS: {
+    LIST: buildApiUrl("/api/hackathons"),
+    DETAIL: (id) => buildApiUrl(`/api/hackathons/${id}`),
+    HOST: buildApiUrl("/api/hackathons"),
+  },
   NOTIFICATIONS: {
     BASE: buildApiUrl("/api/notifications"),
     READ: (id) => (id ? buildApiUrl(`/api/notifications/${id}/read`) : ""),


### PR DESCRIPTION
## Summary

Fixes #2454

Both `HostHackathon` and `SubmitProject` forms ran their client-side validation and then called `toast.success()` with no authentication check and no backend API call. Any unauthenticated visitor could fill the form, see a success message, and have nothing persisted.

**Changes across 3 files:**

`src/Pages/Hackathons/HostHackathon.js`
- Import `useAuth`, `useNavigate`, `API_ENDPOINTS`, `apiUtils`
- Add `useEffect` that redirects to `/login` when `isAuthenticated()` is false
- Check auth again inside `handleSubmit` before submitting
- Replace `toast.success()` with `apiUtils.post(API_ENDPOINTS.HACKATHONS.HOST, payload, token)`
- Add `isSubmitting` state to disable the button and show "Submitting..." during the request
- Show error toast on API failure

`src/Pages/Projects/SubmitProject.js`
- Same auth guard, same API wiring via `API_ENDPOINTS.PROJECTS.SUBMIT`

`src/config/api.js`
- Add `HACKATHONS: { LIST, DETAIL, HOST }` entries using the existing `buildApiUrl` helper

## Test plan

- [ ] Unauthenticated user visiting `/host-hackathon` is redirected to `/login`
- [ ] Authenticated user can fill and submit the form; request goes to `POST /api/hackathons`
- [ ] Button shows "Submitting..." and is disabled while the request is in flight
- [ ] API error shows a toast with the server's error message
- [ ] Same behaviour for `/submit-project` against `POST /api/projects`

Could you please add the appropriate GSSoC/difficulty labels to this PR? It would help with contribution tracking. Thank you!