### PR TITLE
fix: remove framer-motion import aliases that broke ESLint unknown-property rule

### DIFF
--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { motion as motionBase, AnimatePresence as AnimatePresenceBase } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "react-toastify";
 import { 
   ArrowRight, 
@@ -80,9 +80,9 @@ const EventCreation = () => {
           onDiscard={handleDiscardDraft} 
         />
 
-        <AnimatePresenceBase mode="wait">
+        <AnimatePresence mode="wait">
           {currentStep === "form" ? (
-            <motionBase
+            <motion
               key="form"
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
@@ -173,9 +173,9 @@ const EventCreation = () => {
                   </p>
                 </div>
               </form>
-            </motionBase>
+            </motion>
           ) : (
-            <motionBase
+            <motion
               key="preview"
               initial={{ opacity: 0, x: 20 }}
               animate={{ opacity: 1, x: 0 }}
@@ -291,9 +291,9 @@ const EventCreation = () => {
                   )}
                 </div>
               </div>
-            </motionBase>
+            </motion>
           )}
-        </AnimatePresenceBase>
+        </AnimatePresence>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes #5537 and #5538 — removes framer-motion import aliases that caused ESLint `react/no-unknown-property` to flag `initial`, `animate`, and `exit` as unknown HTML props, blocking deployment.

## Problem

The import `import { motion as motionBase, AnimatePresence as AnimatePresenceBase } from "framer-motion"` aliased the exports. ESLint's `react/no-unknown-property` rule only recognizes framer-motion props on components named `motion.*` or on direct (non-aliased) imports from `framer-motion`. It does not recognize `motionBase` as a motion component, so `initial`/`animate`/`exit` were flagged as unknown HTML attributes.

## Fix

- Changed import to `import { motion, AnimatePresence } from "framer-motion"`
- Replaced all `<motionBase>` with `<motion>` and `<AnimatePresenceBase>` with `<AnimatePresence>`

This is a pure rename — zero behavior change.

## Changes

- `src/components/EventCreation.jsx` — Removed framer-motion import aliases
