### PR TITLE
chore: remove unused variables in event pages (#5129)

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -1,5 +1,4 @@
 import "./EventDetails.print.css";
-import useRecentlyViewed from "../../hooks/useRecentlyViewed";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useEffect, useState, useRef } from "react";
@@ -17,7 +16,6 @@ import { logError } from "../../utils/errorLogger";
 const EventDetailsPage = () => {
   const { eventId } = useParams();
   const navigate = useNavigate();
-  const { addRecentlyViewed } = useRecentlyViewed();
   const latestRequestIdRef = useRef(0);
   const [loading, setLoading] = useState(true);
   const [event, setEvent] = useState(null);


### PR DESCRIPTION
## 🚀 Description

This PR removes unused variables from event-related components to reduce ESLint warnings and improve code cleanliness without affecting existing functionality.

### Root Cause

Several variables were declared or destructured but never used within their respective components.

Examples:

Before:

```js
const { addRecentlyViewed } = useRecentlyViewed();
```

and

```js
const eventSharingData = ...
```

These values were never referenced after declaration, causing ESLint `no-unused-vars` warnings.

### Changes Made

* Removed the unused `addRecentlyViewed` hook binding from `EventDetailsPage`.
* Removed unused event-related variables identified by ESLint.
* Removed the unused `secondaryBtn` variable.
* Preserved all existing event page functionality and rendering behavior.

### Validation

✅ ESLint warnings related to unused variables in the modified files are resolved.

Executed:

```bash
npx eslint src/Pages/Events/EventCard.js src/Pages/Events/EventDetailsPage.js src/Pages/Home/components/Hero.js --max-warnings=-1
```

✅ Build verification completed.

```bash
npm run build
```

### Files Modified

* src/Pages/Events/EventCard.js
* src/Pages/Events/EventDetailsPage.js
* src/Pages/Home/components/Hero.js

### Issue

Fixes #5129

---

## 🛠️ Type of Change

* [x] Code cleanup
* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A — unused variable cleanup only.

---

## ✅ Checklist

* [x] Changes are limited to the assigned issue
* [x] No functionality changes introduced
* [x] Self-reviewed
* [x] ESLint warnings reduced
* [x] Existing behavior preserved
