### PR TITLE
fix : stabilize validationRules with useRef in useFormValidation (closes #2838)

### DIFF
--- a/src/hooks/useFormValidation.js
+++ b/src/hooks/useFormValidation.js
@@ -3,6 +3,11 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 export const useFormValidation = (initialState, validationRules, options = {}) => {
   const { debounceMs = 300, validateOnBlur = false } = options;
   const timeoutRef = useRef(null);
+  const validationRulesRef = useRef(validationRules);
+
+  useEffect(() => {
+    validationRulesRef.current = validationRules;
+  }, [validationRules]);
   
   const [values, setValues] = useState(initialState);
   const [errors, setErrors] = useState({});
@@ -11,61 +16,58 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
 
   // Validate a single field
   const validateField = useCallback((name, value, allValues) => {
-    if (!validationRules[name]) return null;
-    
-    const validator = validationRules[name];
+    if (!validationRulesRef.current[name]) return null;
+
+    const validator = validationRulesRef.current[name];
     let error;
-    
+
     if (typeof validator === 'function') {
       error = validator(value, allValues);
     } else if (typeof validator === 'object' && validator.validate) {
       error = validator.validate(value, allValues);
     }
-    
+
     return error === true ? null : error;
-  }, [validationRules]);
+  }, []);
 
   // Validate all fields
   const validateAll = useCallback(() => {
     const newErrors = {};
     let isValid = true;
-    
-    Object.keys(validationRules).forEach((name) => {
+
+    Object.keys(validationRulesRef.current).forEach((name) => {
       const error = validateField(name, values[name], values);
       if (error) {
         newErrors[name] = error;
         isValid = false;
       }
     });
-    
+
     setErrors(newErrors);
     setIsFormValid(isValid);
     return isValid;
-  }, [values, validationRules, validateField]);
+  }, [values, validateField]);
 
   // Handle input change with debounced validation
   const handleChange = useCallback((e) => {
     const { name, value } = e.target;
     setValues(prev => ({ ...prev, [name]: value }));
-    
-    // Mark field as touched
+
     setTouched(prev => ({ ...prev, [name]: true }));
-    
-    // Clear error immediately for better UX
+
     setErrors(prev => ({ ...prev, [name]: null }));
-    
-    // Debounced validation
-    if (validationRules[name] && !validateOnBlur) {
+
+    if (validationRulesRef.current[name] && !validateOnBlur) {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      
+
       timeoutRef.current = setTimeout(() => {
         const error = validateField(name, value, { ...values, [name]: value });
         setErrors(prev => ({ ...prev, [name]: error }));
       }, debounceMs);
     }
-  }, [validationRules, validateOnBlur, debounceMs, validateField, values]);
+  }, [validateOnBlur, debounceMs, validateField, values]);
 
   // Clean up timeout on unmount
   useEffect(() => {
@@ -78,22 +80,22 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
   const handleBlur = useCallback((e) => {
     const { name, value } = e.target;
     setTouched(prev => ({ ...prev, [name]: true }));
-    
-    if (validationRules[name]) {
+
+    if (validationRulesRef.current[name]) {
       const error = validateField(name, value, values);
       setErrors(prev => ({ ...prev, [name]: error }));
     }
-  }, [validationRules, validateField, values]);
+  }, [validateField, values]);
 
   // Update form validity when values or errors change
   useEffect(() => {
     const hasErrors = Object.values(errors).some(error => error !== null);
-    const allRequiredFieldsTouched = Object.keys(validationRules).every(
+    const allRequiredFieldsTouched = Object.keys(validationRulesRef.current).every(
       key => touched[key] || values[key] !== ''
     );
-    
+
     setIsFormValid(!hasErrors && allRequiredFieldsTouched);
-  }, [errors, touched, values, validationRules]);
+  }, [errors, touched, values]);
 
   // Reset form
   const resetForm = useCallback(() => {


### PR DESCRIPTION
## Summary
- Stabilize validationRules with useRef to prevent recreation of callback functions on every render
- validationRules is stored in a ref and updated via useEffect, eliminating it from useCallback dependency arrays
- This fixes the issue where validateField, validateAll, handleChange, and handleBlur were recreated on every render

## Changes
- Add validationRulesRef = useRef(validationRules)
- Add useEffect to sync validationRulesRef.current when validationRules changes
- Replace validationRules with validationRulesRef.current in all callbacks
- Remove validationRules from all useCallback dependency arrays

## Verification
Test by using useFormValidation with inline validationRules and profiling - callbacks should no longer recreate on every render.

## Issue
Refs #2838