### PR TITLE
fix: prevent TypeError crash when filtering items with null titles in…

### DIFF
--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -136,7 +136,7 @@ export default function UserDashboard() {
   const activeProjects = safeData.filter(d => d && d.type === "Project" && d.projectStatus !== "Done");
 
   const filteredData = MOCK_DATA.filter(item => {
-    const matchSearch = item.title.toLowerCase().includes(searchQuery.toLowerCase());
+    const matchSearch = (item.title || "").toLowerCase().includes(searchQuery.toLowerCase());
     const matchType = filterType === "All" || item.type === filterType;
     const matchStatus = filterStatus === "All"
       || item.status === filterStatus


### PR DESCRIPTION
## Description
This PR fixes a fatal `TypeError` vulnerability in `UserDashboard.js` that caused the dashboard to completely crash (White Screen of Death) when attempting to filter items with missing or null titles.
Closes #3600 
### The Issue
During the search filter loop, the component executed `item.title.toLowerCase().includes(...)`. If an item in the array arrived with a missing, null, or undefined `title` property (e.g. from an incomplete database record or malformed mock data), JavaScript immediately threw `TypeError: Cannot read properties of null (reading 'toLowerCase')`, breaking the React component tree and rendering the dashboard unusable. 

### The Fix
- Implemented a safe string fallback `(item.title || "")` before invoking string prototype methods in `src/components/user/UserDashboard.js`.
- The dashboard search filter now safely ignores items with missing titles instead of crashing the application.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
