### PR TITLE
Fix: Remove redundant Share button from EventCard to declutter UI

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -113,19 +113,6 @@ const EventCard = ({ event, cacheInfo = null }) => {
     });
   }, [event.id]);
 
-  const handleCopyLink = useCallback((e) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    navigator.clipboard
-      .writeText(`${window.location.origin}/events/${event.id}`)
-      .then(() => {
-        toast.success("Event link copied to clipboard!", { autoClose: 2000 });
-      })
-      .catch(() => {
-        toast.error("Could not copy link. Please try again.", { autoClose: 2500 });
-      });
-  }, [event.id]);
 
   const handleBookmarkToggle = useCallback((e) => {
     e.preventDefault();
@@ -186,15 +173,6 @@ const EventCard = ({ event, cacheInfo = null }) => {
           </div>
         </ShareMenu>
 
-        <button
-          type="button"
-          onClick={handleCopyLink}
-          className="relative min-h-[36px] min-w-[36px] rounded-full border border-gray-200 bg-white/90 p-2 shadow backdrop-blur-sm focus-visible:ring-2 focus-visible:ring-indigo-500 hover:border-indigo-200 dark:border-gray-700 dark:bg-gray-800/90 dark:text-gray-300 dark:hover:border-indigo-500 dark:hover:text-indigo-400 transition-all duration-200"
-          title="Copy Event Link"
-          aria-label={`Copy link for ${event.title}`}
-        >
-          <Share2 size={14} className="text-gray-600 dark:text-gray-300" aria-hidden="true" />
-        </button>
 
         <a
           href={addEventToGoogleCalendar(event)}


### PR DESCRIPTION
## 📌 Summary
This pull request improves the UI of the `EventCard` component by removing a redundant "Copy Link" share button.

## 🔗 Related Issue
Closes #4105

## 🛠️ Changes Made
- **`src/Pages/Events/EventCard.js`**: Removed the standalone `handleCopyLink` button since the adjacent `ShareMenu` already provides full sharing and copy-link functionality.

## 🧪 How to Test
1. Pull the branch locally and start the app.
2. View any event card on the homepage.
3. Hover over the card to reveal the actions overlay. You should now only see one Share icon instead of two identical icons.

## 📸 Screenshots (if UI changes)
*The duplicate share button has been removed, creating a cleaner action bar.*

## ✅ Checklist
- [x] Code follows the project's code style
- [x] Self-review done
- [x] No console errors or warnings
- [x] Tested locally
- [x] Related issue linked

## 📝 Additional Notes
This prevents user confusion about having two identical buttons with overlapping functionality.