### PR TITLE
fix(perf): reduce O(N*M) tag matching to O(N) with Set in conflictDetection.js

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -220,18 +220,21 @@ export const suggestAlternativeEvents = (
   });
 
   // Prioritise events of the same category / type / tags as the target
+  const targetTagSet = new Set(targetEvent.tags || []);
+
   const sameCategoryEvents = nonConflictingEvents.filter(
     (event) =>
       event.category === targetEvent.category ||
       event.type === targetEvent.type ||
-      event.tags?.some((tag) => targetEvent.tags?.includes(tag))
+      event.tags?.some((tag) => targetTagSet.has(tag))
   );
 
   if (sameCategoryEvents.length >= maxSuggestions) {
     return sameCategoryEvents.slice(0, maxSuggestions);
   }
 
-  const otherEvents = nonConflictingEvents.filter((event) => !sameCategoryEvents.includes(event));
+  const sameCategorySet = new Set(sameCategoryEvents);
+  const otherEvents = nonConflictingEvents.filter((event) => !sameCategorySet.has(event));
 
   return [...sameCategoryEvents, ...otherEvents].slice(0, maxSuggestions);
 };


### PR DESCRIPTION
## Summary

Fixes #5555

## Problem

Two nested-loop issues in the event recommendations conflict detection:

1. Line 227: \event.tags?.some((tag) => targetEvent.tags?.includes(tag))\ — O(M*K) per event (50 events × 10 tags × 10 tags = 5,000 includes() per render)
2. Line 234: \sameCategoryEvents.includes(event)\ — O(N*S) linear scan

## Fix

1. Converted \	argetEvent.tags\ to a \Set\ once before the filter — \	argetTagSet.has(tag)\ is O(1) per tag
2. Converted \sameCategoryEvents\ to a \Set\ for the exclusion check

## Changes

- \src/utils/conflictDetection.js\ — Set-based tag matching and exclusion