### PR TITLE
fix(utils): clear orphaned timeout in githubProfileCache race

### DIFF
--- a/src/utils/githubProfileCache.js
+++ b/src/utils/githubProfileCache.js
@@ -76,12 +76,15 @@ export function fetchProfileWithCache(username, fetcher) {
   const existing = inFlightRequests.get(username);
   if (existing) return existing;
 
-  // 🔥 FIX: Create a timeout promise that rejects after 10 seconds
-  const timeoutPromise = new Promise((_, reject) =>
-    setTimeout(() => reject(new Error(`Fetch timeout for profile: ${username}`)), FETCH_TIMEOUT_MS)
-  );
+  // Race the fetcher against the timeout and always clear the timer when settled
+  let timeoutId;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error(`Fetch timeout for profile: ${username}`)),
+      FETCH_TIMEOUT_MS
+    );
+  });
 
-  // 🔥 FIX: Race the fetcher against the timeout
   const request = Promise.race([fetcher(username), timeoutPromise]).then(
     (data) => {
       setCachedProfile(username, data);
@@ -89,11 +92,14 @@ export function fetchProfileWithCache(username, fetcher) {
       return data;
     },
     (err) => {
-      // If the fetch fails OR the timeout triggers, we properly clean up the Map
       inFlightRequests.delete(username);
       throw err;
     }
-  );
+  ).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
 
   inFlightRequests.set(username, request);
   return request;


### PR DESCRIPTION
## Summary
- Track the timeout id used in `Promise.race` for profile fetches
- Clear the timer in `finally` so successful responses do not orphan idle timeouts

Fixes #5010

## Test plan
- [x] `node tests/githubProfileCache.test.mjs`

Made with [Cursor](https://cursor.com)