### PR TITLE
fix: return new object in applyAchievementBonus instead of mutating in-place

### DIFF
--- a/src/utils/leaderboardUtils.js
+++ b/src/utils/leaderboardUtils.js
@@ -79,10 +79,10 @@ export function calculatePrPoints(labels) {
 export function applyAchievementBonus(contributor) {
   for (const { minPrs, bonus } of ACHIEVEMENT_THRESHOLDS) {
     if (contributor.prs >= minPrs) {
-      contributor.points += bonus;
-      return;
+      return { ...contributor, points: contributor.points + bonus };
     }
   }
+  return contributor;
 }
 
 // ─── Filtering ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #5076

**Problem:**
`applyAchievementBonus` mutates `contributor.points` directly via `contributor.points += bonus`. When called with a React state object, the reference stays the same — React's change detection does not trigger a re-render. `useMemo` and `shouldComponentUpdate` guards watching `contributor.points` silently miss the update.

**Fix:**
Returns a new object using spread `{ ...contributor, points: contributor.points + bonus }` instead of mutating in-place. Also added explicit `return contributor` when no threshold matches.

**Files changed:**
- `src/utils/leaderboardUtils.js` 