### PR TITLE
fix: add missing fetchWithTimeout imports to 4 API handlers

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -3,6 +3,7 @@
 
 import { verifyAuth } from "./middleware/auth.js";
 import { buildCorsHeaders } from "./auth/cors.js";
+import { fetchWithTimeout } from "./lib/fetchWithTimeout.js";
 
 // ---------------------------------------------------------------------------
 // Guards

--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -1,4 +1,5 @@
 import { verifyAuth } from "./middleware/auth.js";
+import { fetchWithTimeout } from "./lib/fetchWithTimeout.js";
 
 const SAFE_GITHUB_PATH_PATTERNS = [
   /^\/repos\/[^/?#]+\/[^/?#]+$/,

--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -1,4 +1,5 @@
 import { getClientIp } from "./lib/getClientIp.js";
+import { fetchWithTimeout } from "./lib/fetchWithTimeout.js";
 
 const GITHUB_REPO = process.env.REACT_APP_GITHUB_REPO || "SandeepVashishtha/Eventra";
 

--- a/api/send-email.js
+++ b/api/send-email.js
@@ -11,6 +11,7 @@
 // ---------------------------------------------------------------------------
 
 import { verifyAuth } from "./middleware/auth.js";
+import { fetchWithTimeout } from "./lib/fetchWithTimeout.js";
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_SENDS = 5;


### PR DESCRIPTION
Fixes #5396. Adds missing fetchWithTimeout imports to api/leaderboard.js, api/github-proxy.js, api/ai-recommendations.js, and api/send-email.js. The source module api/lib/fetchWithTimeout.js exists and exports correctly but was never imported in these consumers, causing ReferenceError crashes at runtime. Let me know if everything looks good!