### PR TITLE
fix: remove unsubstituted VITE_GOOGLE_CLIENT_ID meta tag from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,39 +13,12 @@
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
 
     <!-- Favicons -->
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="/favicon.ico"
-    />       
-    <link
-      rel="shortcut icon"
-      href="/favicon.ico"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="/favicon-32x32.png"
-    />
-
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="/favicon-16x16.png"
-    />
-
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="/apple-touch-icon.png"
-    />
-
-    <link
-      rel="manifest"
-      href="/manifest.json"
-    />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.json" />
 
     <!-- Responsive -->
     <meta
@@ -54,24 +27,11 @@
     />
 
     <!-- Theme -->
-    <meta
-      name="theme-color"
-      content="#0f172a"
-    />
-    <meta
-      name="mobile-web-app-capable"
-      content="yes"
-    />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Eventra" />
 
-    <meta
-      name="apple-mobile-web-app-status-bar-style"
-      content="black-translucent"
-    />
-
-    <meta
-      name="apple-mobile-web-app-title"
-      content="Eventra"
-    />
     <!-- Primary SEO -->
     <meta
       name="description"
@@ -81,34 +41,16 @@
     <!-- Preconnect for faster external resource loading -->
     <link rel="preconnect" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://api.github.com" />
-
-    <link
-      rel="preconnect"
-      href="https://accounts.google.com"
-      crossorigin
-    />
-    <link
-      rel="dns-prefetch"
-      href="https://accounts.google.com"
-    />
-
-    <link
-      rel="preconnect"
-      href="https://fonts.googleapis.com"
-    />
-
-    <link
-      rel="preconnect"
-      href="https://fonts.gstatic.com"
-      crossorigin
-    />
+    <link rel="preconnect" href="https://accounts.google.com" crossorigin />
+    <link rel="dns-prefetch" href="https://accounts.google.com" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
     <!-- Fonts -->
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
-
     <noscript>
       <link
         href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
@@ -120,9 +62,7 @@
     <script src="/theme-init.js"></script>
 
     <!-- Title -->
-    <title>
-      Eventra - Open Source Event Management Platform
-    </title>
+    <title>Eventra - Open Source Event Management Platform</title>
     <meta property="og:title" content="Eventra - Platform for Builders" />
     <meta property="og:description" content="A premium, modern platform for organizing and attending events, hackathons, and projects." />
     <meta property="og:type" content="website" />
@@ -130,16 +70,7 @@
     <meta property="og:image" content="/Eventra.png" />
 
     <!-- Google Sign In -->
-    <meta
-      name="google-signin-client_id"
-      content="%VITE_GOOGLE_CLIENT_ID%"
-    />
-
-    <script
-      src="https://accounts.google.com/gsi/client"
-      async
-      defer
-    ></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
 
     <!-- EmailJS -->
     <script
@@ -149,10 +80,7 @@
   </head>
 
   <body class="bg-white text-black dark:bg-gray-900 dark:text-white">
-    <noscript>
-      You need to enable JavaScript to run this app.
-    </noscript>
-
+    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="/src/index.jsx"></script>
   </body>


### PR DESCRIPTION
## 🚀 Description
Removes the broken `<meta name="google-signin-client_id">` tag from index.html 
that was rendering the raw placeholder string `%VITE_GOOGLE_CLIENT_ID%` in 
production. This variable is never defined at build time on Vercel, so the 
placeholder was being served as-is to all users, silently breaking Google 
Sign-In for everyone.

Fixes #4136

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)
**Before (live page source):**
`<meta name="google-signin-client_id" content="%VITE_GOOGLE_CLIENT_ID%">`

**After:**
Tag removed entirely. VITE_GOOGLE_CLIENT_ID is already documented in .env.example for contributors.

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings