### PR TITLE
security(auth): require JWT_SECRET before issuing tokens

### DIFF
--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -1,6 +1,7 @@
 import jwt from "jsonwebtoken";
 import { OAuth2Client } from "google-auth-library";
 import { users } from "./signup.js";
+import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 
 // ---------------------------------------------------------------------------
 // Google OAuth Configuration
@@ -13,8 +14,7 @@ const client = new OAuth2Client(GOOGLE_CLIENT_ID);
 // JWT Configuration
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET || "your-super-secret-jwt-key-change-in-production";
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "7d";
+const JWT_SECRET = getJwtSecret();
 
 // ---------------------------------------------------------------------------
 // CORS Headers

--- a/api/auth/jwt-config.js
+++ b/api/auth/jwt-config.js
@@ -1,0 +1,20 @@
+// Centralized JWT configuration shared by all auth endpoints.
+// Production must fail closed if the signing secret is missing; otherwise a
+// predictable fallback would let attackers forge valid Eventra tokens.
+const DEVELOPMENT_JWT_SECRET = "eventra-local-development-jwt-secret";
+
+export const getJwtSecret = () => {
+  const secret = process.env.JWT_SECRET;
+
+  if (secret && secret.trim()) {
+    return secret;
+  }
+
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("JWT_SECRET must be configured in production");
+  }
+
+  return DEVELOPMENT_JWT_SECRET;
+};
+
+export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "7d";

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,13 +1,13 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { users } from "./signup.js";
+import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 
 // ---------------------------------------------------------------------------
 // JWT Configuration
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET || "your-super-secret-jwt-key-change-in-production";
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "7d";
+const JWT_SECRET = getJwtSecret();
 
 // ---------------------------------------------------------------------------
 // Validation Helpers

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -1,5 +1,6 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
+import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 
 // ---------------------------------------------------------------------------
 // In-memory user storage (replace with database in production)
@@ -11,8 +12,7 @@ const users = new Map();
 // JWT Configuration
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET || "your-super-secret-jwt-key-change-in-production";
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "7d";
+const JWT_SECRET = getJwtSecret();
 
 // ---------------------------------------------------------------------------
 // Validation Helpers


### PR DESCRIPTION
## Summary
This PR removes the hardcoded JWT signing fallback from the auth endpoints and centralizes JWT configuration so production fails closed when `JWT_SECRET` is missing.

## What changed
- added a shared JWT config helper for auth endpoints
- removed predictable fallback secrets from login, signup, and Google OAuth handlers
- kept a local development fallback so tests and non-production flows still work intentionally

## Why this matters
A missing production secret should never degrade into a forgeable token setup. This change makes misconfiguration loud instead of silently insecure.

## Verification
- `node tests/signupEndpoint.test.mjs`
- `node tests/loginEndpoint.test.mjs`
- `node tests/googleOAuthEndpoint.test.mjs`

Closes #2831