### PR TITLE
fix(auth): import node:crypto for randomUUID in google OAuth endpoint

### DIFF
--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import jwt from "jsonwebtoken";
 import { OAuth2Client } from "google-auth-library";
 import { users } from "./signup.js";


### PR DESCRIPTION
## Summary
- Adds `import crypto from "node:crypto"` so `crypto.randomUUID()` works in the Google OAuth handler.

## Test plan
- [x] `node tests/googleOAuthEndpoint.test.mjs`

Closes #4856

Made with [Cursor](https://cursor.com)