### PR TITLE
fix(ui): resolve preview tag layout overflow on mobile viewports

### DIFF
--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -1602,30 +1602,31 @@ const EventCreation = () => {
 
                 <div className="p-6 sm:p-8 space-y-6">
                   {/* Title & Category */}
+                  {/* Title & Category */}
                   <div>
-                    <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white mb-2">
-                      {formData.title || "Untitled Event"}
-                    </h3>
-                    <div className="flex flex-wrap gap-2">
-                      <span className="inline-flex items-center px-3 py-1 rounded-lg 
-                                     bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 
-                                     dark:text-indigo-300 text-sm font-medium">
-                        {categories.find(c => c.value === formData.category)?.label || "Uncategorized"}
-                      </span>
-                      {formData.tags.slice(0, 3).map((tag, i) => (
-                        <span key={i} className="inline-flex items-center px-2.5 py-0.5 
-                                               rounded-full bg-gray-100 dark:bg-gray-700 
-                                               text-gray-700 dark:text-gray-300 text-xs">
-                          #{tag}
+                  <h3 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white mb-2 break-words">
+                  {formData.title || "Untitled Event"}
+                  </h3>
+                  <div className="flex flex-wrap items-center gap-2 w-full max-w-full overflow-hidden">
+                  <span className="inline-flex items-center px-3 py-1 rounded-lg flex-shrink-0
+                  bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700
+                  dark:text-indigo-300 text-sm font-medium break-words max-w-full">
+                    {categories.find(c => c.value === formData.category)?.label || "Uncategorized"}
+                    </span>
+                    {formData.tags.slice(0, 3).map((tag, i) => (
+                      <span key={i} className="inline-flex items-center px-2.5 py-0.5
+                      rounded-full bg-gray-100 dark:bg-gray-700
+                      text-gray-700 dark:text-gray-300 text-xs break-all max-w-[150px] sm:max-w-xs truncate">
+                        #{tag}
                         </span>
                       ))}
                       {formData.tags.length > 3 && (
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                        <span className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0">
                           +{formData.tags.length - 3} more
-                        </span>
-                      )}
-                    </div>
-                  </div>
+                          </span>
+                        )}
+                        </div>
+                        </div>
 
                   {/* Description */}
                   <p className="text-gray-600 dark:text-gray-300 leading-relaxed">


### PR DESCRIPTION
### Overview
This Pull Request resolves the mobile UI layout overflow bug where long or multiple event tags inside the `EventCreation` preview wrapper would clip past the card container boundaries or trigger an undesirable horizontal scroll on screens smaller than `640px`.

### Changes Made
- Added `break-words` and `overflow-hidden` constraints to the tag preview flex wrapper.
- Implemented `break-all`, explicit `max-w`, and CSS `truncate` ellipsis fallback text processing onto individual event tags to handle exceptionally long text strings safely.
- Appended `flex-shrink-0` layout configuration onto the `+X more` indicator element to block structural text smashing on tightly constrained device viewports.

### Verification
Verified against responsive viewport layouts via browser developer inspection configurations utilizing mock data vectors. 

Closes #4170