### PR TITLE
fix(ui): resolve header overlapping by adding inline-block spacing to…

### DIFF
--- a/src/components/CollaborationMap.jsx
+++ b/src/components/CollaborationMap.jsx
@@ -51,8 +51,9 @@ export default function CollaborationMap() {
       `}</style>
 
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center space-y-4 mb-12">
-          <span className="text-xs uppercase tracking-[0.25em] text-indigo-400 font-bold bg-indigo-500/10 px-3.5 py-1.5 rounded-full border border-indigo-500/20">
+        {/* Header Block with fixed responsive spacing */}
+        <div className="text-center space-y-6 mb-12">
+          <span className="inline-block text-xs uppercase tracking-[0.25em] text-indigo-400 font-bold bg-indigo-500/10 px-3.5 py-1.5 rounded-full border border-indigo-500/20">
             Global Network
           </span>
           <h2 className="text-3xl sm:text-4xl font-bold tracking-tight bg-linear-to-r from-white via-slate-100 to-indigo-200 bg-clip-text text-transparent">


### PR DESCRIPTION
# UI Layout Fix: Added inline-block spacing to collaboration map badge

## Description
This PR resolves a UI layout/responsiveness issue in `CollaborationMap.jsx` where the 'Global Network' badge element was overlapping and clipping directly into the 'Collaboration Hubs' section heading. 

Because the badge was originally rendered as a standard inline `<span>`, it was failing to properly honor the vertical spacing (`space-y-*`) guidelines of its parent layout container. Converting the element to an `inline-block` ensures the browser respects its vertical box-model bounds perfectly across all screen sizes. The parent vertical element spacing was also adjusted to `space-y-6` to give the title card modern, clean visual breathing room.

Fixes #5524 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots after fix
<img width="1331" height="283" alt="Screenshot 2026-06-02 142716" src="https://github.com/user-attachments/assets/802b2785-15e3-4fe5-a328-1e1cde08c7df" />

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports