### PR TITLE
fix(theme/ui): improve dark mode text contrast and upgrade hero stats cards

### DIFF
--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -348,7 +348,7 @@ border-b border-gray-100 dark:border-slate-900">
           {/* Subtext */}
           <motion.p
             variants={fadeUp}
-            className="text-sm sm:text-base md:text-lg text-gray-600 dark:text-gray-800 max-w-3xl mx-auto mt-2 mb-7 sm:mb-8 px-4 sm:px-0"
+            className="text-sm sm:text-base md:text-lg text-gray-600 dark:text-gray-400 max-w-3xl mx-auto mt-2 mb-7 sm:mb-8 px-4 sm:px-0"
           >
             Connect with developers, learn new skills, and grow your network at
             the best tech events, hackathons, and workshops in your area.
@@ -540,10 +540,10 @@ text-gray-600 dark:text-gray-300"
                   variants={fadeUp}
                   whileHover={{ y: -5 }}
                   transition={{ duration: prefersReducedMotion ? 0 : 0.2 }}
-                  className="flex flex-col items-center justify-center p-6 bg-white/60 dark:bg-gray-900/40 backdrop-blur-md rounded-2xl border border-gray-200/60 dark:border-gray-800/60 shadow-sm"
+                  className="flex flex-col items-center justify-center p-6 bg-white/70 dark:bg-slate-900/60 backdrop-blur-xl rounded-2xl border border-gray-200/80 dark:border-slate-800/80 shadow-lg hover:shadow-indigo-500/10 hover:border-indigo-300 dark:hover:border-indigo-700 transition-all duration-300"
                 >
                   
-                  <p className="text-3xl font-bold mb-2 text-gray-900 dark:text-white">
+                  <p className="text-4xl font-extrabold mb-1 bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-purple-600 dark:from-indigo-400 dark:to-purple-400">
                     {statsReady ? (
                       // AFTER
 <CountUp
@@ -559,7 +559,7 @@ text-gray-600 dark:text-gray-300"
                       </>
                     )}
                   </p>
-                  <p className="text-gray-500 dark:text-gray-600 text-xs sm:text-sm font-semibold uppercase tracking-wider">
+                  <p className="text-gray-500 dark:text-gray-400 text-xs sm:text-sm font-semibold uppercase tracking-wider">
                     {stat.label}
                   </p>
                 </motion.div>

--- a/src/Pages/Home/components/HomeCTA.jsx
+++ b/src/Pages/Home/components/HomeCTA.jsx
@@ -45,7 +45,7 @@ export default function CTASection() {
   height="24"
   viewBox="0 0 24 24"
   fill="none"
-  stroke="black"
+  stroke="currentColor"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"


### PR DESCRIPTION
### Description
This PR delivers high-end UI design refinements and critical dark mode readability upgrades to the homepage.

### Changes implemented
* **Stats Card Premium Styling**: Replaced basic flat stats boxes in the Hero section with glowing, highly glassmorphic cards (`bg-white/70 dark:bg-slate-900/60 backdrop-blur-xl border border-gray-200/80 dark:border-slate-800/80 shadow-lg`). Added a vibrant gradient effect (`from-indigo-600 to-purple-600`) to the CountUp numbers, making them pop elegantly.
* **Critical Hero Subtext Visibility**: Fixed the hero description paragraph being completely invisible on dark backgrounds by changing it from `dark:text-gray-800` to `dark:text-gray-400`. This ensures crisp text readability on all themes.
* **Hero Stats Label Visibility**: Changed stats labels from `dark:text-gray-600` to `dark:text-gray-400`, resolving another high-priority contrast violation under dark mode.
* **CTA Icon Color Invariance**: Replaced hardcoded black stroke in the CTA section Explore Hackathons SVG button with `currentColor`, making it dynamically adapt to light/dark text colors properly.

Verified locally under all themes to confirm a stunning, visually pristine developer experience.