### PR TITLE
Restore document body overflow on ConfirmationModal close

### DIFF
--- a/src/components/common/ConfirmationModal.js
+++ b/src/components/common/ConfirmationModal.js
@@ -19,6 +19,7 @@ const ConfirmationModal = ({
     if (!isOpen) return undefined;
 
     const previouslyFocusedElement = document.activeElement;
+    const originalOverflow = document.body.style.overflow;
 
     document.body.style.overflow = "hidden";
 
@@ -60,7 +61,7 @@ const ConfirmationModal = ({
     document.addEventListener("keydown", handleKeyDown);
 
     return () => {
-      document.body.style.overflow = "auto";
+      document.body.style.overflow = originalOverflow;
 
       document.removeEventListener(
         "keydown",


### PR DESCRIPTION
This pull request updates the way scroll locking is handled in the `ConfirmationModal` component to better preserve the original `overflow` style on the `body` element. Instead of always setting `overflow` to `"auto"` when the modal closes, the code now saves and restores the original value.

Improvements to modal scroll locking:

* [`src/components/common/ConfirmationModal.js`](diffhunk://#diff-70419b2635796efa7e209e6dd3b7af04aea530a654d2f9cf7558aa244360a738R22): Stores the original `document.body.style.overflow` value before setting it to `"hidden"`, and restores it when the modal is closed to avoid unintended side effects on page scrolling.

Closes #3377 