### PR TITLE
fix: add missing createRateLimiter import and clean up duplicate expo…

### DIFF
--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -3,7 +3,7 @@ import jwt from "jsonwebtoken";
 import { getJwtSecret, JWT_EXPIRES_IN } from "./jwt-config.js";
 
 import { buildCorsHeaders, corsResponse } from "./cors.js";
-
+import { createRateLimiter } from "../lib/rateLimit.js";
 
 // ---------------------------------------------------------------------------
 // In-memory user storage
@@ -302,8 +302,6 @@ async function handler(req, res) {
 // ---------------------------------------------------------------------------
 
 export default handler;
-
-export { users };
 
 export { users, usersById, usersByUsername };
 


### PR DESCRIPTION
## Description

\`api/auth/signup.js\` uses \`createRateLimiter()\` at line 46 but never imports it, causing a \`ReferenceError\` at runtime. This PR adds the missing import from \`../lib/rateLimit.js\`.

Also removes a duplicate \`export { users }\` statement — \`users\` was already exported alongside \`usersById\` and \`usersByUsername\` on the following line.

## Changes

- Added \`import { createRateLimiter } from \"../lib/rateLimit.js\"\` to signup.js
- Removed redundant \`export { users }\` (line 306) — kept the combined export on line 308

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings" 2>&1
{"message":"Resource not accessible by personal access token","documentation_url":"https://docs.github.com/rest/pulls/pulls#update-a-pull-request","status":"403"}gh: Resource not accessible by personal access token (HTTP 403)