### PR TITLE
fix: remove eventra-offline-queue-updated listener on unmount in OfflineBanner

### DIFF
--- a/src/components/common/OfflineBanner.jsx
+++ b/src/components/common/OfflineBanner.jsx
@@ -36,9 +36,9 @@ export default function OfflineBanner() {
     window.addEventListener("eventra-offline-queue-updated", handleQueueUpdated);
 
     return () => {
-      clearTimeout(timer);
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("eventra-offline-queue-updated", handleQueueUpdated);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, []);


### PR DESCRIPTION
Fixes #5071

**Problem:**
`OfflineBanner.jsx` adds a listener for `"eventra-offline-queue-updated"` on line 36 but the cleanup function never removes it. On every unmount, the listener leaks — stale closures continue calling `setQueueCount`/`setVisible` on an unmounted component.

Also removed `clearTimeout(timer)` from cleanup — `timer` is declared but never assigned, making it always `undefined` (dead code).

**Fix:**
- Added `window.removeEventListener("eventra-offline-queue-updated", handleQueueUpdated)` to cleanup
- Removed dead `clearTimeout(timer)` call

**Files changed:**
- `src/components/common/OfflineBanner.jsx` 