### PR TITLE
Memoize getDeviceFingerprint() — eliminate repeated canvas allocation and GPU draw on every activity event

### DIFF
--- a/src/utils/deviceFingerprint.js
+++ b/src/utils/deviceFingerprint.js
@@ -8,39 +8,51 @@ import CryptoJS from "crypto-js";
  *
  * SALT STRATEGY
  * ─────────────
- * The previous implementation used a static hardcoded string
- * ("eventra_session_recovery_crypto_salt_9273") as the HMAC salt. Because
- * the salt is compiled into the public JavaScript bundle, any attacker who
- * downloads the bundle can read it, precompute the hash for known fingerprint
- * inputs, and forge a fingerprint for a victim device.
+ * The salt is derived from `window.location.origin` so that each deployment
+ * (production, staging, localhost) produces a different fingerprint and
+ * rainbow-table precomputation does not transfer across deployments.
  *
- * The salt is now derived from `window.location.origin` so that:
- *  - Each deployment (production, staging, localhost) has a different salt.
- *  - The salt is not a static string that appears anywhere in the source tree.
- *  - Rainbow-table precomputation against one deployment does not transfer to
- *    another.
+ * MEMOIZATION
+ * ────────────
+ * The previous implementation ran the full canvas allocation and GPU-rendered
+ * draw on every call. `getDeviceFingerprint()` is invoked from `saveSession()`
+ * in `SessionRecoveryContext.js` which fires up to once per second during user
+ * activity. Each call created a 180×30 canvas element, called `fillRect`,
+ * `fillText`, and `toDataURL()` — all synchronous main-thread GPU operations.
  *
- * This is the same per-origin derivation strategy used by secureStorage.js.
- * The salt is still technically reconstructable by anyone who knows the origin,
- * but that raises the attack cost significantly compared to a literal constant.
+ * The device fingerprint is stable for the lifetime of the page: the user's
+ * screen resolution, user-agent, and canvas rendering do not change mid-session.
+ * Memoizing after the first computation reduces the per-call cost from O(GPU)
+ * to O(1) for all subsequent calls without changing the fingerprint value.
  *
- * Gracefully falls back to a consistent hash in non-browser environments
- * (Node.js / unit testing) so tests remain deterministic.
+ * The cache is module-level so it persists for the page lifetime and is reset
+ * on navigation (new page load reinitialises the module).
  *
  * @returns {string} SHA-256 hex string representing the device fingerprint.
  */
+
+let _memoizedFingerprint = null;
+
 export const getDeviceFingerprint = () => {
+  // Return cached value if already computed this page load
+  if (_memoizedFingerprint !== null) {
+    return _memoizedFingerprint;
+  }
+
   // Graceful fallback for server-side rendering or unit testing (Node.js)
   if (typeof window === "undefined" || typeof document === "undefined") {
     const fallbackData = "eventra-node-test-environment-fingerprint-fallback";
-    return CryptoJS.SHA256(fallbackData).toString();
+    _memoizedFingerprint = CryptoJS.SHA256(fallbackData).toString();
+    return _memoizedFingerprint;
   }
 
   try {
     const screenInfo = `${window.screen?.width || 0}x${window.screen?.height || 0}x${window.screen?.colorDepth || 0}`;
     const navInfo = `${window.navigator?.userAgent || ""}_${window.navigator?.language || ""}_${window.navigator?.hardwareConcurrency || 0}`;
 
-    // Offscreen canvas fingerprint — captures GPU/font rendering subtleties
+    // Offscreen canvas fingerprint — captures GPU/font rendering subtleties.
+    // Created once here and discarded; the resulting hash is memoized so
+    // no canvas element is allocated on subsequent calls.
     let canvasHash = "";
     try {
       const canvas = document.createElement("canvas");
@@ -67,14 +79,27 @@ export const getDeviceFingerprint = () => {
     // avoids salt collisions if two deployments share the same hostname root.
     const salt = `eventra:fingerprint:${window.location.origin}`;
 
-    return CryptoJS.SHA256(fingerprintRaw + salt).toString();
+    _memoizedFingerprint = CryptoJS.SHA256(fingerprintRaw + salt).toString();
+    return _memoizedFingerprint;
   } catch {
     // Ultimate fallback — still origin-scoped so cross-origin replay is harder
-    const fallbackSalt = typeof window !== "undefined"
-      ? window.location.origin
-      : "eventra-fallback";
-    return CryptoJS.SHA256(`eventra-fingerprint-fallback:${fallbackSalt}`).toString();
+    const fallbackSalt =
+      typeof window !== "undefined" ? window.location.origin : "eventra-fallback";
+    _memoizedFingerprint = CryptoJS.SHA256(
+      `eventra-fingerprint-fallback:${fallbackSalt}`,
+    ).toString();
+    return _memoizedFingerprint;
   }
+};
+
+/**
+ * Clears the memoized fingerprint. Intended for use in tests only so each
+ * test starts with a fresh computation.
+ *
+ * @internal
+ */
+export const _clearFingerprintCache = () => {
+  _memoizedFingerprint = null;
 };
 
 /**


### PR DESCRIPTION
**What is the problem**
`getDeviceFingerprint()` was called inside `saveSession()` in `SessionRecoveryContext.js`, which fires up to once per second during user activity (mousedown, keypress, scroll, click, touchstart). Each call created a new 180×30 `<canvas>` element, performed GPU-composited draw calls (`fillRect`, `fillText`), and called `toDataURL()` — all synchronous main-thread operations. The device fingerprint is stable for the lifetime of the page; there was no reason to recompute it more than once.

**What was changed**
- `src/utils/deviceFingerprint.js` — added `_memoizedFingerprint` module-level variable; the full computation (canvas, navigator, SHA-256) runs only on the first call per page load; all subsequent calls return the cached string in O(1)
- Added `_clearFingerprintCache()` export for tests to reset the cache between test cases

**Why this approach**
Module-level memoization is the simplest, zero-overhead cache for a value that is page-load-stable. The cache is automatically reset on every navigation (new page reinitialises the module).

**How to test**
1. Import `getDeviceFingerprint` and call it 10 times — confirm it returns the same value each time and that `document.createElement` is called only once
2. Call `_clearFingerprintCache()` and confirm the next call runs the full computation again

**Edge cases covered**
- SSR / Node.js fallback path is also memoized
- Error fallback path is also memoized
- Tests can reset the cache via `_clearFingerprintCache()`

**Lines changed**
47 lines added, 22 lines removed — 69 total in `src/utils/deviceFingerprint.js`

**Verification**
- [x] Root cause fully resolved
- [x] All edge cases handled
- [x] No regressions introduced
- [x] Code matches project style and conventions

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4102