### PR TITLE
fix: pass location prop to NavList in MobileDrawer to prevent runtime crash on mobile navigation

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -678,6 +678,7 @@ const MobileDrawer = ({ isOpen, drawerRef, openDropdown, setOpenDropdown, closeA
 
           <div className="flex-grow p-3.5 sm:p-4 space-y-2 overflow-y-auto">
             <NavList
+              location={location}
               openDropdown={openDropdown}
               onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)}
               onLinkClick={closeAllMenus}


### PR DESCRIPTION
## Summary
Fixes a missing `location` prop in `MobileDrawer` that caused a runtime 
crash when `NavList` tried to access `location.pathname` on mobile.

## Problem
`MobileDrawer` calls `useLocation()` and has `location` available locally 
but never passed it to `NavList`. Inside `NavList`, `location` was 
`undefined` for the mobile drawer render path, causing `location.pathname` 
to throw a runtime crash. This meant the entire mobile navigation drawer 
failed to render correctly and active link highlighting was completely 
broken for all users on screens narrower than 1280px.

Note: The desktop `DesktopNavLinks` component correctly passes `location` 
to `NavList` — this was only missing in the mobile path.

## Changes Made
- Added `location={location}` prop to `NavList` inside `MobileDrawer`

## Files Changed
- `src/components/Layout/Navbar.js`

## Testing
- App loads without errors
- Mobile drawer opens correctly on viewport < 1280px
- Active nav link highlighted correctly based on current page
- Navigating between pages updates active state correctly in mobile drawer
- No console errors related to pathname access

## Related Issue
Closes #3891 