### PR TITLE
fix: remove unused maxRequests field from rate limiter entries

### DIFF
--- a/api/lib/rateLimit.js
+++ b/api/lib/rateLimit.js
@@ -33,7 +33,7 @@ export const createRateLimiter = (windowMs = 60_000, maxRequests = 10) => {
     const entry = store.get(key);
 
     if (!entry || now - entry.windowStart >= windowMs) {
-      store.set(key, { count: 1, windowStart: now, maxRequests });
+      store.set(key, { count: 1, windowStart: now });
       return true;
     }
 


### PR DESCRIPTION
Fixes #5486

## Summary
The \store.set()\ call in \pi/lib/rateLimit.js\ included a \maxRequests\ property in every entry, but the \check()\ method always compared against the function parameter, not the stored value. Removed the dead field.

## Changes
- \pi/lib/rateLimit.js\: Removed \maxRequests\ from the stored entry object