### PR TITLE
perf: O(1) user lookup in login via username index

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,6 +1,6 @@
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
-import { users } from "./signup.js";
+import { users, usersByUsername } from "./signup.js";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 import { createRateLimiter } from "../middleware/rateLimiter.js";
 import { buildCorsHeaders, corsResponse } from "./cors.js";
@@ -59,17 +59,13 @@ const validateLoginInput = (usernameOrEmail, password) => {
 const findUserByUsernameOrEmail = (usernameOrEmail) => {
   const normalizedInput = usernameOrEmail.trim().toLowerCase();
   
-  // Search through all users
-  for (const [key, user] of users.entries()) {
-    if (
-      user.email === normalizedInput ||
-      user.username === normalizedInput ||
-      user.email === usernameOrEmail.trim() ||
-      user.username === usernameOrEmail.trim()
-    ) {
-      return user;
-    }
-  }
+  // O(1) lookup: try email key first (primary key), then username index
+  const byEmail = users.get(normalizedInput);
+  if (byEmail) return byEmail;
+  
+  const byUsername = usersByUsername.get(normalizedInput);
+  if (byUsername) return byUsername;
+  
   return null;
 };
 

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -30,6 +30,7 @@ if (process.env.NODE_ENV === "production" && !process.env.DATABASE_URL) {
 }
 
 const users = new Map();
+const usersByUsername = new Map();
 
 // ---------------------------------------------------------------------------
 // JWT Configuration
@@ -229,6 +230,9 @@ async function handler(req, res) {
 
     // Store user (in production, save to database)
     users.set(normalizedEmail, newUser);
+    if (newUser.username) {
+      usersByUsername.set(newUser.username.toLowerCase(), newUser);
+    }
 
     // -----------------------------------------------------------------------
     // Generate JWT token
@@ -298,4 +302,4 @@ const signupRateLimiter = createRateLimiter({
 });
 
 export default signupRateLimiter(handler);
-export { users };
+export { users, usersByUsername };


### PR DESCRIPTION
Fixes #5482

## Summary
\indUserByUsernameOrEmail\ in \pi/auth/login.js\ used O(n) iteration over the entire \users\ Map, checking every entry against four match conditions (email lowercased, username lowercased, email original, username original). Added a \usersByUsername\ secondary index in \signup.js\ so lookups are O(1).

## Changes
- \pi/auth/signup.js\: Added \usersByUsername\ Map, populated on signup, exported alongside \users\
- \pi/auth/login.js\: Replaced O(n) iteration with two O(1) \Map.get()\ lookups