### PR TITLE
fix(test): mock navigator for Node 22 clipboard tests

### DIFF
--- a/tests/shareUtils-copyToClipboard.test.mjs
+++ b/tests/shareUtils-copyToClipboard.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 
-global.navigator = {
-  clipboard: undefined
-};
+Object.defineProperty(globalThis, "navigator", {
+  value: { clipboard: undefined },
+  configurable: true,
+  writable: true,
+});
 global.document = {
   createElement: () => ({
     value: "",


### PR DESCRIPTION
## Summary
- Replaces direct `global.navigator = …` assignment with `Object.defineProperty`
- Avoids TypeError on Node 22 where `navigator` is a read-only global

Fixes #4388

## Test plan
- [ ] Run `node tests/shareUtils-copyToClipboard.test.mjs` on Node 22

Made with [Cursor](https://cursor.com)