### PR TITLE
fix: resolve Events page crash - correct CountUp component import

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -7,7 +7,7 @@ import ModernSearchInput from "../../components/common/ModernSearchInput";
 import CountUpLib from "react-countup";
 import { darkTheme } from "../../components/styles/theme";
 
-const CountUp = CountUpLib;
+const CountUp = CountUpLib.default || CountUpLib;
 
 // 🔥 THE FIX: Single, clean declarations placed in the correct order 🔥
 const SEARCH_HISTORY_KEY = "eventra.events.searchHistory";


### PR DESCRIPTION
Fixes #4818

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## 🚀 Description
EventHero.js imported CountUpLib from react-countup and assigned 
it directly to CountUp. However, react-countup's default export 
resolves to an object in this environment, not a React component,
causing a complete page crash for all users visiting /events.

Fixed by using CountUpLib.default || CountUpLib to safely resolve
the correct component reference.

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings