### PR TITLE
fix: inline theme-init script and remove CRA template syntax from ind…

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,25 @@
       />
     </noscript>
 
-    <!-- Prevent Theme Flickering -->
-    <script src="%PUBLIC_URL%/theme-init.js"></script>
+    <!-- Prevent Theme Flickering (inlined to avoid Vite module bundling warning) -->
+    <script>
+      (function () {
+        try {
+          var savedTheme = localStorage.getItem("theme");
+          var systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+          var theme = savedTheme || (systemDark ? "dark" : "light");
+          document.documentElement.classList.add("no-transition");
+          document.documentElement.classList.remove("light", "dark");
+          document.documentElement.classList.add(theme);
+          document.documentElement.style.colorScheme = theme;
+          window.addEventListener("load", function () {
+            document.documentElement.classList.remove("no-transition");
+          });
+        } catch (e) {
+          console.error("Theme initialization failed:", e);
+        }
+      })();
+    </script>
 
     <!-- Title -->
     <title>
@@ -130,12 +147,6 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://eventra.vercel.app/" />
     <meta property="og:image" content="/Eventra.png" />
-
-    <!-- Google Sign In -->
-    <meta
-      name="google-signin-client_id"
-      content="%REACT_APP_GOOGLE_CLIENT_ID%"
-    />
 
     <script
       src="https://accounts.google.com/gsi/client"


### PR DESCRIPTION
## Description
Resolves **[Migration Fix 25]** — Fix non-module script loading issue in `index.html`.
Closes #3869 
### The Issue
Vite warns: `<script src="%PUBLIC_URL%/theme-init.js"> can't be bundled without type="module"`. This is caused by two legacy CRA patterns:
1. `%PUBLIC_URL%` placeholder (not supported by Vite)
2. External script reference without `type="module"`

### The Fix
- **Inlined the theme-init script** directly in `index.html` — eliminates both the `%PUBLIC_URL%` reference and the Vite bundling warning, while preserving the synchronous (render-blocking) execution required to prevent dark/light mode flickering.
- **Removed the stale `%REACT_APP_GOOGLE_CLIENT_ID%` meta tag** — Vite does not support CRA-style `%VARIABLE%` HTML template substitution. The Google Client ID is already correctly injected at runtime via the `@react-oauth/google` JavaScript provider.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (Vite Migration)
