### PR TITLE
docs: Add Storybook developer guide

### DIFF
--- a/docs/storybook-guide.md
+++ b/docs/storybook-guide.md
@@ -1,0 +1,12 @@
+# Storybook Developer Guide
+
+This guide explains how to document, test, and catalog Eventra components using Storybook locally.
+
+## How to Start
+Launch the local Storybook dev instance:
+```bash
+npm run storybook
+```
+
+## Story Conventions
+Create a `{ComponentName}.stories.jsx` file adjacent to your React component, declaring state permutations using Args.


### PR DESCRIPTION
This PR introduces setup steps, stories configurations, and styling conventions for isolation rendering under `docs/storybook-guide.md`. Fixes #4052.