### PR TITLE
fix: strip HTML tags before computing wordCount in getEventReadTime

### DIFF
--- a/src/utils/readTimeUtils.js
+++ b/src/utils/readTimeUtils.js
@@ -44,10 +44,11 @@ export const formatReadTime = (minutes) => {
 export const getEventReadTime = (event) => {
   const description = event?.description || '';
   const minutes = calculateReadTime(description);
-  
+  const plainText = description.replace(/<[^>]*>/g, '').trim();
+
   return {
     minutes,
     display: formatReadTime(minutes),
-    wordCount: description.trim().split(/\s+/).filter(word => word.length > 0).length,
+    wordCount: plainText.split(/\s+/).filter(word => word.length > 0).length,
   };
 };


### PR DESCRIPTION
Fixes #5073

**Problem:**
In `readTimeUtils.js` line 51, `wordCount` splits the raw description including HTML tags. `calculateReadTime` (line 46) internally strips HTML before counting words. This means `minutes` and `wordCount` are computed from different inputs — for `<p>Hello world</p>`, minutes counts 2 words but wordCount returns 3.

**Fix:**
Added `const plainText = description.replace(/<[^>]*>/g, '').trim()` and used `plainText` for `wordCount` — consistent with how `calculateReadTime` computes word count internally.

**Files changed:**
- `src/utils/readTimeUtils.js` 