### PR TITLE
fix: add UI error toast feedback to prevent silent failures during ti…

### DIFF
--- a/src/components/common/QRTicket/useTicketDownload.js
+++ b/src/components/common/QRTicket/useTicketDownload.js
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from "react";
+import toast from "react-hot-toast";
 
 export function useTicketDownload(ticketRef, ticketId = "ticket") {
   const [downloading, setDownloading] = useState(false);
@@ -37,6 +38,7 @@ export function useTicketDownload(ticketRef, ticketId = "ticket") {
       link.click();
     } catch (err) {
       console.error("[QRTicket] PNG download failed:", err);
+      toast.error("Failed to download PNG. Please try again.");
     } finally {
       setDownloading(false);
     }
@@ -66,6 +68,7 @@ export function useTicketDownload(ticketRef, ticketId = "ticket") {
       pdf.save(`eventra-ticket-${ticketId}.pdf`);
     } catch (err) {
       console.error("[QRTicket] PDF download failed:", err);
+      toast.error("Failed to download PDF. Please try again.");
     } finally {
       setDownloading(false);
     }


### PR DESCRIPTION
## Description
This PR resolves a poor UX bug in `useTicketDownload.js` where ticket generation failures were silently failing without informing the user.
Closes #3608 
### The Issue
When a user clicks to download a ticket as a PDF or PNG, the hook uses `html2canvas` to parse the DOM. This process is prone to occasional failures (e.g., cross-origin image constraints, missing refs, or memory limits on mobile). When a failure occurred, the `catch` block merely executed `console.error` and immediately reset the `downloading` state to false. This meant the user clicked the download button, saw a brief loading state, and then nothing happened, providing zero UI feedback and causing severe UX frustration.

### The Fix
- Imported `react-hot-toast` into `src/components/common/QRTicket/useTicketDownload.js`.
- Added `toast.error()` notifications to the `catch` blocks of both `downloadPNG` and `downloadPDF`.
- Users are now properly notified with a clean UI toast if their ticket generation fails, rather than experiencing a silent failure.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
