### PR TITLE
feat: add PR size labeler workflow

### DIFF
--- a/.github/workflows/pr-label-inheritance.yml
+++ b/.github/workflows/pr-label-inheritance.yml
@@ -31,6 +31,7 @@ jobs:
               'level:',       // owned by difficulty.yml
               'type:',        // owned by type-labeler.yml
               'quality:',     // owned by quality-labeler.yml
+              'size/',         // owned by size-labeler.yml
               'gssoc:',       // owned by pr-auto-assign.yml
               'mentor:',      // managed manually by mentors
             ];

--- a/.github/workflows/size-labeler.yml
+++ b/.github/workflows/size-labeler.yml
@@ -1,0 +1,89 @@
+name: PR Size Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-size-label:
+    name: Assign size label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure size labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const repo = {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            };
+
+            const labels = {
+              'size/XS': {
+                color: '009900',
+                description: 'Extra-small pull request'
+              },
+              'size/S': {
+                color: '77bb00',
+                description: 'Small pull request'
+              },
+              'size/M': {
+                color: 'eebb00',
+                description: 'Medium pull request'
+              },
+              'size/L': {
+                color: 'ee9900',
+                description: 'Large pull request'
+              },
+              'size/XL': {
+                color: 'ee5500',
+                description: 'Extra-large pull request'
+              },
+              'size/XXL': {
+                color: 'ee0000',
+                description: 'Very large pull request'
+              }
+            };
+
+            for (const [name, meta] of Object.entries(labels)) {
+              try {
+                await github.rest.issues.getLabel({ ...repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  ...repo,
+                  name,
+                  color: meta.color,
+                  description: meta.description
+                });
+                console.log(`Created missing label: ${name}`);
+              }
+            }
+
+      - name: Detect and apply size label
+        uses: pascalgn/size-label-action@v0.5.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IGNORED: |
+            package-lock.json
+            yarn.lock
+            pnpm-lock.yaml
+            dist/**
+            build/**
+            coverage/**
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "10": "S",
+              "50": "M",
+              "200": "L",
+              "500": "XL",
+              "1000": "XXL"
+            }


### PR DESCRIPTION
## Summary
- Added a dedicated GitHub Actions workflow to label pull requests by diff size.
- Used `pascalgn/size-label-action@v0.5.7` with thresholds for `size/XS` through `size/XXL`.
- Added a preflight step to create missing size labels automatically.
- Ignored lock files and generated output directories from size calculations.
- Updated PR label inheritance so `size/` labels are treated as workflow-managed labels.

## Why
Large pull requests are harder to review and triage quickly. Automatic size labels give maintainers an immediate signal about review effort without opening the full diff.

## Validation
- Ran `git diff --cached --check` before committing.
- Checked the changed workflow files for trailing whitespace.

## Related Issue
Closes #5283
