### PR TITLE
test(security): add validateSearchQuery edge-case unit tests

### DIFF
--- a/tests/validateSearchQuery.test.mjs
+++ b/tests/validateSearchQuery.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+
+const { validateSearchQuery } = await import("../src/utils/inputSanitization.js");
+
+assert.deepEqual(validateSearchQuery(""), { isValid: true, error: null });
+assert.deepEqual(validateSearchQuery("   "), { isValid: true, error: null });
+assert.deepEqual(validateSearchQuery(123), {
+  isValid: false,
+  error: "Search query must be a string",
+});
+assert.deepEqual(validateSearchQuery(null), {
+  isValid: false,
+  error: "Search query must be a string",
+});
+assert.deepEqual(validateSearchQuery("{ $gt: '' }"), {
+  isValid: false,
+  error: "Search query contains invalid characters",
+});
+assert.deepEqual(validateSearchQuery("a".repeat(201)), {
+  isValid: false,
+  error: "Search query must be less than 200 characters",
+});
+
+console.log("validateSearchQuery edge-case tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/validateSearchQuery.test.mjs` for non-string input, injection patterns, and length limits

Fixes #4302

## Test plan
- [ ] Run `node tests/validateSearchQuery.test.mjs`

Made with [Cursor](https://cursor.com)