### PR TITLE
[Build Fix 2] Fix duplicate React imports in EventDetails.js

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -1,6 +1,5 @@
 import "./EventDetails.print.css";
-import React, { useEffect, useState, useMemo } from "react";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { Helmet } from "react-helmet-async";
 import { sanitizeMarkdown } from "../../utils/sanitizeHtml";
 import { toast } from "react-toastify";


### PR DESCRIPTION
Had two import lines from 'react' that declared some of the same hooks (useEffect, useState) on each line, which breaks the build. Merged them into one import.

File: src/Pages/Events/EventDetails.js

Closes #3830