### PR TITLE
fix: remove duplicate ThemeProvider from App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,6 @@ import ErrorBoundary from "./components/common/ErrorBoundary";
 import SectionErrorBoundary from "./components/common/SectionErrorBoundary";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import NotificationToastContainer from "./components/common/NotificationProvider";
-import { ThemeProvider } from "./context/ThemeContext";
 import { NotificationProvider } from "./context/NotificationContext";
 import { AuthProvider } from "./context/AuthContext";
 import { MyEventsProvider } from "./context/MyEventsContext";
@@ -125,103 +124,101 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <ThemeProvider>
-        <AuthProvider>
-          <NotificationProvider>
-            <MyEventsProvider>
-              <SessionRecoveryProvider>
-                <NotificationToastContainer />
+      <AuthProvider>
+        <NotificationProvider>
+          <MyEventsProvider>
+            <SessionRecoveryProvider>
+              <NotificationToastContainer />
+              <Suspense fallback={null}>
+                <ReminderChecker />
+              </Suspense>
+              <OfflineSyncManager />
+
+              <div className="App">
+                <SectionErrorBoundary label="Navigation Bar">
+                  <Navbar cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
+                </SectionErrorBoundary>
+
+                <OfflineBanner />
+                <OfflineConflictModal />
+
                 <Suspense fallback={null}>
-                  <ReminderChecker />
+                  <KeyboardShortcutsModal
+                    isOpen={showKeyboardModal}
+                    onClose={() => setShowKeyboardModal(false)}
+                  />
                 </Suspense>
-                <OfflineSyncManager />
 
-                <div className="App">
-                  <SectionErrorBoundary label="Navigation Bar">
-                    <Navbar cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
-                  </SectionErrorBoundary>
+                <Suspense fallback={null}>
+                  <OnboardingChecklist />
+                </Suspense>
 
-                  <OfflineBanner />
-                  <OfflineConflictModal />
+                <main
+                  id="main-content"
+                  className="relative z-10 min-h-[85vh] bg-white dark:bg-slate-950 text-black dark:text-white transition-colors duration-300"
+                >
+                  <PageTransition>
+                    <ErrorBoundary>
+                      <Suspense fallback={pageLoader}>
+                        <Routes location={location} key={location.pathname}>
+                          <Route
+                            path="/register/:id"
+                            element={
+                              <ProtectedRoute>
+                                <EventRegistration />
+                              </ProtectedRoute>
+                            }
+                          />
+                          <Route path="/event-recommendation" element={<EventRecommendation />} />
+                          <Route path="/saved-events" element={<SavedEventsPage />} />
+                          <Route path="*" element={<AppRoutes />} />
+                        </Routes>
+                      </Suspense>
+                    </ErrorBoundary>
+                  </PageTransition>
+                </main>
 
+                <ScrollToTop />
+
+                <SectionErrorBoundary label="Chatbot Assist" silent>
                   <Suspense fallback={null}>
-                    <KeyboardShortcutsModal
-                      isOpen={showKeyboardModal}
-                      onClose={() => setShowKeyboardModal(false)}
-                    />
+                    <Chatbot />
                   </Suspense>
+                </SectionErrorBoundary>
 
+                <SectionErrorBoundary label="Footer">
                   <Suspense fallback={null}>
-                    <OnboardingChecklist />
+                    {!isDashboardOrAdmin && <Footer />}
                   </Suspense>
+                </SectionErrorBoundary>
 
-                  <main
-                    id="main-content"
-                    className="relative z-10 min-h-[85vh] bg-white dark:bg-slate-950 text-black dark:text-white transition-colors duration-300"
-                  >
-                    <PageTransition>
-                      <ErrorBoundary>
-                        <Suspense fallback={pageLoader}>
-                          <Routes location={location} key={location.pathname}>
-                            <Route
-                              path="/register/:id"
-                              element={
-                                <ProtectedRoute>
-                                  <EventRegistration />
-                                </ProtectedRoute>
-                              }
-                            />
-                            <Route path="/event-recommendation" element={<EventRecommendation />} />
-                            <Route path="/saved-events" element={<SavedEventsPage />} />
-                            <Route path="*" element={<AppRoutes />} />
-                          </Routes>
-                        </Suspense>
-                      </ErrorBoundary>
-                    </PageTransition>
-                  </main>
+                <Suspense fallback={null}>
+                  <ScrollToTopButton />
+                </Suspense>
+                {/* Enhanced back-to-top with progress ring - appears at 400px */}
+                <Suspense fallback={null}>
+                  <BackToTop />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <FeedbackButton />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <ThemeCustomizerDrawer />
+                </Suspense>
+                <Suspense fallback={null}>
+                  <SessionRecovery />
+                </Suspense>
 
-                  <ScrollToTop />
-
-                  <SectionErrorBoundary label="Chatbot Assist" silent>
-                    <Suspense fallback={null}>
-                      <Chatbot />
-                    </Suspense>
-                  </SectionErrorBoundary>
-
-                  <SectionErrorBoundary label="Footer">
-                    <Suspense fallback={null}>
-                      {!isDashboardOrAdmin && <Footer />}
-                    </Suspense>
-                  </SectionErrorBoundary>
-
+                <SectionErrorBoundary label="Custom Cursor" silent>
                   <Suspense fallback={null}>
-                    <ScrollToTopButton />
+                    <FluidCursor enabled={cursorEnabled} />
                   </Suspense>
-                  {/* Enhanced back-to-top with progress ring - appears at 400px */}
-                  <Suspense fallback={null}>
-                    <BackToTop />
-                  </Suspense>
-                  <Suspense fallback={null}>
-                    <FeedbackButton />
-                  </Suspense>
-                  <Suspense fallback={null}>
-                    <ThemeCustomizerDrawer />
-                  </Suspense>
-                  <Suspense fallback={null}>
-                    <SessionRecovery />
-                  </Suspense>
-
-                  <SectionErrorBoundary label="Custom Cursor" silent>
-                    <Suspense fallback={null}>
-                      <FluidCursor enabled={cursorEnabled} />
-                    </Suspense>
-                  </SectionErrorBoundary>
-                </div>
-              </SessionRecoveryProvider>
-            </MyEventsProvider>
-          </NotificationProvider>
-        </AuthProvider>
-      </ThemeProvider>
+                </SectionErrorBoundary>
+              </div>
+            </SessionRecoveryProvider>
+          </MyEventsProvider>
+        </NotificationProvider>
+      </AuthProvider>
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
## 🚀 Description

Removes the redundant `ThemeProvider` wrapper from `src/App.jsx`. The provider was already mounted at a higher level in `src/index.jsx`, causing double state initialization, duplicate `matchMedia` listeners, and wasted re-renders on every theme change.

With this fix, the component tree has a single `ThemeProvider` in `index.jsx`, ensuring all descendants (including `RealTimeProvider`) can properly access theme context without duplication.

Fixes #5087

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Screenshots / Video (if applicable)

N/A — this is an internal architecture fix with no visual changes. The app renders identically but with one fewer provider re-initialization on mount and theme toggle.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings