### PR TITLE
fix: suppress session-expired toast for anonymous guest users

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -54,8 +54,15 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   const clearExpiredSession = useCallback(() => {
+    // 🔥 FIX: Check if a user was actually logged in before blasting them with an "Expired" toast.
+    // Anonymous users (who trigger a 401 on mount) shouldn't see this.
+    const hadPreviousSession = !!localStorage.getItem("user") || !!sessionStorage.getItem("token");
+
     console.warn("[AuthContext] Session expiration detected. Clearing session state immediately.");
     clearSession();
+
+    // If they were never logged in, this is just a guest pinging the API. Silent exit.
+    if (!hadPreviousSession) return;
 
     if (expiryToastShownRef.current) {
       return;


### PR DESCRIPTION
## 🚀 Description
Fixes a confusing UX bug where anonymous users were greeted with a "Session expired" toast notification on their first visit to the application.

Previously, `clearExpiredSession` was called automatically when the application performed its initial `GET /profile` check and received a 401 (as expected for guest users). This triggered a toast notification regardless of whether an active session actually existed.

**Changes:**
- Added a `hadPreviousSession` check within `clearExpiredSession` to verify if the user had any stored session data before triggering the UI notification.
- Guests now receive a silent 401 response without the misleading error message.

Fixes #3799 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code