### PR TITLE
[Build Fix 5] Fix duplicate loading declaration in EventDetailsPage.js

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -24,8 +24,6 @@ const EventDetailsPage = () => {
   const shareUrl = event ? `${window.location.origin}/events/${event.id}` : "";
   const shareText = event ? `Check out this event: ${event.title}` : "";
 
-  const [loading, setLoading] = useState(true);
-  const [event, setEvent] = useState(null);
   const shareLinks = event
     ? {
         twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,


### PR DESCRIPTION
## Description

Removed duplicate const declarations for loading and event in EventDetailsPage.js.

## Problem

Lines 27-28 redeclared const [loading, setLoading] and const [event, setEvent] which were already declared on lines 19-20. This caused ESLint parsing errors and potential runtime conflicts.

## Fix

Removed the duplicate declarations. The shareLinks block that followed them is left in place since it uses the already-declared event variable.

## Related Issue

Closes #3833