### PR TITLE
test(security): add sanitizeSearchQuery edge-case unit tests

### DIFF
--- a/tests/sanitizeSearchQuery.edge.test.mjs
+++ b/tests/sanitizeSearchQuery.edge.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+
+const { sanitizeSearchQuery } = await import("../src/utils/inputSanitization.js");
+
+assert.equal(sanitizeSearchQuery(undefined), "");
+assert.equal(sanitizeSearchQuery(42), "");
+assert.equal(sanitizeSearchQuery("  hello  "), "hello");
+assert.equal(sanitizeSearchQuery("a{b}c[d]"), "abcd");
+assert.equal(sanitizeSearchQuery("line\nbreak"), "linebreak");
+assert.equal(sanitizeSearchQuery("a".repeat(250)).length, 200);
+
+console.log("sanitizeSearchQuery edge-case tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/sanitizeSearchQuery.edge.test.mjs` for non-string input, bracket stripping, and max-length truncation

Fixes #4300

## Test plan
- [ ] Run `node tests/sanitizeSearchQuery.edge.test.mjs`

Made with [Cursor](https://cursor.com)