### PR TITLE
fix(contributors): prevent anonymous contributors from being filtered…

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -170,7 +170,8 @@ const Contributors = () => {
           );
         }
 
-        const validContributors = data.filter((c) => c && c.login);
+        // Support anonymous contributors by checking for either login or name
+        const validContributors = data.filter((c) => c && (c.login || c.name));
 
         if (validContributors.length === 0) hasMore = false;
         else {
@@ -336,7 +337,7 @@ const Contributors = () => {
                       decoding="async"
                       width="80"
                       height="80"
-                      src={c.avatar_url}
+                      src={c.avatar_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(c.name || "Anon")}&background=random`}
                       alt={`${c.name || c.login || "Contributor"}'s GitHub profile picture`}
                       className="w-20 h-20 rounded-full border-4 border-black shadow-xl"
                     />


### PR DESCRIPTION
## Description
This PR resolves an issue where Anonymous Contributors were completely missing from the `Contributors.js` page, despite the API explicitly requesting them via the `anon=true` parameter.
Closes #3114 
Previously, after the GitHub API returned the contributor payload, a strict `.filter((c) => c && c.login)` was applied. Because anonymous contributors lack a GitHub `login` (they only have an email and a `name`), this filter accidentally wiped all anonymous contributors from the array before they could be rendered.

### Changes Made
- **Restored Anonymous Data:** Updated the filter to `c && (c.login || c.name)`, allowing anonymous contributors to proceed to the rendering phase.
- **Fallback Avatar:** Added a dynamic fallback to `ui-avatars.com` using the contributor's name. Previously, because anonymous contributors lack an `avatar_url`, rendering them would result in a broken image icon.

## Type of Change
- [x] Bug fix (resolves missing data)
- [x] UX Improvement (prevents broken avatars)
