### PR TITLE
fix: respect user-provided AbortSignal in fetchWithTimeout to prevent memory leaks

### DIFF
--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -22,10 +22,21 @@ export const fetchWithTimeout = async (
     controller.abort();
   }, timeout);
 
+  // 🔥 FIX: Link the user's custom abort signal to our internal controller.
+  const handleUserAbort = () => controller.abort();
+
+  if (options.signal) {
+    if (options.signal.aborted) {
+      controller.abort();
+    } else {
+      options.signal.addEventListener("abort", handleUserAbort);
+    }
+  }
+
   try {
     const response = await fetch(url, {
       ...options,
-      signal: controller.signal,
+      signal: controller.signal, // This now responds to BOTH the timeout and the user's unmount signal
     });
 
     let data = null;
@@ -50,10 +61,10 @@ export const fetchWithTimeout = async (
     };
   } catch (error) {
     if (error.name === "AbortError") {
-      logger.error("[fetchWithTimeout] Request timeout:", url);
+      logger.error("[fetchWithTimeout] Request aborted or timed out:", url);
 
       throw new FetchError(
-        `Request timed out after ${timeout}ms`
+        `Request timed out after ${timeout}ms or was manually aborted`
       );
     }
 
@@ -62,5 +73,9 @@ export const fetchWithTimeout = async (
     throw error;
   } finally {
     clearTimeout(timeoutId);
+    // 🔥 FIX: Always clean up the event listener to prevent memory leaks
+    if (options.signal) {
+      options.signal.removeEventListener("abort", handleUserAbort);
+    }
   }
 };


### PR DESCRIPTION
## 🚀 Description
Fixes a network memory leak where `fetchWithTimeout` was completely overriding the user-provided `AbortController.signal`. 

Previously, if a component unmounted while a request was fetching, the component would trigger an abort, but the `fetch` call ignored it because its `signal` was hardcoded to the internal timeout controller. This caused the browser to finish downloading the data in the background, leading to wasted bandwidth and React "state update on an unmounted component" errors.

**Changes:**
- Added a listener that binds `options.signal` to the internal `controller.abort()`.
- The network request will now correctly terminate if *either* the timeout is reached OR the React component unmounts.
- Ensured the event listener is cleanly removed in the `finally` block.

Fixes #3743 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Network optimization / Memory leak prevention

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code