### PR TITLE
fix: guard against division by zero in ScrollProgressBar when page is not scrollable

### DIFF
--- a/src/components/common/ScrollProgressBar.jsx
+++ b/src/components/common/ScrollProgressBar.jsx
@@ -15,8 +15,9 @@ const ScrollProgressBar = () => {
       const scrollableHeight =
         documentHeight - windowHeight;
 
-      const progress =
-        (scrollTop / scrollableHeight) * 100;
+      const progress = scrollableHeight > 0
+        ? (scrollTop / scrollableHeight) * 100
+        : 0;
 
       setScrollProgress(progress);
     };


### PR DESCRIPTION
Fixes #5072

**Problem:**
In `ScrollProgressBar.jsx` lines 18–19, `progress = (scrollTop / scrollableHeight) * 100` has no guard for when `scrollableHeight` is 0 or negative (page content fits within viewport). This causes division by zero — `progress` becomes `NaN`, setting `width: "NaN%"` which the browser ignores, making the bar invisible.

**Fix:**
Added a guard so progress defaults to `0` when `scrollableHeight <= 0`.

**Files changed:**
- `src/components/common/ScrollProgressBar.jsx` 