### PR TITLE
docs: Add font preloading and rendering display swap guide

### DIFF
--- a/docs/font-display-swap.md
+++ b/docs/font-display-swap.md
@@ -1,0 +1,11 @@
+# Web Fonts Styling Guide
+
+Configure custom Google Fonts configurations to support immediate system-font rendering fallback.
+
+## CSS Configurations
+```css
+@font-face {
+  font-family: 'Outfit';
+  font-display: swap;
+}
+```


### PR DESCRIPTION
This PR provides font preloading rules and rendering parameters under `docs/font-display-swap.md` to boost LCP scores. Fixes #4205.