### PR TITLE
fix(cors): omit Allow-Credentials header when origin falls back to wildcard

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -35,17 +35,19 @@ const corsHeaders = (req) => {
   const allowedOrigin = process.env.ALLOWED_ORIGIN;
   const requestOrigin = req.headers?.origin;
 
-  let corsOrigin = allowedOrigin || "*";
+  const corsOrigin = allowedOrigin || "*";
   if (allowedOrigin && requestOrigin !== allowedOrigin) {
     console.warn(`[CORS] Origin mismatch - Request: ${requestOrigin}, Allowed: ${allowedOrigin}`);
   }
-  if (allowedOrigin && allowedOrigin !== "*") {
-    corsOrigin = allowedOrigin;
-  }
+
+  // Access-Control-Allow-Credentials must not be sent with a wildcard origin.
+  // Per the CORS spec, browsers reject credentialed responses when the reflected
+  // origin is "*". Only set the header when a specific origin is configured.
+  const isSpecificOrigin = corsOrigin !== "*";
 
   return {
     "Access-Control-Allow-Origin": corsOrigin,
-    "Access-Control-Allow-Credentials": "true",
+    ...(isSpecificOrigin && { "Access-Control-Allow-Credentials": "true" }),
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
   };

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -57,17 +57,19 @@ const corsHeaders = (req) => {
   const allowedOrigin = process.env.ALLOWED_ORIGIN;
   const requestOrigin = req.headers?.origin;
 
-  let corsOrigin = allowedOrigin || "*";
+  const corsOrigin = allowedOrigin || "*";
   if (allowedOrigin && requestOrigin !== allowedOrigin) {
     console.warn(`[CORS] Origin mismatch - Request: ${requestOrigin}, Allowed: ${allowedOrigin}`);
   }
-  if (allowedOrigin && allowedOrigin !== "*") {
-    corsOrigin = allowedOrigin;
-  }
+
+  // Access-Control-Allow-Credentials must not be sent with a wildcard origin.
+  // Per the CORS spec, browsers reject credentialed responses when the reflected
+  // origin is "*". Only set the header when a specific origin is configured.
+  const isSpecificOrigin = corsOrigin !== "*";
 
   return {
     "Access-Control-Allow-Origin": corsOrigin,
-    "Access-Control-Allow-Credentials": "true",
+    ...(isSpecificOrigin && { "Access-Control-Allow-Credentials": "true" }),
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
   };

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -63,17 +63,19 @@ const corsHeaders = (req) => {
   const allowedOrigin = process.env.ALLOWED_ORIGIN;
   const requestOrigin = req.headers?.origin;
 
-  let corsOrigin = allowedOrigin || "*";
+  const corsOrigin = allowedOrigin || "*";
   if (allowedOrigin && requestOrigin !== allowedOrigin) {
     console.warn(`[CORS] Origin mismatch - Request: ${requestOrigin}, Allowed: ${allowedOrigin}`);
   }
-  if (allowedOrigin && allowedOrigin !== "*") {
-    corsOrigin = allowedOrigin;
-  }
+
+  // Access-Control-Allow-Credentials must not be sent with a wildcard origin.
+  // Per the CORS spec, browsers reject credentialed responses when the reflected
+  // origin is "*". Only set the header when a specific origin is configured.
+  const isSpecificOrigin = corsOrigin !== "*";
 
   return {
     "Access-Control-Allow-Origin": corsOrigin,
-    "Access-Control-Allow-Credentials": "true",
+    ...(isSpecificOrigin && { "Access-Control-Allow-Credentials": "true" }),
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
   };


### PR DESCRIPTION
## Summary

Fixes #3166.

The `corsHeaders` helper in all three auth endpoints (`login.js`, `signup.js`, `logout.js`) unconditionally set `Access-Control-Allow-Credentials: true` even when the `ALLOWED_ORIGIN` environment variable was not configured and the origin fell back to `"*"`.

This violates the CORS specification: browsers reject credentialed responses that pair `Access-Control-Allow-Origin: *` with `Access-Control-Allow-Credentials: true`. In practice this broke cookie-based auth flows in any deployment without `ALLOWED_ORIGIN` set.

## Root Cause

```js
// Before: always emits the header regardless of origin value
return {
  "Access-Control-Allow-Origin": corsOrigin,   // could be "*"
  "Access-Control-Allow-Credentials": "true",  // spec violation when origin is "*"
  ...
};
```

## Fix

`Access-Control-Allow-Credentials` is now only included when a specific, non-wildcard origin is configured:

```js
const isSpecificOrigin = corsOrigin !== "*";

return {
  "Access-Control-Allow-Origin": corsOrigin,
  ...(isSpecificOrigin && { "Access-Control-Allow-Credentials": "true" }),
  ...
};
```

The same fix is applied identically to `login.js`, `signup.js`, and `logout.js`.

## Test Plan

- [ ] With `ALLOWED_ORIGIN` unset: verify responses carry `Access-Control-Allow-Origin: *` and no `Allow-Credentials` header
- [ ] With `ALLOWED_ORIGIN=https://yourapp.com`: verify responses carry both `Access-Control-Allow-Origin: https://yourapp.com` and `Access-Control-Allow-Credentials: true`
- [ ] Confirm login, signup, and logout still work end-to-end when `ALLOWED_ORIGIN` is set

## Related

- Closes #3166

---

**Program:** GSSoC 2026
**Type:** Security bug fix