### PR TITLE
fix: prevent crash from unsafe localStorage access in App state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,9 +57,13 @@ function App() {
       Loading page...
     </div>
   );
-  const [cursorEnabled, setCursorEnabled] = useState(
-    localStorage.getItem("cursor") !== "off",
-  );
+  const [cursorEnabled, setCursorEnabled] = useState(() => {
+    try {
+      return localStorage.getItem("cursor") !== "off";
+    } catch {
+      return true; // fallback safe default
+    }
+  });
   const [showKeyboardModal, setShowKeyboardModal] = useState(false);
 
   useLenis();


### PR DESCRIPTION
## Issue Number:  #4288 
## 🐛 Summary
This PR fixes a potential runtime crash in the App component caused by unsafe access to localStorage during initial state initialization.

In restricted environments (private browsing, disabled storage, or security-restricted browsers), direct localStorage access can throw an error and result in a blank screen.

---

## 🔧 Change Made

Replaced unsafe localStorage usage with a safe initializer using try/catch.

### Before

const [cursorEnabled, setCursorEnabled] = useState(
  localStorage.getItem("cursor") !== "off",
);

### After
const [cursorEnabled, setCursorEnabled] = useState(() => {
  try {
    return localStorage.getItem("cursor") !== "off";
  } catch {
    return true;
  }
});
### 🧠 Why this is needed

- Prevents app crash during initial render
- Handles restricted browser environments safely
- Avoids blank screen issues

### ⚠️ Note

- This repository currently has unrelated build issues due to JSX parsing in some files.
- This PR does not modify or depend on those changes and only addresses a localized runtime safety issue.

### 🧪 Testing

- App loads correctly in browser
- Cursor toggle still works as expected
- No UI or routing changes introduced