### PR TITLE
fix: prevent stale state update in event details

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -1,5 +1,5 @@
 import "./EventDetails.print.css";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import { sanitizeMarkdown } from "../../utils/sanitizeHtml";
 import { toast } from "react-toastify";
@@ -43,11 +43,16 @@ const EventDetails = () => {
 
   const { isRegistered } = useMyEvents();
 
+  const activeRequestId = useRef(0);
+
   const loadEvent = useCallback(async () => {
+    const currentRequestId = ++activeRequestId.current;
+
     setFetchLoading(true);
     setFetchError(null);
     try {
       const res = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
+      if (currentRequestId !== activeRequestId.current) return;
       if (res.ok && res.data) {
         const raw = res.data?.data ?? res.data;
         setEvent({ ...raw, status: getEventStatus(raw) });
@@ -55,6 +60,7 @@ const EventDetails = () => {
         throw new Error(res.data?.message || `Event not found (${res.status})`);
       }
     } catch {
+      if (currentRequestId !== activeRequestId.current) return;
       // Fall back to bundled mock data when the API is unreachable
       const fallback = mockEvents.find((item) => String(item.id) === eventId);
       if (fallback) {
@@ -63,7 +69,9 @@ const EventDetails = () => {
         setFetchError("Event not found.");
       }
     } finally {
-      setFetchLoading(false);
+      if (currentRequestId === activeRequestId.current) {
+        setFetchLoading(false);
+      }
     }
   }, [eventId]);
 

--- a/tests/eventDetails.test.mjs
+++ b/tests/eventDetails.test.mjs
@@ -195,3 +195,5 @@ describe('EventDetails — API fetch logic unit tests', () => {
     const eventId = '999';
     const fallback = mockEvents.find((item) => String(item.id) === eventId);
     assert.strictEqual(fallback, undefined, 'Fallback must return undefined for unknown id');
+  });
+});


### PR DESCRIPTION
## What changed
Fixed a race condition in `EventDetails` by introducing a `useRef`-based active request ID tracker inside `loadEvent()`. Only the most recently initiated API request is now allowed to update the component state. I also fixed a missing bracket syntax error in the associated unit tests file.

## Why it changed
When users rapidly navigated between event pages, older API requests that resolved slowly could overwrite the component state for the current event page, leading to a stale and incorrect UI due to race conditions.

## Related issue
Closes #5080

## Test evidence
- Ran `npm run test:unit` to ensure the core logic API unit tests still pass successfully.