### PR TITLE
docs: Add ARIA form accessibility and input labeling guide

### DIFF
--- a/docs/aria-labels-form-inputs.md
+++ b/docs/aria-labels-form-inputs.md
@@ -1,0 +1,12 @@
+# Event Creation A11y Standards
+
+Ensure all inputs satisfy screen reader contrast and descriptor protocols.
+
+## Implementation
+```jsx
+<input 
+  type="text" 
+  aria-label="Event Title Input" 
+  aria-required="true"
+/>
+```


### PR DESCRIPTION
This PR documents ARIA specifications and input descriptions under `docs/aria-labels-form-inputs.md` for WCAG accessibility compliance. Fixes #4209.