### PR TITLE
fix : restore comment block in offlineEventCache to resolve unexpected token syntax error

### DIFF
--- a/src/utils/offlineEventCache.js
+++ b/src/utils/offlineEventCache.js
@@ -126,6 +126,7 @@ export const saveAllCachedEventDetails = (events = []) => {
   return writeJson(EVENT_DETAILS_CACHE_KEY, cached);
 };
 
+/**
  * Returns the cached detail for a single event, or null if absent or older
  * than DETAIL_CACHE_TTL_MS. Prunes the expired entry and any other stale
  * sibling entries from the detail cache on access.


### PR DESCRIPTION
Refs #4468.

Summary of What Has Been Done:
Restore the JSDoc comment block opener (/**) in src/utils/offlineEventCache.js preceding the getCachedEventDetail function declaration.

Changes Made:
- Added /** at line 128 to properly encapsulate the module-level documentation.

Impact it Made:
- Resolves syntax-blocking parsing issues when evaluating the offlineEventCache module.