### PR TITLE
test(utils): add unit tests for userProfileAnalyzer

### DIFF
--- a/tests/userProfileAnalyzer.test.mjs
+++ b/tests/userProfileAnalyzer.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+
+const store = {};
+global.localStorage = {
+  getItem: (key) => (key in store ? store[key] : null),
+  setItem: (key, value) => {
+    store[key] = String(value);
+  },
+  removeItem: (key) => {
+    delete store[key];
+  },
+};
+
+const { getUserProfile } = await import("../src/utils/userProfileAnalyzer.js");
+
+const emptyProfile = getUserProfile();
+assert.deepEqual(emptyProfile.interests, [], "defaults interests to empty array");
+assert.deepEqual(emptyProfile.techStack, [], "defaults techStack to empty array");
+assert.deepEqual(emptyProfile.eventTypes, [], "defaults eventTypes to empty array");
+assert.equal(emptyProfile.level, "Beginner", "defaults level to Beginner");
+
+localStorage.setItem(
+  "eventra_user_profile",
+  JSON.stringify({
+    interests: ["ai"],
+    techStack: ["react"],
+    eventTypes: ["hackathon"],
+    level: "Advanced",
+  })
+);
+
+assert.deepEqual(getUserProfile(), {
+  interests: ["ai"],
+  techStack: ["react"],
+  eventTypes: ["hackathon"],
+  level: "Advanced",
+}, "loads saved profile fields from localStorage");
+
+console.log("userProfileAnalyzer tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/userProfileAnalyzer.test.mjs` for default profile fields and localStorage retrieval

Fixes #4345

## Test plan
- [ ] Run `node tests/userProfileAnalyzer.test.mjs`

Made with [Cursor](https://cursor.com)