### PR TITLE
fix: use Lenis scrollTo in BackToTopButton when Lenis is active

### DIFF
--- a/src/components/common/BackToTopButton.jsx
+++ b/src/components/common/BackToTopButton.jsx
@@ -29,10 +29,11 @@ const BackToTopButton = ({ threshold = 300, positionClass = "bottom-6 right-6" }
   }, [threshold]);
 
   const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
+    if (window.lenis) {
+      window.lenis.scrollTo(0, { immediate: false });
+    } else {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
   };
 
   return (


### PR DESCRIPTION
Fixes #4906

**Problem:**
`BackToTopButton.jsx` always calls `window.scrollTo()` directly. When Lenis smooth-scroll is active, this conflicts with Lenis's scroll hijacking — causing a jerky animation. `ScrollToTop.jsx` (lines 16–19) already has the correct Lenis guard pattern but `BackToTopButton.jsx` did not.

**Fix:**
Added a `window.lenis` check — uses `window.lenis.scrollTo()` when Lenis is active, falls back to `window.scrollTo()` otherwise.

**Files changed:**
- `src/components/common/BackToTopButton.jsx` 