### PR TITLE
[Build Fix 1] Fix unterminated JSX parsing error in NavbarLinks.jsx

### DIFF
--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -8,7 +8,7 @@ import React, {
   useCallback,
   useMemo,
 } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import { 
   Moon, Sun, Search, Bell, User, ChevronDown, 
   Plus, Settings, LogOut, HelpCircle, Globe, 
@@ -28,9 +28,6 @@ import { useScrollProgress } from "../../hooks/useScrollProgress"; // custom hoo
 // is code-split and does NOT conflict with the lazy import in App.jsx,
 // removing the "dynamically imported but also statically imported" Rollup warning.
 const KeyboardShortcutsModal = lazy(() => import("../common/KeyboardShortcutsModal"));
-import React, { useEffect, useRef, useState } from "react";
-import { NavLink, useLocation } from "react-router-dom";
-import { ChevronDown } from "lucide-react";
 import { NAV_ITEMS } from "./constants/navItems";
 
 const NavbarLinks = ({ vertical = false, onClick }) => {
@@ -176,6 +173,19 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
           );
         }
 
+        return (
+          <NavLink
+            key={item.name}
+            to={item.href}
+            onClick={onClick}
+            className={({ isActive }) => getNavLinkClasses(isActive)}
+          >
+            {item.icon}
+            <span>{item.name}</span>
+          </NavLink>
+        );
+      })}
+
       {/* Keyboard Shortcuts Modal — loaded lazily to avoid bundling upfront */}
       <Suspense fallback={null}>
         <KeyboardShortcutsModal
@@ -190,19 +200,6 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
           ]}
         />
       </Suspense>
-    </>
-        return (
-          <NavLink
-            key={item.name}
-            to={item.href}
-            onClick={onClick}
-            className={({ isActive }) => getNavLinkClasses(isActive)}
-          >
-            {item.icon}
-            <span>{item.name}</span>
-          </NavLink>
-        );
-      })}
     </nav>
   );
 };


### PR DESCRIPTION
## Description

Fixed a build-breaking unterminated JSX parsing error in NavbarLinks.jsx.

## Problem

The map callback for NAV_ITEMS only had a return for items with subItems (dropdown menus). Items without subItems fell through to nothing, and misplaced JSX (KeyboardShortcutsModal) inside the map callback caused Vite to fail with 'Unterminated regular expression'.

## Fix

1. Added the missing return for plain nav items (non-subItems) inside the map callback
2. Moved KeyboardShortcutsModal outside the map callback, correctly placed as a sibling to the mapped links
3. Removed duplicate imports: React hooks, ChevronDown, NavLink, useLocation

## Severity

**This is a critical build fix.** The error completely blocks Vite production builds, preventing deployment to Vercel/Netlify/Cloudflare. The issue was pre-labeled as level:critical - please ensure this tag is applied.

## Related Issue

Closes #3829

## Checklist

- [x] File parses successfully
- [x] JSX is well-formed
- [x] No duplicate imports remain