### PR TITLE
fix: replace undefined react-icons/fi references with already-imported lucide-react equivalents in FeedbackPage

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -574,7 +574,7 @@ const FeedbackPage = () => {
                   value={formData.name}
                   onChange={handleChange}
                   error={errors.name}
-                  icon={FiUser}
+                  icon={User}
                   required={true}
                 />
 
@@ -585,7 +585,7 @@ const FeedbackPage = () => {
                   value={formData.email}
                   onChange={handleChange}
                   error={errors.email}
-                  icon={FiMail}
+                  icon={Mail}
                   required={true}
                 />
 
@@ -596,7 +596,6 @@ const FeedbackPage = () => {
                   onChange={handleSelectChange}
                   options={feedbackTypes}
                   error={errors.feedbackType}
-                  icon={FiMessageSquare}
                   required={true}
                 />
 


### PR DESCRIPTION
## Summary
Fixes a critical crash on the Feedback page caused by referencing FiUser, FiMail, and FiMessageSquare icons from react-icons/fi which is not installed or imported in this project.

## Problem
FeedbackPage.jsx used FiUser, FiMail, and FiMessageSquare as icon props. These names come from the react-icons/fi package which is never imported. At runtime this throws ReferenceError and crashes the entire feedback page.

## Fix
Replaced FiUser with User and FiMail with Mail — both equivalent icons that are already imported from lucide-react. Removed the unused icon prop from CustomFloatingSelect since that component does not consume it.

## Changes
- src/Pages/Feedback/FeedbackPage.jsx — replaced Fi* icon references with lucide-react equivalents

Closes #5622 