### PR TITLE
docs: Add Docker setup troubleshooting guide

### DIFF
--- a/docs/docker-troubleshooting.md
+++ b/docs/docker-troubleshooting.md
@@ -1,0 +1,13 @@
+# Docker Deployment Troubleshooting Guide
+
+Resolutions for common errors encountered during local containerized setups of Eventra.
+
+## 1. Port Allocation Conflicts
+If `localhost:8080` or `localhost:3000` is already in use, modify the port mapping attributes in `docker-compose.yml`:
+```yaml
+ports:
+  - "8081:8080"
+```
+
+## 2. PostgreSQL Connection Failures
+Ensure that database service containers have fully completed initialization before boot-up of the Spring Boot application container.


### PR DESCRIPTION
This PR creates `docs/docker-troubleshooting.md` to help contributors resolve common container network and port allocation conflicts. Fixes #4042.