### PR TITLE
docs: add JSDoc documentation for FluidCursor and RespawningText components

### DIFF
--- a/src/components/visual/FluidCursor.js
+++ b/src/components/visual/FluidCursor.js
@@ -1,8 +1,38 @@
+/**
+ * @fileoverview FluidCursor - WebGL-based fluid cursor animation for Eventra
+ * @module components/visual/FluidCursor
+ */
 "use client";
 import { useEffect, useRef } from "react";
 import { useState } from "react";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 
+/**
+ * A React component that renders a WebGL-powered fluid simulation
+ * as a cursor trail effect on the page. Creates a colorful, interactive
+ * fluid animation that follows mouse and touch movements.
+ *
+ * Automatically disabled on:
+ * - Mobile/touch devices (viewport ≤ 768px or coarse pointer)
+ * - When `prefers-reduced-motion` accessibility setting is enabled
+ * - When explicitly disabled via the `enabled` prop
+ *
+ * Uses HTML5 Canvas and WebGL (with WebGL2 fallback to WebGL1) for rendering.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {boolean} [props.enabled=true] - Whether the fluid cursor animation is active
+ *
+ * @returns {JSX.Element|null} A fixed-position canvas overlay, or null if disabled
+ *
+ * @example
+ * // Enable fluid cursor (default)
+ * <FluidCursor />
+ *
+ * @example
+ * // Conditionally enable based on user preference
+ * <FluidCursor enabled={userPreferences.fluidCursor} />
+ */
 const FluidCursor = ({ enabled = true }) => {
   const canvasRef = useRef(null);
   const [isMobileViewport, setIsMobileViewport] = useState(false);

--- a/src/components/visual/RespawningText.js
+++ b/src/components/visual/RespawningText.js
@@ -1,7 +1,36 @@
+/**
+ * @fileoverview RespawningText - Animated typewriter text component for Eventra
+ * @module components/visual/RespawningText
+ */
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
+/**
+ * A React component that displays an animated typewriter effect,
+ * cycling through an array of text strings by typing and deleting
+ * them sequentially with configurable speeds.
+ *
+ * Automatically respects the user's `prefers-reduced-motion`
+ * accessibility setting.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {string[]} [props.texts=["Discover & Join"]] - Array of text strings to cycle through
+ * @param {number} [props.typingSpeed=150] - Delay in milliseconds between each character typed
+ * @param {number} [props.deletingSpeed=100] - Delay in milliseconds between each character deleted
+ * @param {number} [props.pauseTime=2000] - Delay in milliseconds before deleting starts
+ *
+ * @returns {JSX.Element} An animated span element with typewriter cursor effect
+ *
+ * @example
+ * <RespawningText
+ *   texts={["Build Events", "Connect Communities", "Track Analytics"]}
+ *   typingSpeed={100}
+ *   deletingSpeed={80}
+ *   pauseTime={3000}
+ * />
+ */
 const RespawningText = ({ texts = ["Discover & Join"], typingSpeed = 150, deletingSpeed = 100, pauseTime = 2000 }) => {
   const [currentText, setCurrentText] = useState("");
   const [textIndex, setTextIndex] = useState(0);


### PR DESCRIPTION
Fixes #3966

## Changes Made
- Added `@fileoverview` JSDoc to `FluidCursor.js` describing the module
- Added component-level JSDoc to `FluidCursor` including props, return type, and usage examples
- Added `@fileoverview` JSDoc to `RespawningText.js` describing the module
- Added component-level JSDoc to `RespawningText` including all props, return type, and usage examples

## Files Updated
- `src/components/visual/FluidCursor.js`
- `src/components/visual/RespawningText.js`

## Type of Change
- [x] Documentation

## Impact
New contributors can now understand these visual components without reading the full implementation.