### PR TITLE
Remove @rolldown binding dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "dependencies": {
         "@headlessui/react": "2.2.10",
         "@heroicons/react": "^2.2.0",
-        "@rolldown/binding-win32-x64-msvc": "^1.0.3",
-        "@heroicons/react": "^2.0.16",
         "@sentry/browser": "9.12.0",
         "@studio-freight/lenis": "^1.0.42",
         "@tailwindcss/postcss": "4.3.0",
@@ -2835,6 +2833,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2851,6 +2850,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2867,6 +2867,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2883,6 +2884,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2899,6 +2901,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2915,6 +2918,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2931,6 +2935,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2947,6 +2952,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2963,6 +2969,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2979,6 +2986,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2995,6 +3003,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3011,6 +3020,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3027,6 +3037,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3043,6 +3054,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3059,6 +3071,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3075,6 +3088,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3091,6 +3105,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3107,6 +3122,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3123,6 +3139,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3139,6 +3156,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3155,6 +3173,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3171,6 +3190,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3187,6 +3207,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3203,6 +3224,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3219,6 +3241,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3235,6 +3258,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5201,21 +5225,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
@@ -5348,81 +5357,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.12.0.tgz",
-      "integrity": "sha512-GXuDEG2Ix8DmVtTkjsItWdusk2CvJ6EPWKYVqFKifxt+IAT3ZbhGZd99Rg3wdRmt9xhCNuS4QrDzDTPMPgfdCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "9.12.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.12.0.tgz",
-      "integrity": "sha512-3+UxoT97QIXNSUQS4ATL1FFws0RkUb6PeaQN8CPndI6mFlqTW5tuVVLNg9Eo1seNg7R/dfk6WHCWrYN1NbFFKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "9.12.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.12.0.tgz",
-      "integrity": "sha512-njEQosFeO/UX+gG+DMRANkPUuz6OIJLb+A1GVylhq9adUgFQydQ9Ay3v7/x1gMhdfHVP6Jeb27qkti0BWYbzBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "9.12.0",
-        "@sentry/core": "9.12.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.12.0.tgz",
-      "integrity": "sha512-p8LuKZgWT/CoQBbDOXkSGjWWnc8WsnAayWgna8M/ZFWNITCNEM2rCuqZOyWOElIlrni+M7qoEA3jS7MZe8Ejxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "9.12.0",
-        "@sentry/core": "9.12.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.12.0.tgz",
-      "integrity": "sha512-4xQYoZqi+VVhNvlhWiwRd57+SMr3Og4sLjuayAA+zIp1Wx/bDcIld697cugLwml/BR+mVJI2eokkgh1CBl6zag==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "9.12.0",
-        "@sentry-internal/feedback": "9.12.0",
-        "@sentry-internal/replay": "9.12.0",
-        "@sentry-internal/replay-canvas": "9.12.0",
-        "@sentry/core": "9.12.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.12.0.tgz",
-      "integrity": "sha512-jOqQK/90uzHmsBvkPTj/DAEFvA5poX4ZRyC7LE1zjg4F5jdOp3+M4W3qCy0CkSTu88Zu5VWBoppCU2Bs34XEqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "9.12.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@headlessui/react": "2.2.10",
     "@heroicons/react": "^2.2.0",
-    "@rolldown/binding-win32-x64-msvc": "^1.0.3",
     "@sentry/browser": "9.12.0",
     "@studio-freight/lenis": "^1.0.42",
     "@tailwindcss/postcss": "4.3.0",


### PR DESCRIPTION
Remove @rolldown/binding-win32-x64-msvc from package.json dependencies and update package-lock.json accordingly. The lockfile no longer contains the binding's node_modules entry and includes regenerated metadata (several dev/optional flags updated and related entries removed) to reflect the updated dependency tree.

## Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
