### PR TITLE
fix: add isValidShareUrl security validation in ShareModal to prevent open-redirect

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -11,6 +11,7 @@ import {
   X,
 } from "lucide-react";
 import { toast } from "react-toastify";
+import { isValidShareUrl } from "../../utils/shareUtils";
 
 const ModalCloseButton = memo(({ onClick }) => (
   <button
@@ -32,6 +33,10 @@ const ShareModal = ({ isOpen, onClose, event }) => {
     }
 
     const shareUrl = `${window.location.origin}/events/${event.id}`;
+    if (!isValidShareUrl(shareUrl)) {
+      console.warn("[ShareModal] Rejected invalid share URL:", shareUrl);
+      return null;
+    }
     const shareText = `Check out this event: ${event.title}`;
 
     return {


### PR DESCRIPTION
## Summary
Closes a security gap where ShareModal built and used share URLs without any validation.

## Problem
shareUtils.js exports isValidShareUrl() specifically to prevent open-redirect attacks. However ShareModal.jsx duplicated the URL-building logic in its own useMemo and never imported or called isValidShareUrl(). This meant the security guard was completely bypassed in the modal.

## Fix
- Imported isValidShareUrl from shareUtils.js into ShareModal.jsx
- Added validation immediately after shareUrl is constructed inside useMemo
- Returns null (modal shows nothing) if the URL fails validation

## Changes
- src/components/common/ShareModal.jsx — added import and URL validation

Closes #5335