### PR TITLE
fix: prevent mock data override on empty hackathon API response

### DIFF
--- a/src/services/hackathonService.js
+++ b/src/services/hackathonService.js
@@ -4,8 +4,17 @@ import mockHackathons from "../Pages/Hackathons/hackathonMockData.json";
 export const fetchHackathons = async () => {
   try {
     const response = await apiUtils.get(API_ENDPOINTS.HACKATHONS.LIST);
+    
+    // 🔥 FIX 1: Explicitly check for HTTP errors so the catch block handles them
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
     const data = await response.json();
-    if (data && data.length > 0) {
+    
+    // 🔥 FIX 2: Return data if it exists, even if it is an empty array.
+    // Previously, an empty database (data.length === 0) accidentally triggered mock data.
+    if (data) {
       return data;
     }
   } catch (error) {


### PR DESCRIPTION
## 🚀 Description
Fixes a data logic bug in `hackathonService.js` that caused the frontend to erroneously display hardcoded mock data when the backend returned a valid empty state.

Previously, the `fetchHackathons` function checked `if (data && data.length > 0)`. If the database was empty, the API legitimately returned `[]`, which failed the length check, bypassed the return statement, and forced the app to render `mockHackathons`. Furthermore, because the native `fetch` API does not throw on HTTP error statuses, server crashes (500s) bypassed the `catch` block entirely.

**Changes:**
- Added an explicit `if (!response.ok)` check to throw HTTP errors into the `catch` block for proper logging and fallback handling.
- Modified the success condition to `if (data)`. This ensures that successfully parsed data is returned to the UI—even if it is an empty array (`[]`)—allowing the application to render its intended empty state rather than fake mock data.

Fixes #4155

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Data logic / Error handling improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code