### PR TITLE
fix(a11y): improve dark mode hero subtitle contrast

### DIFF
--- a/src/components/styles/components.css
+++ b/src/components/styles/components.css
@@ -557,7 +557,11 @@
   transition: color 0.3s ease;
 }
 .dark .hero-subtitle {
-  color: #d1d5db;
+  color: #e5e7eb;
+}
+
+.dark .hero-subtitle strong {
+  color: #93c5fd;
 }
 
 /* Highlight strong tags inside subtitle */


### PR DESCRIPTION
## Summary
- Lightens dark-mode hero subtitle text and strong-tag accent colors for better WCAG contrast.

## Test plan
- [x] CSS review of dark-mode hero subtitle colors

Closes #4916

Made with [Cursor](https://cursor.com)