### PR TITLE
fix: remove trailing space in AboutCTA import path that breaks builds on Linux and CI

### DIFF
--- a/src/Pages/About/AboutPage.js
+++ b/src/Pages/About/AboutPage.js
@@ -1,5 +1,5 @@
 import ModernAbout from "./ModernAbout";
-import AboutCTA from "./AboutCTA ";
+import AboutCTA from "./AboutCTA";
 import SEOHead from "../../components/SEOHead";
 const AboutPage = () => {
   return (


### PR DESCRIPTION
## Summary
Fixes a module resolution failure caused by a trailing space in the AboutCTA import path in AboutPage.js.

## Problem
The import read "./AboutCTA " with a trailing space. On Windows and macOS this resolves silently due to case-insensitive file systems. On Linux and CI environments with case-sensitive file systems this throws Module not found and breaks the About page build.

## Fix
Removed the trailing space — changed "./AboutCTA " to "./AboutCTA".

## Changes
- src/Pages/About/AboutPage.js — fixed import path

Closes #5643 