### PR TITLE
fix: move push subscription migration check before localStorage write

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -462,24 +462,23 @@ export const NotificationProvider = ({ children }) => {
         subscribed: true,
         subscribedAt: new Date().toISOString(),
       };
-      try {
-        window.localStorage.setItem(PUSH_SUBSCRIPTION_KEY, JSON.stringify(safeLocalRecord));
-      } catch {
-        // Non-fatal — the subscription is still active; local status just won't persist
-      }
 
-      // Migrate: remove any existing full subscription object that may have been
-      // stored by a previous version of this code before this fix was applied.
-      // This runs once per subscribe() call and is a no-op if the key is absent.
+      // Migrate: check for legacy subscription object with sensitive keys BEFORE overwriting.
       const existing = window.localStorage.getItem(PUSH_SUBSCRIPTION_KEY);
       if (existing) {
         try {
           const parsed = JSON.parse(existing);
           if (parsed?.keys) {
-            // Old format with sensitive keys — replace with the safe record
-            window.localStorage.setItem(PUSH_SUBSCRIPTION_KEY, JSON.stringify(safeLocalRecord));
+            // Old format with sensitive keys detected — will be replaced by safe record below
+            console.info("[NotificationContext] Migrating legacy push subscription record.");
           }
         } catch { /* non-fatal */ }
+      }
+
+      try {
+        window.localStorage.setItem(PUSH_SUBSCRIPTION_KEY, JSON.stringify(safeLocalRecord));
+      } catch {
+        // Non-fatal — the subscription is still active; local status just won't persist
       }
 
       const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.PUSH_SUBSCRIBE;


### PR DESCRIPTION
Fixes #5417

## Description
The push subscription migration check was reading `PUSH_SUBSCRIPTION_KEY` from localStorage **after** `safeLocalRecord` had already been written to it on the line above. This meant `parsed?.keys` was always `false` — the migration block was dead code that never triggered.

**Before (broken order):**
1. Write `safeLocalRecord` to localStorage ← overwrites old data
2. Read localStorage back → always gets `safeLocalRecord` (no `.keys`)
3. `if (parsed?.keys)` → never true → migration never runs

**After (correct order):**
1. Read existing localStorage value first
2. Check for legacy `.keys` field and log if found
3. Write `safeLocalRecord` → safely overwrites old data

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings