### PR TITLE
test(utils): add registerUtils edge-case unit tests

### DIFF
--- a/tests/registerUtils.edge.test.mjs
+++ b/tests/registerUtils.edge.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+
+const store = {};
+global.localStorage = {
+  getItem: (key) => (key in store ? store[key] : null),
+  setItem: (key, value) => {
+    store[key] = String(value);
+  },
+};
+
+const { isAlreadyRegistered, saveRegistration } = await import(
+  "../src/utils/registerUtils.js"
+);
+
+assert.equal(isAlreadyRegistered("", "user@example.com"), false);
+assert.equal(isAlreadyRegistered("event-1", ""), false);
+assert.equal(isAlreadyRegistered("event-1", "   "), false);
+
+saveRegistration("event-1", "  User@Example.Com  ");
+assert.equal(isAlreadyRegistered("event-1", "user@example.com"), true);
+
+saveRegistration("event-1", "user@example.com");
+assert.equal(
+  JSON.parse(localStorage.getItem("eventRegistrations"))["event-1"].length,
+  1,
+  "duplicate saveRegistration is idempotent"
+);
+
+console.log("registerUtils edge-case tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/registerUtils.edge.test.mjs` for empty identifiers, email normalization, and idempotent saves

Fixes #4330

## Test plan
- [ ] Run `node --test tests/registerUtils.edge.test.mjs`

Made with [Cursor](https://cursor.com)