### PR TITLE
fix: correct spread order in merge resolution to give server values priority in OfflineConflictModal

### DIFF
--- a/src/components/common/OfflineConflictModal.jsx
+++ b/src/components/common/OfflineConflictModal.jsx
@@ -33,7 +33,7 @@ export default function OfflineConflictModal() {
       detail: {
         itemId: item.id,
         resolution, // "local", "server", or "merge"
-        mergedPayload: resolution === "merge" ? { ...serverPayload, ...localPayload } : null
+        mergedPayload: resolution === "merge" ? { ...localPayload, ...serverPayload } : null
       }
     }));
     setIsOpen(false);


### PR DESCRIPTION
## Summary
Fixes wrong spread order in `OfflineConflictModal.jsx` where the 
"Merge Both Changes" button was silently overwriting server values 
with local values instead of performing a real merge.

## Problem
The `mergedPayload` was built as `{ ...serverPayload, ...localPayload }` 
which means local keys always overwrite server keys. This made 
"Merge Both Changes" functionally identical to "Overwrite Server 
with Local" — server-side changes were silently discarded for all 
conflicting keys with no warning to the user.

## Changes Made
- Swapped spread order from `{ ...serverPayload, ...localPayload }` 
  to `{ ...localPayload, ...serverPayload }` so server values take 
  priority for conflicting keys since the server is the source of truth

## Files Changed
- `src/components/common/OfflineConflictModal.jsx`

## Testing
- App loads without errors
- Conflict modal appears correctly when triggered
- "Merge Both Changes" now correctly gives server values priority
- "Discard Local & Keep Server" and "Overwrite Server with Local" 
  buttons continue to work correctly
- No console errors

## Related Issue
Closes #3498 