### PR TITLE
feat: add calendar export buttons to event details page

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -1,15 +1,15 @@
-import useRecentlyViewed from "../../hooks/useRecentlyViewed";  
+import useRecentlyViewed from "../../hooks/useRecentlyViewed";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
 import DOMPurify from "dompurify";
 import CountdownTimer from "../../components/common/CountdownTimer";
-import { Calendar, MapPin, Clock, Users, Tag, ArrowLeft } from "lucide-react";
+import { Calendar, MapPin, Clock, Users, Tag, ArrowLeft, CalendarPlus } from "lucide-react";
 import { Helmet } from "react-helmet-async";
 import eventsMockData from "./eventsMockData.json";
 import { getEventStatus } from "../../utils/eventUtils";
-
-// Removed unused imports: addEventToGoogleCalendar, ShareMenu, CertificateDownload, generateEventSharingData
+import { downloadICSFile, generateGoogleCalendarLink, generateOutlookLink } from "../../utils/calendarExporter";
+import { toast } from "react-hot-toast";
 
 const EventDetailsPage = () => {
   const { eventId } = useParams();
@@ -93,10 +93,9 @@ const EventDetailsPage = () => {
 
           <button
             type="button"
-            onClick={() = aria-label="button">
-              navigate("/events")
-            }
+            onClick={() => navigate("/events")}
             className="inline-flex items-center gap-2 px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg font-semibold transition-colors"
+            aria-label="Back to Events"
           >
             <ArrowLeft size={18} aria-hidden="true" />
             Back to Events
@@ -109,13 +108,11 @@ const EventDetailsPage = () => {
   const isPastEvent =
     getEventStatus(event) === "past" || getEventStatus(event) === "ended";
 
-  // Removed unused derived values and handlers to satisfy linting rules
-
   const pageUrl = `${window.location.origin}/events/${event.id}`;
-const pageTitle = `${event.title} | Eventra`;
-const pageDescription = event.description?.substring(0, 160) || "Join this event on Eventra.";
+  const pageTitle = `${event.title} | Eventra`;
+  const pageDescription = event.description?.substring(0, 160) || "Join this event on Eventra.";
 
-return (
+  return (
     <div className="min-h-screen mt-16 bg-gradient-to-l from-sky-50 via-white to-white dark:from-gray-900 dark:to-black">
       <Helmet>
         <title>{pageTitle}</title>
@@ -141,10 +138,9 @@ return (
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <button
             type="button"
-            onClick={() = aria-label="button">
-              navigate("/events")
-            }
+            onClick={() => navigate("/events")}
             className="inline-flex items-center gap-2 text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 font-semibold transition-colors"
+            aria-label="Back to Events"
           >
             <ArrowLeft size={20} aria-hidden="true" />
             Back to Events
@@ -215,7 +211,7 @@ return (
                 About This Event
               </h2>
 
-              <p 
+              <p
                 className="text-gray-600 dark:text-gray-300 text-lg leading-relaxed"
                 dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(event.description) }}
               />
@@ -266,8 +262,62 @@ return (
               </Link>
             )}
 
+            {/* Add to Calendar Section */}
+            {!isPastEvent && (
+              <div className="bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200 dark:border-gray-700">
+                <h3 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                  Add to Calendar
+                </h3>
+                <div className="flex flex-col gap-3">
+                  <button
+                    onClick={() => {
+                      downloadICSFile(event);
+                      toast.success("Calendar invite downloaded!");
+                    }}
+                    className="inline-flex items-center justify-center gap-2 w-full rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 px-4 py-3 text-sm font-semibold hover:bg-green-50 dark:hover:bg-green-900/20 hover:border-green-300 dark:hover:border-green-700 transition-all duration-200"
+                    aria-label="Download .ics calendar invite"
+                  >
+                    <CalendarPlus size={16} className="text-green-500" />
+                    Download .ics Invite
+                  </button>
+                  
+                  {generateGoogleCalendarLink(event) && (
+                    <a
+                      href={generateGoogleCalendarLink(event)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center gap-2 w-full rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 px-4 py-3 text-sm font-semibold hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-all duration-200"
+                      aria-label="Add to Google Calendar"
+                    >
+                      <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                        <path fill="#4285F4" d="M22 12c0-5.52-4.48-10-10-10S2 6.48 2 12s4.48 10 10 10 10-4.48 10-10z"/>
+                        <path fill="#fff" d="M13 7h-2v6l5.25 3.15.75-1.23-4-2.37z"/>
+                      </svg>
+                      Add to Google Calendar
+                    </a>
+                  )}
+                  
+                  {generateOutlookLink(event) && (
+                    <a
+                      href={generateOutlookLink(event)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center gap-2 w-full rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 px-4 py-3 text-sm font-semibold hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-all duration-200"
+                      aria-label="Add to Outlook Calendar"
+                    >
+                      <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                        <path fill="#0078D4" d="M2 6l10-4 10 4v12l-10 4L2 18z"/>
+                        <path fill="#fff" d="M12 4L4 7v10l8 3 8-3V7z"/>
+                      </svg>
+                      Add to Outlook
+                    </a>
+                  )}
+                </div>
+              </div>
+            )}
+
             <button
-              onClick={() = aria-label="button"> window.print()}
+              onClick={() => window.print()}
               className="print-hide flex items-center justify-center gap-2 w-full px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg text-sm text-gray-800 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
               aria-label="Print or save as PDF"
             >


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3032

## Rationale for this change
Users currently have to manually add event details to their personal calendars, which reduces attendance likelihood. This PR adds a convenient "Add to Calendar" section with support for Google Calendar, Outlook, and .ics download to improve user engagement and event attendance.

## What changes are included in this PR?
- Added "Add to Calendar" section in the EventDetailsPage sidebar
- Integrated existing calendarExporter utilities (downloadICSFile, generateGoogleCalendarLink, generateOutlookLink)
- Added CalendarPlus icon from lucide-react
- Added toast notifications for user feedback
- Calendar buttons only appear for upcoming events (not past events)
- Fixed syntax errors in onclick handlers

## Are these changes tested?
- Tested locally with `npm start`
- Verified all 3 calendar buttons render correctly
- Tested .ics download functionality
- Tested Google Calendar and Outlook links open correctly
- Verified buttons only show for upcoming events

## Are there any user-facing changes?
Yes - Users will now see a new "Add to Calendar" section below the "Register Now" button on event detail pages with options to:
- Download .ics calendar invite
- Add to Google Calendar
- Add to Outlook Calendar