### PR TITLE
Cap seenNotificationIds Set at 500 entries to prevent unbounded memory growth in NotificationContext

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -86,8 +86,32 @@ export const NotificationProvider = ({ children }) => {
 
   const isMounted = useRef(true);
   const activeTokenRef = useRef(token);
-  const seenNotificationIds = useRef(new Set());
   const hasCompletedInitialFetch = useRef(false);
+
+  // ---------------------------------------------------------------------------
+  // Bounded seen-notification Set
+  //
+  // seenNotificationIds deduplicates incoming notifications so browser push
+  // alerts do not fire twice for the same ID across polling cycles. The Set
+  // previously grew without bound: every polled ID was added but nothing was
+  // ever removed. On long-running sessions (open tabs left running overnight)
+  // the Set accumulated thousands of string IDs, increasing GC pressure.
+  //
+  // MAX_SEEN_IDS caps the Set. When the cap is reached the insertion helper
+  // evicts the oldest entry (Sets preserve insertion order, so the first value
+  // is the oldest) before adding the new one — a constant-time O(1) eviction.
+  // ---------------------------------------------------------------------------
+  const MAX_SEEN_IDS = 500;
+  const seenNotificationIds = useRef(new Set());
+
+  const addSeenId = (id) => {
+    if (seenNotificationIds.current.has(id)) return;
+    if (seenNotificationIds.current.size >= MAX_SEEN_IDS) {
+      const oldest = seenNotificationIds.current.values().next().value;
+      seenNotificationIds.current.delete(oldest);
+    }
+    seenNotificationIds.current.add(id);
+  };
 
   const groupedNotifications = useMemo(() => {
     return notifications.reduce((groups, notification) => {
@@ -285,7 +309,7 @@ export const NotificationProvider = ({ children }) => {
           return isNew && !notification.isRead;
         });
 
-        normalizedData.forEach((notification) => seenNotificationIds.current.add(notification.id));
+        normalizedData.forEach((notification) => addSeenId(notification.id));
         setNotifications(normalizedData);
         setUnreadCount(normalizedData.filter((n) => !n.isRead).length);
 


### PR DESCRIPTION
**What is the problem**
`seenNotificationIds` in `NotificationContext.js` is a `useRef(new Set())` that adds every polled notification ID but never evicts old ones. It is only cleared on token change. On long-running sessions (8 h × 60-s polling × 20 notifications/poll = ~9 600 entries) the Set grows without bound, increasing GC pressure.

**What was changed**
- `src/context/NotificationContext.js` — added `MAX_SEEN_IDS = 500` constant and `addSeenId()` helper that evicts the oldest entry (O(1) via Set insertion-order iterator) before inserting a new one when the cap is reached; replaced the direct `.add()` call site with `addSeenId()`

**Why this approach**
JavaScript `Set` preserves insertion order, making the oldest entry always the `.values().next().value`. Evict-oldest-on-cap is the simplest bounded-Set pattern with O(1) per-operation cost.

**How to test**
Call `addSeenId` 600 times — confirm `seenNotificationIds.current.size === 500` after all calls.

**Lines changed**
26 added, 2 removed — 28 total in `src/context/NotificationContext.js`

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4225