### PR TITLE
test(auth): align JWT permission assertions with auth architecture

### DIFF
--- a/tests/googleOAuthEndpoint.test.mjs
+++ b/tests/googleOAuthEndpoint.test.mjs
@@ -186,7 +186,6 @@ const simulateGoogleOAuth = async (credential) => {
     email: user.email,
     username: user.username,
     roles: roles,
-    permissions: permissions,
     provider: user.provider || "google",
   };
   const token = jwt.sign(jwtPayload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
@@ -298,7 +297,7 @@ console.log("Running Google OAuth endpoint tests...");
   assert.ok(payload.id, "JWT should contain user id");
   assert.ok(payload.email, "JWT should contain email");
   assert.ok(payload.roles, "JWT should contain roles");
-  assert.ok(payload.permissions, "JWT should contain permissions");
+  assert.equal(payload.permissions, undefined, "JWT should NOT contain permissions");
   assert.ok(payload.exp, "JWT should contain expiration");
   assert.equal(payload.provider, "google", "JWT should contain provider info");
   console.log("✓ Test 6: JWT token contains required claims");

--- a/tests/loginEndpoint.test.mjs
+++ b/tests/loginEndpoint.test.mjs
@@ -243,7 +243,7 @@ console.log("Running login endpoint tests...");
   assert.ok(payload.id, "JWT should contain user id");
   assert.ok(payload.email, "JWT should contain email");
   assert.ok(payload.roles, "JWT should contain roles");
-  assert.ok(payload.permissions, "JWT should contain permissions");
+  assert.equal(payload.permissions, undefined, "JWT should NOT contain permissions");
   assert.ok(payload.exp, "JWT should contain expiration");
   console.log("✓ Test 11: JWT token contains required claims");
 }


### PR DESCRIPTION
## 🚀 Description

This PR fixes stale JWT permission assertions in authentication unit tests.

The production authentication flow intentionally excludes `permissions` from JWT payloads to prevent stale authorization data from being embedded in long-lived tokens. Current permissions are derived server-side at request time so role changes, suspensions, and permission revocations take effect immediately.

However, the test suite was still asserting that JWTs contain a `permissions` field, causing failures and creating a mismatch between production behavior and test expectations.

### Changes Made

* Updated JWT assertions in `tests/loginEndpoint.test.mjs`
* Updated JWT assertions in `tests/googleOAuthEndpoint.test.mjs`
* Removed stale `permissions` field from mocked JWT payload generation
* Verified that JWT payloads only contain identity-related claims:

  * `id`
  * `email`
  * `roles`
  * `provider` (where applicable)
  * `exp`

### Motivation

This change aligns the test suite with the intended security architecture and prevents tests from validating deprecated JWT behavior.

Fixes #4570

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)

N/A — test-only changes.

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
