### PR TITLE
docs: Add LocalStorage fail-safe and context fallback guide

### DIFF
--- a/docs/localstorage-session-fallback.md
+++ b/docs/localstorage-session-fallback.md
@@ -1,0 +1,12 @@
+# LocalStorage Fail-Safe Guide
+
+Always wrap standard LocalStorage requests to prevent client crashes under private browsing configurations.
+
+## Implementation
+```javascript
+try {
+  localStorage.setItem(key, val);
+} catch (e) {
+  // Fallback to memory context storage
+}
+```


### PR DESCRIPTION
This PR introduces guidelines for try-catch context handlers under `docs/localstorage-session-fallback.md` to prevent crashes. Fixes #4203.