### PR TITLE
Eliminate response.clone() in fetchWithTimeout — read body once, halve peak memory per request

### DIFF
--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -39,19 +39,34 @@ export const fetchWithTimeout = async (
       signal: controller.signal, // This now responds to BOTH the timeout and the user's unmount signal
     });
 
+    // Read the body once — directly from the response stream.
+    //
+    // The previous implementation used response.clone().json() which allocates
+    // a duplicate of the entire body in memory before parsing, doubling peak
+    // consumption for every request. Since callers consume the returned `data`
+    // field rather than response.body, there is no need to keep the original
+    // stream open. Read directly and skip the clone.
     let data = null;
+    const contentType = response.headers.get("content-type") || "";
 
     try {
-      data = await response.clone().json();
+      if (contentType.includes("application/json") || contentType.includes("/json")) {
+        data = await response.json();
+      } else {
+        const text = await response.text().catch(() => null);
+        if (typeof text === "string") {
+          try { data = JSON.parse(text); } catch { data = text; }
+        }
+      }
     } catch {
-      data = await response.text().catch(() => null);
+      data = null;
     }
 
     if (!response.ok) {
       throw new FetchError(
         data?.message || `Request failed with status ${response.status}`,
         response.status,
-        data
+        data,
       );
     }
 


### PR DESCRIPTION
**What is the problem**
`fetchWithTimeout.js` called `response.clone().json()` to parse the body, which creates a full in-memory duplicate of the response stream before parsing. Since callers use the returned `data` field (not `response.body`), the clone is unnecessary — it doubles the peak heap allocation for every request. For 10+ concurrent contributor profile fetches this is a measurable memory spike.

**What was changed**
- `src/utils/fetchWithTimeout.js` — replaced `response.clone().json()` with a direct single-read path: check `Content-Type` header to choose between `.json()` and `.text()` with a JSON.parse fallback; removed the clone entirely

**Why this approach**
Reading the body directly is the standard pattern. The `.clone()` only makes sense when both the cloned and original streams need to be consumed independently — which is not the case here.

**How to test**
All existing call sites (`ContributorsCarousel`, `useOfflineSync`) receive `{ response, data }` as before — no interface change. Verify JSON responses still parse correctly and that non-JSON text responses return the text string as `data`.

**Lines changed**
18 added, 3 removed — 21 total in `src/utils/fetchWithTimeout.js`

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4226