### PR TITLE
fix(ics): strip carriage returns in escapeICSText to prevent CRLF line injection

### DIFF
--- a/src/utils/calendarExporter.js
+++ b/src/utils/calendarExporter.js
@@ -13,12 +13,15 @@ const formatToICSDate = (dateStr) => {
   return date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
 };
 
-// Helper to safely escape special characters in ICS strings
+// Helper to safely escape special characters in ICS strings (RFC 5545 compliant).
+// Carriage returns (\r) are stripped before newlines are escaped so that
+// user-supplied text cannot inject extra ICS content lines via CRLF sequences.
 const escapeICSText = (text = "") => {
   return text
     .replace(/\\/g, "\\\\")
     .replace(/;/g, "\\;")
     .replace(/,/g, "\\,")
+    .replace(/\r/g, "")
     .replace(/\n/g, "\\n");
 };
 


### PR DESCRIPTION
## Summary

Fixes #3168.

The `escapeICSText` helper in `src/utils/calendarExporter.js` escaped backslashes, semicolons, commas, and newlines but left bare carriage returns (`\r`) untouched. A crafted event field containing a `\r\n` sequence (CRLF) would inject a new line into the exported `.ics` file, allowing arbitrary ICS properties to be appended.

**Example attack vector (before fix):**

```
title: "Team Meeting\r\nATTACH:http://malicious.example"
```

would produce this in the downloaded `.ics`:

```
SUMMARY:Team Meeting
ATTACH:http://malicious.example
```

## Change

Added `.replace(/\r/g, "")` before the `\n` escape in `escapeICSText`:

```js
const escapeICSText = (text = "") => {
  return text
    .replace(/\\/g, "\\\\")
    .replace(/;/g, "\;")
    .replace(/,/g, "\\,")
    .replace(/\r/g, "")      // added: strip CR before CRLF can form
    .replace(/\n/g, "\\n");
};
```

Bare carriage returns are now stripped before they can combine with a subsequent `\n` to form an ICS line break.

## Test Plan

- [ ] Create an event with `\r\n` in the title, description, and location fields
- [ ] Export the event as `.ics`
- [ ] Verify the exported file contains no injected ICS property lines
- [ ] Import the `.ics` into a calendar client (Google Calendar / Apple Calendar) and confirm the event displays correctly

## Related

- Closes #3168

---

**Program:** GSSoC 2026
**Type:** Security bug fix