### PR TITLE
fix: remove duplicate w-5/6 class in ProjectCardSkeleton

### DIFF
--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -40,7 +40,7 @@ const ProjectCardSkeleton = () => (
     <div className="p-6">
       <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-3/4 mb-4"></div>
       <div className="h-4 bg-gray-100 dark:bg-gray-600 rounded w-full mb-2"></div>
-      <div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded w-5/6 mb-4"></div>
+      <div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded mb-4"></div>
       <div className="flex flex-wrap gap-2 mb-4">
         <div className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-16"></div>
         <div className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-24"></div>


### PR DESCRIPTION
Closes #4709

---

## 📝 Description
Removed a duplicate `w-5/6` Tailwind CSS class from the description skeleton `div`
inside the `ProjectCardSkeleton` component in `ProjectsPage.js`.

This was a copy-paste error — the class appeared twice on the same element.
Tailwind silently ignores the duplicate but it:
- Triggers ESLint warnings
- Slightly increases bundle size
- Clutters the className string

---

## 📂 Files Changed
| File | Change |
|------|--------|
| `src/Pages/Projects/ProjectsPage.js` | Removed duplicate `w-5/6` class |

---

## 🔍 Code Diff

**Before:**
```jsx
<div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded w-5/6 mb-4"></div>
```

**After:**
```jsx
<div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded mb-4"></div>
```

---

## 🧪 Testing
- App loads without errors
- Projects page renders correctly
- Skeleton UI displays identically before and after
- No console errors or ESLint warnings

