### PR TITLE
Fix: Correct broken TOC anchor to match Architecture & Documentation heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Eventra is a comprehensive, open-source platform designed to empower organizers 
 - [Overview](#overview)
 - [Live Demo](#live-demo)
 - [API Reference](#api-reference)
-- [Architecture & Roles](#-architecture--roles)
+<!-- Fix: Corrected broken TOC anchor to match actual heading 'Architecture & Documentation' -->
+- [Architecture & Documentation](#architecture--documentation)
 - [Project Insights](#project-insights)
 - [Features](#features)
 - [Tech Stack](#tech-stack)


### PR DESCRIPTION
## 🚀 Description
Fixed a broken Table of Contents anchor link in README.md.

The TOC had [Architecture & Roles](#-architecture--roles) 
but the actual section heading is "Architecture & Documentation".
This mismatch caused the TOC link to not navigate to the 
correct section when clicked.

Fixed by updating both the link text and anchor to match 
the actual heading "Architecture & Documentation".

Fixes #

## 🛠️ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## 📸 Screenshots / Video (if applicable)
No visual changes — documentation fix only.

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings