### PR TITLE
fix: improve navbar layout and responsiveness

### DIFF
--- a/src/components/navbar/DesktopNavbar.jsx
+++ b/src/components/navbar/DesktopNavbar.jsx
@@ -13,7 +13,7 @@ const DesktopNavbar = ({
   toggleCursor,
 }) => {
   return (
-    <div className="hidden lg:flex items-center justify-between flex-1 gap-2">
+    <div className="hidden xl:flex items-center justify-between flex-1 min-w-0 gap-2">
       <NavbarLinks />
 
       <div className="flex items-center gap-4 mr-5">

--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -13,7 +13,7 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
             ? "text-black dark:text-white border-black dark:border-white font-semibold bg-gray-100 dark:bg-gray-800"
             : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white border-transparent hover:bg-gray-50 dark:hover:bg-gray-800/50"
         }`
-      : `flex gap-2 items-center text-sm font-medium transition-all duration-200 px-1 py-2 border-b-2 rounded-t-md ${
+      : `flex gap-1 items-center text-sm font-medium transition-all duration-200 px-1 lg:px-2 py-2 border-b-2 rounded-t-md whitespace-nowrap ${
           active
             ? "text-black dark:text-white border-black dark:border-white font-semibold"
             : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white border-transparent hover:border-gray-300 dark:hover:border-gray-600"
@@ -25,7 +25,7 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
       className={`flex ${
         vertical
           ? "flex-col items-start w-full gap-2"
-          : "items-center gap-3 mx-7"
+          : "items-center gap-2 lg:gap-3 xl:gap-4 mx-2 lg:mx-4 min-w-0 flex-wrap"
       }`}
       aria-label={vertical ? "Mobile primary links" : "Primary links"}
     >
@@ -38,7 +38,7 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
           return (
             <div
               key={item.name}
-              className={`relative group/nav flex items-center ${
+              className={`relative group/nav flex items-center shrink-0 ${
                 vertical ? "w-full flex-col items-start" : "flex-none"
               }`}
             >


### PR DESCRIPTION
## 🚀 Description
Improved navbar responsiveness and alignment at 100% browser zoom.

### Fixes #2020 

### Changes made:
- Reduced excessive navbar spacing and margins
- Improved responsive behavior for desktop navigation
- Prevented layout compression and overflow issues
- Added better flex handling with `min-w-0` and `shrink-0`
- Delayed desktop navbar rendering to larger breakpoints (`xl`)
- Improved link spacing and wrapping behavior

This fixes the navbar appearing correctly only at ~67% zoom and breaking at normal 100% zoom levels.

Fixes #<issue-number>

---

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

### Before
- Navbar overlaps and compresses at 100% zoom
- 
<img width="1322" height="63" alt="image" src="https://github.com/user-attachments/assets/88876f19-4783-4e7b-893e-0614fd45f451" />


### After
- Navbar remains aligned and responsive at standard zoom levels
<img width="1124" height="43" alt="image" src="https://github.com/user-attachments/assets/ebed9561-49d3-4bdc-a490-c56a99e875fa" />

---

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings