### PR TITLE
fix: add index fallback for undefined ev.id key in CalendarView

### DIFF
--- a/src/components/CalendarView.jsx
+++ b/src/components/CalendarView.jsx
@@ -24,11 +24,11 @@ const CalendarView = ({ events }) => {
         Your Registered Events
       </h3>
       <ul className="space-y-3">
-        {events.map((reg) => {
+        {events.map((reg, index) => {
           const ev = reg.event || reg;
           return (
             <li
-              key={ev.id}
+              key={ev.id ?? `reg-${index}`}
               className="p-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
             >
               <p className="font-medium text-gray-900 dark:text-gray-100">


### PR DESCRIPTION
Fixes #4893

**Problem:**
In `events.map((reg) => ...)`, `const ev = reg.event || reg` can resolve to an object with no `.id`. When `ev.id` is undefined, React silently falls back to array index — causing incorrect component reuse and stale renders.

**Fix:**
- Added `index` to the `.map()` callback
- Changed `key={ev.id}` to `key={ev.id ?? \`reg-${index}\`}`

**Files changed:**
- `src/components/CalendarView.jsx` 