### PR TITLE
fix: resolve 30-second session dead zone in getTokenTTL

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,4 +1,3 @@
-
 import { safeJsonParse } from "./safeJsonParse.js";
 
 /** Grace period (in seconds) to account for clock skew between browser and server. */
@@ -45,5 +44,8 @@ export function isTokenValid(token) {
 export function getTokenTTL(token) {
   const payload = decodeJwtPayload(token);
   if (!payload || typeof payload.exp !== "number") return -1;
-  return payload.exp - Math.floor(Date.now() / 1000);
+  
+  // 🔥 FIX: Apply the CLOCK_SKEW_BUFFER so the TTL matches the expiration logic.
+  // This prevents the background refresh timer from firing too late.
+  return (payload.exp - CLOCK_SKEW_BUFFER) - Math.floor(Date.now() / 1000);
 }


### PR DESCRIPTION
## 🚀 Description
Fixes a race condition between token validation and token refresh timing in `src/utils/auth.js`. 

Previously, `isTokenExpired` proactively invalidated the JWT using a 30-second `CLOCK_SKEW_BUFFER`, but `getTokenTTL` returned the raw time-to-live without accounting for this buffer. This caused background refresh timers to schedule themselves 30 seconds too late, creating a dead zone where the user's token was treated as expired by API interceptors before the refresh cycle could execute.

**Changes:**
- Updated `getTokenTTL` to subtract `CLOCK_SKEW_BUFFER` from `payload.exp`.
- Ensures background refresh timers will now reliably fire before `isTokenExpired` evaluates to true.

Fixes #3727 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Authentication / Security improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code