### PR TITLE
[Feature] Guard useKeyboardShortcuts against contenteditable elements & add /notifications shortcut

### DIFF
--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -16,7 +16,8 @@ const useKeyboardShortcuts = ({
 
       const isTyping =
         active &&
-        ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName);
+        (["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName) ||
+          active.getAttribute("contenteditable") === "true");
 
       if (isTyping) return;
 
@@ -98,6 +99,9 @@ const useKeyboardShortcuts = ({
         keyBuffer.current = [];
       } else if (combo === "ga") {
         navigate("/leaderBoard");
+        keyBuffer.current = [];
+      } else if (combo === "gn") {
+        navigate("/notifications");
         keyBuffer.current = [];
       } else if (combo === "gf") {
         navigate("/faq");


### PR DESCRIPTION
Closes #4646. Enhances the input element typing check to include contenteditable elements (which prevents shortcuts from firing inside WYSIWYG editors or text description spaces). Additionally, adds the 'gn' key combo to quickly navigate to the notifications page. Contributing on behalf of GSSoc '26.