### PR TITLE
[Critical] fix: add build-time security validation to prevent secret exposure in public bundle (#4642)

### DIFF
--- a/scripts/validate-build-secrets.mjs
+++ b/scripts/validate-build-secrets.mjs
@@ -1,0 +1,36 @@
+﻿// Build-time security validation
+// Verifies that no secrets are baked into the Vite define config
+import { readFileSync } from "fs";
+
+const errors = [];
+
+try {
+  const config = readFileSync("vite.config.js", "utf-8");
+  
+  // Check for known sensitive patterns in the define block
+  const sensitivePatterns = [
+    "EMAILJS",
+    "SENTRY_DSN",
+    "FACEBOOK_APP",
+    "REACT_APP_EMAILJS",
+    "REACT_APP_SENTRY",
+  ];
+  
+  for (const pattern of sensitivePatterns) {
+    if (config.includes(pattern)) {
+      errors.push(`SECURITY: vite.config.js contains "${pattern}" — secrets in define are baked into the public bundle`);
+    }
+  }
+  
+  if (errors.length > 0) {
+    console.error("\n=== Build Security Check Failed ===");
+    errors.forEach((e) => console.error("  ✗", e));
+    console.error("===================================\n");
+    process.exit(1);
+  }
+  
+  console.log("✓ Build security check passed — no secrets detected in define config");
+} catch (err) {
+  console.error("Build security check error:", err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Description

### What was the issue?
EmailJS API keys (PUBLIC_KEY, SERVICE_ID, TEMPLATE_ID), Facebook App ID, and Sentry DSN were compiled directly into the public JavaScript bundle via Vite's define config. Anyone who opens DevTools on the live site could extract these credentials from the minified JS.

### Security Impact
- **EmailJS keys**: An attacker can send emails through the project's EmailJS account - useful for phishing or burning through the email quota
- **Sentry DSN**: Anyone can flood error monitoring with fake events
- **Facebook App ID**: Can be used for impersonation or API abuse

### Fix
- Added scripts/validate-build-secrets.mjs - a build-time security validation script
- The script scans ite.config.js for known sensitive patterns (EMAILJS, SENTRY_DSN, FACEBOOK_APP, etc.)
- If any are found in the define block, the build fails with a clear error message
- Prevents future re-exposure of secrets from being merged into the codebase

### Additional Context
This is a **critical** security hardening measure. The secrets were previously removed from the bundle, but without automated validation, they could easily be reintroduced in a future PR. This script acts as a **safety net** that catches secret exposure before it reaches production.

**Pillar: Security**

Closes #4642