### PR TITLE
fix: handle clipboard and share errors in EventDetailsPage

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -7,6 +7,7 @@ import { sanitizeHtml } from "../../utils/sanitizeHtml";
 import CountdownTimer from "../../components/common/CountdownTimer";
 import { Calendar, MapPin, Clock, Users, Tag, ArrowLeft, WifiOff } from "lucide-react";
 import { Share2, Twitter, Facebook, Linkedin, MessageCircle, Copy, Check } from "lucide-react";
+import { toast } from "react-toastify";
 import { getEventStatus } from "../../utils/eventUtils";
 // Note: eventsMockData.json is NOT statically imported here.
 // It is loaded dynamically (and only in development/fallback mode) so that
@@ -39,7 +40,7 @@ const EventDetailsPage = () => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Clipboard write failed silently
+      toast.error("Failed to copy link to clipboard");
     }
   };
 
@@ -51,7 +52,11 @@ const EventDetailsPage = () => {
           text: shareText,
           url: shareUrl,
         });
-      } catch {}
+      } catch (err) {
+        if (err.name !== "AbortError") {
+          toast.error("Unable to share event");
+        }
+      }
     }
   };
 


### PR DESCRIPTION
## 🚀 Description
This PR fixes a bug in `EventDetailsPage.js` where errors during `navigator.clipboard.writeText` and `navigator.share` were silently swallowed by empty `catch` blocks. This prevented users from knowing if their action failed (e.g. due to permissions). The fix adds `toast.error` notifications to provide clear feedback.

Fixes #3957

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
N/A

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings