### PR TITLE
fix: remove unused RecentlyViewedEvents import from HomePage

### DIFF
--- a/src/Pages/Home/HomePage.jsx
+++ b/src/Pages/Home/HomePage.jsx
@@ -7,8 +7,6 @@ import CollaborationMap from "../../components/CollaborationMap";
 
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 
-import RecentlyViewedEvents from '../../components/common/RecentlyViewedEvents';
-
 
 
 


### PR DESCRIPTION
## Summary
Removes the unused `RecentlyViewedEvents` import from 
`src/Pages/Home/HomePage.jsx` that was imported but never 
rendered in the JSX.

## Problem
`RecentlyViewedEvents` was imported at the top of `HomePage.jsx` 
but never used anywhere in the component's JSX. This caused:
- Unnecessary bundle weight in production
- ESLint `no-unused-vars` warning
- Risk of masking real issues in CI lint checks
- Unnecessary side effects from the unused import

## Changes Made
- Removed unused `RecentlyViewedEvents` import from `HomePage.jsx`

## Files Changed
- `src/Pages/Home/HomePage.jsx`

## Testing
- Home page loads without errors
- All sections render correctly
- No ESLint warnings related to unused imports
- No console errors

## Related Issue
Closes #3360 