### PR TITLE
feat: add automated PR size labeler github actions workflow

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,25 @@
+name: Pull Request Size Labeler
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  label-size:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Size Labeler
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          SIZES: >
+            {
+              "0": "size/XS",
+              "20": "size/S",
+              "100": "size/M",
+              "500": "size/L",
+              "1000": "size/XL"
+            }


### PR DESCRIPTION
Closes #4477 

🧩 **Problem Solved**
Repository maintainers lack a fast visual filter to prioritize smaller, fast-turnaround PRs over heavy code updates.

💡 **Approach**
- Created `.github/workflows/pr-size-labeler.yml` running on pull requests.
- Setup clear mathematical buckets based on additions and deletions.

🧪 **Testing**
- Checked actions metadata validation locally.