### PR TITLE
fix: add isInitialLoad guard to prevent redundant localStorage write on mount in useBookmarks

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -57,7 +57,13 @@ const useBookmarks = (userId = "guest") => {
   const storageKeyRef = useRef(storageKey);
   storageKeyRef.current = storageKey;
 
+  const isInitialLoad = useRef(true);
+
   useEffect(() => {
+    if (isInitialLoad.current) {
+      isInitialLoad.current = false;
+      return;
+    }
     try {
       localStorage.setItem(storageKeyRef.current, JSON.stringify(bookmarks));
     } catch {


### PR DESCRIPTION
Fixes #5418

## Description
The persistence `useEffect` in `useBookmarks.js` had no guard for the initial load. On mount, `bookmarks` is initialized from localStorage via lazy `useState` — this immediately triggers the effect and writes the same data back to localStorage before any user interaction.

`MyEventsContext` in the same codebase already uses an `isInitialLoad` ref (lines 115, 125–128) to prevent exactly this pattern. `useBookmarks` was missing the same guard.

**Fix:**
Added `const isInitialLoad = useRef(true)` and an early return on first effect execution — identical to the pattern already established in `MyEventsContext`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings