### PR TITLE
fix: Resolve accessibility aria-label typo in ShareModal component

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -36,7 +36,7 @@ const ShareModal = ({ event, onClose }) => {
           <button
             onClick={onClose}
             className="text-xl"
-           aria-label="button">
+           aria-label="Close modal">
             ✕
           </button>
         </div>
@@ -86,8 +86,7 @@ const ShareModal = ({ event, onClose }) => {
 
           <button
             onClick={copyLink}
-            className="rounded-xl bg-indigo-600 px-4 py-3 text-white"
-           aria-label="button">
+            className="rounded-xl bg-indigo-600 px-4 py-3 text-white">
             Copy Link
           </button>
         </div>


### PR DESCRIPTION
## 🚀 Description
This PR fixes meaningless `aria-label` attributes in `ShareModal.jsx` by providing a descriptive label for the close button and removing the redundant label on the Copy Link button. This improves accessibility for screen readers.

Fixes #3952

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings