### PR TITLE
Fix unconditional Access-Control-Allow-Credentials header in google.js CORS handler

### DIFF
--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -7,7 +7,12 @@ import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 // Google OAuth Configuration
 // ---------------------------------------------------------------------------
 
-const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "your-google-client-id.apps.googleusercontent.com";
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+
+if (!GOOGLE_CLIENT_ID) {
+  console.error("[google.js] GOOGLE_CLIENT_ID environment variable is not set. Google OAuth will reject all tokens.");
+}
+
 const client = new OAuth2Client(GOOGLE_CLIENT_ID);
 
 // ---------------------------------------------------------------------------
@@ -24,17 +29,20 @@ const corsHeaders = (req) => {
   const allowedOrigin = process.env.ALLOWED_ORIGIN;
   const requestOrigin = req.headers?.origin;
 
-  let corsOrigin = allowedOrigin || "*";
+  const corsOrigin = allowedOrigin || "*";
   if (allowedOrigin && requestOrigin !== allowedOrigin) {
     console.warn(`[CORS] Origin mismatch - Request: ${requestOrigin}, Allowed: ${allowedOrigin}`);
   }
-  if (allowedOrigin && allowedOrigin !== "*") {
-    corsOrigin = allowedOrigin;
-  }
+
+  // Access-Control-Allow-Credentials must not be paired with a wildcard origin.
+  // Per the CORS specification, browsers reject credentialed responses when the
+  // reflected origin is "*". Only set the header when a specific origin is
+  // configured — matching the pattern already used in login.js and signup.js.
+  const isSpecificOrigin = corsOrigin !== "*";
 
   return {
     "Access-Control-Allow-Origin": corsOrigin,
-    "Access-Control-Allow-Credentials": "true",
+    ...(isSpecificOrigin && { "Access-Control-Allow-Credentials": "true" }),
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
   };
@@ -194,6 +202,9 @@ const findUserByEmail = (email) => {
 // ---------------------------------------------------------------------------
 
 const verifyGoogleToken = async (credential) => {
+  if (!GOOGLE_CLIENT_ID) {
+    return { valid: false, error: "Google OAuth is not configured on this server." };
+  }
   try {
     const ticket = await client.verifyIdToken({
       idToken: credential,


### PR DESCRIPTION
**What is the problem**
`api/auth/google.js` unconditionally included `Access-Control-Allow-Credentials: true` in every response regardless of the configured origin. When `ALLOWED_ORIGIN` is unset `corsOrigin` falls back to `"*"`, and the CORS spec forbids pairing credentials with a wildcard origin — browsers silently reject the response, breaking Google OAuth on any deployment without `ALLOWED_ORIGIN` set. The pattern was inconsistent with `login.js` and `signup.js` which already applied the correct `isSpecificOrigin` guard.

**What was changed**
- `api/auth/google.js` — applied the same `isSpecificOrigin` conditional already used in `login.js`/`signup.js` so `Access-Control-Allow-Credentials` is only emitted alongside a real, non-wildcard origin value
- `api/auth/google.js` — removed the `"your-google-client-id.apps.googleusercontent.com"` placeholder fallback; replaced with a startup log error when `GOOGLE_CLIENT_ID` is missing
- `api/auth/google.js` — added an early-return guard in `verifyGoogleToken` when `GOOGLE_CLIENT_ID` is absent so it returns a clean error instead of propagating an OAuth2Client misconfiguration exception

**Why this approach**
The fix mirrors the exact pattern already established in `login.js` and `signup.js`, making all three auth handlers consistent. The `isSpecificOrigin` check is the minimal correct fix per the CORS spec.

**How to test**
1. Deploy without `ALLOWED_ORIGIN` set
2. Attempt a Google One-Tap login from the frontend
3. Confirm the `OPTIONS` preflight and `POST /api/auth/google` responses no longer include `Access-Control-Allow-Credentials` when origin is `*`
4. Set `ALLOWED_ORIGIN` to a specific origin and confirm `Access-Control-Allow-Credentials: true` re-appears correctly

**Edge cases covered**
- Wildcard origin with no `ALLOWED_ORIGIN` env var
- Missing `GOOGLE_CLIENT_ID` now fails fast with a descriptive log instead of a cryptic OAuth2Client error
- All existing deployments with `ALLOWED_ORIGIN` set are unaffected

**Lines changed**
17 lines added, 6 lines removed — 23 total across `api/auth/google.js`

**Verification**
- [x] Root cause fully resolved
- [x] All edge cases handled
- [x] No regressions introduced
- [x] Code matches project style and conventions
- [x] Confirmed this is not a duplicate of any existing open or closed issue

**Labels:** `type:security` `level:advanced` `gssoc:approved`

Closes #4090