### PR TITLE
fix: resolve hanging requests in fetchProfileWithCache by adding timeout

### DIFF
--- a/src/utils/githubProfileCache.js
+++ b/src/utils/githubProfileCache.js
@@ -24,6 +24,7 @@
  */
 
 const PROFILE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const FETCH_TIMEOUT_MS = 10000; // 🔥 10 seconds timeout limit
 
 /** @type {Map<string, { data: object, fetchedAt: number }>} */
 const profileCache = new Map();
@@ -75,13 +76,20 @@ export function fetchProfileWithCache(username, fetcher) {
   const existing = inFlightRequests.get(username);
   if (existing) return existing;
 
-  const request = fetcher(username).then(
+  // 🔥 FIX: Create a timeout promise that rejects after 10 seconds
+  const timeoutPromise = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(`Fetch timeout for profile: ${username}`)), FETCH_TIMEOUT_MS)
+  );
+
+  // 🔥 FIX: Race the fetcher against the timeout
+  const request = Promise.race([fetcher(username), timeoutPromise]).then(
     (data) => {
       setCachedProfile(username, data);
       inFlightRequests.delete(username);
       return data;
     },
     (err) => {
+      // If the fetch fails OR the timeout triggers, we properly clean up the Map
       inFlightRequests.delete(username);
       throw err;
     }
@@ -101,7 +109,7 @@ export function fetchProfileWithCache(username, fetcher) {
  * caller.
  *
  * @template T, R
- * @param {T[]}             items        - Items to process
+ * @param {T[]}            items        - Items to process
  * @param {function(T): Promise<R>} taskFn - Async function to call per item
  * @param {number}          [concurrency=5]
  * @returns {Promise<PromiseSettledResult<R>[]>}


### PR DESCRIPTION
## 🚀 Description
Fixes a critical UX bug in `fetchProfileWithCache`. Previously, if the provided `fetcher` hung indefinitely without rejecting, the username was permanently stuck in the `inFlightRequests` Map. Any subsequent attempts to load that contributor's profile would return the stalled promise, causing the UI to hang in a loading state.

**Changes:**
- Implemented a 10-second `timeoutPromise`.
- Wrapped the original `fetcher` in a `Promise.race()` against the timeout.
- Guaranteed that `inFlightRequests.delete(username)` runs in the `.catch()` block if the timeout triggers, clearing the lock and allowing future retries.

Fixes #3409 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas