### PR TITLE
fix: correct logger import path in Leaderboard and FeatureErrorBoundary (#3785)

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -21,7 +21,7 @@ import SkeletonLeaderboard from "../../components/common/SkeletonLeaderboard";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 import { useLeaderboardStream, SSE_STATUS } from "../../context/RealTimeContext";
 import { getAchievementBadge } from "../../utils/leaderboardUtils";
-import { logger } from "../utils/logger";
+import { logger } from "../../utils/logger";
 import { storageManager } from "../../utils/storage/storageManager";
 import { STORAGE_KEYS } from "../../utils/storage/storageKeys";
 import { validators } from "../../utils/storage/storageValidators";

--- a/src/components/common/FeatureErrorBoundary.jsx
+++ b/src/components/common/FeatureErrorBoundary.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AlertTriangle, RefreshCw } from "lucide-react";
-import { logger } from "../utils/logger";
+import { logger } from "../../utils/logger";
 
 class FeatureErrorBoundary extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Fixes #3785

## Changes
- Fixed incorrect logger import path in `src/Pages/Leaderboard/Leaderboard.jsx`
- Fixed incorrect logger import path in `src/components/common/FeatureErrorBoundary.jsx`

Both files were importing from `../utils/logger` which doesn't resolve correctly 
from their directory depth. Updated to `../../utils/logger` to correctly point 
to `src/utils/logger.js`.

## Testing
- `npm run build` completes successfully after this fix