### PR TITLE
fix: replace require() with ES module import for normalizeDateString in conflictDetection

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -21,6 +21,7 @@ import {
   getUserTimezone,
   parseEventToUTC,
   parseTimeString,
+  normalizeDateString,
 } from './timezoneUtils.js';
 
 // ---------------------------------------------------------------------------
@@ -129,14 +130,9 @@ export const doEventsOverlap = (
   // Only reached when date/time fields are unparseable (e.g. undefined).
   // The legacy code compared raw date strings; we still do that but via
   // normalizeDateString for format-tolerance.
-  try {
-    const { normalizeDateString } = require('./timezoneUtils');
-    const d1 = normalizeDateString(event1?.date);
-    const d2 = normalizeDateString(event2?.date);
-    if (d1 && d2 && d1 !== d2) return false;
-  } catch {
-    if (event1?.date !== event2?.date) return false;
-  }
+  const d1 = normalizeDateString(event1?.date);
+  const d2 = normalizeDateString(event2?.date);
+  if (d1 && d2 && d1 !== d2) return false;
 
   const r1 = getEventTimeRange(event1, fallbackDuration);
   const r2 = getEventTimeRange(event2, fallbackDuration);


### PR DESCRIPTION
## Summary
Fixes a CommonJS `require()` call inside an ES module in 
`conflictDetection.js` by replacing it with a proper ES module 
import for `normalizeDateString`.

## Problem
`conflictDetection.js` uses ES module `import` syntax throughout 
but contained a `require('./timezoneUtils')` call inside a 
`try/catch` block in the legacy fallback path of `doEventsOverlap`. 
Mixing CommonJS `require()` inside an ES module is unreliable and 
throws in strict ESM environments. The `try/catch` silently swallowed 
the error and fell back to raw date string comparison — causing 
incorrect conflict detection without any warning.

## Changes Made
- Added `normalizeDateString` to the existing ES module import from 
  `timezoneUtils.js` at the top of the file
- Removed the `require()` call and `try/catch` wrapper
- Used `normalizeDateString` directly

## Files Changed
- `src/utils/conflictDetection.js`

## Testing
- App loads without errors
- Event conflict detection works correctly
- No console errors related to require or ESM
- Conflict modal appears correctly for overlapping events

## Related Issue
Closes #5102 