### PR TITLE
fix: escape unescaped quotes in HostHackathon page

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -286,7 +286,7 @@ const HostHackathon = () => {
           Host Your Hackathon
         </h1>
         <p className="text-xs sm:text-base text-gray-600 dark:text-gray-400">
-          "Fill in the details below and let's get your hackathon live!"
+         &quot;Fill in the details below and let&apos;s get your hackathon live!&quot;
         </p>
       </motion.div>
 


### PR DESCRIPTION
## 🚀 Description
The HostHackathon page contained unescaped quotation marks and apostrophes on line 289, violating the react/no-unescaped-entities ESLint rule. Replaced " with &quot; and ' with &apos; to fix the lint errors while keeping the rendered text unchanged.
Fixes #4261

## 🛠️ Type of change

 Bug fix (non-breaking change which fixes an issue)


## 📸 Screenshots
Not applicable — text rendering unchanged.

## ✅ Checklist

✅My code follows the style guidelines of this project
✅I have performed a self-review of my code
✅ My changes generate no new warnings