### PR TITLE
Fix bookmarkUtils.js: persist minimal event fields and enforce MAX_BOOKMARKS = 200 cap

### DIFF
--- a/src/utils/bookmarkUtils.js
+++ b/src/utils/bookmarkUtils.js
@@ -1,6 +1,39 @@
 import { safeJsonParse } from "./safeJsonParse.js";
+
 const BOOKMARKS_STORAGE_KEY = "eventra_bookmarked_events";
 const BOOKMARKS_CHANGED_EVENT = "eventraBookmarksChanged";
+
+// ---------------------------------------------------------------------------
+// Limits
+//
+// MAX_BOOKMARKS caps the number of entries in the `eventra_bookmarked_events`
+// localStorage key to prevent quota exhaustion. This is a separate code path
+// from useBookmarks.js (which uses `bookmarks_<userId>` keys). Both must
+// enforce the same cap independently.
+//
+// When the cap is exceeded the oldest entry (smallest bookmarkedAt) is dropped
+// so the total stays within bounds.
+// ---------------------------------------------------------------------------
+export const MAX_BOOKMARKS = 200;
+
+// ---------------------------------------------------------------------------
+// Minimal bookmark shape
+//
+// Previously: { ...event, bookmarkedAt }  — the full event object spread
+// Now: only the fields needed to render the bookmarks list and navigate
+// to the event detail page. The full event is fetched on demand when the
+// user opens the event.
+// ---------------------------------------------------------------------------
+const toBookmarkEntry = (event) => ({
+  id: event?.id,
+  title: event?.title ?? "",
+  date: event?.date ?? "",
+  location: event?.location ?? "",
+  type: event?.type ?? event?.category ?? "",
+  image: event?.image ?? event?.imageUrl ?? "",
+  status: event?.status ?? "",
+  bookmarkedAt: new Date().toISOString(),
+});
 
 const normalizeEventId = (eventId) => String(eventId);
 
@@ -9,8 +42,8 @@ const readBookmarks = () => {
 
   try {
     const rawBookmarks = window.localStorage.getItem(BOOKMARKS_STORAGE_KEY);
-    const parsedBookmarks = safeJsonParse(rawBookmarks, []);
-    return Array.isArray(parsedBookmarks) ? parsedBookmarks : [];
+    const parsed = safeJsonParse(rawBookmarks, []);
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
@@ -23,38 +56,100 @@ const writeBookmarks = (bookmarks) => {
     window.localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(bookmarks));
     window.dispatchEvent(new CustomEvent(BOOKMARKS_CHANGED_EVENT, { detail: bookmarks }));
   } catch {
-    // localStorage can be unavailable or full. Keep the UI usable if persistence fails.
+    // localStorage can be unavailable or full — keep the UI usable if persistence fails
   }
 };
 
 export const getBookmarkedEvents = () => readBookmarks();
+
+export const getBookmarkCount = () => readBookmarks().length;
 
 export const isEventBookmarked = (eventId) => {
   const normalizedId = normalizeEventId(eventId);
   return readBookmarks().some((event) => normalizeEventId(event.id) === normalizedId);
 };
 
+/**
+ * Add an event to the bookmark list.
+ *
+ * - Skips duplicate IDs (idempotent).
+ * - Stores only the minimal display fields — not the full event object.
+ * - If the list would exceed MAX_BOOKMARKS, drops the oldest entry first.
+ *
+ * @param {object} event - The event to bookmark.
+ * @returns {Array} The updated bookmark list.
+ */
 export const addBookmarkedEvent = (event) => {
+  if (!event?.id) return readBookmarks();
+
   const bookmarks = readBookmarks();
   const normalizedId = normalizeEventId(event.id);
 
-  if (bookmarks.some((bookmarkedEvent) => normalizeEventId(bookmarkedEvent.id) === normalizedId)) {
+  if (bookmarks.some((b) => normalizeEventId(b.id) === normalizedId)) {
     return bookmarks;
   }
 
-  const nextBookmarks = [{ ...event, bookmarkedAt: new Date().toISOString() }, ...bookmarks];
+  const entry = toBookmarkEntry(event);
+  let nextBookmarks = [entry, ...bookmarks];
+
+  if (nextBookmarks.length > MAX_BOOKMARKS) {
+    // Sort oldest-first and drop the last (oldest) entry to stay within limit
+    nextBookmarks = [...nextBookmarks].sort(
+      (a, b) => new Date(a.bookmarkedAt).getTime() - new Date(b.bookmarkedAt).getTime(),
+    );
+    nextBookmarks.shift();
+    // Re-sort newest-first for consistent read order
+    nextBookmarks.sort(
+      (a, b) => new Date(b.bookmarkedAt).getTime() - new Date(a.bookmarkedAt).getTime(),
+    );
+  }
+
   writeBookmarks(nextBookmarks);
   return nextBookmarks;
 };
 
+/**
+ * Remove a single bookmark by event ID.
+ *
+ * @param {string|number} eventId
+ * @returns {Array} The updated bookmark list.
+ */
 export const removeBookmarkedEvent = (eventId) => {
   const normalizedId = normalizeEventId(eventId);
   const nextBookmarks = readBookmarks().filter(
-    (event) => normalizeEventId(event.id) !== normalizedId
+    (event) => normalizeEventId(event.id) !== normalizedId,
   );
 
   writeBookmarks(nextBookmarks);
   return nextBookmarks;
+};
+
+/**
+ * Remove all bookmarks, clearing both in-memory state and localStorage.
+ *
+ * @returns {Array} Empty array.
+ */
+export const clearAllBookmarks = () => {
+  writeBookmarks([]);
+  return [];
+};
+
+/**
+ * Enforce the MAX_BOOKMARKS cap on the existing stored list.
+ * Call this on app startup to prune any legacy over-limit entries.
+ *
+ * @returns {Array} The pruned bookmark list (or original if within limit).
+ */
+export const pruneBookmarks = () => {
+  const bookmarks = readBookmarks();
+  if (bookmarks.length <= MAX_BOOKMARKS) return bookmarks;
+
+  const sorted = [...bookmarks].sort(
+    (a, b) => new Date(b.bookmarkedAt).getTime() - new Date(a.bookmarkedAt).getTime(),
+  );
+  const pruned = sorted.slice(0, MAX_BOOKMARKS);
+  writeBookmarks(pruned);
+  return pruned;
 };
 
 export const subscribeToBookmarkChanges = (callback) => {


### PR DESCRIPTION
**What is the problem**
`bookmarkUtils.js` stored `{ ...event, bookmarkedAt }` — the full event object — for every bookmark in `eventra_bookmarked_events` with no count limit. This is a separate localStorage path from `useBookmarks.js` (which was fixed in #4098 / PR #4128). Large event objects can be several kilobytes each; uncapped growth exhausts the 5–10 MB localStorage quota and silently breaks all other write-dependent features (offline queue, session recovery, auth).

**What was changed**
- `src/utils/bookmarkUtils.js` — added `toBookmarkEntry()` storing only 8 display fields (id, title, date, location, type, image, status, bookmarkedAt) instead of spreading the full object
- Added `MAX_BOOKMARKS = 200` constant; `addBookmarkedEvent()` drops the oldest entry when the cap would be exceeded
- Added `getBookmarkCount()`, `clearAllBookmarks()`, and `pruneBookmarks()` helpers for startup cleanup and consumer use
- Added guard against events with no `id`

**Why this approach**
Matches the pattern established in `useBookmarks.js` PR #4128, ensuring both bookmark persistence layers use the same minimal-field approach.

**How to test**
1. Add 201 bookmarks via `addBookmarkedEvent`
2. Confirm `getBookmarkCount() === 200` — the oldest was dropped
3. Inspect localStorage — entries contain only the 8 minimal fields

**Lines changed**
101 added, 6 removed — 107 total in `src/utils/bookmarkUtils.js`

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4224