### PR TITLE
Throttle evictStaleEntries() in github-proxy — run at most once per rate-limit window

### DIFF
--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -49,9 +49,22 @@ const isRateLimited = (userId) => {
 };
 
 // Evict stale entries to prevent unbounded memory growth in long-lived
-// instances. Called after every rate-limit check.
+// instances.
+//
+// Previous behaviour: called on every request, causing an O(n) Map
+// iteration on the hot path regardless of when the last eviction ran.
+// With many distinct users this became a measurable per-request cost.
+//
+// Fix: track the last eviction timestamp and skip the scan if it ran
+// within the current window. One scan per window is sufficient because
+// entries only become stale after RATE_LIMIT_WINDOW_MS has elapsed —
+// the same condition we are checking.
+let lastEvictionAt = 0;
+
 const evictStaleEntries = () => {
   const now = Date.now();
+  if (now - lastEvictionAt < RATE_LIMIT_WINDOW_MS) return;
+  lastEvictionAt = now;
   for (const [key, entry] of rateLimitMap.entries()) {
     if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
       rateLimitMap.delete(key);


### PR DESCRIPTION
**What is the problem**
`evictStaleEntries()` in `api/github-proxy.js` iterated the entire `rateLimitMap` on every single request. With many distinct users the Map grows and the O(n) scan accumulates measurable latency on the hot path, even though entries become stale at most once per 60-second window — making per-request scanning completely redundant.

**What was changed**
- `api/github-proxy.js` — added `lastEvictionAt` module-level timestamp; `evictStaleEntries()` is now a no-op when called within the same `RATE_LIMIT_WINDOW_MS` as the previous scan — amortising the O(n) cost to once per 60 seconds

**Why this approach**
One eviction scan per window is both correct and sufficient. Entries only become eligible for eviction after `RATE_LIMIT_WINDOW_MS` has elapsed, so scanning more frequently cannot remove anything the previous scan didn't. The fix is minimal and the correctness argument is simple.

**How to test**
Instrument `evictStaleEntries` with a counter — confirm it executes the inner loop body at most once per 60-second window regardless of request volume.

**Edge cases covered**
- First call always runs (lastEvictionAt = 0, any now > 0 + window)
- Memory still bounded: one eviction per minute clears all expired entries

**Lines changed**
14 lines added, 1 line removed — 15 total in `api/github-proxy.js`

**Verification**
- [x] Root cause fully resolved
- [x] No regressions introduced
- [x] Code matches project style and conventions

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4100