### PR TITLE
style: remove oversized generated comment block from BackToTop

### DIFF
--- a/src/components/common/BackToTop.jsx
+++ b/src/components/common/BackToTop.jsx
@@ -1,20 +1,3 @@
-/**
- * BackToTop
- *
- * A floating "scroll to top" button that:
- * - Appears after the user scrolls more than SCROLL_THRESHOLD px (default 400)
- * - Smoothly scrolls back to the top on click
- * - Fades in/out with a CSS transition
- * - Is fully keyboard-accessible (focusable, Enter/Space activates it)
- * - Respects prefers-reduced-motion by using instant scroll when enabled
- * - Shows a subtle scroll progress arc so the user knows how far they've scrolled
- *
- * Usage:
- *   import BackToTop from "../common/BackToTop";
- *   // In your component/layout return:
- *   <BackToTop />
- */
-
 import { useEffect, useState, useCallback } from "react";
 import { ChevronUp } from "lucide-react";
 


### PR DESCRIPTION
**Description**
This PR removes the very large, auto-generated block comment at the top of the `BackToTop` component to improve code maintainability and developer experience.

**Changes Made**
- Deleted the 16-line redundant JSDoc-style comment block from `src/components/common/BackToTop.jsx`.
- Cleaned up the top of the file so that it directly begins with imports, improving readability.

**Benefits**
- Cleaner source files.
- Easier code reviews.
- Improved contributor experience and better maintainability.

**Related Issues**
Fixes #5070