### PR TITLE
fix(user): prevent QuotaExceededError crash on profile image upload and fix modal clipping

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import ReactDOM from "react-dom"; // 🔥 FIX: Required for Modal Portal
 import { useAuth } from "../../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import { safeJsonParse } from "../../utils/safeJsonParse";
@@ -175,6 +176,18 @@ const EditProfile = () => {
   const handleImageChange = (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    // 🔥 FIX 1: Prevent LocalStorage QuotaExceededError Crash
+    // Enforce a strict 1MB limit. Base64 inflates sizes by ~33%, meaning
+    // anything over 1MB risks exceeding the total ~5MB localStorage boundary.
+    if (file.size > 1048576) {
+      alert("Image is too large. Please select an image under 1MB to prevent browser storage errors.");
+      if (fileInputRef.current) {
+        fileInputRef.current.value = null;
+      }
+      return;
+    }
+
     const reader = new FileReader();
     reader.onload = () => {
       const result = typeof reader.result === "string" ? reader.result : "";
@@ -592,9 +605,10 @@ const EditProfile = () => {
   );
 };
 
+// 🔥 FIX 2: Wrapped the modal in a React Portal to prevent layout/z-index clipping
 const ConfirmModal = ({ open, onCancel, onConfirm, loading }) => {
   if (!open) return null;
-  return (
+  return ReactDOM.createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/50" onClick={onCancel} />
       <div className="relative w-full max-w-md mx-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-6 z-10">
@@ -620,7 +634,8 @@ const ConfirmModal = ({ open, onCancel, onConfirm, loading }) => {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };
 


### PR DESCRIPTION
## Description
This PR resolves a fatal crash vulnerability and an architectural UI bug within the `EditProfile` component.

**Changes made:**
- **Storage Crash Prevention:** Added a strict 1MB file size limit to `handleImageChange`. Previously, the component allowed any size image to be converted to Base64 and saved to `localStorage`, which easily exceeded the browser's ~5MB hard limit. This would throw an uncaught `QuotaExceededError` and permanently corrupt the user's local authentication state.
- **Z-Index/Overflow Protection:** Wrapped the inline `ConfirmModal` using `ReactDOM.createPortal` so it renders directly into `document.body`. This guarantees the modal is never clipped by parent containers with `overflow: hidden` or trapped by nested `z-index` contexts.

Fixes #5123

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX stability improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code