### PR TITLE
fix: route AI service through apiUtils and sanitize prompt variables

### DIFF
--- a/src/services/aiRecommendationService.js
+++ b/src/services/aiRecommendationService.js
@@ -2,31 +2,27 @@ import { apiUtils } from "../config/api";
 
 export const generateAIInsights = async (event, profile) => {
   try {
+    // 🔥 FIX 1: Added logical OR fallbacks to prevent "undefined" from polluting the AI prompt
     const prompt = `
 You are an AI event recommendation assistant.
 
 User Profile:
-- Interests: ${profile.interests?.join(", ")}
-- Tech Stack: ${profile.techStack?.join(", ")}
-- Preferred Event Type: ${profile.eventTypes?.join(", ")}
-- Skill Level: ${profile.level}
+- Interests: ${profile.interests?.join(", ") || "None specified"}
+- Tech Stack: ${profile.techStack?.join(", ") || "None specified"}
+- Preferred Event Type: ${profile.eventTypes?.join(", ") || "Any"}
+- Skill Level: ${profile.level || "Not specified"}
 
 Event:
-- Title: ${event.title}
-- Category: ${event.category}
-- Description: ${event.description}
+- Title: ${event.title || "Unknown"}
+- Category: ${event.category || "General"}
+- Description: ${event.description || "No description available"}
 
 Explain in 3 concise bullet points why this event matches the user.
 `;
 
     // Make request to our secure backend proxy instead of exposing the API key to the frontend
-    const response = await fetch("/api/ai-recommendations", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ prompt }),
-    });
+    // 🔥 FIX 2: Replaced raw fetch with apiUtils to ensure JWT Auth tokens and interceptors are applied
+    const response = await apiUtils.post("/api/ai-recommendations", { prompt });
 
     const data = await response.json();
 


### PR DESCRIPTION
## 🚀 Description
Fixes two integration bugs in `aiRecommendationService.js` that caused production authentication failures and degraded LLM prompt quality.

**1. Authentication Drop Fix:**
Previously, the service imported `apiUtils` but utilized the native browser `fetch` API. This bypassed the centralized API interceptors, stripping the Authorization headers (JWTs) from the request and resulting in `401 Unauthorized` errors when hitting the protected AI proxy route.
* **Fix:** Replaced the raw `fetch` call with `apiUtils.post()`.

**2. Prompt Pollution Fix:**
The template literal relied on optional chaining without fallbacks. If a user profile lacked certain fields, JavaScript interpolated the literal string `"undefined"` into the prompt, confusing the LLM context.
* **Fix:** Added logical OR fallbacks (e.g., `|| "None specified"`) to all interpolated profile and event variables to ensure clean, deterministic AI prompts.

Fixes #4153

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security / Authentication routing

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code