### PR TITLE
docs: align SSE environment variable name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ REACT_APP_API_URL=http://localhost:8080/api
 # Set to false for frontend-only development without running backend
 REACT_APP_USE_REAL_API=false
 
+# Optional SSE endpoint for real-time streams
+# Defaults to REACT_APP_API_URL when omitted
+REACT_APP_SSE_URL=http://localhost:4001
+
 # ============================================
 # OPTIONAL: Feature Toggles
 # ============================================

--- a/docs/ENV_SETUP_GUIDE.md
+++ b/docs/ENV_SETUP_GUIDE.md
@@ -155,7 +155,7 @@ GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxx
 # ============================================
 # Optional: SSE Real-time Features
 # ============================================
-REACT_APP_SSE_SERVER_URL=http://localhost:5000
+REACT_APP_SSE_URL=http://localhost:4001
 ```
 
 ---
@@ -172,7 +172,7 @@ REACT_APP_SSE_SERVER_URL=http://localhost:5000
 | **REACT_APP_EMAILJS_SERVICE_ID** | ❌ Optional | EmailJS service identifier | `service_abc123xyz` | ✅ Yes | Enables contact form emails |
 | **REACT_APP_EMAILJS_TEMPLATE_ID** | ❌ Optional | EmailJS email template | `template_abc123xyz` | ✅ Yes | Paired with SERVICE_ID |
 | **REACT_APP_EMAILJS_PUBLIC_KEY** | ❌ Optional | EmailJS public API key | `AbCdEfGhIjKlMnOpQrS` | ✅ Yes | Public key for client-side requests |
-| **REACT_APP_SSE_SERVER_URL** | ❌ Optional | Server-Sent Events endpoint | `http://localhost:5000` | ✅ Yes | Enables real-time notifications |
+| **REACT_APP_SSE_URL** | ❌ Optional | Server-Sent Events endpoint | `http://localhost:4001` | ✅ Yes | Enables real-time notifications |
 | **GITHUB_TOKEN** | ❌ Optional | GitHub API authentication | `ghp_xxxxxxxxxxxxxxxxxxxx` | ❌ **No** | Keep private! Use Vercel secrets |
 | **REACT_APP_MOCK_EVENTS** | ❌ Optional | Enable mock event data | `true` or `false` | ✅ Yes | Fallback when API unavailable |
 
@@ -190,7 +190,7 @@ Understanding what happens when optional integrations are missing helps prevent 
 |---------|-------------------|-------------------|----------|
 | **Google OAuth Sign-In** | `REACT_APP_GOOGLE_CLIENT_ID` | 🔴 Disabled | Google button hidden or shows error; email/password login still works |
 | **Contact Form Emails** | All `REACT_APP_EMAILJS_*` (3 vars) | 🟡 Warning | Contact form shows; submission attempted but may fail silently or log error |
-| **Real-time Notifications** | `REACT_APP_SSE_SERVER_URL` | 🟡 Degraded | Page still loads; live updates won't work; user sees stale data until refresh |
+| **Real-time Notifications** | `REACT_APP_SSE_URL` | 🟡 Degraded | Page still loads; live updates won't work; user sees stale data until refresh |
 | **GitHub Integration** | `GITHUB_TOKEN` | 🟡 Limited | GitHub profile links work; direct API calls may fail (rate limited) |
 | **Event Analytics** | Backend running | 🔴 Disabled | Analytics dashboard still renders but shows no data |
 | **Email Notifications** | Backend + EmailJS | 🟡 Partial | Users won't receive email; but can still see in-app notifications |
@@ -651,7 +651,7 @@ EventSource connection failed
 2. **SSE URL Misconfigured:**
    ```bash
    # .env should have:
-   REACT_APP_SSE_SERVER_URL=http://localhost:5000
+   REACT_APP_SSE_URL=http://localhost:4001
    ```
 
 3. **Browser Not Supporting SSE:**


### PR DESCRIPTION
## 🚀 Description
Aligned the documented SSE environment variable name with the code and validation script. The app reads `REACT_APP_SSE_URL`, so the environment setup guide and `.env.example` now use that name instead of the outdated `REACT_APP_SSE_SERVER_URL`.

Fixes #3234

## 🛠️ Type of change
- [x] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Tested with:

node tests\validateEnv.test.mjs

node scripts\validate-env.js

Note: validate-env passes with the expected local warning that REACT_APP_API_URL is not set in the current shell.