### PR TITLE
fix(auth): remove duplicate sessionStorage.setItem('token') from pers…

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -168,17 +168,42 @@ export const AuthProvider = ({ children }) => {
     };
   }, [token, clearExpiredSession]);
 
+  /**
+   * persistSession
+   *
+   * Saves the authenticated session after a successful login.
+   *
+   * Token storage responsibility
+   * ────────────────────────────
+   * setToken() (from secureStorage.js) is the single source of truth for
+   * writing the JWT to sessionStorage. Calling sessionStorage.setItem("token")
+   * directly here would:
+   *   1. Duplicate the write — both setToken() and the inline call would
+   *      store the same value, bypassing the secureStorage abstraction layer.
+   *   2. Create a silent inconsistency if secureStorage.js is ever changed
+   *      to use a different storage key or storage type (e.g. cookies) —
+   *      the direct call here would keep writing to the old location.
+   *
+   * The user profile (non-sensitive) remains in localStorage so it survives
+   * tab close and is available for UI personalisation on next visit.
+   *
+   * @param {string} sessionToken - Eventra-issued JWT from the backend
+   * @param {object} sessionUser  - Normalised user profile object
+   */
   const persistSession = (sessionToken, sessionUser) => {
+    // Write the JWT via secureStorage — sessionStorage, tab-scoped
     setToken(sessionToken);
+    // Update React state
     setUser(sessionUser);
     try {
-      sessionStorage.setItem("token", sessionToken);
+      // Store the non-sensitive user profile for UI personalisation across sessions
       localStorage.setItem("user", JSON.stringify(sessionUser));
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error('Error persisting session:', error);
+      console.error('[AuthContext] Error persisting user profile:', error);
     }
   };
+
   const normalizeRoles = (roles = []) => {
     return roles.map((role) => {
       const normalized = String(role).toUpperCase();


### PR DESCRIPTION
#2667
```
fix(auth): remove duplicate sessionStorage.setItem('token') from persistSession

## 🚀 Description

persistSession() in src/context/AuthContext.js wrote the JWT to sessionStorage
twice on every successful login:

  setToken(sessionToken);                     // via secureStorage.js (correct)
  sessionStorage.setItem('token', token);     // direct call (duplicate, bypasses abstraction)

This violated the single-responsibility principle of secureStorage.js — which
was specifically introduced to be the ONLY place that reads/writes the JWT,
so that changing the storage mechanism (e.g. migrating to HttpOnly cookies)
only requires a change in one file.

The duplicate direct call caused two problems:

1. TWO WRITES PER LOGIN: The JWT was written to sessionStorage twice in the
   same synchronous call stack on every login — wasteful and semantically
   incorrect. Both writes target the same key with the same value, creating
   two independent failure points for what should be a single atomic operation.

2. HIDDEN STORAGE DEPENDENCY: The inline sessionStorage.setItem() hardcodes
   the implementation detail of secureStorage.js (storage type: sessionStorage,
   key name: 'token'). If secureStorage.js is ever updated to use a different
   key or a different storage backend (e.g. HttpOnly cookies via a server
   endpoint), the inline call here would silently continue writing to the
   old location — leaving a stale, orphaned token in sessionStorage with
   no error or warning.

Fixes # (issue)

## Implementation Details

- Removed sessionStorage.setItem('token', sessionToken) from persistSession().
- setToken() from secureStorage.js remains as the sole JWT writer — it is
  the single source of truth for all token storage operations.
- localStorage.setItem('user', ...) is retained — the user profile is
  non-sensitive and intentionally survives tab close for UI personalisation,
  unlike the JWT which is scoped to the current tab via sessionStorage.
- Added a JSDoc comment to persistSession() explaining the storage
  responsibility boundary so future contributors understand why the direct
  call must not be re-introduced.
- Error log prefix updated to '[AuthContext]' for easier filtering in
  production logs.

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)

N/A — this is an internal storage logic fix with no UI changes.
The fix can be verified by:
1. Opening DevTools → Application → Session Storage.
2. Logging in with any valid account.
3. Setting a breakpoint at persistSession() in AuthContext.js.
4. Stepping through and confirming sessionStorage["token"] is written
   exactly once (via setToken()), not twice.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
```