### PR TITLE
chore: add type module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A modern website for Eventra - platform for builders",
   "private": true,
+  "type": "module",
   "engines": {
     "node": "22.x",
     "npm": ">=9.6.4"


### PR DESCRIPTION
## 🚀 Description
This PR fixes a configuration issue where the lack of `"type": "module"` in `package.json` causes widespread `MODULE_TYPELESS_PACKAGE_JSON` warnings across the test suite and Node execution when parsing ES modules.

Fixes #3956

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings