### PR TITLE
fix: correct named import to default import for useReducedMotion in Signup

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { useReducedMotion } from '../../hooks/useReducedMotion';
+import useReducedMotion from '../../hooks/useReducedMotion';
 import { API_ENDPOINTS, apiUtils } from "../../config/api";
 import { useAuth } from "../../context/AuthContext";
 import PasswordStrengthIndicator from "./PasswordStrengthIndicator";


### PR DESCRIPTION
## Summary
Fixes incorrect named import of `useReducedMotion` hook in `Signup.js` 
that caused reduced motion accessibility support to silently break.

## Problem
`useReducedMotion` is exported as a default export from its module.
`Signup.js` was importing it as a named export `{ useReducedMotion }`,
which resolves to `undefined`. This meant `prefersReducedMotion` was
always `undefined`, and all animation durations on the Signup page
never reduced to `0` even when the user had enabled reduced motion
in their OS accessibility settings.

`Login.js` already uses the correct default import and works as expected.

## Changes Made
- Changed `import { useReducedMotion }` to `import useReducedMotion`
  in `src/components/auth/Signup.js`

## Files Changed
- `src/components/auth/Signup.js`

## Testing
- Signup page loads without errors
- No console errors related to useReducedMotion
- Animations respect OS reduced motion preference on Signup page
- Login page continues to work correctly

## Related Issue
Closes #3354