### PR TITLE
fix(accessibility): remove aria-live conflict with role alert

### DIFF
--- a/src/components/common/Alert.jsx
+++ b/src/components/common/Alert.jsx
@@ -50,7 +50,6 @@ const Alert = ({
     <div
       className={`flex items-start gap-4 rounded-lg border p-4 ${config.container} ${className}`}
       role="alert"
-      aria-live="polite"
     >
       <div className="flex-shrink-0">
         <Icon className={`h-5 w-5 ${config.iconColor}`} aria-hidden="true" />


### PR DESCRIPTION
## Description
The `Alert` component had both `role="alert"` and `aria-live="polite"` on the same element.

`role="alert"` is implicitly `aria-live="assertive"` (interrupts immediately), but the explicit `aria-live="polite"` was overriding this on some screen readers (notably NVDA + Firefox), causing urgent error messages to be silently dropped or announced too late.

**Fix:** Removed `aria-live="polite"` — `role="alert"` alone is sufficient per WAI-ARIA spec.

Fixes #5337

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings