### PR TITLE
fix: implement WebRTC DataChannel flow control to prevent buffer congestion (#5467)

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -381,6 +381,44 @@ export class P2PFileTransferCoordinator {
     }
   }
 
+  // Regulate chunk transmission using DataChannel flow control
+  async sendChunks(fileChunks) {
+    const total = fileChunks.length;
+    const channel = this.channel;
+    if (!channel) return;
+
+    // Monitor bufferedAmount and pause sending when the buffer is congested
+    channel.bufferedAmountLowThreshold = 65536; // 64 KB
+    let index = 0;
+
+    const sendNext = () => {
+      while (index < total) {
+        if (!channel || channel.readyState !== "open") {
+          break;
+        }
+
+        // Check if browser DataChannel buffer is congested
+        if (channel.bufferedAmount > channel.bufferedAmountLowThreshold) {
+          channel.onbufferedamountlow = () => {
+            channel.onbufferedamountlow = null;
+            sendNext();
+          };
+          return;
+        }
+
+        const chunk = fileChunks[index];
+        channel.send(JSON.stringify({
+          chunkIndex: chunk.chunkIndex,
+          totalChunks: total,
+          data: chunk.data
+        }));
+        index++;
+      }
+    };
+
+    sendNext();
+  }
+
   // Setup WebRTC DataChannel handlers for transferring chunks
   setupDataChannel() {
     if (!this.channel) return;
@@ -392,18 +430,7 @@ export class P2PFileTransferCoordinator {
       if (!this.isInitiator) {
         const fileChunks = await getCachedFile(this.fileId);
         if (fileChunks) {
-          const total = fileChunks.length;
-          fileChunks.forEach((chunk, index) => {
-            setTimeout(() => {
-              if (this.channel && this.channel.readyState === "open") {
-                this.channel.send(JSON.stringify({
-                  chunkIndex: chunk.chunkIndex,
-                  totalChunks: total,
-                  data: chunk.data
-                }));
-              }
-            }, index * 200); // Throttling chunk transmissions
-          });
+          this.sendChunks(fileChunks);
         }
       }
     };


### PR DESCRIPTION
## Description
This pull request replaces the arbitrary 200ms `setTimeout` chunk sending delay with dynamic WebRTC DataChannel flow control in `src/utils/p2pFileTransfer.js`.

### Key Changes:
- Configured a threshold limit of 64KB (`bufferedAmountLowThreshold`) on the `RTCDataChannel`.
- Implemented a dynamic chunk sending mechanism that monitors `channel.bufferedAmount`.
- When the outbound buffer exceeds the threshold, sending pauses and registers an `onbufferedamountlow` event listener to resume chunk transmission once the buffer drains, maximizing bandwidth utilization and preventing connection drops.

Fixes #5467

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
