### PR TITLE
Add hourly Vercel deploy workflow

### DIFF
--- a/.github/workflows/hourly-deploy.yml
+++ b/.github/workflows/hourly-deploy.yml
@@ -1,0 +1,27 @@
+name: Hourly Vercel Deploy
+
+on:
+  schedule:
+    - cron: '0 * * * *'   # Runs at the top of every hour (UTC)
+
+  workflow_dispatch:       # Also allows manual trigger from GitHub Actions UI
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel Config
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Introduce a new GitHub Actions workflow (.github/workflows/hourly-deploy.yml) that triggers a Vercel deployment every hour (cron '0 * * * *' UTC) and can also be run manually via workflow_dispatch. The job runs on ubuntu-latest, checks out the repo, installs the Vercel CLI, pulls Vercel config for the production environment, runs a production build, and deploys using the provided secrets.VERCEL_TOKEN. This ensures periodic automated deployments and an option for manual triggers.

