### PR TITLE
refactor: extract duplicated ROLE_PERMISSIONS map into shared api/lib/permissions.js

### DIFF
--- a/api/auth/google.js
+++ b/api/auth/google.js
@@ -2,6 +2,7 @@ import jwt from "jsonwebtoken";
 import { OAuth2Client } from "google-auth-library";
 import { users } from "./signup.js";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
+import { ROLE_PERMISSIONS, getPermissionsForRoles } from "../lib/permissions.js";
 
 // ---------------------------------------------------------------------------
 // Google OAuth Configuration
@@ -70,111 +71,8 @@ const DEFAULT_PERMISSIONS = [
 ];
 
 // ---------------------------------------------------------------------------
-// Role Permissions
+// Role Permissions (delegated to shared permissions.js)
 // ---------------------------------------------------------------------------
-
-const ROLE_PERMISSIONS = {
-  SUPER_ADMIN: [
-    "events:view",
-    "events:create",
-    "events:edit",
-    "events:delete",
-    "events:register",
-    "hackathons:view",
-    "hackathons:host",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "users:view",
-    "users:edit",
-    "users:delete",
-    "analytics:view",
-    "content:moderate",
-    "profile:edit",
-    "profile:view",
-    "notifications:manage",
-    "admin:access",
-  ],
-  ADMIN: [
-    "events:view",
-    "events:create",
-    "events:edit",
-    "events:delete",
-    "events:register",
-    "hackathons:view",
-    "hackathons:host",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "users:view",
-    "analytics:view",
-    "content:moderate",
-    "profile:edit",
-    "profile:view",
-    "notifications:manage",
-    "admin:access",
-  ],
-  ORGANIZER: [
-    "events:view",
-    "events:create",
-    "events:edit",
-    "events:register",
-    "hackathons:view",
-    "hackathons:host",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "analytics:view",
-    "profile:edit",
-    "profile:view",
-  ],
-  VOLUNTEER: [
-    "events:view",
-    "events:register",
-    "hackathons:view",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "content:moderate",
-    "profile:edit",
-    "profile:view",
-  ],
-  ATTENDEE: [
-    "events:view",
-    "events:register",
-    "hackathons:view",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "profile:edit",
-    "profile:view",
-  ],
-  USER: [
-    "events:view",
-    "events:register",
-    "projects:view",
-    "projects:submit",
-    "hackathons:view",
-    "hackathons:participate",
-    "profile:edit",
-    "profile:view",
-  ],
-};
-
-const getPermissionsForRoles = (roles) => {
-  const permissionsSet = new Set();
-  roles.forEach((role) => {
-    const normalizedRole = role.toUpperCase();
-    const perms = ROLE_PERMISSIONS[normalizedRole] || ROLE_PERMISSIONS.USER;
-    perms.forEach((perm) => permissionsSet.add(perm));
-  });
-  return Array.from(permissionsSet);
-};
 
 // ---------------------------------------------------------------------------
 // Generate User ID

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { users } from "./signup.js";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
+import { ROLE_PERMISSIONS, getPermissionsForRoles } from "../lib/permissions.js";
 
 // Pre-compute a dummy bcrypt hash at module load time (same cost factor used in signup.js).
 // When a login attempt references a username or email that does not exist, we still run
@@ -65,111 +66,8 @@ const corsResponse = (res, status, data, req) => {
 };
 
 // ---------------------------------------------------------------------------
-// Default Permissions based on roles
+// Default Permissions based on roles (delegated to shared permissions.js)
 // ---------------------------------------------------------------------------
-
-const ROLE_PERMISSIONS = {
-  SUPER_ADMIN: [
-    "events:view",
-    "events:create",
-    "events:edit",
-    "events:delete",
-    "events:register",
-    "hackathons:view",
-    "hackathons:host",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "users:view",
-    "users:edit",
-    "users:delete",
-    "analytics:view",
-    "content:moderate",
-    "profile:edit",
-    "profile:view",
-    "notifications:manage",
-    "admin:access",
-  ],
-  ADMIN: [
-    "events:view",
-    "events:create",
-    "events:edit",
-    "events:delete",
-    "events:register",
-    "hackathons:view",
-    "hackathons:host",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "users:view",
-    "analytics:view",
-    "content:moderate",
-    "profile:edit",
-    "profile:view",
-    "notifications:manage",
-    "admin:access",
-  ],
-  ORGANIZER: [
-    "events:view",
-    "events:create",
-    "events:edit",
-    "events:register",
-    "hackathons:view",
-    "hackathons:host",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "analytics:view",
-    "profile:edit",
-    "profile:view",
-  ],
-  VOLUNTEER: [
-    "events:view",
-    "events:register",
-    "hackathons:view",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "content:moderate",
-    "profile:edit",
-    "profile:view",
-  ],
-  ATTENDEE: [
-    "events:view",
-    "events:register",
-    "hackathons:view",
-    "hackathons:participate",
-    "projects:view",
-    "projects:submit",
-    "projects:upvote",
-    "profile:edit",
-    "profile:view",
-  ],
-  USER: [
-    "events:view",
-    "events:register",
-    "projects:view",
-    "projects:submit",
-    "hackathons:view",
-    "hackathons:participate",
-    "profile:edit",
-    "profile:view",
-  ],
-};
-
-const getPermissionsForRoles = (roles) => {
-  const permissionsSet = new Set();
-  roles.forEach((role) => {
-    const normalizedRole = role.toUpperCase();
-    const perms = ROLE_PERMISSIONS[normalizedRole] || ROLE_PERMISSIONS.USER;
-    perms.forEach((perm) => permissionsSet.add(perm));
-  });
-  return Array.from(permissionsSet);
-};
 
 // ---------------------------------------------------------------------------
 // Find user by username or email

--- a/api/lib/permissions.js
+++ b/api/lib/permissions.js
@@ -1,0 +1,104 @@
+const ROLE_PERMISSIONS = {
+  SUPER_ADMIN: [
+    "events:view",
+    "events:create",
+    "events:edit",
+    "events:delete",
+    "events:register",
+    "hackathons:view",
+    "hackathons:host",
+    "hackathons:participate",
+    "projects:view",
+    "projects:submit",
+    "projects:upvote",
+    "users:view",
+    "users:edit",
+    "users:delete",
+    "analytics:view",
+    "content:moderate",
+    "profile:edit",
+    "profile:view",
+    "notifications:manage",
+    "admin:access",
+  ],
+  ADMIN: [
+    "events:view",
+    "events:create",
+    "events:edit",
+    "events:delete",
+    "events:register",
+    "hackathons:view",
+    "hackathons:host",
+    "hackathons:participate",
+    "projects:view",
+    "projects:submit",
+    "projects:upvote",
+    "users:view",
+    "analytics:view",
+    "content:moderate",
+    "profile:edit",
+    "profile:view",
+    "notifications:manage",
+    "admin:access",
+  ],
+  ORGANIZER: [
+    "events:view",
+    "events:create",
+    "events:edit",
+    "events:register",
+    "hackathons:view",
+    "hackathons:host",
+    "hackathons:participate",
+    "projects:view",
+    "projects:submit",
+    "projects:upvote",
+    "analytics:view",
+    "profile:edit",
+    "profile:view",
+  ],
+  VOLUNTEER: [
+    "events:view",
+    "events:register",
+    "hackathons:view",
+    "hackathons:participate",
+    "projects:view",
+    "projects:submit",
+    "projects:upvote",
+    "content:moderate",
+    "profile:edit",
+    "profile:view",
+  ],
+  ATTENDEE: [
+    "events:view",
+    "events:register",
+    "hackathons:view",
+    "hackathons:participate",
+    "projects:view",
+    "projects:submit",
+    "projects:upvote",
+    "profile:edit",
+    "profile:view",
+  ],
+  USER: [
+    "events:view",
+    "events:register",
+    "projects:view",
+    "projects:submit",
+    "hackathons:view",
+    "hackathons:participate",
+    "profile:edit",
+    "profile:view",
+  ],
+};
+
+const getPermissionsForRoles = (roles) => {
+  const permissionsSet = new Set();
+  roles.forEach((role) => {
+    const normalizedRole = role.toUpperCase();
+    const perms = ROLE_PERMISSIONS[normalizedRole] || ROLE_PERMISSIONS.USER;
+    perms.forEach((perm) => permissionsSet.add(perm));
+  });
+  return Array.from(permissionsSet);
+};
+
+export { ROLE_PERMISSIONS, getPermissionsForRoles };


### PR DESCRIPTION
## Description

The ROLE_PERMISSIONS constant (mapping roles like SUPER_ADMIN, ADMIN, ORGANIZER, VOLUNTEER, ATTENDEE, USER to their permission arrays) was independently defined across three separate locations - pi/auth/login.js, pi/auth/google.js, and src/config/roles.js. The two API-side copies (~70 lines each) were maintained independently with no mechanism to detect drift, creating a high-risk privilege escalation vector.

## Problem

If a permission is added or removed in one auth handler but not the other, users receive **different permissions depending on whether they log in via email/password or Google OAuth**:

| Scenario | login.js | google.js | Result |
|----------|----------|-----------|--------|
| Admin added to ORGANIZER in login.js only | ? Has ORGANIZER access | ? Still has old permissions | Inconsistent UX |
| Security-critical permission removed from google.js only | ? Still has permission | ? Permission revoked | Privilege escalation via login method |

Additionally, the duplicated getPermissionsForRoles() helper function was identical in both files, meaning any behavioral change would need to be applied in two places.

## Fix

1. **Created** pi/lib/permissions.js exporting ROLE_PERMISSIONS and getPermissionsForRoles()
2. **Updated** pi/auth/login.js to import from ../lib/permissions.js - removed ~100 lines of inline definitions
3. **Updated** pi/auth/google.js to import from ../lib/permissions.js - removed ~100 lines of inline definitions

The frontend copy in src/config/roles.js is intentionally kept separate (different runtime, different build), but the API-side duplication is now fully consolidated.

## Testing

1. **Login flow**: Email/password login still returns correct permissions for all role types
2. **Google OAuth flow**: Google login returns identical permissions for the same roles
3. **New user creation**: Both auth paths use the shared getPermissionsForRoles() helper, ensuring consistent defaults
4. **Regression**: All existing permission-dependent functionality (event CRUD, analytics access, admin panel) continues to work unchanged

## Related Issue

Closes #5089

## Type of Change

- [x] Refactor (code deduplication)
- [x] Security improvement
- [ ] New feature
- [ ] Performance improvement

## Additional Context

**Severity**: High - permission drift between auth methods is a privilege escalation vulnerability. While the two copies are currently identical, any future PR that modifies one but not the other would silently create an authorization discrepancy.

The shared module is placed in pi/lib/permissions.js following the existing pattern used by pi/lib/getClientIp.js. It exports both the ROLE_PERMISSIONS constant and the getPermissionsForRoles() helper so future auth endpoints (e.g., OTP-based login, magic link) can use the same source of truth.

**Impact**: ~100 lines of duplicated code removed per file (200 lines total). Single source of truth for role-to-permission mappings across all server-side auth handlers.