### PR TITLE
fix: clear interval when countdown reaches zero in CountdownTimer and…

### DIFF
--- a/src/components/common/CountdownTimer.jsx
+++ b/src/components/common/CountdownTimer.jsx
@@ -21,7 +21,9 @@ export const CountdownBadge = ({ date, time }) => {
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setTimeLeft(calculateTimeLeft(deadline));
+      const remaining = calculateTimeLeft(deadline);
+      setTimeLeft(remaining);
+      if (!remaining) clearInterval(timer);
     }, 1000);
     return () => clearInterval(timer);
   }, [deadline]);
@@ -49,7 +51,9 @@ const CountdownTimer = ({ date, time }) => {
 
   useEffect(() => {
     const timer = setInterval(() => {
-      setTimeLeft(calculateTimeLeft(deadline));
+      const remaining = calculateTimeLeft(deadline);
+      setTimeLeft(remaining);
+      if (!remaining) clearInterval(timer);
     }, 1000);
     return () => clearInterval(timer);
   }, [deadline]);


### PR DESCRIPTION
## 🚀 Description
Both CountdownTimer and CountdownBadge components in CountdownTimer.jsx used setInterval to update every second. But when the deadline passed and timeLeft became null, the interval was never cleared. It kept calling calculateTimeLeft every second forever returning null every time — wasting memory and CPU even after the countdown finished.

Fixed by storing the calculated value in a variable inside setInterval and calling clearInterval immediately when the value is null, stopping the timer as soon as the countdown reaches zero.

Fixes #2515

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings