### PR TITLE
[Fix] Fix teardownCspReporting memory leak — removeEventListener received wrong reference

### DIFF
--- a/src/utils/cspReporting.js
+++ b/src/utils/cspReporting.js
@@ -74,16 +74,29 @@ function sendReport(report) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Module-scoped handler reference
+//
+// Storing the handler at module scope is the only way to guarantee that
+// initCspReporting() and teardownCspReporting() operate on the SAME function
+// object. addEventListener/removeEventListener use reference equality, so
+// passing a new anonymous function to removeEventListener silently fails to
+// remove the previously registered listener, causing a memory leak.
+// ---------------------------------------------------------------------------
+let _cspHandler = null;
+
 /**
  * Attaches the CSP violation listener to the document.
  *
  * Call this once from the application entry point (index.js) after the
- * DOM is ready.
+ * DOM is ready. Calling it again while already active is a no-op.
  */
 export function initCspReporting() {
   if (typeof document === 'undefined') return;
+  // Guard against double registration
+  if (_cspHandler) return;
 
-  document.addEventListener('securitypolicyviolation', (event) => {
+  _cspHandler = (event) => {
     const report = buildReport(event);
 
     if (isDev) {
@@ -99,16 +112,23 @@ export function initCspReporting() {
     }
 
     sendReport(report);
-  });
+  };
+
+  document.addEventListener('securitypolicyviolation', _cspHandler);
 }
 
 /**
  * Removes the CSP violation listener.
- * Useful in unit tests to reset between test cases.
+ *
+ * Uses the same `_cspHandler` reference that was registered in
+ * `initCspReporting()` so the listener is actually removed. Previously
+ * this passed a new anonymous function to removeEventListener, which
+ * silently did nothing and caused a memory leak on every test teardown.
  */
 export function teardownCspReporting() {
   if (typeof document === 'undefined') return;
-  // Re-adding without the original reference would leave the old listener
-  // attached; this is a best-effort teardown for test environments only.
-  document.removeEventListener('securitypolicyviolation', () => {});
+  if (!_cspHandler) return;
+
+  document.removeEventListener('securitypolicyviolation', _cspHandler);
+  _cspHandler = null;
 }


### PR DESCRIPTION
Closes #3742

## Problem

`src/utils/cspReporting.js` `teardownCspReporting()` called:

```js
document.removeEventListener('securitypolicyviolation', () => {});
```

`removeEventListener` uses **reference equality** to find the handler to remove. Passing a new anonymous `() => {}` never matches the handler registered in `initCspReporting()`. The listener was silently never removed, causing a memory leak on every test teardown and whenever the app attempted cleanup.

## Fix

- Introduced a module-scoped `_cspHandler` variable to hold the event listener reference
- `initCspReporting()` assigns to `_cspHandler` before calling `addEventListener`, and guards against double-registration
- `teardownCspReporting()` uses the same `_cspHandler` reference for `removeEventListener`, then nulls it
- Added no-op guard when `teardownCspReporting` is called before `initCspReporting`

## Test plan
- [ ] Call `initCspReporting()` then `teardownCspReporting()` — confirm listener is actually removed
- [ ] Call `teardownCspReporting()` without prior init — should not throw
- [ ] Confirm lint passes: `npm run lint`
- [ ] Confirm build passes: `GENERATE_SOURCEMAP=false npm run build`