### PR TITLE
fix(events): move localStorage.getItem inside try-catch to prevent ap…

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -52,16 +52,16 @@ const EventDetails = () => {
   useEffect(() => {
     if (!event) return;
 
-    const viewedEvents = safeParseJson(localStorage.getItem("recentlyViewedEvents"), []);
-    const updatedEvents = [
-      event,
-      ...viewedEvents.filter((item) => item.id !== event.id),
-    ].slice(0, 6);
-
     try {
+      const viewedEvents = safeParseJson(localStorage.getItem("recentlyViewedEvents"), []);
+      const updatedEvents = [
+        event,
+        ...viewedEvents.filter((item) => item.id !== event.id),
+      ].slice(0, 6);
+
       localStorage.setItem("recentlyViewedEvents", JSON.stringify(updatedEvents));
     } catch (error) {
-      console.warn("[EventDetails] Failed to save recently viewed events:", error);
+      console.warn("[EventDetails] Failed to access or save recently viewed events in localStorage:", error);
     }
   }, [event]);
 


### PR DESCRIPTION
## Description
This PR resolves an application crash vulnerability in `EventDetails.js` caused by unhandled `localStorage.getItem` exceptions.
Closes #2991
While `localStorage.setItem` was correctly wrapped in a `try-catch` block in a previous commit, the `localStorage.getItem("recentlyViewedEvents")` call was left outside of it. If a user visits the Event Details page with strict privacy settings enabled (e.g., Safari Private Browsing or disabled third-party cookies), accessing `getItem` will instantly throw a `SecurityError`, causing a fatal React component crash before the `try` block is ever reached.

### Changes Made
- Moved the `localStorage.getItem` read operation and subsequent array processing safely inside the `try` block.
- Updated the catch block warning to correctly log both access and storage failures.

## Type of Change
- [x] Bug fix (prevents fatal React component crashes)
- [x] Security/Integrity (hardening against strict browser privacy policies)
