### PR TITLE
fix(auth): use .every() instead of .some() for requiredPermissions in ProtectedRoute

### DIFF
--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -61,7 +61,7 @@ const ProtectedRoute = ({
   // SECURITY: Check required permissions against JWT claims.
   // Permissions must be verified server-side for critical operations.
   if (requiredPermissions.length > 0) {
-    const hasRequiredPermission = requiredPermissions.some(permission => hasPermission(permission));
+    const hasRequiredPermission = requiredPermissions.every(permission => hasPermission(permission));
     if (!hasRequiredPermission) {
       return <Navigate to="/unauthorized" replace state={{ from: location }} />;
     }


### PR DESCRIPTION
## Description
`requiredPermissions` was using `.some()` (OR logic), meaning a user only needed 
ONE of the listed permissions to access a protected route — not all of them.

`requiredScopes` on line 74 correctly uses `.every()` (AND logic). This fix makes 
`requiredPermissions` consistent with `requiredScopes`.

**Fix:** Changed `.some()` to `.every()` so users must hold ALL required permissions.

Fixes #5339

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings