### PR TITLE
fix: add click-outside and Escape key handlers to NotificationBell dropdown

### DIFF
--- a/src/components/common/NotificationBell.jsx
+++ b/src/components/common/NotificationBell.jsx
@@ -1,10 +1,34 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";  
 import { Bell } from "lucide-react";
 import { useNotifications } from "../../hooks/useNotifications";
 import "./NotificationBell.css";
 
 const NotificationBell = () => {
   const [open, setOpen] = useState(false);
+
+  const wrapperRef = useRef(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
 
   const {
     notifications,
@@ -13,11 +37,8 @@ const NotificationBell = () => {
   } = useNotifications();
 
   return (
-    <div className="notification-wrapper">
-      <button
-        className="notification-bell"
-        onClick={() => setOpen(!open)}
-      >
+    <div className="notification-wrapper" ref={wrapperRef}>
+      <button className="notification-bell" onClick={() => setOpen(!open)} aria-expanded={open} aria-haspopup="true">
         <Bell size={22} />
 
         {unreadCount > 0 && (


### PR DESCRIPTION
## Summary
Fixes a UX and accessibility issue where the NotificationBell dropdown could only be closed by clicking the bell icon again.

## Problem
No click-outside handler or Escape key listener existed on the dropdown. Users had no standard way to dismiss it. The bell button also lacked aria-expanded making it invisible to screen readers.

## Fix
- Added wrapperRef with document mousedown listener to close on outside click
- Added window keydown listener to close on Escape key
- Both listeners are gated behind the open state and properly cleaned up
- Added aria-expanded and aria-haspopup to the bell button

## Changes
- src/components/common/NotificationBell.jsx — added ref, two useEffects, aria attributes

Closes #5598 