### PR TITLE
fix(auth): remove permissions from JWT payload to prevent stale role claims

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -251,22 +251,22 @@ export default async function handler(req, res) {
     }
 
     // -----------------------------------------------------------------------
-    // Get permissions based on roles
-    // -----------------------------------------------------------------------
-
-    const roles = user.roles || ["USER"];
-    const permissions = getPermissionsForRoles(roles);
-
-    // -----------------------------------------------------------------------
     // Generate JWT token
     // -----------------------------------------------------------------------
+    // Only identity claims are embedded in the token. Permissions are
+    // intentionally excluded: baking them into a 7-day JWT means a role
+    // change (demotion, suspension, permission revocation) cannot take
+    // effect until the token naturally expires. Callers that need the
+    // current permission set should derive it server-side from the user's
+    // roles on every request using getPermissionsForRoles(roles).
+
+    const roles = user.roles || ["USER"];
 
     const jwtPayload = {
       id: user.id,
       email: user.email,
       username: user.username,
       roles: roles,
-      permissions: permissions,
     };
 
     const token = jwt.sign(jwtPayload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
@@ -280,6 +280,10 @@ export default async function handler(req, res) {
     
     // Normalize EVENT_MANAGER to ORGANIZER for frontend compatibility
     const normalizedRole = primaryRole === "EVENT_MANAGER" ? "ORGANIZER" : primaryRole;
+
+    // Derive permissions fresh from the user's current roles so the response
+    // always reflects the latest role assignment, not a stale token snapshot.
+    const permissions = getPermissionsForRoles(roles);
 
     const userResponse = {
       id: user.id,


### PR DESCRIPTION
## Description

Closes #4199

`api/auth/login.js` embedded the fully resolved permissions array directly in the JWT payload at sign time:

```js
const jwtPayload = {
  id: user.id,
  email: user.email,
  roles: roles,
  permissions: permissions,  // baked in at login, never refreshed
};
const token = jwt.sign(jwtPayload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
```

With `JWT_EXPIRES_IN` defaulting to `7d`, any server-side role change (demoting an ADMIN, suspending an account, revoking a specific permission) could not take effect until the user's existing token naturally expired. A demoted ADMIN retained all ADMIN permissions on every authenticated API call for up to 7 days after the change.

**Root cause:** permissions are derived from roles at login time and frozen into the token. They are never re-derived from the server-side user record on subsequent requests.

**Fix:** Remove `permissions` from `jwtPayload` so only identity claims (`id`, `email`, `username`, `roles`) are signed into the token. Move the `getPermissionsForRoles()` call to after the JWT is signed, just before the response body is assembled, so callers still receive the current permission set in the login response. Any middleware or endpoint that needs to check permissions at request time should re-derive them from the token's `roles` claim using `getPermissionsForRoles()`.

## Related Issue

Closes #4199

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `api/auth/login.js`:
  - Removed `permissions` from `jwtPayload` before calling `jwt.sign()`.
  - Moved `getPermissionsForRoles(roles)` call to after the token is signed, just before `userResponse` is built.
  - Added a comment explaining why permissions are excluded from the token.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side security fix with no visual change.

## Testing Done

1. Register a user and log in. Confirm the response body still includes `permissions` derived from the current roles.
2. Decode the returned JWT (e.g. via jwt.io). Confirm the payload contains `id`, `email`, `username`, `roles` but NOT `permissions`.
3. Update the user's roles server-side (simulate a demotion). Log in again and confirm the new token reflects the updated roles and that the response body's `permissions` match the new roles.
4. Verify that no existing middleware that reads `req.user.permissions` from the decoded token is broken (callers must derive permissions from `req.user.roles` using `getPermissionsForRoles`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc