### PR TITLE
fix: return success status from offline queue solved

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -350,15 +350,19 @@ const EventRegistration = () => {
           userId: user?.id || null,
         };
 
-        pushToQueue({ eventId: parseInt(eventId), payload });
+        const success = await pushToQueue({ eventId: parseInt(eventId), payload });
 
-        setRegistered(true);
-        addRegistration(event, formData);
-        clearSession();
-        toast.warning(
-          "Network error. Registration queued and will sync when you are online.",
-          { autoClose: 4000 }
-        );
+        if (success) {
+          setRegistered(true);
+          addRegistration(event, formData);
+          clearSession();
+          toast.warning(
+            "Network error. Registration queued and will sync when you are online.",
+            { autoClose: 4000 }
+          );
+        } else {
+          toast.error("Offline registration queue is full. Please reconnect to the internet to register.");
+        }
         return;
       }
 

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -76,13 +76,14 @@ export const pushToQueue = async (item) => {
   const queue = getQueue();
   if (queue.length >= 15) {
     console.warn('Offline queue limit reached. Dropping item to prevent local overflow.');
-    return;
+    return false;
   }
   queue.push(actionItem);
   try {
     localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
   } catch (error) {
     console.error('Error writing localStorage backup:', error);
+    return false;
   }
 
   // 2. Async IndexedDB background write
@@ -95,8 +96,10 @@ export const pushToQueue = async (item) => {
       request.onsuccess = () => resolve();
       request.onerror = () => reject(request.error);
     });
+    return true;
   } catch (err) {
     console.error("IndexedDB push failed:", err);
+    return true; // Still queued in localStorage fallback
   }
 };
 

--- a/src/utils/offlineQueue.test.js
+++ b/src/utils/offlineQueue.test.js
@@ -1,0 +1,48 @@
+import { pushToQueue, getQueue, clearQueue } from './offlineQueue';
+
+describe('offlineQueue', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    // Silence console warnings/errors during test execution
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('queues items successfully and returns true', async () => {
+    const item = { eventId: 101, payload: { name: 'Test User' } };
+    const success = await pushToQueue(item);
+    
+    expect(success).toBe(true);
+    const queue = getQueue();
+    expect(queue.length).toBe(1);
+    expect(queue[0].eventId).toBe(101);
+  });
+
+  it('limits queue to 15 items and returns false when full', async () => {
+    // Fill the queue with 15 items
+    for (let i = 0; i < 15; i++) {
+      const success = await pushToQueue({ eventId: i, payload: {} });
+      expect(success).toBe(true);
+    }
+
+    // Attempting to push 16th item should fail and return false
+    const success16 = await pushToQueue({ eventId: 16, payload: {} });
+    expect(success16).toBe(false);
+
+    // Verify queue length remains 15
+    const queue = getQueue();
+    expect(queue.length).toBe(15);
+  });
+
+  it('clears queue successfully', async () => {
+    await pushToQueue({ eventId: 1, payload: {} });
+    expect(getQueue().length).toBe(1);
+
+    await clearQueue();
+    expect(getQueue().length).toBe(0);
+  });
+});


### PR DESCRIPTION
Issue solved- #2156 

Root Cause: pushToQueue in offlineQueue.js silently returned void when the queue was full. EventRegistration.js never verified if the write succeeded, showing a misleading "registration queued" success warning, leading to silent data loss.
Refactoring:
Refactored pushToQueue in 
offlineQueue.js
 to return a promise resolving to a boolean (true/false) representing success or overflow drop.
Updated proceedWithRegistration in 
EventRegistration.js
 to await the queue result. If it fails, we display a clear error toast notifying the user that the queue is full and they must reconnect to register.
Unit Tests: Added 
offlineQueue.test.js
 checking the queue boundary size (returns true for ≤15 items, false for >15 items) and queue clearing logic.