### PR TITLE
fix: expose API errors in development mode in useCalendarEvents instead of silently using mock data

### DIFF
--- a/src/Pages/Calendar/useCalendarEvents.js
+++ b/src/Pages/Calendar/useCalendarEvents.js
@@ -24,6 +24,8 @@ const useCalendarEvents = () => {
       setEvents(normalizeEvents(apiEvents));
     } catch (error) {
       if (process.env.NODE_ENV === "development") {
+        console.warn("Failed to fetch events. Falling back to mock data.", error);
+        setLoadError(error?.message || "Failed to load events.");
         setEvents(normalizeEvents(mockEvents));
       } else {
         setEvents([]);


### PR DESCRIPTION
## Summary
Fixes a developer experience issue where API failures were silently hidden in development mode, making it impossible to detect broken API endpoints during local development.

## Problem
The catch block in useCalendarEvents.js only set loadError in production. In development, it fell back to mock data with zero indication that the API had failed. This means a broken API endpoint could go undetected through entire development cycles and only surface in production.

## Fix
Added a console.warn and setLoadError call in the development catch branch. Mock data fallback is preserved for convenience, but developers are now clearly informed via console and UI state that the API is unavailable.

## Changes
- src/Pages/Calendar/useCalendarEvents.js — added console.warn and setLoadError in dev mode catch block

Closes #5350 