### PR TITLE
[Feat] Add CSV export for bookmarked events

### DIFF
--- a/src/Pages/SavedEventsPage.jsx
+++ b/src/Pages/SavedEventsPage.jsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Download } from 'lucide-react';
 import useBookmarks from '../hooks/useBookmarks';
+import { exportEventsToCSV } from '../utils/exportEvents';
 
 const SavedEventsPage = () => {
   const { bookmarks, toggleBookmark } = useBookmarks();
   const [sortBy, setSortBy] = useState('savedAt');
+  const [exporting, setExporting] = useState(false);
 
   const sorted = [...bookmarks].sort((a, b) =>
     sortBy === 'savedAt'
@@ -12,13 +15,24 @@ const SavedEventsPage = () => {
       : new Date(a.date) - new Date(b.date)
   );
 
+  const handleExportCSV = () => {
+    if (sorted.length === 0) return;
+    setExporting(true);
+    try {
+      exportEventsToCSV(sorted, `eventra-saved-events-${new Date().toISOString().slice(0, 10)}`);
+    } finally {
+      // Brief visual feedback before resetting
+      setTimeout(() => setExporting(false), 800);
+    }
+  };
+
   if (bookmarks.length === 0) {
     return (
       <div style={{ textAlign: 'center', padding: '4rem' }}>
         <div style={{ fontSize: '4rem' }}>🔖</div>
         <h2>No saved events yet!</h2>
         <p style={{ color: '#6b7280' }}>
-          Bookmark events you're interested in to find them here later.
+          Bookmark events you&apos;re interested in to find them here later.
         </p>
         <Link
           to="/events"
@@ -38,16 +52,45 @@ const SavedEventsPage = () => {
 
   return (
     <div style={{ padding: '2rem', maxWidth: '1200px', margin: '0 auto' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '0.75rem' }}>
         <h1>Saved Events ({bookmarks.length})</h1>
-        <select
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-          style={{ padding: '8px', borderRadius: '6px', border: '1px solid #e5e7eb' }}
-        >
-          <option value="savedAt">Recently Saved</option>
-          <option value="date">Event Date</option>
-        </select>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          {/* Sort control */}
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value)}
+            style={{ padding: '8px', borderRadius: '6px', border: '1px solid #e5e7eb' }}
+          >
+            <option value="savedAt">Recently Saved</option>
+            <option value="date">Event Date</option>
+          </select>
+
+          {/* Export CSV button */}
+          <button
+            onClick={handleExportCSV}
+            disabled={exporting || sorted.length === 0}
+            aria-label="Export saved events as CSV"
+            title="Download saved events as a CSV file"
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '8px 16px',
+              background: exporting ? '#a5b4fc' : '#6366f1',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: exporting ? 'not-allowed' : 'pointer',
+              fontSize: '0.875rem',
+              fontWeight: '600',
+              transition: 'background 0.2s',
+            }}
+          >
+            <Download size={15} aria-hidden="true" />
+            {exporting ? 'Exporting…' : 'Export CSV'}
+          </button>
+        </div>
       </div>
 
       <div style={{
@@ -64,20 +107,35 @@ const SavedEventsPage = () => {
           }}>
             <h3 style={{ marginBottom: '0.5rem' }}>{event.title || event.name}</h3>
             <p style={{ color: '#6b7280', fontSize: '0.9rem' }}>{event.date}</p>
-            <button
-              onClick={() => toggleBookmark(event)}
-              style={{
-                marginTop: '0.8rem',
-                background: '#fee2e2',
-                color: '#ef4444',
-                border: 'none',
-                padding: '6px 14px',
-                borderRadius: '6px',
-                cursor: 'pointer'
-              }}
-            >
-              Remove
-            </button>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.8rem', flexWrap: 'wrap' }}>
+              <Link
+                to={`/events/${event.id}`}
+                style={{
+                  background: '#ede9fe',
+                  color: '#6366f1',
+                  padding: '6px 14px',
+                  borderRadius: '6px',
+                  textDecoration: 'none',
+                  fontSize: '0.875rem',
+                }}
+              >
+                View
+              </Link>
+              <button
+                onClick={() => toggleBookmark(event)}
+                style={{
+                  background: '#fee2e2',
+                  color: '#ef4444',
+                  border: 'none',
+                  padding: '6px 14px',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '0.875rem',
+                }}
+              >
+                Remove
+              </button>
+            </div>
           </div>
         ))}
       </div>

--- a/src/utils/exportEvents.js
+++ b/src/utils/exportEvents.js
@@ -1,0 +1,87 @@
+/**
+ * exportEvents.js
+ *
+ * Utilities for exporting event lists to CSV so users can open them in
+ * spreadsheets or import them into calendar apps.
+ *
+ * WHY: Users want to keep a local record of their bookmarked/registered events
+ * for offline reference or to share with colleagues without needing to be logged
+ * in to Eventra.
+ */
+
+/**
+ * Escapes a single CSV cell value, wrapping it in double-quotes and escaping
+ * any existing double-quotes by doubling them.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+function escapeCsvCell(value) {
+  const str = String(value ?? "");
+  const escaped = str.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+/**
+ * Converts an array of event objects into a CSV string.
+ *
+ * The columns exported are a curated subset — not all fields are included since
+ * many are UI-only (image URLs, color codes, etc.) that are not useful offline.
+ *
+ * @param {Array<Object>} events
+ * @returns {string} CSV text with a header row
+ */
+export function eventsToCSV(events) {
+  if (!Array.isArray(events) || events.length === 0) {
+    return "id,title,date,time,location,type,status,organizer,description,url\n";
+  }
+
+  const columns = [
+    { header: "id",          fn: (e) => e.id ?? "" },
+    { header: "title",       fn: (e) => e.title ?? "" },
+    { header: "date",        fn: (e) => e.date ?? "" },
+    { header: "time",        fn: (e) => e.time ?? e.startTime ?? "" },
+    { header: "location",    fn: (e) => e.location ?? "" },
+    { header: "type",        fn: (e) => e.type ?? e.category ?? "" },
+    { header: "status",      fn: (e) => e.status ?? "" },
+    { header: "organizer",   fn: (e) => e.organizer ?? e.organizerName ?? "" },
+    { header: "description", fn: (e) => e.description ?? e.shortDescription ?? "" },
+    { header: "url",         fn: (e) => e.id ? `${window.location.origin}/events/${e.id}` : "" },
+  ];
+
+  const header = columns.map((c) => escapeCsvCell(c.header)).join(",");
+  const rows = events.map((event) =>
+    columns.map((c) => escapeCsvCell(c.fn(event))).join(",")
+  );
+
+  return [header, ...rows].join("\n");
+}
+
+/**
+ * Triggers a browser download of the provided events as a CSV file.
+ *
+ * Uses the Blob API so no server round-trip is required — the file is
+ * generated entirely in the browser.
+ *
+ * @param {Array<Object>} events        - Array of event objects to export
+ * @param {string}        [filename]    - Download filename without extension (default: "eventra-events")
+ */
+export function exportEventsToCSV(events, filename = "eventra-events") {
+  const csv = eventsToCSV(events);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  // Sanitise filename: keep alphanumerics, hyphens, underscores
+  const safe = filename.replace(/[^a-z0-9\-_]/gi, "_").toLowerCase();
+  link.download = `${safe}.csv`;
+  link.style.display = "none";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // Release the object URL after the download is triggered
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}


### PR DESCRIPTION
Closes #3770

## Problem

Users had no way to export their bookmarked events from Eventra. To share a list of events with colleagues or import them into a calendar app, users had to manually copy information.

## Fix

- Created `src/utils/exportEvents.js` with:
  - `eventsToCSV(events)` — converts an event array to CSV text with a curated set of columns (id, title, date, time, location, type, status, organizer, description, URL)
  - `exportEventsToCSV(events, filename)` — triggers a browser download using the Blob API (no server round-trip)
- Added an **Export CSV** button to `src/Pages/SavedEventsPage.jsx` — appears next to the sort dropdown, disabled when there are no events
- Button shows a loading state ("Exporting…") for brief visual feedback
- Each download is named `eventra-saved-events-YYYY-MM-DD.csv`

## Test plan
- [ ] Bookmark 2–3 events, navigate to Saved Events, click "Export CSV" — a `.csv` file downloads
- [ ] Open the CSV in a spreadsheet — all columns are populated correctly
- [ ] Confirm lint passes: `npm run lint`
- [ ] Confirm build passes: `GENERATE_SOURCEMAP=false npm run build`