### PR TITLE
fix(security): validate req.body before rate-limit check in signup.js

### DIFF
--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -133,25 +133,11 @@ async function handler(req, res) {
   }
 
   try {
-    const { firstName, lastName, email, password, confirmPassword } = req.body;
-
-    // -----------------------------------------------------------------------
-    // Rate Limiting (signup spam protection)
-    // -----------------------------------------------------------------------
-
-    const clientIp = req.headers?.["x-forwarded-for"]?.split(",")[0]?.trim()
-      || req.headers?.["x-real-ip"]
-      || req.socket?.remoteAddress
-      || "unknown";
-
-    signupRateLimiter.evictStale();
-
-    if (!signupRateLimiter.check(clientIp)) {
-      return corsResponse(req, res, 429, {
-        error: "Too many signup attempts. Please try again later.",
-        retryAfter: 60,
-      });
+    if (!req.body || typeof req.body !== "object") {
+      return corsResponse(req, res, 400, { error: "Request body is required" });
     }
+
+    const { firstName, lastName, email, password, confirmPassword } = req.body;
 
     // -----------------------------------------------------------------------
     // Input Validation
@@ -198,6 +184,25 @@ async function handler(req, res) {
 
     if (users.has(normalizedEmail)) {
       return corsResponse(req, res, 409, { error: "An account with this email already exists" });
+    }
+
+    // -----------------------------------------------------------------------
+    // Rate Limiting (signup spam protection)
+    // Run after input validation so malformed requests don't burn the budget.
+    // -----------------------------------------------------------------------
+
+    const clientIp = req.headers?.["x-forwarded-for"]?.split(",")[0]?.trim()
+      || req.headers?.["x-real-ip"]
+      || req.socket?.remoteAddress
+      || "unknown";
+
+    signupRateLimiter.evictStale();
+
+    if (!signupRateLimiter.check(clientIp)) {
+      return corsResponse(req, res, 429, {
+        error: "Too many signup attempts. Please try again later.",
+        retryAfter: 60,
+      });
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #5551 — moves the rate-limit check in signup.js to after input validation, and adds a null guard on `req.body`.

## Problem

The rate-limit `check()` ran before input validation, so 3 empty/malformed POSTs per minute would exhaust the target IP's rate-limit window, locking out legitimate signups. Also, `req.body` was destructured without a null guard, causing a TypeError → 500 for wrong Content-Type requests.

## Fix

- Added `req.body` null guard before destructuring
- Moved all input validation (name, email, password, confirmPassword, duplicate email) before the rate-limit check
- Rate-limit now only decrements for requests with valid payloads

## Changes

- `api/auth/signup.js` — Reordered operations: body guard → destructure → validate → rate-limit → hash
