### PR TITLE
docs: add delete event API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -693,6 +693,45 @@ Authorization: Bearer <token>
 
 ---
 
+## Delete Event
+
+| Method | Endpoint |
+|--------|----------|
+| DELETE | `/api/events/{id}` |
+
+Deletes an existing event by ID. This endpoint is restricted to authenticated users with `ADMIN` or `SUPER_ADMIN` authority.
+
+### Authentication
+
+---
+
+Requires a valid JWT token.
+
+```http
+Authorization: Bearer <token>
+```
+
+#### Success Response
+
+```http
+204 No Content
+```
+
+#### Error Responses
+
+| Status | Reason |
+|---|---|
+| `401 Unauthorized` | Missing or invalid JWT |
+| `403 Forbidden` | Authenticated user does not have `ADMIN` or `SUPER_ADMIN` authority |
+| `404 Not Found` | Event ID does not exist |
+
+#### Additional Notes
+
+- Related event registrations are automatically cleaned up by the backend before the event is deleted.
+
+
+---
+
 # Project APIs
 
 ## Submit Project


### PR DESCRIPTION
## Related Issue

Related to SandeepVashishtha/Eventra#2100  
Backend implementation: SandeepVashishtha/Eventra-Backend#32

## Description

This PR updates the API documentation to include the newly added backend event deletion endpoint.

## Changes Made

- Documented `DELETE /api/events/{id}`
- Added authentication and authorization requirements
- Added path parameter details
- Added success response behavior
- Added validation/error response notes

## Notes

The backend implementation for this endpoint is handled in the Eventra-Backend repository. This PR only syncs the frontend/docs repository documentation with the backend API behavior.