### PR TITLE
security(cors): restrict credentialed auth origins

### DIFF
--- a/api/auth/cors.js
+++ b/api/auth/cors.js
@@ -1,0 +1,43 @@
+const DEFAULT_ALLOWED_ORIGINS = [
+  "https://eventra.sandeepvashishtha.tech",
+  "https://eventra.vercel.app",
+  "http://localhost:3000",
+  "http://localhost:5173",
+];
+
+const parseAllowedOrigins = () => {
+  const configured = process.env.ALLOWED_ORIGINS || process.env.ALLOWED_ORIGIN || "";
+  const origins = configured
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+    // Credentialed CORS cannot safely use '*', so ignore it if configured.
+    .filter((origin) => origin !== "*");
+
+  return origins.length > 0 ? origins : DEFAULT_ALLOWED_ORIGINS;
+};
+
+const isLocalDevelopmentOrigin = (origin) =>
+  process.env.NODE_ENV !== "production" &&
+  /^http:\/\/(localhost|127\.0\.0\.1):\d+$/.test(origin);
+
+export const buildCorsHeaders = (req = {}) => {
+  const requestOrigin = req.headers?.origin || "";
+  const allowedOrigins = parseAllowedOrigins();
+  const allowedOrigin =
+    requestOrigin && (allowedOrigins.includes(requestOrigin) || isLocalDevelopmentOrigin(requestOrigin))
+      ? requestOrigin
+      : allowedOrigins[0];
+
+  return {
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Vary": "Origin",
+  };
+};
+
+export const corsResponse = (req, res, status, data) => {
+  return res.status(status).set(buildCorsHeaders(req)).json(data);
+};


### PR DESCRIPTION
## Summary
This PR replaces wildcard credentialed CORS on the auth endpoints with an allowlisted origin helper shared by login, signup, and Google OAuth.

## What changed
- added a reusable auth CORS helper
- stopped returning `Access-Control-Allow-Origin: *` for credentialed auth responses
- added `Vary: Origin` and support for configured allowlisted origins
- updated login, signup, and Google OAuth handlers to use the shared helper

## Why this matters
Credentialed CORS should never use a wildcard origin. This change makes the auth surface safer and more predictable across browsers.

## Verification
- `node tests/signupEndpoint.test.mjs`
- `node tests/loginEndpoint.test.mjs`
- `node tests/googleOAuthEndpoint.test.mjs`
- confirmed no auth endpoint still returns the old wildcard credentialed CORS pattern

Closes #2833