### PR TITLE
fix: use correct clearTimeout/clearInterval based on timer type in AuthContext

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -220,8 +220,11 @@ export const AuthProvider = ({ children }) => {
     }
 
     return () => {
-      clearTimeout(timeoutId);
-      clearInterval(timeoutId);
+      if (typeof expSeconds === "number") {
+        clearTimeout(timeoutId);
+      } else {
+        clearInterval(timeoutId);
+      }
     };
   }, [token, clearExpiredSession]);
 


### PR DESCRIPTION
## Summary
Fixes incorrect timer cleanup in the token expiry `useEffect` in 
`src/context/AuthContext.js` where both `clearTimeout` and `clearInterval` 
were called on the same timer ID regardless of which timer was created.

## Problem
The cleanup function blindly called both `clearTimeout` and `clearInterval` 
on the same `timeoutId`. When a `setTimeout` was used, `clearInterval` was 
unnecessarily called on it and vice versa. This is incorrect and can cause 
subtle timer leaks in some environments.

## Changes Made
- Added a condition in the cleanup function to call `clearTimeout` only 
  when `setTimeout` was used
- Added a condition to call `clearInterval` only when `setInterval` was used

## Files Changed
- `src/context/AuthContext.js`

## Testing
- App loads without errors
- Login/logout flow works correctly
- Session timer fires and clears correctly
- No console errors related to timers

## Related Issue
Closes #3349 