### PR TITLE
fix: prevent stale async response from overwriting fresh event data in EventDetails (#3658)

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -43,16 +43,18 @@ const EventDetails = () => {
 
   const { isRegistered } = useMyEvents();
 
-  const activeRequestId = useRef(0);
+  const latestRequestIdRef = useRef(0);
 
   const loadEvent = useCallback(async () => {
-    const currentRequestId = ++activeRequestId.current;
+    const requestId = ++latestRequestIdRef.current;
+    const isLatestRequest = () => latestRequestIdRef.current === requestId;
 
     setFetchLoading(true);
     setFetchError(null);
+
     try {
       const res = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
-      if (currentRequestId !== activeRequestId.current) return;
+      if (!isLatestRequest()) return;
       if (res.ok && res.data) {
         const raw = res.data?.data ?? res.data;
         setEvent({ ...raw, status: getEventStatus(raw) });
@@ -60,7 +62,7 @@ const EventDetails = () => {
         throw new Error(res.data?.message || `Event not found (${res.status})`);
       }
     } catch {
-      if (currentRequestId !== activeRequestId.current) return;
+      if (!isLatestRequest()) return;
       // Fall back to bundled mock data when the API is unreachable
       const fallback = mockEvents.find((item) => String(item.id) === eventId);
       if (fallback) {
@@ -69,7 +71,7 @@ const EventDetails = () => {
         setFetchError("Event not found.");
       }
     } finally {
-      if (currentRequestId === activeRequestId.current) {
+      if (isLatestRequest()) {
         setFetchLoading(false);
       }
     }


### PR DESCRIPTION
## Description
When navigating between event detail pages rapidly, the EventDetails component can display stale data from a previous (slower) API response overwriting the current (faster) one.

## Root Cause
The loadEvent callback fires on every eventId change via useEffect. Each call is an independent async chain without request tracking.

## What Changed
- Added latestRequestIdRef that increments on every loadEvent invocation
- Each loadEvent checks isLatestRequest() before every state update
- Stale responses are silently discarded

## Type: Bug fix