### PR TITLE
fix(validation): guard null password input before length check

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -44,7 +44,8 @@ export const validate = {
     return EMAIL_REGEX.test(val) || "Invalid email format";
   },
 
-  password: (val) => val.length >= 8 || "Password must be at least 8 characters",
+  password: (val) =>
+    (val && val.length >= 8) || "Password must be at least 8 characters",
 
   required: (val) => (val && val.trim() !== "") || "This field is required",
 

--- a/tests/validatePasswordSync.test.mjs
+++ b/tests/validatePasswordSync.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.resolve(__dirname, "../src/validation.js"), "utf8");
+
+assert.match(
+  src,
+  /password:\s*\(val\)\s*=>\s*\n?\s*\(val && val\.length >= 8\)/,
+  "validate.password must guard null/undefined before reading length",
+);
+
+console.log("validate.password sync guard tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds null/empty guard to `validate.password` and a contract test to prevent regressions.

## Test plan
- [x] `node tests/validatePasswordSync.test.mjs`

Closes #4903

Made with [Cursor](https://cursor.com)