### PR TITLE
fix: correct corsResponse argument order in signup rate-limit response

### DIFF
--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -145,10 +145,10 @@ async function handler(req, res) {
     signupRateLimiter.evictStale();
 
     if (!signupRateLimiter.check(clientIp)) {
-      return corsResponse(res, 429, {
+      return corsResponse(req, res, 429, {
         error: "Too many signup attempts. Please try again later.",
         retryAfter: 60,
-      }, req);
+      });
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #5481

## Summary
Same bug as #5480 in \pi/auth/signup.js\. \corsResponse\ was called as \(res, 429, data, req)\ instead of \(req, res, 429, data)\.

## Changes
- \pi/auth/signup.js\: Fixed argument order in the rate-limit response path.