### PR TITLE
fix(test): use defineProperty for navigator mock in cspReporting tests

### DIFF
--- a/tests/cspReporting.test.mjs
+++ b/tests/cspReporting.test.mjs
@@ -39,12 +39,16 @@ global.Blob = MockBlob;
 
 // Mock navigator.sendBeacon
 let beaconSent = null;
-global.navigator = {
-  sendBeacon(url, blob) {
-    beaconSent = { url, blob };
-    return true;
-  }
-};
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  writable: true,
+  value: {
+    sendBeacon(url, blob) {
+      beaconSent = { url, blob };
+      return true;
+    },
+  },
+});
 
 // Import functions dynamically so NODE_ENV changes are active during evaluation
 const { initCspReporting, teardownCspReporting } = await import("../src/utils/cspReporting.js");
@@ -108,7 +112,6 @@ if (originalReportUri === undefined) {
 }
 console.warn = originalConsoleWarn;
 delete global.document;
-delete global.navigator;
 delete global.Blob;
 
 console.log("cspReporting tests passed ✓");


### PR DESCRIPTION
## Summary
- Replaces direct `global.navigator = ...` assignment with `Object.defineProperty` so cspReporting tests run on Node 22+.

## Test plan
- [x] `node --loader ./tests/loaders/jsExtension.mjs tests/cspReporting.test.mjs`

Closes #4625

Made with [Cursor](https://cursor.com)