### PR TITLE
docs(hooks): add JSDoc for useNotifications hook

### DIFF
--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -4,6 +4,20 @@ import { logger } from "../utils/logger";
 
 const STORAGE_KEY = "eventra_notifications";
 
+/**
+ * Manages in-app notifications with IndexedDB persistence and browser permission helpers.
+ *
+ * Loads stored notifications on mount, persists updates after the initial load completes,
+ * and exposes helpers to add notifications, mark all as read, and request push permission.
+ *
+ * @returns {{
+ *   notifications: Array,
+ *   unreadCount: number,
+ *   addNotification: function,
+ *   markAllAsRead: function,
+ *   requestPermission: function,
+ * }}
+ */
 export const useNotifications = () => {
   const [notifications, setNotifications] = useState([]);
 


### PR DESCRIPTION
## Summary
- Documents IndexedDB persistence behavior and the hook return API

Fixes #4337

## Test plan
- [ ] Confirm JSDoc renders in IDE hover for `useNotifications`

Made with [Cursor](https://cursor.com)