### PR TITLE
fix: remove stray semicolon in send-email.js (closes #5407)

### DIFF
--- a/api/send-email.js
+++ b/api/send-email.js
@@ -131,5 +131,4 @@ async function handler(req, res) {
 }
 
 export default verifyAuth(handler);
-;
 


### PR DESCRIPTION
Closes #5407

## Description

Removes a stray trailing `;` on line 134 of `api/send-email.js` that was left behind after a prior cleanup removed the duplicate export blocks described in #5407.

The other two files mentioned in the issue (`ai-recommendations.js` and `github-proxy.js`) were already fixed by a previous commit and need no changes.

Fixes #5407

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings