### PR TITLE
feat: add markdown link validator github action workflow to prevent broken docs links

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,0 +1,17 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://linkedin.com/"
+    },
+    {
+      "pattern": "^https://www.linkedin.com/"
+    },
+    {
+      "pattern": "^https://eventra.sandeepvashishtha.in/"
+    }
+  ],
+  "timeout": "10s",
+  "retryOn429": true,
+  "retryCount": 2,
+  "fallbackToGet": true
+}

--- a/.github/workflows/markdown-link-validator.yml
+++ b/.github/workflows/markdown-link-validator.yml
@@ -1,0 +1,25 @@
+name: Markdown Link Validator
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - '**/*.md'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - '**/*.md'
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Run Markdown Link Checker
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          check-modified-files-only: 'yes'
+          config-file: '.github/markdown-link-check-config.json'


### PR DESCRIPTION
🧩 **Problem Solved**
Documentation URLs are prone to rot and breaking, leading to confusing guides for developers and contributors.

💡 **Approach**
- Created `.github/workflows/markdown-link-validator.yml` to trigger on `.md` modifications.
- Structured `.github/markdown-link-check-config.json` with domain exceptions (e.g. LinkedIn, Eventra demo host) to avoid false-positives and rate limits.

🧪 **Testing**
- Verified local and Actions configurations against mock documents with deliberate broken links.

Closes #4474 