### PR TITLE
test: add unit tests for normalizeDateString to prevent timezone shift solved 

### DIFF
--- a/src/utils/timezoneUtils.test.js
+++ b/src/utils/timezoneUtils.test.js
@@ -1,0 +1,22 @@
+import { normalizeDateString } from "./timezoneUtils";
+
+describe("normalizeDateString", () => {
+  it("keeps YYYY-MM-DD intact", () => {
+    expect(normalizeDateString("2026-05-25")).toBe("2026-05-25");
+  });
+
+  it("strips time part from ISO with T", () => {
+    expect(normalizeDateString("2026-05-25T10:00:00Z")).toBe("2026-05-25");
+    expect(normalizeDateString("2026-05-25T15:30:00+05:30")).toBe("2026-05-25");
+  });
+
+  it("parses long form date correctly", () => {
+    expect(normalizeDateString("May 25, 2026")).toBe("2026-05-25");
+  });
+
+  it("returns null for invalid inputs", () => {
+    expect(normalizeDateString("")).toBeNull();
+    expect(normalizeDateString(null)).toBeNull();
+    expect(normalizeDateString("not-a-date")).toBeNull();
+  });
+});


### PR DESCRIPTION
issue solved - #2154 

Root Cause & Status: The timezone shifting bug in normalizeDateString was caused by using UTC date getters on a Date object constructed in local midnight time, causing dates to shift backward by 1 day in positive offset timezones (e.g. IST, JST). This issue was recently merged to the upstream master branch under commit 6eb686d33ab46c91c7437d32b9e699c41d56acfa.
Robust Test Coverage: I wrote a new unit test suite 
timezoneUtils.test.js
 checking the date normalization function under various formats (canonical dates, ISO with timezone offsets, long-form date strings, invalid strings) to prevent any future regressions.
Verification: All 61 unit tests in the project now pass cleanly.