### PR TITLE
fix: enhance card emojis and star rating accessibility under WCAG standards

### DIFF
--- a/src/components/SearchFilter.js
+++ b/src/components/SearchFilter.js
@@ -253,15 +253,19 @@ const SearchFilter = () => {
             <div className="event-content">
               <h3 className="event-title">{event.title}</h3>
               <p className="event-description">{event.description}</p>
-              <div className="event-meta">
+              <div className="event-meta" aria-label="Event details">
                 <span className="event-date">
-                  📅 {new Date(event.date).toLocaleDateString()}
+                  <span role="img" aria-label="Date" className="mr-1">📅</span> {new Date(event.date).toLocaleDateString()}
                 </span>
-                <span className="event-location">📍 {event.location}</span>
-                <span className="event-attendees">👥 {event.attendees}</span>
+                <span className="event-location">
+                  <span role="img" aria-label="Location" className="mr-1">📍</span> {event.location}
+                </span>
+                <span className="event-attendees">
+                  <span role="img" aria-label="Attendees" className="mr-1">👥</span> {event.attendees}
+                </span>
               </div>
-              <div className="event-rating">
-                <span className="stars">⭐⭐⭐⭐⭐</span>
+              <div className="event-rating" aria-label={`Rating: ${event.rating} out of 5 stars`}>
+                <span className="stars" aria-hidden="true">⭐⭐⭐⭐⭐</span>
                 <span className="rating-value">{event.rating}</span>
               </div>
               <div className="event-actions">


### PR DESCRIPTION
Closes #4484 

🧩 **Problem Solved**
Search event grid cards caused auditory noise on accessibility screen readers due to unmapped raw emojis.

💡 **Approach**
- Wrapped card emojis in `span` elements equipped with `role="img"` and detailed `aria-label` tags.
- Implemented `aria-hidden="true"` on raw star strings, providing clear dynamic rating voice descriptions.

🧪 **Testing**
- Verified elements directly using screen reader voice simulation checks.