### PR TITLE
fix : added null safety for getCategoryLabel in advancedFilterUtils

### DIFF
--- a/src/utils/advancedFilterUtils.js
+++ b/src/utils/advancedFilterUtils.js
@@ -44,6 +44,7 @@ export const PRICE_RANGES = [
  * Get category label from mapping
  */
 export const getCategoryLabel = (categoryKey) => {
+  if (!categoryKey) return categoryKey;
   const category = EVENT_CATEGORIES.find(
     (cat) =>
       cat.label.toLowerCase().replace(/\s+/g, "-") ===


### PR DESCRIPTION
Refs #4547.

Summary of What Has Been Done:
Added null/undefined guard for categoryKey parameter in getCategoryLabel function in src/utils/advancedFilterUtils.js to prevent TypeError when called with falsy values.

Changes Made:
- Modified getCategoryLabel in src/utils/advancedFilterUtils.js
- Added null/undefined check that returns the categoryKey as-is when falsy

Impact it Made:
- Prevents TypeError when getCategoryLabel is called with null/undefined
- Improves robustness of the filtering system
- Returns falsy values as-is to allow callers to handle edge cases