### PR TITLE
fix: skip WebGL init and animation loop when prefersReducedMotion is true in FluidCursor

### DIFF
--- a/src/components/visual/FluidCursor.js
+++ b/src/components/visual/FluidCursor.js
@@ -27,7 +27,7 @@ const FluidCursor = ({ enabled = true }) => {
   }, []);
 
   useEffect(() => {
-    if (!enabled || isMobileViewport) {
+    if (!enabled || isMobileViewport || prefersReducedMotion) {
       return undefined;
     }
 


### PR DESCRIPTION
## Summary
Fixes a background resource leak in `FluidCursor.js` where the full 
WebGL pipeline was initialized and the animation loop ran indefinitely 
even when the user had reduced motion enabled in their OS accessibility 
settings.

## Problem
The `useEffect` that sets up WebGL, compiles shaders, starts the 
`requestAnimationFrame` loop, and attaches mouse/touch event listeners 
only checked `!enabled || isMobileViewport` — it did not check 
`prefersReducedMotion`. While the JSX correctly returned `null` for 
reduced motion users, the entire WebGL pipeline still ran in the 
background consuming GPU and CPU resources unnecessarily. This violates 
WCAG 2.1 Success Criterion 2.3.3 (Animation from Interactions).

## Changes Made
- Added `prefersReducedMotion` to the early return guard in the 
  second `useEffect` so WebGL is never initialized when reduced 
  motion is preferred

## Files Changed
- `src/components/visual/FluidCursor.js`

## Testing
- App loads without errors
- Fluid cursor works correctly when motion is enabled
- No WebGL activity or animation frames when reduced motion is on
- No console errors

## Related Issue
Closes #3889  