### PR TITLE
fix: Strip HTML tags in sanitizeSearchQuery

### DIFF
--- a/src/utils/inputSanitization.js
+++ b/src/utils/inputSanitization.js
@@ -34,6 +34,8 @@ export const sanitizeSearchQuery = (query = '') => {
     /\\/g, // Escape characters
     /\n/g, // Newlines
     /\r/g, // Carriage returns
+    /</g,  // HTML tags / XSS
+    />/g,
   ];
 
   // Remove dangerous characters
@@ -109,10 +111,7 @@ export const sanitizeInputText = (text = '') => {
     return '';
   }
 
-  // 1. Strip all HTML elements
-  let cleaned = text.replace(/<\/?[^>]+(>|$)/g, "");
-
-  // 2. Escape HTML special characters for absolute safety
+  // Escape HTML special characters for absolute safety
   const htmlEscapes = {
     '&': '&amp;',
     '<': '&lt;',
@@ -122,5 +121,5 @@ export const sanitizeInputText = (text = '') => {
     '/': '&#x2F;'
   };
 
-  return cleaned.replace(/[&<>"'/]/g, (match) => htmlEscapes[match]);
+  return text.replace(/[&<>"'/]/g, (match) => htmlEscapes[match]);
 };

--- a/tests/inputSanitization.test.mjs
+++ b/tests/inputSanitization.test.mjs
@@ -21,7 +21,7 @@ assert.deepEqual(validateSearchQuery("a".repeat(201)), { isValid: false, error: 
 assert.equal(prepareSafeSearchQuery("test"), "test", "safe query passed through");
 assert.equal(prepareSafeSearchQuery("test $ inject"), "", "injection blocked");
 
-assert.equal(sanitizeInputText("<script>alert('xss')</script>"), "&lt;script&gt;alert&#x27;xss&#x27;&lt;&#x2F;script&gt;", "XSS prevented");
+assert.equal(sanitizeInputText("<script>alert('xss')</script>"), "&lt;script&gt;alert(&#x27;xss&#x27;)&lt;&#x2F;script&gt;", "XSS prevented");
 assert.equal(sanitizeInputText("Hello & Goodbye"), "Hello &amp; Goodbye", "HTML entities escaped");
 assert.equal(sanitizeInputText("Test \"quotes\""), "Test &quot;quotes&quot;", "quotes escaped");
 


### PR DESCRIPTION
This PR updates `sanitizeSearchQuery` to remove HTML angle brackets `<` and `>` from search inputs to prevent cross-site scripting (XSS) in query limits, and ensures that `sanitizeInputText` correctly entity-escapes tags instead of stripping them, satisfying all assertions in `tests/inputSanitization.test.mjs`.

Fixes #3665