### PR TITLE
fix: describe QR ticket modal actions

### DIFF
--- a/src/components/common/QRTicket/QRTicketModal.jsx
+++ b/src/components/common/QRTicket/QRTicketModal.jsx
@@ -148,7 +148,7 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
             disabled={downloading}
             className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4 rounded-xl text-sm font-semibold text-white transition-opacity disabled:opacity-50"
             style={{ background: "#7c3aed" }}
-           aria-label="button">
+           aria-label="Save ticket as PNG">
             <DownloadIcon />
             {downloading ? "Saving…" : "Save PNG"}
           </button>
@@ -163,7 +163,7 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
               color: "white",
               border: "1px solid rgba(255,255,255,0.12)",
             }}
-           aria-label="button">
+           aria-label="Download ticket as PDF">
             <FileIcon />
             {downloading ? "…" : "PDF"}
           </button>
@@ -177,7 +177,7 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
               color: "white",
               border: "1px solid rgba(255,255,255,0.12)",
             }}
-           aria-label="button">
+           aria-label="Share ticket">
             <ShareIcon />
             Share
           </button>


### PR DESCRIPTION
## Summary
Improved accessibility for QR ticket modal action buttons by replacing generic `aria-label="button"` values with descriptive action labels.

## Changes
- Updated PNG download button label to `Save ticket as PNG`
- Updated PDF download button label to `Download ticket as PDF`
- Updated share button label to `Share ticket`

## Testing
- Verified the diff in `src/components/common/QRTicket/QRTicketModal.jsx`
- Confirmed `aria-label="button"` is no longer present in `QRTicketModal.jsx`
- Not run: project dependencies are not installed locally

Closes #4774 