### PR TITLE
fix(registration): remove hard block to allow waitlist submissions

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -251,8 +251,7 @@ const EventRegistration = () => {
     // Quick UX hint based on the latest visible event snapshot.
     const isFull = await checkEventCapacity(eventId, event);
     if (isFull) {
-      toast.error("This event is currently full. Registration may no longer be available.");
-      return;
+      toast.info("This event is full. You will be added to the waitlist.");
     }
 
     // Check for scheduling conflicts


### PR DESCRIPTION
## Description
This PR resolves a critical logic bug in `EventRegistration.js` that completely prevented users from joining the waitlist for full events.
Closes #3115 
Previously, if an event was full, `handleSubmit` would throw a toast error and `return;` immediately. Because of this early return, the execution never reached `proceedWithRegistration()`, rendering the waitlist API integration and the "Join Waitlist" button completely useless.

### Changes Made
- Removed the strict `return;` block in the capacity check inside `handleSubmit`.
- Replaced the error toast with an informational toast (`toast.info`) to let the user know they are joining the waitlist.
- The form now correctly falls through to `proceedWithRegistration()` and hits the `/api/events/:id/waitlist` endpoint as originally intended.

## Type of Change
- [x] Bug fix (resolves broken waitlist feature)
