### PR TITLE
fix: redirect unauthenticated users to /login instead of /unauthorized (4 auth redirect bugs)

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -247,6 +247,7 @@ const AdminDashboard = () => {
   }, [location.pathname]);
 
   if (!isAdmin) {
+    if (!user) return <Navigate to="/login" replace />;
     return <Navigate to="/unauthorized" replace />;
   }
   /* Stats */

--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -49,11 +49,30 @@ const ProtectedRoute = ({
     );
   }
 
+  // If the user is not authenticated, send them to login regardless of which
+  // downstream check fails. This handles the edge case where isAuthenticated()
+  // returns true (e.g. stale session data) but role/permission checks still fail
+  // for an unauthenticated user — we redirect to /login instead of /unauthorized.
+  const redirectIfUnauthenticated = () => {
+    if (!isAuthenticated()) {
+      return (
+        <Navigate
+          to={redirectTo}
+          replace
+          state={{ from: location, sessionExpired }}
+        />
+      );
+    }
+    return null;
+  };
+
   // SECURITY: Check required roles against JWT token (server-signed, authoritative).
   // hasRole() verifies roles from the JWT, not localStorage, preventing privilege escalation.
   if (requiredRoles.length > 0) {
     const hasRequiredRole = requiredRoles.some(role => hasRole(role));
     if (!hasRequiredRole) {
+      const authRedirect = redirectIfUnauthenticated();
+      if (authRedirect) return authRedirect;
       return <Navigate to="/unauthorized" replace state={{ from: location }} />;
     }
   }
@@ -63,6 +82,8 @@ const ProtectedRoute = ({
   if (requiredPermissions.length > 0) {
     const hasRequiredPermission = requiredPermissions.every(permission => hasPermission(permission));
     if (!hasRequiredPermission) {
+      const authRedirect = redirectIfUnauthenticated();
+      if (authRedirect) return authRedirect;
       return <Navigate to="/unauthorized" replace state={{ from: location }} />;
     }
   }
@@ -73,6 +94,8 @@ const ProtectedRoute = ({
     const userScopes = user?.scopes || user?.scope?.split(' ') || [];
     const hasRequiredScope = requiredScopes.every(scope => userScopes.includes(scope));
     if (!hasRequiredScope) {
+      const authRedirect = redirectIfUnauthenticated();
+      if (authRedirect) return authRedirect;
       return <Navigate to="/unauthorized" replace state={{ from: location }} />;
     }
   }
@@ -81,6 +104,8 @@ const ProtectedRoute = ({
   if (validateContext && typeof validateContext === 'function') {
     const isContextValid = validateContext({ user, location });
     if (!isContextValid) {
+      const authRedirect = redirectIfUnauthenticated();
+      if (authRedirect) return authRedirect;
       return <Navigate to="/unauthorized" replace state={{ from: location }} />;
     }
   }


### PR DESCRIPTION
## Summary

Fixes 4 auth redirect bugs where unauthenticated users hitting protected routes were sent to `/unauthorized` ("Access Denied") instead of `/login`.

Fixes #5498, #5487, #5478, #5474

## Root Cause

`ProtectedRoute.js` correctly redirects unauthenticated users to `/login` at the initial auth check (line 42). However, if `isAuthenticated()` returns `true` due to stale/broken session data, the user passes that check and fails at the role/permission/scope/context guards, which all unconditionally redirect to `/unauthorized`.

## Fix

Added a `redirectIfUnauthenticated()` helper that each downstream guard calls before redirecting to `/unauthorized`. If the user is no longer authenticated at that point, they get sent to `/login` instead.

Also fixed the inline admin guard in `AdminDashboard.js` to check for `null user` before redirecting to `/unauthorized`.

## Changes

- `src/components/auth/ProtectedRoute.js` — Added `redirectIfUnauthenticated()` guard to all 4 downstream checks (roles, permissions, scopes, context)
- `src/components/admin/AdminDashboard.js` — Check `!user` before redirecting to `/unauthorized`
