### PR TITLE
fix: prevent stale state update on TicketScanner unmount

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -32,6 +32,7 @@ export default function TicketScanner() {
   const [manualEventName, setManualEventName] = useState("Global AI Hackathon");
 
   const qrCodeInstanceRef = useRef(null);
+  const isMountedRef = useRef(true);
   const readerId = "html5-qr-reader";
 
   // Load cameras
@@ -59,6 +60,7 @@ export default function TicketScanner() {
 
     return () => {
       // Cleanup scanner on unmount
+      isMountedRef.current = false;
       stopScanner();
     };
   }, []);
@@ -68,7 +70,9 @@ export default function TicketScanner() {
     if (qrCodeInstanceRef.current && qrCodeInstanceRef.current.isScanning) {
       try {
         await qrCodeInstanceRef.current.stop();
-        setScannerStatus("stopped");
+        if (isMountedRef.current) {
+          setScannerStatus("stopped");
+        }
       } catch (err) {
         console.error("Failed to stop scanner:", err);
       }

--- a/src/components/admin/TicketScanner.test.jsx
+++ b/src/components/admin/TicketScanner.test.jsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { render, act } from "@testing-library/react";
+import TicketScanner from "./TicketScanner";
+
+// Mock toast to avoid errors during render
+jest.mock("react-toastify", () => ({
+  toast: {
+    error: jest.fn(),
+    warning: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+// We will track the stop promise to resolve it manually
+let resolveStop;
+const mockStop = jest.fn().mockReturnValue(
+  new Promise((resolve) => {
+    resolveStop = resolve;
+  })
+);
+
+// Mock Html5Qrcode
+jest.mock("html5-qrcode", () => {
+  class MockHtml5Qrcode {
+    constructor() {
+      this.isScanning = true;
+    }
+    start = jest.fn().mockResolvedValue();
+    stop = mockStop;
+
+    static getCameras = jest.fn().mockResolvedValue([
+      { id: "cam1", label: "Back Camera" },
+    ]);
+  }
+  return { Html5Qrcode: MockHtml5Qrcode };
+});
+
+describe("TicketScanner Component", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    console.error.mockRestore();
+  });
+
+  it("should not update scannerStatus if component unmounts while camera is stopping", async () => {
+    // 1. Render the component
+    const { unmount } = render(<TicketScanner />);
+
+    // Wait for the initial getCameras promise to resolve
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // 2. Unmount the component.
+    // This triggers the useEffect cleanup, which calls stopScanner().
+    unmount();
+
+    // The mockStop should have been called
+    expect(mockStop).toHaveBeenCalled();
+
+    // 3. Resolve the stop promise while the component is unmounted
+    await act(async () => {
+      if (resolveStop) resolveStop();
+      // Allow event loop to process the resolution
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    // If the fix is successful, we won't see the "Can't perform a React state update on an unmounted component"
+    // warning in the console because isMountedRef prevents setScannerStatus from being called.
+    // We expect the console.error NOT to have been called with the React state update warning.
+    const consoleCalls = console.error.mock.calls.map(call => call[0]);
+    const hasUnmountedWarning = consoleCalls.some(msg => 
+      typeof msg === "string" && msg.includes("unmounted component")
+    );
+    
+    expect(hasUnmountedWarning).toBe(false);
+  });
+});

--- a/test_cleanup.cjs
+++ b/test_cleanup.cjs
@@ -1,0 +1,17 @@
+const React = require('react');
+const { renderHook } = require('@testing-library/react');
+
+function useTest() {
+  let cleaned = false;
+  React.useEffect(() => {
+    return () => {
+      cleaned = true;
+    };
+  }, []);
+  return () => cleaned;
+}
+
+const { result, unmount } = renderHook(() => useTest());
+console.log('Before unmount:', result.current());
+unmount();
+console.log('After unmount:', result.current());


### PR DESCRIPTION
Description 
This PR resolves a memory leak and a race condition inside the TicketScanner component. Previously, if an admin navigated away from the scanner page while the camera hardware was actively shutting down, the component would attempt to update the React state (setScannerStatus) after unmounting.

Changes Made

Introduced an isMountedRef flag to reliably track the component's lifecycle.
Wrapped the asynchronous setScannerStatus call inside stopScanner with a mount-state guard.
Added a new unit test suite (TicketScanner.test.jsx) to explicitly verify that unmount lifecycle events correctly swallow pending camera shutdown state updates.
Benefits

Eliminates React warnings regarding state updates on unmounted components.
Fixes race conditions and memory leaks during rapid navigation away from the scanner tool.
Makes the admin dashboard more stable.
Related Issues Fixes stale state update and memory leak in TicketScanner.jsx.
