### PR TITLE
refactor: improve ConfirmationModal accessibility using useFocusTrap …

### DIFF
--- a/src/components/common/ConfirmationModal.js
+++ b/src/components/common/ConfirmationModal.js
@@ -1,14 +1,6 @@
-import React, { useEffect, useId, useRef } from "react";
+import React, { useEffect, useId } from "react";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import "./ConfirmationModal.css";
-
-const FOCUSABLE_SELECTOR = [
-  "a[href]",
-  "button:not([disabled])",
-  "textarea:not([disabled])",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(",");
 
 const ConfirmationModal = ({
   isOpen,
@@ -19,9 +11,7 @@ const ConfirmationModal = ({
   confirmText = "Confirm",
   cancelText = "Cancel",
 }) => {
-  const cancelButtonRef = useRef(null);
-  const modalRef = useRef(null);
-  const previouslyFocusedElementRef = useRef(null);
+  const modalRef = useFocusTrap(isOpen);
   const titleId = useId();
   const descriptionId = useId();
 
@@ -29,48 +19,11 @@ const ConfirmationModal = ({
     if (!isOpen) return;
 
     const prevOverflow = document.body.style.overflow;
-    previouslyFocusedElementRef.current = document.activeElement;
-
     document.body.style.overflow = "hidden";
-    cancelButtonRef.current?.focus();
 
     const handleKeyDown = (event) => {
       if (event.key === "Escape") {
         onClose();
-        return;
-      }
-
-      if (event.key !== "Tab") return;
-
-      const focusableElements = Array.from(
-        modalRef.current.querySelectorAll(FOCUSABLE_SELECTOR)
-      ).filter((el) => !el.hasAttribute("disabled"));
-
-      if (focusableElements.length === 0) {
-        event.preventDefault();
-        modalRef.current?.focus();
-        return;
-      }
-
-      const firstFocusableElement = focusableElements[0];
-      const lastFocusableElement = focusableElements[focusableElements.length - 1];
-      const activeElement = document.activeElement;
-
-      if (event.shiftKey && activeElement === firstFocusableElement) {
-        event.preventDefault();
-        lastFocusableElement.focus();
-        return;
-      }
-
-      if (!event.shiftKey && activeElement === lastFocusableElement) {
-        event.preventDefault();
-        firstFocusableElement.focus();
-        return;
-      }
-
-      if (!modalRef.current?.contains(activeElement)) {
-        event.preventDefault();
-        firstFocusableElement.focus();
       }
     };
 
@@ -79,10 +32,6 @@ const ConfirmationModal = ({
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.body.style.overflow = prevOverflow;
-      if (previouslyFocusedElementRef.current?.isConnected) {
-        previouslyFocusedElementRef.current.focus();
-      }
-      previouslyFocusedElementRef.current = null;
     };
   }, [isOpen, onClose]);
 
@@ -119,7 +68,6 @@ const ConfirmationModal = ({
 
         <div className="confirmation-modal-actions">
           <button
-            ref={cancelButtonRef}
             type="button"
             className="confirmation-modal-btn confirmation-modal-btn-cancel"
             onClick={onClose}


### PR DESCRIPTION
### Description
This PR resolves an issue with the `ConfirmationModal` component where its focus trapping and keyboard accessibility implementation was brittle, duplicated, and incomplete.

### Changes Made
- Removed the manual and verbose `useEffect` implementation managing Tab cycles and focus constraints.
- Integrated the centralized `useFocusTrap` hook, delegating all focus management, including aggressive focus bounds and restoring the previously active element upon unmounting.
- Retained the existing `Escape` key handling gracefully, allowing keyboard users to dismiss the modal predictably.
- Ensured `role="dialog"`, `aria-modal="true"`, and the descriptive dynamic IDs are correctly attached to the container that receives the new focus trap reference.

### Benefits
- Codebase standardization by reusing the shared `useFocusTrap` hook, drastically reducing the file size.
- Reliable focus containment for keyboard-only and screen reader users (WCAG compliance).
- Prevents users from tabbing to background elements while the modal overlay is active.

### Related Issues
Fixes #5063
