### PR TITLE
fix: Configure ALLOWED_ORIGIN in signupEndpoint tests

### DIFF
--- a/tests/signupEndpoint.test.mjs
+++ b/tests/signupEndpoint.test.mjs
@@ -1,3 +1,4 @@
+process.env.ALLOWED_ORIGIN = "http://localhost:3000";
 import assert from "node:assert/strict";
 import handler from "../api/auth/signup.js";
 


### PR DESCRIPTION
This PR defines `process.env.ALLOWED_ORIGIN` in `tests/signupEndpoint.test.mjs` so that CORS Allow-Credentials headers are correctly set by the mock router during testing, resolving the failure in signup validation runs.

Fixes #3704