### PR TITLE
fix: prevent mobile overflow in connectivity network filters

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.css
+++ b/src/components/visual/CollaborationNetworkMap.css
@@ -290,8 +290,14 @@
 @media (max-width: 768px) {
   .cnm-filters {
     flex-direction: column;
+    box-sizing: border-box;
   }
   .filter-group {
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .filter-input, .filter-select {
+    min-width: 0;
     width: 100%;
   }
   .cnm-stats-bar {


### PR DESCRIPTION
## 🚀 Description

This PR fixes a responsive layout issue in the Collaboration Network filters that could cause horizontal overflow and compressed filter controls on smaller mobile screens.

### Changes Made

* Added `box-sizing: border-box` to mobile filter containers
* Added `min-width: 0` to filter inputs and selects
* Ensured filter controls can properly shrink within their parent container
* Added `width: 100%` where needed for consistent mobile sizing
* Eliminated horizontal overflow in narrow viewport layouts

### Investigation Notes

The issue report also mentioned duplicate event descriptions in the "What's Happening Now" section. I investigated this behavior but could not reproduce it in the current codebase. Event descriptions are rendered from their respective data sources and were displaying correctly during validation.

The responsive overflow issue in the Collaboration Network filters was reproducible and has been fixed.

Fixes #4250

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)

### Before

* Filter controls could overflow the viewport on narrow mobile screens
* Layout width exceeded viewport width in some cases

### After

* Filter controls stay within viewport bounds
* No horizontal overflow detected on mobile breakpoints
* Improved responsive behavior for filter inputs and selects

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
