### PR TITLE
fix: replace throw with return false in login catch block to prevent unhandled promise rejection

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -307,7 +307,7 @@ export const AuthProvider = ({ children }) => {
       } catch (error) {
         if (!isMountedRef.current) return false;
         setAuthRequestState({ loading: false, error: getAuthErrorMessage(error, "Login failed. Please try again.") });
-        throw error;
+        return false;
       }
     },
     [extractSession, persistSession, setAuthRequestState]


### PR DESCRIPTION
## Summary
Fixes a bug where the `login` function both set error state AND threw 
the error, forcing double error handling at every call site and causing 
unhandled promise rejections when try/catch was omitted.

## Problem
```js
// BEFORE (broken)
} catch (error) {
  setAuthRequestState({ loading: false, error: getAuthErrorMessage(...) });
  throw error;
  // ❌ sets error state AND throws
  // ❌ every caller must wrap in try/catch AND watch authRequest.error
  // ❌ unhandled promise rejection if caller forgets try/catch
  // ❌ error can appear twice in UI
}
```

## Fix
```js
// AFTER (fixed)
} catch (error) {
  if (!isMountedRef.current) return false;
  setAuthRequestState({ loading: false, error: getAuthErrorMessage(...) });
  return false;
  // ✅ consistent return contract — false means failure
  // ✅ authRequest.error is single source of truth
  // ✅ no unhandled promise rejections
  // ✅ callers only need to check return value
}
```

## Impact
- No more unhandled promise rejections on failed login
- Single error handling pattern — check return value or authRequest.error
- Error message appears exactly once in UI
- All login call sites work correctly without try/catch

## Testing
- Failed login shows error message correctly ✅
- No unhandled promise rejection in DevTools console ✅
- Successful login redirects correctly ✅
- No console errors ✅

Fixes #5155 