### PR TITLE
fix: stabilize handleMouseUp in InteractiveWhiteboard with useCallbac…

### DIFF
--- a/src/components/hackathons/InteractiveWhiteboard.jsx
+++ b/src/components/hackathons/InteractiveWhiteboard.jsx
@@ -213,7 +213,7 @@ const InteractiveWhiteboard = () => {
   }, [tool, color, size, isSolid]);
 
   // Drawing move handler
-  const handleMouseMove = (e) => {
+  const handleMouseMove = useCallback((e) => {
     if (tool === "sticky") return;
     if (!isDrawing) return;
     e.stopPropagation();
@@ -235,23 +235,25 @@ const InteractiveWhiteboard = () => {
         height: coords.y - prev.y,
       };
     });
-  };
+  }, [tool, isDrawing]);
 
-  // Finalize drawing on mouse up / touch end
-  const handleMouseUp = (e) => {
+  // Finalize drawing on mouse up / touch end / mouse leave
+  const handleMouseUp = useCallback((e) => {
     if (tool === "sticky") return;
     if (!isDrawing) return;
-    e.stopPropagation();
+    if (e && typeof e.stopPropagation === "function") {
+      e.stopPropagation();
+    }
 
     setCurrentElement((prev) => {
-      if (!prev) return null;
-      const finalized = prev;
-      setElements((els) => [...els, finalized]);
+      if (prev) {
+        setElements((els) => [...els, prev]);
+      }
       return null;
     });
 
     setIsDrawing(false);
-  };
+  }, [tool, isDrawing]);
 
   return (
     <div 
@@ -399,9 +401,11 @@ const InteractiveWhiteboard = () => {
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
         onTouchStart={handleMouseDown}
         onTouchMove={handleMouseMove}
         onTouchEnd={handleMouseUp}
+        onTouchCancel={handleMouseUp}
       >
         {/* HTML5 Canvas Element */}
         <canvas ref={canvasRef} className="absolute inset-0 block bg-[#090a0f]" />


### PR DESCRIPTION
## Description
Resolves **[Runtime Fix 18]** — Fix undefined/unstable `handleMouseUp` handler in `InteractiveWhiteboard.jsx`.
Closes #3847 
### The Issue
The `handleMouseUp` and `handleMouseMove` handlers were plain arrow functions that captured stale closure values of `isDrawing` and `tool`. This caused drawing sessions to never terminate properly, especially when:
- The mouse left the canvas area during a stroke
- A touch interaction was interrupted (e.g., incoming notification)
- React re-rendered the component between mousedown and mouseup

### The Fix
1. **Wrapped both handlers in `useCallback`** with `[tool, isDrawing]` dependencies to prevent stale closures
2. **Added `onMouseLeave` handler** — finalizes drawing when the cursor exits the canvas
3. **Added `onTouchCancel` handler** — cleans up if the touch is interrupted
4. **Guarded `e.stopPropagation()`** — prevents crashes on synthetic/null events from `mouseleave` or `touchcancel`
5. **Simplified finalization logic** — removed unnecessary intermediate variable

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
