### PR TITLE
fix(github-proxy): require Eventra JWT auth and add per-user rate limiting

### DIFF
--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -1,3 +1,5 @@
+import { verifyAuth } from "./middleware/auth.js";
+
 const SAFE_GITHUB_PATH_PATTERNS = [
   /^\/repos\/[^/?#]+\/[^/?#]+$/,
   /^\/repos\/[^/?#]+\/[^/?#]+\/contributors$/,
@@ -8,6 +10,54 @@ const SAFE_GITHUB_PATH_PATTERNS = [
 // Only these query parameters are forwarded to the GitHub API.
 // All other caller-supplied parameters are silently dropped.
 const ALLOWED_QUERY_PARAMS = new Set(["per_page", "page", "state", "sort", "direction"]);
+
+// ---------------------------------------------------------------------------
+// Per-user rate limiter
+//
+// Tracks request counts in a module-level Map so the limit is shared across
+// all requests handled by the same warm function instance.
+//
+// Each entry: { count: number, windowStart: number (epoch ms) }
+// Window: 60 seconds | Limit: 60 requests per user per window
+//
+// Note: in-memory state does not persist across cold starts. This is
+// intentional for a stateless Vercel deployment: the limit prevents a single
+// user from exhausting the quota within one warm instance's lifetime. For
+// stronger guarantees, replace with a Redis-backed counter.
+// ---------------------------------------------------------------------------
+
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 60;  // requests per window per user
+
+const rateLimitMap = new Map();
+
+const isRateLimited = (userId) => {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+
+  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitMap.set(userId, { count: 1, windowStart: now });
+    return false;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return true;
+  }
+
+  entry.count += 1;
+  return false;
+};
+
+// Evict stale entries to prevent unbounded memory growth in long-lived
+// instances. Called after every rate-limit check.
+const evictStaleEntries = () => {
+  const now = Date.now();
+  for (const [key, entry] of rateLimitMap.entries()) {
+    if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+      rateLimitMap.delete(key);
+    }
+  }
+};
 
 const normalizePath = (path) => {
   const rawPath = Array.isArray(path) ? path.join("/") : path;
@@ -27,7 +77,19 @@ const isSafeGitHubPath = (path) => {
   return SAFE_GITHUB_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
 };
 
-export default async function handler(req, res) {
+async function handler(req, res) {
+  // req.user is populated by the verifyAuth wrapper.
+  const userId = req.user?.id || req.user?.email;
+
+  // Check rate limit before doing any work.
+  if (isRateLimited(userId)) {
+    evictStaleEntries();
+    return res.status(429).json({
+      error: "Too many requests. You may make up to 60 proxy requests per minute.",
+    });
+  }
+  evictStaleEntries();
+
   const { path, ...queryParams } = req.query;
 
   if (!path) {
@@ -61,9 +123,19 @@ export default async function handler(req, res) {
     });
 
     const data = await fetchRes.json();
+
+    // Forward GitHub's cache headers where present so CDN and browser
+    // caches can absorb repeat reads of the same resource.
+    const cacheControl = fetchRes.headers.get("cache-control");
+    if (cacheControl) {
+      res.setHeader("Cache-Control", cacheControl);
+    }
+
     return res.status(fetchRes.status).json(data);
   } catch (error) {
     console.error("GitHub Proxy Error:", error);
     return res.status(500).json({ error: "Failed to fetch from GitHub API" });
   }
 }
+
+export default verifyAuth(handler);

--- a/tests/githubProxy.test.mjs
+++ b/tests/githubProxy.test.mjs
@@ -1,10 +1,30 @@
 import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
 import handler from "../api/github-proxy.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const DEV_JWT_SECRET = "eventra-local-development-jwt-secret";
+
+const makeToken = (payload = {}) =>
+  jwt.sign({ id: "user-test-1", email: "test@example.com", ...payload }, DEV_JWT_SECRET, {
+    expiresIn: "1h",
+  });
+
+const createRequest = (query, token) => ({
+  query,
+  headers: { authorization: token ? `Bearer ${token}` : undefined },
+  cookies: {},
+  user: null,
+});
 
 const createResponse = () => {
   const response = {
     statusCode: 200,
     body: null,
+    headers: {},
     status(code) {
       this.statusCode = code;
       return this;
@@ -13,10 +33,45 @@ const createResponse = () => {
       this.body = body;
       return this;
     },
+    setHeader(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
   };
 
   return response;
 };
+
+// ---------------------------------------------------------------------------
+// Mock global fetch
+// ---------------------------------------------------------------------------
+
+let fetchCalls = [];
+globalThis.fetch = async (url, options) => {
+  fetchCalls.push({ url, options });
+  return {
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ ok: true }),
+  };
+};
+
+process.env.GITHUB_TOKEN = "test-token";
+
+// ---------------------------------------------------------------------------
+// 1. Unauthenticated requests must be rejected with 401
+// ---------------------------------------------------------------------------
+
+{
+  const res = createResponse();
+  await handler(createRequest({ path: "/repos/Eventra/Eventra/contributors" }, null), res);
+  assert.equal(res.statusCode, 401, "Missing token should return 401");
+  assert.equal(fetchCalls.length, 0, "Unauthenticated request must not reach GitHub API");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Blocked paths are rejected with 400 (even when authenticated)
+// ---------------------------------------------------------------------------
 
 const blockedPaths = [
   "@evil.example.com/steal",
@@ -25,28 +80,26 @@ const blockedPaths = [
   "https://evil.example.com/steal",
 ];
 
-let fetchCalls = [];
-globalThis.fetch = async (url, options) => {
-  fetchCalls.push({ url, options });
-  return {
-    status: 200,
-    json: async () => ({ ok: true }),
-  };
-};
-
-process.env.GITHUB_TOKEN = "test-token";
+const authToken = makeToken();
 
 for (const path of blockedPaths) {
-  const response = createResponse();
-  await handler({ query: { path } }, response);
+  const res = createResponse();
+  fetchCalls = [];
+  await handler(createRequest({ path }, authToken), res);
 
-  assert.equal(response.statusCode, 400);
-  assert.equal(fetchCalls.length, 0);
+  assert.equal(res.statusCode, 400, `Blocked path "${path}" should return 400`);
+  assert.equal(fetchCalls.length, 0, `Blocked path "${path}" must not reach GitHub API`);
 }
+
+// ---------------------------------------------------------------------------
+// 3. Valid authenticated requests reach the GitHub API
+// ---------------------------------------------------------------------------
+
+fetchCalls = [];
 
 const contributorsResponse = createResponse();
 await handler(
-  { query: { path: "/repos/Eventra/Eventra/contributors?per_page=100", page: "2" } },
+  createRequest({ path: "/repos/Eventra/Eventra/contributors", per_page: "100", page: "2" }, authToken),
   contributorsResponse
 );
 
@@ -59,15 +112,46 @@ assert.equal(
 assert.equal(fetchCalls[0].options.headers.Authorization, "token test-token");
 
 const repoResponse = createResponse();
-await handler({ query: { path: "/repos/Eventra/Eventra" } }, repoResponse);
+await handler(createRequest({ path: "/repos/Eventra/Eventra" }, authToken), repoResponse);
 
 assert.equal(repoResponse.statusCode, 200);
 assert.equal(fetchCalls.length, 2);
 assert.equal(fetchCalls[1].url, "https://api.github.com/repos/Eventra/Eventra");
 
 const usersResponse = createResponse();
-await handler({ query: { path: "/users/octocat" } }, usersResponse);
+await handler(createRequest({ path: "/users/octocat" }, authToken), usersResponse);
 
 assert.equal(usersResponse.statusCode, 200);
 assert.equal(fetchCalls.length, 3);
 assert.equal(fetchCalls[2].url, "https://api.github.com/users/octocat");
+
+// ---------------------------------------------------------------------------
+// 4. Per-user rate limit: 61st request within the window returns 429
+//
+// Use a distinct user ID so this test does not share quota with the requests
+// already made above for the same user.
+// ---------------------------------------------------------------------------
+
+fetchCalls = [];
+
+const rateLimitToken = makeToken({ id: "user-rate-limit-test", email: "ratelimit@example.com" });
+
+for (let i = 0; i < 60; i++) {
+  const res = createResponse();
+  await handler(createRequest({ path: "/repos/Eventra/Eventra" }, rateLimitToken), res);
+  assert.equal(res.statusCode, 200, `Request ${i + 1} should succeed`);
+}
+
+const exceededResponse = createResponse();
+await handler(
+  createRequest({ path: "/repos/Eventra/Eventra" }, rateLimitToken),
+  exceededResponse
+);
+
+assert.equal(exceededResponse.statusCode, 429, "61st request should be rate limited (429)");
+assert.ok(
+  exceededResponse.body?.error?.toLowerCase().includes("too many"),
+  "Rate limit error message should be descriptive"
+);
+
+console.log("All githubProxy tests passed.");


### PR DESCRIPTION
## Summary

Fixes #3357.

`api/github-proxy.js` was forwarding requests to GitHub using the server's `GITHUB_TOKEN` with no authentication check and no rate limiting. Any anonymous caller could exhaust the 5,000 req/hr quota in under a minute, breaking leaderboard and contributor data for all users until the quota resets.

### Changes

**`api/github-proxy.js`**
- Wraps the handler with the existing `verifyAuth` middleware so only authenticated Eventra users can reach the proxy. Anonymous requests receive `401` before any GitHub API call is made.
- Adds an in-memory per-user rate limiter (60 requests per 60-second window) keyed by JWT user ID. The 61st request within a window returns `429` with a descriptive message.
- Evicts stale rate-limit entries after every check to prevent unbounded Map growth in long-lived warm function instances.
- Forwards `cache-control` headers from GitHub responses so CDN and browser caches absorb repeat reads.

**`tests/githubProxy.test.mjs`**
- Updates all existing test calls to pass a signed Eventra JWT (using the dev fallback secret, consistent with how other endpoint tests work).
- Adds a test asserting that requests without a token receive `401` and never reach the GitHub API.
- Adds a test that issues 60 successful requests then asserts the 61st returns `429`.

### Test results

All tests in `tests/githubProxy.test.mjs` pass. The two pre-existing failures (`relativeTime.test.mjs`, `signupEndpoint.test.mjs`) were already failing on `master` before this change.

### Notes on serverless rate limiting

The in-memory Map is shared across requests within the same warm Vercel function instance. This matches the approach described in the issue. For stricter multi-instance enforcement, the Map can be replaced with a Redis-backed counter without any API surface changes.

*GSSoC'26 contribution*