### PR TITLE
Fix: ShareMenu fails silently if native share is cancelled or rejected

### DIFF
--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -4,6 +4,7 @@ import { Share2, Copy, Mail, Check } from 'lucide-react';
 import { FiFacebook, FiLinkedin } from 'react-icons/fi';
 import { FaWhatsapp, FaTelegram } from 'react-icons/fa';
 import { generateSharingUrl, copyToClipboard } from '../../../utils/shareUtils';
+import { toast } from 'react-toastify';
 import './ShareMenu.css';
 
 /**
@@ -98,7 +99,10 @@ const ShareMenu = ({
         url: shareData.url || window.location.href,
       })
       .then(()=>setIsOpen(false))
-      .catch((err)=>console.error('Error sharing:', err));
+      .catch((err) => {
+        console.error('Error sharing:', err);
+        toast.error("Failed to share event", { autoClose: 2000 });
+      });
       return;
     }
     if (platform === 'copy') {


### PR DESCRIPTION
## 📌 Summary
This pull request improves user experience and interface feedback within the `ShareMenu` component by explicitly notifying the user if a native OS share operation fails or is aborted.

## 🔗 Related Issue
Closes #4077

## 🛠️ Changes Made
- **`src/components/common/ShareMenu/ShareMenu.js`**: Imported `toast` from `react-toastify` and added a visual error notification (`toast.error`) inside the `navigator.share` Promise rejection handler.

## 🧪 How to Test
1. Pull the branch and view an event.
2. Click the Share button to open the `ShareMenu`.
3. Trigger a system share (e.g., on a mobile device or supported desktop browser) and immediately cancel/dismiss the OS share sheet.
4. A toast notification should appear informing you that the share action failed.

## 📸 Screenshots (if UI changes)
*No visual UI changes.*

## ✅ Checklist
- [x] Code follows the project's code style
- [x] Self-review done
- [x] No console errors or warnings
- [x] Tested locally
- [x] Related issue linked

## 📝 Additional Notes
Previously, cancelled shares simply logged to the console while leaving the ShareMenu hanging open.