### PR TITLE
fix: remove enableScrollSpy from CountUp to resolve null target errors

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -163,7 +163,7 @@ export default function ModernAbout() {
               >
                 <h3 className="text-black dark:text-white text-xl sm:text-2xl font-bold mb-1">
                   {s.value.includes("+") ? (
-                    <CountUp start={0} end={parseInt(s.value)} duration={3} suffix="+" enableScrollSpy scrollSpyOnce />
+                    <CountUp start={0} end={parseInt(s.value)} duration={3} suffix="+" />
                   ) : (
                     s.value
                   )}
@@ -262,3 +262,4 @@ function MissionSection({ anim, prefersReducedMotion }) {
     </section>
   );
 }
+

--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -510,9 +510,7 @@ export default function EventHero({
                   duration={2.5}
                   prefix={stat.prefix}
                   suffix={stat.suffix}
-                  enableScrollSpy
-                  scrollSpyOnce
-                />
+                  />
               </p>
 
               <p
@@ -532,3 +530,4 @@ export default function EventHero({
     </div>
   );
 }
+

--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -237,9 +237,7 @@ export default function HackathonHero({
                   duration={2.5}
                   prefix={stat.prefix}
                   suffix={stat.suffix}
-                  enableScrollSpy
-                  scrollSpyOnce
-                />
+                  />
               </p>
               <p className="mt-1 text-sm font-medium text-slate-500 dark:text-slate-400">
                 {stat.label}
@@ -251,3 +249,4 @@ export default function HackathonHero({
     </div>
   );
 }
+

--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -554,3 +554,4 @@ text-gray-600 dark:text-gray-300"
 };
 
 export default Hero;
+


### PR DESCRIPTION
Fixes #2581. The eact-countup library was throwing CountUp target is null or undefined errors due to issues with its scroll spy implementation. By removing enableScrollSpy and scrollSpyOnce, the animation will now run safely on component mount without throwing errors, which is appropriate for these top-of-the-fold Hero components.