### PR TITLE
fix(sync): prevent race condition with distributed lock mechanism solve #2747

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -133,11 +133,7 @@ const useOfflineSync = () => {
     // when the useEffect is cleaned up (component unmount or token change).
     const conflictController = new AbortController();
 
-    const handleOnline = async () => {
-      if (isSyncing.current) {
-        return;
-      }
-
+    const executeSync = async () => {
       const queue = await getQueueIndexedDB();
       if (queue.length === 0) {
         return;
@@ -229,6 +225,80 @@ const useOfflineSync = () => {
         }
       } finally {
         isSyncing.current = false;
+      }
+    };
+
+    const executeSyncWithLocalLock = async () => {
+      const LOCK_KEY = "eventra_offline_sync_local_lock";
+      const LOCK_TIMEOUT_MS = 30_000;
+
+      const now = Date.now();
+      const lockVal = localStorage.getItem(LOCK_KEY);
+
+      if (lockVal) {
+        try {
+          const parsed = JSON.parse(lockVal);
+          if (parsed && parsed.timestamp && now - parsed.timestamp < LOCK_TIMEOUT_MS) {
+            console.log("[useOfflineSync] Local sync lock is held by another active tab. Skipping.");
+            return;
+          }
+        } catch (e) {}
+      }
+
+      const currentTabId = Math.random().toString(36).slice(2, 9);
+      const lockData = JSON.stringify({ timestamp: now, tabId: currentTabId });
+      
+      try {
+        localStorage.setItem(LOCK_KEY, lockData);
+      } catch (e) {
+        // If localStorage fails (private mode etc.), run sync directly to avoid blocking
+        await executeSync();
+        return;
+      }
+
+      const heartbeatInterval = setInterval(() => {
+        try {
+          localStorage.setItem(LOCK_KEY, JSON.stringify({ timestamp: Date.now(), tabId: currentTabId }));
+        } catch (e) {}
+      }, 10_000);
+
+      try {
+        await executeSync();
+      } finally {
+        clearInterval(heartbeatInterval);
+        try {
+          const checkVal = localStorage.getItem(LOCK_KEY);
+          if (checkVal) {
+            const parsed = JSON.parse(checkVal);
+            if (parsed && parsed.tabId === currentTabId) {
+              localStorage.removeItem(LOCK_KEY);
+            }
+          }
+        } catch (e) {}
+      }
+    };
+
+    const handleOnline = async () => {
+      if (isSyncing.current) {
+        return;
+      }
+
+      // Check if navigator.locks is supported natively (modern browsers)
+      if (typeof navigator?.locks?.request === "function") {
+        try {
+          await navigator.locks.request("eventra_offline_sync_lock", { ifAvailable: true }, async (lock) => {
+            if (!lock) {
+              console.log("[useOfflineSync] Sync lock is held by another tab via Web Locks. Skipping.");
+              return;
+            }
+            await executeSync();
+          });
+        } catch (err) {
+          console.warn("[useOfflineSync] Web Locks request failed, falling back to LocalStorage lock:", err);
+          await executeSyncWithLocalLock();
+        }
+      } else {
+        await executeSyncWithLocalLock();
       }
     };
 

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -91,7 +91,7 @@ export const getQueueIndexedDB = async () => {
  * @returns {string} A collision-resistant unique ID string
  */
 const generateQueueId = () => {
-  if (typeof crypto?.randomUUID === "function") {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();
   }
   // Fallback: timestamp + 9 random base-36 chars (36^9 ≈ 101 billion combinations)


### PR DESCRIPTION
## 🐛 Fix: Concurrent Offline Sync Operations Trigger Database Race Condition

**Closes #2747

---

### 📋 Problem

When multiple browser tabs or windows were open simultaneously, each running
the offline sync hook (useOfflineSync), they would all attempt to flush the
offline queue at the same time upon reconnection. This caused concurrent writes
to the database — leading to duplicate entries, data corruption, and
inconsistent application state.

The root issue was the complete absence of any cross-tab coordination
mechanism, meaning every tab independently raced to process the same queued
operations.

---

### ✅ Solution

Implemented a distributed locking strategy to guarantee only one tab/window
performs the sync at any given time.

**Primary — Web Locks API (navigator.locks.request)**
- Uses the browser-native Web Locks API to acquire an exclusive named lock
  (eventra_sync_lock) before executing any sync operation.
- Only the tab that successfully acquires the lock proceeds; all others wait
  or abort gracefully.
- Automatically released when sync completes or the tab closes.

**Fallback — localStorage Heartbeat Lock**
- For browsers that don't support the Web Locks API, a heartbeat-based lock
  is implemented using localStorage.
- A lock entry is written with a timestamp; any competing tab checks if the
  lock is stale (> 30 seconds old) before attempting to steal it.
- Prevents indefinite deadlocks in edge cases (e.g., tab crashes mid-sync).

**Additional Fix — crypto.randomUUID() Guard (offlineQueue.js)**
- Added a typeof crypto !== 'undefined' check before calling
  crypto.randomUUID() to prevent a fatal ReferenceError in Jest/JSDOM.

---

### 🔧 Files Changed

- src