### PR TITLE
feat: improve mobile-first responsiveness for 320px-480px screens in …

### DIFF
--- a/src/components/user/UserDashboard.css
+++ b/src/components/user/UserDashboard.css
@@ -1781,3 +1781,82 @@
     gap: var(--ud-space-md);
   }
 }
+/* ── Extra small screens (320px - 480px) mobile-first fixes ── */
+@media (max-width: 380px) {
+  .ud-topbar {
+    padding: 0.75rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .ud-username {
+    font-size: 1.1rem;
+  }
+
+  .ud-greeting {
+    font-size: 0.72rem;
+  }
+
+  .ud-search {
+    width: 100px;
+  }
+
+  .ud-search-wrap:focus-within {
+    width: 180px;
+  }
+
+  .ud-content {
+    padding: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  .ud-stats-grid {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .ud-quick-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.65rem;
+  }
+
+  .ud-stat-card {
+    padding: 0.85rem;
+  }
+
+  .ud-stat-value {
+    font-size: 1.4rem;
+  }
+
+  .ud-three-col {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .ud-card {
+    padding: 0.85rem;
+  }
+
+  .ud-topbar-right {
+    gap: 0.35rem;
+  }
+
+  .ud-footer {
+    padding: 1rem 0.75rem;
+  }
+
+  .ud-footer-links {
+    gap: 0.65rem;
+  }
+
+  .ud-notif-panel {
+    width: 260px;
+    right: -40px;
+  }
+
+  .ud-table th,
+  .ud-table td {
+    padding: 0.6rem 0.5rem;
+    font-size: 0.78rem;
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3024

## Rationale for this change
The dashboard had spacing and overflow issues on very small viewports (320px-480px). 
Elements like the topbar, stat cards, and quick actions were cramped or cut off 
on iPhone SE and similar small devices.

## What changes are included in this PR?
- Added targeted media query for max-width 380px in UserDashboard.css
- Reduced topbar padding and username font size on tiny screens
- Narrowed search input width on small viewports
- Forced single-column layout for stats grid on very small screens
- Reduced card padding and gap for better space usage
- Fixed notification panel overflow on narrow screens
- Reduced table cell padding for better horizontal fit
- EventDetailsPage and Footer were already mobile-optimized

## Are these changes tested?
Manually tested on Chrome DevTools with iPhone SE (375px) and Galaxy S8 (360px) 
viewports.

## Are there any user-facing changes?
Yes — dashboard now renders correctly on small mobile devices without overflow 
or cramped elements.