### PR TITLE
fix: prevent non-idempotent api retries #5067

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -195,12 +195,22 @@ const normalizeApiError = (error) => {
   );
 };
 
-// 🔥 HERE IS WHERE WE FIXED THE BUG 🔥
 // We completely removed the `if (!config.signal)` block that was generating the Ghost AbortController.
 API.interceptors.request.use((config) => {
   if (isDev) {
     console.debug(`[API ${config.method?.toUpperCase()}]`, buildApiUrl(config.url || ""));
   }
+  
+  const method = config.method?.toUpperCase();
+  if (method && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+    if (!config.headers['Idempotency-Key'] && !config.headers['X-Idempotency-Key']) {
+      const generateId = () => typeof crypto !== 'undefined' && crypto.randomUUID 
+        ? crypto.randomUUID() 
+        : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+      config.headers['Idempotency-Key'] = generateId();
+    }
+  }
+  
   return config;
 });
 

--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -95,8 +95,8 @@ const useOfflineSync = () => {
     });
   };
 
-    // 🔥 FIX: Added 'signal' parameter to pass the abort context down to fetchWithTimeout
-    const postWithBackoff = async (url, payload, authToken, attempt = 0, forceOverride = false, signal = null) => {
+    // 🔥 FIX: Added 'signal' and 'idempotencyKey' parameters
+    const postWithBackoff = async (url, payload, authToken, attempt = 0, forceOverride = false, signal = null, idempotencyKey = null) => {
       if (attempt > 0) {
         const baseDelayMs = BASE_BACKOFF_MS * Math.pow(2, attempt - 1);
         const jitterMs = Math.random() * 500;
@@ -108,6 +108,7 @@ const useOfflineSync = () => {
       const headers = { 'Content-Type': 'application/json' };
       if (authToken) headers.Authorization = `Bearer ${authToken}`;
       if (forceOverride) headers['X-Override-Conflict'] = 'true';
+      if (idempotencyKey) headers['Idempotency-Key'] = idempotencyKey;
 
       const { response, data } = await fetchWithTimeout(
         url,
@@ -231,7 +232,8 @@ const useOfflineSync = () => {
               token,
               0,
               false,
-              conflictController.signal // 🔥 FIX: Pass signal
+              conflictController.signal, // 🔥 FIX: Pass signal
+              item.id // Pass idempotency key
             );
 
             // Handle Conflict loop — pass the abort signal so the waiter
@@ -241,10 +243,10 @@ const useOfflineSync = () => {
 
               if (resolution.resolution === "local") {
                 // Retry with force flag
-                res = await postWithBackoff(url, item.payload, token, 0, true, conflictController.signal);
+                res = await postWithBackoff(url, item.payload, token, 0, true, conflictController.signal, item.id);
               } else if (resolution.resolution === "merge") {
                 // Post merged content
-                res = await postWithBackoff(url, resolution.mergedPayload, token, 0, true, conflictController.signal);
+                res = await postWithBackoff(url, resolution.mergedPayload, token, 0, true, conflictController.signal, item.id);
               } else {
                 // Discard local (treated as handled success so we proceed)
                 res = { status: "success" };


### PR DESCRIPTION
### Description
This PR resolves an issue where non-idempotent operations (such as POST, PUT, PATCH, and DELETE) could be executed multiple times during network failures or offline-sync retries, leading to duplicate records, multiple payments, or data inconsistencies.

Instead of disabling automatic retries entirely—which degrades the offline-first experience—this PR implements a robust **Idempotency-Key** safeguard.

### Changes Made
- **Global API Interceptor (`src/config/api.js`)**: Automatically generates and appends an `Idempotency-Key` (UUIDv4) header to all mutating HTTP methods (POST, PUT, PATCH, DELETE) if one is not already present.
- **Offline Sync Queue (`src/hooks/useOfflineSync.js`)**: Now explicitly passes the offline action item's unique `id` as the `Idempotency-Key` when retrying requests in the background. If a network drops after the server processes an offline action, the next background sync will reuse the same key, allowing the server to safely return the cached response instead of duplicating the side effect.

### Benefits
- Prevents duplicate side-effects (e.g., double registrations) across the entire application.
- Preserves the resiliency of the offline queue without risking data inconsistency.

### Related Issues
Fixes #5067