### PR TITLE
feat: coordinate event reminder notifications across tabs using BroadcastChannel

### DIFF
--- a/src/components/reminders/ReminderChecker.js
+++ b/src/components/reminders/ReminderChecker.js
@@ -1,8 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { toast } from "react-toastify";
 import { popDueReminders } from "../../utils/reminderUtils";
 
 const CHECK_INTERVAL_MS = 30 * 1000;
+const CHANNEL_NAME = "eventra_reminders_sync_channel";
 
 const showBrowserNotification = (reminder) => {
   if (typeof window === "undefined" || !("Notification" in window)) return;
@@ -21,11 +22,43 @@ const showBrowserNotification = (reminder) => {
 };
 
 const ReminderChecker = () => {
+  const notifiedIdsRef = useRef(new Set());
+  const channelRef = useRef(null);
+
   useEffect(() => {
+    // Establish BroadcastChannel for tab coordination
+    if (typeof window !== "undefined" && "BroadcastChannel" in window) {
+      const channel = new BroadcastChannel(CHANNEL_NAME);
+      channelRef.current = channel;
+
+      channel.onmessage = (event) => {
+        if (event.data?.type === "REMINDER_NOTIFIED" && event.data?.id) {
+          notifiedIdsRef.current.add(event.data.id);
+        }
+      };
+    }
+
     const checkReminders = () => {
       const dueReminders = popDueReminders();
 
       dueReminders.forEach((reminder) => {
+        // Skip if this reminder has already been notified by another tab
+        if (notifiedIdsRef.current.has(reminder.id)) {
+          return;
+        }
+
+        // Add to our locally tracked notified set
+        notifiedIdsRef.current.add(reminder.id);
+
+        // Broadcast to other tabs that we've handled this reminder
+        if (channelRef.current) {
+          channelRef.current.postMessage({
+            type: "REMINDER_NOTIFIED",
+            id: reminder.id,
+          });
+        }
+
+        // Trigger notification
         toast.info(`${reminder.event.title} starts ${reminder.timingLabel}.`, {
           toastId: `reminder-due-${reminder.id}`,
           autoClose: 6000,
@@ -38,7 +71,12 @@ const ReminderChecker = () => {
     checkReminders();
     const intervalId = window.setInterval(checkReminders, CHECK_INTERVAL_MS);
 
-    return () => window.clearInterval(intervalId);
+    return () => {
+      window.clearInterval(intervalId);
+      if (channelRef.current) {
+        channelRef.current.close();
+      }
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
### Problem Solved
If a user keeps multiple Eventra browser tabs open, each tab runs its own `ReminderChecker` interval. When a reminder becomes due, every single tab pops it from storage and fires duplicate Toasts and browser push sounds. This floods the user with redundant alerts and degrades the premium feel of the platform.

### Approach
1. Established a native browser `BroadcastChannel` named `"eventra_reminder_sync_channel"` inside `ReminderChecker.js`.
2. When any tab first pops and displays a due reminder, it records it in a `notifiedIdsRef` and broadcasts a `"REMINDER_NOTIFIED"` event containing the unique `reminder.id` to all other open tabs.
3. Other tabs listen to the channel, add the ID to their locally tracked notified Set, and automatically suppress/skip showing duplicate toast alerts or browser notifications for that ID.
4. Correctly manages resources by closing the channel inside the React cleanup hook on unmount.
5. Fully backward-compatible and gracefully degrades to standard isolated checks if the environment does not support `BroadcastChannel`.

### Related Issues
Closes #4609

---
I am contributing on behalf of GSSoc’26!