### PR TITLE
Fix: Restore missing JSDoc comment opener in offlineEventCache

### DIFF
--- a/src/utils/offlineEventCache.js
+++ b/src/utils/offlineEventCache.js
@@ -126,6 +126,7 @@ export const saveAllCachedEventDetails = (events = []) => {
   return writeJson(EVENT_DETAILS_CACHE_KEY, cached);
 };
 
+/**
  * Returns the cached detail for a single event, or null if absent or older
  * than DETAIL_CACHE_TTL_MS. Prunes the expired entry and any other stale
  * sibling entries from the detail cache on access.


### PR DESCRIPTION
﻿## Description
Added the missing /** JSDoc comment opener before getCachedEventDetail function. The opening was absent while the closing */ was present, causing SyntaxError: Unexpected token *.

## Related Issue
Fixes #4468

## Type of Change
- [x] Bug fix

program: gssoc
