### PR TITLE
feat: Add CSRF token management utility

### DIFF
--- a/src/utils/csrfToken.js
+++ b/src/utils/csrfToken.js
@@ -1,0 +1,68 @@
+/**
+ * CSRF Token Management Utility
+ *
+ * Reads the CSRF token from a <meta> tag or cookie and provides
+ * a helper to attach it to fetch requests.
+ */
+
+const CSRF_META_NAME = "csrf-token";
+const CSRF_COOKIE_NAME = "XSRF-TOKEN";
+const CSRF_HEADER_NAME = "X-CSRF-Token";
+
+/**
+ * Reads the CSRF token from the page's <meta> tag.
+ * Expected: <meta name="csrf-token" content="TOKEN_VALUE">
+ * @returns {string|null}
+ */
+export function getCSRFTokenFromMeta() {
+  const meta = document.querySelector(`meta[name="${CSRF_META_NAME}"]`);
+  return meta ? meta.getAttribute("content") : null;
+}
+
+/**
+ * Reads the CSRF token from a cookie.
+ * @param {string} [name] - Cookie name (default: XSRF-TOKEN)
+ * @returns {string|null}
+ */
+export function getCSRFTokenFromCookie(name = CSRF_COOKIE_NAME) {
+  const cookies = document.cookie.split(";").map((c) => c.trim());
+  for (const cookie of cookies) {
+    if (cookie.startsWith(`${name}=`)) {
+      return decodeURIComponent(cookie.substring(name.length + 1));
+    }
+  }
+  return null;
+}
+
+/**
+ * Gets the CSRF token from meta tag or cookie (in that order).
+ * @returns {string|null}
+ */
+export function getCSRFToken() {
+  return getCSRFTokenFromMeta() || getCSRFTokenFromCookie();
+}
+
+/**
+ * Wraps the native fetch API to automatically include the CSRF token
+ * on state-changing requests (POST, PUT, PATCH, DELETE).
+ *
+ * @param {string} url
+ * @param {RequestInit} options
+ * @returns {Promise<Response>}
+ */
+export function csrfFetch(url, options = {}) {
+  const method = (options.method || "GET").toUpperCase();
+  const needsCSRF = ["POST", "PUT", "PATCH", "DELETE"].includes(method);
+
+  if (needsCSRF) {
+    const token = getCSRFToken();
+    if (token) {
+      options.headers = {
+        ...options.headers,
+        [CSRF_HEADER_NAME]: token,
+      };
+    }
+  }
+
+  return fetch(url, options);
+}


### PR DESCRIPTION
## Summary
Adds a `csrfToken.js` utility for managing CSRF tokens on the frontend. Automatically reads the CSRF token from meta tags or cookies and attaches it to API requests.

## Changes
- Added `src/utils/csrfToken.js`

Addresses #4528

cc @SandeepVashishtha