### PR TITLE
feat: handle API rate limiting and add exponential backoff retry 

### DIFF
--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -216,9 +216,18 @@ const Signup = () => {
     } catch (err) {
       console.error("Signup error:", { message: err.message, email: formData.email });
       setSubmitStatus('error');
+      
+      let errorMessage = getPublicErrorMessage(err, AUTH_ERRORS.registrationFailed);
+      
+      if (err.name === "RateLimitError") {
+        errorMessage = "Too many attempts. Please try again in a minute.";
+      } else if (err.isTimeout || err.isNetworkError) {
+        errorMessage = "Network timeout or connection error. Please check your connection and try again.";
+      }
+      
       setErrors(prev => ({ 
         ...prev, 
-        submit: getPublicErrorMessage(err, AUTH_ERRORS.registrationFailed) 
+        submit: errorMessage
       }));
     } finally {
       setLoading(false);

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -81,6 +81,13 @@ export class ApiError extends Error {
   }
 }
 
+export class RateLimitError extends ApiError {
+  constructor(message, { status = 429, data = null } = {}) {
+    super(message, { status, data });
+    this.name = "RateLimitError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Axios Instance
 // ---------------------------------------------------------------------------
@@ -157,6 +164,13 @@ const normalizeApiError = (error) => {
     );
   }
 
+  if (status === 429) {
+    return new RateLimitError(
+      error.response?.data?.message || "Too many requests, please try again later.",
+      { status, data: error.response?.data || null }
+    );
+  }
+
   return new ApiError(
     error.response?.data?.message ||
       error.message ||
@@ -188,16 +202,21 @@ API.interceptors.response.use(
     }
 
     const retryCount = config._retryCount || 0;
-    if (RETRYABLE_STATUS_CODES.includes(status) && retryCount < MAX_RETRIES) {
+    const isNonMutating = config.method?.toUpperCase() === 'GET';
+    const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status) || (status === 429);
+    
+    // Retry non-mutating requests with exponential backoff
+    if (isNonMutating && isRetryableStatus && retryCount < MAX_RETRIES) {
       config._retryCount = retryCount + 1;
+      const delay = RETRY_DELAY_MS * Math.pow(2, retryCount);
 
       if (isDev) {
         console.debug(
-          `[API ${config.method?.toUpperCase()}] ${config.url} returned ${status}, retrying in ${RETRY_DELAY_MS}ms (attempt ${config._retryCount})...`
+          `[API ${config.method?.toUpperCase()}] ${config.url} returned ${status}, retrying in ${delay}ms (attempt ${config._retryCount})...`
         );
       }
 
-      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      await new Promise((resolve) => setTimeout(resolve, delay));
       return API(config);
     }
     throw normalizeApiError(error);


### PR DESCRIPTION
Resolves #3110

## Description
This PR enhances the client-side API configuration to handle `429 Too Many Requests` elegantly, and introduces an exponential backoff mechanism for safer API retries. By providing actionable feedback to users, we prevent confusion and frustration when the API goes down or becomes overwhelmed.

## Changes Made
- **Created `RateLimitError`**: Extended the custom `ApiError` utility in `apiUtils.js` (`src/config/api.js`) to specifically construct and throw a `RateLimitError` whenever a `429` status code is encountered from the server.
- **Exponential Backoff Retry Strategy**: Overhauled the Axios response interceptor in `api.js` to intelligently apply an exponential backoff retry mechanism. Retries will now only trigger for non-mutating (GET) requests when encountering transient errors or rate limits, scaling the delay across successive attempts.
- **Enhanced Signup UX**: Updated the primary submission catch block in the `Signup.js` component to identify when a `RateLimitError` is thrown, translating the raw error into a friendly, actionable UI message: "Too many attempts. Please try again in a minute." Added defensive messaging for standard network timeouts as well.

## Testing
- Code structure and interceptor configuration validated manually.
- The `Signup.js` error block is thoroughly structured to override the generic `getPublicErrorMessage` utility fallback when these explicit conditions are met.
