### PR TITLE
refactor(theme): integrate ThemeToggleButton with global ThemeContext to prevent desync

### DIFF
--- a/src/components/common/ThemeToggleButton.jsx
+++ b/src/components/common/ThemeToggleButton.jsx
@@ -1,42 +1,30 @@
-import { useEffect, useState } from "react";
+import React from "react";
+import { useTheme } from "../../context/ThemeContext";
 import { FiSun, FiMoon } from "react-icons/fi";
 
 const ThemeToggleButton = () => {
-  const [darkMode, setDarkMode] = useState(
-    () => localStorage.getItem("theme") === "dark"
-  );
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (darkMode) {
-      root.classList.add("dark");
-      localStorage.setItem("theme", "dark");
-    } else {
-      root.classList.remove("dark");
-      localStorage.setItem("theme", "light");
-    }
-  }, [darkMode]);
+  const { isDarkMode, toggleTheme } = useTheme();
 
   return (
     <button
-      className="flex items-center cursor-pointer select-none"
-      onClick={() => setDarkMode((prev) => !prev)}
+      className="flex items-center cursor-pointer select-none focus:outline-none"
+      onClick={toggleTheme}
       role="switch"
-      aria-checked={darkMode}
-      aria-label={darkMode ? "Switch to Light Mode" : "Switch to Dark Mode"}
+      aria-checked={isDarkMode}
+      aria-label={isDarkMode ? "Switch to Light Mode" : "Switch to Dark Mode"}
     >
       <div
-        className={`w-12 h-6 rounded-full p-1 bg-gray-300 dark:bg-gray-700 relative`} // reduced size
+        className="w-12 h-6 rounded-full p-1 bg-gray-300 dark:bg-gray-700 relative transition-colors duration-200"
       >
         <div
           className={`w-5 h-5 bg-white rounded-full shadow-lg flex items-center justify-center
             transform transition-all duration-300 ease-in-out absolute top-0.5
-            ${darkMode ? "translate-x-6" : "translate-x-0"}`} // adjusted translation
+            ${isDarkMode ? "translate-x-6" : "translate-x-0"}`}
         >
-          {darkMode ? (
-            <FiSun className="text-yellow-500 text-sm" /> // smaller icon
+          {isDarkMode ? (
+            <FiSun className="text-yellow-500 text-sm" />
           ) : (
-            <FiMoon className="text-gray-700 text-sm" /> // smaller icon
+            <FiMoon className="text-gray-700 text-sm" />
           )}
         </div>
       </div>


### PR DESCRIPTION

Fixes #4221 

- **Problem:** The ThemeToggleButton managed its own isolated dark mode state and local storage queries, causing desynced layout states when changing styles in the settings customizer drawer.
- **Solution:** Replaced local states, storage manipulation, and manual DOM edits inside the toggle button with direct bindings to the global `useTheme` context.
- **Impact:** Ensures complete synchronization between the navigation toggle switch, appearance preferences, custom visual skin variables, and OS settings.

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
