### PR TITLE
fix(security): validate req.body before rate-limit check in login.js

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -85,7 +85,23 @@ async function handler(req, res) {
   }
 
   try {
+    if (!req.body || typeof req.body !== "object") {
+      return corsResponse(req, res, 400, { error: "Request body is required" });
+    }
+
     const { usernameOrEmail, password } = req.body;
+
+    // -----------------------------------------------------------------------
+    // Input Validation
+    // Run before rate-limit so malformed requests don't burn the budget.
+    // -----------------------------------------------------------------------
+
+    const validationErrors = validateLoginInput(usernameOrEmail, password);
+    if (validationErrors.length > 0) {
+      return corsResponse(req, res, 400, { 
+        error: validationErrors.join(", ") 
+      });
+    }
 
     // -----------------------------------------------------------------------
     // Rate Limiting (brute-force protection)
@@ -102,17 +118,6 @@ async function handler(req, res) {
       return corsResponse(req, res, 429, {
         error: "Too many login attempts. Please try again later.",
         retryAfter: 60,
-      });
-    }
-
-    // -----------------------------------------------------------------------
-    // Input Validation
-    // -----------------------------------------------------------------------
-
-    const validationErrors = validateLoginInput(usernameOrEmail, password);
-    if (validationErrors.length > 0) {
-      return corsResponse(req, res, 400, { 
-        error: validationErrors.join(", ") 
       });
     }
 


### PR DESCRIPTION
## Summary

Fixes #5552 — moves the rate-limit check in login.js to after input validation, and adds a null guard on `req.body`.

## Problem

Same pattern as signup.js (#5551): the rate-limit `check()` ran before input validation, so 5 empty/malformed POSTs per 15-minute window would exhaust the target IP's rate-limit, locking out legitimate logins. The `req.body` destructure also lacked a null guard.

## Fix

- Added `req.body` null guard before destructuring
- Moved input validation before the rate-limit check
- Rate-limit now only decrements for requests with valid credentials

## Changes

- `api/auth/login.js` — Reordered operations: body guard → destructure → validate → rate-limit → authenticate
