### PR TITLE
[Build Fix 5] Fix duplicate loading declaration in EventDetailsPage.js

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -24,8 +24,6 @@ const EventDetailsPage = () => {
   const shareUrl = event ? `${window.location.origin}/events/${event.id}` : "";
   const shareText = event ? `Check out this event: ${event.title}` : "";
 
-  const [loading, setLoading] = useState(true);
-  const [event, setEvent] = useState(null);
   const shareLinks = event
     ? {
         twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,


### PR DESCRIPTION
Two const [loading, setLoading] and const [event, setEvent] declarations in the same function scope - ESLint chokes on it at build time. Removed the duplicate pair (lines were redundant, first declaration handles it).

File: src/Pages/Events/EventDetailsPage.js

Closes #3833