### PR TITLE
Fix: Chatbot throws unhandled exceptions when localStorage is unavailable

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -47,12 +47,16 @@ export default function Chatbot() {
 
   // Expiration check on mount (2 hours threshold)
   useEffect(() => {
-    const lastActive = localStorage.getItem("eventra_chatbot_last_active");
-    const twoHours = 2 * 60 * 60 * 1000;
-    if (lastActive && Date.now() - parseInt(lastActive) > twoHours) {
-      setMessages(INITIAL_MESSAGES);
+    try {
+      const lastActive = localStorage.getItem("eventra_chatbot_last_active");
+      const twoHours = 2 * 60 * 60 * 1000;
+      if (lastActive && Date.now() - parseInt(lastActive) > twoHours) {
+        setMessages(INITIAL_MESSAGES);
+      }
+      localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());
+    } catch (e) {
+      console.warn("localStorage unavailable for Chatbot expiration check");
     }
-    localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());
   }, [setMessages]);
 
   useEffect(() => {
@@ -63,7 +67,11 @@ export default function Chatbot() {
 
   // Sync last active timestamp when messages change
   useEffect(() => {
-    localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());
+    try {
+      localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());
+    } catch (e) {
+      console.warn("localStorage unavailable for Chatbot sync");
+    }
   }, [messages]);
 
   const handleClearConversation = () => {


### PR DESCRIPTION
## 📌 Summary
This pull request fixes a critical initialization bug in the `Chatbot` component where unhandled synchronous `localStorage` operations would crash the entire React application in restrictive environments (e.g., Safari Private Browsing or when Quota is Exceeded).

## 🔗 Related Issue
Closes #4070

## 🛠️ Changes Made
- **`src/components/Chatbot.jsx`**: Wrapped all `localStorage.setItem` and `getItem` calls within the initialization and message sync `useEffect` hooks in robust `try/catch` blocks.

## 🧪 How to Test
1. Pull the branch locally.
2. Disable `localStorage` in your browser settings (or run in an environment where quota is intentionally exceeded).
3. Load the application. The Chatbot should silently fail to save history without crashing the overarching React render cycle.

## 📸 Screenshots (if UI changes)
*No visual UI changes.*

## ✅ Checklist
- [x] Code follows the project's code style
- [x] Self-review done
- [x] No console errors or warnings
- [x] Tested locally
- [x] Related issue linked

## 📝 Additional Notes
This ensures the application degrades gracefully when client storage is unavailable, improving overall platform resilience.