### PR TITLE
fix(footer): correct grid spans, gradient, and logo alt

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -193,13 +193,13 @@ const Footer = () => {
   return (
     <footer className="border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
       
-      <div className="mt-10 max-w-full mx-auto px-6 py-20 grid lg:grid-cols-3 gap-x-12 gap-y-12 bg-linear-to-t from-slate-50 dark:from-slate-900">
+      <div className="mt-10 max-w-full mx-auto px-6 py-20 grid lg:grid-cols-3 gap-x-12 gap-y-12 bg-gradient-to-t from-slate-50 dark:from-slate-900">
         
         {/* BRAND */}
-        <div className="lg:col-span-5 flex flex-col gap-6 items-center">
+        <div className="lg:col-span-1 flex flex-col gap-6 items-center">
           
           <div className="flex items-center gap-3">
-            <img src="/favicon.png" className="w-10 h-10" />
+            <img src="/favicon.png" alt="Eventra logo" className="w-10 h-10" />
             <h2 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
               Eventra
             </h2>
@@ -214,7 +214,7 @@ const Footer = () => {
         </div>
 
         {/* LINKS */}
-        <div className="lg:col-span-7">
+        <div className="lg:col-span-2">
           <FooterLinks />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fixes invalid `lg:col-span-5/7` values for a 3-column footer grid
- Replaces `bg-linear-to-t` with `bg-gradient-to-t`
- Adds `alt` text to the Eventra logo image

Fixes #4381

## Test plan
- [ ] Inspect footer layout on large screens — brand spans 1 col, links span 2
- [ ] Verify footer gradient background renders
- [ ] Run accessibility check — logo has descriptive alt text

Made with [Cursor](https://cursor.com)