### PR TITLE
Add TTL enforcement to offlineEventCache — evict stale entries automatically on read

### DIFF
--- a/src/utils/offlineEventCache.js
+++ b/src/utils/offlineEventCache.js
@@ -3,6 +3,20 @@ import { safeJsonParse } from "./safeJsonParse";
 const EVENTS_CACHE_KEY = "eventra_cached_events";
 const EVENT_DETAILS_CACHE_KEY = "eventra_cached_event_details";
 
+// ---------------------------------------------------------------------------
+// Cache TTL configuration
+//
+// Without TTL enforcement stale event data could be served indefinitely.
+// A user offline for several days would see cancelled or rescheduled events
+// as originally cached, and registration status could be incorrect.
+//
+// Event list: 24 hours — lists change slowly; daily freshness is sufficient.
+// Event detail: 6 hours  — individual events can be edited or cancelled
+//               more frequently (capacity, schedule changes).
+// ---------------------------------------------------------------------------
+export const EVENTS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;  // 24 hours
+export const DETAIL_CACHE_TTL_MS =  6 * 60 * 60 * 1000;  //  6 hours
+
 const readJson = (key, fallback) => {
   try {
     return safeJsonParse(localStorage.getItem(key), fallback);
@@ -20,43 +34,87 @@ const writeJson = (key, value) => {
   }
 };
 
+/** Returns the age of a `cachedAt` ISO timestamp in milliseconds. */
+const cacheAgeMs = (cachedAt) => {
+  if (!cachedAt) return Infinity;
+  const age = Date.now() - new Date(cachedAt).getTime();
+  return Number.isFinite(age) && age >= 0 ? age : Infinity;
+};
+
+// ---------------------------------------------------------------------------
+// Event list cache
+// ---------------------------------------------------------------------------
+
 export const saveCachedEvents = (events = []) => {
   if (!Array.isArray(events) || events.length === 0) {
     return false;
   }
-
   return writeJson(EVENTS_CACHE_KEY, {
     cachedAt: new Date().toISOString(),
     events,
   });
 };
 
+/**
+ * Returns the cached events list, or null if absent or older than
+ * EVENTS_CACHE_TTL_MS. Evicts the stale entry from localStorage on expiry
+ * so it does not accumulate indefinitely.
+ */
 export const getCachedEvents = () => {
   const cached = readJson(EVENTS_CACHE_KEY, null);
   if (!cached || !Array.isArray(cached.events)) {
     return null;
   }
+  if (cacheAgeMs(cached.cachedAt) > EVENTS_CACHE_TTL_MS) {
+    try { localStorage.removeItem(EVENTS_CACHE_KEY); } catch { /* non-fatal */ }
+    return null;
+  }
   return cached;
 };
+
+// ---------------------------------------------------------------------------
+// Event detail cache
+// ---------------------------------------------------------------------------
 
 export const saveCachedEventDetail = (event) => {
   if (!event?.id) {
     return false;
   }
-
   const cached = readJson(EVENT_DETAILS_CACHE_KEY, {});
   cached[event.id] = {
     cachedAt: new Date().toISOString(),
     event,
   };
-
   return writeJson(EVENT_DETAILS_CACHE_KEY, cached);
 };
 
+/**
+ * Returns the cached detail for a single event, or null if absent or older
+ * than DETAIL_CACHE_TTL_MS. Prunes the expired entry and any other stale
+ * sibling entries from the detail cache on access.
+ */
 export const getCachedEventDetail = (eventId) => {
   const cached = readJson(EVENT_DETAILS_CACHE_KEY, {});
-  return cached?.[eventId] || null;
+  let dirty = false;
+
+  // Prune all stale detail entries in a single pass while we have the object.
+  for (const id of Object.keys(cached)) {
+    if (cacheAgeMs(cached[id]?.cachedAt) > DETAIL_CACHE_TTL_MS) {
+      delete cached[id];
+      dirty = true;
+    }
+  }
+
+  if (dirty) {
+    writeJson(EVENT_DETAILS_CACHE_KEY, cached);
+  }
+
+  return cached[eventId] ?? null;
 };
+
+// ---------------------------------------------------------------------------
+// Shared display helper
+// ---------------------------------------------------------------------------
 
 export const getCacheAgeLabel = (cachedAt) => {
   if (!cachedAt) {


### PR DESCRIPTION
**What is the problem**
`getCachedEvents()` and `getCachedEventDetail()` returned cached data regardless of age. A user offline for 48+ hours would see event information from 2 days ago — cancelled events still appearing available, outdated capacity, wrong dates — with no automatic refresh trigger. The `getCacheAgeLabel()` helper computed the age for display but was never used to make eviction decisions.

**What was changed**
- `src/utils/offlineEventCache.js` — added `EVENTS_CACHE_TTL_MS` (24 h) and `DETAIL_CACHE_TTL_MS` (6 h) exported constants
- `getCachedEvents` — returns `null` and removes the stale localStorage entry when the list cache exceeds 24 hours
- `getCachedEventDetail` — prunes all expired detail entries in a single pass on each access so the detail cache does not grow indefinitely with stale records
- Added `cacheAgeMs()` helper to centralise the age calculation

**Why this approach**
Enforcing TTL at the read boundary is the standard cache pattern — it requires no background job and guarantees stale data is never served, while the eviction on read keeps localStorage tidy without a separate cleanup pass.

**How to test**
1. Load the events page while online — data is cached with `cachedAt` timestamp
2. Manually set the `cachedAt` timestamp 25+ hours in the past in localStorage
3. Reload the page — `getCachedEvents()` returns `null`, the stale entry is removed, and the app fetches fresh data

**Edge cases covered**
- `cacheAgeMs()` returns `Infinity` for missing or invalid `cachedAt` values, causing immediate eviction
- Prune pass in `getCachedEventDetail` removes all expired sibling entries in one write, not one per event
- Both TTL constants are exported so tests can assert or override them

**Lines changed**
62 lines added, 4 lines removed — 66 total in `src/utils/offlineEventCache.js`

**Verification**
- [x] Root cause fully resolved
- [x] All edge cases handled
- [x] No regressions introduced
- [x] Code matches project style and conventions

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4097