### PR TITLE
fix(sync): prevent offline registration data loss by preserving faile… solve#2382

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -170,6 +170,7 @@ const useOfflineSync = () => {
 
           if (retries >= MAX_RETRIES) {
             droppedCount++;
+            failedQueue.push(item);
             continue;
           }
 
@@ -224,7 +225,7 @@ const useOfflineSync = () => {
 
         if (droppedCount > 0) {
           toast.error(
-            `${droppedCount} registration(s) dropped after ${MAX_RETRIES} attempts.`,
+            `${droppedCount} registration(s) paused after ${MAX_RETRIES} failed attempts. Retained in local drafts.`,
           );
         }
       } finally {

--- a/src/hooks/useOfflineSync.test.js
+++ b/src/hooks/useOfflineSync.test.js
@@ -99,4 +99,34 @@ describe('useOfflineSync', () => {
     // Our fix should complete it in under 500ms.
     expect(duration).toBeLessThan(500);
   });
+
+  it('preserves items with retryCount >= MAX_RETRIES in the offline queue instead of deleting them', async () => {
+    const queue = [
+      { id: '1', retryCount: 3, endpoint: '/api/register/1', payload: {} },
+    ];
+    getQueueIndexedDB.mockResolvedValue(queue);
+
+    const TestComponent = () => {
+      useOfflineSync();
+      return null;
+    };
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<TestComponent />);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    // Verify fetch was NOT called because retryCount >= 3
+    expect(global.fetch).not.toHaveBeenCalled();
+    // Verify setQueue was called to preserve the item
+    expect(setQueue).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ id: '1', retryCount: 3 })
+    ]));
+    expect(clearQueue).not.toHaveBeenCalled();
+  });
 });

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -91,7 +91,7 @@ export const getQueueIndexedDB = async () => {
  * @returns {string} A collision-resistant unique ID string
  */
 const generateQueueId = () => {
-  if (typeof crypto?.randomUUID === "function") {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
   // Fallback: timestamp + 9 random base-36 chars (36^9 ≈ 101 billion combinations)


### PR DESCRIPTION
closes #2383 
This PR addresses issue #2383 by preventing permanent data loss for offline registrations that fail to synchronize after 3 attempts.

Changes Proposed:
- Local Storage Retention: Updated `useOfflineSync.js` to preserve failed sync items in the local queue when they hit `MAX_RETRIES = 3`, instead of dropping them entirely. 
- Bandwidth Efficiency: Preserved items are safely skipped on automatic online sync runs to avoid infinite loops and unnecessary server load.
- Safe ID Generation (Jest Fix): Safely checked `crypto` existence using `typeof crypto !== "undefined"` inside `offlineQueue.js` to resolve a Node/Jest reference crash.
- New Unit Test: Implemented a dedicated test verifying that offline actions reaching the retry threshold are saved back to the database.