### PR TITLE
fix: isolate scroll context in ThemeCustomizerDrawer to prevent backd…

### DIFF
--- a/src/components/common/ThemeCustomizerDrawer.jsx
+++ b/src/components/common/ThemeCustomizerDrawer.jsx
@@ -41,12 +41,20 @@ export default function ThemeCustomizerDrawer() {
     }
   };
 
+  // Prevent scroll event propagation to backdrop
+  const handleScrollPropagation = (e) => {
+    e.stopPropagation();
+  };
+
   return (
     <AnimatePresence>
       {isCustomizerOpen && (
         <div
           onClick={handleBackdropClick}
-          className="fixed inset-0 z-50 flex justify-end bg-black/40 dark:bg-black/60 backdrop-blur-xs transition-opacity duration-300"
+          onWheel={handleScrollPropagation}
+          onTouchMove={handleScrollPropagation}
+          className="fixed inset-0 z-50 flex justify-end bg-black/40 dark:bg-black/60 backdrop-blur-xs transition-opacity duration-300 overscroll-contain"
+          style={{ overscrollBehavior: "contain" }}
           data-lenis-prevent
         >
           {/* Drawer Container */}
@@ -56,7 +64,10 @@ export default function ThemeCustomizerDrawer() {
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: "100%", opacity: 0.9 }}
             transition={{ type: "spring", stiffness: 220, damping: 24 }}
-            className="w-full sm:w-[420px] h-full bg-white/70 dark:bg-slate-950/75 backdrop-blur-xl border-l border-slate-200/50 dark:border-slate-800/40 p-6 flex flex-col shadow-2xl relative overflow-hidden"
+            onWheel={handleScrollPropagation}
+            onTouchMove={handleScrollPropagation}
+            className="w-full sm:w-[420px] h-full bg-white/70 dark:bg-slate-950/75 backdrop-blur-xl border-l border-slate-200/50 dark:border-slate-800/40 p-6 flex flex-col shadow-2xl relative overflow-hidden overscroll-contain"
+            style={{ overscrollBehavior: "contain" }}
             data-lenis-prevent
           >
             {/* Header */}
@@ -82,7 +93,13 @@ export default function ThemeCustomizerDrawer() {
               </div>
 
               {/* Theme Settings Sections */}
-              <div className="flex-1 min-h-0 py-6 space-y-8 overflow-y-auto pr-1" data-lenis-prevent>
+              <div
+                className="flex-1 min-h-0 py-6 space-y-8 overflow-y-auto pr-1 overscroll-contain"
+                style={{ overscrollBehavior: "contain" }}
+                onWheel={handleScrollPropagation}
+                onTouchMove={handleScrollPropagation}
+                data-lenis-prevent
+              >
                 {/* Mode Selector (Light vs Dark) */}
                 <div className="space-y-3">
                   <span className="text-xs font-black uppercase tracking-widest text-indigo-500">


### PR DESCRIPTION
### Description
Isolates the scroll context of the Theme Customizer drawer panel to prevent touch and mousewheel events from propagating to the parent viewport background.

### Resolves
Closes #2464 

### Why this change is necessary?
Previously, when opening the Theme Customizer panel and scrolling through its premium skins or configurations, the scroll actions propagated to the underlying layout. This caused the main background dashboard/home view to scroll underneath, disorienting the user and disrupting panel focus.

### Proposed Changes
- **Scroll Bubbling Blocked**: Captured and called `e.stopPropagation()` on React `onWheel` and `onTouchMove` events for the customizer backdrop, the drawer container, and the internal settings lists.
- **Visual Containment**: Applied `style={{ overscrollBehavior: 'contain' }}` and the CSS `overscroll-contain` class directly to all scrolling layers, forcing the user agent to lock scrolling to the drawer card itself.

### Verification Steps
1. Open the Theme Customizer drawer panel.
2. Place cursor/touch actions inside the settings view or customizer backdrop and scroll.
3. Verify that the parent home page background remains perfectly static and scrolling stays isolated to the panel.
