### PR TITLE
docs: Add React frontend developer onboarding guide

### DIFF
--- a/docs/frontend-onboarding.md
+++ b/docs/frontend-onboarding.md
@@ -1,0 +1,19 @@
+# React Frontend Onboarding Guide
+
+Welcome to the Eventra React Frontend codebase! This guide will help you understand the architecture, tools, and conventions used to build our seamless user interface.
+
+## Tech Stack
+- **React**: Component-based user interface library.
+- **Vite**: Ultra-fast build tool and bundler.
+- **Vanilla CSS**: Styled with performance-driven responsive design rules.
+
+## Directory Layout
+- `/src/components`: Reusable, stateless UI building blocks.
+- `/src/pages`: Feature-specific container components mapped to router endpoints.
+- `/src/contexts`: Global state providers (e.g. Auth, Theme).
+- `/src/hooks`: Custom React hooks encapsulate business logic.
+
+## Developer Workflow
+1. Run `npm install` to download standard dependencies.
+2. Execute `npm run dev` to start the local hot-reloading development server.
+3. Make sure all files follow the Prettier formatting configuration rules before committing.


### PR DESCRIPTION
This PR adds a comprehensive onboarding guide for the React frontend under the `docs/` folder. Relocates details regarding tech stack, directory layout, and standard dev workflows to a centralized location to help new contributors. Fixes #4036.