### PR TITLE
refactor: remove duplicate phone validator declaration

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -72,7 +72,6 @@ export const validate = {
   },
 
   fullName: (val) => (val && val.trim() !== "") || "Full name is required",
-  phone: (val) => phonePattern.test(val) || VALIDATION_MESSAGES.invalidPhone,
 
   /**
    * Phone: length check first (min 10), then linear-time regex.


### PR DESCRIPTION
## 🚀 Description

Removed a duplicate `phone` validator declaration from `src/validation.js`.

The `validate` object previously contained two `phone` property definitions. The first validator implementation was immediately overwritten by a second, more robust implementation later in the same object block.

### Changes Made

* Removed the redundant initial `phone` validator declaration
* Retained the existing improved validator that strips formatting characters before validating phone number length

### Result

* Improved code readability and maintainability
* Eliminated redundant object key declaration
* Preserved existing validation behavior

Fixes #<issue-number>

---

## 🛠️ Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A

---

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
