### PR TITLE
fix: resolve ignored valid state styles and redundant a11y required stutter

### DIFF
--- a/src/components/forms/FormFieldWrapper.jsx
+++ b/src/components/forms/FormFieldWrapper.jsx
@@ -42,13 +42,13 @@ const mergeDescribedBy = (...ids) => ids.filter(Boolean).join(" ") || undefined;
  *
  * @example
  * <FormFieldWrapper
- *   id="email"
- *   label="Email"
- *   required
- *   validationState="error"
- *   message="Email is already registered"
+ * id="email"
+ * label="Email"
+ * required
+ * validationState="error"
+ * message="Email is already registered"
  * >
- *   <input type="email" />
+ * <input type="email" />
  * </FormFieldWrapper>
  */
 const FormFieldWrapper = ({
@@ -93,7 +93,8 @@ const FormFieldWrapper = ({
         className: joinClasses(
           "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition-colors placeholder:text-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:placeholder:text-gray-500",
           invalid && "border-red-500 focus:border-red-500 focus:ring-red-500/20 dark:border-red-400",
-          validationState === "success" && "border-green-500 focus:border-green-500 focus:ring-green-500/20 dark:border-green-400",
+          // 🔥 FIX 1: Support both success AND valid states for the styling
+          (validationState === "success" || validationState === "valid") && "border-green-500 focus:border-green-500 focus:ring-green-500/20 dark:border-green-400",
           loading && "border-blue-500 dark:border-blue-400",
           prefix && "pl-10",
           (showStatusIcon || suffix) && "pr-10",
@@ -122,7 +123,7 @@ const FormFieldWrapper = ({
               *
             </span>
           )}
-          {required && <span className="sr-only"> required</span>}
+          {/* 🔥 FIX 2: Removed redundant sr-only required span to prevent screen reader stutter. aria-required handles this. */}
         </label>
       )}
 


### PR DESCRIPTION
## 🚀 Description
This PR resolves two UI/Accessibility issues in `FormFieldWrapper.js` that caused styling inconsistencies and redundant screen reader announcements.

**1. Styling Fix:**
The component logic supported both `"success"` and `"valid"` states, but the CSS string concatenation strictly checked `validationState === "success"`. Consequently, any implementation using `validationState="valid"` failed to apply success-state border and ring styles.
* **Fix:** Updated the conditional check to `(validationState === "success" || validationState === "valid")`.

**2. Accessibility Stutter Fix:**
When the `required` prop was set to `true`, the component injected an `aria-required="true"` attribute into the input field *and* rendered a hidden `<span>` inside the label with text "required". This caused screen readers to redundantly announce the required state twice.
* **Fix:** Removed the redundant `<span className="sr-only"> required</span>` element. The `aria-required` attribute on the input is sufficient for screen readers to convey the field's requirements.

Fixes #4159 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI / Accessibility (a11y) improvement

## ✔️ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code