### PR TITLE
fix(auth/google): return 503 when GOOGLE_CLIENT_ID is unset and remove permissions from JWT

### DIFF
--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -286,6 +286,17 @@ export default async function handler(req, res) {
     return corsResponse(res, 405, { error: "Method not allowed" }, req);
   }
 
+  // Fail fast with a clear 503 when GOOGLE_CLIENT_ID is not configured.
+  // Without this guard the verifyGoogleToken helper returns a generic 401
+  // "Invalid or expired Google token" for every request, making the
+  // misconfiguration invisible to operators and confusing to users.
+  // Returning 503 here distinguishes a configuration error from a bad token.
+  if (!GOOGLE_CLIENT_ID) {
+    return corsResponse(res, 503, {
+      error: "Google Sign-In is not available. Please contact the site administrator.",
+    }, req);
+  }
+
   try {
     const { credential } = req.body;
 
@@ -320,22 +331,20 @@ export default async function handler(req, res) {
     const user = createOrUpdateUserFromGoogle(googlePayload);
 
     // -----------------------------------------------------------------------
-    // Get permissions based on roles
-    // -----------------------------------------------------------------------
-
-    const roles = user.roles || ["USER"];
-    const permissions = getPermissionsForRoles(roles);
-
-    // -----------------------------------------------------------------------
     // Generate JWT token
     // -----------------------------------------------------------------------
+    // Only identity claims are embedded. Permissions are excluded so that any
+    // server-side role change takes effect on the next sign-in rather than
+    // persisting in the token for up to JWT_EXPIRES_IN (7 days by default).
+    // This mirrors the fix applied to login.js in issue #4199.
+
+    const roles = user.roles || ["USER"];
 
     const jwtPayload = {
       id: user.id,
       email: user.email,
       username: user.username,
       roles: roles,
-      permissions: permissions,
       provider: user.provider || "google",
     };
 
@@ -347,6 +356,10 @@ export default async function handler(req, res) {
 
     const primaryRole = roles[0] || "ATTENDEE";
     const normalizedRole = primaryRole === "EVENT_MANAGER" ? "ORGANIZER" : primaryRole;
+
+    // Derive permissions fresh from the current roles for the response body.
+    // They are intentionally omitted from the JWT above.
+    const permissions = getPermissionsForRoles(roles);
 
     const userResponse = {
       id: user.id,


### PR DESCRIPTION
## Description

Closes #4200

Two related issues remain in `api/auth/google.js` after the earlier placeholder-fallback removal:

**Issue 1 — Misleading 401 on missing configuration:**
When `GOOGLE_CLIENT_ID` is not set, the handler fell through to `verifyGoogleToken`, which returned a generic `401 Invalid or expired Google token`. This response is indistinguishable from a real bad-token failure, making a server misconfiguration invisible to operators and confusing to users who see a login failure they cannot explain.

**Fix:** added an explicit `503 Service Unavailable` guard at the top of the POST handler, before any credential parsing. The response body says "Google Sign-In is not available. Please contact the site administrator." so the problem is immediately obvious in logs and to callers.

**Issue 2 — Permissions embedded in JWT (same as #4199 in login.js):**
`google.js` still embedded the full `permissions` array in the JWT payload. A role change (demotion, suspension) could not take effect until the 7-day token expired, because the permissions were baked in at sign time.

**Fix:** removed `permissions` from `jwtPayload`. Added `getPermissionsForRoles(roles)` call immediately before the response body is assembled so callers still receive the current permission set, derived fresh from the stored roles.

## Related Issue

Closes #4200

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `api/auth/google.js`:
  - Added early `503` return when `GOOGLE_CLIENT_ID` is falsy, placed before the `try` block so it fires regardless of credential content.
  - Removed `permissions` from `jwtPayload`.
  - Moved `getPermissionsForRoles(roles)` call to after `jwt.sign()`, just before `userResponse` is assembled.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side security fix with no visual change.

## Testing Done

1. Start the server without `GOOGLE_CLIENT_ID` set. Call `POST /api/auth/google` with any credential. Confirm `503 Google Sign-In is not available` is returned.
2. Start with a valid `GOOGLE_CLIENT_ID`. Confirm Google login works normally.
3. Decode the returned JWT. Confirm the payload contains `id`, `email`, `username`, `roles`, `provider` but NOT `permissions`.
4. Confirm the login response body still includes the `permissions` array derived from the user's current roles.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc