### PR TITLE
fix: resolve data loss race condition in trackUserInterest with update queue

### DIFF
--- a/src/utils/activityTracker.js
+++ b/src/utils/activityTracker.js
@@ -1,29 +1,42 @@
-export const trackUserInterest = (
-  interest
-) => {
+// 🔥 FIX: In-memory queue and lock to prevent localStorage race conditions
+let isUpdating = false;
+let interestQueue = [];
 
-  const existing =
-    JSON.parse(
-      localStorage.getItem(
-        "eventra_user_profile"
-      )
-    ) || {};
+const processInterestQueue = () => {
+  if (isUpdating || interestQueue.length === 0) return;
+  isUpdating = true;
 
-  const interests =
-    existing.interests || [];
+  try {
+    const existing = JSON.parse(localStorage.getItem("eventra_user_profile")) || {};
+    let interests = existing.interests || [];
+    let modified = false;
 
-  if (!interests.includes(interest)) {
+    while (interestQueue.length > 0) {
+      const interest = interestQueue.shift();
+      if (!interests.includes(interest)) {
+        interests.push(interest);
+        modified = true;
+      }
+    }
 
-    interests.push(interest);
-
+    if (modified) {
+      localStorage.setItem(
+        "eventra_user_profile",
+        JSON.stringify({ ...existing, interests })
+      );
+    }
+  } catch (error) {
+    console.error("Failed to update user interests:", error);
+  } finally {
+    isUpdating = false;
+    if (interestQueue.length > 0) {
+      processInterestQueue();
+    }
   }
+};
 
-  localStorage.setItem(
-    "eventra_user_profile",
-    JSON.stringify({
-      ...existing,
-      interests,
-    })
-  );
-
+export const trackUserInterest = (interest) => {
+  if (!interest) return;
+  interestQueue.push(interest);
+  processInterestQueue();
 };


### PR DESCRIPTION
## 🚀 Description
Fixes a data integrity bug where rapid sequential calls to `trackUserInterest` would cause `localStorage` read-modify-write race conditions, resulting in dropped/overwritten user interests.

**Changes:**
- Implemented an in-memory queue (`interestQueue`) to batch incoming interest updates.
- Added a locking mechanism (`isUpdating`) to ensure `localStorage` is only accessed and modified by one process at a time.
- Batched updates mean fewer `localStorage` disk writes, improving performance during rapid user interactions.

Fixes #3408

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Data integrity fix

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code