### PR TITLE
fix(config): default to relative API URLs for all non-development env…

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -27,8 +27,8 @@ const resolveEnvApiBaseUrl = () => {
   if (envUrl) {
     return normalizeApiBaseUrl(envUrl);
   }
-  if (process.env.NODE_ENV === "production") {
-    console.warn("VITE_API_URL environment variable is missing in production. Defaulting to relative API requests.");
+  if (!isDev) {
+    console.warn(`VITE_API_URL environment variable is missing in ${process.env.NODE_ENV}. Defaulting to relative API requests.`);
     return "";
   }
   return "http://localhost:8080";


### PR DESCRIPTION
## Description This PR fixes a critical environment configuration bug that caused API requests to fail in non-production deployment environments (like staging, preview, or test).
Closes #4950 
Previously, if VITE_API_URL was not explicitly provided in the environment variables, the fallback logic only used a safe relative URL "" if NODE_ENV === "production". Any other environment (e.g., staging) would incorrectly fall back to "http://localhost:8080", breaking the app for QA testers and automated preview builds.

### Changes Made

Robust Environment Fallback (src/config/api.js): Updated the resolveEnvApiBaseUrl function to check if (!isDev) instead of explicitly checking for "production". This ensures that all deployed environments correctly default to relative API paths when an explicit URL is not provided.
## Impact The frontend can now be safely deployed to staging, testing, and preview environments without API requests breaking by trying to target a local developer port.

