### PR TITLE
test(storage): add unit tests for storageManager utility

### DIFF
--- a/src/utils/storage/storageManager.js
+++ b/src/utils/storage/storageManager.js
@@ -1,5 +1,5 @@
-import { STORAGE_KEYS } from "./storageKeys";
-import { validators } from "./storageValidators";
+import { STORAGE_KEYS } from "./storageKeys.js";
+import { validators } from "./storageValidators.js";
 
 const DEFAULT_EXPIRY = 1000 * 60 * 60; // 1 hour
 

--- a/tests/storageManager.test.mjs
+++ b/tests/storageManager.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+
+const store = {};
+global.localStorage = {
+  getItem: (key) => (key in store ? store[key] : null),
+  setItem: (key, value) => {
+    store[key] = String(value);
+  },
+  removeItem: (key) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(store)) delete store[key];
+  },
+};
+
+const { storageManager } = await import("../src/utils/storage/storageManager.js");
+
+let now = 1_000_000;
+const originalDateNow = Date.now;
+Date.now = () => now;
+
+try {
+  storageManager.set("profile", { name: "Ada" }, 5000);
+  assert.deepEqual(
+    storageManager.get("profile"),
+    { name: "Ada" },
+    "returns stored value before expiry"
+  );
+
+  now += 6000;
+  assert.equal(storageManager.get("profile"), null, "expires TTL-backed entries");
+
+  localStorage.setItem("bad-shape", "plain-string");
+  assert.equal(storageManager.get("bad-shape"), null, "rejects invalid payload shape");
+
+  storageManager.set("validated", { ok: true }, 5000);
+  now = 1_000_000;
+  assert.deepEqual(
+    storageManager.get("validated", (value) => value?.ok === true),
+    { ok: true },
+    "passes custom validator"
+  );
+  assert.equal(
+    storageManager.get("validated", () => false),
+    null,
+    "removes entries that fail validation"
+  );
+
+  storageManager.remove("validated");
+  assert.equal(storageManager.get("validated"), null, "removeItem clears key");
+
+  storageManager.set("a", 1, 5000);
+  storageManager.set("b", 2, 5000);
+  storageManager.clear();
+  assert.equal(storageManager.get("a"), null, "clear removes all entries");
+  assert.equal(storageManager.get("b"), null, "clear removes all entries");
+
+  console.log("storageManager tests passed ✓");
+} finally {
+  Date.now = originalDateNow;
+}


### PR DESCRIPTION
## Summary
- Adds `tests/storageManager.test.mjs` for TTL expiry, invalid payloads, validation, remove, and clear
- Uses explicit `.js` imports in `storageManager.js` for Node ESM test resolution

Fixes #4357

## Test plan
- [ ] Run `node tests/storageManager.test.mjs`

Made with [Cursor](https://cursor.com)