### PR TITLE
fix: prevent cross-user localStorage contamination when userId changes in useBookmarks

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -2,7 +2,7 @@
  * @fileoverview useBookmarks - Event bookmarks management hook
  * @module hooks/useBookmarks
  */
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
 /**
  * A custom React hook that manages bookmarked events for a user,
@@ -54,13 +54,27 @@ const useBookmarks = (userId = "guest") => {
     }
   });
 
+  const storageKeyRef = useRef(storageKey);
+  storageKeyRef.current = storageKey;
+
   useEffect(() => {
     try {
-      localStorage.setItem(storageKey, JSON.stringify(bookmarks));
+      localStorage.setItem(storageKeyRef.current, JSON.stringify(bookmarks));
     } catch {
       // localStorage full — fail silently; in-memory state remains correct
     }
-  }, [bookmarks, storageKey]);
+  }, [bookmarks]);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (!stored) { setBookmarks([]); return; }
+      const parsed = JSON.parse(stored);
+      setBookmarks(Array.isArray(parsed) ? parsed : []);
+    } catch {
+      setBookmarks([]);
+    }
+  }, [storageKey]);
 
   /**
    * Toggles bookmark state for an event.


### PR DESCRIPTION
## Summary
Fixes a critical bug where changing userId caused one user's bookmarks to be written into another user's localStorage key.

## Problem
useBookmarks had a single useEffect with [bookmarks, storageKey] as dependencies. When userId changed, both triggers fired simultaneously — the save effect ran first and wrote the old user's bookmarks to the new key, then the re-sync read that already-contaminated key. Net result: cross-user data contamination.

## Fix
- Introduced a storageKeyRef (useRef) to track the current storage key synchronously
- Removed storageKey from the save effect's dependency array so it only fires when bookmarks change
- Added a separate re-sync useEffect that runs only when storageKey changes, correctly loading the new user's bookmarks

## Changes
- src/hooks/useBookmarks.js — added useRef, separated save and re-sync effects

Closes #5345 