### PR TITLE
fix(auth): check isActive before bcrypt.compare in login to prevent account probing

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -227,6 +227,13 @@ export default async function handler(req, res) {
       }, req);
     }
 
+    // Check if user is active
+    if (user.isActive === false) {
+      return corsResponse(res, 401, { 
+        error: "Invalid credentials" 
+      }, req);
+    }
+
     // -----------------------------------------------------------------------
     // Verify password using BCrypt
     // -----------------------------------------------------------------------
@@ -236,13 +243,6 @@ export default async function handler(req, res) {
     if (!isPasswordValid) {
       return corsResponse(res, 401, { 
         error: "Invalid credentials" 
-      }, req);
-    }
-
-    // Check if user is active
-    if (user.isActive === false) {
-      return corsResponse(res, 401, { 
-        error: "Account is deactivated. Please contact support." 
       }, req);
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a security and performance bug in `api/auth/login.js` where the `isActive` 
check was placed **after** `bcrypt.compare()`, allowing deactivated accounts to probe 
whether their password was still valid.

Closes #3226 

---

## Problem

The previous login flow ran in this order:

1. Find user by email
2. ❌ Run `bcrypt.compare()` (slow ~300ms operation)
3. ❌ Only THEN check if `user.isActive === false`

This caused two issues:
- **Security**: A deactivated user could tell their password was correct because they 
  received `"Account is deactivated"` instead of `"Invalid credentials"` — a classic 
  account probing / user enumeration vulnerability.
- **Performance**: Server wasted expensive bcrypt CPU cycles on accounts that should 
  have been rejected immediately.

---

## Fix

Moved the `isActive` check to **before** `bcrypt.compare()` and changed the error 
message to the generic `"Invalid credentials"` to prevent information leakage.

**Before:**
```js
const isPasswordValid = await bcrypt.compare(password, user.password);
if (!isPasswordValid) { return 401 "Invalid credentials" }

if (user.isActive === false) { return 401 "Account is deactivated" } // ❌ too late
```

**After:**
```js
if (user.isActive === false) {
  return corsResponse(res, 401, { error: "Invalid credentials" }, req); // ✅ early exit
}

const isPasswordValid = await bcrypt.compare(password, user.password); // ✅ only for active users
if (!isPasswordValid) {
  return corsResponse(res, 401, { error: "Invalid credentials" }, req);
}
```

---

## Changes

- `api/auth/login.js` — moved `isActive` check above `bcrypt.compare()`
- Changed deactivated account error message from `"Account is deactivated. 
  Please contact support."` to generic `"Invalid credentials"` to prevent 
  account status leakage

---

## Type of Change

- [x] Bug fix
- [x] Security fix
- [ ] New feature
- [ ] Breaking change

---

## Testing

- [x] Verified deactivated account now returns `"Invalid credentials"` (not account status)
- [x] Verified active account with wrong password still returns `"Invalid credentials"`
- [x] Verified active account with correct password logs in successfully
- [x] Confirmed `bcrypt.compare` is skipped for inactive accounts