### PR TITLE
fix(csp): remove unsafe-inline and unsafe-eval from CSP meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <!-- Security: Content-Security-Policy fallback for non-Vercel environments -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' ws://localhost:* http://localhost:* http://127.0.0.1:* https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://fonts.googleapis.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' ws://localhost:* http://localhost:* http://127.0.0.1:* https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://fonts.googleapis.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     />
 
     <!-- Security: Prevent MIME sniffing -->


### PR DESCRIPTION
## 🚀 Description
The Content-Security-Policy was set via two conflicting sources: the HTML meta tag allowed `'unsafe-inline'` and `'unsafe-eval'`, while the Vercel header policy omitted them. This created two concrete problems:

1. **Developer confusion** — inline scripts work in development but break in production without notice, leading to inadvertent inline script dependencies
2. **Fragile security** — if the HTTP header is ever misconfigured, the meta tag becomes the only active policy and permits unrestricted inline script execution

The inline theme-flicker prevention script was already extracted to `public/theme-init.js` (loaded via `<script src="/theme-init.js">` matching `'self'`), so no inline script dependency remains. The fix removes `'unsafe-inline'` and `'unsafe-eval'` from the meta tag's `script-src` — the meta tag is retained as a fallback for non-Vercel environments but is now consistent with the production header policy.

Fixes #4238

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My code generates no new warnings