### PR TITLE
fix: resolve ReferenceError crash on zero-result search in Hero compo…

### DIFF
--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -434,7 +434,7 @@ text-gray-600 dark:text-gray-300"
                         >
                           No results match "
                           <span className="font-medium text-gray-700 dark:text-white">
-                            {searchQuery}
+                            {searchTerm}
                           </span>
                           "
                         </motion.div>
@@ -522,7 +522,7 @@ text-gray-600 dark:text-gray-300"
           </motion.div>
 
           {/* Animated Stats Cards */}
-          {!searchQuery.trim() && (
+          {!searchTerm.trim() && (
             <SectionErrorBoundary label="Statistics">
             <motion.div
               variants={fadeUp}


### PR DESCRIPTION
## Description
This PR fixes a critical `ReferenceError` vulnerability in the Home Page's `Hero` component that caused the entire application to crash when a user executed a search with no matching results.
Closes #3599
### The Issue
The component attempted to render a `searchQuery` variable inside the "No results match" state UI, and also used it to conditionally hide the Animated Stats Cards (`{!searchQuery.trim()}`). However, `searchQuery` was never defined in this component—the actual state variable tracking the user's input was named `searchTerm`. Because of this, typing a query that yielded zero results threw an unhandled `ReferenceError: searchQuery is not defined`, resulting in a fatal React crash.

### The Fix
- Replaced the undefined `searchQuery` references with the correct `searchTerm` state variable in `src/Pages/Home/components/Hero.js`.
- The global search bar now gracefully handles zero-result searches without crashing the Home Page.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
