### PR TITLE
fix: clear stacked timers in OfflineBanner using useRef to prevent timer leak

### DIFF
--- a/src/components/common/OfflineBanner.jsx
+++ b/src/components/common/OfflineBanner.jsx
@@ -5,15 +5,16 @@ import "./OfflineBanner.css";
 export default function OfflineBanner() {
   const [status, setStatus] = useState(navigator.onLine ? "online" : "offline");
   const [visible, setVisible] = useState(!navigator.onLine);
+  const timerRef = useRef(null);
 
   useEffect(() => {
     const handleOnline = () => {
       setStatus("online");
       setVisible(true);
-      const timer = setTimeout(() => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
         setVisible(false);
       }, 4000);
-      return () => clearTimeout(timer);
     };
 
     const handleOffline = () => {
@@ -27,6 +28,7 @@ export default function OfflineBanner() {
     return () => {
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
+      if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Fixes a timer leak in `OfflineBanner.jsx` where `clearTimeout` was 
returned from an event listener instead of being called in the 
`useEffect` cleanup, causing stacked timers on rapid connection toggling.

## Problem
`handleOnline` created a `setTimeout` every time the user came back 
online but the `return () => clearTimeout(timer)` inside it was 
returned from the event listener — browsers ignore event listener 
return values entirely. This meant:
- Every online event created a new 4-second timer
- Old timers were never cleared
- On rapid toggling, multiple timers fired `setVisible(false)` at 
  wrong times causing the banner to flicker unexpectedly
- Timers were never cleaned up on component unmount

## Changes Made
- Added `timerRef` using `useRef` to track the active timer
- Clear existing timer before creating a new one in `handleOnline`
- Clear the timer in `useEffect` cleanup on component unmount

## Files Changed
- `src/components/common/OfflineBanner.jsx`

## Testing
- App loads without errors
- Offline banner appears correctly when going offline
- Online banner appears and disappears after 4 seconds when going online
- Rapid online/offline toggling no longer causes flickering
- No console errors

## Related Issue
Closes #3486 