### PR TITLE
docs: add project categories API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -937,16 +937,18 @@ GET /api/projects
 |--------|----------|
 | GET | `/api/projects/categories` |
 
-Returns a list of available project categories. No authentication required.
+Returns the static list of supported project categories used by the Projects gallery/module.
 
-### Example Request
+### Authentication
+Not required. Public endpoint.
 
-```bash
-GET /api/projects/categories
-```
+### Request
+No request body.
 
-### Successful Response (200)
+### Success Response
+Status: `200 OK`
 
+#### Response example:
 ```json
 [
   "Mobile Development",
@@ -954,9 +956,16 @@ GET /api/projects/categories
   "Developer Tools",
   "Machine Learning",
   "DevOps",
-  "Design"
+  "Design",
+  "IoT",
+  "Blockchain"
 ]
 ```
+
+### Notes
+- This endpoint is public and does not require JWT authentication.
+- This PR only documents the project categories endpoint.
+- Other Projects APIs will be documented separately when implemented.
 
 ---
 


### PR DESCRIPTION
## Related PR

Related backend implementation: SandeepVashishtha/Eventra-Backend#40

## Description

Updates the API documentation to include the newly added backend project categories endpoint.

## Changes Made

* Documented `GET /api/projects/categories`
* Added authentication details for the public endpoint
* Added success response example with supported project categories
* Added notes clarifying that other Projects APIs will be documented separately when implemented

## Notes

The backend implementation for this endpoint is handled in the Eventra-Backend repository. This PR only syncs the frontend/docs repository documentation with the backend API behavior.