### PR TITLE
fix: remove duplicate project skeleton width class

### DIFF
--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -40,7 +40,7 @@ const ProjectCardSkeleton = () => (
     <div className="p-6">
       <div className="h-6 bg-gray-200 dark:bg-gray-600 rounded w-3/4 mb-4"></div>
       <div className="h-4 bg-gray-100 dark:bg-gray-600 rounded w-full mb-2"></div>
-      <div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded w-5/6 mb-4"></div>
+      <div className="h-4 w-5/6 bg-gray-100 dark:bg-gray-600 rounded mb-4"></div>
       <div className="flex flex-wrap gap-2 mb-4">
         <div className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-16"></div>
         <div className="h-6 bg-gray-100 dark:bg-gray-600 rounded-full w-24"></div>


### PR DESCRIPTION
## Summary
- Remove the duplicate `w-5/6` Tailwind class from `ProjectCardSkeleton`
- Keep the skeleton layout unchanged while resolving the cleanup issue

## Validation
- `git diff --check`
- Targeted search confirmed the duplicate `w-5/6` class is no longer present

Closes #4709
