### PR TITLE
feat: implement strict timeouts for external service calls

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -114,7 +114,7 @@ async function handler(req, res) {
       });
     }
 
-    const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    const response = await fetchWithTimeout("https://api.groq.com/openai/v1/chat/completions", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -130,7 +130,7 @@ async function handler(req, res) {
         ],
         temperature: 0.7,
       }),
-    });
+    }, 12000);
 
     const data = await response.json();
 
@@ -143,6 +143,11 @@ async function handler(req, res) {
   } catch (error) {
     console.error("[Groq Proxy API] Request Failed:", error);
     return res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export default verifyAuth(handler);
+
   }
 }
 

--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -128,12 +128,12 @@ async function handler(req, res) {
   const token = process.env.GITHUB_TOKEN;
 
   try {
-    const fetchRes = await fetch(url.toString(), {
+    const fetchRes = await fetchWithTimeout(url.toString(), {
       headers: {
         Accept: "application/vnd.github.v3+json",
         ...(token ? { Authorization: `token ${token}` } : {}),
       },
-    });
+    }, 10000);
 
     const data = await fetchRes.json();
 
@@ -148,6 +148,11 @@ async function handler(req, res) {
   } catch (error) {
     console.error("GitHub Proxy Error:", error);
     return res.status(500).json({ error: "Failed to fetch from GitHub API" });
+  }
+}
+
+export default verifyAuth(handler);
+
   }
 }
 

--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -145,7 +145,7 @@ export default async function handler(req, res) {
   try {
     const contributorsUrl = `https://api.github.com/repos/${GITHUB_REPO}/contributors`;
     const [contributorsRes, firstPagePrs] = await Promise.all([
-      fetch(contributorsUrl, { headers }),
+      fetchWithTimeout(contributorsUrl, { headers }, 10000),
       fetchPrPage(1, headers),
     ]);
 
@@ -212,5 +212,8 @@ export default async function handler(req, res) {
   } catch (error) {
     console.error("[Leaderboard API] Aggregation Error:", error);
     return res.status(500).json({ error: "Failed to compile leaderboard data" });
+  }
+}
+iled to compile leaderboard data" });
   }
 }

--- a/api/lib/fetchWithTimeout.js
+++ b/api/lib/fetchWithTimeout.js
@@ -1,0 +1,21 @@
+/**
+ * Server-side fetch with timeout support.
+ * @param {string} url
+ * @param {object} options
+ * @param {number} timeout - ms
+ * @returns {Promise<Response>}
+ */
+export const fetchWithTimeout = async (url, options = {}, timeout = 8000) => {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    return response;
+  } finally {
+    clearTimeout(id);
+  }
+};

--- a/api/send-email.js
+++ b/api/send-email.js
@@ -100,7 +100,7 @@ async function handler(req, res) {
   });
 
   try {
-    const response = await fetch("https://api.emailjs.com/api/v1.0/email/send", {
+    const response = await fetchWithTimeout("https://api.emailjs.com/api/v1.0/email/send", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -114,7 +114,7 @@ async function handler(req, res) {
           event_date: eventDateStr,
         },
       }),
-    });
+    }, 8000);
 
     if (!response.ok) {
       const text = await response.text().catch(() => "");
@@ -126,6 +126,11 @@ async function handler(req, res) {
   } catch (error) {
     console.error("[send-email] Request failed:", error);
     return res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+export default verifyAuth(handler);
+;
   }
 }
 


### PR DESCRIPTION
Fixes #5271

### Description
This PR introduces strict, enforceable timeouts for all external API calls within the serverless function layer. This prevents individual requests from hanging and exhausting the execution quota if upstream services (EmailJS, GitHub, Groq) become slow or unresponsive.

### Changes Made
- **Timeout Utility:** Created \pi/lib/fetchWithTimeout.js\ using the \AbortController\ pattern.
- **Email Service:** Added an 8s timeout to EmailJS confirmation sends.
- **GitHub Proxy:** Added a 10s timeout to GitHub API proxy requests.
- **AI Recommendations:** Added a 12s timeout to Groq LLM inference calls.