### PR TITLE
fix: reset feedback form state on event navigation to prevent lockout

### DIFF
--- a/src/components/feedback/EventFeedbackForm.jsx
+++ b/src/components/feedback/EventFeedbackForm.jsx
@@ -21,6 +21,12 @@ const EventFeedbackForm = ({ eventId, eventTitle = "this event" }) => {
     const key = `feedback-submitted-${eventId}`;
     if (localStorage.getItem(key)) {
       setSubmitted(true);
+    } else {
+      // 🔥 FIX: Reset the form state when navigating to a new, unreviewed event
+      setSubmitted(false);
+      setRating(0);
+      setHoveredRating(0);
+      setComment("");
     }
   }, [eventId]);
 


### PR DESCRIPTION
## 🚀 Description
Fixes a cross-event state bleed where a user is locked out of submitting feedback for multiple events during a single SPA session.

Previously, the initialization `useEffect` only checked if an event was already reviewed (setting `submitted` to `true`), but failed to reset the component state when the `eventId` changed to an unreviewed event. This caused the "Thank you for your feedback!" success screen to persist across completely different event pages.

**Changes:**
- Added an `else` block to the `eventId` dependency effect.
- Explicitly resets `submitted`, `rating`, `hoveredRating`, and `comment` to their default values if no `localStorage` entry exists for the newly loaded event.

Fixes #4112 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code