### PR TITLE
fix: correct malformed onClick handler in StyledDropdown

### DIFF
--- a/src/components/StyledDropdown.js
+++ b/src/components/StyledDropdown.js
@@ -169,7 +169,8 @@ const Dropdown = ({
                 {opt}
                 <button
                   type="button"
-                  onClick={() = aria-label="button"> handleSelect(opt)}
+                  aria-label="button"
+                  onClick={() => handleSelect(opt)}
                   onKeyDown={(event) => handleOptionKeyDown(event, opt)}
                   className={`w-full px-4 py-2 text-left text-sm cursor-pointer hover:bg-indigo-50 dark:hover:bg-gray-700 focus:bg-indigo-50 dark:focus:bg-gray-700 focus:outline-none text-gray-700 dark:text-gray-100 ${
                     value === opt


### PR DESCRIPTION
## Description

Fixed malformed JSX syntax in `src/components/StyledDropdown.js` that caused JSX parsing and compilation failures.

### Changes Made

* Replaced invalid `onClick` handler syntax with:

  ```jsx
  onClick={() => handleSelect(opt)}
  ```
* Corrected misplaced JSX attributes.
* Ensured valid JSX formatting.
* Kept the fix minimal without modifying unrelated functionality.

### Notes

This PR only addresses the malformed JSX syntax issue reported in Issue #3653 and intentionally avoids unrelated changes.

Fixes #3653
