### PR TITLE
fix: resolve ESLint import order and act() warnings in useLocalStorage tests

### DIFF
--- a/src/hooks/useLocalStorage.test.js
+++ b/src/hooks/useLocalStorage.test.js
@@ -1,8 +1,9 @@
-global.IS_REACT_ACT_ENVIRONMENT = true;
-
+/* eslint-disable testing-library/no-unnecessary-act */
 import React, { useEffect, act } from "react";
 import { createRoot } from "react-dom/client";
 import useLocalStorage from "./useLocalStorage";
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("useLocalStorage", () => {
   let container;


### PR DESCRIPTION
## 🚀 Description

This PR fixes ESLint validation issues in `src/hooks/useLocalStorage.test.js` that were causing CI lint failures and blocking deployment pipelines.

### Changes made:
- Reordered ES module imports to satisfy `import/first` lint rules
- Moved `global.IS_REACT_ACT_ENVIRONMENT = true;` below imports
- Added ESLint override for valid native React `act()` usage
- Prevented false-positive `testing-library/no-unnecessary-act` warnings
- Improved compatibility with CI and Vercel deployment checks

Affected file:
- `src/hooks/useLocalStorage.test.js`

This resolves lint failures occurring during:
- `npm run lint`

Fixes #3099 

---

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A

---

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings