### PR TITLE
feat(floorplan): warn before exiting FloorPlanDesigner with unsaved m…solve #2381

### DIFF
--- a/src/Pages/Events/FloorPlanDesignerPage.js
+++ b/src/Pages/Events/FloorPlanDesignerPage.js
@@ -1,12 +1,17 @@
-import React from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import React, { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
 import { ArrowLeft, Calendar, MapPin, Users, Info } from "lucide-react";
 import FloorPlanDesigner from "../../components/events/FloorPlanDesigner";
+import ConfirmationModal from "../../components/common/ConfirmationModal";
 import eventsMockData from "./eventsMockData.json";
 
 const FloorPlanDesignerPage = () => {
   const { eventId } = useParams();
   const navigate = useNavigate();
+
+  const [isDirty, setIsDirty] = useState(false);
+  const [pendingPath, setPendingPath] = useState(null);
+  const [isExitModalOpen, setIsExitModalOpen] = useState(false);
 
   // Load the corresponding event info from mock data
   const event = eventsMockData.find((e) => e.id === parseInt(eventId)) || {
@@ -19,6 +24,15 @@ const FloorPlanDesignerPage = () => {
     type: "meetup"
   };
 
+  const handleNavigate = (path) => {
+    if (isDirty) {
+      setPendingPath(path);
+      setIsExitModalOpen(true);
+    } else {
+      navigate(path);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-white dark:bg-slate-950 py-8 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto space-y-6">
@@ -27,7 +41,7 @@ const FloorPlanDesignerPage = () => {
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 bg-white/40 dark:bg-gray-900/40 backdrop-blur-md border border-gray-200/50 dark:border-gray-800/50 rounded-2xl p-4 shadow-sm">
           <div className="flex items-center gap-3">
             <button
-              onClick={() => navigate(`/events/${event.id}`)}
+              onClick={() => handleNavigate(`/events/${event.id}`)}
               className="p-2 bg-indigo-500/10 hover:bg-indigo-500/20 text-indigo-600 dark:text-indigo-400 rounded-xl transition-all cursor-pointer border border-indigo-500/15"
               title="Back to event details"
             >
@@ -35,11 +49,21 @@ const FloorPlanDesignerPage = () => {
             </button>
             <div>
               <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 font-semibold uppercase tracking-wider">
-                <Link to="/events" className="hover:text-indigo-500">Events</Link>
+                <button
+                  onClick={() => handleNavigate("/events")}
+                  className="hover:text-indigo-500 cursor-pointer bg-transparent border-none p-0 text-inherit font-semibold text-xs uppercase tracking-wider"
+                >
+                  Events
+                </button>
                 <span>/</span>
-                <Link to={`/events/${event.id}`} className="hover:text-indigo-500 line-clamp-1">{event.title}</Link>
+                <button
+                  onClick={() => handleNavigate(`/events/${event.id}`)}
+                  className="hover:text-indigo-500 cursor-pointer bg-transparent border-none p-0 text-inherit font-semibold text-xs uppercase tracking-wider line-clamp-1 max-w-[200px] text-left"
+                >
+                  {event.title}
+                </button>
                 <span>/</span>
-                <span className="text-indigo-500">Floor Plan</span>
+                <span className="text-indigo-500 font-semibold uppercase tracking-wider">Floor Plan</span>
               </div>
               <h2 className="text-xl sm:text-2xl font-black text-gray-900 dark:text-white leading-tight mt-0.5">
                 {event.title}
@@ -68,7 +92,7 @@ const FloorPlanDesignerPage = () => {
 
         {/* Live Designer Component Mount */}
         <div className="bg-white/30 dark:bg-gray-900/30 backdrop-blur-md rounded-2xl shadow-lg border border-gray-200/40 dark:border-gray-800/40 overflow-hidden">
-          <FloorPlanDesigner eventId={event.id} />
+          <FloorPlanDesigner eventId={event.id} onDirtyChange={setIsDirty} />
         </div>
 
         {/* Info Helper Footer bar */}
@@ -80,6 +104,20 @@ const FloorPlanDesignerPage = () => {
         </div>
 
       </div>
+
+      <ConfirmationModal
+        isOpen={isExitModalOpen}
+        onClose={() => setIsExitModalOpen(false)}
+        onConfirm={() => {
+          setIsExitModalOpen(false);
+          setIsDirty(false); // reset dirty flag to allow navigation
+          navigate(pendingPath);
+        }}
+        title="Unsaved Modifications"
+        message="You have unsaved changes on your floor plan designer layout. Are you sure you want to discard them and leave?"
+        confirmText="Discard & Exit"
+        cancelText="Keep Editing"
+      />
     </div>
   );
 };

--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -54,8 +54,9 @@ const checkCollision = (el1, el2) => {
   );
 };
 
-const FloorPlanDesigner = ({ eventId = "default" }) => {
+const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
   const [elements, setElements] = useState([]);
+  const [lastSavedElementsStr, setLastSavedElementsStr] = useState("");
   const [selectedId, setSelectedId] = useState(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   
@@ -73,22 +74,49 @@ const FloorPlanDesigner = ({ eventId = "default" }) => {
   const elementStartRef = useRef({ x: 0, y: 0 });
   const panStartRef = useRef({ x: 0, y: 0 });
 
+  const isDirty = !!(lastSavedElementsStr && JSON.stringify(elements) !== lastSavedElementsStr);
+
+  useEffect(() => {
+    if (onDirtyChange) {
+      onDirtyChange(isDirty);
+    }
+  }, [isDirty, onDirtyChange]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      if (isDirty) {
+        e.preventDefault();
+        e.returnValue = "You have unsaved changes on your floor plan layout. Are you sure you want to leave?";
+        return e.returnValue;
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [isDirty]);
+
   // Load layout from local storage or set preset
   useEffect(() => {
     const savedLayout = localStorage.getItem(`eventra_floorplan_${eventId}`);
+    let initialElements = [];
     if (savedLayout) {
       try {
-        setElements(JSON.parse(savedLayout));
+        initialElements = JSON.parse(savedLayout);
       } catch (e) {
-        setElements(PRESETS.banquet);
+        initialElements = PRESETS.banquet;
       }
     } else {
-      setElements(PRESETS.banquet);
+      initialElements = PRESETS.banquet;
     }
+    setElements(initialElements);
+    setLastSavedElementsStr(JSON.stringify(initialElements));
   }, [eventId]);
 
   const saveLayout = () => {
-    localStorage.setItem(`eventra_floorplan_${eventId}`, JSON.stringify(elements));
+    const serialized = JSON.stringify(elements);
+    localStorage.setItem(`eventra_floorplan_${eventId}`, serialized);
+    setLastSavedElementsStr(serialized);
     toast.success("Venue floor plan successfully saved!");
   };
 

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -91,7 +91,7 @@ export const getQueueIndexedDB = async () => {
  * @returns {string} A collision-resistant unique ID string
  */
 const generateQueueId = () => {
-  if (typeof crypto?.randomUUID === "function") {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
   // Fallback: timestamp + 9 random base-36 chars (36^9 ≈ 101 billion combinations)


### PR DESCRIPTION
closes #2381

### Summary
Prevents accidental data loss in `FloorPlanDesigner` by checking for unsaved changes before a user leaves the designer page.

### Key Changes
* **Dirty State Tracking**: Computes an `isDirty` flag dynamically by comparing current elements with a stringified save baseline.
* **Tab Close & Refresh Protection**: Leverages a window `beforeunload` listener to prompt users when refreshing or closing the browser window.
* **SPA Route Protection**: Exposes the dirty state to `FloorPlanDesignerPage.js` to block internal React Router navigations (back button, breadcrumbs) and show Eventra’s native `ConfirmationModal`.
* **Testing Fix**: Replaced a direct property access on `crypto` with a safe `typeof` check in `offlineQueue.js` to fix Jest execution crashes.

### Test Coverage
* Automated: Verified Jest test suites run green (`74/74` tests passed).
* Manual: Tested reload alerts, tab close blocks, and custom navigation modal transitions.