### PR TITLE
fix(auth): prevent infinite layout re-render loops on silent token expiration (issue-#2007)

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -40,9 +40,23 @@ export const AuthProvider = ({ children }) => {
    * Guards against duplicate toasts with a ref flag.
    */
   const clearExpiredSession = useCallback(() => {
-    if (expiryToastShownRef.current) return;
-    expiryToastShownRef.current = true;
+    // eslint-disable-next-line no-console
+    console.warn("[AuthContext] Session expiration detected. Clearing session state immediately to prevent infinite layout re-render loops.");
+    
+    // 1. Immediately purge session state to prevent infinite render loops.
+    // By resetting token and user state to null synchronously, any concurrent
+    // render phases (e.g., layout components checking isAuthenticated) will
+    // abort early, avoiding resetting needsExpiryCleanupRef.
     clearSession();
+
+    // 2. Perform UI notification side effects once per expired session lifecycle.
+    if (expiryToastShownRef.current) {
+      // eslint-disable-next-line no-console
+      console.log("[AuthContext] Expiry warning already shown. Skipping duplicate toast notification.");
+      return;
+    }
+    expiryToastShownRef.current = true;
+
     toast.info("Session expired. Please log in again.", {
       toastId: "session-expired",
       autoClose: 5000,


### PR DESCRIPTION
### **Description**
This PR addresses and fixes a critical security and architectural bug (**#2007**) where a silent token expiration mid-session triggers an infinite rendering/update loop across page layouts.

### **The Problem**
- During render, if `isAuthenticated()` determines that the session token is no longer valid, it flags the session for cleanup via a deferred reference: `needsExpiryCleanupRef.current = true`.
- In `useEffect()`, the cleanup handler `clearExpiredSession()` is called. 
- However, if the toast notification guard `expiryToastShownRef.current` was already set to `true` (meaning the alert had already been shown once during the current session), `clearExpiredSession()` returned early **before** executing `clearSession()`.
- Because `clearSession()` was bypassed, the expired `token` and `user` state fields were never set to `null` in the React context. 
- As a result, subsequent layout render cycles (such as when the router navigated to `/login`) called `isAuthenticated()` again, which saw the non-null expired token, set `needsExpiryCleanupRef.current = true` again, and triggered a continuous re-render loop.

### **The Solution**
- **Immediate State Clearance**: Modified `clearExpiredSession` in [AuthContext.js](file:///c:/Open%20Source/Eventra/src/context/AuthContext.js#L42-L66) to clear context state immediately upon detection, resetting `user` and `token` to `null` **before** evaluating any toast notification/guard checks.
- **Render Loop Termination**: Synchronously setting `user` and `token` to `null` guarantees that subsequent evaluations of `isAuthenticated()` return `false` on the initial checks (`if (!user || !token)`) without setting the cleanup flag or triggering more effects.
- **Robust Notification Management**: Kept the ref check and warning toast logic untouched beneath the state cleanup step, ensuring the warning message is shown exactly once per expiration cycle.
- **eslint-disable Handling**: Wrapped console diagnostics inside ESLint comments to prevent rules like `no-console` from blocking production builds.

### **Verification / Testing**
- Verified that `node tests/auth.test.mjs` executes and passes cleanly.
- Confirmed with ESLint that no errors or warnings were introduced in `AuthContext.js`.