### PR TITLE
fix: enforce strict validation in relativeTime getters to prevent inv

### DIFF
--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -1,8 +1,9 @@
 export function getRelativeTime(dateInput) {
+  if (!dateInput) return null;
   const now = new Date();
   const date = new Date(dateInput);
 
-  if (isNaN(date)) return null;
+  if (isNaN(date.getTime())) return null;
 
   const diffMs = date - now;
   const diffSec = Math.round(diffMs / 1000);
@@ -30,13 +31,18 @@ export function getRelativeTime(dateInput) {
 }
 
 export function getSmartDateLabel(dateInput, timeInput = "") {
+  if (!dateInput) return "—";
+
+  const parsed = new Date(dateInput);
+  if (isNaN(parsed.getTime())) return "—";
+
   const relative = getRelativeTime(
     timeInput ? `${dateInput} ${timeInput}` : dateInput
   );
 
   if (relative) return relative;
 
-  return new Date(dateInput).toLocaleDateString("en-US", {
+  return parsed.toLocaleDateString("en-US", {
     weekday: "short",
     day: "numeric",
     month: "short",

--- a/src/utils/relativeTime.test.js
+++ b/src/utils/relativeTime.test.js
@@ -1,0 +1,52 @@
+import { getRelativeTime, getSmartDateLabel } from './relativeTime';
+
+describe('relativeTime utilities', () => {
+  describe('getRelativeTime', () => {
+    it('returns null for falsy, null, or undefined inputs', () => {
+      expect(getRelativeTime('')).toBeNull();
+      expect(getRelativeTime(null)).toBeNull();
+      expect(getRelativeTime(undefined)).toBeNull();
+    });
+
+    it('returns null for invalid date strings', () => {
+      expect(getRelativeTime('invalid-date')).toBeNull();
+    });
+
+    it('returns relative time descriptions for valid past and future dates', () => {
+      const now = new Date();
+      
+      const pastSecDate = new Date(now.getTime() - 30 * 1000);
+      expect(getRelativeTime(pastSecDate.toISOString())).toBe('Just ended');
+
+      const futureMinDate = new Date(now.getTime() + 10 * 60 * 1000);
+      expect(getRelativeTime(futureMinDate.toISOString())).toBe('In 10 minutes');
+    });
+  });
+
+  describe('getSmartDateLabel', () => {
+    it('returns "—" for falsy, null, or undefined date inputs', () => {
+      expect(getSmartDateLabel('')).toBe('—');
+      expect(getSmartDateLabel(null)).toBe('—');
+      expect(getSmartDateLabel(undefined)).toBe('—');
+    });
+
+    it('returns "—" for invalid date inputs', () => {
+      expect(getSmartDateLabel('invalid-date')).toBe('—');
+    });
+
+    it('returns relative description if available', () => {
+      const futureMinDate = new Date(Date.now() + 10 * 60 * 1000);
+      expect(getSmartDateLabel(futureMinDate.toISOString())).toBe('In 10 minutes');
+    });
+
+    it('returns formatted local date string if no relative description', () => {
+      // 50 days in future (more than 30 days, so getRelativeTime returns null)
+      const dateStr = '2026-07-15';
+      const formatted = getSmartDateLabel(dateStr);
+      // Expected output formats depending on local timezone, but should contain Month, Day, and Year
+      expect(formatted).toContain('Jul');
+      expect(formatted).toContain('15');
+      expect(formatted).toContain('2026');
+    });
+  });
+});


### PR DESCRIPTION
Issue fixed- #2158 



Root Cause: getSmartDateLabel inside relativeTime.js did not validate if dateInput was falsy or invalid. When dateInput was null, new Date(null) evaluated to the Unix Epoch (1970-01-01), rendering epoch dates like "Dec 31, 1969" or "Jan 1, 1970". When dateInput was empty "" or invalid, it rendered raw "Invalid Date" in the UI.
Refactoring: Modified 
relativeTime.js
 to:
Validate falsy or invalid inputs in getRelativeTime(dateInput) early and return null.
Validate falsy or invalid inputs in getSmartDateLabel(dateInput) early and return "—".
Unit Tests: Added 
relativeTime.test.js
 checking validation bounds, invalid and null/empty string handlers, and relative/absolute date parsing.