### PR TITLE
fix: trim search queries before Fuse search

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -282,7 +282,7 @@ const debouncedSearchQuery = useDebounce(searchQuery, 300);
   }), [hackathons]);
 
   const searchedHackathons = debouncedSearchQuery
-    ? fuse.search(debouncedSearchQuery).map((result) => result.item)
+    ? fuse.search(debouncedSearchQuery.trim()).map((result) => result.item)
     : hackathons;
 
   const filteredHackathons = filterHackathons(searchedHackathons, {

--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -158,7 +158,7 @@ const Hero = () => {
 
   useEffect(() => {
     if (debouncedTerm.trim()) {
-      setSearchResults(searchIndex.search(debouncedTerm).slice(0, SEARCH_RESULT_LIMIT));
+      setSearchResults(searchIndex.search(debouncedTerm.trim()).slice(0, SEARCH_RESULT_LIMIT));
       setShowResults(true);
       return;
     }


### PR DESCRIPTION
## Description
This PR fixes search behavior when users enter leading or trailing whitespace in search inputs.
- Trimmed search queries before performing Fuse.js searches on the Home page.
- Trimmed search queries before performing Fuse.js searches on the Hackathons page.

Fixes #5258 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

Before: 
<img width="1155" height="578" alt="image" src="https://github.com/user-attachments/assets/a11bd0ef-eadc-493e-8a15-b906b2525c23" />
<img width="1084" height="316" alt="image" src="https://github.com/user-attachments/assets/2791766f-6e94-459b-9a88-d2075c08fafc" />

After:
<img width="1165" height="523" alt="image" src="https://github.com/user-attachments/assets/603d7303-a618-48ec-b63e-63e15627bbe7" />
<img width="1270" height="532" alt="image" src="https://github.com/user-attachments/assets/367f6bd1-2ee9-4ab7-ab3c-575016a8be4d" />

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
