### PR TITLE
fix(reminders): timezone-aware trigger calculation (fixes #5199)

### DIFF
--- a/src/utils/reminderUtils.js
+++ b/src/utils/reminderUtils.js
@@ -1,4 +1,4 @@
-import { parseEventDateTimeLocal } from "./timezoneUtils.js";
+import { parseEventToUTC, getUserTimezone } from "./timezoneUtils.js";
 import { safeJsonParse } from "./safeJsonParse.js";
 
 export const REMINDERS_STORAGE_KEY = "eventra_event_reminders";
@@ -20,7 +20,9 @@ export const getReminderId = (eventId, timing) => `${normalizeEventId(eventId)}:
 
 export const getEventDateTime = (event) => {
   if (!event?.date) return null;
-  return parseEventDateTimeLocal(event.date, event.time);
+  const tz = event.timezone || event.timeZone || getUserTimezone();
+  const startMs = parseEventToUTC(event.date, event.time, tz);
+  return startMs !== null ? new Date(startMs) : null;
 };
 
 export const isPastEvent = (event) => {

--- a/tests/reminderUtils.test.mjs
+++ b/tests/reminderUtils.test.mjs
@@ -17,8 +17,12 @@ const _listeners = {};
 global.window = {
   localStorage: {
     getItem: (key) => (key in _lsStore ? _lsStore[key] : null),
-    setItem: (key, val) => { _lsStore[key] = String(val); },
-    removeItem: (key) => { delete _lsStore[key]; },
+    setItem: (key, val) => {
+      _lsStore[key] = String(val);
+    },
+    removeItem: (key) => {
+      delete _lsStore[key];
+    },
   },
   addEventListener: (event, cb) => {
     if (!_listeners[event]) _listeners[event] = [];
@@ -65,8 +69,8 @@ function futureEvent(offsetMinutes = 120) {
   return {
     id: "evt-1",
     title: "Test Event",
-    date: d.toISOString().split("T")[0],   // YYYY-MM-DD
-    time: d.toTimeString().slice(0, 5),    // HH:MM
+    date: d.toISOString().split("T")[0], // YYYY-MM-DD
+    time: d.toTimeString().slice(0, 5), // HH:MM
     location: "Berlin",
   };
 }
@@ -85,11 +89,7 @@ assert.equal(
   "evt-42::15m",
   "getReminderId returns a colon-separated composite key"
 );
-assert.equal(
-  getReminderId(99, "1h"),
-  "99::1h",
-  "getReminderId coerces numeric eventId to string"
-);
+assert.equal(getReminderId(99, "1h"), "99::1h", "getReminderId coerces numeric eventId to string");
 
 // ── isPastEvent ──────────────────────────────────────────────────────────────
 const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
@@ -106,11 +106,7 @@ assert.equal(
   "isPastEvent returns false for an event 6 hours in the future"
 );
 
-assert.equal(
-  isPastEvent({}),
-  true,
-  "isPastEvent returns true when event has no date"
-);
+assert.equal(isPastEvent({}), true, "isPastEvent returns true when event has no date");
 
 // ── getReminderTriggerTime ────────────────────────────────────────────────────
 const futureEvt = futureEvent(120);
@@ -182,5 +178,23 @@ addReminder(evtR, "15m");
 assert.equal(hasReminder(evtR.id, "15m"), true, "reminder exists before removal");
 removeReminder(evtR.id, "15m");
 assert.equal(hasReminder(evtR.id, "15m"), false, "reminder absent after removeReminder");
+
+// ── timezone-aware reminders ───────────────────────────────────────────────────
+const timezoneEvt = {
+  id: "evt-tz",
+  title: "Kolkata Event",
+  date: "2026-06-01",
+  time: "10:00 AM",
+  timezone: "Asia/Kolkata",
+};
+const tzTrigger = getReminderTriggerTime(timezoneEvt, "1h");
+// 10:00 AM Asia/Kolkata is 04:30 AM UTC.
+// 1 hour before is 03:30 AM UTC (2026-06-01T03:30:00Z)
+const expectedTzTrigger = new Date(Date.UTC(2026, 5, 1, 3, 30, 0, 0)); // 5 = June
+assert.equal(
+  tzTrigger.getTime(),
+  expectedTzTrigger.getTime(),
+  "getReminderTriggerTime calculates correct timezone-aware trigger time"
+);
 
 console.log("All reminderUtils tests passed ✓");


### PR DESCRIPTION
# fix(reminders): timezone-aware trigger calculation (#5199)

## Description
Resolves a bug where browser/offline event reminders fired at the wrong time (or was treated as past/elapsed incorrectly) when the user's local timezone differed from the event's location timezone. 

Previously, `getEventDateTime` used `parseEventDateTimeLocal` which parsed dates blindly in the user's local browser timezone. This PR refactors it to use `parseEventToUTC` to accurately resolve the event's local time based on its metadata timezone (`event.timezone` / `event.timeZone`), with a safe fallback to `getUserTimezone()` to retain backward-compatibility for event structures lacking explicit timezone data.

Fixes #5199

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass (specifically `reminderUtils.test.mjs`)
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
