### PR TITLE
fix(events): use dynamic date-time for past/upcoming filters

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -9,6 +9,7 @@ import Fuse from "fuse.js";
 import StyledDropdown from "../../components/StyledDropdown";
 import { EventCardSkeleton } from "../../components/common/SkeletonLoaders";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
+import { getEventTimingStatus } from "./eventPaginationUtils";
 
 const renderCardSection = (isLoading, filteredEvents, viewMode, filterType) => {
   if (isLoading) {
@@ -78,12 +79,11 @@ const EventsPage = () => {
     }
 
     const final = results.filter((event) => {
-      return (
-        filterType === "all" ||
-        (filterType === "upcoming" && event.status === "upcoming") ||
-        (filterType === "past" && event.status === "past") ||
-        event.type === filterType
-      );
+      if (filterType === "all") return true;
+      if (filterType === "upcoming" || filterType === "past") {
+        return getEventTimingStatus(event) === filterType;
+      }
+      return event.type === filterType;
     });
 
     setFilteredEvents(final);

--- a/src/Pages/Events/eventPaginationUtils.js
+++ b/src/Pages/Events/eventPaginationUtils.js
@@ -32,14 +32,28 @@ export const getVisiblePaginationPages = (currentPage, totalPages, siblingCount 
   };
 };
 
-export const filterEventsByType = (events, filterType) => {
+export const getEventDateTime = (event) => {
+  if (!event?.date) return null;
+  const time = event.time || "23:59";
+  const parsed = new Date(`${event.date}T${time}`);
+  return Number.isNaN(parsed.getTime()) ? new Date(event.date) : parsed;
+};
+
+export const getEventTimingStatus = (event, now = new Date()) => {
+  const eventDateTime = getEventDateTime(event);
+  if (!eventDateTime) {
+    return event?.status === "past" ? "past" : "upcoming";
+  }
+  return eventDateTime < now ? "past" : "upcoming";
+};
+
+export const filterEventsByType = (events, filterType, now = new Date()) => {
   return events.filter((event) => {
-    return (
-      filterType === "all" ||
-      (filterType === "upcoming" && event.status === "upcoming") ||
-      (filterType === "past" && event.status === "past") ||
-      event.type === filterType
-    );
+    if (filterType === "all") return true;
+    if (filterType === "upcoming" || filterType === "past") {
+      return getEventTimingStatus(event, now) === filterType;
+    }
+    return event.type === filterType;
   });
 };
 


### PR DESCRIPTION
## Summary
- Adds `getEventDateTime` / `getEventTimingStatus` helpers in `eventPaginationUtils.js`
- Updates event filtering to compare event date+time against current time instead of relying on static `status` labels

Fixes #1105

## Test plan
- [ ] Open `/events` and switch between All / Upcoming / Past filters
- [ ] Verify events with past dates appear under Past even if mock `status` is still `upcoming`
- [ ] Confirm type-based filters (workshop, meetup, etc.) still work

Made with [Cursor](https://cursor.com)