### PR TITLE
fix: reset isSyncing ref in useEffect cleanup to prevent permanent sync block

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -368,9 +368,8 @@ const useOfflineSync = () => {
 
     return () => {
       window.removeEventListener("online", handleOnline);
-      // Abort any in-progress conflict resolution waiter so its event
-      // listener is removed and the sync loop exits cleanly on unmount.
       conflictController.abort();
+      isSyncing.current = false;
       if (idleId !== null) {
         window.cancelIdleCallback(idleId);
       }


### PR DESCRIPTION
## Summary
Fixes a silent bug in `useOfflineSync.js` where `isSyncing.current` 
was never reset to `false` in the `useEffect` cleanup, permanently 
blocking all future sync attempts after a token or user change.

## Problem
`isSyncing.current` is set to `true` at the start of a sync and 
`false` at the end. However if `token` or `user` changes mid-sync 
(e.g. login, token refresh), the `useEffect` tears down via its 
cleanup function before the sync finishes. Since `isSyncing.current` 
was never reset in the cleanup, it stayed `true` permanently. Every 
subsequent sync attempt was silently blocked by the `if (isSyncing.current) return` 
guard in `handleOnline`, with no error shown to the user.

## Changes Made
- Added `isSyncing.current = false` to the `useEffect` cleanup 
  function so the next effect run always starts with a clean sync state

## Files Changed
- `src/hooks/useOfflineSync.js`

## Testing
- App loads without errors
- Offline sync triggers correctly after login/logout cycle
- Sync is not permanently blocked after token or user changes
- No console errors related to sync

## Related Issue
Closes #3494 