### PR TITLE
docs: add event response DTO note

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -448,6 +448,12 @@ This endpoint retrieves the event directly by ID and does not apply public-only 
     }
 ```
 
+### Event Response Note
+
+Event create, update, and detail APIs return a sanitized event response object instead of the raw backend entity. The response includes public event fields such as `id`, `title`, `description`, `location`, `eventDate`, `capacity`, `registeredCount`, and `public`.
+
+Internal backend fields such as registered user entities, attendee details, and JPA metadata are not exposed in event API responses.
+
 ---
 
 ## Register for Event


### PR DESCRIPTION
## Related Issue

Related to SandeepVashishtha/Eventra#3098
Backend implementation: SandeepVashishtha/Eventra-Backend#33

## Description

Added a small API documentation note clarifying that event create, update, and detail endpoints return a sanitized event response object instead of exposing raw backend entities.

## Notes

The actual implementation for this feature/security improvement is handled in the `Eventra-Backend` repository. This PR only updates the frontend/API documentation to reflect the updated backend response contract.

## Type of PR

* [x] Documentation update

## Checklist

* [x] Updated documentation only
* [x] No frontend logic changed
* [x] No breaking changes
