### PR TITLE
fix(utils): correct logger import path in offlineQueue

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -2,7 +2,7 @@
 // Self-Healing Offline Queue Utility (IndexedDB backed with LocalStorage Backup)
 // ---------------------------------------------------------------------------
 import { safeJsonParse } from "./safeJsonParse.js";
-import { logger } from "../utils/logger";
+import { logger } from "./logger.js";
 
 const QUEUE_KEY = "eventra_offline_queue";
 const DB_NAME = "eventra_offline_db";


### PR DESCRIPTION
## Summary
- Fixes the logger import in `offlineQueue.js` from `../utils/logger` to `./logger.js`
- Allows Node ESM tests to resolve the module when running from the utils directory

Fixes #4391

## Test plan
- [ ] Run `node tests/offlineQueue.test.mjs` — all tests pass

Made with [Cursor](https://cursor.com)