### PR TITLE
fix: add null guard to validate.password to prevent TypeError

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -44,7 +44,7 @@ export const validate = {
     return EMAIL_REGEX.test(val) || "Invalid email format";
   },
 
-  password: (val) => val.length >= 8 || "Password must be at least 8 characters",
+  password: (val) => (val && val.length >= 8) || "Password must be at least 8 characters",
 
   required: (val) => (val && val.trim() !== "") || "This field is required",
 


### PR DESCRIPTION
### Description
Fixes a bug in `src/validation.js` where `validate.password` throws `TypeError: Cannot read properties of null (reading 'length')` when called with `null` or `undefined`.

The `validate.email` function on line 43 correctly guards against null values, but `validate.password` on line 47 does not. This one-line fix adds the same null guard pattern.

### Before
```js
password: (val) => val.length >= 8 || "Password must be at least 8 characters",
```

### After
```js
password: (val) => (val && val.length >= 8) || "Password must be at least 8 characters",
```

### Difficulty & Label Request
- Assessed difficulty: **level:beginner**
- Maintainer: please apply the `level:beginner` label if this assessment is appropriate, so this contribution is scored correctly under GSSoC 2026 guidelines.
- Maintainer: please also apply the `gssoc:approved` label after review so this PR earns its base GSSoC points. Thank you!

### Type
- [x] Bug fix

### Testing & Verification
- [x] `validate.password(null)` now returns error message instead of throwing TypeError
- [x] `validate.password(undefined)` now returns error message instead of throwing TypeError
- [x] `validate.password("short")` still returns error message for short passwords
- [x] `validate.password("validPass1!")` still returns `true` for valid passwords

### GSSoC 2026 Compliance & Transparency
- **AI Assistance Disclosure:** AI assistance was used to develop this solution. All generated logic has been audited, verified, and locally tested by me to meet project standards.
- Closes #4903