### PR TITLE
fix(hooks): replace console calls with logger in storage hooks

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { safeJsonParse } from "../utils/safeJsonParse.js";
+import { logger } from "../utils/logger.js";
 
 const useLocalStorage = (key, initialValue) => {
   const initialValueRef = useRef(initialValue);
@@ -14,7 +15,7 @@ const useLocalStorage = (key, initialValue) => {
       const item = window.localStorage.getItem(key);
       return safeJsonParse(item, initialValueRef.current);
     } catch (error) {
-      console.warn(`useLocalStorage: error reading key "${key}":`, error);
+      logger.warn(`useLocalStorage: error reading key "${key}":`, error);
       return initialValueRef.current;
     }
   }, [key]);
@@ -34,7 +35,7 @@ const useLocalStorage = (key, initialValue) => {
           return newValue;
         });
       } catch (error) {
-        console.warn(`useLocalStorage: error setting key "${key}":`, error);
+        logger.warn(`useLocalStorage: error setting key "${key}":`, error);
       }
     },
     [key]
@@ -49,7 +50,7 @@ const useLocalStorage = (key, initialValue) => {
       isInternalWrite.current = true;
       window.dispatchEvent(new CustomEvent("local-storage", { detail: { key } }));
     } catch (error) {
-      console.warn(`useLocalStorage: error removing key "${key}":`, error);
+      logger.warn(`useLocalStorage: error removing key "${key}":`, error);
     }
   }, [key]);
 

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -38,7 +38,9 @@ export const useNotifications = () => {
     if (!didLoadRef.current) return;
     // Persist on every change — including when the list is cleared to []
     // so that markAllAsRead and future "clear all" features are durable.
-    idbSet(STORAGE_KEY, JSON.stringify(notifications)).catch(console.error);
+    idbSet(STORAGE_KEY, JSON.stringify(notifications)).catch((error) => {
+      logger.error("Failed to persist notifications to indexedDB", error);
+    });
   }, [notifications]);
 
   const requestPermission = async () => {

--- a/src/hooks/useRecentlyViewed.js
+++ b/src/hooks/useRecentlyViewed.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { safeJsonParse } from "../utils/safeJsonParse";
+import { logger } from "../utils/logger";
 
 const STORAGE_KEY = 'eventra_recently_viewed';
 const MAX_ITEMS = 10;
@@ -55,7 +56,7 @@ const useRecentlyViewed = () => {
         setRecentlyViewed(fresh);
       }
     } catch (err) {
-      console.error('Failed to load recently viewed events:', err);
+      logger.error('Failed to load recently viewed events:', err);
       setRecentlyViewed([]);
     }
   }, []);
@@ -65,7 +66,7 @@ const useRecentlyViewed = () => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(recentlyViewed));
     } catch (err) {
-      console.error('Failed to save recently viewed events:', err);
+      logger.error('Failed to save recently viewed events:', err);
     }
   }, [recentlyViewed]);
 
@@ -101,7 +102,7 @@ const useRecentlyViewed = () => {
     try {
       localStorage.removeItem(STORAGE_KEY);
     } catch (err) {
-      console.error('Failed to clear recently viewed events:', err);
+      logger.error('Failed to clear recently viewed events:', err);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Replace `console.warn` / `console.error` with shared `logger` in `useLocalStorage`, `useRecentlyViewed`, and `useNotifications`
- Ensures consistent log formatting and avoids raw console usage in storage error paths

Fixes #5015

## Test plan
- [x] Verified imports resolve to existing `src/utils/logger.js`

Made with [Cursor](https://cursor.com)