### PR TITLE
Add 7-day TTL eviction and minimal field storage to useRecentlyViewed

### DIFF
--- a/src/hooks/useRecentlyViewed.js
+++ b/src/hooks/useRecentlyViewed.js
@@ -4,31 +4,55 @@ import { safeJsonParse } from "../utils/safeJsonParse";
 const STORAGE_KEY = 'eventra_recently_viewed';
 const MAX_ITEMS = 10;
 
+// Entries older than RECENTLY_VIEWED_TTL_MS are treated as stale and evicted
+// on load. 7 days balances relevance against storage growth.
+export const RECENTLY_VIEWED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Minimal entry shape
+//
+// Previously stored the full event object spread:
+//   [event, ...filtered].slice(0, MAX_ITEMS)
+//
+// Full objects can be several kilobytes each. 10 entries = up to ~50 KB for
+// a display-only list of small cards. Store only the fields needed to render
+// the recently-viewed card and navigate to the event detail page.
+// ---------------------------------------------------------------------------
+const toRecentlyViewedEntry = (event) => ({
+  id: event?.id,
+  title: event?.title ?? "",
+  date: event?.date ?? "",
+  location: event?.location ?? "",
+  image: event?.image ?? event?.imageUrl ?? "",
+  category: event?.category ?? event?.type ?? "",
+  viewedAt: Date.now(),
+});
+
+const isEntryFresh = (entry) => {
+  const viewedAt = entry?.viewedAt;
+  if (!viewedAt || typeof viewedAt !== "number") return false;
+  return Date.now() - viewedAt < RECENTLY_VIEWED_TTL_MS;
+};
+
 /**
  * useRecentlyViewed
- * 
- * Custom hook to track and manage recently viewed events using localStorage.
- * 
- * Usage:
- *   const { recentlyViewed, addRecentlyViewed, clearHistory } = useRecentlyViewed();
- * 
- * Call `addRecentlyViewed(event)` when a user opens/views an event.
- * The hook stores the full event object (id, title, date, image, category, etc.)
- * so the section can render without extra API calls.
- * 
- * Limits: MAX_ITEMS entries; duplicate events are moved to the top.
+ *
+ * Tracks and persists the list of recently viewed events.
+ *  - Capped at MAX_ITEMS = 10 entries
+ *  - Entries older than RECENTLY_VIEWED_TTL_MS (7 days) are evicted on mount
+ *  - Stores only minimal display fields, not the full event object
  */
 const useRecentlyViewed = () => {
   const [recentlyViewed, setRecentlyViewed] = useState([]);
 
-  // Load from localStorage on mount
+  // Load from localStorage on mount, filtering out stale entries immediately
   useEffect(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
-        setRecentlyViewed(
-          safeJsonParse(stored, []),
-        );
+        const parsed = safeJsonParse(stored, []);
+        const fresh = Array.isArray(parsed) ? parsed.filter(isEntryFresh) : [];
+        setRecentlyViewed(fresh);
       }
     } catch (err) {
       console.error('Failed to load recently viewed events:', err);
@@ -47,17 +71,17 @@ const useRecentlyViewed = () => {
 
   /**
    * Add or move an event to the front of the recently viewed list.
-   * @param {Object} event - The event object to track.
-   *   Expected shape: { id, title, date, location, image, category, ... }
+   * Stores only the minimal display entry — not the full event object.
+   *
+   * @param {Object} event - Event object to track.
    */
   const addRecentlyViewed = useCallback((event) => {
     if (!event || !event.id) return;
 
     setRecentlyViewed((prev) => {
-      // Remove existing entry for this event (avoid duplicates)
       const filtered = prev.filter((e) => e.id !== event.id);
-      // Prepend and cap at MAX_ITEMS
-      return [event, ...filtered].slice(0, MAX_ITEMS);
+      const entry = toRecentlyViewedEntry(event);
+      return [entry, ...filtered].slice(0, MAX_ITEMS);
     });
   }, []);
 
@@ -70,7 +94,7 @@ const useRecentlyViewed = () => {
   }, []);
 
   /**
-   * Clear the entire recently viewed history.
+   * Clear the entire recently viewed history from state and localStorage.
    */
   const clearHistory = useCallback(() => {
     setRecentlyViewed([]);


### PR DESCRIPTION
**What is the problem**
`useRecentlyViewed.js` stored the full event object for every recently viewed event with no expiry check. Entries from months ago persisted as "recently viewed" forever, and full objects consume significantly more storage than needed for a display-only list.

**What was changed**
- `src/hooks/useRecentlyViewed.js` — added `RECENTLY_VIEWED_TTL_MS = 7 days` constant and `isEntryFresh()` filter; stale entries are evicted on mount
- Added `toRecentlyViewedEntry()` storing only 6 display fields (id, title, date, location, image, category) plus `viewedAt` timestamp instead of the full event object

**Lines changed**
46 added, 22 removed — 68 total in `src/hooks/useRecentlyViewed.js`

**Labels:** `type:performance` `level:advanced` `gssoc:approved`

Closes #4232