### PR TITLE
Move EmailJS credentials server-side — prevent EMAILJS_PUBLIC_KEY, SERVICE_ID and TEMPLATE_ID from being bundled into the frontend

### DIFF
--- a/api/send-email.js
+++ b/api/send-email.js
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------
+// Serverless email confirmation proxy
+//
+// Sends event registration confirmation emails via EmailJS server-side so
+// the service ID, template ID, and public key are never bundled into the
+// frontend JavaScript. All three values are read from server-only environment
+// variables (without the REACT_APP_ prefix).
+//
+// Protected by verifyAuth so only authenticated users can trigger sends.
+// Per-user rate limiting (5 sends per minute) prevents spam abuse.
+// ---------------------------------------------------------------------------
+
+import { verifyAuth } from "./middleware/auth.js";
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_SENDS = 5;
+const rateLimitMap = new Map();
+let lastEvictionAt = 0;
+
+const checkRateLimit = (userId) => {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+
+  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    rateLimitMap.set(userId, { count: 1, windowStart: now });
+    return true;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX_SENDS) return false;
+  entry.count += 1;
+  return true;
+};
+
+const evictStale = () => {
+  const now = Date.now();
+  if (now - lastEvictionAt < RATE_LIMIT_WINDOW_MS) return;
+  lastEvictionAt = now;
+  for (const [key, entry] of rateLimitMap.entries()) {
+    if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) rateLimitMap.delete(key);
+  }
+};
+
+// Basic email format validation — prevents obviously malformed addresses from
+// reaching the EmailJS API and consuming quota.
+const isValidEmail = (email) =>
+  typeof email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email.trim());
+
+async function handler(req, res) {
+  const corsOrigin = process.env.ALLOWED_ORIGIN || "*";
+  res.setHeader("Access-Control-Allow-Origin", corsOrigin);
+  if (corsOrigin !== "*") res.setHeader("Access-Control-Allow-Credentials", "true");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed. Use POST." });
+  }
+
+  const userId = req.user?.id || req.user?.email || "unknown";
+  evictStale();
+
+  if (!checkRateLimit(userId)) {
+    res.setHeader("Retry-After", "60");
+    return res.status(429).json({ error: "Too many email requests. Please wait before sending another." });
+  }
+
+  const serviceId = process.env.EMAILJS_SERVICE_ID;
+  const templateId = process.env.EMAILJS_TEMPLATE_ID;
+  const publicKey = process.env.EMAILJS_PUBLIC_KEY;
+
+  if (!serviceId || !templateId || !publicKey) {
+    return res.status(500).json({ error: "Email service is not configured on the server." });
+  }
+
+  const { toEmail, toName, eventName, eventDate } = req.body || {};
+
+  if (!toEmail || !isValidEmail(toEmail)) {
+    return res.status(400).json({ error: "A valid recipient email address is required." });
+  }
+
+  const recipientName = typeof toName === "string" ? toName.slice(0, 100).trim() : "Participant";
+  const eventTitle = typeof eventName === "string" ? eventName.slice(0, 200).trim() : "your event";
+  const eventDateStr = typeof eventDate === "string" ? eventDate.slice(0, 50).trim() : "";
+
+  try {
+    const response = await fetch("https://api.emailjs.com/api/v1.0/email/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        service_id: serviceId,
+        template_id: templateId,
+        user_id: publicKey,
+        template_params: {
+          to_email: toEmail.trim(),
+          to_name: recipientName,
+          event_name: eventTitle,
+          event_date: eventDateStr,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      console.error("[send-email] EmailJS error:", response.status, text);
+      return res.status(502).json({ error: "Email delivery failed. Please try again later." });
+    }
+
+    return res.status(200).json({ sent: true });
+  } catch (error) {
+    console.error("[send-email] Request failed:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export default verifyAuth(handler);

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -41,20 +41,23 @@ import ConfettiCanvas from "../../components/common/ConfettiCanvas";
 
 const MAX_NOTES_CHARS = 500;
 
-const EMAILJS_PUBLIC_KEY = process.env.REACT_APP_EMAILJS_PUBLIC_KEY;
-const EMAILJS_SERVICE_ID = process.env.REACT_APP_EMAILJS_SERVICE_ID;
-const EMAILJS_TEMPLATE_ID = process.env.REACT_APP_EMAILJS_TEMPLATE_ID;
-
-function sendConfirmationEmail(userEmail, userName, eventName, eventDate) {
-  const finalName = userName || "Participant";
-  if (EMAILJS_PUBLIC_KEY && EMAILJS_SERVICE_ID && EMAILJS_TEMPLATE_ID && window.emailjs) {
-    window.emailjs.init(EMAILJS_PUBLIC_KEY);
-    window.emailjs.send(EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, {
-      to_email: userEmail,
-      to_name: finalName,
-      event_name: eventName,
-      event_date: eventDate,
-    }).catch(() => { });
+// EmailJS credentials are no longer read from REACT_APP_* environment
+// variables here. They were previously bundled into the frontend JavaScript,
+// allowing any visitor to extract them and abuse the EmailJS quota.
+//
+// Confirmation emails are now sent via the /api/send-email serverless handler
+// which reads EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, and EMAILJS_PUBLIC_KEY
+// as server-only environment variables (no REACT_APP_ prefix).
+async function sendConfirmationEmail(userEmail, userName, eventName, eventDate) {
+  try {
+    await apiUtils.post("/api/send-email", {
+      toEmail: userEmail,
+      toName: userName || "Participant",
+      eventName: eventName || "",
+      eventDate: eventDate || "",
+    });
+  } catch {
+    // Confirmation email failure is non-fatal — registration already succeeded
   }
 }
 


### PR DESCRIPTION
**What is the problem**
`EMAILJS_PUBLIC_KEY`, `EMAILJS_SERVICE_ID`, and `EMAILJS_TEMPLATE_ID` were read from `REACT_APP_*` env vars and used directly from the browser. `vite.config.js` inlines all `REACT_APP_*` variables into the compiled JS bundle, exposing all three credentials to any visitor who inspects the source.

**What was changed**
- `api/send-email.js` (new) — serverless handler protected by `verifyAuth`, reads credentials from non-`REACT_APP_` env vars, validates recipient email, enforces 5 sends/min per-user rate limit, proxies to EmailJS REST API
- `src/Pages/Events/EventRegistration.js` — replaced direct `window.emailjs` calls with `apiUtils.post("/api/send-email", ...)`, removed the three `REACT_APP_EMAILJS_*` constants

**Lines changed**
136 total (new file 120 lines + 17 added / 14 removed in EventRegistration.js)

**Labels:** `type:security` `level:advanced` `gssoc:approved`

Closes #4231