### PR TITLE
fix(ui): render OfflineConflictModal via portal

### DIFF
--- a/src/components/common/OfflineConflictModal.jsx
+++ b/src/components/common/OfflineConflictModal.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { AlertTriangle, Server, X, Edit3 } from "lucide-react";
 import "./OfflineConflictModal.css";
 import { useFocusTrap } from "../../hooks/useFocusTrap";
@@ -42,7 +43,7 @@ export default function OfflineConflictModal() {
     setConflictData(null);
   };
 
-  return (
+  return createPortal(
     <div className="ocm-modal-overlay">
       <div
         ref={trapRef}
@@ -131,6 +132,7 @@ export default function OfflineConflictModal() {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary
- Render the offline conflict modal with `createPortal` into `document.body`
- Prevents parent containers with `overflow: hidden` from clipping the dialog

Fixes #4973

## Test plan
- [ ] Manual: trigger offline conflict event and verify modal overlays full viewport

Made with [Cursor](https://cursor.com)