### PR TITLE
fix(memory): resolve state update on unmounted component in ApiDocs.js

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import useReducedMotion from "../hooks/useReducedMotion.js";
@@ -105,6 +105,14 @@ const ApiDocs = () => {
   const [terminalOutput, setTerminalOutput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
   const handleParamChange = (name, val) => {
     setParams(prev => ({ ...prev, [name]: val }));
   };
@@ -116,7 +124,7 @@ const ApiDocs = () => {
     // Track execution for onboarding checklist
     localStorage.setItem("eventra_sandbox_executed", "true");
     
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       let data = [];
       const headers = {
         Status: "200 OK",


### PR DESCRIPTION
## 🚀 Description
Fixes a memory leak where navigating away from ApiDocs while a mock 
request was pending caused a state update on an unmounted component.

Added a `useRef` to track the active `setTimeout` and a `useEffect` 
cleanup that calls `clearTimeout` on unmount, safely aborting any 
background execution.

Fixes #3157 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings