### PR TITLE
feat: replace window.confirm with toast confirmation dialogs in Chatb…

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useMemo, useState } from "react"
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
+import { toast } from "react-toastify";
 import {
   Bot,
   Minus,
@@ -66,11 +67,40 @@ export default function Chatbot() {
   }, [messages]);
 
   const handleClearConversation = () => {
-    if (window.confirm("Are you sure you want to clear your conversation history?")) {
-      setMessages(INITIAL_MESSAGES);
-    }
+    toast(
+      ({ closeToast }) => (
+        <div>
+          <p className="text-sm font-semibold mb-2">Clear conversation history?</p>
+          <p className="text-xs text-gray-500 mb-3">This action cannot be undone.</p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                setMessages(INITIAL_MESSAGES);
+                toast.success("Conversation cleared!");
+                closeToast();
+              }}
+              className="px-3 py-1.5 bg-red-500 hover:bg-red-600 text-white text-xs font-semibold rounded-lg transition-colors"
+            >
+              Yes, Clear
+            </button>
+            <button
+              onClick={closeToast}
+              className="px-3 py-1.5 bg-gray-200 hover:bg-gray-300 text-gray-700 text-xs font-semibold rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ),
+      {
+        autoClose: false,
+        closeOnClick: false,
+        draggable: false,
+        closeButton: false,
+        position: "top-center",
+      }
+    );
   };
-
   // Auto-scroll messages to bottom of container when new ones arrive or state changes
   const chatLogsRef = useRef(null);
   const wasOpenRef = useRef(false);

--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -141,10 +141,40 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
   };
 
   const loadPreset = (presetName) => {
-    if (window.confirm(`Are you sure you want to load the ${presetName} layout? Current changes will be overwritten.`)) {
-      setElements(PRESETS[presetName]);
-      setSelectedId(null);
-    }
+    toast(
+      ({ closeToast }) => (
+        <div>
+          <p className="text-sm font-semibold mb-2">Load {presetName} layout?</p>
+          <p className="text-xs text-gray-500 mb-3">Current changes will be overwritten.</p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => {
+                setElements(PRESETS[presetName]);
+                setSelectedId(null);
+                toast.success(`${presetName} layout loaded!`);
+                closeToast();
+              }}
+              className="px-3 py-1.5 bg-indigo-500 hover:bg-indigo-600 text-white text-xs font-semibold rounded-lg transition-colors"
+            >
+              Yes, Load
+            </button>
+            <button
+              onClick={closeToast}
+              className="px-3 py-1.5 bg-gray-200 hover:bg-gray-300 text-gray-700 text-xs font-semibold rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ),
+      {
+        autoClose: false,
+        closeOnClick: false,
+        draggable: false,
+        closeButton: false,
+        position: "top-center",
+      }
+    );
   };
 
   // Helper to prepare the SVG for export by cloning and stripping specific attributes/styles


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3033

## Rationale for this change
window.confirm() calls in Chatbot and FloorPlanDesigner were blocking the UI 
and providing an inconsistent, browser-native experience that didn't match 
the app's design system.

## What changes are included in this PR?
- Replaced window.confirm in Chatbot.jsx with a react-toastify confirmation 
  toast with "Yes, Clear" and "Cancel" buttons
- Added react-toastify import to Chatbot.jsx (was missing)
- Replaced window.confirm in FloorPlanDesigner.js with a react-toastify 
  confirmation toast with "Yes, Load" and "Cancel" buttons
- Both toasts are non-blocking, non-auto-closing, and centered at top
- Success toast shown after confirmed action in both cases
- react-toastify was already installed, no new dependencies added

## Are these changes tested?
Manually tested — confirmation toasts appear correctly, confirming executes 
the action and shows success toast, cancelling dismisses without any changes.

## Are there any user-facing changes?
Yes — users now see polished toast confirmation dialogs instead of browser 
native alert popups for clearing chat history and loading floor plan presets.