### PR TITLE
fix: remove 429 from retryable status codes to avoid worsening rate limit situation

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -216,7 +216,7 @@ API.interceptors.response.use(
 
     const retryCount = config._retryCount || 0;
     const isNonMutating = config.method?.toUpperCase() === 'GET';
-    const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status) || (status === 429);
+    const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status);
     
     // Retry non-mutating requests with exponential backoff
     if (isNonMutating && isRetryableStatus && retryCount < MAX_RETRIES) {


### PR DESCRIPTION
## Summary
Fixes a bug where the API retry logic retried `429 Rate Limit` responses,
actively making the rate limiting situation worse.

## Problem
```js
// BEFORE (broken)
const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status) || (status === 429);
// ❌ 429 means "too many requests, slow down"
// ❌ app immediately retries — defeats rate limiting
// ❌ can trigger longer cooldown bans from the server
```

## Fix
```js
// AFTER (fixed)
const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status);
// ✅ only retries genuine server failures (502, 503, 504)
// ✅ 429 surfaces immediately via RateLimitError
// ✅ respects server rate limiting as intended
```

## Impact
- 429 responses are no longer retried
- Rate limiting works correctly as the server intends
- No wasted bandwidth on requests the server will reject
- 502/503/504 still retry correctly with exponential backoff

## Testing
- API calls work correctly for normal requests ✅
- 429 responses surface RateLimitError immediately ✅
- 502/503/504 still retry once as expected ✅
- No console errors ✅

Fixes #5152 