### PR TITLE
test: Add comprehensive unit tests for githubApiClient

### DIFF
--- a/tests/githubApiClient.test.mjs
+++ b/tests/githubApiClient.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { buildGitHubProxyUrl, getGitHubRepoDetails } from "../src/utils/githubApiClient.js";
+
+const proxyUrl = buildGitHubProxyUrl("/repos/octocat/hello-world", { page: 1 });
+assert.ok(proxyUrl.includes("page=1"));
+assert.ok(proxyUrl.includes("path=%2Frepos%2Foctocat%2Fhello-world"));
+
+const repoInfo = getGitHubRepoDetails("https://github.com/octocat/hello-world.git");
+assert.equal(repoInfo.owner, "octocat");
+assert.equal(repoInfo.repo, "hello-world");
+
+console.log("githubApiClient tests passed ✓");


### PR DESCRIPTION
This PR introduces `tests/githubApiClient.test.mjs` verifying proxy query extensions and owner/repo extractors in `githubApiClient.js`.

Fixes #3689