### PR TITLE
fix(ux): Update theme-color meta tag dynamically on theme toggle

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -121,12 +121,15 @@ export const ThemeProvider = ({ children }) => {
 
     const metaTheme = document.querySelector('meta[name="theme-color"]');
     if (metaTheme) {
-      metaTheme.setAttribute(
-        "content",
-        customHsl && customHsl.active
-          ? `hsl(${customHsl.h}, ${customHsl.s}%, ${customHsl.l}%)`
-          : "#ffffff"
-      );
+      let themeColor = "#ffffff";
+      if (customHsl && customHsl.active) {
+        themeColor = `hsl(${customHsl.h}, ${customHsl.s}%, ${customHsl.l}%)`;
+      } else {
+        const isDark = document.documentElement.classList.contains("dark") || 
+                       window.matchMedia("(prefers-color-scheme: dark)").matches;
+        themeColor = isDark ? "#090e1a" : "#ffffff";
+      }
+      metaTheme.setAttribute("content", themeColor);
     }
   }, [activeThemeId, customHsl]);
 


### PR DESCRIPTION
## Description
 Closes #5173

This PR improves the mobile and PWA user experience by dynamically updating the browser's `<meta name="theme-color">` tag whenever the user toggles the theme, ensuring the browser's status bar and UI perfectly matches the application's current background.

### Changes Made:
- Refactored `src/context/ThemeContext.js` to observe theme changes.
- Added dynamic detection logic referencing the `.dark` class on the root element.
- The theme-color now seamlessly transitions between `#090e1a` (for Dark Mode) and `#ffffff` (for Light Mode).

### Why this is needed:
Previously, the theme-color meta tag was hardcoded to `#ffffff`, causing a jarring white status bar on mobile browsers even when the application was in dark mode.