### PR TITLE
fix: stabilize chatbot Escape key close handler

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -124,6 +124,13 @@ export default function Chatbot() {
     }
   }, [messages, isMinimized, isOpen, isTyping]);
 
+  const handleClose = useCallback(() => {
+    clearReplyTimer();
+    setIsTyping(false);
+    setIsOpen(false);
+    setIsMinimized(false);
+  }, [clearReplyTimer]);
+
   // Listen for Escape key to close the chatbot (accessibility)
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -135,7 +142,7 @@ export default function Chatbot() {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen]);
+  }, [handleClose, isOpen]);
 
   const wasOpenRef = useRef(false);
   const wasMinimizedRef = useRef(false);
@@ -195,13 +202,6 @@ export default function Chatbot() {
 
   const handleOpen = () => {
     setIsOpen(true);
-    setIsMinimized(false);
-  };
-
-  const handleClose = () => {
-    clearReplyTimer();
-    setIsTyping(false);
-    setIsOpen(false);
     setIsMinimized(false);
   };
 


### PR DESCRIPTION
Closes #4436

This PR stabilizes the chatbot close handler used by the global Escape key listener. The component already had Escape key handling, but the effect did not include the close handler in its dependency list. Moving `handleClose` above the listener and memoizing it with `useCallback` keeps the behavior dependency-correct while preserving the existing close behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Ran `git diff --check`
- [x] Performed self-review of the changed chatbot close flow
- [ ] Lint not run locally because dependencies were not installed and `npm ci` failed on the lockfile

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings from the checks I could run