### PR TITLE
fix: move conditional early return after all hook calls in AdminDashboard

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -130,11 +130,6 @@ const AdminDashboard = () => {
     setActiveTab("overview");
   }, [location.pathname]);
 
-  if (!isAdmin) {
-    if (!user) return <Navigate to="/login" replace />;
-    return <Navigate to="/unauthorized" replace />;
-  }
-
   const loadUsers = useCallback(async (page, search) => {
     setUsersLoading(true);
     setUsersError(null);
@@ -221,6 +216,11 @@ const AdminDashboard = () => {
     }, 300);
     return () => clearTimeout(timer);
   }, [searchEvent]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!isAdmin) {
+    if (!user) return <Navigate to="/login" replace />;
+    return <Navigate to="/unauthorized" replace />;
+  }
 
   const handleConfirmDelete = async () => {
     const { type, id } = confirmModal;


### PR DESCRIPTION
## Summary

Fixes #5539, #5540, #5541, #5542, #5543 — moves the `if (!isAdmin)` early return guard in `AdminDashboard` to after all hook calls, satisfying React's Rules of Hooks.

## Problem

The component had a conditional early return at lines 133-136 that sat before 3 `useCallback` and 5 `useEffect` calls. React's Rules of Hooks require every hook to be called unconditionally on every render — hooks placed after a conditional return execute on different render paths, breaking hook ordering.

This caused ESLint to flag 5 separate Rules of Hooks violations, blocking deployment.

## Fix

Moved the `if (!isAdmin) { return <Navigate ... /> }` guard from before the hooks (line 133) to after the last `useEffect` hook (now at line 220). All 8 hooks now run unconditionally. Non-admin users still get redirected before any admin JSX renders.

## Changes

- `src/components/admin/AdminDashboard.js` — Moved conditional early return after all hook calls
