### PR TITLE
feat: fix dark mode implementation with proper ThemeProvider wrapper

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import ErrorBoundary from "./components/common/ErrorBoundary";
 import OnboardingChecklist from "./components/user/OnboardingChecklist";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import NotificationToastContainer from "./components/common/NotificationProvider";
+import { ThemeProvider } from "./context/ThemeContext";
 import { NotificationProvider } from "./context/NotificationContext";
 import { AuthProvider } from "./context/AuthContext";
 import { MyEventsProvider } from "./context/MyEventsContext";
@@ -100,133 +101,85 @@ function App() {
   }, []);
 
   return (
-    <AuthProvider>
-      <NotificationProvider>
-        <MyEventsProvider>
-          <SessionRecoveryProvider>
-            <NotificationProvider />
-            <ReminderChecker />
-            <NotificationToastContainer />
+    <ThemeProvider>
+      <ErrorBoundary>
+        <AuthProvider>
+          <NotificationProvider>
+            <MyEventsProvider>
+              <SessionRecoveryProvider>
+                <NotificationToastContainer />
+                <ReminderChecker />
+                <OfflineSyncManager />
 
-            <OfflineSyncManager />
+                <div className="App">
+                  <SectionErrorBoundary label="Navigation Bar">
+                    <Navbar cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
+                  </SectionErrorBoundary>
 
-            <Router>
-            <div className="App">
-              <a href="#main-content" className="skip-to-content">
-                Skip to main content
-              </a>
-              <Navbar
-                cursorEnabled={cursorEnabled}
-                toggleCursor={toggleCursor}
-              />
+                  <OfflineBanner />
+                  <OfflineConflictModal />
 
-              <main
-                id="main-content"
-                tabIndex={-1}
-                className="
-                  relative
-                  z-10
-                min-h-[85vh]
-                  bg-white
-                  dark:bg-slate-950
-                  text-black
-                  dark:text-white
-                  transition-colors
-                  duration-300
-                "
-              >
-                <PageTransition>
-                  <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
-                    <Routes>
-                      <Route path="/register/:id" element={<RegistrationPage />} />
-                      <Route path="*" element={<AppRoutes />} />
-                    </Routes>
-    <ErrorBoundary>
-      <AuthProvider>
-        <NotificationProvider>
-          <MyEventsProvider>
-            <SessionRecoveryProvider>
-              <ReminderChecker />
-              <NotificationToastContainer />
-              <OfflineSyncManager />
+                  <KeyboardShortcutsModal
+                    isOpen={showKeyboardModal}
+                    onClose={() => setShowKeyboardModal(false)}
+                  />
 
-              <div className="App">
-                <SectionErrorBoundary label="Navigation Bar">
-                  <Navbar cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
-                </SectionErrorBoundary>
-                <OfflineBanner />
-                <OfflineConflictModal />
-                <KeyboardShortcutsModal
-                  isOpen={showKeyboardModal}
-                  onClose={() => setShowKeyboardModal(false)}
-                />
-                <OnboardingChecklist />
+                  <OnboardingChecklist />
 
-                <main
-                  id="main-content"
-                  className="
-                    relative z-10 min-h-[85vh]
-                    bg-white dark:bg-slate-950
-                    text-black dark:text-white
-                    transition-colors duration-300
-                  "
-                >
-                  <PageTransition>
-                    <SectionErrorBoundary label="Page Content">
-                      <Suspense
-                        fallback={
-                          <div className="flex items-center justify-center min-h-screen">
-                            Loading...
-                          </div>
-                        }
-                      >
-                        <Routes>
-                          <Route
-                            path="/register/:id"
-                            element={
-                              <ProtectedRoute>
-                                <EventRegistration />
-                              </ProtectedRoute>
-                            }
-                          />
-                          <Route
-                            path="/event-recommendation"
-                            element={<EventRecommendation />}
-                          />
-                          <Route path="*" element={<AppRoutes />} />
-                        </Routes>
-                      </Suspense>
-                    </SectionErrorBoundary>
-                  </PageTransition>
-                </main>
+                  <main
+                    id="main-content"
+                    className="relative z-10 min-h-[85vh] bg-white dark:bg-slate-950 text-black dark:text-white transition-colors duration-300"
+                  >
+                    <PageTransition>
+                      <SectionErrorBoundary label="Page Content">
+                        <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Loading...</div>}>
+                          <Routes>
+                            <Route
+                              path="/register/:id"
+                              element={
+                                <ProtectedRoute>
+                                  <EventRegistration />
+                                </ProtectedRoute>
+                              }
+                            />
+                            <Route path="/event-recommendation" element={<EventRecommendation />} />
+                            <Route path="/saved-events" element={<SavedEventsPage />} />
+                            <Route path="*" element={<AppRoutes />} />
+                          </Routes>
+                        </Suspense>
+                      </SectionErrorBoundary>
+                    </PageTransition>
+                  </main>
 
-                <ScrollToTop />
+                  <ScrollToTop />
 
-                <SectionErrorBoundary label="Chatbot Assist" silent>
-                  <Suspense fallback={null}>
-                    <Chatbot />
-                  </Suspense>
-                </SectionErrorBoundary>
+                  <SectionErrorBoundary label="Chatbot Assist" silent>
+                    <Suspense fallback={null}>
+                      <Chatbot />
+                    </Suspense>
+                  </SectionErrorBoundary>
 
-                <SectionErrorBoundary label="Footer">
-                  <Suspense fallback={null}>
-                    {!isDashboardOrAdmin && <Footer />}
-                  </Suspense>
-                </SectionErrorBoundary>
+                  <SectionErrorBoundary label="Footer">
+                    <Suspense fallback={null}>
+                      {!isDashboardOrAdmin && <Footer />}
+                    </Suspense>
+                  </SectionErrorBoundary>
 
-                <ScrollToTopButton />
-                <FeedbackButton />
-                <ThemeCustomizerDrawer />
-                <SessionRecovery />
-                <SectionErrorBoundary label="Custom Cursor" silent>
-                  <FluidCursor enabled={cursorEnabled} />
-                </SectionErrorBoundary>
-              </div>
-            </SessionRecoveryProvider>
-          </MyEventsProvider>
-        </NotificationProvider>
-      </AuthProvider>
-    </ErrorBoundary>
+                  <ScrollToTopButton />
+                  <FeedbackButton />
+                  <ThemeCustomizerDrawer />
+                  <SessionRecovery />
+
+                  <SectionErrorBoundary label="Custom Cursor" silent>
+                    <FluidCursor enabled={cursorEnabled} />
+                  </SectionErrorBoundary>
+                </div>
+              </SessionRecoveryProvider>
+            </MyEventsProvider>
+          </NotificationProvider>
+        </AuthProvider>
+      </ErrorBoundary>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/navbar/ThemeToggle.jsx
+++ b/src/components/navbar/ThemeToggle.jsx
@@ -1,118 +1,33 @@
 import React from "react";
-
-import {
-  Moon,
-  Sun,
-  Monitor,
-} from "lucide-react";
-
+import { Moon, Sun, Monitor } from "lucide-react";
 import { useTheme } from "../../context/ThemeContext";
 
 const ThemeToggle = () => {
-  const {
-    theme,
-    isDarkMode,
-    toggleTheme,
-    setTheme,
-  } = useTheme();
+  const { theme, isDarkMode, toggleTheme, setTheme } = useTheme();
 
   return (
-    <div
-      className="
-        flex
-        items-center
-        gap-2
-      "
-    >
-      {/* Toggle Button */}
+    <div className="flex items-center gap-2">
       <button
-        onClick={
-          toggleTheme
-        }
-        aria-label={`Switch to ${
-          isDarkMode
-            ? "light"
-            : "dark"
-        } mode`}
-        aria-pressed={
-          isDarkMode
-        }
-        className="
-          relative
-          flex
-          items-center
-          justify-center
-
-          w-11
-          h-11
-
-          rounded-full
-
-          bg-gray-200
-          dark:bg-gray-800
-
-          text-black
-          dark:text-white
-
-          shadow-md
-
-          hover:scale-110
-          hover:shadow-lg
-
-          transition-all
-          duration-300
-
-          focus:outline-none
-          focus:ring-2
-          focus:ring-blue-500
-        "
+        onClick={toggleTheme}
+        aria-label={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
+        aria-pressed={isDarkMode}
+        className="relative flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 dark:bg-gray-800 text-black dark:text-white shadow-md hover:scale-110 hover:shadow-lg transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
       >
-        <div
-          className="
-            transition-transform
-            duration-500
-          "
-        >
-          {isDarkMode ? (
-            <Sun size={20} />
-          ) : (
-            <Moon size={20} />
-          )}
+        <div className="transition-transform duration-500">
+          {isDarkMode ? <Sun size={20} /> : <Moon size={20} />}
         </div>
       </button>
 
-      {/* System Mode Button */}
       <button
-        onClick={() = aria-label="button">
-          setTheme(
-            "system"
-          )
-        }
-        className={`
-          flex
-          items-center
-          justify-center
-
-          w-11
-          h-11
-
-          rounded-full
-
-          transition-all
-          duration-300
-
-          ${
-            theme ===
-            "system"
-              ? "bg-blue-500 text-white"
-              : "bg-gray-200 dark:bg-gray-800 dark:text-white"
-          }
-        `}
+        onClick={() => setTheme("system")}
+        className={`flex items-center justify-center w-11 h-11 rounded-full transition-all duration-300 ${
+          theme === "system"
+            ? "bg-blue-500 text-white"
+            : "bg-gray-200 dark:bg-gray-800 dark:text-white"
+        }`}
         aria-label="Use system theme"
       >
-        <Monitor
-          size={18}
-        />
+        <Monitor size={18} />
       </button>
     </div>
   );


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3029

## Rationale for this change
The dark mode infrastructure existed (ThemeContext, ThemeToggle) but was non-functional because App.js was not wrapped with ThemeProvider. Additionally, App.js contained corrupted duplicate code that broke the component tree.

## What changes are included in this PR?
- Wrapped App.js with ThemeProvider at the root level
- Fixed corrupted App.js with duplicate providers and unclosed tags
- Fixed ThemeToggle.jsx syntax error in onClick handler
- Verified tailwind.config.cjs has darkMode: 'class' enabled
- Theme preference persists in localStorage
- Sun/Moon toggle works in Navbar

## Are these changes tested?
- Tested theme toggle switches between light/dark modes
- Verified theme persists after page refresh
- Checked multiple pages render correctly in both themes
- Tested system theme preference detection

## Are there any user-facing changes?
Yes - Users can now toggle between light and dark modes using the Sun/Moon button in the Navbar. Theme preference is saved and persists across sessions.