### PR TITLE
fix: correct Quest Center route from /dashboard/achievements to /dashboard/quests in UserDashboard

### DIFF
--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -187,7 +187,7 @@ export default function UserDashboard() {
             <Trophy size={18} />
             <span>Achievements</span>
           </Link>
-          <Link to="/dashboard/achievements" className="ud-nav-item">
+          <Link to="/dashboard/quests" className="ud-nav-item">
             <Zap size={18} />
             <span>Quest Center</span>
           </Link>


### PR DESCRIPTION
## Summary
Fixes a duplicate route bug in `UserDashboard.js` where both 
**Achievements** and **Quest Center** sidebar links pointed to 
`/dashboard/achievements`, making Quest Center completely inaccessible.

## Problem
Both sidebar nav items used the same `to="/dashboard/achievements"` 
prop. Clicking **Quest Center** silently redirected users to the 
Achievements page with no indication of the error. The Quest Center 
was effectively unreachable from the sidebar navigation.

## Changes Made
- Changed Quest Center `Link` route from `/dashboard/achievements` 
  to `/dashboard/quests`

## Files Changed
- `src/components/user/UserDashboard.js`

## Testing
- App loads without errors
- Achievements link correctly navigates to `/dashboard/achievements`
- Quest Center link correctly navigates to `/dashboard/quests`
- Both sidebar items lead to distinct destinations
- No console errors

## Related Issue
Closes #4482