### PR TITLE
fix: resolve missing VirtualVenueWalkthrough reference

### DIFF
--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -39,6 +39,7 @@ const BookmarkedEvents = lazy(() => import('../../Pages/Events/BookmarkedEvents'
 const RemindersPage = lazy(() => import('../../Pages/Events/RemindersPage'));
 const EventAnalyticsDashboard = lazy(() => import('../../Pages/Events/EventAnalyticsDashboard'));
 const FloorPlanDesignerPage = lazy(() => import('../../Pages/Events/FloorPlanDesignerPage'));
+const VirtualVenueWalkthrough = lazy(() => import('../../Pages/Events/VirtualVenueWalkthrough'));
 const MyCalendar = lazy(() => import('../../Pages/Calendar/MyCalendar'));
 
 export const getPublicRoutes = () => [


### PR DESCRIPTION
## 🚀 Description

Fixes the runtime error caused by a missing `VirtualVenueWalkthrough` import in `PublicRoutes.js`.

### Root Cause

The route configuration referenced `VirtualVenueWalkthrough` without importing it, resulting in:

```text
VirtualVenueWalkthrough is not defined
```

This caused the application to hit the global error boundary and prevented affected routes from rendering correctly.

### Changes Made

* Added the missing lazy import for `VirtualVenueWalkthrough`
* Preserved existing route behavior and component logic
* Applied the smallest possible fix with no functional changes

### Validation

* Confirmed the `VirtualVenueWalkthrough is not defined` runtime error is resolved
* Verified the component exists and is correctly exported
* No regressions introduced by this change

Fixes #4445

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)

N/A

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
