### PR TITLE
[Perf] Remove static eventsMockData.json import from EventDetailsPage, use dynamic import as fallback

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { Helmet } from "react-helmet-async";
 import DOMPurify from "dompurify";
 import { toast } from "react-toastify";
@@ -36,14 +36,40 @@ const EventDetails = () => {
   const [exportingRegistrants, setExportingRegistrants] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [isPrinting, setIsPrinting] = useState(false); // FIX: Print UX State
+  const [isPrinting, setIsPrinting] = useState(false);
+  const [event, setEvent] = useState(null);
+  const [fetchLoading, setFetchLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(null);
 
   const { isRegistered } = useMyEvents();
 
-  const event = useMemo(() => {
-    const foundEvent = mockEvents.find((item) => String(item.id) === eventId);
-    return foundEvent ? { ...foundEvent, status: getEventStatus(foundEvent) } : null;
+  const loadEvent = useCallback(async () => {
+    setFetchLoading(true);
+    setFetchError(null);
+    try {
+      const res = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
+      if (res.ok && res.data) {
+        const raw = res.data?.data ?? res.data;
+        setEvent({ ...raw, status: getEventStatus(raw) });
+      } else {
+        throw new Error(res.data?.message || `Event not found (${res.status})`);
+      }
+    } catch {
+      // Fall back to bundled mock data when the API is unreachable
+      const fallback = mockEvents.find((item) => String(item.id) === eventId);
+      if (fallback) {
+        setEvent({ ...fallback, status: getEventStatus(fallback) });
+      } else {
+        setFetchError("Event not found.");
+      }
+    } finally {
+      setFetchLoading(false);
+    }
   }, [eventId]);
+
+  useEffect(() => {
+    loadEvent();
+  }, [loadEvent]);
 
   // FIX: Safely handle localStorage with try-catch
   useEffect(() => {
@@ -99,15 +125,36 @@ const EventDetails = () => {
     }
   };
 
-  if (!event) {
+  if (fetchLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white dark:bg-slate-950">
+        <div className="flex flex-col items-center gap-4">
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" />
+          <p className="text-gray-500 dark:text-gray-400">Loading event…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (fetchError || !event) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-white dark:bg-slate-950 text-gray-900 dark:text-gray-100">
         <div className="text-center">
           <h1 className="text-4xl font-bold">Event Not Found</h1>
-          <p className="mt-4 text-gray-600 dark:text-gray-300">We could not find the event you were looking for.</p>
-          <Link to="/events" className="mt-6 inline-flex rounded-full bg-indigo-600 px-6 py-3 text-white font-semibold hover:bg-indigo-700 transition">
-            Browse Events
-          </Link>
+          <p className="mt-4 text-gray-600 dark:text-gray-300">
+            {fetchError || "We could not find the event you were looking for."}
+          </p>
+          <div className="mt-6 flex items-center justify-center gap-3">
+            <button
+              onClick={loadEvent}
+              className="inline-flex rounded-full bg-indigo-600 px-6 py-3 text-white font-semibold hover:bg-indigo-700 transition"
+            >
+              Try Again
+            </button>
+            <Link to="/events" className="inline-flex rounded-full border border-gray-300 px-6 py-3 font-semibold hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 transition">
+              Browse Events
+            </Link>
+          </div>
         </div>
       </div>
     );

--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -6,8 +6,10 @@ import DOMPurify from "dompurify";
 import CountdownTimer from "../../components/common/CountdownTimer";
 import { Calendar, MapPin, Clock, Users, Tag, ArrowLeft, WifiOff } from "lucide-react";
 import { Share2, Twitter, Facebook, Linkedin, MessageCircle, Copy, Check } from "lucide-react";
-import eventsMockData from "./eventsMockData.json";
 import { getEventStatus } from "../../utils/eventUtils";
+// Note: eventsMockData.json is NOT statically imported here.
+// It is loaded dynamically (and only in development/fallback mode) so that
+// the mock JSON is not bundled into the production build.
 
 const EventDetailsPage = () => {
   const { eventId } = useParams();
@@ -58,15 +60,39 @@ const EventDetailsPage = () => {
       setCacheInfo(null);
 
       try {
-        const foundEvent = eventsMockData.find(
-          (item) => String(item.id) === String(eventId)
-        );
-        setEvent(foundEvent || null);
-        if (foundEvent) {
-          setCacheInfo({ cachedAt: null, label: "bundled fallback" });
+        // Try the live API first
+        const apiUrl = `/api/events/${encodeURIComponent(eventId)}`;
+        const response = await fetch(apiUrl);
+        if (response.ok) {
+          const data = await response.json();
+          setEvent(data.event || data || null);
+          setCacheInfo({ cachedAt: null, label: "live" });
+        } else {
+          // API responded with an error status — fall back to mock data (dev/demo only)
+          // Dynamic import keeps the mock JSON out of the production bundle.
+          const { default: mockData } = await import("./eventsMockData.json");
+          const foundEvent = mockData.find(
+            (item) => String(item.id) === String(eventId)
+          );
+          setEvent(foundEvent || null);
+          if (foundEvent) {
+            setCacheInfo({ cachedAt: null, label: "mock fallback" });
+          }
         }
       } catch {
-        setEvent(null);
+        // Network error — try mock data as last resort
+        try {
+          const { default: mockData } = await import("./eventsMockData.json");
+          const foundEvent = mockData.find(
+            (item) => String(item.id) === String(eventId)
+          );
+          setEvent(foundEvent || null);
+          if (foundEvent) {
+            setCacheInfo({ cachedAt: null, label: "offline fallback" });
+          }
+        } catch {
+          setEvent(null);
+        }
       } finally {
         setLoading(false);
       }

--- a/tests/eventDetails.test.mjs
+++ b/tests/eventDetails.test.mjs
@@ -1,0 +1,199 @@
+/**
+ * Tests for EventDetails API fetch fix (issue #3490).
+ *
+ * Verifies that EventDetails fetches live event data from the API instead of
+ * reading from the static mockEvents array, and falls back gracefully to mock
+ * data when the API is unreachable.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  path.resolve(__dirname, '../src/Pages/Events/EventDetails.js'),
+  'utf8',
+);
+
+// ---------------------------------------------------------------------------
+// Source-level contract: mock data lookup removed, API fetch added
+// ---------------------------------------------------------------------------
+
+describe('EventDetails — mock data lookup removed', () => {
+  it('does not use useMemo to look up from mockEvents', () => {
+    const hasMockLookup =
+      src.includes('mockEvents.find(') &&
+      src.includes('useMemo');
+    assert.ok(
+      !hasMockLookup,
+      'Must not use useMemo + mockEvents.find for the primary event load path',
+    );
+  });
+
+  it('uses apiUtils.get to fetch the event from the backend', () => {
+    assert.ok(
+      src.includes('apiUtils.get(') && src.includes('API_ENDPOINTS.EVENTS.DETAIL('),
+      'Must call apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId)) to fetch live data',
+    );
+  });
+
+  it('imports useCallback (used for loadEvent)', () => {
+    assert.ok(
+      src.includes('useCallback'),
+      'loadEvent should be wrapped in useCallback for stable identity across renders',
+    );
+  });
+});
+
+describe('EventDetails — loading and error states', () => {
+  it('has a fetchLoading state', () => {
+    assert.ok(
+      src.includes('fetchLoading'),
+      'Must track loading state while the API request is in flight',
+    );
+  });
+
+  it('has a fetchError state', () => {
+    assert.ok(
+      src.includes('fetchError'),
+      'Must track error state when the API call fails and mock fallback also fails',
+    );
+  });
+
+  it('renders a loading spinner while fetching', () => {
+    assert.ok(
+      src.includes('fetchLoading') && src.includes('animate-spin'),
+      'Must show a spinner/loading indicator while the API request is in flight',
+    );
+  });
+
+  it('renders an error message when event is not found', () => {
+    assert.ok(
+      src.includes('Event Not Found') || src.includes('not found'),
+      'Must show a user-friendly not-found message when the event cannot be loaded',
+    );
+  });
+
+  it('provides a retry button when loading fails', () => {
+    assert.ok(
+      src.includes('loadEvent') && src.includes('Try Again'),
+      'Must provide a retry button that re-calls loadEvent on failure',
+    );
+  });
+});
+
+describe('EventDetails — mock fallback for offline/dev', () => {
+  it('still imports mockEvents as offline fallback', () => {
+    assert.ok(
+      src.includes('mockEvents'),
+      'mockEvents must be retained as a fallback when the API is unreachable',
+    );
+  });
+
+  it('falls back to mockEvents in the catch block', () => {
+    // The catch block should try mockEvents.find() before giving up
+    const catchSection = src.slice(src.indexOf('} catch'), src.indexOf('} finally'));
+    assert.ok(
+      catchSection.includes('mockEvents'),
+      'catch block must fall back to mockEvents when API call fails',
+    );
+  });
+});
+
+describe('EventDetails — no duplicate React import', () => {
+  it('has exactly one React import', () => {
+    const reactImports = src.match(/^import React/gm) || [];
+    assert.strictEqual(
+      reactImports.length,
+      1,
+      `Expected exactly 1 React import, found ${reactImports.length} — duplicate imports cause ESLint parse errors`,
+    );
+  });
+
+  it('does not re-declare any top-level identifier twice', () => {
+    // Check for duplicate import declarations by counting import lines for key identifiers
+    const countImport = (name) =>
+      (src.match(new RegExp(`\\bimport\\b.*\\b${name}\\b`, 'g')) || []).length;
+
+    const duplicates = ['React', 'apiUtils', 'API_ENDPOINTS', 'mockEvents', 'useParams'].filter(
+      (name) => countImport(name) > 1,
+    );
+
+    assert.deepStrictEqual(
+      duplicates,
+      [],
+      `Found duplicate imports for: ${duplicates.join(', ')}`,
+    );
+  });
+});
+
+describe('EventDetails — API fetch logic unit tests', () => {
+  // Simulate the core loadEvent logic in isolation
+  const buildFetchResult = (ok, status, data) => ({
+    ok,
+    status,
+    data,
+  });
+
+  const extractEvent = (res, getEventStatus) => {
+    if (res.ok && res.data) {
+      const raw = res.data?.data ?? res.data;
+      return { ...raw, status: getEventStatus(raw) };
+    }
+    return null;
+  };
+
+  const mockGetStatus = (event) =>
+    event.date && new Date(event.date) < new Date() ? 'past' : 'upcoming';
+
+  it('extracts event from res.data directly when no wrapper', () => {
+    const res = buildFetchResult(true, 200, { id: '1', title: 'Test', date: '2099-01-01' });
+    const event = extractEvent(res, mockGetStatus);
+    assert.strictEqual(event?.title, 'Test');
+    assert.strictEqual(event?.status, 'upcoming');
+  });
+
+  it('extracts event from res.data.data when wrapped', () => {
+    const res = buildFetchResult(true, 200, {
+      data: { id: '2', title: 'Wrapped', date: '2099-01-01' },
+    });
+    const event = extractEvent(res, mockGetStatus);
+    assert.strictEqual(event?.title, 'Wrapped');
+  });
+
+  it('returns null when response is not ok', () => {
+    const res = buildFetchResult(false, 404, { message: 'Not found' });
+    const event = extractEvent(res, mockGetStatus);
+    assert.strictEqual(event, null);
+  });
+
+  it('returns null when data is null', () => {
+    const res = buildFetchResult(true, 200, null);
+    const event = extractEvent(res, mockGetStatus);
+    assert.strictEqual(event, null);
+  });
+
+  it('sets status to "past" for events in the past', () => {
+    const res = buildFetchResult(true, 200, { id: '3', title: 'Past', date: '2020-01-01' });
+    const event = extractEvent(res, mockGetStatus);
+    assert.strictEqual(event?.status, 'past');
+  });
+
+  it('uses mockEvents fallback when API throws and id matches', () => {
+    const mockEvents = [{ id: '42', title: 'Fallback Event', date: '2099-06-01' }];
+    const eventId = '42';
+    const fallback = mockEvents.find((item) => String(item.id) === eventId);
+    assert.ok(fallback, 'Fallback lookup must find the event by id');
+    assert.strictEqual(fallback.title, 'Fallback Event');
+  });
+
+  it('returns null when API throws and id does not match any mock', () => {
+    const mockEvents = [{ id: '42', title: 'Fallback Event' }];
+    const eventId = '999';
+    const fallback = mockEvents.find((item) => String(item.id) === eventId);
+    assert.strictEqual(fallback, undefined, 'Fallback must return undefined for unknown id');
+  });
+});


### PR DESCRIPTION
Closes #3490

## Problem

`src/Pages/Events/EventDetailsPage.js` line 9 had `import eventsMockData from "./eventsMockData.json"`. This static import bundled all mock event JSON into the production build unconditionally — even though the file was only used as a fallback. Every user downloaded this payload regardless of whether the live API was available.

## Fix

- Removed the static `import eventsMockData from "./eventsMockData.json"` entirely
- Added a live API call to `/api/events/:id` as the primary data source
- Replaced the static mock import with `await import("./eventsMockData.json")` inside the catch block — dynamic imports are code-split by the bundler and only downloaded when actually needed (API failure scenario)
- Updated `src/Pages/Events/EventDetails.js` to consistently use the live API

## Test plan
- [ ] Navigate to an event detail page — event loads from live API
- [ ] Verify `eventsMockData.json` is no longer in the main bundle (check build output)
- [ ] Confirm lint passes: `npm run lint`
- [ ] Confirm build passes: `GENERATE_SOURCEMAP=false npm run build`