### PR TITLE
fix(gamification): resolve XP claim race condition and stale derived state

### DIFF
--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -131,6 +131,9 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
   useEffect(() => { saveQuestState(state); }, [state]);
 
   // Derive demo progress from props (totalEvents, currentStreak)
+  // 🔥 FIX 2: Added state.dailyResetAt and state.weeklyResetAt to dependency array.
+  // This ensures that when the clock rolls over and the quests are wiped clean, 
+  // this effect re-runs to correctly repopulate progress from the active props!
   useEffect(() => {
     setState(prev => {
       const dp = { ...prev.dailyProgress };
@@ -144,7 +147,7 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
       wp['wq-4'] = Math.min(5, totalEvents);
       return { ...prev, dailyProgress: dp, weeklyProgress: wp };
     });
-  }, [totalEvents, currentStreak]);
+  }, [totalEvents, currentStreak, state.dailyResetAt, state.weeklyResetAt]);
 
   // Countdown timer
   useEffect(() => {
@@ -166,13 +169,19 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
   // ─── Claim handler ───────────────────────────────────────────────────────────
   const claimXP = (questId, xp, isWeekly) => {
     const claimedKey = isWeekly ? 'weeklyClaimed' : 'dailyClaimed';
-    if (state[claimedKey][questId]) return; // already claimed
+    
+    // 🔥 FIX 1: Moved the check INSIDE the functional setState.
+    // Checking the closure 'state' allows spam-click double-claiming exploits.
+    // Checking 'prev' guarantees atomic verification.
+    setState(prev => {
+      if (prev[claimedKey][questId]) return prev; // Already claimed, block exploit
 
-    setState(prev => ({
-      ...prev,
-      [claimedKey]: { ...prev[claimedKey], [questId]: true },
-      lifetimeXP: prev.lifetimeXP + xp,
-    }));
+      return {
+        ...prev,
+        [claimedKey]: { ...prev[claimedKey], [questId]: true },
+        lifetimeXP: prev.lifetimeXP + xp,
+      };
+    });
 
     setClaimFlash(questId);
     fireConfetti(confettiRef);


### PR DESCRIPTION
## Description
This PR resolves two critical logic vulnerabilities within the `QuestCenter` component. First, it patches an infinite XP race condition that allowed users to exploit React's batching behavior by spamming the claim button. Second, it fixes a stale derivation bug where quests failed to correctly recalculate progress when the daily timer reset while the app remained open.

**Changes made:**
- **Race Condition Patch:** Relocated the claim verification logic into the functional `setState` callback (`prev => {...}`) to ensure atomic state updates and block multi-click exploitation.
- **Dependency Optimization:** Added `state.dailyResetAt` and `state.weeklyResetAt` to the derivation `useEffect` dependency array, ensuring the UI correctly repopulates active quests immediately following a midnight reset.

Fixes #5113

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security patch

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code