### PR TITLE
fix: clear localStorage user key in clearSession to prevent stale data after logout

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -51,6 +51,7 @@ export const AuthProvider = ({ children }) => {
     document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; SameSite=Strict";
     sessionStorage.removeItem("token");
     syncSecureStorage.removeItem("user");
+    localStorage.removeItem("user");
     return true;
   }, []);
 


### PR DESCRIPTION
## Summary
Fixes a bug where `clearSession` never cleared `localStorage`, leaving 
stale user data after logout and causing false "Session expired" toasts 
for fresh visitors.

## Problem
```js
// BEFORE (broken)
const clearSession = useCallback(() => {
    setUser(null);
    setToken(null);
    document.cookie = "token=; expires=...";
    sessionStorage.removeItem("token");
    syncSecureStorage.removeItem("user");
    // ❌ localStorage never cleared
    // ❌ hadPreviousSession always true
    // ❌ guest users see "Session expired" toast
}, []);
```

## Fix
```js
// AFTER (fixed)
const clearSession = useCallback(() => {
    setUser(null);
    setToken(null);
    document.cookie = "token=; expires=...";
    sessionStorage.removeItem("token");
    syncSecureStorage.removeItem("user");
    localStorage.removeItem("user"); // ✅ stale data cleared
}, []);
```

## Impact
- Stale user data no longer persists in localStorage after logout
- Guest users no longer see false "Session expired" toast
- clearExpiredSession correctly identifies fresh vs returning sessions
- Security improved — display profile cleared on logout

## Testing
- Logged in and out — no stale data in localStorage ✅
- Fresh incognito window — no "Session expired" toast ✅
- Normal logout flow works correctly ✅
- No console errors ✅

Fixes #5149 