### PR TITLE
fix: remove dead code branch in resolveEnvApiBaseUrl to ensure production warning fires

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -28,9 +28,7 @@ const resolveEnvApiBaseUrl = () => {
     return normalizeApiBaseUrl(envUrl);
   }
   if (process.env.NODE_ENV === "production") {
-    if (isDev) {
-      console.warn("REACT_APP_API_URL environment variable is missing in production. Defaulting to relative API requests.");
-    }
+    console.warn("REACT_APP_API_URL environment variable is missing in production. Defaulting to relative API requests.");
     return "";
   }
   return "http://localhost:8080";


### PR DESCRIPTION
## Summary
Removes the dead `if (isDev)` branch inside `resolveEnvApiBaseUrl()` in 
`src/config/api.js` that prevented a critical production warning from ever firing.

## Problem
`isDev` is `true` only when `NODE_ENV === "development"`. The `console.warn` 
was wrapped inside `if (isDev)` but that check was nested inside 
`if (process.env.NODE_ENV === "production")` — making it impossible for 
`isDev` to ever be `true` there. The warning was dead code and never executed.

## Changes Made
- Removed the inner `if (isDev)` wrapper from the production warning in `resolveEnvApiBaseUrl()`
- Warning now correctly fires whenever `REACT_APP_API_URL` is missing in production

## Files Changed
- `src/config/api.js`

## Testing
- App loads without errors in development
- All API calls work correctly
- Warning now fires in production when `REACT_APP_API_URL` is missing

## Related Issue
Closes #3347