### PR TITLE
[Security] Add rel=noopener noreferrer to all target=_blank links

### DIFF
--- a/src/Pages/Leaderboard/ContributorGuide.js
+++ b/src/Pages/Leaderboard/ContributorGuide.js
@@ -671,7 +671,7 @@ const ContributorGuide = () => {
         <motion.a
           href="https://github.com/SandeepVashishtha/Eventra"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
           className="inline-flex items-center justify-center gap-3 bg-gradient-to-r from-sky-100 to-amber-100 text-black font-semibold px-8 py-3 rounded-full shadow-lg hover:from-sky-200 hover:to-amber-200 transition-all duration-300"

--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -605,7 +605,7 @@ const GSSoCContribution = () => {
               <motion.button
                 whileHover={{ scale: 1.03 }}
                 whileTap={{ scale: 0.98 }}
-                onClick={() => window.open("https://gssoc.girlscript.tech", "_blank")}
+                onClick={() => window.open("https://gssoc.girlscript.tech", "_blank", "noopener,noreferrer")}
                 className="w-full mt-3 sm:mt-4 py-2.5 bg-white text-indigo-600 font-semibold rounded-xl flex items-center justify-center gap-2 hover:bg-indigo-50 transition-colors focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-indigo-600"
                 aria-label="View GSSoC leaderboard (opens in new tab)"
               >
@@ -836,7 +836,7 @@ const GSSoCContribution = () => {
           <motion.button
             whileHover={{ scale: 1.03 }}
             whileTap={{ scale: 0.98 }}
-            onClick={() => window.open("https://github.com/SandeepVashishtha/Eventra", "_blank")}
+            onClick={() => window.open("https://github.com/SandeepVashishtha/Eventra", "_blank", "noopener,noreferrer")}
             className="px-6 sm:px-8 py-3 rounded-full font-semibold text-white bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-2 dark:focus:ring-offset-black"
           >
             <GitBranch className="w-4 h-4" aria-hidden="true" />
@@ -847,7 +847,7 @@ const GSSoCContribution = () => {
           <motion.button
             whileHover={{ scale: 1.03 }}
             whileTap={{ scale: 0.98 }}
-            onClick={() => window.open("https://discord.gg/eventra", "_blank")}
+            onClick={() => window.open("https://discord.gg/eventra", "_blank", "noopener,noreferrer")}
             className="px-6 sm:px-8 py-3 rounded-full font-semibold text-white bg-[#5865F2] hover:bg-[#4752C4] shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-[#5865F2] focus:ring-offset-2 dark:focus:ring-offset-black"
           >
             <MessageCircle className="w-4 h-4" aria-hidden="true" />

--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -258,7 +258,7 @@ class ErrorBoundary extends React.Component {
         try {
           const blob = new Blob([report], { type: "text/plain" });
           const url = URL.createObjectURL(blob);
-          window.open(url, "_blank");
+          window.open(url, "_blank", "noopener,noreferrer");
         } catch (_) {}
       });
   };

--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -61,7 +61,7 @@ const ShareModal = ({ event, onClose }) => {
           <a
             href={shareLinks.twitter}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="rounded-xl bg-black px-4 py-3 text-center text-white"
           >
             Twitter/X
@@ -70,7 +70,7 @@ const ShareModal = ({ event, onClose }) => {
           <a
             href={shareLinks.linkedin}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="rounded-xl bg-blue-700 px-4 py-3 text-center text-white"
           >
             LinkedIn
@@ -79,7 +79,7 @@ const ShareModal = ({ event, onClose }) => {
           <a
             href={shareLinks.whatsapp}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="rounded-xl bg-green-600 px-4 py-3 text-center text-white"
           >
             WhatsApp


### PR DESCRIPTION
Closes #3736

## Problem

Multiple `target="_blank"` links and `window.open()` calls across the codebase were missing `rel="noopener noreferrer"`. This enables tab-napping attacks where the opened page can access `window.opener` and redirect the parent tab to a phishing site.

## Fix

- Added `rel="noopener noreferrer"` to all `target="_blank"` anchor elements across:
  - `src/Pages/Leaderboard/ContributorGuide.js`
  - `src/Pages/Leaderboard/GSSoCContribution.js`
  - `src/components/common/ErrorBoundary.jsx`
  - `src/components/common/ShareModal.jsx`
- Fixed `window.open()` calls to pass `"noopener,noreferrer"` as the third `windowFeatures` argument

## Test plan
- [ ] Verify all `target="_blank"` links have `rel="noopener noreferrer"` with: `grep -rn 'target="_blank"' src/ | grep -v noopener`
- [ ] Confirm lint passes: `npm run lint`
- [ ] Confirm build passes: `GENERATE_SOURCEMAP=false npm run build`