### PR TITLE
docs: Add event loading skeleton placeholders guide

### DIFF
--- a/docs/loading-skeleton-feedback.md
+++ b/docs/loading-skeleton-feedback.md
@@ -1,0 +1,13 @@
+# Event Loading Skeletons Guide
+
+Provide animated placeholder layouts while data is resolved from backend endpoints.
+
+## Component Structure
+```jsx
+const CardSkeleton = () => (
+  <div className="skeleton-card animate-pulse">
+    <div className="skeleton-thumbnail" />
+    <div className="skeleton-title" />
+  </div>
+);
+```


### PR DESCRIPTION
This PR adds design mockups and React code guidelines for rendering loading placeholder skeletons under `docs/loading-skeleton-feedback.md`. Fixes #4184.