### PR TITLE
perf(security): Remove unused EmailJS script from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,11 +72,7 @@
     <!-- Google Sign In -->
     <script src="https://accounts.google.com/gsi/client" async defer></script>
 
-    <!-- EmailJS -->
-    <script
-      src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js"
-      async
-    ></script>
+    <!-- Removed EmailJS -->
   </head>
 
   <body>


### PR DESCRIPTION
## Description
 Closes #5171

This PR removes an unused external CDN dependency to improve the application's security posture and initial load performance.

### Changes Made:
- Removed the `<script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js">` tag from `public/index.html`.

### Why this is needed:
The EmailJS script was being loaded asynchronously on the initial page hit but was not actively utilized anywhere in the application source code. Removing it reduces the payload size, prevents unnecessary network requests to third-party domains, and strictly adheres to our Content Security Policy.