### PR TITLE
fix: preserve signup response roles

### DIFF
--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { API_ENDPOINTS, apiUtils } from "../../config/api";
 import { useAuth } from "../../context/AuthContext";
+import { resolveSignupRoles } from "../../utils/signupRoleUtils.js";
 import { FormFieldWrapper, ValidationMessage } from "../forms";
 import PasswordStrengthIndicator from "./PasswordStrengthIndicator";
 import { User, AtSign, Lock, Eye, EyeOff, Zap } from "lucide-react";
@@ -251,14 +252,15 @@ const SignupForm = () => {
         return;
       }
 
+      const roles = resolveSignupRoles(data);
       const sessionUser = {
         id: data?.id,
         firstName: data?.firstName ?? formData.firstName.trim(),
         lastName: data?.lastName ?? formData.lastName.trim(),
         email: data?.email ?? formData.email.trim(),
         username: data?.username ?? formData.email.trim(),
-        role: data?.role ?? "USER",
-        roles: data?.role ? [data.role] : ["USER"],
+        role: roles[0],
+        roles,
         permissions: data?.permissions ?? [],
       };
 

--- a/src/utils/signupRoleUtils.js
+++ b/src/utils/signupRoleUtils.js
@@ -1,0 +1,34 @@
+import { ROLES } from "../config/roles.js";
+
+const VALID_APP_ROLES = new Set(Object.values(ROLES));
+const LEGACY_ROLE_ALIASES = {
+  USER: ROLES.ATTENDEE,
+};
+
+const normalizeRole = (role) => {
+  if (typeof role !== "string") return null;
+
+  const normalized = role.trim().toUpperCase();
+  return LEGACY_ROLE_ALIASES[normalized] ?? normalized;
+};
+
+export const resolveSignupRoles = (data = {}) => {
+  const roleCandidates =
+    Array.isArray(data.roles) && data.roles.length > 0 ? data.roles : [data.role];
+
+  const roles = roleCandidates.reduce((resolvedRoles, role) => {
+    const normalizedRole = normalizeRole(role);
+
+    if (
+      normalizedRole &&
+      VALID_APP_ROLES.has(normalizedRole) &&
+      !resolvedRoles.includes(normalizedRole)
+    ) {
+      resolvedRoles.push(normalizedRole);
+    }
+
+    return resolvedRoles;
+  }, []);
+
+  return roles.length > 0 ? roles : [ROLES.ATTENDEE];
+};

--- a/tests/signupRoleUtils.test.mjs
+++ b/tests/signupRoleUtils.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+
+import { ROLES } from "../src/config/roles.js";
+import { resolveSignupRoles } from "../src/utils/signupRoleUtils.js";
+
+assert.deepEqual(resolveSignupRoles({ roles: ["ORGANIZER"] }), [ROLES.ORGANIZER]);
+
+assert.deepEqual(resolveSignupRoles({ roles: ["organizer", "ORGANIZER", "VOLUNTEER"] }), [
+  ROLES.ORGANIZER,
+  ROLES.VOLUNTEER,
+]);
+
+assert.deepEqual(resolveSignupRoles({ role: "ADMIN" }), [ROLES.ADMIN]);
+
+assert.deepEqual(resolveSignupRoles({ roles: ["UNKNOWN"], role: "ADMIN" }), [ROLES.ATTENDEE]);
+
+assert.deepEqual(resolveSignupRoles({ roles: ["USER"] }), [ROLES.ATTENDEE]);
+
+assert.deepEqual(resolveSignupRoles({}), [ROLES.ATTENDEE]);
+
+console.log("signup role normalization verified");


### PR DESCRIPTION
## What I found

Closes #4806.

I traced the signup flow from the API response into the first client session. The form only read `data.role`, so an API response containing the canonical `roles` array silently lost those server-assigned roles and fell back to `USER`. That fallback is also inconsistent with the role constants used by the app.

## What I changed

I added `resolveSignupRoles()` and used it at the current signup submission point. It prefers a non-empty `data.roles` array, falls back to `data.role`, normalizes and deduplicates values, rejects roles unknown to `src/config/roles.js`, and maps the legacy `USER` value to `ATTENDEE`.

I kept the change to the current signup component and a small utility rather than spreading normalization across the authentication flow. The regression test covers array and singular responses, duplicates, casing, legacy `USER`, invalid values, and missing roles. I also rebuilt the branch on current `master` so this PR no longer contains merge-history conflicts or unrelated files.

## Verification

- `node tests/signupRoleUtils.test.mjs` passes
- `node --check src/utils/signupRoleUtils.js` passes
- `git diff --check upstream/master...HEAD` passes
- `npm test` discovers and runs the new test; the checkout still has five unrelated baseline failures: `errorMessages`, `eventDetails`, `eventRegistrationAdditionalInfo`, `rateLimitUtils`, and `sseMultiplexer`
- I could not run `npm run lint -- --quiet` because this checkout does not have the `eslint` dependency installed

This is my GSSoC 2026 fix for the assigned issue.