### PR TITLE
fix: remove document.cookie token write from AuthContext

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -47,7 +47,6 @@ export const AuthProvider = ({ children }) => {
 
     setUser(null);
     setToken(null);
-    document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; SameSite=Strict";
     sessionStorage.removeItem("token");
     localStorage.removeItem("user");
     return true;
@@ -230,14 +229,6 @@ export const AuthProvider = ({ children }) => {
   const persistSession = useCallback((sessionToken, sessionUser) => {
     setToken(sessionToken);
     setUser(sessionUser);
-    try {
-      if (sessionToken && sessionToken !== 'cookie-managed') {
-        document.cookie = `token=${sessionToken}; path=/; Secure; SameSite=Strict`;
-      }
-    } catch (err) {
-      // Ignore cookie write failures in strict environments
-    }
-
     try {
       localStorage.setItem("user", JSON.stringify(sessionUser));
     } catch (error) {


### PR DESCRIPTION
## Description

`persistSession` in `src/context/AuthContext.js` was writing the auth token to `document.cookie`:

```js
document.cookie = `token=${sessionToken}; path=/; Secure; SameSite=Strict`;
```

The `document.cookie` API is a JavaScript interface. Any attribute written to it is set on a normal, JS-accessible cookie regardless of what flags are included. A `HttpOnly` flag in a `document.cookie` string is silently discarded by the browser. The resulting cookie is readable by `document.cookie` in any script on the page, exposing the session token to XSS-based theft.

The login and signup serverless handlers already set a proper HttpOnly cookie via the `Set-Cookie` response header. The client-side `document.cookie` write is redundant and creates a second, unprotected copy of the same token.

**Changes:**

- Remove `document.cookie = \`token=...\`` from `persistSession`.
- Remove the corresponding `document.cookie = "token=; expires=..."` expiry line from `clearSession`. Only the server-side logout endpoint (which sends `Set-Cookie: token=; Expires=...`) can clear an HttpOnly cookie; the client-side assignment had no effect on the HttpOnly version.
- The server-set HttpOnly cookie remains the authoritative session credential. React state holds the token for in-memory access; `localStorage` persists the user profile for UI rendering.

## Type of Change

- [x] Bug fix (security)

## Related Issues

Closes #3165

## Testing

- After login, `document.cookie` no longer contains `token=...`
- After logout (server clears the HttpOnly cookie), the session is fully terminated
- Existing `validateSession` flow (which pings the backend on mount) continues to work because it relies on the HttpOnly cookie being sent automatically by the browser

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] All existing tests pass