### PR TITLE
feat: add Strict-Transport-Security (HSTS) header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,11 @@
       "source": "/(.*)",
       "headers": [
         {
-          "key": "X-Frame-Options",
+                  {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        "key": "X-Frame-Options",
           "value": "DENY"
         },
         {


### PR DESCRIPTION
Fixes #2597. Added HSTS header with 2-year max-age, includeSubDomains, and preload directive to vercel.json to prevent protocol downgrade attacks.