### PR TITLE
fix: correct undefined isRetryableMethod to isNonMutating in axios retry interceptor

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -231,7 +231,7 @@ API.interceptors.response.use(
     
     // Retry only idempotent reads/probes. Do not blind-retry mutations or 429s,
     // because those can duplicate writes or worsen server-side rate limiting.
-    if (isRetryableMethod && isRetryableStatus && retryCount < MAX_RETRIES) {
+    if (isNonMutating && isRetryableStatus && retryCount < MAX_RETRIES) {
       config._retryCount = retryCount + 1;
       const delay = RETRY_DELAY_MS * Math.pow(2, retryCount);
 


### PR DESCRIPTION
## Summary

Fixes #5532 — one-character fix in the Axios response error interceptor.

## Problem

The retry-on-5xx logic in `src/config/api.js:234` referenced `isRetryableMethod`, a variable that was **never declared** in any scope. This is a typo — it was meant to be `isNonMutating` (defined on line 229 as `config.method?.toUpperCase() === 'GET'`).

Since `isRetryableMethod` evaluates to `undefined` (falsy), the entire retry block was **dead code** — it never executed. Any transient 502/503/504 from the backend during deployments caused a hard failure instead of an automatic retry with exponential backoff.

## Fix

Replaced `isRetryableMethod` with `isNonMutating` on line 234.

## Changes

- `src/config/api.js` — Fixed undefined variable reference in Axios response interceptor
