### PR TITLE
docs: add update event API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -624,6 +624,63 @@ Authorization: Bearer <token>
 
 ---
 
+## Update Event
+
+| Method | Endpoint |
+|--------|----------|
+| PUT | `/api/events/{id}` |
+
+Updates an existing event by ID. This endpoint is restricted to authenticated users with `ORGANIZER` or `ADMIN` authority.
+
+*This is a companion documentation update for backend issue #2099 and backend update-event API work.*
+
+### Authentication
+
+---
+
+Requires a valid JWT token.
+
+```http
+Authorization: Bearer <token>
+```
+
+#### Request Body
+
+```json
+{
+  "title": "Updated Event",
+  "description": "Updated event description",
+  "location": "Updated Location",
+  "eventDate": "2026-12-30T10:00:00",
+  "capacity": 150,
+  "isPublic": true
+}
+```
+
+#### Field Notes
+
+- `registeredCount` is preserved during update and cannot be directly edited.
+- `capacity` must not be lower than current `registeredCount`.
+- Owner-only authorization is not enforced because the Event model currently does not track event ownership.
+
+#### Success Response
+
+```http
+200 OK
+```
+
+#### Error Responses
+
+| Status | Reason |
+|---|---|
+| `400 Bad Request` | Invalid payload |
+| `403 Forbidden` | Unauthorized roles such as `CLIENT` |
+| `404 Not Found` | Event ID does not exist |
+| `409 Conflict` | Capacity is lower than current registeredCount |
+
+
+---
+
 # Project APIs
 
 ## Submit Project

--- a/docs/BACKEND_API_REQUIREMENTS.md
+++ b/docs/BACKEND_API_REQUIREMENTS.md
@@ -409,9 +409,31 @@ POST /api/events/create
 PUT /api/events/{id}
 ```
 
-**Auth Required:** Yes — Roles: `ADMIN`, `ORGANIZER` (own events), `SUPER_ADMIN`  
-**Request Body:** Same as create, fields optional for partial updates  
-**Success Response `200`:** Updated event object
+**Auth Required:** Yes — Roles: `ADMIN`, `ORGANIZER`  
+**Description:** Updates an existing event. Companion update for issue #2099.  
+**Request Body:**
+```json
+{
+  "title": "Updated Event",
+  "description": "Updated event description",
+  "location": "Updated Location",
+  "eventDate": "2026-12-30T10:00:00",
+  "capacity": 150,
+  "isPublic": true
+}
+```
+
+**Field Constraints:**
+- `registeredCount` is preserved and cannot be directly edited.
+- `capacity` cannot be reduced below current `registeredCount`.
+- Owner-only authorization is not enforced as the Event model currently lacks ownership tracking.
+
+**Success Response `200`:** Updated event object  
+**Error Responses:**
+- `400` — Invalid payload
+- `403` — Forbidden (e.g., CLIENT role)
+- `404` — Event not found
+- `409` — Conflict (capacity < registeredCount)
 
 ---
 


### PR DESCRIPTION
## Related Issue

Related to SandeepVashishtha/Eventra#2099  
Backend implementation: SandeepVashishtha/Eventra-Backend#31

## Description

This PR updates the API documentation to include the newly added backend event update endpoint.

## Changes Made

- Documented `PUT /api/events/{id}`
- Added authentication and authorization requirements
- Added request body example
- Added success response behavior
- Added validation/error response notes
- Documented capacity and `registeredCount` behavior during updates

## Notes

The backend implementation for this endpoint is handled in the Eventra-Backend repository. This PR only syncs the frontend/docs repository documentation with the backend API behavior.