### PR TITLE
feat: add OpenGraph Meta Tags for SEO

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -142,6 +142,11 @@
     <title>
       Eventra - Open Source Event Management Platform
     </title>
+    <meta property="og:title" content="Eventra - Platform for Builders" />
+    <meta property="og:description" content="A premium, modern platform for organizing and attending events, hackathons, and projects." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://eventra.vercel.app/" />
+    <meta property="og:image" content="%PUBLIC_URL%/Eventra.png" />
 
     <!-- Google Sign In -->
     <meta


### PR DESCRIPTION
Fixes #2595. Added standard OpenGraph meta tags to public/index.html to improve social media sharing and SEO.