### PR TITLE
Fix navbar text overlapping on medium/large devices (#3851)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16855,6 +16855,23 @@
         }
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -533,8 +533,22 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
         onClick={closeAllMenus}
       />
 
-      <nav ref={navRef} data-aos="fade-down" data-aos-once="true" data-aos-duration="1000"
-        className="fixed top-0 left-0 w-full z-40 shadow-sm bg-white dark:bg-gray-900 border-b border-black/10 dark:border-white/10">
+      <nav
+  ref={navRef}
+  data-aos="fade-down"
+  data-aos-once="true"
+  data-aos-duration="1000"
+  className="
+    fixed top-0 left-0 w-full z-40
+    backdrop-blur-xl
+    bg-white/60 dark:bg-gray-900/50
+    border-b border-white/20 dark:border-white/10
+    shadow-lg shadow-black/5 dark:shadow-black/20
+    transition-all duration-300
+    supports-[backdrop-filter]:bg-white/40
+    dark:supports-[backdrop-filter]:bg-gray-900/40
+  "
+>
         <div className="w-full flex items-center h-20 px-6 md:px-12 relative">
           <Link to="/" className="flex-shrink-0 z-20">
             <h2 className="text-3xl font-semibold tracking-tight text-black dark:text-white" style={{ fontFamily: '"Anton", sans-serif' }}>

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -30,11 +30,11 @@ import {
 // --- Helpers to reduce complexity ---
 const getUserDisplayNames = (user) => {
   if (!user) return { primary: "User", secondary: null };
-  const primary = (user.fullName?.trim()) || 
-                 [user.firstName, user.lastName].filter(Boolean).join(" ").trim() || 
-                 (user.username?.trim()) || 
-                 (user.email?.trim()) || 
-                 "User";
+  const primary = (user.fullName?.trim()) ||
+    [user.firstName, user.lastName].filter(Boolean).join(" ").trim() ||
+    (user.username?.trim()) ||
+    (user.email?.trim()) ||
+    "User";
   const secondaryCand = (user.email?.trim()) || (user.username?.trim()) || "";
   const secondary = secondaryCand && secondaryCand !== primary ? secondaryCand : null;
   return { primary, secondary };
@@ -56,7 +56,7 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile }) => (
   <button
     onClick={toggleTheme}
     title={isDarkMode ? "Switch to Light Mode" : "Switch to Dark Mode"}
-    className={isMobile 
+    className={isMobile
       ? "flex-1 flex items-center justify-center gap-3 px-4 py-2.5 rounded-lg bg-black dark:bg-white text-white dark:text-black hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors font-medium"
       : "flex items-center gap-1 px-2 py-1 mr-2 text-xs font-normal bg-black text-white dark:bg-white dark:text-black rounded-md hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-all"
     }
@@ -74,7 +74,7 @@ const CursorToggleButton = ({ cursorEnabled, toggleCursor, isMobile }) => (
   <button
     onClick={toggleCursor}
     title={cursorEnabled ? "Disable Fluid Cursor" : "Enable Fluid Cursor"}
-    className={isMobile 
+    className={isMobile
       ? "flex-1 flex items-center justify-center gap-3 px-4 py-2.5 rounded-lg bg-black dark:bg-white text-white dark:text-black hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-colors font-medium"
       : "flex items-center gap-1 px-2 py-1 mr-3 text-xs font-normal bg-black text-white dark:bg-white dark:text-black rounded-md hover:bg-zinc-800 dark:hover:bg-zinc-200 transition-all"
     }
@@ -86,19 +86,19 @@ const CursorToggleButton = ({ cursorEnabled, toggleCursor, isMobile }) => (
 
 const AuthButtons = ({ isMobile, closeAllMenus }) => (
   <div className={isMobile ? "space-y-3" : "flex items-center space-x-1"}>
-    <Link 
-      to="/login" 
-      onClick={isMobile ? closeAllMenus : undefined} 
-      className={isMobile 
+    <Link
+      to="/login"
+      onClick={isMobile ? closeAllMenus : undefined}
+      className={isMobile
         ? "flex items-center justify-center gap-2 w-full py-2.5 rounded-xl font-semibold text-white bg-black hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-zinc-200 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300 border border-transparent"
         : "px-4 py-2 text-base font-medium text-black/75 hover:text-black dark:text-white/75 dark:hover:text-white transition-colors"
       }
     >
       {isMobile && <LogIn className="w-5 h-5" />}Sign In
     </Link>
-    <Link 
-      to="/signup" 
-      onClick={isMobile ? closeAllMenus : undefined} 
+    <Link
+      to="/signup"
+      onClick={isMobile ? closeAllMenus : undefined}
       className={isMobile
         ? "flex items-center justify-center gap-2 w-full py-2.5 rounded-xl font-semibold text-black dark:text-white bg-white dark:bg-black/50 hover:bg-gray-100 dark:hover:bg-white/10 border-2 border-black/15 dark:border-white/20 hover:border-black/25 dark:hover:border-white/30 shadow-md hover:shadow-lg transform hover:-translate-y-0.5 transition-all duration-300"
         : "px-5 py-2 text-sm font-semibold text-white transition-all duration-300 bg-black hover:bg-zinc-800 rounded-lg shadow-md hover:shadow-lg hover:-translate-y-0.5 dark:bg-white dark:text-black dark:hover:bg-zinc-200 focus:outline-none focus:ring-4 focus:ring-black/20 dark:focus:ring-white/20"
@@ -113,11 +113,10 @@ const MobileNavLink = ({ item, isActive, onClick }) => (
   <Link
     to={item.href}
     onClick={onClick}
-    className={`flex items-center gap-3 w-full px-4 py-2.5 rounded-lg transition-colors text-base font-medium ${
-      isActive
+    className={`flex items-center gap-3 w-full px-4 py-2.5 rounded-lg transition-colors text-base font-medium ${isActive
         ? "bg-black/10 dark:bg-white/15 border border-black/10 dark:border-white/20 text-black dark:text-white"
         : "text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/10"
-    }`}
+      }`}
   >
     {item.icon}{item.name}
   </Link>
@@ -127,11 +126,10 @@ const MobileNavGroup = ({ item, isActive, isOpen, onToggle, closeAllMenus, locat
   <div key={item.name}>
     <button
       onClick={onToggle}
-      className={`flex items-center justify-between w-full px-4 py-2.5 rounded-lg transition-colors text-left text-base font-medium ${
-        isActive
+      className={`flex items-center justify-between w-full px-4 py-2.5 rounded-lg transition-colors text-left text-base font-medium ${isActive
           ? "bg-black/10 dark:bg-white/15 border border-black/10 dark:border-white/20 text-black dark:text-white"
           : "text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/10"
-      }`}
+        }`}
     >
       <span className="flex items-center gap-3">{item.icon} {item.name}</span>
       <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? "rotate-180" : ""}`} />
@@ -143,11 +141,10 @@ const MobileNavGroup = ({ item, isActive, isOpen, onToggle, closeAllMenus, locat
             key={sub.name}
             to={sub.href}
             onClick={closeAllMenus}
-            className={`flex items-center gap-3 px-4 py-2 rounded-md text-base font-medium ${
-              location.pathname === sub.href
+            className={`flex items-center gap-3 px-4 py-2 rounded-md text-base font-medium ${location.pathname === sub.href
                 ? "bg-black/10 dark:bg-white/15 border border-black/10 dark:border-white/20 text-black dark:text-white"
                 : "text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white"
-            }`}
+              }`}
           >
             {sub.icon}{sub.name}
           </Link>
@@ -160,11 +157,10 @@ const MobileNavGroup = ({ item, isActive, isOpen, onToggle, closeAllMenus, locat
 const DesktopNavLink = ({ item, isActive }) => (
   <Link
     to={item.href}
-    className={`text-base font-medium transition-colors ${
-      isActive
+    className={`text-base font-medium transition-colors ${isActive
         ? "text-black dark:text-white"
         : "text-black/70 hover:text-black dark:text-white/70 dark:hover:text-white"
-    }`}
+      }`}
   >
     {item.name}
   </Link>
@@ -174,11 +170,10 @@ const DesktopNavGroup = ({ item, isActive, isOpen, onToggle, setOpenDropdown, lo
   <div className="relative">
     <button
       onClick={onToggle}
-      className={`flex items-center gap-1 text-base font-medium transition-colors ${
-        isActive || isOpen
+      className={`flex items-center gap-1 text-base font-medium transition-colors ${isActive || isOpen
           ? "text-black dark:text-white"
           : "text-black/70 hover:text-black dark:text-white/70 dark:hover:text-white"
-      }`}
+        }`}
     >
       {item.name}
       <ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`} />
@@ -195,11 +190,10 @@ const DesktopNavGroup = ({ item, isActive, isOpen, onToggle, setOpenDropdown, lo
             key={sub.name}
             to={sub.href}
             onClick={() => setOpenDropdown(null)}
-            className={`group flex items-center gap-3 w-full px-3 py-2 text-base font-medium rounded-md transition-colors ${
-              location.pathname === sub.href
+            className={`group flex items-center gap-3 w-full px-3 py-2 text-base font-medium rounded-md transition-colors ${location.pathname === sub.href
                 ? "bg-black/10 dark:bg-white/15 text-black dark:text-white"
                 : "text-gray-700 dark:text-gray-300 hover:bg-black/5 dark:hover:bg-white/10"
-            }`}
+              }`}
           >
             {React.cloneElement(sub.icon, { className: "w-5 h-5 text-gray-500 dark:text-gray-400" })}
             {sub.name}
@@ -229,19 +223,19 @@ const MobileDrawerHeader = ({ closeBtnRef, closeAllMenus }) => (
   </div>
 );
 
-const MobileDrawerFooter = ({ 
-  isAuthenticated, user, primaryLine, secondaryLine, closeAllMenus, location, 
-  handleLogoutClick, isDarkMode, toggleTheme, cursorEnabled, toggleCursor 
+const MobileDrawerFooter = ({
+  isAuthenticated, user, primaryLine, secondaryLine, closeAllMenus, location,
+  handleLogoutClick, isDarkMode, toggleTheme, cursorEnabled, toggleCursor
 }) => (
   <div className="p-4 border-t border-gray-200 dark:border-white/20">
     {isAuthenticated() ? (
-      <MobileUserSection 
-        user={user} 
-        primaryLine={primaryLine} 
-        secondaryLine={secondaryLine} 
-        closeAllMenus={closeAllMenus} 
-        location={location} 
-        handleLogoutClick={handleLogoutClick} 
+      <MobileUserSection
+        user={user}
+        primaryLine={primaryLine}
+        secondaryLine={secondaryLine}
+        closeAllMenus={closeAllMenus}
+        location={location}
+        handleLogoutClick={handleLogoutClick}
       />
     ) : (
       <AuthButtons isMobile={true} closeAllMenus={closeAllMenus} />
@@ -253,13 +247,13 @@ const MobileDrawerFooter = ({
   </div>
 );
 
-const UserProfileDropdown = ({ 
-  user, primaryLine, secondaryLine, showProfileDropdown, setShowProfileDropdown, 
-  location, handleLogoutClick 
+const UserProfileDropdown = ({
+  user, primaryLine, secondaryLine, showProfileDropdown, setShowProfileDropdown,
+  location, handleLogoutClick
 }) => (
   <div className="relative profile-container">
-    <button 
-      onClick={() => setShowProfileDropdown(!showProfileDropdown)} 
+    <button
+      onClick={() => setShowProfileDropdown(!showProfileDropdown)}
       className="flex items-center gap-2 text-sm font-medium text-black/90 dark:text-white/90 hover:text-black dark:hover:text-white transition-colors"
     >
       {user?.profilePicture ? (
@@ -308,8 +302,8 @@ const UserProfileDropdown = ({
   </div>
 );
 
-const MobileUserSection = ({ 
-  user, primaryLine, secondaryLine, closeAllMenus, location, handleLogoutClick 
+const MobileUserSection = ({
+  user, primaryLine, secondaryLine, closeAllMenus, location, handleLogoutClick
 }) => (
   <div className="space-y-1">
     <div className="flex items-center gap-3 px-3 py-2 mb-2">
@@ -359,10 +353,10 @@ const NAV_ITEMS = [
 const NavList = ({ location, openDropdown, onToggleGroup, onLinkClick, isMobile }) => (
   <>
     {NAV_ITEMS.map((item) => {
-      const isActive = item.href 
-        ? location.pathname === item.href 
+      const isActive = item.href
+        ? location.pathname === item.href
         : item.subItems?.some(s => location.pathname === s.href);
-      
+
       if (item.subItems) {
         return isMobile ? (
           <MobileNavGroup key={item.name} item={item} isActive={isActive} isOpen={openDropdown === item.name} onToggle={() => onToggleGroup(item.name)} closeAllMenus={onLinkClick} location={location} />
@@ -382,12 +376,12 @@ const NavList = ({ location, openDropdown, onToggleGroup, onLinkClick, isMobile 
 const DesktopNavLinks = ({ openDropdown, setOpenDropdown }) => {
   const location = useLocation();
   return (
-    <div className="hidden lg:flex absolute left-[48%] transform -translate-x-1/2 space-x-5 z-10">
-      <NavList 
-        location={location} 
-        openDropdown={openDropdown} 
-        onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)} 
-        isMobile={false} 
+    <div className="hidden xl:flex absolute left-[48%] transform -translate-x-1/2 space-x-5 z-10">
+      <NavList
+        location={location}
+        openDropdown={openDropdown}
+        onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)}
+        isMobile={false}
       />
     </div>
   );
@@ -412,27 +406,27 @@ const MobileDrawer = ({ isOpen, drawerRef, openDropdown, setOpenDropdown, closeA
       <MobileDrawerHeader closeBtnRef={closeBtnRef} closeAllMenus={closeAllMenus} />
 
       <div className="flex-grow p-3.5 sm:p-4 space-y-2 overflow-y-auto">
-        <NavList 
-          location={location} 
-          openDropdown={openDropdown} 
-          onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)} 
-          onLinkClick={closeAllMenus} 
-          isMobile={true} 
+        <NavList
+          location={location}
+          openDropdown={openDropdown}
+          onToggleGroup={(name) => setOpenDropdown(openDropdown === name ? null : name)}
+          onLinkClick={closeAllMenus}
+          isMobile={true}
         />
       </div>
 
-      <MobileDrawerFooter 
-        isAuthenticated={isAuthenticated} 
-        user={user} 
-        primaryLine={primaryLine} 
-        secondaryLine={secondaryLine} 
-        closeAllMenus={closeAllMenus} 
-        location={location} 
-        handleLogoutClick={handleLogoutClick} 
-        isDarkMode={isDarkMode} 
-        toggleTheme={toggleTheme} 
-        cursorEnabled={cursorEnabled} 
-        toggleCursor={toggleCursor} 
+      <MobileDrawerFooter
+        isAuthenticated={isAuthenticated}
+        user={user}
+        primaryLine={primaryLine}
+        secondaryLine={secondaryLine}
+        closeAllMenus={closeAllMenus}
+        location={location}
+        handleLogoutClick={handleLogoutClick}
+        isDarkMode={isDarkMode}
+        toggleTheme={toggleTheme}
+        cursorEnabled={cursorEnabled}
+        toggleCursor={toggleCursor}
       />
     </div>
   );
@@ -534,11 +528,11 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
       />
 
       <nav
-  ref={navRef}
-  data-aos="fade-down"
-  data-aos-once="true"
-  data-aos-duration="1000"
-  className="
+        ref={navRef}
+        data-aos="fade-down"
+        data-aos-once="true"
+        data-aos-duration="1000"
+        className="
     fixed top-0 left-0 w-full z-40
     backdrop-blur-xl
     bg-white/60 dark:bg-gray-900/50
@@ -548,7 +542,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
     supports-[backdrop-filter]:bg-white/40
     dark:supports-[backdrop-filter]:bg-gray-900/40
   "
->
+      >
         <div className="w-full flex items-center h-20 px-6 md:px-12 relative">
           <Link to="/" className="flex-shrink-0 z-20">
             <h2 className="text-3xl font-semibold tracking-tight text-black dark:text-white" style={{ fontFamily: '"Anton", sans-serif' }}>
@@ -558,20 +552,20 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
           <DesktopNavLinks openDropdown={openDropdown} setOpenDropdown={setOpenDropdown} />
 
-          <div className="hidden lg:flex items-center ml-auto z-20">
+          <div className="hidden xl:flex items-center ml-auto z-20">
             <ThemeToggleButton isDarkMode={isDarkMode} toggleTheme={toggleTheme} isMobile={false} />
             <CursorToggleButton cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} isMobile={false} />
 
             <div className="flex items-center space-x-2 ml-2">
               {isAuthenticated() ? (
-                <UserProfileDropdown 
-                  user={user} 
-                  primaryLine={primaryLine} 
-                  secondaryLine={secondaryLine} 
-                  showProfileDropdown={showProfileDropdown} 
-                  setShowProfileDropdown={setShowProfileDropdown} 
-                  location={location} 
-                  handleLogoutClick={handleLogoutClick} 
+                <UserProfileDropdown
+                  user={user}
+                  primaryLine={primaryLine}
+                  secondaryLine={secondaryLine}
+                  showProfileDropdown={showProfileDropdown}
+                  setShowProfileDropdown={setShowProfileDropdown}
+                  location={location}
+                  handleLogoutClick={handleLogoutClick}
                 />
               ) : (
                 <AuthButtons isMobile={false} />
@@ -579,7 +573,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
             </div>
           </div>
 
-          <div className="lg:hidden ml-auto">
+          <div className="xl:hidden ml-auto">
             <button ref={toggleBtnRef} onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)} aria-expanded={isMobileMenuOpen} aria-label="Open navigation" className="p-2 rounded-md text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/10">
               <svg className="h-5 w-5 sm:h-6 sm:w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />


### PR DESCRIPTION
## Description

This PR fixes navbar text overlapping on medium and large screen sizes (~1000px–1200px).

### Changes made

* Extended mobile drawer behavior until `xl` breakpoint
* Changed desktop navbar visibility from `lg` → `xl`
* Prevented overlap between navbar items and action buttons (theme toggle, cursor toggle, auth buttons)

### Result

* Better responsive behavior on medium/large screens
* No overlapping navigation items
* Cleaner layout consistency

Fixes #3851

Screenshot : - 
<img width="1919" height="794" alt="image" src="https://github.com/user-attachments/assets/aafc3aeb-8085-402d-be3a-22e319ed7df5" />
