### PR TITLE
Fix: ProjectCard image alt attribute violates accessibility if title is missing

### DIFF
--- a/src/Pages/Projects/ProjectCard.js
+++ b/src/Pages/Projects/ProjectCard.js
@@ -352,7 +352,7 @@ const ProjectCard = ({ project, index, isBookmarked, onBookmarkToggle }) => {
           }`} loading="lazy"/>
         <img
           src={project.image}
-          alt={project.title}
+          alt={project.title || "Project preview"}
           loading="lazy"
           decoding="async"
           onLoad={() => setIsLoaded(true)}


### PR DESCRIPTION
## 📌 Summary
This pull request resolves a WCAG accessibility violation in the `ProjectCard` component where the main project image `alt` attribute would evaluate to `undefined` if a project title was not provided.

## 🔗 Related Issue
Closes #4080

## 🛠️ Changes Made
- **`src/Pages/Projects/ProjectCard.js`**: Added a fallback string (`"Project preview"`) to the image's `alt` attribute mapping to ensure screen readers always receive descriptive text.

## 🧪 How to Test
1. Pull the branch locally.
2. Render a `ProjectCard` passing a mock project object without a `title` property.
3. Inspect the DOM element. The `<img>` tag should now contain `alt="Project preview"` instead of lacking the attribute completely.

## 📸 Screenshots (if UI changes)
*No visual UI changes.*

## ✅ Checklist
- [x] Code follows the project's code style
- [x] Self-review done
- [x] No console errors or warnings
- [x] Tested locally
- [x] Related issue linked

## 📝 Additional Notes
A simple but important fix for maintaining our commitment to accessibility standards.