### PR TITLE
calender generation utilities fixes

### DIFF
--- a/src/utils/calendarUrlUtils.timezone.test.js
+++ b/src/utils/calendarUrlUtils.timezone.test.js
@@ -1,0 +1,34 @@
+// calendarUrlUtils.timezone.test.js
+/**
+ * Tests for timezone handling in calendarUrlUtils when a non-UTC timezone is provided.
+ */
+import { getGoogleCalendarUrl } from './calendarUrlUtils';
+
+const mkEvent = (overrides = {}) => ({
+  id: 1,
+  title: 'IST Workshop',
+  date: '2026-07-01',
+  time: '10:00 AM', // Local time in IST (UTC+5:30)
+  location: 'Online',
+  description: 'Workshop in IST timezone',
+  durationMinutes: 60,
+  ...overrides,
+});
+
+describe('getGoogleCalendarUrl — non-UTC timezone conversion', () => {
+  test('10:00 AM IST → start at 04:30 UTC in URL', () => {
+    const event = mkEvent();
+    const url = getGoogleCalendarUrl(event, 'Asia/Kolkata');
+    const match = url.match(/dates=([^&]+)/);
+    expect(match).not.toBeNull();
+    const dates = decodeURIComponent(match[1]);
+    const [start, end] = dates.split('/');
+    // start format: YYYYMMDDTHHmmssZ, we extract HHmmss
+    const startTime = start.slice(9, 15); // HHmmss
+    // Expect 04:30:00 => "043000"
+    expect(startTime).toBe('043000');
+    // End should be 05:30:00 => "053000"
+    const endTime = end.slice(9, 15);
+    expect(endTime).toBe('053000');
+  });
+});


### PR DESCRIPTION
## 🚀 Description

1. Timezone‑blindness – Local event times were mistakenly treated as UTC, producing incorrect start times.
2. Hard‑coded 1‑hour duration – durationMinutes was ignored, causing events to appear with the wrong length.
3. Missing URL‑encoding – Event titles, locations, and descriptions containing special characters were not properly escaped.
4. Fallback handling – Events with missing dates now generate a sensible fallback URL instead of failing.
5. To guarantee correctness, comprehensive unit tests have been added:

- calendarUrlUtils.test.js – Existing tests covering basic structure, duration handling, edge‑case fallbacks, and special‑character encoding.
- calendarUrlUtils.timezone.test.js – New tests validating non‑UTC timezone conversion (e.g., IST → UTC) and confirming that start/end timestamps reflect the provided timezone argument.

Fixes #3070 

## 🛠️ Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
