### PR TITLE
test(security): add unit tests for sanitizeInputText utility

### DIFF
--- a/tests/sanitizeInputText.test.mjs
+++ b/tests/sanitizeInputText.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+
+const { sanitizeInputText } = await import("../src/utils/inputSanitization.js");
+
+assert.equal(sanitizeInputText(""), "");
+assert.equal(sanitizeInputText(null), "");
+assert.equal(
+  sanitizeInputText("<img src=x onerror=alert(1)>"),
+  "&lt;img src=x onerror=alert(1)&gt;"
+);
+assert.equal(sanitizeInputText("Tom & Jerry"), "Tom &amp; Jerry");
+assert.equal(sanitizeInputText(`Say "hello"`), "Say &quot;hello&quot;");
+assert.equal(sanitizeInputText("path/to/file"), "path&#x2F;to&#x2F;file");
+
+console.log("sanitizeInputText tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/sanitizeInputText.test.mjs` for HTML entity escaping on plain-text inputs

Fixes #4303

## Test plan
- [ ] Run `node tests/sanitizeInputText.test.mjs`

Made with [Cursor](https://cursor.com)