### PR TITLE
perf: add stale entry eviction to AI recommendations rate limiter

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -42,8 +42,21 @@ const SYSTEM_PROMPT =
 const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
 const RATE_LIMIT_MAX_REQUESTS = 10;
 const rateLimitMap = new Map();
+let lastEvictionAt = 0;
+
+const evictStaleEntries = () => {
+  const now = Date.now();
+  if (now - lastEvictionAt < RATE_LIMIT_WINDOW_MS) return;
+  lastEvictionAt = now;
+  for (const [key, entry] of rateLimitMap.entries()) {
+    if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+      rateLimitMap.delete(key);
+    }
+  }
+};
 
 const checkRateLimit = (userId) => {
+  evictStaleEntries();
   const now = Date.now();
   const entry = rateLimitMap.get(userId);
 


### PR DESCRIPTION
Fixes #5484

## Summary
The `rateLimitMap` in `api/ai-recommendations.js` accumulated entries for every distinct userId without ever evicting stale ones. Added `evictStaleEntries()` called at the start of `checkRateLimit`, following the same sliding-window pattern used by `leaderboard.js` and `send-email.js`.

## Changes
- `api/ai-recommendations.js`: Added `lastEvictionAt` tracker and `evictStaleEntries()` that purges entries whose window has expired, running at most once per `RATE_LIMIT_WINDOW_MS`
