### PR TITLE
fix(docs): clear pending timeout on rapid ApiDocs execute clicks

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -107,6 +107,11 @@ const ApiDocs = () => {
   };
 
   const executeMockRequest = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
     setIsLoading(true);
     setTerminalOutput("");
     


### PR DESCRIPTION
## Summary
- Clear any pending `timeoutRef` before starting a new mock API execution
- Prevents queued timeouts from racing and showing stale terminal output

Fixes #4958

## Test plan
- [ ] Manual: click Execute Request rapidly on API Docs page and confirm output matches latest click

Made with [Cursor](https://cursor.com)