### PR TITLE
fix: execute missing Jest suites and resolve timezone conflict bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "react-scripts build",
     "build:fast": "cross-env GENERATE_SOURCEMAP=false DISABLE_ESLINT_PLUGIN=true NODE_OPTIONS=\"--no-deprecation --max-old-space-size=4096\" react-scripts build",
     "test": "react-scripts test",
-    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs && node tests/userNameUtils.test.mjs && node tests/relativeTime.test.mjs && node tests/registerUtils.test.mjs && node tests/bookmarkUtils.test.mjs",
+    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs && node tests/userNameUtils.test.mjs && node tests/relativeTime.test.mjs && node tests/registerUtils.test.mjs && node tests/bookmarkUtils.test.mjs && node tests/auth.test.mjs && node tests/eventDraftUtils.test.mjs && node tests/exportCsv.test.mjs && node tests/githubProxy.test.mjs && node tests/hackathonFilterUtils.test.mjs",
     "eject": "react-scripts eject",
     "lint": "eslint src --ext .js,.jsx --max-warnings=-1",
     "lint:fix": "eslint src --ext .js,.jsx --fix",

--- a/src/utils/calendarUrlUtils.test.js
+++ b/src/utils/calendarUrlUtils.test.js
@@ -12,7 +12,7 @@
 import {
   getGoogleCalendarUrl,
   getOutlookCalendarUrl,
-} from '../src/utils/calendarUrlUtils';
+} from './calendarUrlUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -52,7 +52,7 @@ const getEffectiveDuration = (event, fallbackMinutes = 60) => {
 export const getEventUTCRange = (event, fallbackDuration = 60, timezone) => {
   if (!event) return null;
 
-  const tz = timezone || getUserTimezone();
+  const tz = event.timezone || event.timeZone || timezone || getUserTimezone();
   const startMs = parseEventToUTC(event.date, event.time, tz);
 
   if (startMs === null) return null;

--- a/src/utils/conflictDetection.test.js
+++ b/src/utils/conflictDetection.test.js
@@ -14,7 +14,7 @@ import {
   formatTimeRange,
   parseTimeToMinutes,
   getEventTimeRange,
-} from '../src/utils/conflictDetection';
+} from './conflictDetection';
 
 // ---------------------------------------------------------------------------
 // Helper: build a minimal event object
@@ -112,11 +112,10 @@ describe('doEventsOverlap — timezone-aware cross-midnight scenarios', () => {
     // 11:00 PM UTC  = 2026-05-25 23:00 UTC  (duration 60 min → ends 2026-05-26 00:00 UTC)
     // 01:00 AM UTC+2 = 2026-05-25 23:00 UTC (duration 60 min → ends 2026-05-26 00:00 UTC)
     // They are the same moment in UTC — should conflict.
-    const eventUTC = mkEvent(1, '2026-05-25', '11:00 PM', 60);
-    const eventUTCPlus2 = mkEvent(2, '2026-05-26', '1:00 AM', 60);
+    const eventUTC = { ...mkEvent(1, '2026-05-25', '11:00 PM', 60), timezone: 'UTC' };
+    const eventUTCPlus2 = { ...mkEvent(2, '2026-05-26', '1:00 AM', 60), timezone: 'Africa/Johannesburg' }; // UTC+2 all year round
 
-    // With UTC+2 timezone
-    expect(doEventsOverlap(eventUTC, eventUTCPlus2, 60, 'UTC')).toBe(true);
+    expect(doEventsOverlap(eventUTC, eventUTCPlus2, 60)).toBe(true);
   });
 
   test('events 3 hours apart in the same timezone do not conflict', () => {

--- a/src/utils/timezoneUtils.js
+++ b/src/utils/timezoneUtils.js
@@ -61,10 +61,10 @@ export const normalizeDateString = (dateInput) => {
   // "Month DD, YYYY" (e.g. "May 25, 2026")
   const parsed = new Date(dateInput);
   if (!Number.isNaN(parsed.getTime())) {
-    // Use UTC parts to avoid off-by-one from local tz offset
-    const y = parsed.getUTCFullYear();
-    const m = String(parsed.getUTCMonth() + 1).padStart(2, '0');
-    const d = String(parsed.getUTCDate()).padStart(2, '0');
+    // Use local parts to avoid off-by-one from local tz offset
+    const y = parsed.getFullYear();
+    const m = String(parsed.getMonth() + 1).padStart(2, '0');
+    const d = String(parsed.getDate()).padStart(2, '0');
     return `${y}-${m}-${d}`;
   }
 


### PR DESCRIPTION
## 🎯 Purpose of this Pull Request

Fixes hidden Jest test execution issues and resolves timezone-related event conflict detection bugs.

Fixes #2485


---

## 🛠️ Description of Changes

* Move `tests/calendarUrlUtils.test.js` and `tests/conflictDetection.test.js` to `src/utils/` so `react-scripts test` auto-discovers and runs them. Previously these 57 test cases were never executed in CI or locally.

* Fix timezone off-by-one bug in `timezoneUtils.js` `normalizeDateString()`: switch from `getUTCDate/getUTCMonth/getUTCFullYear` to local getters when parsing human-readable date strings like `"May 25, 2026"`. In positive UTC offset environments (IST, JST, etc.), UTC getters shifted the normalized date backward by one day, causing mixed-format overlap tests to return false negatives.

* Update `getEventUTCRange()` in `conflictDetection.js` to read `event.timezone` and `event.timeZone` before falling back to the passed/browser timezone. This allows conflict detection to correctly compare events stored in different timezones (e.g. a UTC event vs a UTC+2 event on different calendar days).

* Extend `package.json` `test:unit` script to include the 5 recently added Node unit test files (`auth`, `eventDraftUtils`, `exportCsv`, `githubProxy`, `hackathonFilterUtils`) that were not wired into the runner.

---

## 🧪 Verification / Testing Done

### Jest test suites

```bash
npm run test
```

Result:

* 3 suites
* 57 tests passing

### Node unit tests

```bash
npm run test:unit
```

Result:

* 11 test files passing

### Build verification

```bash
npm run build:fast
```

Result:

* Compiled successfully without errors

---

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update



---

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
