### PR TITLE
fix: replace undefined isRetryableMethod with isNonMutating in API retry interceptor

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -231,13 +231,13 @@ API.interceptors.response.use(
     
     // Retry only idempotent reads/probes. Do not blind-retry mutations or 429s,
     // because those can duplicate writes or worsen server-side rate limiting.
-    if (isRetryableMethod && isRetryableStatus && retryCount < MAX_RETRIES) {
+    if (isNonMutating && isRetryableStatus && retryCount < MAX_RETRIES) {
       config._retryCount = retryCount + 1;
       const delay = RETRY_DELAY_MS * Math.pow(2, retryCount);
 
       if (isDev) {
         console.debug(
-          `[API ${method}] ${config.url} returned ${status}, retrying in ${delay}ms (attempt ${config._retryCount})...`
+          `[API ${config.method?.toUpperCase()}] ${config.url} returned ${status}, retrying in ${delay}ms (attempt ${config._retryCount})...`
         );
       }
 


### PR DESCRIPTION
Fixes #5401

- Changed `isRetryableMethod` to `isNonMutating` on line 233 — the variable was never defined, making the retry guard always falsy
- Changed `method` to `config.method?.toUpperCase()` on line 239 in the debug log — `method` was also never declared

Both are in `src/config/api.js` inside the Axios response interceptor retry logic.

Let me know if everything looks good!