### PR TITLE
fix: associate validation messages using aria-describedby #5066

### DIFF
--- a/src/components/common/FormInput.jsx
+++ b/src/components/common/FormInput.jsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 
 const FormInput = ({
   label,
@@ -5,17 +6,24 @@ const FormInput = ({
   className = "",
   ...props
 }) => {
+  const generatedId = useId();
+  const inputId = props.id || props.name || generatedId;
+  const errorId = `${inputId}-error`;
+
   return (
     <div className="w-full space-y-2">
       
       {label && (
-        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+        <label htmlFor={inputId} className="block text-sm font-medium text-slate-700 dark:text-slate-300">
           {label}
         </label>
       )}
 
       <input
         {...props}
+        id={inputId}
+        aria-invalid={error ? "true" : "false"}
+        aria-describedby={error ? errorId : props['aria-describedby']}
         className={`
           w-full
           px-4
@@ -44,7 +52,7 @@ const FormInput = ({
       />
 
       {error && (
-        <p className="text-sm text-red-500">
+        <p id={errorId} className="text-sm text-red-500" role="alert">
           {error}
         </p>
       )}


### PR DESCRIPTION
### Description
This PR resolves an accessibility issue where form validation errors were only indicated visually but were not programmatically associated with their corresponding form inputs for screen readers.

### Changes Made
- **`src/components/common/FormInput.jsx`**:
  - Imported and utilized React's `useId()` to generate a unique, stable fallback ID for inputs if an ID or name is not explicitly provided.
  - Wired the `<label>` to the `<input>` using `htmlFor`.
  - Added `id` to the error message `<p>` tag and appended `role="alert"`.
  - Injected `aria-describedby` on the `<input>` field, linking it to the error element whenever a validation error is present.
  - Bound `aria-invalid` to the presence of an error state.

### Benefits
- Form validation error announcements are now accurately conveyed to screen readers.
- Improves WCAG accessibility compliance and overall user experience for keyboard/assistive-device users.

### Related Issues
Fixes #5066