### PR TITLE
fix(auth): reliably clear expired sessions after token expiry

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -32,7 +32,6 @@ export const AuthProvider = ({ children }) => {
   });
 
   const isMountedRef = useRef(false);
-  const needsExpiryCleanupRef = useRef(false);
   const expiryToastShownRef = useRef(false);
 
   useEffect(() => {
@@ -175,12 +174,10 @@ export const AuthProvider = ({ children }) => {
     return () => setOnUnauthorizedHandler(null);
   }, []); // <--- Empty array here ensures it only runs once!
 
-  useEffect(() => {
-    if (needsExpiryCleanupRef.current) {
-      needsExpiryCleanupRef.current = false;
-      clearExpiredSession();
-    }
-  }, [clearExpiredSession]);
+  // (removed broken ref-based cleanup) We no longer rely on a ref toggle
+  // to trigger expiry cleanup. Expiry is handled by the token expiry timer
+  // and by scheduling an async cleanup from `isAuthenticated()` when a
+  // stale token is observed during render checks.
 
   // --- Smart Token Expiry Timeout ---
   useEffect(() => {
@@ -384,7 +381,20 @@ export const AuthProvider = ({ children }) => {
   const isAuthenticated = useCallback(() => {
     if (!user || !token) return false;
     if (token !== "cookie-managed" && !isTokenValid(token)) {
-      needsExpiryCleanupRef.current = true;
+      // Schedule cleanup asynchronously to avoid side-effects during render.
+      // We double-check token validity when the microtask runs to avoid
+      // race conditions with concurrent state updates.
+      Promise.resolve().then(() => {
+        try {
+          if (!isTokenValid(token)) {
+            clearExpiredSessionRef.current?.();
+          }
+        } catch (e) {
+          // swallow any check errors — we don't want auth checks to crash render
+          // eslint-disable-next-line no-console
+          console.error("Error during scheduled auth cleanup:", e);
+        }
+      });
       return false;
     }
     return true;


### PR DESCRIPTION
## 🚀 Description
Fixes inconsistent authentication state caused by expired session cleanup not executing properly.

Previously, the expired-session cleanup flow relied on a `useRef` mutation combined with a `useEffect` dependency flow. Since updating `ref.current` does not trigger rerenders or effect execution, expired sessions were not reliably cleaned up. 

This caused scenarios where:
* `isAuthenticated()` returned false
* but stale user/token state still remained
* protected UI could still appear authenticated

**Changes Made:**
* Removed broken `needsExpiryCleanupRef` cleanup flow
* Removed unused ref-based effect dependency logic
* Scheduled async cleanup safely from `isAuthenticated()`
* Preserved existing auth/session architecture
* Avoided render-phase side effects
* Prevented unnecessary rerenders

Fixes #3306

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings