### PR TITLE
fix: resolve unterminated JSX structure in ErrorBoundary

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -78,7 +78,7 @@ ${JSON.stringify(report.localStorage, null, 2)}
 
           {/* Glassmorphic Card */}
           <div className="max-w-2xl w-full bg-white/10 dark:bg-slate-900/40 backdrop-blur-xl border border-white/20 dark:border-slate-800/50 shadow-2xl rounded-3xl p-6 sm:p-8 space-y-6 relative overflow-hidden">
-            
+
             {/* Header Icon + Title */}
             <div className="flex flex-col items-center text-center space-y-3">
               <div className="p-4 bg-rose-500/20 text-rose-400 rounded-2xl border border-rose-500/30 animate-pulse">
@@ -168,11 +168,10 @@ ${JSON.stringify(report.localStorage, null, 2)}
               </button>
               <button
                 onClick={this.handleCopyReport}
-                className={`flex-1 px-4 py-3 rounded-xl text-sm font-semibold transition flex items-center justify-center gap-1.5 border border-indigo-500/30 ${
-                  this.state.copied
+                className={`flex-1 px-4 py-3 rounded-xl text-sm font-semibold transition flex items-center justify-center gap-1.5 border border-indigo-500/30 ${this.state.copied
                     ? "bg-emerald-600/90 text-white border-emerald-500/30"
                     : "bg-indigo-600 hover:bg-indigo-500 text-white shadow-md shadow-indigo-900/30"
-                }`}
+                  }`}
               >
                 {this.state.copied ? (
                   <>
@@ -190,7 +189,7 @@ ${JSON.stringify(report.localStorage, null, 2)}
                   </>
                 )}
               </button>
-
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
## 🚀 Description

This PR fixes a JSX parser/build failure in `ErrorBoundary.jsx` caused by an unclosed container element near the action buttons section.

### Changes Made
- Added the missing closing `</div>` in the action buttons container
- Fixed unterminated JSX structure causing Babel parser errors
- Restored valid JSX hierarchy for the ErrorBoundary component

### Result
- `npm run dev` now compiles successfully past this component
- ErrorBoundary renders correctly again
- JSX parser errors are resolved

Fixes #2715 

---

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings