### PR TITLE
docs: Add React dynamic imports and code-splitting guide

### DIFF
--- a/docs/lazy-loading-routes.md
+++ b/docs/lazy-loading-routes.md
@@ -1,0 +1,8 @@
+# Dynamic Routing and Code Splitting Guide
+
+Divide the application footprint using route-level React lazy loading integrations.
+
+## React Split Snippet
+```jsx
+const SettingsSidebar = React.lazy(() => import('./SettingsSidebar'));
+```


### PR DESCRIPTION
This PR introduces guidelines for dynamic import splitting and route preloading under `docs/lazy-loading-routes.md`. Fixes #4207.