### PR TITLE
fix(security): add CORS headers to verifyAuth 401 responses

### DIFF
--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -1,6 +1,7 @@
 import jwt from "jsonwebtoken";
 import { getJwtSecret } from "../auth/jwt-config.js";
 import { users, usersById } from "../auth/signup.js";
+import { buildCorsHeaders } from "../auth/cors.js";
 
 // ---------------------------------------------------------------------------
 // JWT Middleware
@@ -8,6 +9,8 @@ import { users, usersById } from "../auth/signup.js";
 
 export const verifyAuth = (handler) => {
   return async (req, res) => {
+    const corsHeaders = buildCorsHeaders(req);
+
     // 1. Extract token from Cookie or Authorization header
     let token = null;
 
@@ -27,7 +30,7 @@ export const verifyAuth = (handler) => {
     }
 
     if (!token) {
-      return res.status(401).json({ error: "Unauthorized: Missing authentication token" });
+      return res.status(401).set(corsHeaders).json({ error: "Unauthorized: Missing authentication token" });
     }
 
     // 2. Verify token signature and expiry
@@ -36,9 +39,9 @@ export const verifyAuth = (handler) => {
       decoded = jwt.verify(token, getJwtSecret());
     } catch (error) {
       if (error.name === "TokenExpiredError") {
-        return res.status(401).json({ error: "Unauthorized: Token expired", expired: true });
+        return res.status(401).set(corsHeaders).json({ error: "Unauthorized: Token expired", expired: true });
       }
-      return res.status(401).json({ error: "Unauthorized: Invalid token" });
+      return res.status(401).set(corsHeaders).json({ error: "Unauthorized: Invalid token" });
     }
 
     // 3. Verify the user referenced by the JWT still exists in the user store.
@@ -64,7 +67,7 @@ export const verifyAuth = (handler) => {
         : usersById.has(userId);
 
       if (!userExists) {
-        return res.status(401).json({
+        return res.status(401).set(corsHeaders).json({
           error: "Unauthorized: Session invalidated. Please log in again.",
           sessionInvalidated: true,
         });


### PR DESCRIPTION
## Summary

Fixes #5549 — adds CORS headers to all 401 response paths in `verifyAuth` middleware so browser-based cross-origin clients can read auth failure responses instead of seeing opaque CORS errors.

## Problem

The `verifyAuth` middleware returned 401 JSON on all auth failures (missing token, expired token, invalid token, user-not-found) without setting any CORS headers. Browser-based cross-origin clients consumed these as opaque CORS failures instead of readable 401 responses, making auth debugging impossible and breaking error handling for login expiry, token revocation, and permission checks.

## Fix

- Imported `buildCorsHeaders` from `../auth/cors.js`
- Computed `corsHeaders` once at the top of the handler
- Added `.set(corsHeaders)` to all 4 `return res.status(401)` paths

## Changes

- `api/middleware/auth.js` — Added CORS headers to all 401 responses
