### PR TITLE
fix: attach focus trap listener to document to prevent focus escape bugs

### DIFF
--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -43,10 +43,23 @@ export function useFocusTrap(isActive) {
       const focusableElements = Array.from(
         container.querySelectorAll(FOCUSABLE_SELECTORS)
       );
-      if (focusableElements.length === 0) return;
+      
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        container.focus();
+        return;
+      }
 
       const first = focusableElements[0];
       const last = focusableElements[focusableElements.length - 1];
+
+      // 🔥 FIX: If focus somehow escapes the container (e.g. user clicked the background),
+      // aggressively pull it back into the trap on the next Tab press.
+      if (!container.contains(document.activeElement)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
 
       if (e.shiftKey) {
         // Shift+Tab: wrap from first to last
@@ -63,10 +76,12 @@ export function useFocusTrap(isActive) {
       }
     };
 
-    container.addEventListener('keydown', handleKeyDown);
+    // 🔥 FIX: Listen on 'document', not 'container'. If focus drops to the body,
+    // container.addEventListener will never catch the Tab key because it doesn't bubble!
+    document.addEventListener('keydown', handleKeyDown);
 
     return () => {
-      container.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keydown', handleKeyDown);
       // Return focus to trigger element when modal closes
       if (previousFocusRef.current && previousFocusRef.current.focus) {
         previousFocusRef.current.focus();


### PR DESCRIPTION
## 🚀 Description
Fixes a critical accessibility flaw where the focus trap could easily be broken. Previously, the `keydown` event listener was attached to the modal `container`. If a user clicked anywhere outside the container (like a backdrop or browser UI), focus would drop to `document.body`. Subsequent `Tab` key presses failed to bubble back to the container, allowing the user to tab freely through the underlying page.

**Changes:**
- Migrated `addEventListener` from the `container` ref to the global `document`.
- Added a safety check inside `handleKeyDown`: if `!container.contains(document.activeElement)`, the hook intercepts the Tab press and forces focus back to the first element in the modal.

Fixes #3733 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility (A11y) improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code