### PR TITLE
Document Sentry DSN environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ REACT_APP_VAPID_PUBLIC_KEY=
 # Optional: CSP reporting endpoint
 REACT_APP_CSP_REPORT_URI=
 
+# Optional: Sentry browser error reporting DSN
+REACT_APP_SENTRY_DSN=
+
 # ============================================
 # Security Warning (Backend-only secrets)
 # ============================================

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Use `.env.example` as the source of truth.
 | `REACT_APP_PUBLIC_URL` | No | Canonical public app URL |
 | `REACT_APP_VAPID_PUBLIC_KEY` | No | Public web-push key |
 | `REACT_APP_CSP_REPORT_URI` | No | CSP report endpoint |
+| `REACT_APP_SENTRY_DSN` | No | Sentry browser error reporting DSN, used only in production |
 
 Security note: never place private secrets in `REACT_APP_*` or `VITE_*` variables because they are exposed to the client bundle.
 

--- a/docs/ENV_SETUP_GUIDE.md
+++ b/docs/ENV_SETUP_GUIDE.md
@@ -31,11 +31,13 @@ npm run dev
 | `REACT_APP_PUBLIC_URL` | No | Canonical public URL used for sharing/SEO helpers |
 | `REACT_APP_VAPID_PUBLIC_KEY` | No | Public push-notification key |
 | `REACT_APP_CSP_REPORT_URI` | No | CSP report endpoint |
+| `REACT_APP_SENTRY_DSN` | No | Sentry browser error reporting DSN; only used in production builds |
 
 ## Security Notes
 
 - Never place private secrets in `REACT_APP_*` variables.
 - Values prefixed with `REACT_APP_` are exposed in the browser bundle.
+- Leave `REACT_APP_SENTRY_DSN` blank for local development unless you intentionally want browser error reports sent to Sentry.
 - Keep private credentials server-side only (for example `GITHUB_TOKEN`).
 
 ## Troubleshooting


### PR DESCRIPTION
## Description
Fixes #3436

Documented the optional `REACT_APP_SENTRY_DSN` environment variable across the sample env file, README, and environment setup guide.

Clarified that the Sentry DSN is used for browser error reporting only in production builds and can be left blank during local development.

## Type of change
- [x] This change requires a documentation update

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports