### PR TITLE
fix: remove lowercase JSX selectedIcon tag in CustomFloatingSelect that silently failed to render

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -198,10 +198,7 @@ const CustomFloatingSelect = ({
 
   return (
     <div className="relative mt-6" ref={dropdownRef}>
-      <div className="relative">
-        {selectedIcon && (
-          <selectedIcon className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 w-5 h-5 z-10" />
-        )}
+      <div className="relative">        
 
         <button
           type="button"


### PR DESCRIPTION
## Summary
Fixes a silent rendering failure in CustomFloatingSelect where the icon was rendered using a lowercase JSX tag which JSX treats as an unknown HTML element, not a React component.

## Problem
<selectedIcon /> was used as a JSX tag but since selectedIcon starts with a lowercase letter, JSX treats it as a native HTML element. Browsers silently ignore unknown elements so the icon never rendered. The icon was already being rendered correctly inside the button via React.createElement making the broken JSX a duplicate that needed to be removed.

## Fix
Removed the broken <selectedIcon /> JSX block. The correct React.createElement rendering inside the button is preserved.

## Changes
- src/Pages/Feedback/FeedbackPage.js — removed broken lowercase JSX icon tag

Closes #5650 