### PR TITLE
fix: replace wildcard CORS fallback in ai-recommendations with shared cors utility (#4656)

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -2,6 +2,7 @@
 // Secures the Groq API key from frontend exposure
 
 import { verifyAuth } from "./middleware/auth.js";
+import { buildCorsHeaders } from "./auth/cors.js";
 
 // ---------------------------------------------------------------------------
 // Guards
@@ -64,17 +65,15 @@ const checkRateLimit = (userId) => {
 // ---------------------------------------------------------------------------
 
 async function handler(req, res) {
-  // Add CORS headers — credentials header must not be paired with wildcard origin
-  const corsOrigin = process.env.ALLOWED_ORIGIN || "*";
-  res.setHeader("Access-Control-Allow-Origin", corsOrigin);
-  if (corsOrigin !== "*") {
-    res.setHeader("Access-Control-Allow-Credentials", "true");
-  }
+  // Use shared CORS utility (never returns wildcard — maintains credentials safety)
+  res.setHeader("Access-Control-Allow-Origin", buildCorsHeaders(req)["Access-Control-Allow-Origin"]);
+  res.setHeader("Access-Control-Allow-Credentials", "true");
   res.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS,PATCH,DELETE,POST,PUT");
   res.setHeader(
     "Access-Control-Allow-Headers",
     "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization"
   );
+  res.setHeader("Vary", "Origin");
 
   if (req.method === "OPTIONS") {
     res.status(200).end();


### PR DESCRIPTION
## Problem

ai-recommendations.js had inline CORS that fell back to '*' (wildcard) when ALLOWED_ORIGIN env var was not set. This is a security issue because:

1. Browsers reject credentialed responses (Access-Control-Allow-Credentials: true) with a wildcard origin, making the endpoint unusable for authenticated requests

2. A wildcard origin allows any website to read the response, which could leak recommendation data

## Fix

Replaced the inline CORS with the shared cors.js utility that:

- Never returns wildcard - falls back to a specific allowlist (production domains + localhost origins)
- Always sends Access-Control-Allow-Credentials: true (safe because the origin is always specific)
- Sets Vary: Origin so CDNs cache per-origin responses correctly

## Type: Security fix