### PR TITLE
fix(hooks): restore document title on unmount

### DIFF
--- a/src/hooks/useDocumentTitle.js
+++ b/src/hooks/useDocumentTitle.js
@@ -2,7 +2,12 @@ import { useEffect } from 'react'
 
 const useDocumentTitle = (title) => {
     useEffect(() => {
+        const previousTitle = document.title
         document.title = title
+
+        return () => {
+            document.title = previousTitle
+        }
     }, [title])
 }
 


### PR DESCRIPTION
## Summary
- Stores the previous `document.title` before updating it in `useDocumentTitle`
- Restores the prior title on unmount to prevent stale tab titles after navigation

Fixes #4386

## Test plan
- [ ] Open a page that sets a custom document title
- [ ] Navigate to a route without its own title hook
- [ ] Confirm the browser tab title is restored

Made with [Cursor](https://cursor.com)