### PR TITLE
fix: replace meaningless aria-label with descriptive label on certificate download button

### DIFF
--- a/src/components/CertificateDownload.jsx
+++ b/src/components/CertificateDownload.jsx
@@ -58,7 +58,7 @@ const CertificateDownload = ({ eventName, eventDate, eventType }) => {
   };
 
   return (
-  <button onClick={generateCertificate} aria-label="button">
+  <button onClick={generateCertificate} aria-label="Download participation certificate">
     📜 Download Certificate
   </button>
 );


### PR DESCRIPTION
Fixes #4900

**Problem:**
`aria-label="button"` on the download button in `CertificateDownload.jsx` is redundant — screen readers already announce the element role as "button". Users hear "button, button" with zero context about the action. This violates WCAG 2.1 SC 4.1.2 (Name, Role, Value).

**Fix:**
Changed `aria-label="button"` to `aria-label="Download participation certificate"`

**Files changed:**
- `src/components/CertificateDownload.jsx` 