### PR TITLE
test(utils): deepEqual for safeJsonParse object fallback

### DIFF
--- a/tests/safeJsonParse.test.mjs
+++ b/tests/safeJsonParse.test.mjs
@@ -14,6 +14,11 @@ try {
   assert.equal(safeJsonParse(""), null, "empty string returns fallback");
   assert.equal(safeJsonParse("invalid-json"), null, "invalid JSON returns fallback");
   assert.deepEqual(safeJsonParse('{"value": 1}'), { value: 1 }, "valid JSON parses correctly");
+  assert.deepEqual(
+    safeJsonParse("invalid-json", { fallback: true }),
+    { fallback: true },
+    "invalid JSON returns fallback object by structure"
+  );
 
   assert.equal(safeParseJson(null), null, "null returns fallback");
   assert.equal(safeParseJson("invalid-json"), null, "invalid JSON returns fallback");


### PR DESCRIPTION
## Summary
- Adds a test case that compares object fallbacks with `assert.deepEqual`
- Validates structural equality instead of reference equality for fallback objects

Fixes #4392

## Test plan
- [ ] Run `node tests/safeJsonParse.test.mjs` — all tests pass

Made with [Cursor](https://cursor.com)