### PR TITLE
feat: complete dark mode implementation and improve theme consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "preview": "vite preview",
     "validate-env": "node scripts/validate-env.js",
     "test": "npm run test:unit",
-    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs && node tests/userNameUtils.test.mjs && node tests/relativeTime.test.mjs && node tests/registerUtils.test.mjs && node tests/bookmarkUtils.test.mjs && node tests/auth.test.mjs && node tests/passwordResetEndpoint.test.mjs && node tests/eventDraftUtils.test.mjs && node tests/exportCsv.test.mjs && node tests/githubProxy.test.mjs && node tests/hackathonFilterUtils.test.mjs && node tests/loginEndpoint.test.mjs && node tests/googleOAuthEndpoint.test.mjs && node tests/logoutEndpoint.test.mjs && node tests/sseMultiplexer.test.mjs",
+    "test:unit": "node tests/eventPaginationUtils.test.mjs && node tests/routeSearchUtils.test.mjs && node tests/userNameUtils.test.mjs && node tests/relativeTime.test.mjs && node tests/registerUtils.test.mjs && node tests/bookmarkUtils.test.mjs && node tests/auth.test.mjs && node tests/passwordResetEndpoint.test.mjs && node tests/eventDraftUtils.test.mjs && node tests/exportCsv.test.mjs && node tests/githubProxy.test.mjs && node tests/hackathonFilterUtils.test.mjs && node tests/loginEndpoint.test.mjs && node tests/googleOAuthEndpoint.test.mjs && node tests/logoutEndpoint.test.mjs && node tests/themeConsistency.test.mjs && node tests/sseMultiplexer.test.mjs",
     "test:e2e": "playwright test",
     "lint": "eslint src --ext .js,.jsx --max-warnings=-1",
     "lint:fix": "eslint src --ext .js,.jsx --fix",

--- a/src/Pages/Events/EventAnalyticsDashboard.css
+++ b/src/Pages/Events/EventAnalyticsDashboard.css
@@ -4,6 +4,7 @@
   min-height: 100vh;
   padding: 32px 24px;
   color: #1e1b4b;
+  transition: background-color 0.25s ease, color 0.25s ease;
 }
 .dark .ead-root {
   background: #0f172a;
@@ -69,8 +70,9 @@
   box-shadow: 0 1px 4px #6366f110;
 }
 .dark .ead-kpi {
-  background: #1e293b;
-  border-color: #334155;
+  background: #111827;
+  border-color: #475569;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
 }
 
 .ead-kpi-val {
@@ -82,10 +84,13 @@
 
 .ead-kpi-label {
   font-size: 11px;
-  color: #9ca3af;
+  color: #64748b;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+.dark .ead-kpi-label {
+  color: #cbd5e1;
 }
 
 /* ── Tabs ── */
@@ -109,20 +114,30 @@
   font-family: inherit;
 }
 .dark .ead-tab {
-  background: #1e293b;
+  background: #111827;
   color: #e2e8f0;
-  border-color: #334155;
+  border-color: #475569;
 }
 
 .ead-tab:hover {
   border-color: #6366f1;
   color: #6366f1;
 }
+.dark .ead-tab:hover {
+  border-color: #818cf8;
+  color: #c7d2fe;
+  background: #1e293b;
+}
 
 .ead-tab--active {
   background: #6366f1;
   border-color: #6366f1;
   color: #fff;
+}
+.dark .ead-tab--active {
+  background: #818cf8;
+  border-color: #818cf8;
+  color: #111827;
 }
 
 /* ── Grid ── */
@@ -141,8 +156,9 @@
   box-shadow: 0 2px 12px #6366f108;
 }
 .dark .ead-card {
-  background: #1e293b;
-  border-color: #334155;
+  background: #111827;
+  border-color: #475569;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.3);
 }
 
 .ead-card--wide {
@@ -161,6 +177,19 @@
 }
 .dark .ead-card-title {
   color: #f8fafc;
+}
+
+.dark .ead-card .recharts-cartesian-axis-tick-value,
+.dark .ead-card .recharts-legend-item-text,
+.dark .ead-card .recharts-text {
+  fill: #cbd5e1;
+  color: #e2e8f0 !important;
+}
+
+.dark .ead-card .recharts-default-tooltip {
+  background-color: #0f172a !important;
+  border-color: #475569 !important;
+  color: #f8fafc !important;
 }
 
 /* ── Feedback ── */
@@ -195,6 +224,9 @@
   height: 10px;
   overflow: hidden;
 }
+.dark .ead-feedback-bar-wrap {
+  background: #334155;
+}
 
 .ead-feedback-bar {
   height: 100%;
@@ -209,6 +241,9 @@
   color: #6366f1;
   width: 52px;
   text-align: right;
+}
+.dark .ead-feedback-rating {
+  color: #c7d2fe;
 }
 
 .ead-feedback-responses {
@@ -243,15 +278,30 @@
   background: #f0fdf4;
   color: #16a34a;
 }
+.dark .ead-sentiment--positive {
+  background: #052e16;
+  color: #bbf7d0;
+  border: 1px solid #166534;
+}
 
 .ead-sentiment--neutral {
   background: #fefce8;
   color: #ca8a04;
 }
+.dark .ead-sentiment--neutral {
+  background: #422006;
+  color: #fde68a;
+  border: 1px solid #92400e;
+}
 
 .ead-sentiment--negative {
   background: #fef2f2;
   color: #dc2626;
+}
+.dark .ead-sentiment--negative {
+  background: #450a0a;
+  color: #fecaca;
+  border: 1px solid #991b1b;
 }
 
 /* ── Responsive ── */

--- a/src/Pages/Events/EventAnalyticsDashboard.js
+++ b/src/Pages/Events/EventAnalyticsDashboard.js
@@ -3,6 +3,7 @@ import {
   LineChart, Line, BarChart, Bar, PieChart, Pie, Cell,
   XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
+import { useTheme } from '../../context/ThemeContext';
 import eventsData from './eventsMockData.json';
 import './EventAnalyticsDashboard.css';
 
@@ -32,40 +33,74 @@ const feedbackData = [
 const COLORS = ['#6366f1', '#8b5cf6', '#06b6d4', '#10b981', '#f59e0b', '#ef4444'];
 const TABS = ['overview', 'registrations', 'demographics', 'feedback'];
 
+const getChartTheme = (isDarkMode) => ({
+  grid: isDarkMode ? '#334155' : '#e5e7eb',
+  axis: isDarkMode ? '#cbd5e1' : '#475569',
+  tooltipBg: isDarkMode ? '#0f172a' : '#ffffff',
+  tooltipText: isDarkMode ? '#f8fafc' : '#1e293b',
+  tooltipBorder: isDarkMode ? '#475569' : '#cbd5e1',
+  legend: isDarkMode ? '#e2e8f0' : '#374151',
+  primary: isDarkMode ? '#818cf8' : '#6366f1',
+  secondary: isDarkMode ? '#38bdf8' : '#c7d2fe',
+});
+
+const chartTooltipProps = (chartTheme) => ({
+  contentStyle: {
+    backgroundColor: chartTheme.tooltipBg,
+    borderColor: chartTheme.tooltipBorder,
+    borderRadius: 12,
+    color: chartTheme.tooltipText,
+    boxShadow: '0 12px 30px rgba(15, 23, 42, 0.18)',
+  },
+  labelStyle: { color: chartTheme.tooltipText, fontWeight: 700 },
+  itemStyle: { color: chartTheme.tooltipText },
+});
+
+const axisTick = (chartTheme, fontSize = 12) => ({
+  fill: chartTheme.axis,
+  fontSize,
+});
+
+const renderPieLabel = (chartTheme) => ({ name, percent, x, y, textAnchor }) => (
+  <text x={x} y={y} fill={chartTheme.axis} fontSize={12} fontWeight={600} textAnchor={textAnchor} dominantBaseline="central">
+    {`${name} ${(percent * 100).toFixed(0)}%`}
+  </text>
+);
+
 // --- Subcomponents (Now accepting props instead of using global scope) ---
 
-const RegistrationLineChart = ({ height = 260, showLegend = false }) => (
+const RegistrationLineChart = ({ chartTheme, height = 260, showLegend = false }) => (
   <ResponsiveContainer width="100%" height={height}>
     <LineChart data={registrationTrends}>
-      <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-      <XAxis dataKey="month" tick={{ fontSize: 12 }} />
-      <YAxis tick={{ fontSize: 12 }} />
-      <Tooltip />
-      {showLegend && <Legend />}
-      <Line type="monotone" dataKey="registrations" stroke="#6366f1" strokeWidth={3} dot={{ r: showLegend ? 6 : 5, fill: '#6366f1' }} activeDot={{ r: 7 }} name="Registrations" />
+      <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.grid} />
+      <XAxis dataKey="month" tick={axisTick(chartTheme)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
+      <YAxis tick={axisTick(chartTheme)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
+      <Tooltip {...chartTooltipProps(chartTheme)} />
+      {showLegend && <Legend wrapperStyle={{ color: chartTheme.legend }} />}
+      <Line type="monotone" dataKey="registrations" stroke={chartTheme.primary} strokeWidth={3} dot={{ r: showLegend ? 6 : 5, fill: chartTheme.primary, stroke: chartTheme.tooltipBg, strokeWidth: 2 }} activeDot={{ r: 7 }} name="Registrations" />
     </LineChart>
   </ResponsiveContainer>
 );
 
-const AttendanceBarChart = ({ data, height = 260, layout = 'horizontal', showLegend = true }) => (
+const AttendanceBarChart = ({ chartTheme, data, height = 260, layout = 'horizontal', showLegend = true }) => (
   <ResponsiveContainer width="100%" height={height}>
     <BarChart data={data} layout={layout}>
-      <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+      <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.grid} />
       {layout === 'vertical' ? (
         <>
-          <XAxis type="number" tick={{ fontSize: 11 }} />
-          <YAxis dataKey="name" type="category" tick={{ fontSize: 11 }} width={110} />
+          <XAxis type="number" tick={axisTick(chartTheme, 11)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
+          <YAxis dataKey="name" type="category" tick={axisTick(chartTheme, 11)} width={110} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
         </>
       ) : (
         <>
-          <XAxis dataKey="name" tick={{ fontSize: 11 }} />
-          <YAxis />
+          <XAxis dataKey="name" tick={axisTick(chartTheme, 11)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
+          <YAxis tick={axisTick(chartTheme)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
         </>
       )}
-      <Tooltip />
-      {showLegend && <Legend />}
-      <Bar dataKey="attendees" fill="#6366f1" radius={layout === 'vertical' ? [0, 6, 6, 0] : [6, 6, 0, 0]} name="Attendees" />
-      <Bar dataKey="capacity" fill="#c7d2fe" radius={layout === 'vertical' ? [0, 6, 6, 0] : [6, 6, 0, 0]} name="Capacity" />
+      <Tooltip {...chartTooltipProps(chartTheme)} />
+      {showLegend && <Legend wrapperStyle={{ color: chartTheme.legend }} />}
+      <Bar dataKey="attendees" fill={chartTheme.primary} radius={layout === 'vertical' ? [0, 6, 6, 0] : [6, 6, 0, 0]} name="Attendees" />
+      <Bar dataKey="capacity" fill={chartTheme.secondary} radius={layout === 'vertical' ? [0, 6, 6, 0] : [6, 6, 0, 0]} name="Capacity" />
     </BarChart>
   </ResponsiveContainer>
 );
@@ -98,42 +133,42 @@ const KPIHeader = ({ totalEvents, registrations, fillRate, avgRating }) => (
   </div>
 );
 
-const OverviewTab = ({ topEvents }) => (
+const OverviewTab = ({ chartTheme, topEvents }) => (
   <div className="ead-grid">
     <div className="ead-card ead-card--wide">
       <h2 className="ead-card-title">📈 Registrations Over Time</h2>
-      <RegistrationLineChart height={260} />
+      <RegistrationLineChart chartTheme={chartTheme} height={260} />
     </div>
     <div className="ead-card ead-card--wide">
       <h2 className="ead-card-title">🏆 Top Performing Events</h2>
-      <AttendanceBarChart data={topEvents} height={260} layout="vertical" />
+      <AttendanceBarChart chartTheme={chartTheme} data={topEvents} height={260} layout="vertical" />
     </div>
   </div>
 );
 
-const RegistrationsTab = ({ topEvents }) => (
+const RegistrationsTab = ({ chartTheme, topEvents }) => (
   <div className="ead-grid">
     <div className="ead-card ead-card--full">
       <h2 className="ead-card-title">📅 Monthly Registration Trends</h2>
-      <RegistrationLineChart height={320} showLegend />
+      <RegistrationLineChart chartTheme={chartTheme} height={320} showLegend />
     </div>
     <div className="ead-card ead-card--full">
       <h2 className="ead-card-title">📊 All Events — Attendance vs Capacity</h2>
-      <AttendanceBarChart data={topEvents} height={320} />
+      <AttendanceBarChart chartTheme={chartTheme} data={topEvents} height={320} />
     </div>
   </div>
 );
 
-const DemographicsTab = ({ typeData, locationData }) => (
+const DemographicsTab = ({ chartTheme, typeData, locationData }) => (
   <div className="ead-grid">
     <div className="ead-card">
       <h2 className="ead-card-title">🎯 Attendees by Event Type</h2>
       <ResponsiveContainer width="100%" height={280}>
         <PieChart>
-          <Pie data={typeData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={100} label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}>
+          <Pie data={typeData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={100} label={renderPieLabel(chartTheme)} labelLine={{ stroke: chartTheme.axis }}>
             {typeData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
           </Pie>
-          <Tooltip />
+          <Tooltip {...chartTooltipProps(chartTheme)} />
         </PieChart>
       </ResponsiveContainer>
     </div>
@@ -141,28 +176,28 @@ const DemographicsTab = ({ typeData, locationData }) => (
       <h2 className="ead-card-title">📍 Attendees by Region</h2>
       <ResponsiveContainer width="100%" height={280}>
         <PieChart>
-          <Pie data={locationData} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={60} outerRadius={100} label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}>
+          <Pie data={locationData} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={60} outerRadius={100} label={renderPieLabel(chartTheme)} labelLine={{ stroke: chartTheme.axis }}>
             {locationData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
           </Pie>
-          <Tooltip />
-          <Legend />
+          <Tooltip {...chartTooltipProps(chartTheme)} />
+          <Legend wrapperStyle={{ color: chartTheme.legend }} />
         </PieChart>
       </ResponsiveContainer>
     </div>
   </div>
 );
 
-const FeedbackTab = () => (
+const FeedbackTab = ({ chartTheme }) => (
   <div className="ead-grid">
     <div className="ead-card ead-card--full">
       <h2 className="ead-card-title">⭐ Average Ratings by Event</h2>
       <ResponsiveContainer width="100%" height={280}>
         <BarChart data={feedbackData}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-          <XAxis dataKey="event" tick={{ fontSize: 12 }} />
-          <YAxis domain={[0, 5]} tick={{ fontSize: 12 }} />
-          <Tooltip />
-          <Bar dataKey="rating" fill="#6366f1" radius={[6, 6, 0, 0]} name="Avg Rating" />
+          <CartesianGrid strokeDasharray="3 3" stroke={chartTheme.grid} />
+          <XAxis dataKey="event" tick={axisTick(chartTheme)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
+          <YAxis domain={[0, 5]} tick={axisTick(chartTheme)} axisLine={{ stroke: chartTheme.grid }} tickLine={{ stroke: chartTheme.grid }} />
+          <Tooltip {...chartTooltipProps(chartTheme)} />
+          <Bar dataKey="rating" fill={chartTheme.primary} radius={[6, 6, 0, 0]} name="Avg Rating" />
         </BarChart>
       </ResponsiveContainer>
     </div>
@@ -197,6 +232,8 @@ const FeedbackTab = () => (
 
 const EventAnalyticsDashboard = () => {
   const [activeTab, setActiveTab] = useState('overview');
+  const { isDarkMode } = useTheme();
+  const chartTheme = useMemo(() => getChartTheme(isDarkMode), [isDarkMode]);
 
   // 🔥 THE ALGO FIX: Single O(N) pass utilizing Hash Maps and useMemo 🔥
   const memoizedEventData = useMemo(() => {
@@ -262,10 +299,10 @@ const EventAnalyticsDashboard = () => {
 
       {/* TAB CONTENT */}
       <div role="tabpanel">
-        {activeTab === 'overview' && <OverviewTab topEvents={topEvents} />}
-        {activeTab === 'registrations' && <RegistrationsTab topEvents={topEvents} />}
-        {activeTab === 'demographics' && <DemographicsTab typeData={typeData} locationData={locationData} />}
-        {activeTab === 'feedback' && <FeedbackTab />}
+        {activeTab === 'overview' && <OverviewTab chartTheme={chartTheme} topEvents={topEvents} />}
+        {activeTab === 'registrations' && <RegistrationsTab chartTheme={chartTheme} topEvents={topEvents} />}
+        {activeTab === 'demographics' && <DemographicsTab chartTheme={chartTheme} typeData={typeData} locationData={locationData} />}
+        {activeTab === 'feedback' && <FeedbackTab chartTheme={chartTheme} />}
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -164,9 +164,16 @@ html {
 
   --input-bg: #ffffff;
   --input-text: #1a1a1a;
+  --input-border: #cbd5e1;
+  --input-placeholder: #64748b;
+  --input-focus-border: #2563eb;
+  --input-focus-ring: rgba(37, 99, 235, 0.18);
 
   --table-bg: #ffffff;
   --modal-bg: #ffffff;
+  --surface-muted: #f8fafc;
+  --surface-hover: #f1f5f9;
+  --card-shadow-color: rgba(15, 23, 42, 0.08);
 
   /* Typography */
   --font-body: 1rem;
@@ -202,6 +209,12 @@ html {
   --danger-bg: #fef2f2;
   --danger-border: #fca5a5;
   --danger-text: #dc2626;
+  --success-bg: #f0fdf4;
+  --success-border: #86efac;
+  --success-text: #15803d;
+  --warning-bg: #fefce8;
+  --warning-border: #fde047;
+  --warning-text: #a16207;
 }
 
 /* Fix #599: Changed from body.dark to .dark
@@ -228,10 +241,26 @@ html {
 
   --input-bg: #111827;
   --input-text: #f8fafc;
+  --input-border: #475569;
+  --input-placeholder: #94a3b8;
+  --input-focus-border: #60a5fa;
+  --input-focus-ring: rgba(96, 165, 250, 0.25);
 
   --table-bg: #111827;
 
   --modal-bg: #1e293b;
+  --surface-muted: #1e293b;
+  --surface-hover: #334155;
+  --card-shadow-color: rgba(0, 0, 0, 0.35);
+  --danger-bg: #450a0a;
+  --danger-border: #991b1b;
+  --danger-text: #fecaca;
+  --success-bg: #052e16;
+  --success-border: #166534;
+  --success-text: #bbf7d0;
+  --warning-bg: #422006;
+  --warning-border: #92400e;
+  --warning-text: #fde68a;
 }
 
 /* Global styles */
@@ -702,14 +731,46 @@ textarea,
 select {
   background-color: var(--input-bg);
   color: var(--input-text);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--input-border);
   transition: all 0.3s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--input-focus-border);
+  box-shadow: 0 0 0 3px var(--input-focus-ring);
+}
+
+input:disabled,
+textarea:disabled,
+select:disabled {
+  background-color: var(--surface-muted);
+  color: var(--text-color-light);
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--input-placeholder);
+  opacity: 1;
+}
+
+select option {
+  background-color: var(--input-bg);
+  color: var(--input-text);
 }
 
 /* Tables */
 table {
   background-color: var(--table-bg);
   color: var(--text-color);
+}
+
+th,
+td {
+  border-color: var(--border-color);
 }
 
 /* Modals */
@@ -787,6 +848,8 @@ select,
   color: var(--text-color);
 
   border: 1px solid var(--border-color);
+
+  box-shadow: 0 4px 16px var(--card-shadow-color);
 }
 
 .input-theme {
@@ -794,7 +857,7 @@ select,
 
   color: var(--input-text);
 
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--input-border);
 }
 
 .section-theme {

--- a/tests/themeConsistency.test.mjs
+++ b/tests/themeConsistency.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const indexCss = readFileSync("src/index.css", "utf8");
+const analyticsJs = readFileSync("src/Pages/Events/EventAnalyticsDashboard.js", "utf8");
+const analyticsCss = readFileSync("src/Pages/Events/EventAnalyticsDashboard.css", "utf8");
+
+assert.match(indexCss, /\.dark\s*{[\s\S]*--input-bg:\s*#111827;/);
+assert.match(indexCss, /\.dark\s*{[\s\S]*--input-border:\s*#475569;/);
+assert.match(indexCss, /input:focus,\s*textarea:focus,\s*select:focus/);
+assert.match(indexCss, /select option\s*{[\s\S]*background-color:\s*var\(--input-bg\);/);
+
+assert.match(analyticsJs, /const getChartTheme = \(isDarkMode\) =>/);
+assert.match(analyticsJs, /stroke={chartTheme\.grid}/);
+assert.match(analyticsJs, /<Tooltip \{\.\.\.chartTooltipProps\(chartTheme\)\} \/>/);
+assert.match(analyticsJs, /const \{ isDarkMode \} = useTheme\(\);/);
+
+assert.match(analyticsCss, /\.dark \.ead-card \.recharts-cartesian-axis-tick-value/);
+assert.match(analyticsCss, /\.dark \.ead-sentiment--positive/);
+assert.match(analyticsCss, /\.dark \.ead-tab--active/);
+
+console.log("theme consistency styles verified");


### PR DESCRIPTION
## 🚀 Description

This PR completes the dark mode consistency pass across the application by improving theme support, accessibility, and visual consistency.

### Changes Made

* Strengthened shared dark theme tokens and styling defaults for inputs, placeholders, disabled controls, select options, tables, cards, and status indicators in `src/index.css`.
* Made Event Analytics charts theme-aware using `useTheme`, including axes, grid lines, tooltips, legends, pie labels, and chart series colors in `EventAnalyticsDashboard.js`.
* Improved dark mode contrast for cards, tabs, KPI sections, Recharts components, feedback bars, and sentiment indicators in `EventAnalyticsDashboard.css`.
* Added a regression test for dark theme styling consistency and integrated it into the unit test workflow.

### Verification

* ✅ Passed: `node tests/themeConsistency.test.mjs`
* ✅ Passed: `.\node_modules\.bin\eslint.cmd src\Pages\Events\EventAnalyticsDashboard.js`
* ⚠️ Full `npm run test:unit` is currently blocked by an unrelated existing failure in `tests/relativeTime.test.mjs` (expected `—`, received `TBD`).
* ⚠️ Production build could not be verified locally because `vite` is unavailable and dependency installation is blocked by the repository engine requirement (Node `22.x` required, current environment uses Node `24.13.0`).

### Impact

* Improves dark mode accessibility and WCAG-compliant contrast.
* Enhances readability across forms, tables, cards, and analytics dashboards.
* Provides a more consistent and polished user experience for dark mode users.

Fixes #2949 

## 🛠️ Type of change

* [x] New feature (non-breaking change which adds functionality)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
