### PR TITLE
fix: enforce react/jsx-no-target-blank rule and fix TeamMatchmaking.jsx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   ],
   "rules": {
     "no-console": "warn",
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "react/jsx-no-target-blank": "error"
   }
 }

--- a/src/Pages/Hackathons/components/TeamMatchmaking.jsx
+++ b/src/Pages/Hackathons/components/TeamMatchmaking.jsx
@@ -493,7 +493,7 @@ const TeamMatchmaking = () => {
                     <a
                       href={team.contact}
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                       className="px-4 py-2 bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-750 text-slate-700 dark:text-slate-300 rounded-xl text-xs font-bold flex items-center gap-1 transition"
                     >
                       <span>Contact builder</span>


### PR DESCRIPTION
## 🚀 Description
This PR improves the security of the application by enforcing the `react/jsx-no-target-blank` ESLint rule across the project. 
Using `target="_blank"` on external links without `rel="noopener noreferrer"` exposes the site to potential reverse tabnapping attacks. While most of the codebase already adhered to this best practice, there was no automated linting rule to enforce it for future contributions.

Fixes #2336 

## 🛠️ Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
