### PR TITLE
fix: Remove redundant aria-label on buttons in SearchFilter

### DIFF
--- a/src/components/SearchFilter.js
+++ b/src/components/SearchFilter.js
@@ -265,8 +265,8 @@ const SearchFilter = () => {
                 <span className="rating-value">{event.rating}</span>
               </div>
               <div className="event-actions">
-                <button className="btn-primary" aria-label="button">Register Now</button>
-                <button className="btn-outline" aria-label="button">Learn More</button>
+                <button className="btn-primary">Register Now</button>
+                <button className="btn-outline">Learn More</button>
               </div>
             </div>
           </motion.div>


### PR DESCRIPTION
## 🚀 Description
This PR fixes a meaningless and redundant `aria-label` in `SearchFilter.js` (`aria-label=\"button\"`) by removing it, since screen readers already announce buttons as such, and the buttons have clear text content.

Fixes #3948

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings