### PR TITLE
fix: safely handle non-string status values in StatusBadge to prevent TypeError crash

### DIFF
--- a/src/components/common/StatusBadge.jsx
+++ b/src/components/common/StatusBadge.jsx
@@ -66,12 +66,12 @@ const STATUS_CONFIG = {
 };
 
 export default function StatusBadge({ status }) {
-  if (!status) return null;
-
-  const key = status.toLowerCase();
-
+  if (status === null || status === undefined) return null;
+  const normalized = String(status).trim();
+  if (!normalized) return null;
+  const key = normalized.toLowerCase();
   const config = STATUS_CONFIG[key] ?? {
-    label: status,
+    label: normalized,
     className: "sb-gray",
   };
 


### PR DESCRIPTION
## Summary
Fixes a TypeError crash and silent render failure in `StatusBadge` 
when non-string status values like numbers or booleans are passed.

## Problem
```js
// BEFORE (broken)
export default function StatusBadge({ status }) {
  if (!status) return null;
  // ❌ !status is true for 0 and false — renders nothing silently
  const key = status.toLowerCase();
  // ❌ crashes with TypeError if status is a number or boolean
}
```

## Fix
```js
// AFTER (fixed)
export default function StatusBadge({ status }) {
  if (status === null || status === undefined) return null;
  // ✅ only skips truly absent values
  const normalized = String(status).trim();
  if (!normalized) return null;
  const key = normalized.toLowerCase();
  // ✅ safely converts any type to string before processing
}
```

## Impact
- StatusBadge no longer crashes for numeric or boolean status values
- status={0} and status={false} now render correctly instead of blank
- Whitespace-only status values are handled gracefully
- No more TypeError propagating up the component tree

## Testing
- Checked all event cards on Events page ✅
- Status badges render correctly for all values ✅
- No TypeError in DevTools console ✅

Fixes #5142