### PR TITLE
fix: resolve cryptographic salt bypass in AES-GCM key derivation

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -60,7 +60,7 @@ const getDerivedKey = () => {
       ['deriveKey'],
     );
 
-    const salt = encoder.encode(`eventra:${window.location.origin}:storage-key-v1`);
+    const salt = DERIVED_KEY_SALT;
 
     return crypto.subtle.deriveKey(
       {


### PR DESCRIPTION
### Problem Solved
Resolves a security vulnerability in `src/utils/secureStorage.js` where the eagerly generated, cryptographically secure random 256-bit browser-unique salt (`DERIVED_KEY_SALT`) was completely ignored during the PBKDF2 key derivation in `getDerivedKey()`. Instead, a public, static salt derived from `window.location.origin` was used, allowing an attacker to precompute the PBKDF2 derived keys.

### Approach
Modified `getDerivedKey()` to correctly pass the browser-unique `DERIVED_KEY_SALT` into the PBKDF2 key derivation.

### Related Issues
Closes #3936

---
I am contributing on behalf of GSSoc’26!