### PR TITLE
fix: remove user-scalable=no from viewport meta tag (WCAG 2.1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <!-- Responsive -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
 
     <!-- Theme -->


### PR DESCRIPTION
## Summary

Removes `maximum-scale=1` and `user-scalable=no` from the `viewport` meta tag in `index.html`.

## Why

These attributes prevent users from pinch-zooming, which:
- Violates **WCAG 2.1 Success Criterion 1.4.4** (Resize text)
- Violates **WCAG 2.1 Success Criterion 1.4.10** (Reflow)
- Makes the app inaccessible for low-vision users who rely on zoom

The fix preserves `viewport-fit=cover` for iOS safe-area handling.

## Change

```diff
- content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+ content="width=device-width, initial-scale=1, viewport-fit=cover"
```

Fixes #4742