### PR TITLE
[Bug] fix(#3359): add per-item payload size cap to pushToQueue in offlineQueue.js

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -312,6 +312,11 @@ const generateQueueId = () => {
  * cross-user action replay. If a user logs out and another user logs in,
  * the queued actions are validated for ownership before replay.
  */
+// Maximum serialised byte length for a single queue item's payload field.
+// With the 15-item slot cap, the total localStorage footprint is at most
+// 15 x 50 KB = 750 KB, safely within the 5 MB browser quota.
+const MAX_PAYLOAD_BYTES = 50 * 1024;
+
 export const pushToQueue = async (item, userId = null) => {
   // Add metadata tracking with security context
   const actionItem = {
@@ -329,6 +334,25 @@ export const pushToQueue = async (item, userId = null) => {
         ? sessionStorage.getItem("session_id") || null
         : null,
   };
+
+  // Guard against oversized payloads before they reach localStorage.
+  // An uncapped payload can fill the 5 MB quota in a single write, causing
+  // every subsequent localStorage.setItem call (including auth-state writes
+  // in AuthContext) to throw QuotaExceededError, silently corrupting the app.
+  const serialisedPayload = JSON.stringify(actionItem.payload);
+  if (serialisedPayload.length > MAX_PAYLOAD_BYTES) {
+    logger.warn(
+      `[OfflineQueue] Payload too large (${serialisedPayload.length} bytes). Dropping item to protect localStorage quota.`
+    );
+    if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+      window.dispatchEvent(
+        new CustomEvent("eventra-offline-queue-full", {
+          detail: { reason: "payload-too-large", eventId: item.eventId },
+        })
+      );
+    }
+    return false;
+  }
 
   // 1. Sync mirror updates immediately (Synchronous fallback)
   const queue = getQueue();


### PR DESCRIPTION
## Summary

Fixes #3359

`pushToQueue` capped the number of queued items at 15 but placed no limit on the serialised size of each item's `payload` field. A single queue entry with an oversized payload (e.g. a base64 file attachment or a large server response) could fill the browser's 5 MB localStorage quota. Once quota is exhausted, every subsequent `localStorage.setItem` call in the app throws `QuotaExceededError` - including auth-state writes in `AuthContext.persistSession`, which silently logs the user out with no actionable error message.

## Root Cause

```js
// Before: no size check on payload
queue.push(actionItem);
localStorage.setItem(QUEUE_KEY, JSON.stringify(queue)); // can throw QuotaExceededError
```

## Fix

Added `MAX_PAYLOAD_BYTES = 50 * 1024` (50 KB). Before the item is pushed to the queue, `pushToQueue` now serialises the payload, measures its byte length, and drops the item if it exceeds the cap.

```js
const serialisedPayload = JSON.stringify(actionItem.payload);
if (serialisedPayload.length > MAX_PAYLOAD_BYTES) {
  logger.warn(`[OfflineQueue] Payload too large (${serialisedPayload.length} bytes). Dropping item.`);
  window.dispatchEvent(new CustomEvent("eventra-offline-queue-full", {
    detail: { reason: "payload-too-large", eventId: item.eventId },
  }));
  return false;
}
```

With all 15 slots occupied at the maximum payload size the worst-case localStorage footprint is 15 x 50 KB = 750 KB, safely within the 5 MB quota.

The existing `eventra-offline-queue-full` event is reused with a `reason: "payload-too-large"` field so callers can surface a meaningful message to the user.

Could you please add the relevant GSSoC labels to this PR? Thank you!