### PR TITLE
fix: add guard for invalid delay value in useDebounce hook

### DIFF
--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -7,17 +7,15 @@ import { useState, useEffect } from "react";
  * @returns {any} The debounced value.
  */
 export default function useDebounce(value, delay = 300) {
+  const safeDelay = typeof delay === 'number' && isFinite(delay) && delay > 0 ? delay : 300;
   const [debouncedValue, setDebouncedValue] = useState(value);
-
   useEffect(() => {
     const handler = setTimeout(() => {
       setDebouncedValue(value);
-    }, delay);
-
+    }, safeDelay);
     return () => {
       clearTimeout(handler);
     };
-  }, [value, delay]);
-
+  }, [value, safeDelay]);
   return debouncedValue;
 }


### PR DESCRIPTION
## Summary
Fixes a silent bug in `useDebounce` where passing an invalid delay 
value like `0`, `NaN`, or a negative number caused unpredictable 
debounce behaviour.

## Problem
```js
// BEFORE (broken)
export default function useDebounce(value, delay = 300) {
  useEffect(() => {
    const handler = setTimeout(() => {
      setDebouncedValue(value);
    }, delay); // ❌ no guard — delay could be 0, NaN or negative
  }, [value, delay]);
}
```

## Fix
```js
// AFTER (fixed)
export default function useDebounce(value, delay = 300) {
  const safeDelay = typeof delay === 'number' && isFinite(delay) && delay > 0 ? delay : 300;
  useEffect(() => {
    const handler = setTimeout(() => {
      setDebouncedValue(value);
    }, safeDelay); // ✅ always a valid positive number
  }, [value, safeDelay]);
}
```

## Impact
- Debounce now works correctly for all valid and invalid delay values
- Search and filter in ActiveFilters always updates correctly
- No more silent stale state issues

## Testing
- Tested search on Events page ✅
- Debounce fires correctly with default delay ✅
- No console errors ✅

Fixes #5121 