### PR TITLE
fix: remove duplicate const loginRateLimiter redeclaration in api/auth/login.js

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -228,16 +228,5 @@ async function handler(req, res) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Export users map for sharing with signup.js (development purposes)
-// In production, replace with actual database
-// ---------------------------------------------------------------------------
-
-const loginRateLimiter = createRateLimiter({
-  max: 5,
-  windowMs: 15 * 60 * 1000,
-  message: "Too many authentication attempts. Please try again later.",
-});
-
 export default loginRateLimiter(handler);
 export { users };


### PR DESCRIPTION
Fixes #5400

Removed duplicate `const loginRateLimiter` declaration at lines 235–243 of `api/auth/login.js`. The handler was already correctly wrapped and exported at line 233. This duplicate was a stale block with different rate limit parameters.

Let me know if everything looks good!