### PR TITLE
Feature/fix debounce cleanup

### DIFF
--- a/src/hooks/useFormValidation.enhanced.js
+++ b/src/hooks/useFormValidation.enhanced.js
@@ -47,6 +47,7 @@ export const useFormValidation = (
   // Refs for debouncing and caching
   const timeoutRefs = useRef({});
   const validationCacheRef = useRef({});
+  const isMountedRef = useRef(true);
 
   /**
    * Clear debounce timeout for a field
@@ -64,10 +65,12 @@ export const useFormValidation = (
   const validateField = useCallback(
     async (fieldName, value, allValues) => {
       if (!validationRules[fieldName]) {
-        setValidationState((prev) => ({
-          ...prev,
-          [fieldName]: "idle",
-        }));
+        if (isMountedRef.current) {
+          setValidationState((prev) => ({
+            ...prev,
+            [fieldName]: "idle",
+          }));
+        }
         return null;
       }
 
@@ -100,10 +103,12 @@ export const useFormValidation = (
             typeof validationResult?.then === "function" || validator?.async;
 
           if (isAsyncValidation) {
-            setValidationState((prev) => ({
-              ...prev,
-              [fieldName]: "validating",
-            }));
+            if (isMountedRef.current) {
+              setValidationState((prev) => ({
+                ...prev,
+                [fieldName]: "validating",
+              }));
+            }
 
             const validationStartedAt = Date.now();
             validationResult = await Promise.race([
@@ -148,25 +153,29 @@ export const useFormValidation = (
           if (finalError) break; // Stop at first error
         } catch (err) {
           finalError = err.message || "Validation error";
-          setValidationState((prev) => ({
-            ...prev,
-            [fieldName]: "error",
-          }));
+          if (isMountedRef.current) {
+            setValidationState((prev) => ({
+              ...prev,
+              [fieldName]: "error",
+            }));
+          }
           break;
         }
       }
 
       // Update validation state
-      if (!finalError) {
-        setValidationState((prev) => ({
-          ...prev,
-          [fieldName]: "success",
-        }));
-      } else {
-        setValidationState((prev) => ({
-          ...prev,
-          [fieldName]: "error",
-        }));
+      if (isMountedRef.current) {
+        if (!finalError) {
+          setValidationState((prev) => ({
+            ...prev,
+            [fieldName]: "success",
+          }));
+        } else {
+          setValidationState((prev) => ({
+            ...prev,
+            [fieldName]: "error",
+          }));
+        }
       }
 
       // Cache the result
@@ -209,7 +218,7 @@ export const useFormValidation = (
             validator?.constructor?.name === "AsyncFunction",
         );
 
-        if (mayValidateAsync) {
+        if (mayValidateAsync && isMountedRef.current) {
           setValidationState((prev) => ({ ...prev, [name]: "validating" }));
         }
 
@@ -218,7 +227,9 @@ export const useFormValidation = (
             ...values,
             [name]: fieldValue,
           });
-          setErrors((prev) => ({ ...prev, [name]: error }));
+          if (isMountedRef.current) {
+            setErrors((prev) => ({ ...prev, [name]: error }));
+          }
         }, debounceMs);
       }
     },
@@ -235,7 +246,9 @@ export const useFormValidation = (
 
       if (validationRules[name] && validateOnBlur) {
         const error = await validateField(name, value, values);
-        setErrors((prev) => ({ ...prev, [name]: error }));
+        if (isMountedRef.current) {
+          setErrors((prev) => ({ ...prev, [name]: error }));
+        }
       }
     },
     [validationRules, values, validateField, validateOnBlur],
@@ -311,11 +324,13 @@ export const useFormValidation = (
 
       try {
         const isValid = await validateAll();
-        if (isValid) {
+        if (isValid && isMountedRef.current) {
           await onSubmit(values);
         }
       } finally {
-        setIsSubmitting(false);
+        if (isMountedRef.current) {
+          setIsSubmitting(false);
+        }
       }
     },
     [validateAll, values],
@@ -343,7 +358,9 @@ export const useFormValidation = (
    * Cleanup on unmount
    */
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
+      isMountedRef.current = false;
       Object.keys(timeoutRefs.current).forEach((fieldName) => {
         clearFieldTimeout(fieldName);
       });

--- a/src/hooks/useFormValidation.test.js
+++ b/src/hooks/useFormValidation.test.js
@@ -471,6 +471,43 @@ describe("useFormValidation - Enhanced with Async Support", () => {
     );
   });
 
+  // Test 13: Unmounted component state update prevention
+  it("should not update state if component unmounts during async validation", async () => {
+    const initialState = { username: "" };
+    const rules = {
+      username: asyncValidators.usernameAvailable,
+    };
+
+    const { result, unmount } = renderHook(() =>
+      useFormValidation(initialState, rules, { debounceMs: 50 }),
+    );
+
+    // Trigger async validation
+    act(() => {
+      result.current.handleChange({
+        target: { name: "username", value: "admin", type: "text" },
+      });
+    });
+
+    // Wait for the debounce timer to fire (validation state becomes "validating")
+    await waitFor(
+      () => {
+        expect(result.current.validationState.username).toBe("validating");
+      },
+      { timeout: 200 },
+    );
+
+    // UNMOUNT the component WHILE the async promise is still pending
+    unmount();
+
+    // Wait enough time for the async validator to resolve
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // After resolution, the error state should NOT have been updated,
+    // avoiding the React warning. The errors should still be empty/undefined.
+    expect(result.current.errors.username).toBeUndefined();
+  });
+
   // Cleanup
   afterEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
Description
 This PR resolves an issue in the useFormValidation hooks where asynchronous validation tasks initiated by debounce timers could outlive the component lifecycle. If a component unmounted while an async validation request was pending, the hook would attempt to update React state once the validation resolved, resulting in a "stale state update on an unmounted component" warning and potential memory leaks.

Changes Made

Introduced an isMountedRef to useFormValidation.enhanced.js to reliably track the component's lifecycle.
Wrapped state updates (setErrors, setValidationState, setIsSubmitting) inside handleChange, validateField, and handleSubmit with an isMountedRef.current guard.
Added a dedicated unit test in useFormValidation.test.js to explicitly reproduce and verify that state updates are safely swallowed if the component unmounts mid-validation.
Benefits

Eliminates React warnings regarding state updates on unmounted components.
Fixes race conditions and memory leaks during rapid navigation away from forms that are currently validating.
The external API and behavior of the hook remain completely unchanged, ensuring zero disruption to existing components.
Related Issues Fixes #5078
