### PR TITLE
fix(utils): remove hardcoded localhost fallback in sseMultiplexer

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -4,6 +4,24 @@ const MULTIPLEX_CHANNEL_NAME = "eventra_sse_multiplexer";
 const LOCK_NAME = "eventra_sse_leader_lock";
 const HEARTBEAT_KEY = "eventra_sse_leader_heartbeat";
 
+const resolveSseBaseUrl = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const configuredUrl =
+    process.env.VITE_SSE_URL
+    || process.env.VITE_API_URL
+    || process.env.REACT_APP_SSE_URL
+    || process.env.REACT_APP_API_URL;
+
+  if (!configuredUrl) {
+    return null;
+  }
+
+  return configuredUrl.replace(/\/$/, "");
+};
+
 // Unique identifier for this tab instance
 const TAB_ID = Math.random().toString(36).substring(2, 9);
 
@@ -275,9 +293,13 @@ class SseMultiplexer {
   }
 
   openEventSource(path) {
-    const sseBaseUrl = typeof window !== "undefined"
-      ? (process.env.VITE_SSE_URL || process.env.VITE_API_URL || process.env.REACT_APP_SSE_URL || process.env.REACT_APP_API_URL || "http://localhost:8080/api/v1")
-      : "http://localhost:8080/api/v1";
+    const sseBaseUrl = resolveSseBaseUrl();
+
+    if (!sseBaseUrl) {
+      logger.warn(`[SSE Multiplexer] Skipping EventSource for ${path}: SSE base URL is not configured`);
+      this.updatePathStatus(path, "error");
+      return;
+    }
 
     logger.log(`[SSE Multiplexer] Leader tab opening physical EventSource: ${sseBaseUrl}${path}`);
     this.updatePathStatus(path, "connecting");


### PR DESCRIPTION
## Summary
- Add `resolveSseBaseUrl()` that reads SSE/API URL from environment variables only
- Skip opening physical EventSource connections when no URL is configured
- Mark path status as `error` instead of silently connecting to localhost in production

Fixes #4979

## Test plan
- [x] `node tests/sseMultiplexer.test.mjs`

Made with [Cursor](https://cursor.com)