### PR TITLE
fix: remove unused imports and variables in authentication components

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -605,7 +605,7 @@ function FAQSectionInner() {
 
         <div className="faq-cards-container">
           {filteredFaqs.length === 0 ? (
-            <div className="max-w-[820px] w-full mx-auto mt-8 mb-16 text-center p-12 rounded-3xl border border-dashed border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/30 backdrop-blur-md animate-pulse">
+            <div className="max-w-205 w-full mx-auto mt-8 mb-16 text-center p-12 rounded-3xl border border-dashed border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-900/30 backdrop-blur-md animate-pulse">
               <div className="inline-flex p-4 rounded-full bg-slate-100 dark:bg-slate-800/80 text-slate-400 dark:text-slate-500 mb-4">
                 <HelpCircle className="w-8 h-8" />
               </div>

--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { API_ENDPOINTS, apiUtils } from "../../config/api";
@@ -56,11 +56,9 @@ const SignupForm = () => {
 
   // Reconstructed missing state variables from the fragmented file
   const [error, setError] = useState("");
-  const [confirmPasswordError, setConfirmPasswordError] = useState("");
-  const [passwordError, setPasswordError] = useState("");
-  const [fieldValidationState, setFieldValidationState] = useState({});
-
-  const emailValidationRequestRef = useRef(0);
+  const [, setConfirmPasswordError] = useState("");
+  const [, setPasswordError] = useState("");
+  const [, setFieldValidationState] = useState({});
   const { password, confirmPassword } = formData;
 
   const setFieldState = useCallback((fieldName, state) => {
@@ -142,7 +140,6 @@ const SignupForm = () => {
   }, [password, confirmPassword, setFieldState]);
 
   useEffect(() => {
-    let isActive = true;
 
     const validatePwd = async () => {
       if (!formData.password) {
@@ -153,9 +150,6 @@ const SignupForm = () => {
     };
     validatePwd();
 
-    return () => {
-      isActive = false;
-    };
   }, [formData.password, setFieldState]);
 
   const handleSubmit = async (e) => {

--- a/src/components/auth/SignupFormExample.jsx
+++ b/src/components/auth/SignupFormExample.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { logger } from "../../utils/logger";
 import { 


### PR DESCRIPTION
This PR removes unused imports, state variables, refs, and cleanup code in the authentication components to address ESLint no-unused-vars warnings.

Changes Made

SignupForm.js

- Removed unused React import
- Removed unused emailValidationRequestRef
- Removed unused isActive cleanup pattern
- Converted unused state values to setter-only state declarations:
- confirmPasswordError
- passwordError
- fieldValidationState

SignupFormExample.jsx

Removed unused React import

Result

- Eliminates ESLint no-unused-vars warnings in authentication components
- Removes dead code and unused declarations
- Preserves existing authentication and validation behavior
- No functional changes