### PR TITLE
fix: replace invalid Tailwind classes h-4.5 w-4.5 with valid h-5 w-5 in CommandPalette

### DIFF
--- a/src/components/common/CommandPalette.jsx
+++ b/src/components/common/CommandPalette.jsx
@@ -294,7 +294,7 @@ export default function CommandPalette({
                           `}
                         >
                           <div className="flex items-center gap-3">
-                            <Icon className={`h-4.5 w-4.5 ${active ? "text-white" : "text-slate-400 dark:text-slate-500 group-hover:text-slate-600"}`} />
+                            <Icon className={`h-5 w-5 ${active ? "text-white" : "text-slate-400 dark:text-slate-500 group-hover:text-slate-600"}`} />
                             <span className="text-sm font-semibold tracking-tight">{name}</span>
                           </div>
                           {active && (


### PR DESCRIPTION
## 🚀 Description
CommandPalette.jsx was using h-4.5 and w-4.5 as Tailwind CSS classes for icon sizing. These are not valid Tailwind utility classes — Tailwind only supports whole number sizes like h-4 and h-5. As a result the icon sizing styles were completely ignored and icons rendered at default browser size instead of the intended size.

Fixes #2512

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings