### PR TITLE
docs: add user profile update API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -324,6 +324,61 @@ Authorization: Bearer YOUR_JWT_TOKEN
 
 ---
 
+## Update User Profile
+
+| Method | Endpoint |
+|--------|----------|
+| PUT | `/api/users/profile` |
+
+Allows the currently authenticated user to update their profile information.
+
+### Request Headers
+
+```bash
+Authorization: Bearer YOUR_JWT_TOKEN
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "firstName": "Johnny",
+  "lastName": "Updated",
+  "username": "johnny3164"
+}
+```
+
+### Successful Response (200)
+
+```json
+{
+  "id": 1,
+  "firstName": "Johnny",
+  "lastName": "Updated",
+  "username": "johnny3164",
+  "email": "john3164@example.com",
+  "role": "CLIENT"
+}
+```
+
+### Error Responses
+
+| Status | Reason |
+|--------|--------|
+| `400 Bad Request` | Validation failure |
+| `401 Unauthorized` | Missing or invalid JWT token |
+| `404 Not Found` | Authenticated user no longer exists |
+| `409 Conflict` | Username already exists |
+
+#### Notes
+
+- Only `firstName`, `lastName`, and `username` can be updated through this endpoint.
+- `id`, `email`, `password`, and `role` are not editable here.
+- The backend uses the authenticated email from the JWT to identify the user.
+
+---
+
 # Event APIs
 
 ## Create Event


### PR DESCRIPTION
## Related Issue

Related to SandeepVashishtha/Eventra#3164  
Backend implementation: SandeepVashishtha/Eventra-Backend#37
## Description

This PR updates the API documentation to include the newly added backend user profile update endpoint.

## Changes Made

- Documented `PUT /api/users/profile`
- Added authentication requirement
- Added request body example
- Added success response example
- Added error response notes
- Mentioned that `id`, `email`, `password`, and `role` are not editable through this endpoint

## Notes

The backend implementation for this endpoint is handled in the Eventra-Backend repository. This PR only syncs the frontend/docs repository documentation with the backend API behavior.