### PR TITLE
fix: reset query and activeIndex when CommandPalette closes to prevent stale search on reopen

### DIFF
--- a/src/components/common/CommandPalette.jsx
+++ b/src/components/common/CommandPalette.jsx
@@ -130,6 +130,8 @@ export default function CommandPalette({
       document.body.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "";
+      setQuery("");
+      setActiveIndex(0);
     }
     return () => {
       document.body.style.overflow = "";


### PR DESCRIPTION
## Summary
Fixes stale state in `CommandPalette.jsx` where `query` and 
`activeIndex` were never reset when the palette closed, causing 
it to reopen with stale search results and wrong keyboard highlight.

## Problem
When a user typed a search query in the Command Palette and then 
closed it, the `query` state was never cleared. On reopening, the 
old search term was still present and only filtered catalog items 
were shown instead of the full list. Similarly, `activeIndex` 
retained its previous position, causing the keyboard highlight to 
start at the wrong item on reopen.

## Changes Made
- Added `setQuery("")` and `setActiveIndex(0)` to the `else` branch 
  of the `isOpen` `useEffect` so both states reset whenever the 
  palette closes

## Files Changed
- `src/components/common/CommandPalette.jsx`

## Testing
- App loads without errors
- Palette opens with empty search box every time
- Full catalog visible on fresh open
- Active highlight resets to first item on reopen
- Search filtering still works correctly while palette is open
- No console errors

## Related Issue
Closes #4505 