### PR TITLE
fix: correct manifest file reference to resolve JSON syntax error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
 
     <link
       rel="manifest"
-      href="%PUBLIC_URL%/site.webmanifest"
+      href="%PUBLIC_URL%/manifest.json"
     />
 
     <!-- Responsive -->


### PR DESCRIPTION
Fixes #2580. The index.html was pointing to 'site.webmanifest' which does not exist, causing a 404 HTML response to fail JSON parsing. Changed it to point to the valid 'manifest.json'.