### PR TITLE
dx(tooling): configure Husky and lint-staged for pre-commit linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "src/**/*.{js,jsx}": ["eslint --fix --max-warnings=0", "prettier --write"],
+  "src/**/*.css": ["prettier --write"]
+}


### PR DESCRIPTION
Fixes #2573. Added .husky/pre-commit hook and .lintstagedrc.json to enforce ESLint and Prettier formatting on staged files before each commit.