### PR TITLE
docs: Add database migrations and schema versioning guide

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,0 +1,8 @@
+# Database Migrations Guide
+
+This guide explains how database schema modifications are tracked, tested, and executed in Eventra.
+
+## Workflow
+1. Schema migrations are declared using XML/SQL changelog files.
+2. Do NOT modify previously executed migration steps; always declare a new schema file for revisions.
+3. Run validation scripts locally to ensure no lockouts occur during production deployment.


### PR DESCRIPTION
This PR documents the schema versioning practices and migration lifecycle flow under `docs/database-migrations.md`. Fixes #4044.