### PR TITLE
[FIX] Prevent Groq API key exposure in frontend

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -95,7 +95,7 @@ async function handler(req, res) {
     });
   }
 
-  const apiKey = process.env.GROQ_API_KEY || process.env.REACT_APP_GROQ_API_KEY;
+  const apiKey = process.env.GROQ_API_KEY;
 
   if (!apiKey) {
     return res.status(500).json({ error: "Groq API key not configured on the server." });

--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -79,6 +79,16 @@ const SENSITIVE_VALUE_PATTERNS = [
 const ALLOWED_EXCEPTIONS = new Set([
   'VITE_GOOGLE_CLIENT_ID',
   'VITE_EMAILJS_PUBLIC_KEY',
+  'REACT_APP_API_URL',
+  'REACT_APP_SENTRY_DSN',
+  'REACT_APP_GITHUB_REPO',
+  'REACT_APP_PUBLIC_URL',
+  'REACT_APP_VAPID_PUBLIC_KEY',
+  'REACT_APP_CSP_REPORT_URI',
+  'REACT_APP_FACEBOOK_APP_ID',
+  'REACT_APP_EMAILJS_PUBLIC_KEY',
+  'REACT_APP_EMAILJS_SERVICE_ID',
+  'REACT_APP_EMAILJS_TEMPLATE_ID',
 ]);
 
 // Required VITE_ variables that MUST be present for the app to function.
@@ -128,6 +138,12 @@ for (const varName of REQUIRED_VARS) {
   } else {
     console.log(`  ✓  ${varName} = [set]`);
   }
+}
+
+if (process.env.REACT_APP_GROQ_API_KEY) {
+  const msg = '[SECURITY LEAK] REACT_APP_GROQ_API_KEY: Groq credentials must never be exposed through a REACT_APP_ variable. Move the secret to GROQ_API_KEY and keep it server-side only.';
+  errors.push(msg);
+  hasErrors = true;
 }
 
 // Check optional variables

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -28,7 +28,7 @@ const resolveEnvApiBaseUrl = () => {
     return normalizeApiBaseUrl(envUrl);
   }
   if (process.env.NODE_ENV === "production") {
-    console.warn("REACT_APP_API_URL environment variable is missing in production. Defaulting to relative API requests.");
+    console.warn("VITE_API_URL environment variable is missing in production. Defaulting to relative API requests.");
     return "";
   }
   return "http://localhost:8080";

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,5 +1,5 @@
 const requiredEnvVars = [
-  "REACT_APP_API_URL",
+  "VITE_API_URL",
 ];
 
 const optionalEnvVars = {
@@ -45,7 +45,7 @@ export const validateEnvironment = () => {
 validateEnvironment();
 
 export const ENV = {
-  API_URL: getEnvVar("REACT_APP_API_URL"),
+  API_URL: getEnvVar("VITE_API_URL"),
   SENTRY_DSN: getEnvVar(
     "REACT_APP_SENTRY_DSN",
     optionalEnvVars.REACT_APP_SENTRY_DSN

--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -276,7 +276,7 @@ class SseMultiplexer {
 
   openEventSource(path) {
     const sseBaseUrl = typeof window !== "undefined"
-      ? (process.env.REACT_APP_SSE_URL || process.env.REACT_APP_API_URL || "http://localhost:8080/api/v1")
+      ? (process.env.VITE_SSE_URL || process.env.VITE_API_URL || process.env.REACT_APP_SSE_URL || process.env.REACT_APP_API_URL || "http://localhost:8080/api/v1")
       : "http://localhost:8080/api/v1";
 
     logger.log(`[SSE Multiplexer] Leader tab opening physical EventSource: ${sseBaseUrl}${path}`);

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,16 +42,19 @@ export default defineConfig(({ mode }) => {
       },
     },
 
-    envPrefix: ["VITE_", "REACT_APP_"],
     define: {
       "process.env.NODE_ENV": JSON.stringify(mode),
       "process.env.PUBLIC_URL": JSON.stringify(""),
-      ...Object.keys(env)
-        .filter((key) => key.startsWith("REACT_APP_") || key.startsWith("VITE_"))
-        .reduce((prev, key) => {
-          prev[`process.env.${key}`] = JSON.stringify(env[key]);
-          return prev;
-        }, {}),
+      "process.env.REACT_APP_API_URL": JSON.stringify(env.REACT_APP_API_URL || env.VITE_API_URL || "/api"),
+      "process.env.REACT_APP_SENTRY_DSN": JSON.stringify(env.REACT_APP_SENTRY_DSN || ""),
+      "process.env.REACT_APP_GITHUB_REPO": JSON.stringify(env.REACT_APP_GITHUB_REPO || "SandeepVashishtha/Eventra"),
+      "process.env.REACT_APP_PUBLIC_URL": JSON.stringify(env.REACT_APP_PUBLIC_URL || "https://eventra.sandeepvashishtha.tech"),
+      "process.env.REACT_APP_VAPID_PUBLIC_KEY": JSON.stringify(env.REACT_APP_VAPID_PUBLIC_KEY || ""),
+      "process.env.REACT_APP_CSP_REPORT_URI": JSON.stringify(env.REACT_APP_CSP_REPORT_URI || ""),
+      "process.env.REACT_APP_FACEBOOK_APP_ID": JSON.stringify(env.REACT_APP_FACEBOOK_APP_ID || ""),
+      "process.env.REACT_APP_EMAILJS_PUBLIC_KEY": JSON.stringify(env.REACT_APP_EMAILJS_PUBLIC_KEY || ""),
+      "process.env.REACT_APP_EMAILJS_SERVICE_ID": JSON.stringify(env.REACT_APP_EMAILJS_SERVICE_ID || ""),
+      "process.env.REACT_APP_EMAILJS_TEMPLATE_ID": JSON.stringify(env.REACT_APP_EMAILJS_TEMPLATE_ID || ""),
     },
 
     server: {


### PR DESCRIPTION
## 🚀 Description
This change removes client-side access to the Groq API key and routes all AI recommendation requests through the secure backend endpoint instead of exposing secrets in browser bundles.

### Summary of changes
- Removed `REACT_APP_GROQ_API_KEY` usage from the frontend path.
- Updated the AI recommendation service to call `/api/ai-recommendations` through the authenticated API layer.
- Restricted env handling so only public frontend values are exposed to the client.
- Updated build-time validation to fail if `REACT_APP_GROQ_API_KEY` is present.
- Kept recommendation functionality intact while ensuring the key remains server-side only.

### Motivation and context
The previous implementation allowed Groq credentials to be read from frontend environment variables and bundled client assets, which could expose the API key to anyone inspecting the browser. This fix centralizes the secret on the server, minimizes env exposure, and preserves the existing AI recommendation flow.

Closes #4029 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings