### PR TITLE
fix(#2446): migrate auth token from localStorage to sessionStorage

### DIFF
--- a/src/components/common/EventCreation.js
+++ b/src/components/common/EventCreation.js
@@ -67,7 +67,7 @@ const EventCreation = () => {
   const [currentStep, setCurrentStep] = useState("form");
 
   const { handleSubmit: submitEventForm, isSubmitting, error: submitError, success: submitSuccess } = useFormSubmit(async (eventData) => {
-    const token = localStorage.getItem("token");
+    const token = sessionStorage.getItem("token");
     if (!token) {
       throw new Error("Authentication required. Please log in and try again.");
     }

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -106,7 +106,7 @@ const normalizeRequestConfig = (configOrToken = {}, maybeToken) => {
       ? configOrToken
       : typeof maybeToken === "string"
         ? maybeToken
-        : localStorage.getItem("token") || "";
+        : sessionStorage.getItem("token") || "";
 
   if (token) {
     config.headers = {

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -28,7 +28,7 @@ export const AuthProvider = ({ children }) => {
   const clearSession = useCallback(() => {
     setUser(null);
     setToken(null);
-    localStorage.removeItem("token");
+    sessionStorage.removeItem("token");
     localStorage.removeItem("user");
   }, []);
 
@@ -48,7 +48,7 @@ export const AuthProvider = ({ children }) => {
 
   useEffect(() => {
     // Check for existing authentication on app start
-    const storedToken = localStorage.getItem("token");
+    const storedToken = sessionStorage.getItem("token");
     const storedUser = localStorage.getItem("user");
 
     if (storedToken && storedUser) {
@@ -170,7 +170,7 @@ export const AuthProvider = ({ children }) => {
     setToken(sessionToken);
     setUser(sessionUser);
     try {
-      localStorage.setItem("token", sessionToken);
+      sessionStorage.setItem("token", sessionToken);
       localStorage.setItem("user", JSON.stringify(sessionUser));
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -1,77 +1,108 @@
 /**
  * secureStorage.js
  *
- * CURRENT STATE  ─ localStorage (transitional)
- * ─────────────────────────────────────────────
- * Tokens and user data are temporarily stored in plain localStorage while
- * the codebase migrates to HttpOnly cookies (see MIGRATION PLAN below).
+ * CURRENT STATE: sessionStorage (transitional)
+ *
+ * Tokens are stored in sessionStorage while the codebase migrates to
+ * HttpOnly cookies (see MIGRATION PLAN below).
  *
  * WHY localStorage IS A SECURITY RISK
- * ────────────────────────────────────
- * Any JavaScript running on the page — including injected XSS payloads or
- * compromised npm packages — can read localStorage without restriction:
  *
- *   localStorage.getItem("token")  // ← any script can do this
+ * Any JavaScript running on the page, including injected XSS payloads or
+ * compromised third-party scripts, can read localStorage without restriction:
  *
- * This makes stored JWTs vulnerable to theft even if the rest of the
- * application is otherwise secure.
+ *   localStorage.getItem("token")  // any script can do this
  *
- * MIGRATION PLAN  ─ HttpOnly Cookies
- * ────────────────────────────────────
+ * localStorage persists indefinitely across browser restarts, giving an
+ * attacker a large window to exfiltrate and reuse a stolen token.
+ *
+ * WHY sessionStorage IS AN IMPROVEMENT
+ *
+ * sessionStorage is also readable by JavaScript on the same origin, so it
+ * does not eliminate XSS risk. However it provides two meaningful improvements:
+ *
+ *   1. The token is cleared automatically when the browser tab or window is
+ *      closed, shrinking the theft-and-reuse window considerably.
+ *   2. sessionStorage is tab-isolated: a script injected into one tab cannot
+ *      read tokens from another tab's sessionStorage.
+ *
+ * MIGRATION PLAN: HttpOnly Cookies (follow-up work)
+ *
  * HttpOnly cookies are completely inaccessible to JavaScript. The browser
- * sends them automatically with every same-origin and credentialed request.
+ * sends them automatically with every same-origin credentialed request.
  *
  * Required backend changes:
  *   1. On login success: Set-Cookie: token=<jwt>; HttpOnly; Secure; SameSite=Strict
- *   2. Expose a POST /api/auth/logout endpoint that clears the cookie server-side.
+ *   2. Expose POST /api/auth/logout that clears the cookie server-side.
  *   3. All protected endpoints read the token from the cookie, not the header.
  *
  * Required frontend changes (once backend supports cookies):
  *   1. Remove setToken / getToken / removeToken calls from AuthContext.
  *   2. Remove the manual Authorization header injection in config/api.js.
  *   3. Ensure Axios keeps withCredentials: true (already set).
- *   4. Remove all localStorage.setItem("token", ...) calls.
+ *   4. Remove all sessionStorage.setItem("token", ...) calls.
  *
- * NOTE: Client-side encryption was intentionally removed — it provided no
+ * NOTE: Client-side encryption was intentionally removed. It provided no
  * real XSS protection because the encryption key was also stored in
  * localStorage, making the entire scheme bypassable with a single read.
- *
- * syncSecureStorage is kept as a plain-text pass-through wrapper to prevent
- * breaking existing imports throughout the application during the transition.
  *
  * @see https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html
  * @see https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
  */
 
-// ─── Token helpers ────────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// One-time migration: move any token left in localStorage into sessionStorage
+// so existing logged-in users are not silently signed out after this change.
+// The localStorage entry is removed immediately after the move.
+// ---------------------------------------------------------------------------
+(function migrateTokenToSessionStorage() {
+  try {
+    const legacy = localStorage.getItem('token');
+    if (legacy && !sessionStorage.getItem('token')) {
+      sessionStorage.setItem('token', legacy);
+    }
+    if (legacy) {
+      localStorage.removeItem('token');
+    }
+    // Remove the old encryption-key artefact from any pre-migration session.
+    localStorage.removeItem('ENCRYPTION_KEY_KEY');
+  } catch {
+    // Storage may be unavailable (e.g. private browsing with strict settings).
+  }
+})();
+
+// ---------------------------------------------------------------------------
+// Token helpers
+// ---------------------------------------------------------------------------
 
 /**
- * Persists the Eventra JWT to localStorage.
+ * Persists the Eventra JWT to sessionStorage.
+ *
+ * The token is scoped to the current browser tab and cleared automatically
+ * when the tab is closed.
  *
  * TODO: Remove once the backend sets the token via an HttpOnly cookie.
- * Until then, this is the only storage mechanism available on the frontend.
  *
  * @param {string} token - The Eventra-issued JWT returned by the backend
  */
 export const setToken = (token) => {
   try {
-    localStorage.setItem('token', token);
+    sessionStorage.setItem('token', token);
   } catch (error) {
     console.error('[secureStorage] Error setting token:', error);
   }
 };
 
 /**
- * Retrieves the stored JWT from localStorage.
+ * Retrieves the stored JWT from sessionStorage.
  *
- * TODO: Remove once the backend manages the token via an HttpOnly cookie
- * (at which point the browser sends the cookie automatically).
+ * TODO: Remove once the backend manages the token via an HttpOnly cookie.
  *
  * @returns {string|null} The stored JWT, or null if not present
  */
 export const getToken = () => {
   try {
-    return localStorage.getItem('token');
+    return sessionStorage.getItem('token');
   } catch (error) {
     console.error('[secureStorage] Error getting token:', error);
     return null;
@@ -79,39 +110,33 @@ export const getToken = () => {
 };
 
 /**
- * Removes the stored JWT from localStorage on logout.
- *
- * Also clears any legacy encryption-key artefacts that may still be present
- * in old browser sessions from the previous (insecure) encrypted-storage
- * implementation.
+ * Removes the stored JWT from sessionStorage on logout.
  *
  * TODO: Replace with a call to POST /api/auth/logout once the backend
  * manages the session via HttpOnly cookies.
  */
 export const removeToken = () => {
   try {
-    localStorage.removeItem('token');
-
-    // Wipe the legacy key-in-storage artefact if it exists from an old session.
-    // The old implementation stored the encryption key in localStorage, which
-    // made the "encryption" trivially bypassable — it has been removed.
-    localStorage.removeItem('ENCRYPTION_KEY_KEY');
+    sessionStorage.removeItem('token');
   } catch (error) {
     console.error('[secureStorage] Error removing token:', error);
   }
 };
 
-// ─── Generic key–value storage wrapper ───────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Generic key-value storage wrapper
+// ---------------------------------------------------------------------------
 
 /**
  * syncSecureStorage
  *
  * A pass-through wrapper around localStorage that maintains API compatibility
  * with the old encrypted-storage implementation. It is kept to avoid breaking
- * the many existing call sites throughout the application.
+ * existing call sites throughout the application.
  *
- * This wrapper does NOT provide encryption or additional security.
- * Do not store sensitive values (passwords, PII) through this interface.
+ * NOTE: This wrapper is intentionally kept on localStorage for non-sensitive
+ * user-preference data (event bookmarks, interests, UI state). Only the auth
+ * token is moved to sessionStorage. Do not store passwords or raw secrets here.
  */
 export const syncSecureStorage = {
   /**
@@ -158,7 +183,7 @@ export const syncSecureStorage = {
 
   /**
    * Clears all localStorage data for the current origin.
-   * Use with caution — this removes ALL keys, not just Eventra's.
+   * Use with caution: this removes ALL keys, not just Eventra's.
    */
   clear: () => {
     try {


### PR DESCRIPTION
## Summary

Fixes #2446

The Eventra JWT was stored in `localStorage`, which persists indefinitely across browser restarts and is readable by any JavaScript running on the page. An XSS payload or compromised third-party script could exfiltrate the token at any point, even days after the user last visited the site.

### Why sessionStorage is an improvement

`sessionStorage` is still readable by same-origin JavaScript, so it does not eliminate XSS risk entirely. It provides two concrete improvements:

1. The token is cleared automatically when the browser tab or window is closed, shrinking the theft-and-reuse window from "indefinitely" to "within the current session".
2. `sessionStorage` is tab-isolated: a script in one tab cannot read tokens from another tab's sessionStorage.

This is a safe intermediate step. The full fix (HttpOnly cookies) requires backend changes listed in the migration plan already documented in `secureStorage.js` and is left as follow-up work.

### Files changed

| File | Change |
|------|--------|
| `src/utils/secureStorage.js` | Switch `setToken`/`getToken`/`removeToken` to `sessionStorage`. Add a one-time migration IIFE that moves any existing `localStorage` token to `sessionStorage` on first load (so logged-in users are not signed out after upgrading). Remove the legacy `ENCRYPTION_KEY_KEY` artefact. Update JSDoc comments. |
| `src/context/AuthContext.js` | Update `clearSession`, the startup restore `useEffect`, and `persistSession` to use `sessionStorage` for the token. The non-sensitive `"user"` profile blob stays in `localStorage`. |
| `src/config/api.js` | Update the token fallback read in `normalizeRequestConfig` from `localStorage` to `sessionStorage`. |
| `src/components/common/EventCreation.js` | Update the direct `localStorage.getItem("token")` read to `sessionStorage`. |

### Test plan

- [ ] Logging in stores the token in `sessionStorage`, not `localStorage`
- [ ] Closing and reopening the browser tab requires a fresh login (token cleared)
- [ ] Existing logged-in users are not signed out after the upgrade (migration IIFE moves the token)
- [ ] `localStorage` no longer contains a `"token"` key after login
- [ ] All authenticated API calls continue to send the `Authorization` header correctly
- [ ] Event creation still works for authenticated users
- [ ] Logout clears the token from `sessionStorage`

Could you please add the appropriate GSSoC/difficulty labels to this PR? It would help with contribution tracking. Thank you!