### PR TITLE
[Feature] Fix leaderboard monthly filter to use a real calendar-month window instead of top-40% heuristic

### DIFF
--- a/src/utils/leaderboardUtils.js
+++ b/src/utils/leaderboardUtils.js
@@ -25,6 +25,7 @@ export const LABEL_POINTS = {
   gssoclevel1: 3,
   gssoclevel2: 7,
   gssoclevel3: 10,
+  gssoclevel4: 15,
 };
 
 /** Fallback points for merged PRs with no recognised level label. */
@@ -108,6 +109,18 @@ export function filterContributors(contributors, search, activeCategory) {
     if (!matchSearch) return false;
 
     if (activeCategory === "monthly") {
+      const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+      const lastActive = c.lastActiveDate
+        ? new Date(c.lastActiveDate).getTime()
+        : c.latestPrDate
+        ? new Date(c.latestPrDate).getTime()
+        : 0;
+
+      if (lastActive > 0) {
+        return lastActive >= thirtyDaysAgo;
+      }
+
+      // Backwards-compatible fallback: top 40% threshold if no dates exist
       const threshold =
         contributors.length > 0
           ? contributors[Math.floor(contributors.length * 0.4)]?.points || 0


### PR DESCRIPTION
Closes #4647. Modifies filterContributors to use a rolling 30-day window check based on lastActiveDate/latestPrDate, falling back to the old percentile logic if dates are absent. Also registers points for gssoclevel4. Contributing on behalf of GSSoc '26.