### PR TITLE
fix: remove invalid HttpOnly attribute from client-side cookie in AuthContext

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -47,8 +47,7 @@ export const AuthProvider = ({ children }) => {
 
     setUser(null);
     setToken(null);
-    document.cookie =
-      "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; HttpOnly; SameSite=Strict";
+    document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; SameSite=Strict";
     sessionStorage.removeItem("token");
     localStorage.removeItem("user");
     return true;
@@ -228,8 +227,10 @@ export const AuthProvider = ({ children }) => {
   const persistSession = useCallback((sessionToken, sessionUser) => {
     setToken(sessionToken);
     setUser(sessionUser);
-    
-    document.cookie = `token=${sessionToken}; path=/; Secure; HttpOnly; SameSite=Strict`;
+    // NOTE: HttpOnly cannot be set via JavaScript (silently ignored by browsers).
+    // HttpOnly must be set server-side via Set-Cookie response header.
+    // Token security against XSS must be handled on the backend.    
+    document.cookie = `token=${sessionToken}; path=/; Secure; SameSite=Strict`;
     
     try {
       localStorage.setItem("user", JSON.stringify(sessionUser));


### PR DESCRIPTION
## Summary
Removes the invalid `HttpOnly` attribute from client-side `document.cookie` calls in `AuthContext.js`.

## Problem
`HttpOnly` is silently ignored by all browsers when set via JavaScript. It can only be set server-side via `Set-Cookie` response header. The existing code created a false sense of security — the JWT token was stored without `HttpOnly` protection despite the code intending otherwise.

## Changes Made
- Removed `HttpOnly` from `document.cookie` in `persistSession()`
- Removed `HttpOnly` from `document.cookie` in `clearSession()`
- Added a comment explaining why `HttpOnly` must be set server-side

## Files Changed
- `src/context/AuthContext.js`

## Testing
- App loads without errors
- Login/logout flow works correctly
- Token cookie appears in DevTools without the misleading `HttpOnly` flag

## Related Issue
Closes #3344 