### PR TITLE
docs: Add Issue and Pull Request style guide

### DIFF
--- a/docs/issue-pr-guide.md
+++ b/docs/issue-pr-guide.md
@@ -1,0 +1,12 @@
+# Issue and Pull Request Guide
+
+This guide outlines the standard conventions for creating highly structured, descriptive, and actionable Issues and PRs in the Eventra project.
+
+## 1. Titles
+Enforce semantic commit conventions on Issue and PR titles:
+- `feat: <title>`: A new feature.
+- `fix: <title>`: A bug fix.
+- `docs: <title>`: Documentation updates.
+
+## 2. Description Requirements
+Every PR must clearly define description context, impact, and standard validation logs.


### PR DESCRIPTION
This PR introduces structuring templates and Semantic Commit conventions under `docs/issue-pr-guide.md` to ensure professional workflows. Fixes #4054.