### PR TITLE
fix: separate setStreaks from setContributors updater to fix React pure updater violation

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -372,32 +372,29 @@ export default function LeaderBoard() {
 
     const preparedContributors = prepareLeaderboardEntries(streamContributors);
 
-    setContributors((prev) => {
-      setStreaks((prevStreaks) => {
-        const updatedStreaks = { ...prevStreaks };
-        const prevRanks = new Map(prev.map((c, idx) => [c.username, idx + 1]));
+    // Compute streaks BEFORE calling any setState
+    const prevRanks = new Map(contributors.map((c, idx) => [c.username, idx + 1]));
+    const updatedStreaks = { ...streaks };
 
-        preparedContributors.forEach((c, newIdx) => {
-          const username = c.username;
-          const newRank = newIdx + 1;
-          const prevRank = prevRanks.get(username);
-          const currentStreak = prevStreaks[username] || { consecutiveUp: 0, onFire: false, rankDifference: 0 };
+    preparedContributors.forEach((c, newIdx) => {
+      const username = c.username;
+      const newRank = newIdx + 1;
+      const prevRank = prevRanks.get(username);
+      const currentStreak = streaks[username] || { consecutiveUp: 0, onFire: false, rankDifference: 0 };
 
-          if (prevRank !== undefined) {
-            const rankDifference = prevRank - newRank;
-            let consecutiveUp = rankDifference > 0 ? currentStreak.consecutiveUp + 1 : rankDifference < 0 ? 0 : currentStreak.consecutiveUp;
-            const onFire = rankDifference >= 3 || consecutiveUp >= 3;
-
-            updatedStreaks[username] = { consecutiveUp, onFire, rankDifference };
-          } else {
-            updatedStreaks[username] = { consecutiveUp: 0, onFire: false, rankDifference: 0 };
-          }
-        });
-
-        return updatedStreaks;
-      });
-      return preparedContributors;
+      if (prevRank !== undefined) {
+        const rankDifference = prevRank - newRank;
+        const consecutiveUp = rankDifference > 0 ? currentStreak.consecutiveUp + 1 : rankDifference < 0 ? 0 : currentStreak.consecutiveUp;
+        const onFire = rankDifference >= 3 || consecutiveUp >= 3;
+        updatedStreaks[username] = { consecutiveUp, onFire, rankDifference };
+      } else {
+        updatedStreaks[username] = { consecutiveUp: 0, onFire: false, rankDifference: 0 };
+      }
     });
+
+    // Now call each setState separately and cleanly
+    setStreaks(updatedStreaks);
+    setContributors(preparedContributors);
 
     setLastUpdated(`Live: ${formatLastUpdated(lastSynced)}`);
 


### PR DESCRIPTION
## Summary
Fixes a React anti-pattern where setStreaks was called inside the setContributors state updater function, violating React's requirement that updaters be pure.

## Problem
React may call state updater functions more than once (especially in Strict Mode and concurrent rendering). Having setStreaks inside setContributors meant streak state could be updated multiple times per render cycle, causing unpredictable streak values.

## Fix
Extracted streak computation to run before any setState calls using current contributors and streaks values directly. Then called setStreaks and setContributors independently and cleanly.

## Changes
- src/Pages/Leaderboard/Leaderboard.jsx — separated streak computation and setState calls

Closes #5615 