### PR TITLE
feat: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/src/components/SkipToContent.jsx
+++ b/src/components/SkipToContent.jsx
@@ -1,0 +1,33 @@
+import "./styles/SkipToContent.css";
+
+/**
+ * SkipToContent - Accessibility skip navigation link.
+ * Appears on Tab focus, allowing keyboard users to bypass navigation.
+ *
+ * Usage: Place at the very top of your App component.
+ * Ensure the main content area has id="main-content".
+ *
+ * @param {Object} props
+ * @param {string} [props.targetId] - ID of the main content element (default: "main-content")
+ */
+export default function SkipToContent({ targetId = "main-content" }) {
+  const handleClick = (e) => {
+    e.preventDefault();
+    const target = document.getElementById(targetId);
+    if (target) {
+      target.setAttribute("tabindex", "-1");
+      target.focus();
+      target.removeAttribute("tabindex");
+    }
+  };
+
+  return (
+    <a
+      href={`#${targetId}`}
+      className="skip-to-content"
+      onClick={handleClick}
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/src/components/styles/SkipToContent.css
+++ b/src/components/styles/SkipToContent.css
@@ -1,0 +1,22 @@
+.skip-to-content {
+  position: absolute;
+  top: -100%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  padding: 0.75rem 1.5rem;
+  background: var(--primary, #6366f1);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border-radius: 0 0 8px 8px;
+  text-decoration: none;
+  transition: top 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.skip-to-content:focus {
+  top: 0;
+  outline: 3px solid #facc15;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
Adds a "Skip to main content" link that appears on keyboard focus, allowing keyboard and screen reader users to bypass the navigation and jump directly to the main content area. This is a WCAG 2.1 Level A requirement.

## Changes
- Added `src/components/SkipToContent.jsx`
- Added `src/components/styles/SkipToContent.css`

cc @SandeepVashishtha