### PR TITLE
fix: change sentiment Excited threshold from > to >= 1.5

### DIFF
--- a/src/utils/sentiment.js
+++ b/src/utils/sentiment.js
@@ -45,7 +45,7 @@ export const analyzeSentiment = (text) => {
  * Gets a descriptive label and an emoji representation based on the sentiment score
  */
 export const getSentimentDisplay = (score) => {
-  if (score > 1.5) {
+  if (score >= 1.5) {
     return {
       emoji: "🌟",
       label: "Excited / Highly Positive",


### PR DESCRIPTION
## Description
Changed the "Excited" sentiment threshold from strict `> 1.5` to `>= 1.5`.

`analyzeSentiment` rounds scores via `toFixed(1)`, so a single positive
keyword produces exactly 1.5 — which previously fell through to "Happy".
Now a score of 1.5 correctly returns "Excited / Highly Positive".

Fixes #5342

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings