### PR TITLE
fix(qr-ticket): prevent state collision by scoping keydown listeners …

### DIFF
--- a/src/components/common/QRTicket/QRTicketModal.jsx
+++ b/src/components/common/QRTicket/QRTicketModal.jsx
@@ -39,13 +39,14 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
     ticket?.ticketId || "ticket"
   );
 
-  // Close on Escape key
+  const modalRef = useRef(null);
+
+  // Focus modal on open to capture localized keyboard events
   useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [isOpen, onClose]);
+    if (isOpen && modalRef.current) {
+      modalRef.current.focus();
+    }
+  }, [isOpen]);
 
   // Lock body scroll while open
   useEffect(() => {
@@ -76,7 +77,10 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
   return (
     // Backdrop
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      ref={modalRef}
+      tabIndex={-1}
+      onKeyDown={(e) => e.key === "Escape" && onClose()}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 outline-none"
       style={{ background: "rgba(0,0,0,0.7)", backdropFilter: "blur(4px)" }}
       onClick={(e) => e.target === e.currentTarget && onClose()}
       role="dialog"


### PR DESCRIPTION
## Description
This PR resolves a state management and event collision issue within `QRTicketModal.jsx`. 
Closes #3148 
Previously, the modal relied on attaching an anonymous `keydown` listener globally to the `window` object to detect the Escape key. Without a centralized portal or focus manager, this unmanaged global listener was highly prone to event collisions, especially if multiple pop-ups were triggered rapidly, leading to out-of-order state execution or closing the wrong UI layer.

### Changes Made
- Eliminated the global `window.addEventListener` logic entirely.
- Transformed the modal backdrop into a localized focus-trap using `useRef`, `tabIndex={-1}`, and auto-focusing on mount.
- Implemented the Escape key detection directly via an `onKeyDown` prop, strictly scoping the event to the active DOM element.
- This inherently improves a11y (accessibility) by ensuring the modal commands screen reader and keyboard focus when rendered.

## Type of Change
- [x] Bug fix (resolves event listener collisions)
- [x] Accessibility (A11y) Improvement
