### PR TITLE
test(utils): add eventDraftUtils edge-case unit tests

### DIFF
--- a/tests/eventDraftUtils.edge.test.mjs
+++ b/tests/eventDraftUtils.edge.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+
+const store = {};
+global.localStorage = {
+  getItem: (key) => (key in store ? store[key] : null),
+  setItem: (key, value) => {
+    store[key] = String(value);
+  },
+  removeItem: (key) => {
+    delete store[key];
+  },
+};
+
+const { saveDraft, getDraft, clearDraft } = await import(
+  "../src/utils/eventDraftUtils.js"
+);
+
+assert.equal(getDraft(), null, "returns null when no draft exists");
+
+localStorage.setItem("event_creation_draft", "{not-json");
+assert.deepEqual(getDraft(), {}, "returns empty object for malformed draft JSON");
+
+saveDraft({ title: "Draft event", step: 2 });
+assert.deepEqual(getDraft(), { title: "Draft event", step: 2 });
+
+clearDraft();
+assert.equal(getDraft(), null, "clearDraft removes stored draft");
+
+console.log("eventDraftUtils edge-case tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/eventDraftUtils.edge.test.mjs` for malformed draft JSON fallback and clearDraft behavior

Fixes #4329

## Test plan
- [ ] Run `node --test tests/eventDraftUtils.edge.test.mjs`

Made with [Cursor](https://cursor.com)