### PR TITLE
fix: calculate unread notifications synchronously to fix async state batching bug

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -96,19 +96,14 @@ export const NotificationProvider = ({ children }) => {
   const markAllAsRead = useCallback(async () => {
     if (!token) return;
 
-    // Capture current unread list synchronously before the optimistic update
-    let unread = [];
-
-    setNotifications((prev) => {
-      unread = prev.filter((n) => !n.isRead);
-      if (unread.length === 0) return prev;
-
-      // Return optimistically updated array
-      return prev.map((n) => ({ ...n, isRead: true }));
-    });
+    // Capture current unread list synchronously using closure state
+    const unread = notifications.filter((n) => !n.isRead);
 
     // Nothing to do if every notification was already read
     if (unread.length === 0) return;
+
+    // Optimistic UI update
+    setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
 
     const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.READ_ALL;
     if (!endpoint || typeof endpoint !== "string" || endpoint.includes("undefined")) {
@@ -125,7 +120,7 @@ export const NotificationProvider = ({ children }) => {
       // Re-fetch to restore accurate server state on unexpected failure
       fetchNotifications();
     }
-  }, [token, fetchNotifications]);
+  }, [token, fetchNotifications, notifications]);
 
   
   // ── Initial fetch + polling ───────────────────────────────────────────────


### PR DESCRIPTION
## 🚀 Description
In `NotificationContext.js`, the `markAllAsRead` function had a logic bug caused by React's asynchronous state batching. 

Previously, it declared `let unread = []` and attempted to mutate it inside the `setNotifications` updater callback. Immediately after the state update call, it checked `if (unread.length === 0) return;`. Because React state updaters are queued asynchronously, `unread` still evaluated to its initial empty array state, causing the function to prematurely `return` and completely skip the `apiUtils.put` network request.

Fixed by capturing the `unread` notifications synchronously using the `notifications` state from the closure *before* calling `setNotifications`. This ensures the exact count is known instantly so the backend API call is correctly triggered.

Fixes #2913 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings