### PR TITLE
test : added unit tests for fetchWithTimeout utility

### DIFF
--- a/tests/fetchWithTimeout.test.mjs
+++ b/tests/fetchWithTimeout.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { fetchWithTimeout, FetchError } from "../src/utils/fetchWithTimeout.js";
+
+// Mock implementation of global.fetch
+const originalFetch = global.fetch;
+
+try {
+  // Test Case 1: Successful JSON Response
+  global.fetch = async (url, options) => {
+    return {
+      ok: true,
+      status: 200,
+      clone: () => ({
+        json: async () => ({ success: true })
+      }),
+      json: async () => ({ success: true })
+    };
+  };
+  
+  const res1 = await fetchWithTimeout("https://api.example.com/json");
+  assert.deepEqual(res1.data, { success: true }, "Should parse successful JSON data");
+  assert.equal(res1.response.status, 200, "Should contain the raw response object");
+  
+  // Test Case 2: Successful Text Response (non-JSON)
+  global.fetch = async (url, options) => {
+    return {
+      ok: true,
+      status: 200,
+      clone: () => ({
+        json: async () => { throw new Error("Not JSON"); }
+      }),
+      text: async () => "plain text content"
+    };
+  };
+  
+  const res2 = await fetchWithTimeout("https://api.example.com/text");
+  assert.equal(res2.data, "plain text content", "Should fallback to plain text parsing");
+
+  // Test Case 3: Failed request (non-ok response)
+  global.fetch = async (url, options) => {
+    return {
+      ok: false,
+      status: 404,
+      clone: () => ({
+        json: async () => ({ message: "Not Found" })
+      })
+    };
+  };
+  
+  await assert.rejects(
+    async () => {
+      await fetchWithTimeout("https://api.example.com/notfound");
+    },
+    (err) => {
+      assert(err instanceof FetchError, "Should throw FetchError");
+      assert.equal(err.status, 404);
+      assert.deepEqual(err.data, { message: "Not Found" });
+      return true;
+    },
+    "Should reject with FetchError on non-ok response"
+  );
+
+  // Test Case 4: Aborted request via timeout (throws AbortError which translates to FetchError)
+  global.fetch = async (url, options) => {
+    const signal = options.signal;
+    return new Promise((resolve, reject) => {
+      const onAbort = () => {
+        const error = new Error("The operation was aborted.");
+        error.name = "AbortError";
+        reject(error);
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort);
+      }
+    });
+  };
+
+  await assert.rejects(
+    async () => {
+      await fetchWithTimeout("https://api.example.com/delay", {}, 10);
+    },
+    (err) => {
+      assert(err instanceof FetchError);
+      assert(err.message.includes("timed out"));
+      return true;
+    },
+    "Should throw FetchError on timeout"
+  );
+
+  // Test Case 5: Manual abort signal
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 10);
+
+  await assert.rejects(
+    async () => {
+      await fetchWithTimeout("https://api.example.com/delay", { signal: controller.signal }, 100);
+    },
+    (err) => {
+      assert(err instanceof FetchError);
+      assert(err.message.includes("manually aborted"));
+      return true;
+    },
+    "Should throw FetchError on manual abort"
+  );
+
+  console.log("fetchWithTimeout tests passed ✓");
+} finally {
+  global.fetch = originalFetch;
+}


### PR DESCRIPTION
Refs #4339.

Summary of What Has Been Done:
Added comprehensive unit test coverage for the fetchWithTimeout utility located in src/utils/fetchWithTimeout.js.

Changes Made:
Created a new unit test suite in tests/fetchWithTimeout.test.mjs validating normal JSON/text fetch parsing, FetchError response details, timeout handling, and custom AbortController signals using Node's native assert/strict module.

Impact it Made:
Secures high-quality code behavior, ensures stability of network routines under custom timeout scenarios, and prevents future regressions.