### PR TITLE
refactor: remove outdated HttpOnly TODO from secureStorage

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -210,8 +210,6 @@ const cryptoSupported = isCryptoAvailable();
  * The token is scoped to the current browser tab and cleared automatically
  * when the tab is closed.
  *
- * TODO: Remove once the backend sets the token via an HttpOnly cookie.
- *
  * @param {string} token - The Eventra-issued JWT returned by the backend
  */
 export const setToken = (token) => {


### PR DESCRIPTION
Fixes #3171

Removes the outdated TODO regarding HttpOnly cookies in \secureStorage.js\.