### PR TITLE
fix(team-matchmaking): remove duplicate JSX props causing ESLint errors

### DIFF
--- a/src/Pages/Hackathons/components/TeamMatchmaking.jsx
+++ b/src/Pages/Hackathons/components/TeamMatchmaking.jsx
@@ -492,7 +492,7 @@ const TeamMatchmaking = () => {
                   <div className="border-t border-slate-100 dark:border-slate-850/60 pt-4 flex items-center justify-between gap-3">
                     <a
                       href={team.contact}
-                      target="_blank" rel="noopener noreferrer"
+                      target="_blank"
                       rel="noopener noreferrer"
                       className="px-4 py-2 bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-750 text-slate-700 dark:text-slate-300 rounded-xl text-xs font-bold flex items-center gap-1 transition"
                     >


### PR DESCRIPTION
## 🚀 Description

This PR resolves ESLint errors in the `TeamMatchmaking` component caused by duplicate JSX props.

The component contained one or more JSX elements with duplicate attributes, triggering the `No duplicate props allowed` lint rule. The redundant props were removed while preserving the intended prop values and existing component behavior.

### Changes made

* Identified duplicate JSX attributes in `src/Pages/Hackathons/components/TeamMatchmaking.jsx`
* Removed redundant duplicate props
* Kept the intended prop values to maintain current functionality
* Ensured the component continues to behave as expected
* Eliminated ESLint duplicate prop warnings

Fixes #4263 

## 🛠️ Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
Not applicable — this change only removes duplicate JSX props and does not introduce any visual or functional UI changes.

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
