### PR TITLE
fix: remove unused Eventra.png preload directive causing browser warn…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -109,13 +109,6 @@
       />
     </noscript>
 
-    <!-- Preload Hero Image -->
-    <link
-      rel="preload"
-      href="%PUBLIC_URL%/Eventra.png"
-      as="image"
-    />
-
     <!-- Prevent Theme Flickering -->
     <script>
       (() => {


### PR DESCRIPTION
Fixes #1875

### Changes
- Removed unused preload directive for Eventra.png from index.html
- The image is not consumed within the load event, making the preload 
  wasteful and triggering repeated browser warnings

### Testing
- Verified preload warning no longer appears in Chrome DevTools console