### PR TITLE
ci: update Node.js version to 20 to resolve build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -33,3 +33,5 @@ jobs:
           GENERATE_SOURCEMAP: false
           DISABLE_ESLINT_PLUGIN: true
           NODE_OPTIONS: --max-old-space-size=4096
+
+


### PR DESCRIPTION
Fixes the recent CI workflow failures where \
pm ci\ was crashing due to \eact-docgen\ requiring Node 20+, while the workflow was still using Node 18.