### PR TITLE
fix(#3165): remove JS-set cookie — server already sets HttpOnly token via Set-Cookie

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -238,13 +238,12 @@ export const AuthProvider = ({ children }) => {
   const persistSession = useCallback((sessionToken, sessionUser) => {
     setToken(sessionToken);
     setUser(sessionUser);
-    try {
-      if (sessionToken && sessionToken !== 'cookie-managed') {
-        document.cookie = `token=${sessionToken}; path=/; Secure; SameSite=Strict`;
-      }
-    } catch {
-      // Ignore cookie write failures in strict environments
-    }
+
+    // The auth token is set exclusively by the server via a Set-Cookie response
+    // header with HttpOnly; Secure; SameSite=Strict. Writing the token through
+    // document.cookie here would create a second, JS-readable copy of the same
+    // credential, exposing it to XSS-based theft. The client-side code only
+    // needs to store the non-sensitive display profile (see below).
 
     // Strip authorization fields before persisting to storage. Roles, scopes,
     // and permissions are always re-derived from the backend on page load via


### PR DESCRIPTION
## Summary

Fixes #3165

`persistSession()` in `src/context/AuthContext.js` was writing the auth token to `document.cookie`. Because the browser's JavaScript `document.cookie` interface silently ignores the `HttpOnly` attribute, this created a JS-readable copy of the credential alongside the server-set HttpOnly cookie, exposing the token to XSS-based theft.

The `api/auth/login.js` endpoint already sends the token in a proper `Set-Cookie` response header with `HttpOnly; Secure; SameSite=Strict`. There is no need for the client to write the token cookie at all.

## Change

**`src/context/AuthContext.js`**
- Removed the `document.cookie` assignment inside `persistSession()`
- Added a comment explaining that token cookie management belongs exclusively to the server
- Non-sensitive display profile storage in `syncSecureStorage` is unchanged

## Test plan

- [ ] Login flow still works end-to-end (token cookie is set by server, not by client JS)
- [ ] Logout still clears the cookie (the existing `document.cookie = "token=; expires=..."` clear in the logout path is still present)
- [ ] Page reload still restores session via `validateSession` backend ping
- [ ] No regressions in auth-protected routes