### PR TITLE
fix: replace meaningless aria-label="button" with descriptive labels for screen reader accessibility

### DIFF
--- a/src/components/admin/AnalyticsDashboard.jsx
+++ b/src/components/admin/AnalyticsDashboard.jsx
@@ -331,7 +331,7 @@ const [activeTab, setActiveTab] = useState('analytics');
         <button
           onClick={triggerManualCheckin}
           className="inline-flex items-center justify-center gap-1.5 px-4 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-xs font-bold text-white shadow-md transition self-start sm:self-auto"
-         aria-label="button">
+         aria-label="Trigger manual check-in scan">
           <Play className="w-3.5 h-3.5 fill-white" />
           Trigger Check-in Scan
         </button>

--- a/src/components/common/NotificationBell.jsx
+++ b/src/components/common/NotificationBell.jsx
@@ -32,7 +32,7 @@ const NotificationBell = () => {
           <div className="notification-header">
             <h4>Notifications</h4>
 
-            <button onClick={markAllAsRead} aria-label="button">
+            <button onClick={markAllAsRead} aria-label="Mark all notifications as read">
               Mark all read
             </button>
           </div>


### PR DESCRIPTION
## Summary
Fixes a WCAG 2.1 Level A accessibility violation where two buttons had aria-label="button" — a meaningless value that makes them unusable for screen reader users.

## Problem
Both NotificationBell.jsx and AnalyticsDashboard.jsx had buttons with aria-label="button". This is worse than having no aria-label at all because it actively provides incorrect, redundant information to assistive technologies. Screen readers would announce "button, button" giving users no context about the button's purpose.

## Fix
Replaced with descriptive labels that clearly communicate each button's action:
- "Mark all notifications as read" for the mark-all-read button in NotificationBell
- "Trigger manual check-in scan" for the simulate button in AnalyticsDashboard

## Changes
- src/components/common/NotificationBell.jsx — fixed aria-label
- src/components/admin/AnalyticsDashboard.jsx — fixed aria-label

Closes #5594 