### PR TITLE
fix(queue): prevent silent data drop when offline queue limit is exce solve#2382

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -91,7 +91,7 @@ export const getQueueIndexedDB = async () => {
  * @returns {string} A collision-resistant unique ID string
  */
 const generateQueueId = () => {
-  if (typeof crypto?.randomUUID === "function") {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
   // Fallback: timestamp + 9 random base-36 chars (36^9 ≈ 101 billion combinations)
@@ -117,17 +117,25 @@ export const pushToQueue = async (item) => {
   const queue = getQueue();
   if (queue.length >= 15) {
     console.warn('Offline queue limit reached. Dropping item to prevent local overflow.');
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent('eventra-offline-queue-full', {
+        detail: { eventId: item.eventId, limit: 15 }
+      }));
+    }
     return false;
   }
   queue.push(actionItem);
+
+  let localStorageSuccess = false;
   try {
     localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+    localStorageSuccess = true;
   } catch (error) {
     console.error('Error writing localStorage backup:', error);
-    return false;
   }
 
   // 2. Async IndexedDB background write
+  let indexedDbSuccess = false;
   try {
     const db = await openDB();
     await new Promise((resolve, reject) => {
@@ -137,11 +145,13 @@ export const pushToQueue = async (item) => {
       request.onsuccess = () => resolve();
       request.onerror = () => reject(request.error);
     });
-    return true;
+    indexedDbSuccess = true;
   } catch (err) {
     console.error("IndexedDB push failed:", err);
-    return true; // Still queued in localStorage fallback
   }
+
+  // Return true if either storage successfully queued the item to prevent data loss
+  return localStorageSuccess || indexedDbSuccess;
 };
 
 /**

--- a/src/utils/offlineQueue.test.js
+++ b/src/utils/offlineQueue.test.js
@@ -45,4 +45,20 @@ describe('offlineQueue', () => {
     await clearQueue();
     expect(getQueue().length).toBe(0);
   });
+
+  it('returns true when localStorage setItem fails but IndexedDB succeeds', async () => {
+    // Mock localStorage.setItem to throw an error
+    const originalSetItem = window.localStorage.setItem;
+    window.localStorage.setItem = jest.fn().mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    const item = { eventId: 999, payload: { name: 'Resilient User' } };
+    const success = await pushToQueue(item);
+
+    expect(success).toBe(true);
+
+    // Restore original setItem
+    window.localStorage.setItem = originalSetItem;
+  });
 });


### PR DESCRIPTION
closes #2382 
This PR addresses issue #2382 by resolving silent data drops and improving storage failure resiliency when writing offline registrations.

Changes Proposed:
- Multi-Storage Resiliency: Decoupled writing to localStorage and IndexedDB. pushToQueue now returns true if either successfully registers the item, preventing data loss when localStorage is full or blocked.
- Event Dispatch: Dispatches a custom window event ('eventra-offline-queue-full') when queue limit (15 items) is exceeded, allowing the UI to capture and alert active users.
- Safe ID Generation (Jest Fix): Checked crypto existence safely via typeof to avoid ReferenceError under Jest.
- Resiliency Unit Test: Added a mock test verifying successful IndexedDB fallback when localStorage throws a QuotaExceededError.