### PR TITLE
fix: move localStorage side effects outside React state updater in useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -35,16 +35,19 @@ const useLocalStorage = (key, initialValue) => {
   }
   });
 
+  
   const setValue = useCallback(
     (value) => {
       try {
         setStoredValue((currentVal) => {
           const newValue = value instanceof Function ? value(currentVal) : value;
-          window.localStorage.setItem(key, JSON.stringify(newValue));
 
-          // 🔥 FIX: Mark as internal before dispatching so listener skips it
-          isInternalWrite.current = true;
-          window.dispatchEvent(new CustomEvent("local-storage", { detail: { key } }));
+          queueMicrotask(() => {
+            window.localStorage.setItem(key, JSON.stringify(newValue));
+            isInternalWrite.current = true;
+            window.dispatchEvent(new CustomEvent("local-storage", { detail: { key } }));
+          });
+
           return newValue;
         });
       } catch (error) {


### PR DESCRIPTION
## Summary
Fixes a React anti-pattern in useLocalStorage where side effects were running inside a state updater function.

## Problem
React state updater functions must be pure. The setValue function was calling window.localStorage.setItem() and window.dispatchEvent() inside setStoredValue()'s updater callback. In React 18 Strict Mode, updaters run twice intentionally — causing double writes to localStorage and double event dispatches per setValue call.

## Fix
Wrapped the side effects in queueMicrotask() so they execute after the pure state update, keeping the updater function clean and React-compliant.

## Changes
- src/hooks/useLocalStorage.js — moved side effects outside state updater

Closes #5331 