### PR TITLE
fix: delay URL.revokeObjectURL in LeaderBoard CSV export to prevent download failure

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -544,10 +544,11 @@ export default function LeaderBoard() {
 
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const link = document.createElement("a");
-    link.href = URL.createObjectURL(blob);
+    const objectUrl = URL.createObjectURL(blob);
+    link.href = objectUrl;
     link.download = `eventra-leaderboard-${new Date().toISOString().split("T")[0]}.csv`;
     link.click();
-    URL.revokeObjectURL(link.href);
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 100);
   }, [sortedContributors, ranksMap]);
 
   const handleKeyDown = useCallback((e) => {


### PR DESCRIPTION
## Summary
Fixes a silent CSV export failure caused by revoking the blob URL immediately after triggering the download.

## Problem
handleExport called URL.revokeObjectURL(link.href) on the very next line after link.click(). Since link.click() triggers the download asynchronously, the blob URL was already destroyed before the browser could fetch it, causing the export to fail silently.

## Fix
Stored the object URL in a separate variable and wrapped URL.revokeObjectURL in setTimeout with a 100ms delay. This gives the browser enough time to initiate the download before the URL is cleaned up, while still freeing memory promptly.

## Changes
- src/features/leaderboard/LeaderBoard.tsx — fixed URL revocation timing in handleExport

Closes #5611 