### PR TITLE
fix: add missing mouse handlers for InteractiveWhiteboard drawing

### DIFF
--- a/src/components/hackathons/InteractiveWhiteboard.jsx
+++ b/src/components/hackathons/InteractiveWhiteboard.jsx
@@ -185,6 +185,64 @@ const InteractiveWhiteboard = () => {
     toast.info("Canvas cleared successfully.");
   };
 
+  // Drawing handlers for the canvas
+  const getCanvasCoords = (e) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    const clientX = e.clientX ?? (e.touches?.[0]?.clientX ?? 0);
+    const clientY = e.clientY ?? (e.touches?.[0]?.clientY ?? 0);
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  };
+
+  const handleMouseDown = useCallback((e) => {
+    if (tool === "sticky") return;
+    e.stopPropagation();
+    const coords = getCanvasCoords(e);
+    if (tool === "pen") {
+      setCurrentElement({
+        type: "path",
+        color, size, isSolid,
+        points: [{ x: coords.x, y: coords.y }],
+      });
+    } else {
+      setCurrentElement({
+        type: "shape",
+        shapeType: tool,
+        color, size, isSolid,
+        x: coords.x, y: coords.y,
+        width: 0, height: 0,
+      });
+    }
+    setIsDrawing(true);
+  }, [tool, color, size, isSolid]);
+
+  const handleMouseMove = useCallback((e) => {
+    if (!isDrawing || !currentElement) return;
+    const coords = getCanvasCoords(e);
+    if (currentElement.type === "path") {
+      setCurrentElement((prev) => ({
+        ...prev,
+        points: [...prev.points, { x: coords.x, y: coords.y }],
+      }));
+    } else {
+      const startX = currentElement.x;
+      const startY = currentElement.y;
+      setCurrentElement((prev) => ({
+        ...prev,
+        width: coords.x - startX,
+        height: coords.y - startY,
+      }));
+    }
+  }, [isDrawing, currentElement]);
+
+  const handleMouseUp = useCallback(() => {
+    if (!isDrawing || !currentElement) return;
+    setElements((prev) => [...prev, currentElement]);
+    setCurrentElement(null);
+    setIsDrawing(false);
+  }, [isDrawing, currentElement]);
+
   return (
     <div 
       className="flex flex-col h-full bg-slate-950 border border-slate-800 rounded-3xl overflow-hidden shadow-2xl relative select-none"


### PR DESCRIPTION
Adds the three missing event handlers (handleMouseDown, handleMouseMove, handleMouseUp) that were referenced in the JSX but never defined - whiteboard was completely broken.

- handleMouseDown: starts a path or shape on click
- handleMouseMove: extends the path or resizes the shape
- handleMouseUp: finalizes the element into history

Closes #3845, closes #3846, closes #3847