### PR TITLE
[Security][Critical] fix(#3356): add auth, prompt length cap, and rate limiting to ai-recommendations

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -1,14 +1,57 @@
 // serverless backend endpoint for AI recommendations
 // Secures the Groq API key from frontend exposure
 
-module.exports = async (req, res) => {
+import { verifyAuth } from "./middleware/auth.js";
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+// Hard limit on prompt length. Groq charges per token; an unbounded prompt
+// lets an unauthenticated caller exhaust the API quota in a single request.
+const MAX_PROMPT_LENGTH = 2000;
+
+// Per-user rate limit: at most RATE_LIMIT_MAX_REQUESTS within RATE_LIMIT_WINDOW_MS.
+// This Map lives in process memory. In a multi-instance serverless deployment,
+// each instance maintains its own window, which reduces but does not eliminate
+// the ability to exceed the limit by spreading requests across warm instances.
+// A Redis-backed limiter would enforce a strict global cap if needed later.
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 10;
+const rateLimitMap = new Map();
+
+const checkRateLimit = (userId) => {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+
+  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitMap.set(userId, { count: 1, windowStart: now });
+    return true;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return false;
+  }
+
+  entry.count += 1;
+  return true;
+};
+
+// ---------------------------------------------------------------------------
+// Handler (wrapped by verifyAuth - requires a valid Eventra JWT)
+// ---------------------------------------------------------------------------
+
+async function handler(req, res) {
   // Add CORS headers
   res.setHeader("Access-Control-Allow-Credentials", true);
-  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader(
+    "Access-Control-Allow-Origin",
+    process.env.ALLOWED_ORIGIN || "*"
+  );
   res.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS,PATCH,DELETE,POST,PUT");
   res.setHeader(
     "Access-Control-Allow-Headers",
-    "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+    "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization"
   );
 
   if (req.method === "OPTIONS") {
@@ -20,8 +63,16 @@ module.exports = async (req, res) => {
     return res.status(405).json({ error: "Method not allowed. Use POST." });
   }
 
-  // We look for GROQ_API_KEY on the server. As a fallback for local testing
-  // while the env var is renamed, we check REACT_APP_GROQ_API_KEY.
+  // req.user is set by verifyAuth after successful JWT verification
+  const userId = req.user?.id || req.user?.email || "unknown";
+
+  // Per-user rate limiting
+  if (!checkRateLimit(userId)) {
+    return res.status(429).json({
+      error: "Too many requests. Please wait before sending another recommendation request.",
+    });
+  }
+
   const apiKey = process.env.GROQ_API_KEY || process.env.REACT_APP_GROQ_API_KEY;
 
   if (!apiKey) {
@@ -31,8 +82,15 @@ module.exports = async (req, res) => {
   try {
     const { prompt } = req.body;
 
-    if (!prompt) {
+    if (!prompt || typeof prompt !== "string" || prompt.trim().length === 0) {
       return res.status(400).json({ error: "Prompt is required." });
+    }
+
+    // Reject oversized prompts before they reach Groq to prevent token-quota drain
+    if (prompt.length > MAX_PROMPT_LENGTH) {
+      return res.status(400).json({
+        error: `Prompt must not exceed ${MAX_PROMPT_LENGTH} characters.`,
+      });
     }
 
     const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
@@ -43,7 +101,7 @@ module.exports = async (req, res) => {
       },
       body: JSON.stringify({
         model: "llama-3.1-8b-instant",
-        messages: [{ role: "user", content: prompt }],
+        messages: [{ role: "user", content: prompt.trim() }],
         temperature: 0.7,
       }),
     });
@@ -60,4 +118,6 @@ module.exports = async (req, res) => {
     console.error("[Groq Proxy API] Request Failed:", error);
     return res.status(500).json({ error: "Internal server error" });
   }
-};
+}
+
+export default verifyAuth(handler);


### PR DESCRIPTION
## Summary

Fixes #3356

`api/ai-recommendations.js` was publicly accessible with no authentication, no prompt-length guard, and no per-user throttle. Any anonymous caller could send arbitrarily large prompts to the Groq API in a tight loop, exhausting the API quota and blocking legitimate users.

## Changes

**`api/ai-recommendations.js`**

1. **Authentication** - The handler is now wrapped with `verifyAuth` from `api/middleware/auth.js`. Unauthenticated requests receive 401 before any Groq call is made.

2. **Prompt length cap** - `MAX_PROMPT_LENGTH = 2000` characters. Prompts exceeding this are rejected with 400 before reaching Groq, preventing single-request token-quota drain.

3. **Per-user rate limiting** - An in-memory Map tracks request counts per user. Exceeding 10 requests per minute returns 429. A comment notes that multi-instance deployments would need a Redis-backed limiter for strict global enforcement.

4. **Module system** - Converted from CJS (`module.exports`) to ESM (`export default`) to match the rest of the `api/` directory and enable the middleware import.

## Before / After

```
Before: curl -X POST /api/ai-recommendations -d '{"prompt":"...1MB..."}' -> 200
After:  curl -X POST /api/ai-recommendations -d '{"prompt":"...1MB..."}' -> 401 (no auth)
        With valid JWT + long prompt -> 400 (exceeds 2000 chars)
        With valid JWT + 11th request in 60s -> 429 (rate limited)
```

Could you please add the relevant GSSoC labels to this PR? Thank you!