### PR TITLE
fix: remove duplicate Events, Calendar, Bookmarks, Reminders nav item…

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -557,10 +557,7 @@ const MobileUserSection = ({
 
 const NAV_ITEMS = [
   { name: "Home", href: "/", icon: <Home className="w-5 h-5" /> },
-  { name: "Events", href: "/events", icon: <Calendar className="w-5 h-5" /> },
-  { name: "Calendar", href: "/calendar", icon: <CalendarDays className="w-5 h-5" /> },
-  { name: "Bookmarks", href: "/bookmarks", icon: <Bookmark className="w-5 h-5" /> },
-  { name: "Reminders", href: "/reminders", icon: <Bell className="w-5 h-5" /> },
+ 
   {
     name: "Event Tools",
     icon: <Calendar className="w-5 h-5" />,


### PR DESCRIPTION
##  Description
Removes duplicate navigation items from the Navbar component. The NAV_ITEMS array 
in `src/components/Layout/Navbar.js` had standalone entries for Events, Calendar, 
Bookmarks, and Reminders which were already present as sub-items inside the 
"Event Tools" dropdown, causing duplicate links in the navbar.

Fixes #2179 

##  Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

##  Screenshots 
<img width="1917" height="922" alt="Screenshot 2026-05-27 141155" src="https://github.com/user-attachments/assets/548b71b4-e1ea-4d4a-b646-7902f146aa27" />

##  Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings