### PR TITLE
fix: auto-clear statusMessage after 4 seconds in NotificationSettings

### DIFF
--- a/src/Pages/NotificationSettings.jsx
+++ b/src/Pages/NotificationSettings.jsx
@@ -76,27 +76,32 @@ const NotificationSettings = () => {
     }));
   };
 
+  const showStatusMessage = (message) => {
+    setStatusMessage(message);
+    setTimeout(() => setStatusMessage(""), 4000);
+  };
+
   const handlePushToggle = async (enabled) => {
     if (enabled) {
       const result = await subscribeToPush();
       if (result.subscribed) {
-        setStatusMessage("Push notifications are active for this browser.");
+        showStatusMessage("Push notifications are active for this browser.");
       } else if (result.reason === "missing-vapid-key") {
-        setStatusMessage("Browser notifications are enabled. Server push needs a VAPID key.");
+        showStatusMessage("Browser notifications are enabled. Server push needs a VAPID key.");
       } else {
-        setStatusMessage("Push notifications could not be enabled in this browser.");
+        showStatusMessage("Push notifications could not be enabled in this browser.");
       }
       return;
     }
 
     await unsubscribeFromPush();
-    setStatusMessage("Push notifications are paused.");
+    showStatusMessage("Push notifications are paused.");
   };
 
   const handleSave = async () => {
     setIsSaving(true);
     const result = await savePreferences(preferences);
-    setStatusMessage(
+    showStatusMessage(
       result.savedRemotely
         ? "Notification preferences saved."
         : "Notification preferences saved locally."
@@ -112,7 +117,7 @@ const NotificationSettings = () => {
       category: "system",
       timestamp: new Date().toISOString(),
     });
-    setStatusMessage(
+    showStatusMessage(
       delivered
         ? "Test notification sent."
         : "Allow browser notifications to send a test notification."


### PR DESCRIPTION
Fixes #5416

## Description
`setStatusMessage` was called in 6 places across `handlePushToggle`, `handleSave`, and `handleTestNotification` but was never cleared. Once set, the status banner persisted on screen indefinitely until the user navigated away — making the UI appear frozen or stale.

**Fix:**
Introduced a `showStatusMessage` helper that calls `setStatusMessage` and schedules a `setTimeout(() => setStatusMessage(""), 4000)` cleanup. All 6 `setStatusMessage` call sites replaced with `showStatusMessage`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings