### PR TITLE
Fix open redirect in shareUtils: validate share URLs and use static redirect_uri in Messenger dialog

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -3,6 +3,45 @@
  * These functions generate URLs for sharing content across various platforms
  */
 
+// ---------------------------------------------------------------------------
+// Share URL validation
+//
+// isValidShareUrl() ensures that only URLs originating from the Eventra
+// application domain are used in share payloads. This prevents an attacker
+// who can craft an event with a malicious URL from exploiting the Messenger
+// share dialog's redirect_uri parameter as an open redirect.
+//
+// Accepts:
+//  - Relative paths starting with /
+//  - Absolute URLs whose origin matches window.location.origin
+//  - The configured REACT_APP_PUBLIC_URL origin
+//
+// Rejects: external URLs, javascript: URIs, data: URIs
+// ---------------------------------------------------------------------------
+export const isValidShareUrl = (url) => {
+  if (!url || typeof url !== "string") return false;
+  if (url.startsWith("/")) return true; // relative path — always same-origin
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "javascript:" || parsed.protocol === "data:") return false;
+
+    const allowedOrigins = new Set();
+    if (typeof window !== "undefined") allowedOrigins.add(window.location.origin);
+
+    const configuredPublicUrl = process.env.REACT_APP_PUBLIC_URL;
+    if (configuredPublicUrl) {
+      try {
+        allowedOrigins.add(new URL(configuredPublicUrl).origin);
+      } catch { /* ignore malformed env var */ }
+    }
+
+    return allowedOrigins.has(parsed.origin);
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Generate a sharing URL for various platforms
  * @param {Object} shareData - The data to share
@@ -11,26 +50,34 @@
  * @param {string} shareData.url - The URL to the content
  * @param {string} shareData.hashtags - Comma-separated list of hashtags (no # symbol)
  * @param {string} platform - The platform to share on ('email', 'twitter', 'facebook', 'messenger', 'linkedin', 'whatsapp', 'telegram')
- * @returns {string} The sharing URL for the specified platform
+ * @returns {string} The sharing URL for the specified platform, or '' if the share URL is invalid
  */
 export const generateSharingUrl = (shareData, platform) => {
   const { title, description, url, hashtags } = shareData;
+
+  // Validate the share URL before encoding it into any platform-specific share
+  // dialog. Reject external or dangerous URLs to prevent open-redirect abuse.
+  if (!isValidShareUrl(url)) {
+    console.warn("[shareUtils] Rejected invalid share URL:", url);
+    return "";
+  }
+
   const encodedUrl = encodeURIComponent(url);
   const encodedTitle = encodeURIComponent(title);
   const encodedDescription = encodeURIComponent(description || '');
   const encodedHashtags = encodeURIComponent(hashtags || '');
-  
+
   switch (platform.toLowerCase()) {
     case 'email':
       return `mailto:?subject=${encodedTitle}&body=${encodedDescription}%0A%0A${encodedUrl}`;
-      
+
     case 'twitter':
     case 'x':
       return `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}&hashtags=${encodedHashtags}`;
-      
+
     case 'facebook':
       return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
-      
+
     case 'messenger': {
       const appId = process.env.REACT_APP_FACEBOOK_APP_ID;
 
@@ -38,21 +85,30 @@ export const generateSharingUrl = (shareData, platform) => {
         return '';
       }
 
-      return `https://www.facebook.com/dialog/send?link=${encodedUrl}&app_id=${appId}&redirect_uri=${encodedUrl}`;
+      // redirect_uri must be a trusted, static application URL — never the
+      // dynamic share URL. Using shareData.url here would allow an attacker
+      // who can craft an event URL to redirect users to an external domain
+      // after the Messenger dialog completes (open redirect).
+      const appOrigin = typeof window !== "undefined"
+        ? window.location.origin
+        : (process.env.REACT_APP_PUBLIC_URL || "");
+      const safeRedirectUri = encodeURIComponent(`${appOrigin}/`);
+
+      return `https://www.facebook.com/dialog/send?link=${encodedUrl}&app_id=${appId}&redirect_uri=${safeRedirectUri}`;
     }
-      
+
     case 'linkedin':
       return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}&title=${encodedTitle}&summary=${encodedDescription}`;
-      
+
     case 'whatsapp':
       return `https://wa.me/?text=${encodedTitle}%20${encodedUrl}`;
-      
+
     case 'telegram':
       return `https://telegram.me/share/url?url=${encodedUrl}&text=${encodedTitle}`;
-    
+
     case 'copy':
-      return url; // Special case for "Copy Link" functionality
-      
+      return url;
+
     default:
       return url;
   }


### PR DESCRIPTION
**What is the problem**
`shareUtils.js` set `redirect_uri=${encodedUrl}` in the Facebook Messenger dialog URL using the dynamic share URL. An attacker who can craft an event with an external URL can redirect users to a malicious destination after the dialog completes.

**What was changed**
- `src/utils/shareUtils.js` — added `isValidShareUrl()` that accepts only same-origin URLs; `generateSharingUrl()` returns `""` for any invalid URL before encoding
- Replaced `redirect_uri=${encodedUrl}` with a static application root URL (`window.location.origin + '/'`)

**Lines changed**
68 added, 12 removed — 80 total in `src/utils/shareUtils.js`

**Labels:** `type:security` `level:advanced` `gssoc:approved`

Closes #4230