### PR TITLE
fix(bookmarks): add stable sort tiebreaker

### DIFF
--- a/src/utils/bookmarkUtils.js
+++ b/src/utils/bookmarkUtils.js
@@ -94,9 +94,10 @@ export const addBookmarkedEvent = (event) => {
 
   if (nextBookmarks.length > MAX_BOOKMARKS) {
     // Sort oldest-first and drop the last (oldest) entry to stay within limit
-    nextBookmarks = [...nextBookmarks].sort(
-      (a, b) => new Date(a.bookmarkedAt).getTime() - new Date(b.bookmarkedAt).getTime(),
-    );
+    nextBookmarks = [...nextBookmarks].sort((a, b) => {
+      const timeDiff = new Date(a.bookmarkedAt).getTime() - new Date(b.bookmarkedAt).getTime();
+      return timeDiff !== 0 ? timeDiff : String(a.id).localeCompare(String(b.id));
+    });
     nextBookmarks.shift();
     // Re-sort newest-first for consistent read order
     nextBookmarks.sort(


### PR DESCRIPTION
## Description

Added a stable tiebreaker when sorting bookmarks with identical timestamps.

Previously, bookmarks created within the same millisecond could have non-deterministic ordering during bookmark limit enforcement.

Fixes #5343

## Type of change

☑ Bug fix (non-breaking change which fixes an issue)

## Checklist

☑ My code follows the style guidelines of this project
☑ I have performed a self-review of my code
☑ My changes generate no new warnings