### PR TITLE
fix(hooks): add debouncedTerm to useDebouncedSearch deps

### DIFF
--- a/src/hooks/useDebouncedSearch.js
+++ b/src/hooks/useDebouncedSearch.js
@@ -37,7 +37,7 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
         clearTimeout(timerRef.current);
       }
     };
-  }, [searchTerm, delay]);
+  }, [searchTerm, debouncedTerm, delay]);
 
   const clear = useCallback(() => {
     setSearchTerm('');


### PR DESCRIPTION
## Summary
- Adds `debouncedTerm` to the `useEffect` dependency array in `useDebouncedSearch`
- Prevents stale closure from leaving `isDebouncing` stuck when the search term reverts to the debounced value

Fixes #4387

## Test plan
- [ ] Type a search term, then quickly revert to the previous debounced value
- [ ] Confirm `isDebouncing` clears correctly

Made with [Cursor](https://cursor.com)