### PR TITLE
test(utils): add boundary assertions for routeSearchUtils

### DIFF
--- a/tests/routeSearchUtils.edge.test.mjs
+++ b/tests/routeSearchUtils.edge.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+
+import { getRouteSearchResults, normalizeSearchText } from "../src/utils/searchUtils.mjs";
+
+assert.equal(normalizeSearchText(null), "");
+assert.equal(normalizeSearchText(undefined), "");
+assert.equal(normalizeSearchText(["Cloud", "Native"]), "cloud native");
+
+const items = [
+  { title: "Café Meetup", description: "networking", location: "Paris" },
+  { title: "Rust Workshop", description: "systems", location: "Berlin" },
+];
+
+assert.equal(
+  getRouteSearchResults(items, "cafe", ["title"]).length,
+  1,
+  "accent-insensitive route search matches normalized text",
+);
+
+assert.deepEqual(
+  getRouteSearchResults(items, "   ", ["title", "description"]).map((item) => item.title),
+  items.map((item) => item.title),
+  "whitespace-only queries return the full listing",
+);
+
+assert.deepEqual(
+  getRouteSearchResults([], "rust", ["title"]),
+  [],
+  "empty datasets safely return no matches",
+);
+
+console.log("routeSearchUtils edge-case tests passed ✓");


### PR DESCRIPTION
## Summary
- Adds `tests/routeSearchUtils.edge.test.mjs` for normalization, accent matching, and empty query handling.

## Test plan
- [x] `node tests/routeSearchUtils.edge.test.mjs`

Closes #4992

Made with [Cursor](https://cursor.com)