### PR TITLE
docs: Add card thumbnail layout shift prevention guide

### DIFF
--- a/docs/image-cls-layout-shift.md
+++ b/docs/image-cls-layout-shift.md
@@ -1,0 +1,12 @@
+# Mitigating CLS in Card Thumbnails
+
+Always specify dimensions or aspect ratios on image containers to avoid page layout shifts.
+
+## Resolution
+```css
+.card-thumbnail {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+```


### PR DESCRIPTION
This PR provides CSS guidelines to mitigate Cumulative Layout Shift in card views under `docs/image-cls-layout-shift.md`. Fixes #4191.