### PR TITLE
fix: remove stray // option from skill level dropdown

### DIFF
--- a/src/Pages/EventRecommendation/EventRecommendation.jsx
+++ b/src/Pages/EventRecommendation/EventRecommendation.jsx
@@ -287,7 +287,7 @@ const EventRecommendation = () => {
                   <option>
                     Beginner
                   </option>
-//
+
                   <option>
                     Intermediate
                   </option>


### PR DESCRIPTION
## 🚀 Description

Removed an unintended `//` entry from the Skill Level dropdown on the Event Recommendation page.

The issue was caused by stray `//` characters accidentally placed directly inside the JSX `<select>` options list, which React rendered as literal text in the UI.

### Changes Made

* Removed the stray `//` entry from:
  `src/Pages/EventRecommendation/EventRecommendation.jsx`

### Result

* Skill Level dropdown now displays only valid options
* No functional or styling changes were introduced

Fixes #<issue-number>

---

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A

---

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
