### PR TITLE
fix: make back-online connection toast disappear after 3 seconds to prevent UX block

### DIFF
--- a/src/components/SessionRecovery.js
+++ b/src/components/SessionRecovery.js
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSessionRecovery } from '../context/SessionRecoveryContext';
-import { WifiOff, RefreshCw, X, CheckCircle, AlertCircle } from 'lucide-react';
+import { Wifi, WifiOff, RefreshCw, X, CheckCircle, AlertCircle } from 'lucide-react';
 
 const SessionRecovery = () => {
   const {
@@ -14,6 +14,19 @@ const SessionRecovery = () => {
   } = useSessionRecovery();
 
   const [isRestoring, setIsRestoring] = useState(false);
+  const [showOnlineToast, setShowOnlineToast] = useState(false);
+  const prevOnlineRef = useRef(isOnline);
+
+  useEffect(() => {
+    if (!prevOnlineRef.current && isOnline) {
+      setShowOnlineToast(true);
+      const timer = setTimeout(() => {
+        setShowOnlineToast(false);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+    prevOnlineRef.current = isOnline;
+  }, [isOnline]);
 
   const handleRestore = async () => {
     setIsRestoring(true);
@@ -57,6 +70,20 @@ const SessionRecovery = () => {
           <div>
             <p className="font-semibold text-sm">Reconnecting...</p>
             <p className="text-xs opacity-90">Attempting to restore connection</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isOnline && showOnlineToast && !showRecoveryPrompt) {
+    return (
+      <div className="fixed bottom-4 right-4 z-[45] animate-slide-up">
+        <div className="bg-green-500 text-white px-4 py-3 rounded-lg shadow-lg flex items-center gap-3">
+          <Wifi size={20} />
+          <div>
+            <p className="font-semibold text-sm">You're back online</p>
+            <p className="text-xs opacity-90">Connection restored</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #4478 

🧩 **Problem Solved**
The success connection banner remained visible forever after recovering connection, blocking crucial corner layout buttons.

💡 **Approach**
- Added transient state `showOnlineToast` to `SessionRecovery.js`.
- Leveraged an transition effect using a `useRef` tracker to capture offline-to-online triggers and execute a 3-second automatic timeout.

🧪 **Testing**
- Artificially toggled network state offline and online. Success toast triggers upon connection restoration and cleanly disappears after 3 seconds.