### PR TITLE
fix: memoize Fuse search index in HackathonPage to prevent expensive rebuild on every render

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -1,5 +1,5 @@
 import TeamMatchmaking from "./components/TeamMatchmaking";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link } from "react-router-dom";
 import { fetchHackathons } from "../../services/hackathonService";
@@ -276,10 +276,10 @@ const debouncedSearchQuery = useDebounce(searchQuery, 300);
     }
   };
 
-  const fuse = new Fuse(hackathons, {
+  const fuse = useMemo(() => new Fuse(hackathons, {
     keys: ["title", "description", "location", "techStack"],
     threshold: 0.4,
-  });
+  }), [hackathons]);
 
   const searchedHackathons = debouncedSearchQuery
     ? fuse.search(debouncedSearchQuery).map((result) => result.item)


### PR DESCRIPTION
## Summary
Fixes a performance bug in `HackathonPage.js` where a new `Fuse` 
search index was built on every component render instead of only 
when the `hackathons` data changed.

## Problem
`new Fuse(hackathons, options)` was called directly in the component 
body without memoization. This meant the full search index was 
rebuilt on every re-render — triggered by scroll events, filter 
toggles, tag selection, search input changes, and any other state 
update. Building a Fuse index is expensive CPU work that scales with 
the size of the hackathons dataset, causing unnecessary performance 
overhead on every interaction.

## Changes Made
- Wrapped the `Fuse` instance in `useMemo` with `hackathons` as 
  the dependency so the index is only rebuilt when the data changes
- Added `useMemo` to the React import

## Files Changed
- `src/Pages/Hackathons/HackathonPage.js`

## Testing
- App loads without errors
- Hackathons page loads correctly
- Search filtering works correctly
- All filters and tags work correctly
- No console errors
- Reduced unnecessary CPU work on every render

## Related Issue
Closes #4515 