### PR TITLE
fix: correct malformed onClick handler in MobileNavbar

### DIFF
--- a/src/components/navbar/MobileNavbar.jsx
+++ b/src/components/navbar/MobileNavbar.jsx
@@ -10,7 +10,8 @@ const MobileNavbar = ({ isOpen, setIsOpen, isAuthenticated, user, logout }) => {
         onClick={() => setIsOpen((prev) => !prev)}
         className="mobile-menu-button lg:hidden inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl p-3 text-gray-700 transition-colors hover:bg-gray-100 hover:text-black dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-white"
         aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-        onClick={() = aria-label="button"> setIsOpen(true)}
+        aria-label="button"
+        onClick={() => setIsOpen(true)}
         onClick={() => setIsOpen(true)}
         className="lg:hidden p-3 min-w-[44px] min-h-[44px] flex items-center justify-center"
         aria-label="Open navigation menu"


### PR DESCRIPTION
## Description

Fixed malformed JSX syntax in `src/components/navbar/MobileNavbar.jsx` that was causing JSX parsing and build failures.

### Changes Made

* Replaced invalid `onClick` handler syntax with:

  ```jsx
  onClick={() => setIsOpen(true)}
  ```
* Moved `aria-label` outside the handler as a proper JSX attribute.
* Kept the fix minimal without modifying unrelated functionality.

### Notes

`MobileNavbar.jsx` no longer contains JSX syntax errors.
The overall project build still reports unrelated pre-existing errors in other files, which were intentionally left untouched to keep this PR scoped only to Issue #3649.

Fixes #3649
