### PR TITLE
feat: synthesize polyphonic ascending game chimes on quest XP claims

### DIFF
--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { toast } from 'react-toastify';
 import {
   Zap, Clock, CheckCircle, Lock, Gift, Target,
   Flame, Star, ChevronDown, Trophy, Sparkles, Timer,
@@ -84,6 +85,63 @@ function fireConfetti(containerRef) {
     setTimeout(() => dot.remove(), 1400);
   }
 }
+
+// Lightweight ascending polyphonic retro chime synthesizer using native Web Audio API
+const playClaimSound = () => {
+  try {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextClass) return;
+
+    const ctx = new AudioContextClass();
+    const now = ctx.currentTime;
+
+    // Define pitch sequence for ascending chime (pentatonic scale feels very positive)
+    const notes = [261.63, 329.63, 392.00, 523.25, 659.25, 783.99, 1046.50]; // C4, E4, G4, C5, E5, G5, C6
+    
+    notes.forEach((freq, idx) => {
+      const triggerTime = now + idx * 0.08;
+      
+      // Oscillator 1: Sine (warm body)
+      const osc1 = ctx.createOscillator();
+      const gainNode = ctx.createGain();
+      
+      osc1.type = 'sine';
+      osc1.frequency.setValueAtTime(freq, triggerTime);
+      
+      // Pitch slide up slightly on each note for extra dynamic bounce
+      osc1.frequency.exponentialRampToValueAtTime(freq * 1.05, triggerTime + 0.12);
+      
+      // Exponential decay envelope
+      gainNode.gain.setValueAtTime(0, triggerTime);
+      gainNode.gain.linearRampToValueAtTime(0.2, triggerTime + 0.02);
+      gainNode.gain.exponentialRampToValueAtTime(0.001, triggerTime + 0.25);
+      
+      osc1.connect(gainNode);
+      gainNode.connect(ctx.destination);
+      
+      osc1.start(triggerTime);
+      osc1.stop(triggerTime + 0.3);
+
+      // Oscillator 2: Triangle (adds subtle retro weight)
+      const osc2 = ctx.createOscillator();
+      const gainNode2 = ctx.createGain();
+      
+      osc2.type = 'triangle';
+      osc2.frequency.setValueAtTime(freq, triggerTime);
+      gainNode2.gain.setValueAtTime(0, triggerTime);
+      gainNode2.gain.linearRampToValueAtTime(0.08, triggerTime + 0.02);
+      gainNode2.gain.exponentialRampToValueAtTime(0.001, triggerTime + 0.2);
+      
+      osc2.connect(gainNode2);
+      gainNode2.connect(ctx.destination);
+      
+      osc2.start(triggerTime);
+      osc2.stop(triggerTime + 0.25);
+    });
+  } catch (error) {
+    console.warn("Web Audio API not allowed or supported on this context:", error);
+  }
+};
 
 // ─── Main QuestCenter component ────────────────────────────────────────────────
 export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
@@ -176,6 +234,11 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
 
     setClaimFlash(questId);
     fireConfetti(confettiRef);
+    playClaimSound();
+    toast.success(`Mission Completed! Claimed +${xp} XP! 🎉`, {
+      icon: "🌟",
+      autoClose: 3500,
+    });
     setTimeout(() => setClaimFlash(null), 1200);
   };
 


### PR DESCRIPTION
### Problem Solved
Currently, when a user completes a quest and clicks "Claim XP" in the `QuestCenter` component, the XP is added, but the action is silent. Premium gamified platforms rely on rich audio-visual feedback to create a satisfying psychological reward loop. Storing large audio assets increases repository size and introduces network latency.

### Approach
1. Implemented a lightweight, native, **zero-dependency polyphonic Web Audio API Synthesizer** inside `QuestCenter.jsx` that programmatically plays a premium, ascending game-chime sound effect upon successfully claiming a quest.
2. Oscillators generate multi-voice frequencies with exponential pitch ramping and decay volume envelopes to sound like a rich retro console chime.
3. Integrated a beautiful, custom Toast notification displaying quest success: `toast.success("Mission Completed! Claimed +X XP! 🎉", { icon: "🌟" })`.
4. Fully respects browser audio permissions and fails silently if browser blocks AudioContext.

### Related Issues
Closes #4607

---
I am contributing on behalf of GSSoc’26!