### PR TITLE
fix: resolve duplicate AppRoutes syntax error

### DIFF
--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -28,10 +28,16 @@ const RouteFallback = () => (
 const AppRoutes = () => (
   <Suspense fallback={<RouteFallback />}>
     <Routes>
+      {/* Public Routes */}
       {getPublicRoutes()}
+
+      {/* Protected Routes */}
       {getProtectedRoutes()}
+
+      {/* Auth Routes */}
       {getAuthRoutes()}
 
+      {/* Achievements Route */}
       <Route
         path="/dashboard/achievements"
         element={
@@ -40,28 +46,6 @@ const AppRoutes = () => (
           </ProtectedRoute>
         }
       />
-const AppRoutes = () => {
-  return (
-    <Suspense fallback={<PageLoader />}>
-      <Routes>
-        {/* Public Routes */}
-        {getPublicRoutes()}
-
-        {/* Protected Routes */}
-        {getProtectedRoutes()}
-
-        {/* Auth Routes */}
-        {getAuthRoutes()}
-
-        {/* Achievements Route */}
-        <Route
-          path="/dashboard/achievements"
-          element={
-            <ProtectedRoute>
-              <UserAchievements />
-            </ProtectedRoute>
-          }
-        />
 
       <Route path="*" element={<NotFoundPage />} />
     </Routes>


### PR DESCRIPTION
## 🚀 Description

Fixed a fatal syntax/parsing error in `src/components/AppRoutes.js` caused by duplicate `AppRoutes` component declarations.

The file contained overlapping JSX where a second `AppRoutes` declaration was appended directly after the initial `<Route>` mapping, resulting in malformed and unparseable component structure.

### Changes Made

* Removed the duplicate/overlapping component declaration
* Merged routing segments into a single valid `AppRoutes` component
* Preserved existing route mappings and routing behavior

### Result

* Resolved the syntax/parsing error in `AppRoutes.js`
* Restored successful compilation for this routing component
* Improved maintainability and readability of routing logic

Note: Other unrelated pre-existing syntax issues may still exist elsewhere in the repository.

Fixes #3614

---

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A

---

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
