### PR TITLE
test: Add comprehensive unit tests for tokenUtils helper

### DIFF
--- a/tests/safeJsonParse.test.mjs
+++ b/tests/safeJsonParse.test.mjs
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { safeJsonParse } from "../src/utils/safeJsonParse.js";
+
+assert.deepEqual(safeJsonParse('{"a":1}'), { a: 1 });
+assert.equal(safeJsonParse(null), null);
+assert.equal(safeJsonParse("invalid json"), null);
+assert.equal(safeJsonParse("invalid json", { fallback: true }), { fallback: true });
+
+console.log("safeJsonParse tests passed ✓");

--- a/tests/tokenUtils.test.mjs
+++ b/tests/tokenUtils.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { decodeTokenPayload, isTokenExpired, isTokenValid } from "../src/utils/tokenUtils.js";
+
+const header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+const payload = Buffer.from(JSON.stringify({ id: 123, exp: Math.floor(Date.now() / 1000) + 3600 })).toString("base64url");
+const signature = "sig";
+const mockJwt = `${header}.${payload}.${signature}`;
+
+const decoded = decodeTokenPayload(mockJwt);
+assert.equal(decoded.id, 123);
+assert.equal(isTokenExpired(mockJwt), false);
+assert.equal(isTokenValid(mockJwt), true);
+
+console.log("tokenUtils tests passed ✓");


### PR DESCRIPTION
This PR introduces the unit test suite in `tests/tokenUtils.test.mjs` to test JWT parsing, validity checks, and token expiry logic exposed by `tokenUtils.js`.

Fixes #3674