### PR TITLE
fix: remove notifications from markAllAsRead deps to prevent polling interval reset

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -386,10 +386,14 @@ export const NotificationProvider = ({ children }) => {
 
     if (!isMounted.current) return;
 
-    const unread = notifications.filter((n) => !n.isRead);
-    if (unread.length === 0) return;
+    let hasUnread = false;
+    setNotifications((prev) => {
+      hasUnread = prev.some((n) => !n.isRead);
+      if (!hasUnread) return prev;
+      return prev.map((n) => ({ ...n, isRead: true }));
+    });
 
-    setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+    if (!hasUnread) return;
 
     const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.READ_ALL;
     if (!isValidEndpoint(endpoint)) return;
@@ -404,7 +408,7 @@ export const NotificationProvider = ({ children }) => {
         fetchNotifications();
       }
     }
-  }, [token, fetchNotifications, notifications]);
+  }, [token, fetchNotifications]);
 
   const subscribeToPush = useCallback(async () => {
     const permission = await requestPushPermission();


### PR DESCRIPTION
Fixes #5414

## Description
`markAllAsRead` had `notifications` in its `useCallback` dependency array. Every new notification caused:

`notifications` changes → `markAllAsRead` recreates → `fetchNotifications` recreates → polling `useEffect` restarts → 60-second interval resets to 0

Under moderate activity, the polling interval never completed a full tick, causing notifications to stop updating.

## Fix
- Removed `notifications` from the dependency array
- Replaced `notifications.filter()` (stale closure read) with a functional `setNotifications((prev) => ...)` update — reads fresh state without needing it as a dependency
- Added `let hasUnread` flag inside the functional update to preserve the early-return behavior

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings