### PR TITLE
[FIX] Remove hardcoded JWT signing secret

### DIFF
--- a/api/auth/jwt-config.js
+++ b/api/auth/jwt-config.js
@@ -1,20 +1,20 @@
 // Centralized JWT configuration shared by all auth endpoints.
-// Production must fail closed if the signing secret is missing; otherwise a
-// predictable fallback would let attackers forge valid Eventra tokens.
-const DEVELOPMENT_JWT_SECRET = "eventra-local-development-jwt-secret";
+// JWT_SECRET is mandatory in every environment so Eventra never falls back to
+// a predictable signing key that could be used to forge tokens.
+const requireJwtSecret = () => {
+  const secret = process.env.JWT_SECRET?.trim();
 
-export const getJwtSecret = () => {
-  const secret = process.env.JWT_SECRET;
-
-  if (secret && secret.trim()) {
+  if (secret) {
     return secret;
   }
 
-  if (process.env.NODE_ENV === "production") {
-    throw new Error("JWT_SECRET must be configured in production");
-  }
-
-  return DEVELOPMENT_JWT_SECRET;
+  throw new Error(
+    "Missing required environment variable: JWT_SECRET. Eventra cannot start without a JWT signing secret."
+  );
 };
+
+export const getJwtSecret = () => requireJwtSecret();
+
+export const JWT_SECRET = requireJwtSecret();
 
 export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "7d";

--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -6,11 +6,7 @@ import { getJwtSecret } from "./jwt-config.js";
 // ---------------------------------------------------------------------------
 
 // Use the same centralised helper as login.js and signup.js so that all three
-// handlers share a consistent signing secret. The previous inline fallback
-// ("your-super-secret-jwt-key-change-in-production") differed from the
-// development fallback in jwt-config.js ("eventra-local-development-jwt-secret"),
-// causing jwt.verify() here to reject every token issued by login.js in local
-// development (the keys never matched).
+// handlers share a consistent signing secret.
 const JWT_SECRET = getJwtSecret();
 
 // ---------------------------------------------------------------------------

--- a/tests/githubProxy.test.mjs
+++ b/tests/githubProxy.test.mjs
@@ -1,12 +1,14 @@
+import "./helpers/authTestEnv.mjs";
 import assert from "node:assert/strict";
 import jwt from "jsonwebtoken";
-import handler from "../api/github-proxy.js";
+const { default: handler } = await import("../api/github-proxy.js");
+const { users } = await import("../api/auth/signup.js");
 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
-const DEV_JWT_SECRET = "eventra-local-development-jwt-secret";
+const DEV_JWT_SECRET = process.env.JWT_SECRET;
 
 const makeToken = (payload = {}) =>
   jwt.sign({ id: "user-test-1", email: "test@example.com", ...payload }, DEV_JWT_SECRET, {
@@ -57,6 +59,22 @@ globalThis.fetch = async (url, options) => {
 };
 
 process.env.GITHUB_TOKEN = "test-token";
+
+users.set("test@example.com", {
+  id: "user-test-1",
+  email: "test@example.com",
+  username: "test@example.com",
+  roles: ["USER"],
+  permissions: ["events:view"],
+});
+
+users.set("ratelimit@example.com", {
+  id: "user-rate-limit-test",
+  email: "ratelimit@example.com",
+  username: "ratelimit@example.com",
+  roles: ["USER"],
+  permissions: ["events:view"],
+});
 
 // ---------------------------------------------------------------------------
 // 1. Unauthenticated requests must be rejected with 401

--- a/tests/googleOAuthEndpoint.test.mjs
+++ b/tests/googleOAuthEndpoint.test.mjs
@@ -1,3 +1,4 @@
+import "./helpers/authTestEnv.mjs";
 import assert from "node:assert/strict";
 
 // ---------------------------------------------------------------------------
@@ -82,10 +83,10 @@ const createRequest = (method, body) => ({
 // Simulated Google OAuth Handler (mirrors api/auth/google.js logic)
 // ---------------------------------------------------------------------------
 
-import { users } from "../api/auth/signup.js";
+const { users } = await import("../api/auth/signup.js");
 import jwt from "jsonwebtoken";
 
-const JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret";
+const JWT_SECRET = process.env.JWT_SECRET;
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "7d";
 
 const DEFAULT_ROLES = ["USER"];

--- a/tests/helpers/authTestEnv.mjs
+++ b/tests/helpers/authTestEnv.mjs
@@ -1,0 +1,9 @@
+import crypto from "node:crypto";
+
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = crypto.randomBytes(32).toString("hex");
+}
+
+if (!process.env.ALLOWED_ORIGIN) {
+  process.env.ALLOWED_ORIGIN = "http://localhost:3000";
+}

--- a/tests/loginEndpoint.test.mjs
+++ b/tests/loginEndpoint.test.mjs
@@ -1,6 +1,7 @@
+import "./helpers/authTestEnv.mjs";
 process.env.ALLOWED_ORIGIN = "http://localhost:3000";
 import assert from "node:assert/strict";
-import handler, { users } from "../api/auth/login.js";
+const { default: handler, users } = await import("../api/auth/login.js");
 
 // Mock allowed origin to test specific CORS headers correctly
 process.env.ALLOWED_ORIGIN = "http://localhost:3000";
@@ -52,7 +53,7 @@ const createRequest = (method, body) => ({
 // Helper: Create a test user by calling signup first
 // ---------------------------------------------------------------------------
 
-import signupHandler from "../api/auth/signup.js";
+const { default: signupHandler } = await import("../api/auth/signup.js");
 
 const createTestUser = async (userData) => {
   const req = createRequest("POST", userData);

--- a/tests/logoutEndpoint.test.mjs
+++ b/tests/logoutEndpoint.test.mjs
@@ -1,3 +1,4 @@
+import "./helpers/authTestEnv.mjs";
 import assert from "node:assert/strict";
 import jwt from "jsonwebtoken";
 
@@ -5,7 +6,7 @@ import jwt from "jsonwebtoken";
 // JWT Configuration
 // ---------------------------------------------------------------------------
 
-const JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret-key";
+const JWT_SECRET = process.env.JWT_SECRET;
 
 // ---------------------------------------------------------------------------
 // Token Blacklist (mirrors api/auth/logout.js)

--- a/tests/signupEndpoint.test.mjs
+++ b/tests/signupEndpoint.test.mjs
@@ -1,6 +1,7 @@
+import "./helpers/authTestEnv.mjs";
 process.env.ALLOWED_ORIGIN = "http://localhost:3000";
 import assert from "node:assert/strict";
-import handler from "../api/auth/signup.js";
+const { default: handler } = await import("../api/auth/signup.js");
 
 // ---------------------------------------------------------------------------
 // Mock Response Helper


### PR DESCRIPTION
## 🚀 Description
This change removes the hardcoded JWT signing secret fallback and makes JWT_SECRET mandatory in every environment. Eventra now fails fast during authentication module initialization if the secret is missing, which prevents predictable token signing and token forgery.

The auth test suite was updated to initialize a generated JWT secret explicitly before importing the authentication modules, so the tests continue to validate login, signup, logout, Google OAuth, and GitHub proxy flows without relying on any fallback secret.

Closes #4031 

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings