### PR TITLE
fix: eagerly import PageTransition to prevent double flash on route changes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import { SessionRecoveryProvider } from "./context/SessionRecoveryContext";
 import useOfflineSync from "./hooks/useOfflineSync";
 import useLenis from "./hooks/useLenis";
 import useKeyboardShortcuts from "./hooks/useKeyboardShortcuts";
+import PageTransition from "./components/common/PageTransition";
 
 // Route-level lazy splits - loaded only when route is visited
 const Footer = lazy(() => import("./components/Layout/Footer"));
@@ -41,7 +42,6 @@ const ScrollToTopButton = lazy(() => import("./components/ScrollToTopButton"));
 const BackToTop = lazy(() => import("./components/common/BackToTop"));
 const ReminderChecker = lazy(() => import("./components/reminders/ReminderChecker"));
 const SessionRecovery = lazy(() => import("./components/SessionRecovery"));
-const PageTransition = lazy(() => import("./components/common/PageTransition"));
 
 const OfflineSyncManager = () => {
   useOfflineSync();


### PR DESCRIPTION
## Summary
Fixes a double flash and broken animation issue caused by lazy loading 
`PageTransition` which wraps the inner `Suspense` block.

## Problem
```js
// BEFORE (broken)
const PageTransition = lazy(() => import("./components/common/PageTransition"));
// ❌ PageTransition suspends first — shows null
// ❌ then inner Suspense shows pageLoader
// ❌ then actual page loads
// ❌ double flash on every route change
// ❌ transition animations never run on first load
```

## Fix
```js
// AFTER (fixed)
import PageTransition from "./components/common/PageTransition";
// ✅ always available before first paint
// ✅ no suspension, no double flash
// ✅ animations work correctly on every route change
```

## Impact
- Smooth route transitions with no double flash
- No layout shift before pageLoader appears
- PageTransition animations work correctly on first load
- Better perceived performance on navigation

## Testing
- Navigated between multiple pages ✅
- No double flash or layout shift ✅
- Page transitions animate smoothly ✅
- No console errors ✅

Fixes #5147 