### PR TITLE
Pause notification polling on hidden tabs using Page Visibility API — add usePageVisibility hook

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { apiUtils, API_ENDPOINTS } from "../config/api";
 import { useAuth } from "./AuthContext";
+import usePageVisibility from "../hooks/usePageVisibility";
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
   PUSH_SUBSCRIPTION_KEY,
@@ -68,6 +69,7 @@ const normalizeNotification = (notification = {}) => ({
 
 export const NotificationProvider = ({ children }) => {
   const { token } = useAuth();
+  const isPageVisible = usePageVisibility();
   const [notifications, setNotifications] = useState([]);
   const [achievements, setAchievements] = useState({
     totalEvents: 0,
@@ -490,14 +492,28 @@ export const NotificationProvider = ({ children }) => {
 
     initData();
 
+    // Visibility-aware polling: skip the network call when the tab is hidden.
+    // The setInterval still fires on schedule so the cadence is maintained, but
+    // the fetch is gated on isPageVisible. When the tab becomes visible again,
+    // a separate useEffect (below) fires an immediate catch-up fetch so no
+    // notifications are missed.
     const intervalId = setInterval(() => {
-      if (isMounted.current && activeTokenRef.current === requestToken) {
+      if (isMounted.current && activeTokenRef.current === requestToken && isPageVisible) {
         fetchNotifications({ isBackground: true });
       }
     }, POLLING_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, [token, fetchNotifications, fetchAchievements]);
+  }, [token, fetchNotifications, fetchAchievements, isPageVisible]);
+
+  // Catch-up fetch: when the tab becomes visible after being hidden, immediately
+  // fetch notifications so the user sees fresh data without waiting up to
+  // POLLING_INTERVAL_MS for the next scheduled tick.
+  useEffect(() => {
+    if (!isPageVisible || !token) return;
+    if (!hasCompletedInitialFetch.current) return;
+    fetchNotifications({ isBackground: true });
+  }, [isPageVisible, token, fetchNotifications]);
 
   return (
     <NotificationContext.Provider

--- a/src/hooks/usePageVisibility.js
+++ b/src/hooks/usePageVisibility.js
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+
+/**
+ * usePageVisibility
+ *
+ * Returns `true` when the current document tab is visible to the user
+ * and `false` when it is hidden (minimised, in a background tab, or the
+ * screen is locked).
+ *
+ * Uses the Page Visibility API (`document.visibilityState` / `visibilitychange`
+ * event) which is supported in all modern browsers.
+ *
+ * Usage:
+ *   const isVisible = usePageVisibility();
+ *   // Pause polling, animations, or timers when isVisible === false
+ *
+ * @returns {boolean} Whether the page is currently visible
+ */
+const usePageVisibility = () => {
+  const getVisibility = () => {
+    if (typeof document === "undefined") return true;
+    return document.visibilityState !== "hidden";
+  };
+
+  const [isVisible, setIsVisible] = useState(getVisibility);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const handleVisibilityChange = () => {
+      setIsVisible(document.visibilityState !== "hidden");
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
+
+  return isVisible;
+};
+
+export default usePageVisibility;


### PR DESCRIPTION
**What is the problem**
`NotificationContext.js` polled `/api/notifications` every 60 seconds via `setInterval` regardless of tab visibility, wasting network, CPU, and battery on background tabs.

**What was changed**
- `src/hooks/usePageVisibility.js` (new) — reusable hook wrapping `document.visibilityState` / `visibilitychange`
- `src/context/NotificationContext.js` — poll guard now checks `isPageVisible` before firing the background fetch; added a catch-up `useEffect` that fires one immediate fetch when the tab becomes visible again

**How to test**
1. Open the app, observe network polling every 60s
2. Switch to another tab — polling stops
3. Switch back — one immediate fetch fires, then polling resumes

**Lines changed**
18 added in `NotificationContext.js` + 42-line new hook = 60 total

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4227