### PR TITLE
fix: use deepStrictEqual in safeJsonParse tests (Fixes #4392)

### DIFF
--- a/tests/safeJsonParse.test.mjs
+++ b/tests/safeJsonParse.test.mjs
@@ -13,11 +13,11 @@ try {
   assert.equal(safeJsonParse(null), null, "null returns fallback");
   assert.equal(safeJsonParse(""), null, "empty string returns fallback");
   assert.equal(safeJsonParse("invalid-json"), null, "invalid JSON returns fallback");
-  assert.deepEqual(safeJsonParse('{"value": 1}'), { value: 1 }, "valid JSON parses correctly");
+  assert.deepStrictEqual(safeJsonParse('{"value": 1}'), { value: 1 }, "valid JSON parses correctly");
 
   assert.equal(safeParseJson(null), null, "null returns fallback");
   assert.equal(safeParseJson("invalid-json"), null, "invalid JSON returns fallback");
-  assert.deepEqual(safeParseJson('{"value": 2}'), { value: 2 }, "valid JSON parses correctly");
+  assert.deepStrictEqual(safeParseJson('{"value": 2}'), { value: 2 }, "valid JSON parses correctly");
 
   assert.equal(capturedErrors.length, 0, "parse fallback should not log errors");
 


### PR DESCRIPTION
**Payment:** USDC Stellar `GCR377MUJ75YKFLNZKT6XPWNDUIEDZDUHUWY5E2LHOBBSSJDU7MJRZXF`