### PR TITLE
fix(#2455): remove early-return localStorage guard so server validates duplicates

### DIFF
--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -95,12 +95,15 @@ const RegistrationPage = () => {
     setErrors((prev) => ({ ...prev, submit: "" }));
 
     try {
+      // Show a fast pre-check hint using the local cache, but always proceed
+      // to the API call so the server remains the authoritative duplicate guard.
       if (isAlreadyRegistered(eventId, formData.email)) {
         setErrors((prev) => ({
           ...prev,
           submit: "You have already registered with this email address.",
         }));
-        return;
+        // Do not return here -- fall through to the API call so the server can
+        // confirm. The server's 409 will be caught below if it rejects.
       }
 
       await apiUtils.post(
@@ -110,6 +113,7 @@ const RegistrationPage = () => {
 
       saveRegistration(eventId, formData.email);
       setSubmitSuccess(true);
+      setErrors((prev) => ({ ...prev, submit: "" }));
       toast.success("Registration successful!");
     } catch (error) {
       const registrationErrorMessage = getRegistrationErrorMessage(error);


### PR DESCRIPTION
## Summary

Fixes #2455

`RegistrationPage.jsx` used `isAlreadyRegistered()` (backed by `localStorage`) as the primary duplicate guard. When this check returned `true`, the handler set an error message and returned early, never making the API call. Clearing localStorage or using a private/incognito window bypasses the check entirely, allowing a second registration to go through without any server-side verification.

**Root cause:** The localStorage check was used as a gatekeeper rather than a UX hint.

**Fix:** Remove the early `return` inside the localStorage check. The API call now always proceeds, and the server-side uniqueness constraint (expected to return 409 Conflict on duplicate) is the authoritative guard. The localStorage check remains as a UX pre-check hint only. The pre-populated error message is cleared on a successful API response so the UI does not show a stale warning.

No changes to `registerUtils.js` or the backend.

## Test plan

- [ ] Normal registration (first time) succeeds and shows success message
- [ ] Clearing localStorage and re-submitting the same email still triggers a server-side duplicate error
- [ ] Private/incognito window re-submit is rejected by the server, not silently accepted
- [ ] The localStorage hint still shows the "already registered" message as a pre-check on subsequent visits
- [ ] API 409 response is displayed as an error toast

Could you please add the appropriate GSSoC/difficulty labels to this PR? It would help with contribution tracking. Thank you!