### PR TITLE
fix: improve dark mode text visibility on Bookmarked Events and Reminders pages

### DIFF
--- a/src/Pages/Events/BookmarkedEvents.js
+++ b/src/Pages/Events/BookmarkedEvents.js
@@ -43,10 +43,10 @@ const BookmarkedEvents = () => {
               <Bookmark size={16} fill="currentColor" />
               {normalizedEvents.length} saved
             </div>
-            <h1 className="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-gray-950 dark:text-gray-800">
+            <h1 className="mt-4 text-3xl sm:text-4xl font-bold tracking-tight text-gray-950 dark:text-slate-100">
               Bookmarked Events
             </h1>
-            <p className="mt-3 max-w-2xl text-sm sm:text-base leading-7 text-gray-600 dark:text-gray-600">
+            <p className="mt-3 max-w-2xl text-sm sm:text-base leading-7 text-gray-600 dark:text-slate-400">
               Revisit the events you saved while exploring Eventra.
             </p>
           </div>
@@ -65,10 +65,10 @@ const BookmarkedEvents = () => {
             <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 text-indigo-600 dark:bg-indigo-950/60 dark:text-indigo-300">
               <Bookmark size={30} />
             </div>
-            <h2 className="text-2xl font-bold text-gray-950 dark:text-gray-400">
+            <h2 className="text-2xl font-bold text-gray-950 dark:text-slate-200">
               No bookmarked events yet
             </h2>
-            <p className="mx-auto mt-3 max-w-xl text-sm sm:text-base leading-7 text-gray-600 dark:text-gray-600">
+            <p className="mx-auto mt-3 max-w-xl text-sm sm:text-base leading-7 text-gray-600 dark:text-slate-400">
               Tap the bookmark icon on any event card to save it here for quick access later.
             </p>
             <Link

--- a/src/Pages/Events/RemindersPage.js
+++ b/src/Pages/Events/RemindersPage.js
@@ -74,10 +74,10 @@ const RemindersPage = () => {
               <Bell size={16} />
               {reminders.length} active
             </div>
-            <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-950 dark:text-gray-800 sm:text-4xl">
+            <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-950 dark:text-slate-100 sm:text-4xl">
               Event Reminders
             </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-7 text-gray-600 dark:text-gray-600 sm:text-base">
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-gray-600 dark:text-slate-400 sm:text-base">
               Manage upcoming reminder alerts for events you have bookmarked or registered for.
             </p>
           </div>


### PR DESCRIPTION
## 🚀 Description

This PR fixes dark mode text visibility issues on the Bookmarked Events and Reminders pages where headings and descriptions became nearly invisible against dark backgrounds.

### Changes made:
- Updated low-contrast dark mode text colors to accessible high-contrast variants
- Fixed heading styles using lighter dark mode text colors
- Fixed description paragraph styles for improved readability
- Improved dark mode accessibility and visual consistency across Events pages

Affected files:
- `src/Pages/Events/BookmarkedEvents.js`
- `src/Pages/Events/RemindersPage.js`

Fixes #2493

---

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings