### PR TITLE
fix: define missing BACKGROUND_SYNC_TAG constant in service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -10,6 +10,7 @@
  * are cached to prevent privacy leaks and stale data exposure.
  */
 const CACHE_NAME = 'eventra-cache-v3';
+const BACKGROUND_SYNC_TAG = 'eventra-offline-queue-sync';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
Fixes #5488

## Summary
`public/service-worker.js` referenced `BACKGROUND_SYNC_TAG` in the `sync` event handler and `notifyClientsToSyncOfflineQueue` function but the constant was never declared. Every background sync event was silently ignored, breaking offline queue replay after connectivity returns.

## Changes
- `public/service-worker.js`: Added `BACKGROUND_SYNC_TAG` constant matching the value in `src/utils/offlineQueue.js`
