### PR TITLE
fix: add click-outside and onBlur handlers to close FAQ search suggestions dropdown

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -203,6 +203,7 @@ function FAQSectionInner() {
   const wrapperRefs = useRef([]);
   const sectionRef = useRef(null);
   const headerRef = useRef(null);
+  const suggestionsRef = useRef(null);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [isHeaderFixed, setIsHeaderFixed] = useState(false);
   const [headerTop, setHeaderTop] = useState(0);
@@ -275,7 +276,7 @@ function FAQSectionInner() {
         setCardStyles(nextStyles);
         ticking = false;
       });
-    };
+    };   
 
     window.addEventListener("scroll", handleScroll, { passive: true });
     window.addEventListener("resize", handleScroll);
@@ -286,6 +287,16 @@ function FAQSectionInner() {
       window.removeEventListener("resize", handleScroll);
     };
   }, [headerHeight]);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (suggestionsRef.current && !suggestionsRef.current.contains(e.target)) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   return (
     <>
@@ -564,6 +575,7 @@ function FAQSectionInner() {
                   setShowSuggestions(true);
                 }}
                 onFocus={() => setShowSuggestions(true)}
+                onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
                 placeholder="Search FAQs..."
                 className="search-input"
               />
@@ -579,7 +591,7 @@ function FAQSectionInner() {
                 </button>
               )}
               {showSuggestions && suggestions.length > 0 && (
-                <div className="suggestions">
+                <div className="suggestions" ref={suggestionsRef}>
                   {suggestions.map((s, i) => (
                     <div
                       key={i}


### PR DESCRIPTION
## Summary
Fixes a UX bug where the FAQ search suggestions dropdown had no close mechanism and remained permanently open once triggered.

## Problem
showSuggestions was only ever set to true. There was no onBlur on the search input and no click-outside listener on the suggestions container, meaning the dropdown could never be dismissed without a page refresh.

## Fix
Added a suggestionsRef on the suggestions container with a document mousedown click-outside listener. Added an onBlur handler on the search input with a 150ms setTimeout delay to allow suggestion clicks to register before the dropdown closes.

## Changes
- src/Pages/FAQ/FAQPage.js — added suggestionsRef, click-outside useEffect, and onBlur handler

Closes #5652 