### PR TITLE
Add lint-staged pre-commit hooks for automated code quality

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,15 @@
       "last 1 safari version"
     ]
   },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix --max-warnings=0",
+      "prettier --write"
+    ],
+    "*.{css,json,md}": [
+      "prettier --write"
+    ]
+  },
   "devDependencies": {
     "@playwright/test": "1.60.0",
     "@storybook/addon-a11y": "^10.4.1",
@@ -103,6 +112,7 @@
     "autoprefixer": "^10.4.21",
     "bcryptjs": "3.0.3",
     "cross-env": "^10.1.0",
+    "lint-staged": "^15.5.1",
     "eslint-plugin-storybook": "10.4.1",
     "jsonwebtoken": "9.0.3",
     "postcss": "8.5.15",


### PR DESCRIPTION
## Description

Adds lint-staged pre-commit configuration to the existing husky setup. The .husky/pre-commit hook already calls 
px lint-staged, but lint-staged was never installed as a dependency and had no configuration, causing the pre-commit hook to fail silently.

## Related Issue

Closes #3812

## Changes Made

- Added lint-staged config to package.json that runs ESLint fix + Prettier format on staged JS/JSX/TS/TSX/CSS/JSON/MD files
- Added lint-staged as a devDependency in package.json

## Testing

- Verified .husky/pre-commit hook exists and calls 
px lint-staged
- lint-staged now resolves to the installed dependency
- Configuration targets the correct file extensions used in the project

## Type of Change

- [x] DevOps improvement (pre-commit quality gates)

## Checklist

- [x] Existing .husky/pre-commit hook now has a working dependency
- [x] Code quality enforced before every commit
- [x] No breaking changes