### PR TITLE
fix: resolve memory leak in exportUtils by revoking Blob URLs

### DIFF
--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -30,6 +30,10 @@ export function exportToCSV(data, filename) {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+
+  // 🔥 FIX: Free up browser memory after download triggers
+  // (100ms delay ensures the browser starts the download before the blob is destroyed)
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 export function exportToJSON(data, filename) {
@@ -44,4 +48,7 @@ export function exportToJSON(data, filename) {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+
+  // 🔥 FIX: Free up browser memory after download triggers
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }


### PR DESCRIPTION
## 🚀 Description
Fixes a critical SPA memory leak in the CSV and JSON export utilities. Previously, `URL.createObjectURL(blob)` was called to generate the downloadable file, but `URL.revokeObjectURL(url)` was never called to clean it up. 

In a single-page application, this caused the browser to hold the Blob data in memory indefinitely, leading to an increasing memory footprint and potential tab crashes during frequent administrative exports.

**Changes:**
- Added `URL.revokeObjectURL(url)` to both `exportToCSV` and `exportToJSON`.
- Wrapped the revocation in a 100ms `setTimeout` to safely ensure the browser has initiated the download sequence before the memory is garbage-collected.

Fixes #3428 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance/Memory improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code