### PR TITLE
fix: remove permissions from signup JWT payload for consistency with login

### DIFF
--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -238,7 +238,6 @@ async function handler(req, res) {
       id: newUser.id,
       email: newUser.email,
       roles: newUser.roles,
-      permissions: newUser.permissions,
     };
 
     const token = jwt.sign(jwtPayload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });


### PR DESCRIPTION
Fixes #5489

## Summary
`signup.js` included `permissions` in the JWT payload while `login.js` intentionally excluded them (see comment at login.js:156-160). This inconsistency meant permission revocation took up to 7 days to take effect for users who signed up and never logged out.

## Changes
- `api/auth/signup.js`: Removed `permissions` from `jwtPayload`
