### PR TITLE
fix: resolve JSON syntax error in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -31,11 +31,11 @@
       "source": "/(.*)",
       "headers": [
         {
-                  {
           "key": "Strict-Transport-Security",
           "value": "max-age=63072000; includeSubDomains; preload"
         },
-        "key": "X-Frame-Options",
+        {
+          "key": "X-Frame-Options",
           "value": "DENY"
         },
         {


### PR DESCRIPTION
Fixes the invalid JSON syntax in \ercel.json\ that is currently breaking all Vercel deployments.