### PR TITLE
fix: show error message with retry button on Events page API failure

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -14,6 +14,7 @@ import useEventListing from "./useEventListing";
 import { useDebouncedValue } from "../../hooks/useDebouncedValue";
 import { prepareSafeSearchQuery } from "../../utils/inputSanitization";
 import SectionErrorBoundary from "../../components/common/SectionErrorBoundary";
+import ErrorMessage from "../../components/common/ErrorMessage";
 import { EventTimeline } from "../../components/EventTimeline";
 import {
   decodeAdvancedFilters,
@@ -28,6 +29,8 @@ const FILTER_STORAGE_KEY = "eventra:event-filters:v1";
 
 const renderCardSection = (
   isLoading,
+  loadError,
+  onRetry,
   paginatedEvents,
   viewMode,
   searchQuery,
@@ -48,6 +51,20 @@ const renderCardSection = (
             <EventCardSkeleton key={`skeleton-${i}`} />
           ))}
         </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex flex-col items-center gap-4 py-16 text-center">
+        <ErrorMessage title="Failed to load events" message={loadError} />
+        <button
+          onClick={onRetry}
+          className="mt-2 px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+        >
+          Try again
+        </button>
       </div>
     );
   }
@@ -304,13 +321,15 @@ const EventsPage = () => {
         />
 
         <SectionErrorBoundary label="Events">
-          {renderCardSection(
-            listing.isLoading,
-            listing.paginatedEvents,
-            listing.viewMode,
-            listing.searchQuery,
-            clearSearchAndFilters
-          )}
+     {renderCardSection(
+  listing.isLoading,
+  listing.loadError,
+  listing.fetchEvents,
+  listing.paginatedEvents,
+  listing.viewMode,
+  listing.searchQuery,
+  clearSearchAndFilters
+)}
 
           {!listing.isLoading && listing.totalPages > 1 && (
             <div className="mt-8 flex justify-center">


### PR DESCRIPTION
- Import ErrorMessage component into EventsPage
- Add loadError and onRetry params to renderCardSection
- Render error UI with Try again button when API call fails
- Fixes #5415

## Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
