### PR TITLE
fix(auth): import node:crypto for randomUUID in signup endpoint

### DIFF
--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -1,4 +1,5 @@
 import bcrypt from "bcryptjs";
+import crypto from "node:crypto";
 import jwt from "jsonwebtoken";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 


### PR DESCRIPTION
## Summary
- Adds `import crypto from "node:crypto"` so `crypto.randomUUID()` works in the signup serverless handler.

## Test plan
- [x] `node tests/signupEndpoint.test.mjs`

Closes #4841

Made with [Cursor](https://cursor.com)