### PR TITLE
fix(theme): remove global dark override breaking Tailwind colors and scope search title color

### DIFF
--- a/src/components/styles/components.css
+++ b/src/components/styles/components.css
@@ -18,20 +18,6 @@
   color: #f3f4f6;
   background-color: #111827;
 }
-
-.dark body,
-.dark section,
-.dark div,
-.dark p,
-.dark span,
-.dark h1,
-.dark h2,
-.dark h3,
-.dark h4,
-.dark h5,
-.dark h6 {
-  color: inherit;
-}
 .dark .search-filter-container {
   color: #d1d5db; /* gray-300 */
 }
@@ -39,7 +25,9 @@
   font-size: 3rem;
   font-weight: 700;
   line-height: 1.2;
-  color: white !important;
+}
+.dark .search-title {
+  color: white;
 }
 .dark .search-header .search-subtitle {
   color: #9ca3af; /* gray-400 */
@@ -589,7 +577,7 @@
   font-family: monospace;
   overflow: hidden;          /* Ensures the text is hidden when typing */
   white-space: nowrap;       /* Prevent line breaks */
-  border-right: 2px solid black;  /* Cursor */
+  border-right: 2px solid currentColor;  /* Cursor */
   animation: typing 4s steps(24) infinite, blink 0.75s step-end infinite;
   width: 0;
   display: inline-block;
@@ -604,7 +592,7 @@
 /* Cursor blink animation */
 @keyframes blink {
   50% { border-color: transparent; }
-  100% { border-color: black; }
+  100% { border-color: currentColor; }
 }
 
 .hero-actions {


### PR DESCRIPTION
### Description
This PR addresses a critical styling conflict that broke dark mode coloring across the entire application.

### Changes implemented
* **Tailwind Color Fix**: Removed the overly broad `.dark body, .dark section, .dark div... { color: inherit; }` CSS rule in `components.css`. This rule was silently overriding and rendering broken, low-contrast text for all Tailwind `dark:text-*` classes site-wide.
* **Search Title Visibility**: Scoped the white color of `.search-title` to dark mode only, resolving an issue where the title was invisible (white on white) in light mode.
* **Cursor border colors**: Configured typing animation cursor borders to dynamically support dark themes by using `currentColor` instead of hardcoded black.

All components now correctly reflect their intended Tailwind dark mode typography.