### PR TITLE
fix(hooks): prevent useDebouncedSearch debounce reset loop

### DIFF
--- a/src/hooks/useDebouncedSearch.js
+++ b/src/hooks/useDebouncedSearch.js
@@ -13,8 +13,17 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
   const [debouncedTerm, setDebouncedTerm] = useState(initialValue);
   const [isDebouncing, setIsDebouncing] = useState(false);
   const timerRef = useRef(null);
+  const delayRef = useRef(delay);
 
   useEffect(() => {
+    delayRef.current = delay;
+  }, [delay]);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
     if (searchTerm === debouncedTerm) {
       setIsDebouncing(false);
       return;
@@ -22,22 +31,17 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
 
     setIsDebouncing(true);
 
-    // Clear any existing timeout to reset the debounce timer
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-    }
-
     timerRef.current = setTimeout(() => {
       setDebouncedTerm(searchTerm);
       setIsDebouncing(false);
-    }, delay);
+    }, delayRef.current);
 
     return () => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
       }
     };
-  }, [searchTerm, debouncedTerm, delay]);
+  }, [searchTerm]);
 
   const clear = useCallback(() => {
     setSearchTerm('');

--- a/tests/useDebouncedSearch.test.mjs
+++ b/tests/useDebouncedSearch.test.mjs
@@ -182,4 +182,21 @@ describe('useDebouncedSearch — behavior contract', () => {
       'Clear function must reset searchTerm and debouncedTerm',
     );
   });
+
+  it('uses delayRef to avoid stale delay without retriggering debounce', () => {
+    assert.ok(
+      src.includes('delayRef'),
+      'Must use delayRef for stable delay access',
+    );
+  });
+
+  it('debounce effect depends only on searchTerm', () => {
+    const debounceEffect = src.match(
+      /useEffect\(\(\) => \{[\s\S]*?setDebouncedTerm\(searchTerm\)[\s\S]*?\}, \[searchTerm\]\)/,
+    );
+    assert.ok(
+      debounceEffect,
+      'Debounce effect must depend only on searchTerm to prevent reset loops',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Track debounce delay in a ref so changing delay does not restart in-flight timers
- Limit debounce effect dependencies to `searchTerm` only to avoid reset loops when `debouncedTerm` updates
- Extend contract tests for delayRef and dependency stability

Fixes #4982

## Test plan
- [x] `node tests/useDebouncedSearch.test.mjs`

Made with [Cursor](https://cursor.com)