### PR TITLE
chore: remove unused imports and props (#5133)

### DIFF
--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -7,7 +7,6 @@ const MobileDrawer = ({
   isOpen,
   closeMenu,
   isAuthenticated,
-  user,
   logout,
 }) => {
   const location = useLocation();

--- a/src/components/navbar/constants/navItems.js
+++ b/src/components/navbar/constants/navItems.js
@@ -4,9 +4,7 @@ import {
   FolderKanban,
   Users,
   Trophy,
-  Info,
   MessageSquare,
-  HelpCircle,
   Book,
   Bookmark,
 } from "lucide-react";

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -1,13 +1,11 @@
 import { lazy } from "react";
 import { Route } from "react-router-dom";
-import PageLayout from "../Layout/PageLayout";
 import ProtectedRoute from "../auth/ProtectedRoute";
 import ErrorBoundary from "../common/ErrorBoundary";
 
 // ─── Lazy-loaded page components ─────────────────────────────────────────────
 // 🔥 FIX: Removed duplicate const declarations for all components
 const HealthCheckPage = lazy(() => import("../../Pages/HealthCheckPage"));
-const CertificateVerifier = lazy(() => import("../../Pages/CertificateVerification/CertificateVerifier"));
 const MockApiResponse = lazy(() => import("../MockApiResponse"));
 
 const HomePage = lazy(() => import("../../Pages/Home/HomePage"));
@@ -34,9 +32,6 @@ const ContactUs = lazy(() => import("../../Pages/Contact/ContactUs"));
 const FeedbackPage = lazy(() => import("../../Pages/Feedback/FeedbackPage"));
 const BookmarkedEvents = lazy(() => import("../../Pages/Events/BookmarkedEvents"));
 const RemindersPage = lazy(() => import("../../Pages/Events/RemindersPage"));
-const EventAnalyticsDashboard = lazy(() => import("../../Pages/Events/EventAnalyticsDashboard"));
-const FloorPlanDesignerPage = lazy(() => import("../../Pages/Events/FloorPlanDesignerPage"));
-const VirtualVenueWalkthrough = lazy(() => import("../../Pages/Events/VirtualVenueWalkthrough"));
 const MyCalendar = lazy(() => import("../../Pages/Calendar/MyCalendar"));
 
 const withModuleBoundary = (children, boundaryName) => (


### PR DESCRIPTION
## Summary

This PR performs code cleanup by removing unused imports and eliminating dead code paths that were no longer referenced in the application.

### Changes Made

* Removed unused navbar drawer prop.
* Removed unused navigation icon imports from `navItems.js`.
* Removed unused lazy route imports from `PublicRoutes.js`.
* Cleaned up related code to reduce lint warnings and improve maintainability.

### Benefits

* Reduces bundle overhead from unused imports.
* Improves code readability and maintainability.
* Eliminates unnecessary ESLint warnings.
* Keeps routing and navigation modules cleaner and easier to maintain.

## Validation

```bash
npx eslint src/components/common/ShareModal.jsx src/components/navbar/MobileDrawer.jsx src/components/navbar/constants/navItems.js src/components/routes/PublicRoutes.js src/setupProxy.js --max-warnings=-1
```

```bash
npm run build
```

Both commands completed successfully.
