### PR TITLE
feat(utils): add httpOnlyStorage cookie helpers with tests

### DIFF
--- a/src/utils/httpOnlyStorage.js
+++ b/src/utils/httpOnlyStorage.js
@@ -1,1 +1,85 @@
 // Frontend storage migration layer for HttpOnly cookies
+
+/**
+ * Read a cookie value by name from document.cookie.
+ * @param {string} name
+ * @returns {string|null}
+ */
+export function getCookie(name) {
+  if (!name || typeof document === "undefined") {
+    return null;
+  }
+
+  const prefix = `${encodeURIComponent(name)}=`;
+  const cookies = document.cookie.split(";").map((c) => c.trim());
+
+  for (const cookie of cookies) {
+    if (cookie.startsWith(prefix)) {
+      return decodeURIComponent(cookie.slice(prefix.length));
+    }
+    const legacyPrefix = `${name}=`;
+    if (cookie.startsWith(legacyPrefix)) {
+      return decodeURIComponent(cookie.slice(legacyPrefix.length));
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Set a cookie on document.cookie.
+ * HttpOnly cookies must be set by the server; this helper is for
+ * non-HttpOnly migration paths and testable client-side fallbacks.
+ *
+ * @param {string} name
+ * @param {string} value
+ * @param {{ path?: string, domain?: string, maxAge?: number, expires?: string, sameSite?: string, secure?: boolean }} [options]
+ */
+export function setCookie(name, value, options = {}) {
+  if (!name || typeof document === "undefined") {
+    return;
+  }
+
+  const {
+    path = "/",
+    domain,
+    maxAge,
+    expires,
+    sameSite = "Strict",
+    secure = true,
+  } = options;
+
+  let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+  cookie += `; path=${path}`;
+
+  if (domain) {
+    cookie += `; domain=${domain}`;
+  }
+  if (maxAge !== undefined) {
+    cookie += `; max-age=${maxAge}`;
+  }
+  if (expires) {
+    cookie += `; expires=${expires}`;
+  }
+  if (sameSite) {
+    cookie += `; SameSite=${sameSite}`;
+  }
+  if (secure) {
+    cookie += "; Secure";
+  }
+
+  document.cookie = cookie;
+}
+
+/**
+ * Delete a cookie by expiring it immediately.
+ * @param {string} name
+ * @param {{ path?: string, domain?: string, sameSite?: string, secure?: boolean }} [options]
+ */
+export function deleteCookie(name, options = {}) {
+  setCookie(name, "", {
+    ...options,
+    maxAge: 0,
+    expires: "Thu, 01 Jan 1970 00:00:00 UTC",
+  });
+}

--- a/tests/httpOnlyStorage.test.mjs
+++ b/tests/httpOnlyStorage.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+
+let cookieJar = "";
+
+globalThis.document = {
+  get cookie() {
+    return cookieJar;
+  },
+  set cookie(value) {
+    const [pair, ...attrs] = value.split(";").map((part) => part.trim());
+    const [name] = pair.split("=");
+    const maxAgeAttr = attrs.find((a) => a.toLowerCase().startsWith("max-age="));
+    const expiresAttr = attrs.find((a) => a.toLowerCase().startsWith("expires="));
+
+    if (
+      (maxAgeAttr && maxAgeAttr.split("=")[1] === "0") ||
+      (expiresAttr && expiresAttr.includes("1970"))
+    ) {
+      const existing = cookieJar
+        .split(";")
+        .map((c) => c.trim())
+        .filter((c) => c && !c.startsWith(`${name}=`));
+      cookieJar = existing.join("; ");
+      return;
+    }
+
+    const without = cookieJar
+      .split(";")
+      .map((c) => c.trim())
+      .filter((c) => c && !c.startsWith(`${name}=`));
+    cookieJar = [...without, pair, ...attrs].filter(Boolean).join("; ");
+  },
+};
+
+const { getCookie, setCookie, deleteCookie } = await import(
+  "../src/utils/httpOnlyStorage.js"
+);
+
+cookieJar = "";
+
+setCookie("session", "abc123", { secure: false });
+assert.equal(getCookie("session"), "abc123", "reads a set cookie");
+
+setCookie("prefs", "dark", { path: "/app", secure: false });
+assert.equal(getCookie("prefs"), "dark", "reads cookie with path option");
+
+setCookie("encoded", "hello world", { secure: false });
+assert.equal(getCookie("encoded"), "hello world", "round-trips URI-encoded values");
+
+deleteCookie("session", { secure: false });
+assert.equal(getCookie("session"), null, "deleteCookie removes the cookie");
+
+assert.equal(getCookie("missing"), null, "unknown cookie returns null");
+assert.equal(getCookie(""), null, "empty name returns null");
+
+cookieJar = "legacy=plain%20text";
+assert.equal(getCookie("legacy"), "plain text", "reads legacy unencoded names");
+
+console.log("httpOnlyStorage tests passed ✓");


### PR DESCRIPTION
## Summary
- Implement `getCookie`, `setCookie`, and `deleteCookie` in `src/utils/httpOnlyStorage.js`
- Add `tests/httpOnlyStorage.test.mjs` with node:test coverage for parse, encode, and delete

## Test plan
- [x] `node tests/httpOnlyStorage.test.mjs`

Fixes #4891

Made with [Cursor](https://cursor.com)