### PR TITLE
docs: Add API endpoint structure and security guide

### DIFF
--- a/docs/api-structure.md
+++ b/docs/api-structure.md
@@ -1,0 +1,12 @@
+# API Endpoint and Security Guide
+
+Documentation of key endpoints, authentication headers, and request-response payloads for the Eventra API.
+
+## Authentication
+All secure endpoints require the standard Bearer token header:
+`Authorization: Bearer <jwt-token>`
+
+## Core Endpoints
+- `POST /api/auth/login`: Authenticate and receive JWT token.
+- `GET /api/events`: List all active, public events.
+- `POST /api/events`: Create a new event (Organizers only).


### PR DESCRIPTION
This PR documents the primary API routes, request payloads, and security headers for Eventra in `docs/api-structure.md`. Fixes #4040.