### PR TITLE
Fix: Build-breaking syntax error in MobileNavbar.jsx

### DIFF
--- a/src/components/navbar/MobileNavbar.jsx
+++ b/src/components/navbar/MobileNavbar.jsx
@@ -10,10 +10,6 @@ const MobileNavbar = ({ isOpen, setIsOpen, isAuthenticated, user, logout }) => {
         onClick={() => setIsOpen((prev) => !prev)}
         className="mobile-menu-button lg:hidden inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl p-3 text-gray-700 transition-colors hover:bg-gray-100 hover:text-black dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
         aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-        onClick={() = aria-label="button"> setIsOpen(true)}
-        onClick={() => setIsOpen(true)}
-        className="lg:hidden p-3 min-w-[44px] min-h-[44px] flex items-center justify-center"
-        aria-label="Open navigation menu"
         aria-expanded={isOpen}
         aria-haspopup="dialog"
         aria-controls="mobile-navigation-drawer"


### PR DESCRIPTION
## Summary

Fixes the build-breaking syntax error in `MobileNavbar.jsx` that prevented the application from compiling with Vite.

## Problem

The `<button>` element had:
- **Three duplicate `onClick` handlers** (lines 10, 13, 14)
- **Two duplicate `className` props** (lines 11, 15)
- **A malformed arrow function** on line 13: `onClick={() = aria-label="button"> setIsOpen(true)}`

This caused a Vite/Rolldown parse error: `Empty parenthesized expression`.

## Fix

Consolidated into a single clean set of props:
- One `onClick` handler using `setIsOpen((prev) => !prev)` for proper toggle behavior
- One `className` with the full set of responsive/dark-mode styles
- Dynamic `aria-label` that reflects the current open/closed state

## Testing

- `npm run build` now completes without errors
- Component renders correctly with toggle functionality intact

Fixes #3618