### PR TITLE
fix: resolve invalid media query syntax causing Vite CSS parser warning

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -10,7 +10,7 @@ module.exports = {
     extend: {
       screens: {
         xs: '380px',
-        short: { raw: '(max-height: 520px)' },
+        short: { raw: '(max-height: 520px) and (orientation: landscape)' },
       },
 
       // =========================


### PR DESCRIPTION
## Description
Resolves **[CSS Fix 20]** — Fix invalid media query syntax causing Vite CSS parser warning.
Closes #3849 
### The Issue
Vite's CSS optimizer reported: `@media (width >= (max-height: 520px))` — an invalid, auto-generated media query that causes build warnings and potential layout inconsistencies.

### Root Cause
The `short` custom screen breakpoint in `tailwind.config.cjs` was defined as:
```js
short: { raw: '(max-height: 520px)' }
