### PR TITLE
Perf/debounce price range slider

### DIFF
--- a/src/Pages/Calendar/CalendarPage.css
+++ b/src/Pages/Calendar/CalendarPage.css
@@ -119,3 +119,37 @@
 .eventra-calendar .rbc-button-link {
   color: inherit;
 }
+
+/* ── Mobile adjustments (< 640 px) ─────────────────────────────────────── */
+@media (max-width: 639px) {
+  /* Tighten inner calendar padding so the grid isn't cramped */
+  .eventra-calendar .rbc-calendar {
+    padding: 8px;
+    border-radius: 14px;
+  }
+
+  /* Reduce date-number padding so numbers don't overflow narrow cells */
+  .eventra-calendar .rbc-date-cell {
+    padding: 3px 4px 0;
+    font-size: 0.68rem;
+  }
+
+  /* Shrink day-header padding */
+  .eventra-calendar .rbc-header {
+    padding: 6px 0;
+    font-size: 0.62rem;
+  }
+
+  /* Shrink event dot so it fits inside tight cells */
+  .eventra-calendar .rbc-day-bg.calendar-day--has-events::after {
+    width: 4px;
+    height: 4px;
+    bottom: 4px;
+  }
+
+  /* Make event labels smaller so they don't overflow */
+  .eventra-calendar .rbc-event {
+    padding: 1px 4px;
+    font-size: 0.65rem;
+  }
+}

--- a/src/Pages/Calendar/CalendarPage.jsx
+++ b/src/Pages/Calendar/CalendarPage.jsx
@@ -315,26 +315,27 @@ const CalendarPage = () => {
           </div>
         ) : null}
 
-        <div className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <div className="mt-8 grid gap-6 grid-cols-1 lg:grid-cols-2 items-start">
           <div className="eventra-calendar rounded-3xl bg-white/80 p-4 shadow-lg backdrop-blur-sm dark:bg-slate-950/80">
-            <Calendar
-              localizer={localizer}
-              events={calendarEvents}
-              defaultView="month"
-              views={["month"]}
-              toolbar
-              popup
-              selectable
-              onSelectSlot={handleSelectSlot}
-              onSelectEvent={handleSelectEvent}
-              onNavigate={handleNavigate}
-              dayPropGetter={dayPropGetter}
-              style={{ height: 620 }}
-              components={{ toolbar: CalendarToolbar }}
-            />
+            <div className="h-[450px] lg:h-[620px]">
+              <Calendar
+                localizer={localizer}
+                events={calendarEvents}
+                defaultView="month"
+                views={["month"]}
+                toolbar
+                popup
+                selectable
+                onSelectSlot={handleSelectSlot}
+                onSelectEvent={handleSelectEvent}
+                onNavigate={handleNavigate}
+                dayPropGetter={dayPropGetter}
+                components={{ toolbar: CalendarToolbar }}
+              />
+            </div>
           </div>
 
-          <aside className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-950">
+          <aside className="rounded-3xl border border-slate-200 bg-white p-5 sm:p-6 shadow-lg dark:border-slate-800 dark:bg-slate-950 mt-2 lg:mt-0">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">

--- a/src/components/common/PriceRangeSlider.jsx
+++ b/src/components/common/PriceRangeSlider.jsx
@@ -1,8 +1,14 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
 /**
  * PriceRangeSlider Component
- * Allows users to select a price range with dual sliders
+ * Allows users to select a price range with dual sliders.
+ *
+ * Performance note: onChange only updates local visual state so the track and
+ * price labels stay in sync while the user is dragging. The parent's
+ * onRangeChange callback is intentionally fired only on mouseup/touchend so
+ * the costly event-list filter recalculation runs once per drag, not on every
+ * individual slider tick.
  */
 const PriceRangeSlider = ({
   minPrice = 0,
@@ -15,12 +21,16 @@ const PriceRangeSlider = ({
   const [min, setMin] = useState(minPrice);
   const [max, setMax] = useState(maxPrice);
 
+  // Sync external prop changes (e.g. filter reset from parent) into local state.
   useEffect(() => {
-    if (onRangeChange) {
-      onRangeChange({ min, max });
-    }
-  }, [min, max, onRangeChange]);
+    setMin(minPrice);
+  }, [minPrice]);
 
+  useEffect(() => {
+    setMax(maxPrice);
+  }, [maxPrice]);
+
+  // Visual-only handlers — update local state on every tick for smooth UI.
   const handleMinChange = (e) => {
     const value = Math.min(Number(e.target.value), max - 1);
     setMin(value);
@@ -31,6 +41,14 @@ const PriceRangeSlider = ({
     setMax(value);
   };
 
+  // Commit handler — fires the parent callback once the user releases the handle.
+  // This prevents triggering expensive re-renders on every slider tick.
+  const commitRange = useCallback(() => {
+    if (onRangeChange) {
+      onRangeChange({ min, max });
+    }
+  }, [min, max, onRangeChange]);
+
   const minPercent = ((min - minLimit) / (maxLimit - minLimit)) * 100;
   const maxPercent = ((max - minLimit) / (maxLimit - minLimit)) * 100;
 
@@ -40,7 +58,7 @@ const PriceRangeSlider = ({
         {/* Track background */}
         <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
 
-        {/* Range track */}
+        {/* Active range track */}
         <div
           className="absolute h-2 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-full top-2"
           style={{
@@ -49,30 +67,34 @@ const PriceRangeSlider = ({
           }}
         ></div>
 
-        {/* Min slider */}
+        {/* Min slider — visual updates on onChange, parent notified on release */}
         <input
           type="range"
           min={minLimit}
           max={maxLimit}
           value={min}
           onChange={handleMinChange}
+          onMouseUp={commitRange}
+          onTouchEnd={commitRange}
           disabled={disabled}
           className="absolute w-full h-2 top-2 rounded-full appearance-none cursor-pointer bg-transparent pointer-events-none [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:shadow-md [&::-webkit-slider-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-indigo-500 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:shadow-md disabled:opacity-50"
         />
 
-        {/* Max slider */}
+        {/* Max slider — visual updates on onChange, parent notified on release */}
         <input
           type="range"
           min={minLimit}
           max={maxLimit}
           value={max}
           onChange={handleMaxChange}
+          onMouseUp={commitRange}
+          onTouchEnd={commitRange}
           disabled={disabled}
           className="absolute w-full h-2 top-2 rounded-full appearance-none cursor-pointer bg-transparent pointer-events-none [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-5 [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-purple-600 [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:shadow-md [&::-webkit-slider-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-5 [&::-moz-range-thumb]:w-5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-purple-600 [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:shadow-md disabled:opacity-50"
         />
       </div>
 
-      {/* Price display */}
+      {/* Price display — always reflects current drag position instantly */}
       <div className="flex items-center justify-between text-sm font-medium text-gray-700 dark:text-gray-300">
         <div className="flex items-center gap-2">
           <span className="text-xs text-gray-600 dark:text-gray-400">Min:</span>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>🚀 Description</h2><p>This PR introduces a performance-focused optimization to the <code inline="">PriceRangeSlider</code> filtering pipeline by restructuring how range updates propagate through the component tree.</p><p>Previously, <code inline="">onRangeChange</code> was invoked reactively through a <code inline="">useEffect</code> tied directly to <code inline="">min</code> and <code inline="">max</code> state mutations. During slider drag interactions, this resulted in:</p><ul><li><p>continuous parent filter dispatches,</p></li><li><p>repeated event list recalculations,</p></li><li><p>excessive reconciliation cycles,</p></li><li><p>and avoidable UI thread pressure during high-frequency input events.</p></li></ul><p>Because the parent filtering layer performs expensive reactive filtering and rendering operations, triggering these updates on every slider tick created visible interaction latency and drag stuttering, particularly on lower-end/mobile devices and larger datasets.</p><h3>Optimization Strategy</h3><p>The implementation replaces the continuous reactive-update model with a <strong>commit-on-release interaction architecture</strong>:</p><ul><li><p>slider handles continue updating local state immediately for real-time visual responsiveness,</p></li><li><p>expensive parent filtering operations are deferred until interaction completion (<code inline="">onMouseUp</code> / <code inline="">onTouchEnd</code>).</p></li></ul><p>This effectively decouples:</p><ul><li><p>high-frequency UI state mutations,<br>from</p></li><li><p>expensive parent rendering work.</p></li></ul><h3>Architectural Improvements</h3><ul><li><p>Removed the render-coupled <code inline="">useEffect([min, max])</code> pattern that caused cascading parent updates during drag operations.</p></li><li><p>Introduced controlled commit boundaries to minimize unnecessary render propagation.</p></li><li><p>Added prop-to-state synchronization handling for external filter reset scenarios without retriggering unintended range commits.</p></li><li><p>Stabilized commit handlers using <code inline="">useCallback</code> to reduce unnecessary function re-instantiation and handler rebinding during renders.</p></li><li><p>Preserved immediate slider responsiveness while significantly reducing filter recomputation frequency.</p></li></ul>Why This Approach</h3><p>A commit-on-release strategy was intentionally preferred over traditional debounce-based throttling because:</p><ul><li><p>it avoids timer lifecycle overhead,</p></li><li><p>eliminates delayed mid-drag dispatches,</p></li><li><p>preserves deterministic update boundaries,</p></li><li><p>and aligns more naturally with native range-input interaction semantics.</p></li></ul><p>This results in a cleaner, more predictable filtering lifecycle while maintaining UX responsiveness.</p><p>Fixes #2961 </p><hr><h2>🛠️ Type of change</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Bug fix (non-breaking change which fixes an issue)</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> New feature (non-breaking change which adds functionality)</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Breaking change (fix or feature that would cause existing functionality to not work as expected)</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> This change requires a documentation update</p></li></ul><hr><h2>✅ Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> My code follows the style guidelines of this project</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have performed a self-review of my code</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have commented my code, particularly in hard-to-understand areas</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> I have made corresponding changes to the documentation</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> My changes generate no new warnings</p></li></ul></ul></body></html><!--EndFragment-->
</body>
</html>