### PR TITLE
fix(ui): About dark mode text and vertical mobile nav

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -173,7 +173,7 @@ export default function ModernAbout() {
           initial="hidden"
           whileInView="visible"
           viewport={{ once: true }}
-          className="text-base sm:text-lg text-black dark:text-gray-300 mb-16"
+          className="text-base sm:text-lg text-gray-700 dark:text-gray-300 mb-16"
           data-aos="fade-up"
           data-aos-delay="200"
         >
@@ -198,8 +198,8 @@ export default function ModernAbout() {
             data-aos-delay="300"
           >
             {/* UPDATED: Card text */}
-            <h3 className="text-black text-2xl font-bold mb-2">100+</h3>
-            <p className="text-black text-sm">Events Managed</p>
+            <h3 className="text-black dark:text-white text-2xl font-bold mb-2">100+</h3>
+            <p className="text-black dark:text-gray-300 text-sm">Events Managed</p>
           </motion.div>
           {stats.map((s) => (
             <motion.div key={s.label} variants={scaleIn} whileHover={prefersReducedMotion ? {} : { scale: 1.05, y: -4 }} transition={{ type: "spring", stiffness: 300, damping: 20 }} className="bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm rounded-2xl shadow-lg shadow-blue-100 dark:shadow-indigo-900/50 p-4 sm:p-5 cursor-default">

--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -15,7 +15,7 @@ const MobileDrawer = ({ isOpen, closeMenu }) => {
       </div>
 
       <div className="p-4">
-        <NavbarLinks />
+        <NavbarLinks layout="vertical" />
       </div>
     </div>
   );

--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -2,11 +2,15 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { NAV_ITEMS } from "./constants/navItems";
 
-const NavbarLinks = () => {
+const NavbarLinks = ({ layout = "horizontal" }) => {
   const location = useLocation();
+  const containerClass =
+    layout === "vertical"
+      ? "flex flex-col items-stretch gap-2 w-full"
+      : "flex items-center gap-5";
 
   return (
-    <div className="flex items-center gap-5">
+    <div className={containerClass}>
       {NAV_ITEMS.map((item) => {
         const active = location.pathname === item.href;
 
@@ -14,7 +18,9 @@ const NavbarLinks = () => {
           <Link
             key={item.name}
             to={item.href || "#"}
-            className={`text-sm font-medium transition-colors whitespace-nowrap ${
+            className={`text-sm font-medium transition-colors ${
+              layout === "vertical" ? "block w-full px-4 py-3 rounded-lg" : "whitespace-nowrap"
+            } ${
               active
                 ? "text-black dark:text-white"
                 : "text-gray-600 hover:text-black dark:text-gray-300 dark:hover:text-white"


### PR DESCRIPTION
## Summary
- Fix About hero/stat text colors for dark mode readability
- Stack mobile drawer nav links vertically with full-width tap targets

Closes #1100
Closes #1099

## Test plan
- [ ] Enable dark mode on About page — stat cards remain readable
- [ ] Open mobile hamburger menu — links render vertically

Made with [Cursor](https://cursor.com)