### PR TITLE
docs: add logout API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -256,7 +256,11 @@ Authenticates the user via Google OAuth and returns a JWT token. Creates a new u
 |--------|----------|
 | POST | `/api/auth/logout` |
 
-Logs out the authenticated user and invalidates their JWT token. Requires JWT authentication.
+Logs out the authenticated user and invalidates the current JWT session. This endpoint invalidates the JWT by adding it to a server-side blacklist; once logged out, the same token can no longer be used to access protected APIs.
+
+### Authentication
+
+Requires a valid Bearer JWT in the `Authorization` header.
 
 ### Request Headers
 
@@ -264,22 +268,21 @@ Logs out the authenticated user and invalidates their JWT token. Requires JWT au
 Authorization: Bearer YOUR_JWT_TOKEN
 ```
 
+### Request Body
+
+None required.
+
 ### Successful Response (200)
 
-```json
-{
-  "message": "Logged out successfully",
-  "timestamp": "2026-05-27T16:00:00.000Z"
-}
+```text
+Logged out successfully
 ```
 
 ### Error Responses
 
 | Status | Reason |
 |--------|--------|
-| `401 Unauthorized` | Missing, invalid, or expired token |
-| `401 Unauthorized` | Token has already been invalidated (logged out) |
-| `405 Method Not Allowed` | Invalid HTTP method (only POST allowed) |
+| `401 Unauthorized` | Missing, malformed, invalid, or blacklisted token |
 
 ---
 


### PR DESCRIPTION
## Related Backend PR

Related to SandeepVashishtha/Eventra-Backend#39

## Description

This PR updates the frontend API documentation to include the newly added backend logout endpoint.

## Changes Made

- Documented `POST /api/auth/logout`
- Added authentication requirement for logout
- Added header details for bearer token usage
- Added success response example
- Added unauthorized response notes
- Noted that logout invalidates the current JWT so it cannot be reused on protected APIs

## Notes

The backend implementation is handled in the Eventra-Backend repository.  
This PR only syncs the frontend/docs repository documentation with the backend API behavior.