### PR TITLE
fix(shortcuts): resolve conflicts between Command Palette and Shortcu…

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -797,14 +797,16 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
   const [showCommandPalette, setShowCommandPalette] = useState(false);
 
   useEffect(() => {
-    const handleKeyDown = (e) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        setShowCommandPalette((prev) => !prev);
-      }
+    const handleToggle = () => setShowCommandPalette((prev) => !prev);
+    const handleClose = () => setShowCommandPalette(false);
+
+    window.addEventListener("toggleCommandPalette", handleToggle);
+    window.addEventListener("closeCommandPalette", handleClose);
+
+    return () => {
+      window.removeEventListener("toggleCommandPalette", handleToggle);
+      window.removeEventListener("closeCommandPalette", handleClose);
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   const drawerRef = useRef(null);

--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -5,16 +5,14 @@ import { NavLink, useLocation } from "react-router-dom";
 import { Search, ChevronDown, Plus, HelpCircle, X } from "lucide-react";
 import { NAV_ITEMS } from "./constants/navItems";
 
-const KeyboardShortcutsModal = lazy(() =>
-  import("../common/KeyboardShortcutsModal")
-);
+
 
 const NavbarLinks = ({ vertical = false, onClick }) => {
   const location = useLocation();
   const navRef = useRef(null);
 
   const [openGroup, setOpenGroup] = useState(null);
-  const [showShortcuts, setShowShortcuts] = useState(false);
+
 
   useEffect(() => {
     setOpenGroup(null);
@@ -202,34 +200,7 @@ const NavbarLinks = ({ vertical = false, onClick }) => {
         );
       })}
 
-      <Suspense fallback={null}>
-        <KeyboardShortcutsModal
-          isOpen={showShortcuts}
-          onClose={() => setShowShortcuts(false)}
-          shortcuts={[
-            {
-              keys: ["Ctrl", "K"],
-              action: "Open search",
-              icon: Search,
-            },
-            {
-              keys: ["Ctrl", "N"],
-              action: "Create new event",
-              icon: Plus,
-            },
-            {
-              keys: ["?"],
-              action: "Show shortcuts",
-              icon: HelpCircle,
-            },
-            {
-              keys: ["Esc"],
-              action: "Close modals",
-              icon: X,
-            },
-          ]}
-        />
-      </Suspense>
+
     </nav>
   );
 };

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -30,9 +30,18 @@ const useKeyboardShortcuts = ({
         key = "/";
       }
 
+      // Command Palette (Ctrl + K or Cmd + K)
+      if ((e.metaKey || e.ctrlKey) && key === "k") {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("toggleCommandPalette"));
+        onCloseHelp?.(); // Close Shortcuts Modal if open
+        return;
+      }
+
       // Open modal (Shift + ? or Shift + /)
       if (e.shiftKey && key === "/") {
         e.preventDefault();
+        window.dispatchEvent(new CustomEvent("closeCommandPalette"));
         onOpenHelp?.();
         return;
       }
@@ -40,13 +49,15 @@ const useKeyboardShortcuts = ({
       // Close modal
       if (key === "escape") {
         e.preventDefault();
+        window.dispatchEvent(new CustomEvent("closeCommandPalette"));
         onCloseHelp?.();
         keyBuffer.current = [];
         return;
       }
 
-      // Prevent navigation shortcuts if the shortcuts modal is open
-      if (isOpen) return;
+      // Prevent navigation shortcuts if any modal is open
+      const hasModalOpen = isOpen || document.body.style.overflow === "hidden" || document.querySelector('[role="dialog"]');
+      if (hasModalOpen) return;
 
       // Ignore navigation sequences if standard command modifier keys are active
       if (e.ctrlKey || e.altKey || e.metaKey) return;

--- a/src/hooks/useKeyboardShortcuts.test.js
+++ b/src/hooks/useKeyboardShortcuts.test.js
@@ -50,7 +50,8 @@ describe("useKeyboardShortcuts", () => {
 
   // ─── Modal shortcuts ───────────────────────────────────────────────────────
 
-  it("opens the help modal when Shift+? is pressed", () => {
+  it("opens the help modal when Shift+? is pressed and closes command palette", () => {
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
     renderHook(
       () => useKeyboardShortcuts({ onOpenHelp, onCloseHelp, isOpen: false }),
       { wrapper }
@@ -58,9 +59,13 @@ describe("useKeyboardShortcuts", () => {
 
     fireKey("?", { shiftKey: true });
     expect(onOpenHelp).toHaveBeenCalledTimes(1);
+    const eventTypes = dispatchSpy.mock.calls.map(call => call[0].type);
+    expect(eventTypes).toContain('closeCommandPalette');
+    dispatchSpy.mockRestore();
   });
 
   it("opens the help modal when Shift+/ is pressed (same logical key)", () => {
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
     renderHook(
       () => useKeyboardShortcuts({ onOpenHelp, onCloseHelp, isOpen: false }),
       { wrapper }
@@ -68,9 +73,13 @@ describe("useKeyboardShortcuts", () => {
 
     fireKey("/", { shiftKey: true });
     expect(onOpenHelp).toHaveBeenCalledTimes(1);
+    const eventTypes = dispatchSpy.mock.calls.map(call => call[0].type);
+    expect(eventTypes).toContain('closeCommandPalette');
+    dispatchSpy.mockRestore();
   });
 
-  it("closes the help modal when Escape is pressed", () => {
+  it("closes the help modal and command palette when Escape is pressed", () => {
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
     renderHook(
       () => useKeyboardShortcuts({ onOpenHelp, onCloseHelp, isOpen: true }),
       { wrapper }
@@ -78,6 +87,23 @@ describe("useKeyboardShortcuts", () => {
 
     fireKey("Escape");
     expect(onCloseHelp).toHaveBeenCalledTimes(1);
+    const eventTypes = dispatchSpy.mock.calls.map(call => call[0].type);
+    expect(eventTypes).toContain('closeCommandPalette');
+    dispatchSpy.mockRestore();
+  });
+
+  it("toggles the command palette when Ctrl+K is pressed and closes help modal", () => {
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+    renderHook(
+      () => useKeyboardShortcuts({ onOpenHelp, onCloseHelp, isOpen: true }),
+      { wrapper }
+    );
+
+    fireKey("k", { ctrlKey: true });
+    expect(onCloseHelp).toHaveBeenCalledTimes(1);
+    const eventTypes = dispatchSpy.mock.calls.map(call => call[0].type);
+    expect(eventTypes).toContain('toggleCommandPalette');
+    dispatchSpy.mockRestore();
   });
 
   // ─── Navigation shortcuts ──────────────────────────────────────────────────


### PR DESCRIPTION
fixes #5082
Summary
Fixes keyboard shortcut conflicts between Command Palette and Keyboard Shortcuts Modal.

Changes Made
Identified conflicting shortcuts: Found that both Command Palette and Keyboard Shortcuts Modal operated independently, leading to simultaneous openings on overlapping keypresses.
Updated shortcut registration: Centralized the Ctrl + K handling within useKeyboardShortcuts.js alongside the Shift + ? modal logic.
Prevented duplicate event handling: Used CustomEvent (toggleCommandPalette / closeCommandPalette) to coordinate state between the central hook and Navbar.js without tightly coupling components.
Cleaned up dead code: Removed an unused <KeyboardShortcutsModal> invocation inside NavbarLinks.jsx which was receiving an invalid shortcuts prop array.
Added/updated tests: Updated useKeyboardShortcuts.test.js to verify that modals dispatch correct close events to prevent simultaneous openings.
Testing
 Existing tests pass
 New shortcut tests added
 Manual verification completed
NOTE:
All changes have been committed to a new branch: fix-keyboard-shortcut-conflicts. You can push it to your fork (git push origin fix-keyboard-shortcut-conflicts) and open a PR against the upstream repository!