### PR TITLE
fix(perf): replace O(N) .find() with O(1) Map lookup in floor plan keydown handler

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -38,10 +38,12 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
   const dragStartRef = useRef({ x: 0, y: 0 });
   const elementStartRef = useRef({ x: 0, y: 0 });
   const panStartRef = useRef({ x: 0, y: 0 });
+  const elementsMapRef = useRef(new Map());
 
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
   useEffect(() => { snapToGridRef.current = snapToGrid; }, [snapToGrid]);
   useEffect(() => { selectedIdRef.current = selectedId; }, [selectedId]);
+  useEffect(() => { elementsMapRef.current = new Map(elements.map((el) => [el.id, el])); }, [elements]);
 
   const updateSelectedElement = (key, value) => {
     const updates = typeof key === "object" ? key : { [key]: value };
@@ -191,7 +193,7 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
     const handleKeyDown = (e) => {
       if (document.activeElement && (document.activeElement.tagName === "INPUT" || document.activeElement.tagName === "SELECT")) return;
       if (!selectedIdRef.current) return;
-      const activeEl = elements.find((el) => el.id === selectedIdRef.current);
+      const activeEl = elementsMapRef.current.get(selectedIdRef.current);
       if (!activeEl) return;
       const step = snapToGridRef.current ? 20 : 5;
       switch (e.key) {


### PR DESCRIPTION
## Summary

Fixes #5554

## Problem

The keydown event handler in FloorPlanDesigner used \elements.find(el => el.id === selectedIdRef.current)\ on every arrow key, rotate, and delete keystroke — an O(N) linear scan of all floor plan elements. With 100+ elements and rapid keystrokes (holding an arrow key), this caused visible editing lag.

## Fix

Added an \elementsMapRef\ that maintains a \Map<id, element>\ synced via \useEffect\ whenever the \elements\ array changes. The keydown handler now uses \Map.get()\ for O(1) lookup.

## Changes

- \src/components/events/FloorPlanDesigner.js\ — Added Map-based element lookup ref