### PR TITLE
Fix/mobile navbar overflow

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -106,6 +106,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
           {/* Right Controls Container */}
           <div className="flex items-center gap-2 xl:gap-4 shrink-0">
+          <div className="hidden sm:flex items-center gap-2 xl:gap-4">
             <button
               type="button"
               onClick={toggleTheme}
@@ -118,10 +119,11 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
               </div>
             </button>
             <CursorToggle cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
+            </div>
             <MobileNavbar isOpen={isMobileMenuOpen} setIsOpen={setIsMobileMenuOpen} isAuthenticated={authenticated} user={user} logout={logout} />
           </div>
         </div>
-        <div className="absolute bottom-0 left-0 w-full h-1 bg-transparent" aria-hidden="true">
+        <div iv className="absolute bottom-0 left-0 w-full h-1 bg-transparent" aria-hidden="true">
           <div className="h-full bg-blue-500 transition-all duration-100 ease-out" style={{ width: `${scrollProgress}%` }} />
         </div>
       </nav>

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -106,6 +106,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
           {/* Right Controls Container */}
           <div className="flex items-center gap-2 xl:gap-4 shrink-0">
+          {/* Hide these on mobile */}
           <div className="hidden sm:flex items-center gap-2 xl:gap-4">
             <button
               type="button"


### PR DESCRIPTION
## 🚀 Description
On mobile viewports, the navbar was displaying the theme toggle and cursor toggle buttons alongside the logo and hamburger icon, causing the navbar to overflow and appear broken. This fix wraps those desktop-only controls in a hidden sm:flex container so they are hidden on mobile and only visible on larger screens.
Fixes # (leave blank or add issue number if one exists)

## 🛠️ Type of change

 Bug fix (non-breaking change which fixes an issue)


## 📸 Screenshots
Before: (broken navbar)
<img width="1080" height="1991" alt="image" src="https://github.com/user-attachments/assets/2e0f1eed-42c6-45aa-992b-0bcf540d14b3" />


After: (fixed navbar)
<img width="557" height="850" alt="{B292169C-AA1C-425F-96F0-785B7A750197}" src="https://github.com/user-attachments/assets/a06ea957-6ecd-49de-bb99-43999cb2d5e6" />



## ✅ Checklist

✅My code follows the style guidelines of this project
✅ I have performed a self-review of my code
✅ My changes generate no new warnings