### PR TITLE
perf: defer initial offline sync using requestIdleCallback to prevent…

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -168,12 +168,29 @@ const useOfflineSync = () => {
 
     window.addEventListener("online", handleOnline);
 
+    let idleId = null;
+    let timeoutId = null;
+
     if (navigator.onLine) {
-      handleOnline();
+      if (typeof window.requestIdleCallback === "function") {
+        idleId = window.requestIdleCallback(() => {
+          handleOnline();
+        });
+      } else {
+        timeoutId = setTimeout(() => {
+          handleOnline();
+        }, 200);
+      }
     }
 
     return () => {
       window.removeEventListener("online", handleOnline);
+      if (idleId !== null) {
+        window.cancelIdleCallback(idleId);
+      }
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
     };
   }, [token]);
 };


### PR DESCRIPTION
### Description
Optimizes the initial mounting phase of the offline synchronization hook (`src/hooks/useOfflineSync.js`) by deferring execution to `requestIdleCallback` (with a timeout fallback) to eliminate main-thread UI freezing on application load.

### Resolves
Closes #2463 

### Why this change is necessary?
Previously, upon application load, `useOfflineSync` immediately and synchronously checked connection status and started retrieving cached drafts from IndexedDB. On slow or congested networks, this CPU-intensive operation blocked the browser's main UI thread, resulting in lag, visual freezes, or sluggish initial page load times.

### Proposed Changes
- **Non-Blocking Execution**: Integrated `requestIdleCallback` to run the initial IndexedDB sync lookup only when the browser has idle cycles and is not busy with high-priority layout painting.
- **Robust Environment Fallback**: Configured a reliable `setTimeout` delay backup (200ms) for browsers without native `requestIdleCallback` support (like Apple Safari).
- **Graceful Unmount Cleanup**: Ensured all pending callbacks/timers are fully aborted on component unmount via `cancelIdleCallback` and `clearTimeout` to guarantee zero memory leaks.

### Verification Steps
1. Load the page under congested/slow 3G network simulation.
2. Confirm that the page mounts smoothly without initial blocking delays or freezing cycles.
