### PR TITLE
fix: resolve frozen lastActivity state and implement throttle in SessionRecoveryContext

### DIFF
--- a/src/context/SessionRecoveryContext.js
+++ b/src/context/SessionRecoveryContext.js
@@ -48,9 +48,17 @@ export const SessionRecoveryProvider = ({ children }) => {
   const saveTimeoutRef = useRef(null);
   const activityTimeoutRef = useRef(null);
 
+  // 🔥 FIX: Throttle React state updates to prevent main-thread thrashing
   const updateActivity = useCallback(() => {
     const now = Date.now();
-    lastActivityRef.current = now;
+    lastActivityRef.current = now; // Always update the ref immediately for accuracy
+
+    if (!activityTimeoutRef.current) {
+      activityTimeoutRef.current = setTimeout(() => {
+        setLastActivity(lastActivityRef.current);
+        activityTimeoutRef.current = null;
+      }, 1000); // Only re-render consumers at most once per second
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 🚀 Description
Fixes a state sync bug where `lastActivity` exposed by `SessionRecoveryContext` was permanently frozen at the initial mount timestamp, breaking any consumer relying on it for idle-detection or auto-logout.

**Changes:**
- Hooked up `setLastActivity` inside the `updateActivity` callback so consumers receive actual updates.
- Utilized the previously abandoned `activityTimeoutRef` to implement a 1-second throttle.
- High-frequency events (`mousemove`, `scroll`) now update the `lastActivityRef` instantly but only trigger a React re-render a maximum of once per second, protecting the main thread from render thrashing.

Fixes #3420 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code