### PR TITLE
docs: add event stream API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -834,6 +834,41 @@ Authorization: Bearer <token>
 
 - Related event registrations are automatically cleaned up by the backend before the event is deleted.
 
+---
+
+## Stream Event Updates (SSE)
+
+| Method | Endpoint |
+|--------|----------|
+| GET | `/api/events/stream` |
+
+Opens a Server-Sent Events stream connection for event updates.
+
+### Authentication
+Public. No authentication required.
+
+### Purpose
+- This endpoint currently establishes a basic SSE connection.
+- It sends an initial connected event to confirm the stream is active.
+- It prepares the backend for future real-time event broadcasts.
+- *Note: Full real-time event create/update/register broadcasting is not yet implemented.*
+
+### Response Media Type
+`text/event-stream`
+
+### Manual Test Command
+```bash
+curl -N http://localhost:8080/api/events/stream
+```
+
+### Example Stream Output
+```text
+event:connected
+data:Stream connected successfully
+```
+
+#### Backend Implementation PR
+[SandeepVashishtha/Eventra-Backend#BACKEND_PR_NUMBER](https://github.com/SandeepVashishtha/Eventra-Backend/pull/BACKEND_PR_NUMBER)
 
 ---
 


### PR DESCRIPTION
## Related Backend Implementation 

Backend implementation: SandeepVashishtha/Eventra-Backend#47

## Description

This PR updates the API documentation to include the newly added event stream endpoint.

The documented endpoint allows clients to open a Server-Sent Events connection using `GET /api/events/stream`. It currently establishes a basic SSE stream and sends an initial `connected` event to confirm that the connection is active.

## Changes Made

* Documented `GET /api/events/stream`
* Added authentication details for the public SSE endpoint
* Added `text/event-stream` response media type
* Added manual `curl` test example
* Added sample SSE output for the initial connection event
* Clarified that full real-time event broadcasting is not implemented yet

## Notes

The backend implementation for this endpoint is handled in the Eventra-Backend repository.
This PR only syncs the frontend/docs repository documentation with the current backend API behavior. It does not modify frontend components or application logic.
