### PR TITLE
fix(#2447): reject offline queue replay when auth token is expired or absent

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -78,6 +78,17 @@ const useOfflineSync = () => {
         return;
       }
 
+      // Refuse to replay queued actions under an expired or missing token.
+      // The queue was saved under a previous session; firing it now could
+      // attach those actions to whichever user happens to be logged in.
+      if (!token || !isTokenValid(token)) {
+        toast.warning(
+          "Offline actions are pending but your session has expired. Please log in again to sync them.",
+          { autoClose: 6000 }
+        );
+        return;
+      }
+
       isSyncing.current = true;
 
       try {


### PR DESCRIPTION
## Summary

Fixes #2447

`useOfflineSync.js` fired all queued offline registrations the moment the browser came back online, using whatever `token` was in the current React context. If the original session had expired, the user had logged out, or a different user had logged in between the time the action was queued and the time connectivity was restored, those requests would be sent under the wrong identity or with no credentials.

**Change:** Add an `isTokenValid(token)` guard at the top of `handleOnline()`. If the token is missing or expired, the sync is aborted immediately and the user receives a toast explaining that they must log in again to flush the queue. The queue itself is preserved so it can be replayed once a valid session is established.

`isTokenValid` is already available in `../utils/tokenUtils` (re-exported from `./auth`).

## Test plan

- [ ] With a valid logged-in session, coming back online syncs the queue as expected
- [ ] After logging out and coming back online, sync is blocked and the toast is shown
- [ ] After the token expires and reconnecting, sync is blocked
- [ ] After logging back in with a valid token and triggering `handleOnline`, the queue is replayed correctly
- [ ] The queue is not cleared when sync is blocked by the token guard

Could you please add the appropriate GSSoC/difficulty labels to this PR? It would help with contribution tracking. Thank you!