### PR TITLE
fix: add fallback to CountUp import in HackathonHero to prevent crash when default export is undefined

### DIFF
--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -7,7 +7,7 @@ import CountUpLib from "react-countup";
 import SectionErrorBoundary from "../../components/common/SectionErrorBoundary";
 import useReducedMotion from "../../hooks/useReducedMotion.js";
 
-const CountUp = CountUpLib.default;
+const CountUp = CountUpLib.default || CountUpLib;
 // Tag component for selected tags in search bar
 const Tag = ({ tag, onRemove }) => (
   <motion.div


### PR DESCRIPTION
## Summary
Fixes missing fallback in `CountUp` import in `HackathonHero.js` 
that could cause a crash when `react-countup` resolves as a 
CommonJS module.

## Problem
`const CountUp = CountUpLib.default` has no fallback. In some 
bundler configurations where `react-countup` resolves as a CJS 
module, `.default` is `undefined` — making `CountUp` undefined 
and crashing the stats section with "Element type is invalid". 
`EventHero.js` already uses the correct pattern.

## Changes Made
- Changed `const CountUp = CountUpLib.default` to 
  `const CountUp = CountUpLib.default || CountUpLib`

## Files Changed
- `src/Pages/Hackathons/HackathonHero.js`

## Testing
- Hackathons page loads correctly
- Stats counters animate correctly
- No console errors
- Consistent with EventHero.js import pattern

## Related Issue
Closes #5106 