### PR TITLE
fix : handle invalid inputs in userNameUtils.mjs safely

### DIFF
--- a/src/utils/userNameUtils.mjs
+++ b/src/utils/userNameUtils.mjs
@@ -1,5 +1,11 @@
 export const getUserFullName = (user) =>
   [user?.firstName, user?.lastName]
-    .map((name) => (typeof name === "string" ? name.trim() : ""))
+    .map((name) =>
+      typeof name === "string"
+        ? name.trim()
+        : typeof name === "number" && isFinite(name)
+        ? String(name)
+        : ""
+    )
     .filter(Boolean)
     .join(" ");

--- a/tests/userNameUtils.extended.test.mjs
+++ b/tests/userNameUtils.extended.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * Extended unit tests for the fixed src/utils/userNameUtils.mjs
+ *
+ * Validates that the helper safely handles null, undefined, object-type,
+ * number-type, and array-type inputs without crashing.
+ */
+
+import assert from "node:assert/strict";
+import { getUserFullName } from "../src/utils/userNameUtils.mjs";
+
+// ── Existing baseline ────────────────────────────────────────────────────────
+assert.equal(getUserFullName(null), "", "null user returns empty string");
+assert.equal(getUserFullName(undefined), "", "undefined user returns empty string");
+assert.equal(getUserFullName({}), "", "empty user object returns empty string");
+assert.equal(getUserFullName({ firstName: "Ada" }), "Ada", "firstName only");
+assert.equal(getUserFullName({ lastName: "Lovelace" }), "Lovelace", "lastName only");
+assert.equal(
+  getUserFullName({ firstName: " Ada ", lastName: " Lovelace " }),
+  "Ada Lovelace",
+  "names are trimmed and joined with a space"
+);
+
+// ── Object / Array / Symbol fields (must not throw) ──────────────────────────
+assert.doesNotThrow(
+  () => getUserFullName({ firstName: {}, lastName: [] }),
+  "object-type fields do not throw"
+);
+assert.equal(
+  getUserFullName({ firstName: {}, lastName: [] }),
+  "",
+  "object/array fields produce empty string"
+);
+
+assert.doesNotThrow(
+  () => getUserFullName({ firstName: Symbol("x"), lastName: "Jones" }),
+  "Symbol firstName does not throw"
+);
+assert.equal(
+  getUserFullName({ firstName: Symbol("x"), lastName: "Jones" }),
+  "Jones",
+  "Symbol firstName is silently dropped"
+);
+
+// ── Number fields (coerced to string) ────────────────────────────────────────
+assert.equal(
+  getUserFullName({ firstName: 42, lastName: "Jones" }),
+  "42 Jones",
+  "numeric firstName is coerced to string"
+);
+assert.equal(
+  getUserFullName({ firstName: "Alice", lastName: 7 }),
+  "Alice 7",
+  "numeric lastName is coerced to string"
+);
+assert.equal(
+  getUserFullName({ firstName: 0, lastName: "Zero" }),
+  "0 Zero",
+  "firstName of 0 is coerced to '0' and included"
+);
+assert.equal(
+  getUserFullName({ firstName: Infinity }),
+  "",
+  "Infinity firstName is ignored"
+);
+assert.equal(
+  getUserFullName({ firstName: NaN }),
+  "",
+  "NaN firstName is ignored"
+);
+
+// ── Boolean fields ───────────────────────────────────────────────────────────
+assert.doesNotThrow(
+  () => getUserFullName({ firstName: true, lastName: false }),
+  "boolean fields do not throw"
+);
+assert.equal(
+  getUserFullName({ firstName: true, lastName: false }),
+  "",
+  "boolean fields produce empty string"
+);
+
+// ── Whitespace-only names ────────────────────────────────────────────────────
+assert.equal(
+  getUserFullName({ firstName: "   ", lastName: "Smith" }),
+  "Smith",
+  "whitespace-only firstName is trimmed and filtered out"
+);
+assert.equal(
+  getUserFullName({ firstName: "Alice", lastName: "\t\n" }),
+  "Alice",
+  "whitespace-only lastName is trimmed and filtered out"
+);
+
+console.log("All userNameUtils tests passed ✓");


### PR DESCRIPTION
Extends getUserFullName() in src/utils/userNameUtils.mjs to safely handle all non-string input types without throwing or silently dropping valid values:\n\n**Before:** Only string fields were accepted; numeric fields like { firstName: 42 } were silently dropped, producing 'Jones' instead of '42 Jones'.\n\n**After:** Finite number fields are coerced to string; Infinity, NaN, booleans, objects, arrays, and Symbols are all safely discarded as empty strings.\n\nAlso adds tests/userNameUtils.extended.test.mjs covering null/undefined user, object/array/Symbol/boolean/number/Infinity/NaN field values, and whitespace-only trimming.