### PR TITLE
fix: prevent infinite recursion stack overflow in activityTracker.js

### DIFF
--- a/src/utils/activityTracker.js
+++ b/src/utils/activityTracker.js
@@ -7,7 +7,16 @@ const processInterestQueue = () => {
   isUpdating = true;
 
   try {
-    const existing = JSON.parse(localStorage.getItem("eventra_user_profile")) || {};
+    let existing = {};
+    try {
+      const raw = localStorage.getItem("eventra_user_profile");
+      if (raw) {
+        existing = JSON.parse(raw) || {};
+      }
+    } catch (parseError) {
+      console.warn("Failed to parse user profile JSON, resetting it:", parseError);
+    }
+
     let interests = existing.interests || [];
     let modified = false;
 
@@ -27,6 +36,7 @@ const processInterestQueue = () => {
     }
   } catch (error) {
     console.error("Failed to update user interests:", error);
+    interestQueue = []; // Clear the queue on persistent error to avoid infinite recursion
   } finally {
     isUpdating = false;
     if (interestQueue.length > 0) {

--- a/tests/activityTracker.test.mjs
+++ b/tests/activityTracker.test.mjs
@@ -3,13 +3,40 @@ import assert from "node:assert/strict";
 const store = {};
 globalThis.localStorage = {
   getItem: (key) => store[key] || null,
-  setItem: (key, val) => { store[key] = String(val); }
+  setItem: (key, val) => {
+    store[key] = String(val);
+  }
 };
 
 import { trackUserInterest } from "../src/utils/activityTracker.js";
 
+// Test 1: Standard functional interest tracking
+store["eventra_user_profile"] = null;
 trackUserInterest("design");
-const profile = JSON.parse(store["eventra_user_profile"]);
-assert.ok(profile.interests.includes("design"));
+let profile = JSON.parse(store["eventra_user_profile"]);
+assert.ok(profile.interests.includes("design"), "Should add design to interests");
+
+// Track another interest
+trackUserInterest("coding");
+profile = JSON.parse(store["eventra_user_profile"]);
+assert.deepEqual(profile.interests, ["design", "coding"], "Should maintain both interests");
+
+// Test 2: Handle corrupt / invalid JSON in localStorage gracefully without stack overflow
+store["eventra_user_profile"] = "{invalid-json-corrupt-data";
+assert.doesNotThrow(() => {
+  trackUserInterest("hacking");
+}, "Should not throw or cause infinite recursion stack overflow on corrupted JSON");
+
+profile = JSON.parse(store["eventra_user_profile"]);
+assert.deepEqual(profile.interests, ["hacking"], "Should successfully reset corrupt storage and add hacking");
+
+// Test 3: Handle complete localStorage write failure gracefully
+globalThis.localStorage.setItem = () => {
+  throw new Error("QuotaExceededError");
+};
+
+assert.doesNotThrow(() => {
+  trackUserInterest("security");
+}, "Should handle storage write failures gracefully without infinite recursion");
 
 console.log("activityTracker tests passed ✓");


### PR DESCRIPTION
### Problem Solved
Resolves a potential browser tab crash due to an infinite recursion call stack overflow in `src/utils/activityTracker.js`. If `localStorage` holds corrupted or invalid JSON under `eventra_user_profile`, calling `trackUserInterest` would trigger a syntax error on `JSON.parse`. Since the queue is never shifted, the `finally` block would recursively invoke `processInterestQueue` indefinitely until a call stack overflow crashed the browser tab.

### Approach
1. Wrapped `JSON.parse` in a safe, inner try-catch block, falling back to `{}` on parse failure to gracefully reconstruct a clean state and overwrite/repair the corrupted storage structure.
2. In the outer try-catch block, added `interestQueue = []` on persistent errors to ensure the queue is cleared, preventing any infinite recursion stack overflow scenarios.
3. Rewrote the unit tests in `tests/activityTracker.test.mjs` to comprehensively validate normal interest tracking, recovery from corrupted storage string, and safe handling of storage write failures without crashing.

### Related Issues
Closes #3937

---
I am contributing on behalf of GSSoc’26!