### PR TITLE
fix(a11y): add aria-label to icon-only buttons in modal and search components

### DIFF
--- a/src/components/EventConflictModal.jsx
+++ b/src/components/EventConflictModal.jsx
@@ -45,6 +45,7 @@ const EventConflictModal = ({
         {/* Close Button */}
         <button
           onClick={onCancel}
+          aria-label="Close conflict dialog"
           className="absolute top-4 right-4 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
         >
           <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
@@ -149,6 +150,7 @@ const EventConflictModal = ({
                   <button
                     key={event.id}
                     onClick={() => onSelectAlternative?.(event)}
+                    aria-label={`Select alternative event: ${event.title}`}
                     className="w-full text-left bg-green-50 dark:bg-green-900/20 rounded-xl p-4 border border-green-200 dark:border-green-800 hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors group"
                   >
                     <div className="flex items-center justify-between">

--- a/src/components/common/SearchEmptyState.jsx
+++ b/src/components/common/SearchEmptyState.jsx
@@ -102,7 +102,7 @@ const SearchEmptyState = ({
           shadow-sm
         "
       >
-        <X size={16} />
+        <X size={16} aria-hidden="true" />
         Clear Search
       </button>
 


### PR DESCRIPTION
Fixes #2694.

This PR improves accessibility for keyboard and screen reader users:
- **EventConflictModal**: Added \ria-label="Close conflict dialog"\ to the icon-only close button (X icon). Added dynamic \ria-label\ to alternative event selector buttons.
- **SearchEmptyState**: Added \ria-hidden="true"\ to the decorative X icon inside the Clear Search button to prevent screen readers from announcing duplicate icon content.