### PR TITLE
fix: add server-side rate limiting to auth endpoints to prevent brute-force and signup spam (#4657)

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -4,6 +4,7 @@ import { users } from "./signup.js";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 import { buildCorsHeaders, corsResponse } from "./cors.js";
 import { ROLE_PERMISSIONS, getPermissionsForRoles } from "../lib/permissions.js";
+import { createRateLimiter } from "../lib/rateLimit.js";
 
 // Pre-compute a dummy bcrypt hash at module load time (same cost factor used in signup.js).
 // When a login attempt references a username or email that does not exist, we still run
@@ -17,6 +18,12 @@ const DUMMY_HASH_PROMISE = bcrypt.hash("__eventra_dummy_constant__", 12);
 // ---------------------------------------------------------------------------
 
 const JWT_SECRET = getJwtSecret();
+
+// ---------------------------------------------------------------------------
+// Rate Limiting (IP-based, 5 attempts per minute)
+// ---------------------------------------------------------------------------
+
+const loginRateLimiter = createRateLimiter(60_000, 5);
 
 // ---------------------------------------------------------------------------
 // Validation Helpers
@@ -82,6 +89,24 @@ export default async function handler(req, res) {
 
   try {
     const { usernameOrEmail, password } = req.body;
+
+    // -----------------------------------------------------------------------
+    // Rate Limiting (brute-force protection)
+    // -----------------------------------------------------------------------
+
+    const clientIp = req.headers?.["x-forwarded-for"]?.split(",")[0]?.trim()
+      || req.headers?.["x-real-ip"]
+      || req.socket?.remoteAddress
+      || "unknown";
+
+    loginRateLimiter.evictStale();
+
+    if (!loginRateLimiter.check(clientIp)) {
+      return corsResponse(res, 429, {
+        error: "Too many login attempts. Please try again later.",
+        retryAfter: 60,
+      }, req);
+    }
 
     // -----------------------------------------------------------------------
     // Input Validation
@@ -183,6 +208,9 @@ export default async function handler(req, res) {
     } catch (e) {
       // Ignore write errors on test response objects
     }
+
+    // Reset rate limit on successful login so a legitimate user is not penalised
+    loginRateLimiter.reset(clientIp);
 
     return corsResponse(req, res, 200, {
       message: "Login successful",

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 import { buildCorsHeaders, corsResponse } from "./cors.js";
+import { createRateLimiter } from "../lib/rateLimit.js";
 
 // ---------------------------------------------------------------------------
 // In-memory user storage
@@ -34,6 +35,12 @@ const users = new Map();
 // ---------------------------------------------------------------------------
 
 const JWT_SECRET = getJwtSecret();
+
+// ---------------------------------------------------------------------------
+// Rate Limiting (IP-based, 3 signups per minute)
+// ---------------------------------------------------------------------------
+
+const signupRateLimiter = createRateLimiter(60_000, 3);
 
 // ---------------------------------------------------------------------------
 // Validation Helpers
@@ -124,6 +131,24 @@ export default async function handler(req, res) {
 
   try {
     const { firstName, lastName, email, password, confirmPassword } = req.body;
+
+    // -----------------------------------------------------------------------
+    // Rate Limiting (signup spam protection)
+    // -----------------------------------------------------------------------
+
+    const clientIp = req.headers?.["x-forwarded-for"]?.split(",")[0]?.trim()
+      || req.headers?.["x-real-ip"]
+      || req.socket?.remoteAddress
+      || "unknown";
+
+    signupRateLimiter.evictStale();
+
+    if (!signupRateLimiter.check(clientIp)) {
+      return corsResponse(res, 429, {
+        error: "Too many signup attempts. Please try again later.",
+        retryAfter: 60,
+      }, req);
+    }
 
     // -----------------------------------------------------------------------
     // Input Validation

--- a/api/lib/rateLimit.js
+++ b/api/lib/rateLimit.js
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// Shared sliding-window rate limiter (in-memory, per-key).
+// For production use, replace with Redis-based implementation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a rate limiter instance with the given window and max requests.
+ *
+ * @param {number} windowMs  — sliding window in milliseconds (default 60s)
+ * @param {number} maxRequests — max requests per window per key (default 10)
+ * @returns {{ check: (key: string) => boolean, evictStale: () => void, reset: (key: string) => void }}
+ */
+export const createRateLimiter = (windowMs = 60_000, maxRequests = 10) => {
+  const store = new Map();
+  let lastEvictionAt = 0;
+
+  const evictStale = () => {
+    const now = Date.now();
+    if (now - lastEvictionAt < windowMs) return;
+    lastEvictionAt = now;
+    for (const [key, entry] of store.entries()) {
+      if (now - entry.windowStart >= windowMs) {
+        store.delete(key);
+      }
+    }
+  };
+
+  /**
+   * Returns true if the request is allowed, false if rate-limited.
+   */
+  const check = (key) => {
+    const now = Date.now();
+    const entry = store.get(key);
+
+    if (!entry || now - entry.windowStart >= windowMs) {
+      store.set(key, { count: 1, windowStart: now, maxRequests });
+      return true;
+    }
+
+    if (entry.count >= maxRequests) {
+      return false;
+    }
+
+    entry.count += 1;
+    return true;
+  };
+
+  /**
+   * Reset the rate limit counter for a specific key (e.g. on successful login).
+   */
+  const reset = (key) => {
+    store.delete(key);
+  };
+
+  return { check, evictStale, reset };
+};


### PR DESCRIPTION
## Problem

The login and signup endpoints had zero server-side rate limiting. Client-side rate limiting (useLoginRateLimit hook, sessionStorage token bucket) is trivially bypassed by sending requests directly to the API. An attacker could: 

- Launch unlimited brute-force password attempts against any account
- Flood the signup endpoint with fake registrations
- Exhaust server resources via repeated auth requests

## Fix

Created a shared sliding-window rate limiter (api/lib/rateLimit.js) and integrated it into both auth endpoints: 

- **login**: 5 attempts/minute per IP, resets on successful login so legit users aren't penalized
- **signup**: 3 attempts/minute per IP (stricter to prevent registration spam)

The limiter uses the same in-memory sliding-window pattern already used by ai-recommendations.js, github-proxy.js, send-email.js, and leaderboard.js - extracted into a reusable utility.

## Type: Security / Feature