### PR TITLE
[Feat] Add /health endpoint for uptime monitoring

### DIFF
--- a/src/Pages/HealthCheckPage.jsx
+++ b/src/Pages/HealthCheckPage.jsx
@@ -1,0 +1,72 @@
+/**
+ * HealthCheckPage
+ *
+ * Renders a minimal health-check response for uptime monitors.
+ * The page is accessible at /health and returns HTTP 200 (the default
+ * for any successfully rendered React page).
+ *
+ * Monitors can poll this URL to verify:
+ *   - The frontend bundle was served (JS executed)
+ *   - The React tree rendered without a fatal error
+ *   - Basic app metadata (version, build time)
+ */
+
+import React, { useEffect } from "react";
+
+const APP_VERSION = process.env.REACT_APP_VERSION || "1.0.0";
+const BUILD_TIME = process.env.REACT_APP_BUILD_TIME || new Date().toISOString();
+
+const HealthCheckPage = () => {
+  // Update the document title so monitor screenshots are unambiguous
+  useEffect(() => {
+    const prev = document.title;
+    document.title = "Eventra — Health Check";
+    return () => {
+      document.title = prev;
+    };
+  }, []);
+
+  const info = {
+    status: "ok",
+    app: "Eventra",
+    version: APP_VERSION,
+    buildTime: BUILD_TIME,
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV || "production",
+  };
+
+  return (
+    <main
+      role="main"
+      aria-label="Health check"
+      className="min-h-screen flex items-center justify-center bg-white dark:bg-gray-950 p-8"
+    >
+      <div className="max-w-lg w-full">
+        {/* Status indicator */}
+        <div className="flex items-center gap-3 mb-6">
+          <span
+            className="inline-block w-4 h-4 rounded-full bg-green-500 animate-pulse"
+            aria-hidden="true"
+          />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            System Operational
+          </h1>
+        </div>
+
+        {/* Machine-readable JSON block (used by simple text-match monitors) */}
+        <pre
+          aria-label="Health check details"
+          className="rounded-xl bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 p-6 text-sm font-mono text-gray-800 dark:text-gray-200 overflow-auto"
+        >
+          {JSON.stringify(info, null, 2)}
+        </pre>
+
+        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400 text-center">
+          This page is intended for automated uptime monitoring only.
+        </p>
+      </div>
+    </main>
+  );
+};
+
+export default HealthCheckPage;

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -34,6 +34,7 @@ const ApiDocs = lazy(() => import("../../Pages/ApiDocs"));
 const HelpCenter = lazy(() => import("../../Pages/HelpCenter"));
 const ContactUs = lazy(() => import("../../Pages/Contact/ContactUs"));
 const FeedbackPage = lazy(() => import("../../Pages/Feedback/FeedbackPage"));
+const HealthCheckPage = lazy(() => import("../../Pages/HealthCheckPage"));
 
 // ─── Auth-required page components ───────────────────────────────────────────
 // These are imported separately to make the intent explicit: they MUST be
@@ -45,6 +46,9 @@ const FloorPlanDesignerPage = lazy(() => import("../../Pages/Events/FloorPlanDes
 const MyCalendar = lazy(() => import("../../Pages/Calendar/MyCalendar"));
 
 export const getPublicRoutes = () => [
+  // Health check endpoint — must be first and require no auth so uptime
+  // monitors can poll it without a session cookie.
+  <Route key="/health" path="/health" element={<HealthCheckPage />} />,
   <Route key="/" path="/" element={<HomePage />} />,
   <Route key="/events" path="/events" element={<EventsPage />} />,
   <Route key="/event-details" path="/events/:eventId" element={<EventDetails />} />,


### PR DESCRIPTION
Closes #3768

## Problem

The frontend had no health-check URL. Uptime monitors (UptimeRobot, StatusCake, etc.) could not verify the app was responding without hitting the full home page and parsing HTML. A dedicated endpoint makes monitoring simpler and avoids false positives from home-page-specific errors.

## Fix

- Created `src/Pages/HealthCheckPage.jsx` — a minimal React page that renders app version, build time, and current timestamp in a `<pre>` block as JSON
- Added a `/health` route at the top of `src/components/routes/PublicRoutes.js` — no auth required, no layout wrapper, no Navbar overhead
- The page sets `document.title` to `"Eventra — Health Check"` for screenshot-based monitors
- Version is read from `REACT_APP_VERSION` env var (falls back to `"1.0.0"`)

## Test plan
- [ ] Navigate to `/health` — page renders with `"status": "ok"` JSON
- [ ] No authentication required — accessible when logged out
- [ ] Confirm lint passes: `npm run lint`
- [ ] Confirm build passes: `GENERATE_SOURCEMAP=false npm run build`