### PR TITLE
Fix: Align calendar focus ring and remove duplicate rel tag on EventCard

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -198,16 +198,14 @@ const EventCard = ({ event, cacheInfo = null }) => {
 
         <a
           href={addEventToGoogleCalendar(event)}
-          target="_blank" rel="noopener noreferrer"
+          target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
           title="Add to Google Calendar"
           aria-label={`Add ${event.title} to Google Calendar`}
-          className="rounded-full focus-visible:ring-2 focus-visible:ring-indigo-500"
+          className="rounded-full border border-gray-200 bg-white/90 p-2 shadow backdrop-blur-sm hover:border-indigo-200 dark:border-gray-700 dark:bg-gray-800/90 dark:hover:border-indigo-500 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-500"
         >
-          <div className="rounded-full border border-gray-200 bg-white/90 p-2 shadow backdrop-blur-sm hover:border-indigo-200 dark:border-gray-700 dark:bg-gray-800/90 dark:hover:border-indigo-500 transition-all duration-200">
-            <Calendar size={14} className="text-gray-600 dark:text-gray-300" aria-hidden="true" />
-          </div>
+          <Calendar size={14} className="text-gray-600 dark:text-gray-300" aria-hidden="true" />
         </a>
       </div>
 


### PR DESCRIPTION
## 📌 Summary
This pull request resolves an accessibility UI bug in the `EventCard` component where the keyboard focus ring for the "Add to Google Calendar" button was incorrectly aligned. It also removes a duplicate JSX attribute syntax error.

## 🔗 Related Issue
Closes #4108

## 🛠️ Changes Made
- **`src/Pages/Events/EventCard.js`**: 
  - Consolidated the visual styles (padding, borders, background, rounded-full) from the inner `<div>` directly onto the parent `<a>` tag.
  - Removed the inner `<div>` wrapper.
  - Removed the duplicate `rel="noopener noreferrer"` attribute.

## 🧪 How to Test
1. Pull the branch locally and start the app.
2. View any event card on the homepage.
3. Use the `Tab` key to navigate focus to the "Add to Google Calendar" button.
4. Observe that the focus ring now perfectly encompasses the circular button instead of forming a disjointed rectangle.

## 📸 Screenshots (if UI changes)
*Keyboard focus outlines are now visually precise and match the shape of the button element.*

## ✅ Checklist
- [x] Code follows the project's code style
- [x] Self-review done
- [x] No console errors or warnings
- [x] Tested locally
- [x] Related issue linked

## 📝 Additional Notes
A simple but important accessibility refinement for keyboard users.