### PR TITLE
ci: implement compulsory clang-format pre-commit hook and workflows

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+SortIncludes: true

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,26 @@
+name: Clang-Format Check
+
+on:
+  pull_request:
+    paths:
+      - "**.cpp"
+      - "**.hpp"
+      - "**.c"
+      - "**.h"
+      - "**.cc"
+      - "**.cxx"
+
+jobs:
+  formatting-check:
+    name: Check Code Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run clang-format style check
+        uses: jidicula/clang-format-action@v4.13.0
+        with:
+          clang-format-version: "18"
+          check-path: "."
+          fallback-style: "Google"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.3
+    hooks:
+      - id: clang-format
+        types_or: [c++, c]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,18 @@ You can help improve Eventra in several ways:
 ```bash
 git checkout -b feature/amazing-feature
 ```
+
+**2.5. Set Up Pre-commit Hooks (Crucial for C++ & Formatting)**
+We enforce strict formatting rules using `pre-commit` and `clang-format`. You must set this up before committing code.
+```bash
+# Install the pre-commit tool (requires Python)
+pip install pre-commit
+
+# Install the git hook scripts in your local repository
+pre-commit install
+```
+Now, clang-format will automatically check and format your C++ files every time you run git commit.
+
 3. Make Your Changes
 Follow the code standards and test your changes locally.
 4. Commit Your Changes
@@ -77,6 +89,13 @@ Submit a PR with a clear description of your changes.
 ## 🧩 Code Standards  
 
 Maintaining consistent coding standards ensures readability, maintainability, and collaboration across **Eventra**.
+
+---
+
+### 🛠️ C++ Standards (Core Engine)
+- Follow **Google C++ Style Guide** for all `.cpp`, `.h`, `.cc`, and `.hpp` files.
+- Ensure strict adherence to our formatting rules using `clang-format`.
+- Use modern C++ features where applicable but maintain performance and memory safety.
 
 ---
 
@@ -176,6 +195,7 @@ Here are some practical examples following our **Conventional Commits** guidelin
 - `refactor: simplify event creation logic` – Refactors code without adding features or fixing bugs.  
 - `test: add integration tests for event routes` – Adds or updates tests.  
 - `chore: update dependencies and clean up scripts` – Routine maintenance tasks.  
+- `ci: setup clang-format pre-commit hook and workflows` – CI/CD or automation changes.  
 
 > ✅ Using these clear and descriptive messages keeps the git history readable and makes collaboration easier.
 


### PR DESCRIPTION
Closes #124

**What does this PR do?**
This PR enforces a consistent C++ coding style across the repository by introducing a mandatory `clang-format` pre-commit hook and a corresponding GitHub Actions CI pipeline.

**Changes Made:**
1. **`.clang-format`**: Added the configuration file based on the standard `Google` style.
2. **`.pre-commit-config.yaml`**: Configured the pre-commit framework to automatically check and format all `.cpp`, `.hpp`, `.c`, and `.h` files.
3. **GitHub Actions (`format-check.yml`)**: Added a CI workflow that runs on every Pull Request to ensure no unformatted code gets merged.
4. **`CONTRIBUTING.md`**: Added a new section explaining how contributors can set up the pre-commit hook locally before pushing their code.