### PR TITLE
test(security): add unit tests for prepareSafeSearchQuery utility

### DIFF
--- a/tests/prepareSafeSearchQuery.test.mjs
+++ b/tests/prepareSafeSearchQuery.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+
+const warnings = [];
+const originalWarn = console.warn;
+console.warn = (...args) => warnings.push(args);
+
+const { prepareSafeSearchQuery } = await import("../src/utils/inputSanitization.js");
+
+assert.equal(prepareSafeSearchQuery("react events"), "react events");
+assert.equal(prepareSafeSearchQuery("  spaced  "), "spaced");
+assert.equal(prepareSafeSearchQuery("bad $ operator"), "");
+assert.equal(prepareSafeSearchQuery(null), "");
+assert.ok(warnings.length >= 1, "logs warning for invalid queries");
+
+console.warn = originalWarn;
+console.log("prepareSafeSearchQuery tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/prepareSafeSearchQuery.test.mjs` for safe query passthrough and invalid input rejection

Fixes #4301

## Test plan
- [ ] Run `node tests/prepareSafeSearchQuery.test.mjs`

Made with [Cursor](https://cursor.com)