### PR TITLE
[Security][Critical] fix(#3353): eliminate timing side-channel in login handler

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -3,6 +3,13 @@ import jwt from "jsonwebtoken";
 import { users } from "./signup.js";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 
+// Pre-compute a dummy bcrypt hash at module load time (same cost factor used in signup.js).
+// When a login attempt references a username or email that does not exist, we still run
+// bcrypt.compare against this hash so the response time is indistinguishable from a real
+// failed-password attempt. Without this, an attacker can enumerate valid account identifiers
+// purely from response timing (user-not-found path: <5 ms vs valid-user path: ~100 ms).
+const DUMMY_HASH_PROMISE = bcrypt.hash("__eventra_dummy_constant__", 12);
+
 // ---------------------------------------------------------------------------
 // JWT Configuration
 // ---------------------------------------------------------------------------
@@ -219,30 +226,27 @@ export default async function handler(req, res) {
     // -----------------------------------------------------------------------
 
     const user = findUserByUsernameOrEmail(usernameOrEmail);
-    
-    if (!user) {
-      // Return generic message to prevent user enumeration
-      return corsResponse(res, 401, { 
-        error: "Invalid credentials" 
-      }, req);
-    }
-
-    // Check if user is active
-    if (user.isActive === false) {
-      return corsResponse(res, 401, { 
-        error: "Invalid credentials" 
-      }, req);
-    }
 
     // -----------------------------------------------------------------------
     // Verify password using BCrypt
+    // Always run bcrypt.compare regardless of whether the user exists so that
+    // response time is uniform across all failure modes. This eliminates the
+    // timing side-channel that would otherwise reveal valid account identifiers.
     // -----------------------------------------------------------------------
 
-    const isPasswordValid = await bcrypt.compare(password, user.password);
-    
-    if (!isPasswordValid) {
-      return corsResponse(res, 401, { 
-        error: "Invalid credentials" 
+    const hashToCompare = user ? user.password : await DUMMY_HASH_PROMISE;
+    const isPasswordValid = await bcrypt.compare(password, hashToCompare);
+
+    if (!user || !isPasswordValid) {
+      return corsResponse(res, 401, {
+        error: "Invalid credentials"
+      }, req);
+    }
+
+    // Check if user is active after confirming identity to keep timing uniform
+    if (user.isActive === false) {
+      return corsResponse(res, 401, {
+        error: "Invalid credentials"
       }, req);
     }
 


### PR DESCRIPTION
## Summary

Fixes #3353

The login handler in `api/auth/login.js` returned a 401 response immediately when a submitted username or email was not found, without calling `bcrypt.compare`. Because `bcrypt.compare` with 12 rounds takes roughly 80-120 ms, the response time was measurably different between a missing account (<5 ms) and a valid account with a wrong password (~100 ms). An attacker could exploit this to enumerate registered accounts with a single request per candidate.

## Root Cause

```js
// Before: bcrypt.compare only called when user exists
const user = findUserByUsernameOrEmail(usernameOrEmail);
if (!user) {
  return corsResponse(res, 401, { error: "Invalid credentials" }, req); // < 5 ms
}
const isPasswordValid = await bcrypt.compare(password, user.password); // ~100 ms
```

## Fix

Pre-compute a dummy bcrypt hash once at module load time (same cost factor as `signup.js`). The handler now always calls `bcrypt.compare` regardless of whether the user was found, using the dummy hash when no account exists. Both failure paths consume the same ~100 ms.

```js
const DUMMY_HASH_PROMISE = bcrypt.hash("__eventra_dummy_constant__", 12);

// Inside handler:
const hashToCompare = user ? user.password : await DUMMY_HASH_PROMISE;
const isPasswordValid = await bcrypt.compare(password, hashToCompare);
if (!user || !isPasswordValid) {
  return corsResponse(res, 401, { error: "Invalid credentials" }, req);
}
```

The `isActive` check is now placed after the bcrypt comparison so all failure modes share the same timing profile.

## Changes

- `api/auth/login.js`: module-level `DUMMY_HASH_PROMISE`, unified bcrypt path, moved `isActive` check

Could you please add the relevant GSSoC labels to this PR? Thank you!