### PR TITLE
fix: call clearExpiredSession directly in isAuthenticated to eliminate stale state race window

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -323,11 +323,11 @@ export const AuthProvider = ({ children }) => {
   const isAuthenticated = useCallback(() => {
     if (!user || !token) return false;
     if (token !== "cookie-managed" && !isTokenValid(token)) {
-      needsExpiryCleanupRef.current = true;
+      clearExpiredSession();
       return false;
     }
     return true;
-  }, [user, token]);
+  }, [user, token, clearExpiredSession]);
 
   const hasRole = useCallback(
     (roleName) => {


### PR DESCRIPTION
## Summary
Fixes a race window where `isAuthenticated` returned `false` for an 
expired token but stale user data remained in state until the next 
render cycle.

## Problem
```js
// BEFORE (broken)
const isAuthenticated = useCallback(() => {
    if (token !== "cookie-managed" && !isTokenValid(token)) {
      needsExpiryCleanupRef.current = true; // ❌ deferred
      return false;
      // ❌ user still in state until next render
      // ❌ components reading user directly see stale data
      // ❌ race window between isAuthenticated(false) and cleanup
    }
}, [user, token]);
```

## Fix
```js
// AFTER (fixed)
const isAuthenticated = useCallback(() => {
    if (token !== "cookie-managed" && !isTokenValid(token)) {
      clearExpiredSession(); // ✅ immediate cleanup
      return false;
      // ✅ user cleared in same call
      // ✅ no stale data accessible via useAuth
      // ✅ no race window
    }
}, [user, token, clearExpiredSession]);
```

## Impact
- Session cleared immediately when expiry detected
- No race window between isAuthenticated and cleanup
- Components reading user directly get consistent state
- ProtectedRoute redirect and session clear happen together

## Testing
- Expired token redirects immediately with session fully cleared ✅
- No stale user data accessible via useAuth after expiry ✅
- Valid token sessions work correctly with no unexpected logouts ✅
- No console errors ✅

Fixes #5157 