### PR TITLE
fix: remove duplicate ThemeContext keys causing ESLint no-dupe-keys warnings

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -163,8 +163,6 @@ export const ThemeProvider = ({ children }) => {
       activeThemeId,
       setActiveThemeId,
       THEMES,
-      isCustomizerOpen,
-      setIsCustomizerOpen,
       customHsl,
       setCustomHsl,
       reducedMotion,


### PR DESCRIPTION
## 🚀 Description

This PR fixes duplicate key declarations inside the `useMemo` value object in `src/context/ThemeContext.js` that were triggering ESLint `no-dupe-keys` warnings.

### Changes made:
- Removed duplicate `isCustomizerOpen` declaration
- Removed duplicate `setIsCustomizerOpen` declaration
- Cleaned the `ThemeContext` value object for improved maintainability
- Prevented redundant property overwrites during context re-evaluation
- Improved compliance with React and JavaScript best practices

Affected file:
- `src/context/ThemeContext.js`

This resolves linting warnings occurring during:
- `npm run lint`

Fixes #3091

---

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings