### PR TITLE
fix: correct syntax and missing commas in PublicRoutes array

### DIFF
--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -134,11 +134,11 @@ export const getPublicRoutes = () => [
   <Route key="/feedback"       path="/feedback"       element={<PageLayout><FeedbackPage /></PageLayout>} />,
   <Route key="/documentation"  path="/documentation"  element={<PageLayout><DocumentationPage /></PageLayout>} />,
 
-  {/*
+  /*
     /analytics — exposes organisation-level event analytics data.
     Requires authentication so that only registered users can view
     aggregate participant and event metrics.
-  */},
+  */
   <Route
     key="/analytics"
     path="/analytics"
@@ -151,11 +151,11 @@ export const getPublicRoutes = () => [
     }
   />,
 
-  {/*
+  /*
     /events/:eventId/floor-plan — venue floor plan designer.
     Requires authentication; only event organisers should be able
     to view or edit a floor plan layout.
-  */},
+  */
   <Route
     key="/events/:eventId/floor-plan"
     path="/events/:eventId/floor-plan"
@@ -168,11 +168,11 @@ export const getPublicRoutes = () => [
     }
   />,
 
-  {/*
+  /*
     /submit-project — allows users to submit projects to hackathons.
     Requires authentication so submissions are linked to a verified
     user account and cannot be made anonymously.
-  */},
+  */
   <Route
     key="/submit-project"
     path="/submit-project"
@@ -185,3 +185,4 @@ export const getPublicRoutes = () => [
     }
   />,
 ];
+


### PR DESCRIPTION
Fixes #2621. Removed the invalid JSX comment brackets \{/* ... */},\ inside the \getPublicRoutes\ JavaScript array, which were evaluating to empty objects and causing routing issues. Replaced them with standard JavaScript block comments \/* ... */\.