### PR TITLE
fix: separate parsing from callback execution to prevent swallowed UI errors in useRealTimeConnection

### DIFF
--- a/src/hooks/useRealTimeConnection.js
+++ b/src/hooks/useRealTimeConnection.js
@@ -79,13 +79,18 @@ export default function useRealTimeConnection(path, { onMessage, enabled = true 
     };
 
     source.onmessage = (evt) => {
+      let payload = evt.data;
+      
       try {
-        const data = JSON.parse(evt.data);
-        onMessageRef.current?.(data, evt.type);
+        payload = JSON.parse(evt.data);
       } catch {
-        // Forward raw string if JSON parsing fails
-        onMessageRef.current?.(evt.data, evt.type);
+        // Forward raw string if JSON parsing fails (payload remains evt.data)
       }
+      
+      // 🔥 FIX: Execute the callback completely outside the try/catch block.
+      // This ensures if the React UI throws an error, it doesn't get swallowed
+      // by the catch block above, preventing a double-execution bug.
+      onMessageRef.current?.(payload, evt.type);
     };
 
     source.onerror = () => {


### PR DESCRIPTION
## 🚀 Description
Fixes a silent logic bug and double-execution trap in the `useRealTimeConnection` hook's message handler. 

Previously, both the `JSON.parse()` operation and the consumer's `onMessage` execution were wrapped in the exact same `try/catch` block. If the JSON was valid but the frontend UI component crashed during the callback execution, the `catch` block mistakenly swallowed the error, hid it from the console, and then fired the callback a second time with raw, unparsed string data.

**Changes:**
- Refactored `source.onmessage` to handle `JSON.parse` safely in isolation.
- Moved `onMessageRef.current?.()` strictly outside the `try/catch` boundary.
- Component-level exceptions will now correctly bubble up without triggering fallback execution logic.

Fixes #3731 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Architectural / Error-handling improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code