### PR TITLE
accessibility(navbar): add high-contrast focus-visible ring indicators

### DIFF
--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -8,12 +8,12 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
 
   const getNavLinkClasses = (active) => {
     return vertical
-      ? `flex gap-2 items-center text-sm font-medium transition-all duration-200 w-full py-2 pl-3 border-l-2 ${
+      ? `flex gap-2 items-center text-sm font-medium transition-all duration-200 w-full py-2 pl-3 border-l-2 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:outline-none dark:focus-visible:ring-indigo-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 focus-visible:rounded-lg ${
           active
             ? "text-black dark:text-white border-black dark:border-white font-semibold bg-gray-100 dark:bg-gray-800"
             : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white border-transparent hover:bg-gray-50 dark:hover:bg-gray-800/50"
         }`
-      : `flex gap-1 items-center text-sm font-medium transition-all duration-200 px-1 lg:px-2 py-2 border-b-2 rounded-t-md whitespace-nowrap ${
+      : `flex gap-1 items-center text-sm font-medium transition-all duration-200 px-1 lg:px-2 py-2 border-b-2 rounded-t-md whitespace-nowrap focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:outline-none dark:focus-visible:ring-indigo-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 focus-visible:rounded-lg ${
           active
             ? "text-black dark:text-white border-black dark:border-white font-semibold"
             : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white border-transparent hover:border-gray-300 dark:hover:border-gray-600"
@@ -56,7 +56,7 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
 
                 <button
                   type="button"
-                  className={`p-1 rounded-md transition-colors ${
+                  className={`p-1 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:outline-none dark:focus-visible:ring-indigo-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 focus-visible:rounded-lg ${
                     isSubItemActive
                       ? "text-black dark:text-white"
                       : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white"
@@ -74,7 +74,7 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
                     to={sub.href}
                     onClick={onClick}
                     className={({ isActive }) =>
-                      `flex items-center gap-2 p-2 rounded-md text-sm font-medium transition-all duration-200 ${
+                      `flex items-center gap-2 p-2 rounded-md text-sm font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:outline-none dark:focus-visible:ring-indigo-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 focus-visible:rounded-lg ${
                         isActive
                           ? "bg-gray-100 dark:bg-gray-700 text-black dark:text-white font-semibold"
                           : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700/50"


### PR DESCRIPTION
### Description
Navigating websites via keyboard is extremely difficult if there are no visible focus indicators (focus rings) on interactive links, buttons, or drawers. This PR adds high-contrast focus rings to all primary and drawer navbar links.

### Requirements Addressed
1. **Focus Outline System**: Injected modern Tailwind CSS focus ring structures (`focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:outline-none dark:focus-visible:ring-indigo-400 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900`) onto all vertical and horizontal navbar links.
2. **Sub-Item Controls**: Configured focus outlines on all sub-menu chevrons and interactive sub-items within `NavbarLinks.jsx`.
3. **Chrome Outline Overrides**: Disabled standard, low-contrast browser default focus rings via `focus-visible:outline-none`.
4. **Visual Validation**: Verified consistent high-contrast rendering across light and dark theme configurations.

### Target Issue
Closes #2540