### PR TITLE
fix: prevent faq answers from being cut off by chatbot button

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -350,7 +350,13 @@ export default function FAQSection() {
           display: flex;
           flex-direction: column;
           align-items: center;
-          padding: 32px 20px 0;
+          padding: 32px max(20px, env(safe-area-inset-right) + 88px) 0 20px;
+        }
+
+        @media (max-width: 640px) {
+          .faq-cards-container {
+            padding-right: 20px;
+          }
         }
 
         .card-pin-wrapper {


### PR DESCRIPTION
## 🚀 Description

Fixes FAQ content being partially hidden by the floating chatbot button.

### Problem

Some FAQ answers could be cut off or obscured when expanded, especially near the bottom-right area of the page where the chatbot widget overlaps page content. This reduced readability and negatively impacted the user experience.

### Changes Made

* Adjusted FAQ layout and spacing to prevent overlap with the chatbot button.
* Ensured expanded FAQ answers remain fully visible and readable.
* Preserved existing FAQ functionality and responsiveness.
* Applied a minimal UI fix without changing FAQ behavior.

### Validation

* Verified FAQ answers are fully visible after expansion.
* Confirmed chatbot button no longer covers FAQ content.
* Checked responsiveness across desktop and mobile layouts.
* No functional regressions introduced.

Fixes #4446

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)

Before: FAQ answers could be partially obscured by the floating chatbot widget.

After: FAQ answers remain fully visible with adequate spacing from the chatbot button.

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
