### PR TITLE
fix: correct corsResponse argument order in login rate-limit response

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -103,10 +103,10 @@ async function handler(req, res) {
     loginRateLimiter.evictStale();
 
     if (!loginRateLimiter.check(clientIp)) {
-      return corsResponse(res, 429, {
+      return corsResponse(req, res, 429, {
         error: "Too many login attempts. Please try again later.",
         retryAfter: 60,
-      }, req);
+      });
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #5480

## Summary
\corsResponse\ was called with wrong arg order in the rate-limit check path of \pi/auth/login.js\. The function signature is \(req, res, status, data)\ but was called as \(res, 429, data, req)\.

## Changes
- \pi/auth/login.js\: Swapped arguments to match the function signature, removing the orphaned trailing \eq\ argument.