### PR TITLE
Align SSE API environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # ============================================
 # For full setup details, see docs/ENV_SETUP_GUIDE.md
 
-# Required: Backend API endpoint
+# Required: Backend API endpoint, including SSE stream endpoints
 REACT_APP_API_URL=http://localhost:8080/api
 
 # Optional: Public repository metadata

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Use `.env.example` as the source of truth.
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `REACT_APP_API_URL` | Yes | Backend API base URL |
+| `REACT_APP_API_URL` | Yes | Backend API base URL used by client requests and SSE streams |
 | `REACT_APP_GITHUB_REPO` | No | Public repo identifier used in metadata |
 | `REACT_APP_PUBLIC_URL` | No | Canonical public app URL |
 | `REACT_APP_VAPID_PUBLIC_KEY` | No | Public web-push key |

--- a/docs/ENV_SETUP_GUIDE.md
+++ b/docs/ENV_SETUP_GUIDE.md
@@ -26,7 +26,7 @@ npm run dev
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `REACT_APP_API_URL` | Yes | Backend API base URL used by client requests |
+| `REACT_APP_API_URL` | Yes | Backend API base URL used by client requests and SSE streams |
 | `REACT_APP_GITHUB_REPO` | No | Public repository identifier for metadata/links |
 | `REACT_APP_PUBLIC_URL` | No | Canonical public URL used for sharing/SEO helpers |
 | `REACT_APP_VAPID_PUBLIC_KEY` | No | Public push-notification key |
@@ -40,7 +40,7 @@ npm run dev
 
 ## Troubleshooting
 
-- If API calls fail, verify `REACT_APP_API_URL` points to a reachable backend.
+- If API calls or SSE streams fail, verify `REACT_APP_API_URL` points to a reachable backend.
 - If shared links are wrong, check `REACT_APP_PUBLIC_URL`.
 - If build-time checks fail, run:
 

--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -282,9 +282,7 @@ class SseMultiplexer {
   openEventSource(path) {
     const sseBaseUrl =
       typeof window !== "undefined"
-        ? process.env.VITE_API_URL ||
-          process.env.REACT_APP_API_URL ||
-          "http://localhost:8080/api/v1"
+        ? process.env.REACT_APP_API_URL || "http://localhost:8080/api/v1"
         : "http://localhost:8080/api/v1";
 
     logger.log(`[SSE Multiplexer] Leader tab opening physical EventSource: ${sseBaseUrl}${path}`);

--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -92,6 +92,8 @@ sseMultiplexer.isLeader = true;
 sseMultiplexer.reconcileConnections();
 
 const runTests = async () => {
+  process.env.REACT_APP_API_URL = "https://api.example.test";
+
   // Test 1: Local subscription and message delivery
   let receivedData = null;
   let receivedType = null;
@@ -104,6 +106,7 @@ const runTests = async () => {
   sseMultiplexer.reconcileConnections();
   assert.equal(eventSources.length, 1);
   assert.equal(eventSources[0].closed, false);
+  assert.equal(eventSources[0].url, "https://api.example.test/stream/leaderboard");
 
   // Wait for the async connection open simulated by MockEventSource
   await new Promise((resolve) => setTimeout(resolve, 15));


### PR DESCRIPTION
## Description
Fixes #3433

Aligned the SSE EventSource base URL with the documented environment variable name by using `REACT_APP_API_URL` consistently. Updated the environment docs to clarify that `REACT_APP_API_URL` is used for both normal client API calls and SSE stream endpoints.

Added a regression assertion to the SSE multiplexer test to verify EventSource URLs are built from `REACT_APP_API_URL`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports