### PR TITLE
refactor(cache): replace manual localStorage cache with useRecentlyVi…

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -22,13 +22,14 @@ import ShareMenu from "../../components/common/ShareMenu";
 import ShareModal from "../../components/common/ShareModal";
 import { generateEventSharingData } from "../../utils/shareUtils";
 import { downloadICSFile, generateGoogleCalendarLink, generateOutlookLink } from "../../utils/calendarExporter";
-import { safeParseJson } from "../../utils/jsonUtils";
+import useRecentlyViewed from "../../hooks/useRecentlyViewed";
 import { apiUtils, API_ENDPOINTS } from "../../config/api";
 import mockEvents from "./eventsMockData.json";
 
 const EventDetails = () => {
   const { eventId } = useParams();
   const { user } = useAuth();
+  const { addRecentlyViewed } = useRecentlyViewed();
 
   const isOrganizer = user?.roles?.includes(ROLES.ORGANIZER) || user?.roles?.includes(ROLES.ADMIN);
 
@@ -70,22 +71,11 @@ const EventDetails = () => {
     loadEvent();
   }, [loadEvent]);
 
-  // Safely handle localStorage with try-catch
+  // Safely handle localStorage cache updates via hook
   useEffect(() => {
     if (!event) return;
-
-    try {
-      const viewedEvents = safeParseJson(localStorage.getItem("recentlyViewedEvents"), []);
-      const updatedEvents = [
-        event,
-        ...viewedEvents.filter((item) => item.id !== event.id),
-      ].slice(0, 6);
-
-      localStorage.setItem("recentlyViewedEvents", JSON.stringify(updatedEvents));
-    } catch {
-      // localStorage unavailable — not critical
-    }
-  }, [event]);
+    addRecentlyViewed(event);
+  }, [event, addRecentlyViewed]);
 
   const handlePrint = () => {
     setIsPrinting(true);


### PR DESCRIPTION
## Description This PR fixes a caching architecture flaw in EventDetails.js where the entire raw event object was being pushed directly into localStorage.
Closes #4952 
Previously, EventDetails.js manually managed the recentlyViewedEvents array. Storing massive, un-trimmed event objects caused local storage bloat and resulted in stale UI rendering (if an event's location or status changed on the backend, the "Recently Viewed" section would continue to display the outdated cached copy indefinitely).

### Changes Made

Hook Integration (src/Pages/Events/EventDetails.js): Completely removed the raw localStorage try-catch block and replaced it with the centralized useRecentlyViewed hook.
The hook safely reduces the object payload down to the minimal required UI fields and strictly enforces a 7-day TTL (Time To Live), keeping the browser storage lean and ensuring users only see fresh data.
## Impact Dramatically reduces browser memory footprint and completely eliminates the stale data bug in the "Recently Viewed" section. This also standardizes caching logic across the codebase.

