### PR TITLE
fix: add missing logger import in FAQPage to prevent ReferenceError on helpfulness vote

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import FAQCTA from "./FaqCTA";
 import SEOHead from "../../components/SEOHead";
+import { logger } from "../../utils/logger";
 
 // Centralized FAQ entries classified under General, Hackathons, or Account categories
 const faqs = [


### PR DESCRIPTION
## Summary
Fixes a ReferenceError crash in FAQPage caused by using the logger utility without importing it.

## Problem
logger was used in two catch blocks in FAQPage.js — one for loading ratings from localStorage and one for saving updated ratings. Since the import was missing, any localStorage error would throw ReferenceError: logger is not defined instead of logging gracefully.

## Fix
Added the missing import statement for the logger utility from utils/logger.

## Changes
- src/Pages/FAQ/FAQPage.js — added missing logger import

Closes #5634 