### PR TITLE
fix: remove blocking backoff delays on first offline sync attempts fixed

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -115,7 +115,7 @@ const useOfflineSync = () => {
               url,
               item.payload,
               token,
-              retries
+              0
             );
 
             // Handle Conflict loop

--- a/src/hooks/useOfflineSync.test.js
+++ b/src/hooks/useOfflineSync.test.js
@@ -1,0 +1,102 @@
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import useOfflineSync from './useOfflineSync';
+import { getQueueIndexedDB, setQueue, clearQueue } from '../utils/offlineQueue';
+
+jest.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ token: 'mock-valid-token' }),
+}));
+
+jest.mock('../utils/tokenUtils', () => ({
+  isTokenValid: () => true,
+}));
+
+jest.mock('../utils/offlineQueue', () => ({
+  getQueueIndexedDB: jest.fn(),
+  setQueue: jest.fn(),
+  clearQueue: jest.fn(),
+}));
+
+describe('useOfflineSync', () => {
+  let container;
+  let root;
+
+  let originalOnLine;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    jest.clearAllMocks();
+
+    originalOnLine = navigator.onLine;
+    Object.defineProperty(navigator, 'onLine', {
+      value: false,
+      configurable: true,
+    });
+
+    // Mock global fetch
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('ok'),
+      })
+    );
+  });
+
+  afterEach(() => {
+    act(() => {
+      if (root) {
+        root.unmount();
+      }
+    });
+    document.body.removeChild(container);
+    container = null;
+    delete global.fetch;
+    Object.defineProperty(navigator, 'onLine', {
+      value: originalOnLine,
+      configurable: true,
+    });
+  });
+
+  it('attempts to sync immediately without backoff delay on first try in active sync run', async () => {
+    const queue = [
+      { id: '1', retryCount: 2, endpoint: '/api/register/1', payload: {} },
+      { id: '2', retryCount: 1, endpoint: '/api/register/2', payload: {} },
+    ];
+    getQueueIndexedDB.mockResolvedValue(queue);
+
+    const TestComponent = () => {
+      useOfflineSync();
+      return null;
+    };
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<TestComponent />);
+    });
+    const startTime = Date.now();
+
+    // Trigger online event to run the sync
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+      // Flush the microtasks
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    const duration = Date.now() - startTime;
+
+    // Verify both items were synced and fetch was called
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(clearQueue).toHaveBeenCalled();
+
+    // Verify it completed quickly (meaning no 1s/2s sequential backoff was applied)
+    // Since items had retryCount: 2 and 1 respectively, the original implementation
+    // would have blocked for 2s + 1s = 3 seconds.
+    // Our fix should complete it in under 500ms.
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
Fixed issue- #2157

Root Cause: The sync loop sequentially replayed offline actions using postWithBackoff. However, postWithBackoff computed the delay based on the item's previous failure retry counts and applied a sleep before sending the POST request. This meant that the first attempt of the active sync loop was delayed by 1s, 2s, or more per item, creating significant sequential network latency even when connection was completely stable.
Refactoring: Modified 
useOfflineSync.js
 to pass 0 instead of retries to the initial call of postWithBackoff in the sync loop. This ensures that the first attempt of each item in the active sync cycle runs immediately without any blocking delays.
Unit Tests: Added 
useOfflineSync.test.js
 to verify that items in the offline queue (with existing retry counts > 0) are synced immediately without any backoff delays (<500ms).