### PR TITLE
fix: Resolve issue #5290 - [Accessibility] Automatically clear tabindex state on shiftLandmarkFocus blur

### DIFF
--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -5,12 +5,10 @@ export default function ScrollToTopButton() {
   const [isChatbotOpen, setIsChatbotOpen] = useState(false);
 
   useEffect(() => {
-    // Listen for chatbot state changes
     const handleChatbotState = () => {
       setIsChatbotOpen(document.querySelector('[data-chatbot-open]') !== null);
     };
     
-    // Check initially and set up observer
     handleChatbotState();
     const observer = new MutationObserver(handleChatbotState);
     observer.observe(document.body, { childList: true, subtree: true });
@@ -20,18 +18,22 @@ export default function ScrollToTopButton() {
     };
   }, []);
 
-  // Position based on chatbot state
   const positionClass = isChatbotOpen 
-    ? "bottom-24 left-6"  // When chatbot is open - bottom left
-    : "bottom-6 right-6 sm:bottom-24 sm:right-6"; // When chatbot is closed - bottom right
+    ? "bottom-24 left-6"
+    : "bottom-6 right-6 sm:bottom-24 sm:right-6";
 
   return <BackToTopButton threshold={50} positionClass={positionClass} />;
 }
-// Accessible landmark container router focus shifting utility helper
+
 export const shiftLandmarkFocus = (elementId) => {
   const container = document.getElementById(elementId);
   if (container) {
     container.setAttribute("tabindex", "-1");
     container.focus();
+    const handleBlur = () => {
+      container.removeAttribute("tabindex");
+      container.removeEventListener("blur", handleBlur);
+    };
+    container.addEventListener("blur", handleBlur);
   }
 };


### PR DESCRIPTION
## Description
Fixes issue #5290.

Attaches a blur listener to programmatically focused elements to restore their original tabindex configuration.