### PR TITLE
test(security): add unit tests for sessionSanitization utility

### DIFF
--- a/tests/sessionSanitization.test.mjs
+++ b/tests/sessionSanitization.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+
+const {
+  sanitizeSessionValue,
+  sanitizeSessionState,
+} = await import("../src/utils/sessionSanitization.js");
+
+const jwt =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature";
+
+assert.equal(sanitizeSessionValue(jwt), "[REDACTED_JWT]");
+assert.equal(sanitizeSessionValue("hello"), "hello");
+
+const sanitized = sanitizeSessionState({
+  user: { name: "Ada" },
+  token: "secret-token",
+  nested: { apiKey: "abc123", note: jwt },
+});
+
+assert.equal(sanitized.user.name, "Ada");
+assert.equal(sanitized.token, "[REDACTED]");
+assert.equal(sanitized.nested.apiKey, "[REDACTED]");
+assert.equal(sanitized.nested.note, "[REDACTED_JWT]");
+
+assert.deepEqual(
+  sanitizeSessionState([{ password: "x" }, { ok: true }]),
+  [{ password: "[REDACTED]" }, { ok: true }]
+);
+
+console.log("sessionSanitization tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/sessionSanitization.test.mjs` for JWT redaction, sensitive key stripping, and nested structures

Fixes #4299

## Test plan
- [ ] Run `node tests/sessionSanitization.test.mjs`

Made with [Cursor](https://cursor.com)