### PR TITLE
[Build Fix 2] Fix duplicate React imports in EventDetails.js

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -1,6 +1,5 @@
 import "./EventDetails.print.css";
-import React, { useEffect, useState, useMemo } from "react";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { Helmet } from "react-helmet-async";
 import { sanitizeMarkdown } from "../../utils/sanitizeHtml";
 import { toast } from "react-toastify";


### PR DESCRIPTION
## Description

Merged two duplicate React import statements into a single import.

## Problem

The file had two separate imports from 'react':
- import React, { useEffect, useState, useMemo } from 'react'
- import React, { useEffect, useState, useCallback } from 'react'

These caused parser failures during build and ESLint errors.

## Fix

Combined into a single import:
- import React, { useEffect, useState, useMemo, useCallback } from 'react'

All four hooks are used in the file (verified).

## Related Issue

Closes #3830

## Checklist

- [x] No duplicate React imports remain
- [x] ESLint passes for EventDetails.js
- [x] Only the required file is modified