### PR TITLE
fix(logout): use getJwtSecret() to fix dev logout and add cookie-clearing header

### DIFF
--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -1,14 +1,43 @@
 import jwt from "jsonwebtoken";
+import { getJwtSecret } from "./jwt-config.js";
 
 // ---------------------------------------------------------------------------
 // JWT Configuration
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET || "your-super-secret-jwt-key-change-in-production";
+// Use the same centralised helper as login.js and signup.js so that all three
+// handlers share a consistent signing secret. The previous inline fallback
+// ("your-super-secret-jwt-key-change-in-production") differed from the
+// development fallback in jwt-config.js ("eventra-local-development-jwt-secret"),
+// causing jwt.verify() here to reject every token issued by login.js in local
+// development (the keys never matched).
+const JWT_SECRET = getJwtSecret();
 
 // ---------------------------------------------------------------------------
-// Token Blacklist (In-memory store - replace with Redis/database in production)
+// Token Blacklist
 // ---------------------------------------------------------------------------
+//
+// ARCHITECTURAL LIMITATION: the Set below is process-local. In a serverless
+// deployment (Vercel, AWS Lambda, etc.) each cold-start creates a fresh process
+// with an empty Set, so a blacklisted token becomes valid again the moment a
+// new function instance spins up.
+//
+// To make logout durable at scale, replace the Set with a shared persistent
+// store. The interface is intentionally kept minimal so it can be swapped:
+//
+//   import { createClient } from "redis";
+//   const redis = createClient({ url: process.env.REDIS_URL });
+//   await redis.connect();
+//
+//   const blacklistToken  = (token, ttlSec) => redis.set(`bl:${token}`, 1, { EX: ttlSec });
+//   const isTokenBlacklisted = (token) => redis.exists(`bl:${token}`).then(Boolean);
+//
+// Until a persistent store is wired up, defence-in-depth is provided by:
+//  1. Short JWT_EXPIRES_IN (default 7d — set to a smaller value in production).
+//  2. The Set-Cookie header sent by the logout response (see handler below),
+//     which clears the cookie in the browser regardless of blacklist state.
+//  3. The in-process blacklist, which is effective within a single long-running
+//     server process (e.g. local development or a non-serverless deployment).
 
 const tokenBlacklist = new Set();
 
@@ -180,6 +209,16 @@ export default async function handler(req, res) {
     // -----------------------------------------------------------------------
 
     blacklistToken(token);
+
+    // -----------------------------------------------------------------------
+    // Clear the session cookie (defence-in-depth for serverless environments
+    // where the in-memory blacklist may not survive across cold starts)
+    // -----------------------------------------------------------------------
+
+    res.setHeader(
+      "Set-Cookie",
+      "token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict"
+    );
 
     // -----------------------------------------------------------------------
     // Return success response


### PR DESCRIPTION
## Summary

Fixes #3169. Also resolves the JWT_SECRET divergence that silently breaks logout in local development.

## Problem 1: JWT_SECRET mismatch breaks logout in every dev environment

`logout.js` used its own inline fallback:

```js
const JWT_SECRET = process.env.JWT_SECRET || "your-super-secret-jwt-key-change-in-production";
```

But `jwt-config.js` (used by `login.js` and `signup.js`) uses a different fallback:

```js
const DEVELOPMENT_JWT_SECRET = "eventra-local-development-jwt-secret";
```

When `JWT_SECRET` is not set in `.env` (the default local dev setup), tokens issued by `login.js` are signed with `"eventra-local-development-jwt-secret"`, but `logout.js` tries to verify them against `"your-super-secret-jwt-key-change-in-production"`. Every `jwt.verify()` call throws `JsonWebTokenError: invalid signature`, so logout returns `401 Invalid token` for all users.

**Fix:** replace the inline fallback with `import { getJwtSecret } from "./jwt-config.js"` so all three auth endpoints share the same signing secret.

## Problem 2: In-memory blacklist is wiped on serverless cold starts (issue #3169)

The `tokenBlacklist = new Set()` is process-local. In serverless deployments (Vercel, AWS Lambda) each cold start creates a fresh process with an empty Set. A token blacklisted during one invocation is valid again the next time a new function instance spins up, making logout ineffective.

**Long-term fix:** swap the Set with a Redis-backed store. The PR adds a clear code comment documenting the exact interface:

```js
// To make logout durable at scale:
// const blacklistToken  = (token, ttlSec) => redis.set(`bl:${token}`, 1, { EX: ttlSec });
// const isTokenBlacklisted = (token) => redis.exists(`bl:${token}`).then(Boolean);
```

**Interim defence-in-depth:** the logout response now sends a `Set-Cookie` header that expires the session cookie immediately in the browser. This clears the cookie regardless of whether the in-memory blacklist survives the next cold start:

```
Set-Cookie: token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict
```

## Test Plan

- [ ] Local dev (no `JWT_SECRET` in `.env`): log in, then log out. Confirm `200 Logged out successfully` (was previously returning `401 Invalid token`)
- [ ] Confirm the `Set-Cookie: token=; Expires=...` header appears in the logout response
- [ ] Confirm that calling a protected endpoint with the old token after logout returns `401`
- [ ] Production deploy with `JWT_SECRET` set: logout still works correctly

## Related

- Closes #3169

---

**Program:** GSSoC 2026
**Type:** Security bug fix