### PR TITLE
fix(docs): correct Architecture TOC anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Eventra is a comprehensive, open-source platform designed to empower organizers 
 - [Overview](#overview)
 - [Live Demo](#live-demo)
 - [API Reference](#api-reference)
-- [Architecture & Roles](#-architecture--roles)
+- [Architecture & Documentation](#architecture--documentation)
 - [Project Insights](#project-insights)
 - [Features](#features)
 - [Tech Stack](#tech-stack)


### PR DESCRIPTION
## Summary
- Updates README TOC link to match the `Architecture & Documentation` heading anchor.

## Test plan
- [x] Verified anchor slug matches heading

Closes #4843

Made with [Cursor](https://cursor.com)