### PR TITLE
fix(chatbot): cap localStorage message history at 100 entries to prevent quota exhaustion

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -28,6 +28,11 @@ const ICON_MAP = {
   Ticket,
 };
 
+// Maximum number of messages retained in localStorage.
+// Older messages beyond this cap are dropped from the front of the array so
+// the serialised JSON never grows large enough to exhaust the 5 MB quota.
+const MAX_STORED_MESSAGES = 100;
+
 // ─── Component ────────────────-----------------------------------------------
 
 export default function Chatbot() {
@@ -146,8 +151,11 @@ export default function Chatbot() {
     const cleanMessage = messageText.trim();
     if (!cleanMessage || isTyping) return;
 
-    // Append User Message
-    setMessages((prev) => [...prev, { role: "user", content: cleanMessage }]);
+    // Append User Message, pruning the oldest entries when the cap is exceeded.
+    setMessages((prev) => {
+      const next = [...prev, { role: "user", content: cleanMessage }];
+      return next.length > MAX_STORED_MESSAGES ? next.slice(next.length - MAX_STORED_MESSAGES) : next;
+    });
     setDraft("");
     setIsTyping(true);
 
@@ -155,10 +163,10 @@ export default function Chatbot() {
     clearReplyTimer();
     replyTimerRef.current = setTimeout(() => {
       const reply = getAssistantReply(cleanMessage);
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: reply.answer, actions: reply.actions },
-      ]);
+      setMessages((prev) => {
+        const next = [...prev, { role: "assistant", content: reply.answer, actions: reply.actions }];
+        return next.length > MAX_STORED_MESSAGES ? next.slice(next.length - MAX_STORED_MESSAGES) : next;
+      });
       setIsTyping(false);
       replyTimerRef.current = null;
     }, 850);


### PR DESCRIPTION
## Description

Closes #4198

`Chatbot.jsx` stored every chat message in `localStorage` via the `useLocalStorage` hook with no upper bound. During an active session, the messages array grew indefinitely: each exchange appended two entries (user + assistant), and the 2-hour inactivity reset only fired when the user was idle. On mobile browsers with a 5 MB localStorage quota, extended sessions could silently throw a `QuotaExceededError`, breaking the chat widget and potentially affecting other localStorage-dependent features for the rest of the session.

**Root cause:** Both `setMessages` calls inside `sendMessage` used simple spread appends with no pruning:
```js
setMessages((prev) => [...prev, { role: "user", content: cleanMessage }]);
// ...
setMessages((prev) => [...prev, { role: "assistant", content: reply.answer, actions: reply.actions }]);
```

**Fix:** Added a `MAX_STORED_MESSAGES` constant set to 100 and enforced it at every `setMessages` call by slicing the oldest entries from the front of the array when the limit is exceeded. This preserves the most recent and contextually relevant messages while bounding storage growth indefinitely.

## Related Issue

Closes #4198

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/components/Chatbot.jsx`:
  - Added `MAX_STORED_MESSAGES = 100` constant above the component.
  - Replaced both simple spread-append `setMessages` calls in `sendMessage` with a function that trims the oldest entries when the array exceeds the cap.
  - Applied the same cap to both the user message append and the assistant reply append.

## Screenshots / Video (if applicable)

Not applicable. This is a data-management fix with no visual change to the chat UI.

## Testing Done

1. Open the chatbot in a browser with DevTools > Application > Local Storage open.
2. Send messages until the history exceeds 100 entries.
3. Confirm that `eventra_chatbot_history` in localStorage never exceeds 100 items (the oldest entries are dropped from the front).
4. Confirm that the chat UI continues to work normally and displays the most recent messages.
5. Verify that the 2-hour inactivity reset still clears the history correctly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with contribution tracking and scoring under GSSoC '26. Thank you!

program: gssoc