### PR TITLE
fix: convert imperative DOM opacity mutation to declarative React sta…

### DIFF
--- a/src/components/common/ConfettiCanvas.jsx
+++ b/src/components/common/ConfettiCanvas.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 const ConfettiCanvas = ({ 
   particleCount = 150, 
@@ -6,6 +6,7 @@ const ConfettiCanvas = ({
   colors = ["#6366f1", "#a855f7", "#ec4899", "#10b981", "#3b82f6", "#f59e0b"] 
 }) => {
   const canvasRef = useRef(null);
+  const [opacity, setOpacity] = useState(1);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -69,10 +70,7 @@ const ConfettiCanvas = ({
     draw();
 
     const timer = setTimeout(() => {
-      if (canvas) {
-        canvas.style.opacity = "0";
-        canvas.style.transition = "opacity 1.5s ease-out";
-      }
+      setOpacity(0);
     }, duration);
 
     return () => {
@@ -86,8 +84,8 @@ const ConfettiCanvas = ({
   return (
     <canvas
       ref={canvasRef}
-      className="fixed inset-0 pointer-events-none z-[9999]"
-      style={{ mixBlendMode: "screen" }}
+      className="fixed inset-0 pointer-events-none z-[9999] transition-opacity duration-[1500ms] ease-out"
+      style={{ mixBlendMode: "screen", opacity }}
     />
   );
 };


### PR DESCRIPTION
## Description
This PR resolves an architectural anti-pattern in `ConfettiCanvas.jsx` where the component was imperatively mutating the DOM, which conflicts with React's reconciliation engine.
Closes #3605 
### The Issue
The component ran a `setTimeout` that directly mutated the DOM using `canvas.style.opacity = "0"`. Because this bypasses React's virtual DOM entirely, if a parent component triggered a re-render while this animation was happening or immediately after, React's reconciliation engine would conflict with the manual style injection, potentially causing visual stuttering or throwing a DOM mismatch warning.

### The Fix
- Refactored `src/components/common/ConfettiCanvas.jsx` to use a `useState` hook to track the `opacity` declaratively.
- Replaced the manual `.style` assignments with standard Tailwind transition utility classes (`transition-opacity duration-[1500ms] ease-out`).
- The component now correctly hands over style control to React's lifecycle, eliminating any risk of DOM mutation conflicts.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (React state optimization)
