### PR TITLE
Fix #8: Move hackathon mock fallback to service layer

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -2,7 +2,7 @@ import TeamMatchmaking from "./components/TeamMatchmaking";
 import React, { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link } from "react-router-dom";
-import mockHackathons from "./hackathonMockData.json";
+import { fetchHackathons } from "../../services/hackathonService";
 import HackathonHero from "./HackathonHero";
 import HackathonCard from "./HackathonCard";
 import { FiCode, FiRotateCw, FiCompass, FiChevronDown, FiX } from "react-icons/fi";
@@ -62,18 +62,26 @@ const HackathonHub = () => {
     cardsSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  // Simulate API call and wire page listeners
+  // Fetch hackathons and wire page listeners
   useEffect(() => {
-    setIsLoading(true);
-    setHackathons(mockHackathons);
-    setIsLoading(false);
-
-    const tags = [
-      ...new Set(
-        mockHackathons.flatMap((hackathon) => hackathon.techStack || []),
-      ),
-    ];
-    setAvailableTags(tags);
+    let isMounted = true;
+    
+    const loadHackathons = async () => {
+      setIsLoading(true);
+      const data = await fetchHackathons();
+      if (isMounted) {
+        setHackathons(data);
+        const tags = [
+          ...new Set(
+            data.flatMap((hackathon) => hackathon.techStack || []),
+          ),
+        ];
+        setAvailableTags(tags);
+        setIsLoading(false);
+      }
+    };
+    
+    loadHackathons();
 
     const handleScroll = () => {
       setIsScrollVisible(window.scrollY > 300);
@@ -90,6 +98,7 @@ const HackathonHub = () => {
     observer.observe(document.body, { childList: true, subtree: true });
 
     return () => {
+      isMounted = false;
       window.removeEventListener("scroll", handleScroll);
       observer.disconnect();
     };

--- a/src/services/hackathonService.js
+++ b/src/services/hackathonService.js
@@ -1,0 +1,16 @@
+import { apiUtils, API_ENDPOINTS } from "../config/api";
+import mockHackathons from "../Pages/Hackathons/hackathonMockData.json";
+
+export const fetchHackathons = async () => {
+  try {
+    const response = await apiUtils.get(API_ENDPOINTS.HACKATHONS.LIST);
+    const data = await response.json();
+    if (data && data.length > 0) {
+      return data;
+    }
+  } catch (error) {
+    console.warn("Failed to fetch hackathons from API, falling back to mock data", error);
+  }
+  
+  return mockHackathons;
+};


### PR DESCRIPTION
## 🚀 Description
This PR resolves an issue in `HackathonPage.js` where the mock data logic was directly imported and handled within the UI component. This made the component tightly coupled to the mock implementation, hindering the transition to a real backend. The mock fallback logic has been extracted into a new, dedicated `hackathonService.js` data-fetching layer.

Fixes #2984 

## 🛠️ Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
