### PR TITLE
fix: respect explicit server event status in getEventStatus instead of always overriding with date-computed status

### DIFF
--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -45,19 +45,16 @@ export const computeDateStatus = (event) => {
 
 export const getEventStatus = (event) => {
   if (!event) return "upcoming";
-
   const explicitStatus = mapStatusKey(event.status);
   const dateStatus = computeDateStatus(event);
 
   if (explicitStatus === "ended") {
     return "ended";
   }
-
-  if (dateStatus) {
-    return dateStatus;
+  if (explicitStatus && explicitStatus !== dateStatus) {
+    return explicitStatus;
   }
-
-  return explicitStatus || "upcoming";
+  return dateStatus || "upcoming";
 };
 
 export const isEventRegistrationClosed = (eventOrStatus) => {


### PR DESCRIPTION
## Summary
Fixes a logic bug in `getEventStatus` in `src/utils/eventUtils.js` 
where the server's explicit event status was always silently overridden 
by the date-computed status, and the final return statement was 
unreachable dead code.

## Problem
`computeDateStatus` always returns a truthy string — `"upcoming"`, 
`"live"`, or `"past"`. The condition `if (dateStatus)` was therefore 
always `true`, meaning `dateStatus` always won over the server's 
explicit `explicitStatus`. This caused:
- Server-assigned event statuses to be silently ignored
- Events marked `"live"` by the server but with a past date to 
  incorrectly display as `"past"`
- The final `return explicitStatus || "upcoming"` to be completely 
  unreachable dead code

## Changes Made
- Changed logic to prioritize `explicitStatus` over `dateStatus` 
  when they differ
- Removed unreachable dead code path
- `dateStatus` is now the fallback when no explicit status exists

## Files Changed
- `src/utils/eventUtils.js`

## Testing
- App loads without errors
- Events page loads correctly
- Event status badges show correct status
- Server explicit status takes priority over date-computed status
- No console errors

## Related Issue
Closes #4491 