### PR TITLE
[Runtime Fix 8] Fix undefined CREATION_STEPS constant in EventCreation.jsx

### DIFF
--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -8,6 +8,7 @@ import TicketTiersSection from "./components/TicketTiersSection";
 import { exportAttendeesToCSV } from "../../../utils/exportCsv";
 import {
   DRAFT_KEY,
+  CREATION_STEPS,
   categories,
   mockAttendees,
   initialFormData,
@@ -56,7 +57,7 @@ import {
 const EventCreation = () => {
   const prefersReducedMotion = useReducedMotion();
   
-  const [currentStep, setCurrentStep] = useState("form");
+  const [currentStep, setCurrentStep] = useState(CREATION_STEPS.FORM);
 
   const { handleSubmit: submitEventForm, isSubmitting, error: submitError, success: submitSuccess } = useFormSubmit(async (eventData) => {
     const token = sessionStorage.getItem("token");
@@ -266,7 +267,7 @@ const EventCreation = () => {
 
   const handleSubmit = () => {
     if (validateForm()) {
-      setCurrentStep("preview");
+      setCurrentStep(CREATION_STEPS.PREVIEW);
     }
   };
 
@@ -340,7 +341,7 @@ const EventCreation = () => {
         errorMessage += error.message || "Please try again.";
       }
       toast.error(errorMessage);
-      setCurrentStep("form");
+      setCurrentStep(CREATION_STEPS.FORM);
     }
   };
 
@@ -443,7 +444,7 @@ const EventCreation = () => {
     setErrors({});
     localStorage.removeItem(DRAFT_KEY);
     setNewTag("");
-    setCurrentStep("form");
+    setCurrentStep(CREATION_STEPS.FORM);
   };
 
   return (
@@ -522,7 +523,7 @@ const EventCreation = () => {
         </div>
       )}
 
-      {currentStep === "form" ? (
+      {currentStep === CREATION_STEPS.FORM ? (
         <>
           {/* Heading Section */}
           <div className="w-full max-w-4xl flex justify-end mb-6">

--- a/src/constants/eventDefaults.js
+++ b/src/constants/eventDefaults.js
@@ -1,4 +1,5 @@
 export const DRAFT_KEY = "eventra_create_event_draft";
+export const CREATION_STEPS = { FORM: "form", PREVIEW: "preview" };
 
 export const categories = [
   { label: "Conference", value: "CONFERENCE" },


### PR DESCRIPTION
## Description
This PR resolves **Runtime Fix 8**, fixing the undefined `CREATION_STEPS` constant issue in the `EventCreation` component and preventing hardcoded string bugs.
Closes #3837 
### The Issue
The multi-step event creation flow (`EventCreation.jsx`) was managing its view state using hardcoded "magic strings" (e.g., `setCurrentStep("form")`, `setCurrentStep("preview")`). A missing `CREATION_STEPS` configuration led to undefined errors when components attempted to reference the centralized state configuration, breaking step navigation and rendering.

### The Fix
- Defined and exported `CREATION_STEPS = { FORM: "form", PREVIEW: "preview" }` in `src/constants/eventDefaults.js`.
- Imported the constant into `EventCreation.jsx`.
- Refactored state initialization, submit handlers, error catches, and JSX rendering conditionals to use the strictly typed `CREATION_STEPS` object, completely eliminating hardcoded step strings.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (State management optimization)
