### PR TITLE
fix: prevent TypeError crash when searching projects with malformed t…

### DIFF
--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -211,7 +211,7 @@ const ProjectGallery = () => {
           project.description.toLowerCase().includes(query) ||
           project.category.toLowerCase().includes(query) ||
           project.author.toLowerCase().includes(query) ||
-          (project.techStack &&
+          (Array.isArray(project.techStack) &&
             project.techStack.some((tech) =>
               tech.toLowerCase().includes(query)
             ))


### PR DESCRIPTION
## Description
This PR resolves a fatal `TypeError` vulnerability in `ProjectsPage.js` that caused the entire Projects search interface to crash if it encountered malformed database entries.
Closes #3601 
### The Issue
When filtering projects by a search query, the component executed `project.techStack.some(...)`. The check beforehand was merely `(project.techStack && ...)`, which only verified that the property was truthy. If a developer accidentally saved a project where `techStack` was a string (e.g., `"React, Node"`) or an object instead of an array, `project.techStack` evaluated to true, but calling `.some()` threw a fatal `TypeError: project.techStack.some is not a function`. This permanently broke the search functionality for all users on the platform until the offending database entry was manually corrected.

### The Fix
- Upgraded the truthy check to a strict `Array.isArray(project.techStack)` type check in `src/Pages/Projects/ProjectsPage.js`.
- The `.some()` method is now guaranteed to only execute on valid arrays, allowing the search filter to safely ignore malformed data without crashing the application.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
