### PR TITLE
fix(api): prefer server-side GITHUB_REPO env in leaderboard endpoint

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -1,4 +1,7 @@
-const GITHUB_REPO = process.env.REACT_APP_GITHUB_REPO || "SandeepVashishtha/Eventra";
+const GITHUB_REPO =
+  process.env.GITHUB_REPO ||
+  process.env.REACT_APP_GITHUB_REPO ||
+  "SandeepVashishtha/Eventra";
 
 const POINTS = {
   gssoclevel1: 3,


### PR DESCRIPTION
## Summary
- Reads `process.env.GITHUB_REPO` first in `api/leaderboard.js`, with `REACT_APP_GITHUB_REPO` kept as fallback for compatibility.

## Test plan
- [x] Manual review of env precedence

Closes #4876

Made with [Cursor](https://cursor.com)