### PR TITLE
fix(utils): safely parse user profile from localStorage

### DIFF
--- a/src/utils/userProfileAnalyzer.js
+++ b/src/utils/userProfileAnalyzer.js
@@ -1,26 +1,15 @@
-export const getUserProfile = () => {
+import { safeJsonParse } from "./safeJsonParse.js";
 
-  const saved =
-    JSON.parse(
-      localStorage.getItem(
-        "eventra_user_profile"
-      )
-    ) || {};
+export const getUserProfile = () => {
+  const saved = safeJsonParse(
+    localStorage.getItem("eventra_user_profile"),
+    {},
+  );
 
   return {
-
-    interests:
-      saved.interests || [],
-
-    techStack:
-      saved.techStack || [],
-
-    eventTypes:
-      saved.eventTypes || [],
-
-    level:
-      saved.level || "Beginner",
-
+    interests: saved.interests || [],
+    techStack: saved.techStack || [],
+    eventTypes: saved.eventTypes || [],
+    level: saved.level || "Beginner",
   };
-
 };


### PR DESCRIPTION
## Summary
- Uses `safeJsonParse` when reading `eventra_user_profile` from localStorage
- Returns default profile fields when stored JSON is malformed

Fixes #4382

## Test plan
- [ ] Set invalid JSON in `localStorage.eventra_user_profile`
- [ ] Open recommendation/profile features and confirm no runtime crash

Made with [Cursor](https://cursor.com)