### PR TITLE
refactor: move service worker unregistration to top of entry point (#2236)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ import * as serviceWorkerRegistration from "./serviceWorkerRegistration";
 // Initialize Global Runtime Monitoring
 initializeGlobalErrorHandling();
 
+// Unregister service worker early to avoid caching conflicts
+serviceWorkerRegistration.unregister();
+
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
@@ -23,4 +26,4 @@ root.render(
   </React.StrictMode>
 );
 
-serviceWorkerRegistration.unregister();
+


### PR DESCRIPTION
## 🚀 Description
This PR moves the `serviceWorkerRegistration.unregister()` invocation from the absolute bottom of `src/index.js` to the top of the file, immediately following `initializeGlobalErrorHandling()`. 

**Motivation and Context:**
Currently, if the React application bundle takes time to load, parse, or execute `root.render()`, the service worker unregistration process is delayed. Moving this call to the top ensures that old or buggy service workers are cleared out as aggressively as possible, preventing aggressive asset caching conflicts.

Fixes #2236 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings