### PR TITLE
fix: add UTF-8 BOM to CSV exports for Excel compatibility

### DIFF
--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -20,7 +20,9 @@ export function exportToCSV(data, filename) {
   }
   
   const csvString = csvRows.join('\n');
-  const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
+  // Add UTF-8 BOM so Microsoft Excel correctly detects UTF-8 encoding
+  // and displays non-ASCII characters (Hindi, accented, emoji) properly.
+  const blob = new Blob(['\uFEFF', csvString], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   
   const link = document.createElement("a");


### PR DESCRIPTION
## Summary

Fixes #5470 — adds UTF-8 Byte Order Mark (BOM) to CSV exports so Microsoft Excel correctly detects UTF-8 encoding.

## Problem

CSV export utilities generate UTF-8 CSV files without a BOM. While the files are technically valid, Microsoft Excel on Windows may not automatically detect UTF-8 encoding. Attendee names, survey responses, and other exported content containing non-ASCII characters (Hindi, accented characters, emoji) appear corrupted when opened in Excel.

## Fix

Added `\uFEFF` (UTF-8 BOM) as the first byte in the Blob constructor. This is a standard signal that Excel and other spreadsheet applications use to recognize UTF-8 encoding.

## Changes

- `src/utils/exportUtils.js` — Added `'\uFEFF'` prefix to the Blob content array
