### PR TITLE
 fix(zoom): use non-passive wheel listener for seat selector (#5194)

### DIFF
--- a/src/components/events/SpatialSeatSelector.jsx
+++ b/src/components/events/SpatialSeatSelector.jsx
@@ -1,23 +1,129 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ZoomIn, ZoomOut, RotateCcw, CheckCircle, ShieldAlert, Sparkles, HelpCircle } from "lucide-react";
+import {
+  ZoomIn,
+  ZoomOut,
+  RotateCcw,
+  CheckCircle,
+  ShieldAlert,
+  Sparkles,
+  HelpCircle,
+} from "lucide-react";
 import "./SpatialSeatSelector.css";
 
 // Fallback presets if no venue layout is stored yet
 const DEFAULT_PRESETS = {
   banquet: [
-    { id: "stage-1", type: "stage", label: "Main Stage", x: 350, y: 50, width: 300, height: 120, rotation: 0, seatsCount: 0, assignedAttendees: {} },
-    { id: "table-1", type: "round-table", label: "VIP Table A", x: 200, y: 300, width: 140, height: 140, rotation: 0, seatsCount: 8, tier: "VIP Front Row", assignedAttendees: { 0: "Amit Sharma", 1: "Priya Singh" } },
-    { id: "table-2", type: "round-table", label: "VIP Table B", x: 660, y: 300, width: 140, height: 140, rotation: 0, seatsCount: 8, tier: "VIP Front Row", assignedAttendees: { 2: "Rohit Verma", 3: "Neha Kapoor" } },
-    { id: "table-3", type: "round-table", label: "Table 1", x: 120, y: 520, width: 120, height: 120, rotation: 0, seatsCount: 6, tier: "General Seating", assignedAttendees: {} },
-    { id: "table-4", type: "round-table", label: "Table 2", x: 440, y: 520, width: 120, height: 120, rotation: 0, seatsCount: 6, tier: "General Seating", assignedAttendees: {} },
-    { id: "table-5", type: "round-table", label: "Table 3", x: 760, y: 520, width: 120, height: 120, rotation: 0, seatsCount: 6, tier: "General Seating", assignedAttendees: {} },
-    { id: "booth-1", type: "booth", label: "Sound & Lights", x: 450, y: 750, width: 100, height: 80, rotation: 0, seatsCount: 0, assignedAttendees: {} },
-    { id: "barrier-1", type: "barrier", label: "Security Line", x: 250, y: 220, width: 500, height: 10, rotation: 0, seatsCount: 0, assignedAttendees: {} }
-  ]
+    {
+      id: "stage-1",
+      type: "stage",
+      label: "Main Stage",
+      x: 350,
+      y: 50,
+      width: 300,
+      height: 120,
+      rotation: 0,
+      seatsCount: 0,
+      assignedAttendees: {},
+    },
+    {
+      id: "table-1",
+      type: "round-table",
+      label: "VIP Table A",
+      x: 200,
+      y: 300,
+      width: 140,
+      height: 140,
+      rotation: 0,
+      seatsCount: 8,
+      tier: "VIP Front Row",
+      assignedAttendees: { 0: "Amit Sharma", 1: "Priya Singh" },
+    },
+    {
+      id: "table-2",
+      type: "round-table",
+      label: "VIP Table B",
+      x: 660,
+      y: 300,
+      width: 140,
+      height: 140,
+      rotation: 0,
+      seatsCount: 8,
+      tier: "VIP Front Row",
+      assignedAttendees: { 2: "Rohit Verma", 3: "Neha Kapoor" },
+    },
+    {
+      id: "table-3",
+      type: "round-table",
+      label: "Table 1",
+      x: 120,
+      y: 520,
+      width: 120,
+      height: 120,
+      rotation: 0,
+      seatsCount: 6,
+      tier: "General Seating",
+      assignedAttendees: {},
+    },
+    {
+      id: "table-4",
+      type: "round-table",
+      label: "Table 2",
+      x: 440,
+      y: 520,
+      width: 120,
+      height: 120,
+      rotation: 0,
+      seatsCount: 6,
+      tier: "General Seating",
+      assignedAttendees: {},
+    },
+    {
+      id: "table-5",
+      type: "round-table",
+      label: "Table 3",
+      x: 760,
+      y: 520,
+      width: 120,
+      height: 120,
+      rotation: 0,
+      seatsCount: 6,
+      tier: "General Seating",
+      assignedAttendees: {},
+    },
+    {
+      id: "booth-1",
+      type: "booth",
+      label: "Sound & Lights",
+      x: 450,
+      y: 750,
+      width: 100,
+      height: 80,
+      rotation: 0,
+      seatsCount: 0,
+      assignedAttendees: {},
+    },
+    {
+      id: "barrier-1",
+      type: "barrier",
+      label: "Security Line",
+      x: 250,
+      y: 220,
+      width: 500,
+      height: 10,
+      rotation: 0,
+      seatsCount: 0,
+      assignedAttendees: {},
+    },
+  ],
 };
 
-const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelectSeat = () => {}, readOnly = false }) => {
+const SpatialSeatSelector = ({
+  eventId = "default",
+  selectedSeat = null,
+  onSelectSeat = () => {},
+  readOnly = false,
+}) => {
   const [elements, setElements] = useState([]);
   const [zoom, setZoom] = useState(0.85);
   const [panOffset, setPanOffset] = useState({ x: 0, y: 0 });
@@ -37,20 +143,27 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
         const parsed = JSON.parse(savedLayout);
         if (Array.isArray(parsed)) {
           // Strict schema validation and sanitization
-          initialElements = parsed.map(el => ({
+          initialElements = parsed.map((el) => ({
             ...el,
-            id: typeof el.id === 'string' || typeof el.id === 'number' ? String(el.id) : Math.random().toString(36).substring(2, 9),
-            type: typeof el.type === 'string' ? el.type : 'round-table',
-            label: typeof el.label === 'string' ? el.label : 'Unknown',
+            id:
+              typeof el.id === "string" || typeof el.id === "number"
+                ? String(el.id)
+                : Math.random().toString(36).substring(2, 9),
+            type: typeof el.type === "string" ? el.type : "round-table",
+            label: typeof el.label === "string" ? el.label : "Unknown",
             x: Number(el.x) || 0,
             y: Number(el.y) || 0,
             width: Number(el.width) || 100,
             height: Number(el.height) || 100,
             rotation: Number(el.rotation) || 0,
             seatsCount: Number(el.seatsCount) || 0,
-            tier: typeof el.tier === 'string' ? el.tier : 'General Seating',
-            assignedAttendees: typeof el.assignedAttendees === 'object' && el.assignedAttendees !== null ? el.assignedAttendees : {},
-            seatLabels: typeof el.seatLabels === 'object' && el.seatLabels !== null ? el.seatLabels : {}
+            tier: typeof el.tier === "string" ? el.tier : "General Seating",
+            assignedAttendees:
+              typeof el.assignedAttendees === "object" && el.assignedAttendees !== null
+                ? el.assignedAttendees
+                : {},
+            seatLabels:
+              typeof el.seatLabels === "object" && el.seatLabels !== null ? el.seatLabels : {},
           }));
         } else {
           initialElements = DEFAULT_PRESETS.banquet;
@@ -83,7 +196,7 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
         positions.push({
           x: centerX + chairDistance * Math.cos(angle),
           y: centerY + chairDistance * Math.sin(angle),
-          index: i
+          index: i,
         });
       }
     } else if (el.type === "rect-table") {
@@ -104,7 +217,7 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
         const dy = py - cY;
         return {
           x: cX + dx * Math.cos(rad) - dy * Math.sin(rad),
-          y: cY + dx * Math.sin(rad) + dy * Math.cos(rad)
+          y: cY + dx * Math.sin(rad) + dy * Math.cos(rad),
         };
       };
 
@@ -159,12 +272,30 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
           setZoom(1.3);
           setPanOffset({
             x: 500 - seat.x,
-            y: 400 - seat.y
+            y: 400 - seat.y,
           });
         }
       }
     }
   }, [readOnly, selectedSeat, elements, getSeatPositions]);
+
+  // Imperatively attach non-passive wheel event listener to avoid console intervention error
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleWheel = (e) => {
+      e.preventDefault();
+      const factor = e.deltaY < 0 ? 1.08 : 0.92;
+      setZoom((prev) => Math.max(0.4, Math.min(2.5, prev * factor)));
+    };
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      container.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
 
   // Pointer drag panning handlers
   const handlePointerDown = (e) => {
@@ -182,7 +313,7 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
     const dy = e.clientY - dragStartRef.current.y;
     setPanOffset({
       x: panStartRef.current.x + dx,
-      y: panStartRef.current.y + dy
+      y: panStartRef.current.y + dy,
     });
   };
 
@@ -190,13 +321,6 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
     if (!isDraggingRef.current) return;
     isDraggingRef.current = false;
     e.currentTarget.releasePointerCapture(e.pointerId);
-  };
-
-  // Wheel zoom handler
-  const handleWheel = (e) => {
-    e.preventDefault();
-    const factor = e.deltaY < 0 ? 1.08 : 0.92;
-    setZoom((prev) => Math.max(0.4, Math.min(2.5, prev * factor)));
   };
 
   // Check if a specific seat index on an element is selected
@@ -217,7 +341,7 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
       elementId: el.id,
       seatIndex: seatIdx,
       seatLabel: `${el.label} - ${label}`,
-      tier: tier
+      tier: tier,
     });
   };
 
@@ -232,7 +356,8 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
           </div>
           <div className="flex gap-4 items-center">
             <div className="text-xs text-zinc-400">
-              Available: <span className="font-bold text-emerald-400">{seatStats.available}</span> / {seatStats.total}
+              Available: <span className="font-bold text-emerald-400">{seatStats.available}</span> /{" "}
+              {seatStats.total}
             </div>
             <div className="text-xs text-zinc-400">
               Occupied: <span className="font-bold text-indigo-400">{seatStats.occupied}</span>
@@ -242,13 +367,12 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
       )}
 
       {/* Seating Viewport */}
-      <div 
+      <div
         ref={containerRef}
         className="ssp-viewport"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
-        onWheel={handleWheel}
       >
         <svg
           className="ssp-blueprint-svg"
@@ -258,21 +382,28 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
           style={{
             transform: `scale(${zoom}) translate(${panOffset.x}px, ${panOffset.y}px)`,
             transformOrigin: "center center",
-            transition: isDraggingRef.current ? "none" : "transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
+            transition: isDraggingRef.current
+              ? "none"
+              : "transform 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)",
           }}
         >
           {/* Visual Defs and Gradients */}
           <defs>
             <pattern id="blueprint-grid" width="30" height="30" patternUnits="userSpaceOnUse">
-              <path d="M 30 0 L 0 0 0 30" fill="none" stroke="rgba(99, 102, 241, 0.03)" strokeWidth="1" />
+              <path
+                d="M 30 0 L 0 0 0 30"
+                fill="none"
+                stroke="rgba(99, 102, 241, 0.03)"
+                strokeWidth="1"
+              />
             </pattern>
-            
+
             {/* VIP/Premium Seat Gradients */}
             <radialGradient id="ssp-vip-avail" cx="50%" cy="50%" r="50%">
               <stop offset="0%" stopColor="#fbbf24" />
               <stop offset="100%" stopColor="#d97706" />
             </radialGradient>
-            
+
             {/* General Admission Gradients */}
             <radialGradient id="ssp-gen-avail" cx="50%" cy="50%" r="50%">
               <stop offset="0%" stopColor="#818cf8" />
@@ -319,7 +450,10 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
                       strokeWidth={1.5}
                     />
                   </>
-                ) : el.type !== "stage" && el.type !== "barrier" && el.type !== "exit" && el.type !== "booth" ? (
+                ) : el.type !== "stage" &&
+                  el.type !== "barrier" &&
+                  el.type !== "exit" &&
+                  el.type !== "booth" ? (
                   <>
                     <path
                       d={`M ${el.x} ${el.y + el.height} 
@@ -347,8 +481,16 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
                     width={el.width}
                     height={el.height}
                     rx={el.type === "stage" ? 8 : 2}
-                    fill={el.type === "stage" ? "rgba(30, 41, 59, 0.85)" : el.type === "exit" ? "rgba(220, 38, 38, 0.15)" : "rgba(31, 41, 55, 0.5)"}
-                    stroke={el.type === "stage" ? "#475569" : el.type === "exit" ? "#dc2626" : "#374151"}
+                    fill={
+                      el.type === "stage"
+                        ? "rgba(30, 41, 59, 0.85)"
+                        : el.type === "exit"
+                          ? "rgba(220, 38, 38, 0.15)"
+                          : "rgba(31, 41, 55, 0.5)"
+                    }
+                    stroke={
+                      el.type === "stage" ? "#475569" : el.type === "exit" ? "#dc2626" : "#374151"
+                    }
                     strokeWidth={el.type === "stage" ? 2 : 1}
                   />
                 )}
@@ -371,7 +513,8 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
                 {(elementSeatPositions.get(el.id) || []).map((seat) => {
                   const isOccupied = el.assignedAttendees[seat.index];
                   const isSelected = isSeatSelected(el.id, seat.index);
-                  const seatLabel = (el.seatLabels && el.seatLabels[seat.index]) || `Seat ${seat.index + 1}`;
+                  const seatLabel =
+                    (el.seatLabels && el.seatLabels[seat.index]) || `Seat ${seat.index + 1}`;
                   const seatTier = el.tier || (isVIP ? "VIP Front Row" : "General Seating");
 
                   // Glow effect for selected seat or active highlight
@@ -392,19 +535,14 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
                           tier: seatTier,
                           occupiedBy: isOccupied || null,
                           x: bbox.left - vrect.left + bbox.width / 2,
-                          y: bbox.top - vrect.top - 10
+                          y: bbox.top - vrect.top - 10,
                         });
                       }}
                       onMouseLeave={() => setHoveredSeat(null)}
                       style={{ cursor: isOccupied ? "not-allowed" : "pointer" }}
                     >
                       {/* 2.5D Chair base drop shadow */}
-                      <circle
-                        cx={seat.x}
-                        cy={seat.y + 3}
-                        r={11}
-                        fill="rgba(0, 0, 0, 0.45)"
-                      />
+                      <circle cx={seat.x} cy={seat.y + 3} r={11} fill="rgba(0, 0, 0, 0.45)" />
 
                       {/* Main Interactive Seat circle */}
                       <circle
@@ -412,26 +550,27 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
                         cy={seat.y}
                         r={11}
                         fill={
-                          isSelected 
-                            ? "url(#ssp-selected)" 
-                            : isOccupied 
-                              ? "#27272a" 
-                              : isVIP 
-                                ? "url(#ssp-vip-avail)" 
+                          isSelected
+                            ? "url(#ssp-selected)"
+                            : isOccupied
+                              ? "#27272a"
+                              : isVIP
+                                ? "url(#ssp-vip-avail)"
                                 : "url(#ssp-gen-avail)"
                         }
                         stroke={
-                          isSelected 
-                            ? "#67e8f9" 
-                            : isOccupied 
-                              ? "#18181b" 
-                              : isVIP 
-                                ? "#f59e0b" 
+                          isSelected
+                            ? "#67e8f9"
+                            : isOccupied
+                              ? "#18181b"
+                              : isVIP
+                                ? "#f59e0b"
                                 : "#6366f1"
                         }
                         strokeWidth={1.5}
                         style={{
-                          transition: "fill 0.25s cubic-bezier(0.4, 0, 0.2, 1), stroke 0.25s cubic-bezier(0.4, 0, 0.2, 1)"
+                          transition:
+                            "fill 0.25s cubic-bezier(0.4, 0, 0.2, 1), stroke 0.25s cubic-bezier(0.4, 0, 0.2, 1)",
                         }}
                       />
 
@@ -458,29 +597,32 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
 
         {/* Viewport Zoom & Reset Controls floating overlay */}
         <div className="ssp-viewport-controls">
-          <button 
+          <button
             type="button"
-            className="ssp-ctrl-btn" 
-            title="Zoom In" 
+            className="ssp-ctrl-btn"
+            title="Zoom In"
             onClick={() => setZoom((z) => Math.min(2.5, z + 0.15))}
           >
             <ZoomIn size={15} />
           </button>
           <div className="ssp-zoom-pct">{Math.round(zoom * 100)}%</div>
-          <button 
+          <button
             type="button"
-            className="ssp-ctrl-btn" 
-            title="Zoom Out" 
+            className="ssp-ctrl-btn"
+            title="Zoom Out"
             onClick={() => setZoom((z) => Math.max(0.4, z - 0.15))}
           >
             <ZoomOut size={15} />
           </button>
           <div className="ssp-ctrl-divider" />
-          <button 
+          <button
             type="button"
-            className="ssp-ctrl-btn" 
-            title="Reset View" 
-            onClick={() => { setZoom(0.85); setPanOffset({ x: 0, y: 0 }); }}
+            className="ssp-ctrl-btn"
+            title="Reset View"
+            onClick={() => {
+              setZoom(0.85);
+              setPanOffset({ x: 0, y: 0 });
+            }}
           >
             <RotateCcw size={15} />
           </button>
@@ -497,19 +639,17 @@ const SpatialSeatSelector = ({ eventId = "default", selectedSeat = null, onSelec
               transition={{ duration: 0.15 }}
               style={{
                 left: hoveredSeat.x,
-                top: hoveredSeat.y
+                top: hoveredSeat.y,
               }}
             >
-              <div className="ssp-pop-title">
-                {hoveredSeat.el.label}
-              </div>
-              <div className="ssp-pop-seat">
-                {hoveredSeat.label}
-              </div>
+              <div className="ssp-pop-title">{hoveredSeat.el.label}</div>
+              <div className="ssp-pop-seat">{hoveredSeat.label}</div>
               <div className="ssp-pop-divider" />
               <div className="ssp-pop-row">
                 <span className="ssp-pop-label">Tier:</span>
-                <span className={`ssp-pop-val ${hoveredSeat.tier.toLowerCase().includes("vip") ? "text-amber-400 font-bold" : "text-indigo-300"}`}>
+                <span
+                  className={`ssp-pop-val ${hoveredSeat.tier.toLowerCase().includes("vip") ? "text-amber-400 font-bold" : "text-indigo-300"}`}
+                >
                   {hoveredSeat.tier}
                 </span>
               </div>


### PR DESCRIPTION
# fix(zoom): use non-passive wheel listener for seat selector (#5194)

## Description
This PR resolves the browser runtime intervention warning/error thrown when a user attempts to scroll/zoom in or out of the seating map in the spatial seat selector. Modern browsers treat scroll/wheel event listeners as passive by default, which throws a runtime exception when calling `e.preventDefault()` and fails to prevent the background page from scrolling during map zoom interactions. 

By registering the wheel listener imperatively using a React Ref and `{ passive: false }` inside a `useEffect` hook, we prevent the event from being treated as passive, allowing us to successfully prevent background page scrolling and clean up the listener properly.

Fixes #5194

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
