### PR TITLE
fix: remove redundant image wording from alt text

### DIFF
--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -369,7 +369,7 @@ const Contributors = () => {
                     <div className="relative">
                       <img loading="lazy" decoding="async" width="65" height="65"
   src={c.avatar_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(c.name || c.login || "Anon")}&background=random`}
-  alt={`${c.name || c.login || "Contributor"}'s GitHub profile picture`}
+  alt={`${c.name || c.login || "Contributor"}'s GitHub profile`}
   className="w-[65px] h-[65px] rounded-full border-4 border-gray-900 dark:border-gray-300 shadow-md relative z-10"
 />
                       <div className="absolute inset-0 rounded-full animate-pulse bg-black/10 blur-sm -z-10"></div>

--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -338,7 +338,7 @@ const Contributors = () => {
                       width="80"
                       height="80"
                       src={c.avatar_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(c.name || "Anon")}&background=random`}
-                      alt={`${c.name || c.login || "Contributor"}'s GitHub profile picture`}
+                      alt={`${c.name || c.login || "Contributor"}'s GitHub profile`}
                       className="w-20 h-20 rounded-full border-4 border-black dark:border-gray-300 shadow-xl"
                     />
                     <div className="absolute inset-0 rounded-full animate-pulse bg-black/10 dark:bg-white/10 blur-md"></div>

--- a/src/stories/Configure.mdx
+++ b/src/stories/Configure.mdx
@@ -67,7 +67,7 @@ export const RightArrow = () => <svg
       >Learn more<RightArrow /></a>
     </div>
     <div className="sb-section-item">
-      <img src={Assets} alt="A representation of typography and image assets" />
+      <img src={Assets} alt="A representation of typography and media assets" />
       <div>
         <h4 className="sb-section-item-heading">Load assets and resources</h4>
         <p className="sb-section-item-paragraph">To link static files (like fonts) to your projects and stories, use the


### PR DESCRIPTION
## 🚀 Description
Fixes #3875

This PR removes redundant image-related wording from alt text across affected components. Screen readers already announce image semantics, so words like “picture” or “image” in alt text create repetitive announcements and reduce accessibility quality.

Changes included:
- Updated contributor avatar alt text from “GitHub profile picture” to “GitHub profile”.
- Updated home contributor carousel avatar alt text similarly.
- Reworded Storybook asset illustration alt text from “image assets” to “media assets”.

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)
Not applicable. Alt text accessibility copy update only.

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings