### PR TITLE
fix: clean relative time fallback label

### DIFF
--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -1,4 +1,3 @@
-
 export function getRelativeTime(dateInput) {
   if (!dateInput) return null;
   const now = new Date();
@@ -35,11 +34,10 @@ export function getRelativeTime(dateInput) {
 }
 
 export function getSmartDateLabel(dateInput, timeInput = "") {
-  if (!dateInput) return "—";
+  if (!dateInput) return "\u2014";
 
   const parsed = new Date(dateInput);
-  if (isNaN(parsed.getTime())) return "—";
-
+  if (isNaN(parsed.getTime())) return "\u2014";
 
   const relative = getRelativeTime(timeInput ? `${dateInput} ${timeInput}` : dateInput);
 

--- a/tests/relativeTime.test.mjs
+++ b/tests/relativeTime.test.mjs
@@ -12,13 +12,14 @@ const past = new Date(now.getTime() - 30000);
 assert.equal(getRelativeTime(future.toISOString()), "Starting soon", "30s in future is starting soon");
 assert.equal(getRelativeTime(past.toISOString()), "Just ended", "30s in past is just ended");
 
-assert.equal(getSmartDateLabel(null), "—", "null date returns —");
-assert.equal(getSmartDateLabel("invalid"), "—", "invalid date returns —");
+assert.equal(getSmartDateLabel(null), "\u2014", "null date returns em dash");
+assert.equal(getSmartDateLabel("invalid"), "\u2014", "invalid date returns em dash");
 
 const tomorrow = new Date(now.getTime() + 86400000);
 const yesterday = new Date(now.getTime() - 86400000);
 const smartFuture = getSmartDateLabel(tomorrow.toISOString());
 const smartPast = getSmartDateLabel(yesterday.toISOString());
 assert.ok(smartFuture.includes("Tomorrow") || !smartFuture.includes("TBD"), "tomorrow date has proper label");
+assert.equal(smartPast, "Yesterday", "yesterday date has proper label");
 
-console.log("relativeTime edge case tests passed ✓");
+console.log("relativeTime edge case tests passed");


### PR DESCRIPTION
## 🚀 Description
Fixed the malformed fallback label in the relative time utility by replacing the corrupted dash output with an ASCII-safe em dash escape. Also updated the relative time unit test to verify invalid date fallbacks and added coverage for yesterday labels.

Fixes #3224

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Tested with:

node tests\relativeTime.test.mjs

Note: npm.cmd run test:unit still stops early because local node_modules is missing fuse.js.