### PR TITLE
fix: move getVisibility outside usePageVisibility hook

### DIFF
--- a/src/hooks/usePageVisibility.js
+++ b/src/hooks/usePageVisibility.js
@@ -16,12 +16,12 @@ import { useState, useEffect } from "react";
  *
  * @returns {boolean} Whether the page is currently visible
  */
-const usePageVisibility = () => {
-  const getVisibility = () => {
-    if (typeof document === "undefined") return true;
-    return document.visibilityState !== "hidden";
-  };
+const getVisibility = () => {
+  if (typeof document === "undefined") return true;
+  return document.visibilityState !== "hidden";
+};
 
+const usePageVisibility = () => {
   const [isVisible, setIsVisible] = useState(getVisibility);
 
   useEffect(() => {


### PR DESCRIPTION
## Description
Moved `getVisibility` function from inside the `usePageVisibility` hook body to module scope. Previously, a new function object was created on every re-render, wasting memory and violating the principle of stable references for non-component functions.

Fixes #5341

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings