### PR TITLE
fix: reset search query and pressed keys when KeyboardShortcutsModal closes

### DIFF
--- a/src/components/common/KeyboardShortcutsModal.jsx
+++ b/src/components/common/KeyboardShortcutsModal.jsx
@@ -232,6 +232,13 @@ const KeyboardShortcutsModal = ({ isOpen, onClose }) => {
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery("");
+      setPressedKeys(new Set());
+    }
+  }, [isOpen]);
+
   const isKeyPressed = (keyId) => {
     return pressedKeys.has(keyId.toLowerCase());
   };


### PR DESCRIPTION
## Summary
Fixes stale state in `KeyboardShortcutsModal.jsx` where `searchQuery` 
and `pressedKeys` were never reset when the modal closed, causing the 
modal to reopen with stale data.

## Problem
When a user typed a search query in the shortcuts modal and then 
closed it, the `searchQuery` state was never cleared. On reopening, 
the old search term was still present and only filtered shortcuts were 
shown instead of the full list. Similarly, `pressedKeys` from the 
previous session remained highlighted incorrectly on reopen.

## Changes Made
- Added a `useEffect` that watches `isOpen` and resets both 
  `searchQuery` and `pressedKeys` to their initial empty state 
  whenever the modal closes

## Files Changed
- `src/components/common/KeyboardShortcutsModal.jsx`

## Testing
- App loads without errors
- Modal opens with empty search box every time
- All shortcuts visible on fresh open
- Pressed keys reset correctly on reopen
- Search filtering still works correctly while modal is open
- No console errors

## Related Issue
Closes #4493 