### PR TITLE
security(routes): require auth for event registration flows

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import ThemeCustomizerDrawer from "./components/common/ThemeCustomizerDrawer";
 import SessionRecovery from "./components/SessionRecovery";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import OnboardingChecklist from "./components/user/OnboardingChecklist";
+import ProtectedRoute from "./components/auth/ProtectedRoute";
 
 import NotificationToastContainer from "./components/common/NotificationProvider";
 import { NotificationProvider } from "./context/NotificationContext";
@@ -149,7 +150,15 @@ function App() {
                     }
                   >
                     <Routes>
-                      <Route path="/register/:id" element={<RegistrationPage />} />
+                      {/* Registration writes user-specific data and must stay behind auth. */}
+                      <Route
+                        path="/register/:id"
+                        element={
+                          <ProtectedRoute>
+                            <RegistrationPage />
+                          </ProtectedRoute>
+                        }
+                      />
 
                       <Route
                         path="/event-recommendation"

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -95,7 +95,7 @@ const registrationLocks = new Map();
 const EventRegistration = () => {
   const { eventId } = useParams();
   const navigate = useNavigate();
-  const { user, isAuthenticated } = useAuth();
+  const { user, token, isAuthenticated } = useAuth();
   const { addRegistration, myEvents } = useMyEvents();
   const { clearSession } = useSessionRecovery();
 
@@ -263,7 +263,10 @@ const EventRegistration = () => {
           ...formData,
           eventId: parseInt(eventId),
           userId: user?.id || null,
-        }
+        },
+        // Registration is authenticated server-side; send the active token
+        // explicitly instead of relying only on global storage lookup.
+        token
       );
 
       // Axios resolves for 2xx — treat as success

--- a/src/Pages/RegistrationPage.jsx
+++ b/src/Pages/RegistrationPage.jsx
@@ -5,6 +5,7 @@ import { FiUser, FiMail, FiPhone, FiBriefcase, FiAward, FiMessageSquare, FiCheck
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { toast } from "react-toastify";
 import { API_ENDPOINTS, apiUtils } from "../config/api";
+import { useAuth } from "../context/AuthContext";
 
 import {
   isAlreadyRegistered,
@@ -32,6 +33,7 @@ const RegistrationPage = () => {
   useDocumentTitle("Eventra | Registration");
   const navigate = useNavigate();
   const { id: eventId = "general" } = useParams();
+  const { token } = useAuth();
   const [formData, setFormData] = useState({
     fullName: "",
     email: "",
@@ -108,7 +110,10 @@ const RegistrationPage = () => {
 
       await apiUtils.post(
         API_ENDPOINTS.EVENTS.REGISTER(eventId),
-        formData
+        formData,
+        // Pass the in-memory token explicitly so this protected write does not
+        // depend on a stale or missing sessionStorage read.
+        token
       );
 
       saveRegistration(eventId, formData.email);

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -64,7 +64,16 @@ export const getPublicRoutes = () => [
   <Route key="/" path="/" element={<HomePage />} />,
   <Route key="/events" path="/events" element={<EventsPage />} />,
   <Route key="/event-details" path="/events/:eventId" element={<EventDetails />} />,
-  <Route key="/register" path="/events/:eventId/register" element={<EventRegistration />} />,
+  // Registration writes to an authenticated backend endpoint; keep guarded.
+  <Route
+    key="/register"
+    path="/events/:eventId/register"
+    element={
+      <ProtectedRoute>
+        <EventRegistration />
+      </ProtectedRoute>
+    }
+  />,
   <Route key="/hackathons" path="/hackathons" element={<HackathonPage />} />,
   <Route key="/hackathon-details" path="/hackathons/:hackathonId" element={<HackathonDetailsPage />} />,
   <Route key="/hackathons-lifecycle" path="/hackathons/:id/lifecycle" element={<HackathonLifecycle />} />,


### PR DESCRIPTION
## Summary
This PR protects both event registration entry points and makes the registration writes explicitly send the active auth token.

## What changed
- wrapped `/register/:id` and `/events/:eventId/register` with `ProtectedRoute`
- passed the active token explicitly for registration POST requests
- added small security comments at the guarded route and write-call sites

## Why this matters
Event registration is a protected write action. The route behavior should match the documented backend expectation that registration requires authentication.

## Verification
- reviewed both registration entry points in the route tree
- verified registration POSTs now send the active token intentionally
- `npx eslint src/App.js src/components/routes/PublicRoutes.js src/Pages/RegistrationPage.jsx src/Pages/Events/EventRegistration.js`

Closes #2834