### PR TITLE
fix(auth): prevent stale context state from allowing expired JWTs into ProtectedRoute

### DIFF
--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -16,10 +16,12 @@ const ProtectedRoute = ({
   const { isAuthenticated, hasRole, hasPermission, loading, user, token, logout } = useAuth();
   const location = useLocation();
 
-  // SECURITY: Distinguish between "never had a token" and "had a token that expired".
-  // Passing sessionExpired lets the Login page show a contextual banner
-  // instead of silently dropping the user on the login form.
-  const sessionExpired = requireAuth && !loading && !isAuthenticated() && !!token && !isTokenValid(token);
+  // 🔥 SECURITY FIX: Calculate true token expiration independent of stale React context state.
+  // This prevents expired tokens from bypassing the gatekeeper if isAuthenticated() hasn't updated yet.
+  const isTokenExpired = !!token && !isTokenValid(token);
+  
+  // sessionExpired now properly flags if the token died, even if the context still thinks they are logged in.
+  const sessionExpired = requireAuth && !loading && isTokenExpired;
 
   // Clean up stale session data cleanly via useEffect to avoid updating the
   // AuthProvider component's state during the ProtectedRoute render phase.
@@ -38,8 +40,8 @@ const ProtectedRoute = ({
     );
   }
 
-  // Check if authentication is required
-  if (requireAuth && !isAuthenticated()) {
+  // 🔥 SECURITY FIX: Actively block the route if the context says they are logged out OR the token mathematically expired.
+  if (requireAuth && (!isAuthenticated() || sessionExpired)) {
     return (
       <Navigate
         to={redirectTo}


### PR DESCRIPTION
## Description
This PR patches a critical RBAC (Role-Based Access Control) vulnerability in `ProtectedRoute.js`. Previously, the route gatekeeper relied solely on React Context (`isAuthenticated()`), which does not automatically update when a JWT natively expires in the background. This allowed expired sessions to bypass the `<Navigate>` block and render protected content to the DOM.

**Changes made:**
- **Decoupled Validity Check:** Calculated mathematical token validity (`isTokenValid`) independently from the stale React Context state.
- **Accurate Expiration Flagging:** Updated the `sessionExpired` variable to accurately flag tokens that have naturally died, even if context still believes the user is authenticated.
- **Active Interception:** Modified the main gatekeeper condition to actively block requests and redirect to `/login` if the context indicates a logout OR the token mathematically expired.

Fixes #4942 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security / RBAC patch (Prevents expired session leaks)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code