### PR TITLE
fix: Resolve issue #5288 - [Bug] Prevent window location restore crashes in ScrollToTop during transitions

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -5,18 +5,18 @@ const ScrollToTop = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    // Disable browser automatic scroll restoration
-    if ("scrollRestoration" in window.history) {
+    if (typeof window !== "undefined" && "scrollRestoration" in window.history) {
       window.history.scrollRestoration = "manual";
     }
   }, []);
 
   useEffect(() => {
-    // Scroll to top on route change
-    if (window.lenis) {
-      window.lenis.scrollTo(0, { immediate: true });
-    } else {
-      window.scrollTo(0, 0);
+    if (typeof window !== "undefined") {
+      if (window.lenis && typeof window.lenis.scrollTo === "function") {
+        window.lenis.scrollTo(0, { immediate: true });
+      } else {
+        window.scrollTo(0, 0);
+      }
     }
   }, [pathname]);
 


### PR DESCRIPTION
## Description
Fixes issue #5288.

Adds safety guards checking for the existence of `window.lenis` and its scroll methods during component transitions.