### PR TITLE
fix: resolve mobile viewport overflow caused by decorative elements (#3441)

### DIFF
--- a/src/Pages/Home/components/HomeCTA.jsx
+++ b/src/Pages/Home/components/HomeCTA.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 
 export default function CTASection() {
   return (
-    <div className="bg-gradient-to-b from-white to-slate-50 dark:from-slate-950 dark:to-slate-950 py-16 sm:py-24 px-4 sm:px-6 lg:px-8 border-t border-slate-200/50 dark:border-slate-800/80">
+    <div className="bg-gradient-to-b from-white to-slate-50 dark:from-slate-950 dark:to-slate-950 py-16 sm:py-24 px-4 sm:px-6 lg:px-8 border-t border-slate-200/50 dark:border-slate-800/80 overflow-hidden">
       {/* Main CTA Section */}
       <section className="relative max-w-6xl mx-auto py-16 sm:py-20 px-6 sm:px-12 rounded-3xl overflow-hidden bg-gradient-to-br from-indigo-500/5 via-purple-500/5 to-pink-500/5 dark:from-indigo-950/30 dark:via-purple-950/20 dark:to-slate-950/40 border border-slate-200/80 dark:border-slate-800/80 shadow-xl shadow-indigo-500/5">
         {/* Soft Background Orbs */}

--- a/src/Pages/Home/components/RecommendationBanner.jsx
+++ b/src/Pages/Home/components/RecommendationBanner.jsx
@@ -1,6 +1,6 @@
 const RecommendationBanner = () => {
   return (
-    <section className="px-4 md:px-8 py-8">
+    <section className="px-4 md:px-8 py-8 overflow-hidden">
       <div className="relative max-w-7xl mx-auto">
         <div aria-hidden className="absolute -left-10 -top-10 w-56 h-56 rounded-full bg-[#D7EAF8] opacity-40 blur-3xl -z-10" />
         <div aria-hidden className="absolute -right-8 top-16 w-44 h-44 rounded-full bg-[#E8F5FB] opacity-35 blur-3xl -z-10" />


### PR DESCRIPTION
## Summary

This PR resolves the mobile viewport overflow issue reported in #3441 by containing decorative background elements that expanded the page width beyond the viewport on smaller devices.
Closes #3441
## Root Cause

Investigation revealed that the navbar was not the direct source of the issue.

The overflow originated from decorative background orbs in:

* `RecommendationBanner.jsx`
* `HomeCTA.jsx`

These absolutely positioned elements extended beyond the viewport boundaries and caused:

* horizontal scrolling
* expanded page canvas width
* degraded mobile navigation experience

## Changes Made

### RecommendationBanner

* Added `overflow-hidden` to the outer section container.
* Prevented the decorative background orb from extending beyond the viewport.

### HomeCTA

* Added `overflow-hidden` to the root wrapper container.
* Ensured the decorative orb remains fully contained across mobile layouts.

## Verification

### Root Cause Isolation

Verified through targeted testing that the identified decorative elements were responsible for the overflow.

### Mobile Validation

Tested at:

* 361px
* 390px
* 720px

Results:

* No horizontal scrollbar
* No horizontal page shift
* `scrollWidth` matches viewport width
* Decorative effects preserved

## Scope

This PR intentionally avoids:

* navbar redesigns
* navigation logic changes
* global overflow rules
* layout system modifications



before  SS:
<img width="1920" height="1080" alt="Screenshot (589)" src="https://github.com/user-attachments/assets/b44baed9-9019-47ef-b07b-1f65f7f155a5" />
<img width="1920" height="1080" alt="Screenshot (588)" src="https://github.com/user-attachments/assets/3182148a-da70-4617-924c-52c2edf1b709" />
<img width="1920" height="1080" alt="Screenshot (587)" src="https://github.com/user-attachments/assets/b0b092d7-6699-4b54-b8b0-6a2bde033821" />
after SS : 
<img width="1920" height="1080" alt="Screenshot (591)" src="https://github.com/user-attachments/assets/c4091b5f-7704-43cc-b258-118d335f15aa" />
<img width="1920" height="1080" alt="Screenshot (590)" src="https://github.com/user-attachments/assets/3eb7472c-24de-4f90-a11e-5f8a42daf71e" />
