### PR TITLE
feat: add reusable event templates for event creation

### DIFF
--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -1,14 +1,17 @@
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { toast } from "react-toastify";
-import { Download, Calendar, Globe, Link2, Plus } from "lucide-react";
+import { Download, Calendar, Globe, Link2, Plus, Save, FileJson } from "lucide-react";
 import { logger } from "../../../utils/logger";
 import useReducedMotion from "../../../hooks/useReducedMotion";
+import { useEventTemplates } from "../../../hooks/useEventTemplates";
 import TicketsStep from "./components/TicketsStep";
 import GeneralInfoStep from "./components/GeneralInfoStep";
 import { exportAttendeesToCSV } from "../../../utils/exportCsv";
 import PreviewStep from "./components/PreviewStep";
 import RestoreDraftModal from "./components/RestoreDraftModal";
+import TemplatePicker from "./components/TemplatePicker";
+import TemplateNamePrompt from "./components/TemplateNamePrompt";
 import GuidelinesSection from "./components/GuidelinesSection";
 import EventDurationSelector from "./components/EventDurationSelector";
 import DateTimeFields from "./components/DateTimeFields";
@@ -79,6 +82,16 @@ const EventCreation = () => {
   const [newTag, setNewTag] = useState("");
   const [isDraftLoaded, setIsDraftLoaded] = useState(false);
   const [showRestoreModal, setShowRestoreModal] = useState(false);
+
+  // Template management states
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
+  const [showTemplateNamePrompt, setShowTemplateNamePrompt] = useState(false);
+  const {
+    templates,
+    handleSaveTemplate,
+    handleLoadTemplate,
+    handleDeleteTemplate,
+  } = useEventTemplates();
 
   const handleInputChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -318,6 +331,41 @@ const EventCreation = () => {
     toast.info("Saved draft discarded.");
   };
 
+  const handleOpenSaveTemplatePrompt = () => {
+    setShowTemplateNamePrompt(true);
+  };
+
+  const handleSaveTemplateSubmit = (templateName) => {
+    const success = handleSaveTemplate(templateName, formData);
+    if (success) {
+      setShowTemplateNamePrompt(false);
+    }
+  };
+
+  const handleOpenTemplatePicker = () => {
+    setShowTemplatePicker(true);
+  };
+
+  const handleLoadTemplateFromPicker = (templateId) => {
+    const templateData = handleLoadTemplate(templateId);
+    if (templateData) {
+      setFormData((prev) => ({
+        ...prev,
+        ...templateData,
+        banner: null,
+        bannerPreview: null,
+      }));
+      setErrors({});
+    }
+  };
+
+  const handleDeleteTemplateFromPicker = (templateId) => {
+    handleDeleteTemplate(templateId, () => {
+      // Refresh templates list after deletion
+      // The templates state will be updated by the hook
+    });
+  };
+
   useEffect(() => {
     if (!isDraftLoaded) return;
 
@@ -391,6 +439,21 @@ const EventCreation = () => {
         onRestore={handleRestoreDraft}
         onDiscard={handleDiscardDraft}
       />
+
+      <TemplatePicker
+        isOpen={showTemplatePicker}
+        templates={templates}
+        onLoad={handleLoadTemplateFromPicker}
+        onDelete={handleDeleteTemplateFromPicker}
+        onClose={() => setShowTemplatePicker(false)}
+      />
+
+      <TemplateNamePrompt
+        isOpen={showTemplateNamePrompt}
+        onSave={handleSaveTemplateSubmit}
+        onCancel={() => setShowTemplateNamePrompt(false)}
+      />
+
       {showRestoreModal && (
         <div
           className="
@@ -469,7 +532,25 @@ const EventCreation = () => {
 
       {currentStep === CREATION_STEPS.FORM ? (
         <>
-          <div className="w-full max-w-4xl flex justify-end mb-6">
+          <div className="w-full max-w-4xl flex justify-end gap-3 mb-6">
+            <button
+              onClick={handleOpenTemplatePicker}
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-purple-600 hover:bg-purple-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-300"
+              aria-label="Load template"
+            >
+              <FileJson size={18} />
+              Use Template
+            </button>
+
+            <button
+              onClick={handleOpenSaveTemplatePrompt}
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-blue-600 hover:bg-blue-700 text-white font-semibold shadow-md hover:shadow-lg transition-all duration-300"
+              aria-label="Save as template"
+            >
+              <Save size={18} />
+              Save as Template
+            </button>
+
             <button
               onClick={() => {
                 exportAttendeesToCSV(mockAttendees, "event-attendees.csv");

--- a/src/components/common/EventCreation/components/TemplateNamePrompt.jsx
+++ b/src/components/common/EventCreation/components/TemplateNamePrompt.jsx
@@ -1,0 +1,117 @@
+import { useState, useRef, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+/**
+ * TemplateNamePrompt Component
+ *
+ * Modal for collecting template name from user before saving.
+ */
+export default function TemplateNamePrompt({
+  isOpen,
+  onSave,
+  onCancel,
+  loading = false,
+}) {
+  const [templateName, setTemplateName] = useState("");
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      // Focus and select input when modal opens
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isOpen]);
+
+  const handleSave = () => {
+    if (templateName.trim()) {
+      onSave(templateName);
+      setTemplateName("");
+    }
+  };
+
+  const handleCancel = () => {
+    setTemplateName("");
+    onCancel();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      handleSave();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+          onClick={handleCancel}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="w-full max-w-md bg-white dark:bg-gray-900 rounded-3xl p-8 shadow-2xl border border-gray-200 dark:border-gray-700"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Save as Template
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
+              Give your template a descriptive name (e.g., "Workshop Template", "Meetup 2026")
+            </p>
+
+            <input
+              ref={inputRef}
+              type="text"
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Enter template name..."
+              maxLength={100}
+              disabled={loading}
+              className="w-full px-4 py-3 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition disabled:opacity-50"
+            />
+
+            <div className="flex justify-end gap-3 mt-8">
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={handleCancel}
+                disabled={loading}
+                className="px-5 py-2 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 font-medium transition disabled:opacity-50"
+                aria-label="Cancel"
+              >
+                Cancel
+              </motion.button>
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={handleSave}
+                disabled={!templateName.trim() || loading}
+                className="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Save template"
+              >
+                {loading ? "Saving..." : "Save"}
+              </motion.button>
+            </div>
+
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-4">
+              {templateName.length > 0 && (
+                <p>{templateName.length}/100 characters</p>
+              )}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/common/EventCreation/components/TemplatePicker.jsx
+++ b/src/components/common/EventCreation/components/TemplatePicker.jsx
@@ -1,0 +1,136 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { Trash2, Download } from "lucide-react";
+
+/**
+ * TemplatePicker Component
+ *
+ * Modal for browsing, loading, and deleting saved event templates.
+ * Displays all available templates with action buttons.
+ */
+export default function TemplatePicker({
+  isOpen,
+  templates,
+  onLoad,
+  onDelete,
+  onClose,
+}) {
+  if (!isOpen) return null;
+
+  const handleLoadClick = (templateId) => {
+    onLoad(templateId);
+    onClose();
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="w-full max-w-2xl bg-white dark:bg-gray-900 rounded-3xl shadow-2xl border border-gray-200 dark:border-gray-700 max-h-[80vh] overflow-hidden flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-indigo-50 to-white dark:from-gray-800 dark:to-gray-900">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                Event Templates
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                {templates.length === 0
+                  ? "No templates saved yet"
+                  : `${templates.length} template${templates.length !== 1 ? "s" : ""} available`}
+              </p>
+            </div>
+
+            {/* Templates List */}
+            <div className="flex-1 overflow-y-auto p-6">
+              {templates.length === 0 ? (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="flex flex-col items-center justify-center py-12 text-center"
+                >
+                  <div className="text-gray-400 dark:text-gray-500 mb-4">
+                    <Download size={48} strokeWidth={1} />
+                  </div>
+                  <p className="text-gray-600 dark:text-gray-400 font-medium">
+                    No templates saved yet
+                  </p>
+                  <p className="text-sm text-gray-500 dark:text-gray-500 mt-2">
+                    Create and save templates to reuse event configurations
+                  </p>
+                </motion.div>
+              ) : (
+                <div className="space-y-3">
+                  {templates.map((template, index) => (
+                    <motion.div
+                      key={template.id}
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ delay: index * 0.05 }}
+                      className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-2xl hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors border border-gray-200 dark:border-gray-700"
+                    >
+                      <div className="flex-1">
+                        <h3 className="font-semibold text-gray-900 dark:text-white">
+                          {template.name}
+                        </h3>
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          Created {new Date(template.createdAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                      <div className="flex gap-2 ml-4">
+                        <motion.button
+                          whileHover={{ scale: 1.05 }}
+                          whileTap={{ scale: 0.95 }}
+                          onClick={() => handleLoadClick(template.id)}
+                          className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors flex items-center gap-2"
+                          aria-label={`Load ${template.name} template`}
+                        >
+                          <Download size={16} />
+                          Load
+                        </motion.button>
+                        <motion.button
+                          whileHover={{ scale: 1.05 }}
+                          whileTap={{ scale: 0.95 }}
+                          onClick={() => onDelete(template.id)}
+                          className="px-4 py-2 rounded-lg border border-red-300 hover:bg-red-50 dark:border-red-700 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400 text-sm font-medium transition-colors flex items-center gap-2"
+                          aria-label={`Delete ${template.name} template`}
+                        >
+                          <Trash2 size={16} />
+                          Delete
+                        </motion.button>
+                      </div>
+                    </motion.div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div className="px-8 py-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 flex justify-end">
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={onClose}
+                className="px-6 py-2 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 font-medium transition-colors"
+                aria-label="Close template picker"
+              >
+                Close
+              </motion.button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/hooks/useEventTemplates.js
+++ b/src/hooks/useEventTemplates.js
@@ -1,0 +1,143 @@
+import { useState, useCallback } from "react";
+import { toast } from "react-toastify";
+import {
+  getTemplates,
+  saveTemplate,
+  loadTemplate,
+  deleteTemplate,
+  templateNameExists,
+} from "../utils/eventTemplateUtils";
+import { logger } from "../utils/logger";
+
+/**
+ * useEventTemplates Hook
+ *
+ * Provides template management functionality for event creation.
+ * Handles loading, saving, deleting templates with error handling and user feedback.
+ */
+export const useEventTemplates = () => {
+  const [templates, setTemplates] = useState(() => getTemplates());
+
+  /**
+   * Refresh templates list from localStorage
+   */
+  const refreshTemplates = useCallback(() => {
+    const updated = getTemplates();
+    setTemplates(updated);
+  }, []);
+
+  /**
+   * Save current form as a template
+   * @param {String} templateName - Name for the template
+   * @param {Object} formData - Current form data
+   * @returns {Boolean} Success status
+   */
+  const handleSaveTemplate = useCallback(
+    (templateName, formData) => {
+      if (!templateName || !templateName.trim()) {
+        toast.error("Please provide a template name.");
+        return false;
+      }
+
+      if (templateNameExists(templateName)) {
+        toast.warning(`Template "${templateName}" already exists.`);
+        return false;
+      }
+
+      try {
+        const created = saveTemplate(templateName, formData);
+
+        if (created) {
+          refreshTemplates();
+          toast.success(`Template "${templateName}" saved successfully!`);
+          logger.info(`[Templates] Saved template: ${templateName}`);
+          return true;
+        } else {
+          toast.error("Failed to save template. Please try again.");
+          return false;
+        }
+      } catch (error) {
+        logger.error("[Templates] Error saving template:", error);
+        toast.error("An error occurred while saving the template.");
+        return false;
+      }
+    },
+    [refreshTemplates]
+  );
+
+  /**
+   * Load a template by ID into form
+   * @param {String} templateId - Template ID to load
+   * @returns {Object|null} Template data or null on error
+   */
+  const handleLoadTemplate = useCallback((templateId) => {
+    try {
+      const templateData = loadTemplate(templateId);
+
+      if (templateData) {
+        const template = templates.find((t) => t.id === templateId);
+        toast.success(
+          `Loaded template "${template?.name || "Template"}"!`
+        );
+        logger.info(`[Templates] Loaded template: ${templateId}`);
+        return templateData;
+      } else {
+        toast.error("Failed to load template. It may have been deleted.");
+        logger.warn("[Templates] Template not found for loading:", templateId);
+        refreshTemplates();
+        return null;
+      }
+    } catch (error) {
+      logger.error("[Templates] Error loading template:", error);
+      toast.error("An error occurred while loading the template.");
+      return null;
+    }
+  }, [templates, refreshTemplates]);
+
+  /**
+   * Delete a template by ID with confirmation
+   * @param {String} templateId - Template ID to delete
+   * @param {Function} onConfirm - Optional callback after confirmation
+   * @returns {Boolean} Success status
+   */
+  const handleDeleteTemplate = useCallback(
+    (templateId, onConfirm) => {
+      try {
+        const template = templates.find((t) => t.id === templateId);
+        const templateName = template?.name || "Template";
+
+        if (window.confirm(`Are you sure you want to delete "${templateName}"?`)) {
+          const deleted = deleteTemplate(templateId);
+
+          if (deleted) {
+            refreshTemplates();
+            toast.success(`Template "${templateName}" deleted.`);
+            logger.info(`[Templates] Deleted template: ${templateId}`);
+
+            if (onConfirm) {
+              onConfirm();
+            }
+
+            return true;
+          } else {
+            toast.error("Failed to delete template. Please try again.");
+            return false;
+          }
+        }
+      } catch (error) {
+        logger.error("[Templates] Error deleting template:", error);
+        toast.error("An error occurred while deleting the template.");
+        return false;
+      }
+    },
+    [templates, refreshTemplates]
+  );
+
+  return {
+    templates,
+    refreshTemplates,
+    handleSaveTemplate,
+    handleLoadTemplate,
+    handleDeleteTemplate,
+  };
+};

--- a/src/utils/eventTemplateUtils.js
+++ b/src/utils/eventTemplateUtils.js
@@ -1,0 +1,165 @@
+import { safeJsonParse } from "./safeJsonParse.js";
+
+const TEMPLATES_KEY = "eventra_event_templates";
+
+/**
+ * Generate a unique template ID
+ */
+const generateTemplateId = () => {
+  return `template_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+};
+
+/**
+ * Fields to exclude when saving a template
+ * These are runtime/user-specific/upload fields
+ */
+const excludeFields = new Set([
+  "banner",
+  "bannerPreview",
+  "eventId",
+  "registrationCounts",
+  "analytics",
+  "createdBy",
+  "updatedAt",
+  "createdAt",
+]);
+
+/**
+ * Filter form data to keep only template-relevant fields
+ */
+const sanitizeTemplateData = (formData) => {
+  const sanitized = {};
+
+  Object.entries(formData).forEach(([key, value]) => {
+    if (!excludeFields.has(key)) {
+      sanitized[key] = value;
+    }
+  });
+
+  return sanitized;
+};
+
+/**
+ * Get all templates from localStorage
+ * @returns {Array} Array of template objects
+ */
+export const getTemplates = () => {
+  try {
+    const stored = localStorage.getItem(TEMPLATES_KEY);
+    if (!stored) return [];
+
+    const templates = safeJsonParse(stored, []);
+    return Array.isArray(templates) ? templates : [];
+  } catch (error) {
+    console.error("[EventTemplates] Error retrieving templates:", error);
+    return [];
+  }
+};
+
+/**
+ * Save a new template to localStorage
+ * @param {String} templateName - User-provided template name
+ * @param {Object} formData - Current event form data
+ * @returns {Object|null} The created template object or null on error
+ */
+export const saveTemplate = (templateName, formData) => {
+  if (!templateName || !templateName.trim()) {
+    console.warn("[EventTemplates] Template name is required");
+    return null;
+  }
+
+  try {
+    const templates = getTemplates();
+
+    const newTemplate = {
+      id: generateTemplateId(),
+      name: templateName.trim(),
+      createdAt: new Date().toISOString(),
+      data: sanitizeTemplateData(formData),
+    };
+
+    templates.push(newTemplate);
+    localStorage.setItem(TEMPLATES_KEY, JSON.stringify(templates));
+
+    return newTemplate;
+  } catch (error) {
+    console.error("[EventTemplates] Error saving template:", error);
+    return null;
+  }
+};
+
+/**
+ * Load a template by ID
+ * @param {String} templateId - Template ID to load
+ * @returns {Object|null} Template data or null if not found
+ */
+export const loadTemplate = (templateId) => {
+  try {
+    const templates = getTemplates();
+    const template = templates.find((t) => t.id === templateId);
+
+    if (!template) {
+      console.warn(`[EventTemplates] Template ${templateId} not found`);
+      return null;
+    }
+
+    return template.data || null;
+  } catch (error) {
+    console.error("[EventTemplates] Error loading template:", error);
+    return null;
+  }
+};
+
+/**
+ * Delete a template by ID
+ * @param {String} templateId - Template ID to delete
+ * @returns {Boolean} True if deleted, false otherwise
+ */
+export const deleteTemplate = (templateId) => {
+  try {
+    const templates = getTemplates();
+    const filteredTemplates = templates.filter((t) => t.id !== templateId);
+
+    if (filteredTemplates.length === templates.length) {
+      console.warn(`[EventTemplates] Template ${templateId} not found for deletion`);
+      return false;
+    }
+
+    localStorage.setItem(TEMPLATES_KEY, JSON.stringify(filteredTemplates));
+    return true;
+  } catch (error) {
+    console.error("[EventTemplates] Error deleting template:", error);
+    return false;
+  }
+};
+
+/**
+ * Clear all templates (use with caution)
+ * @returns {Boolean} True if cleared
+ */
+export const clearAllTemplates = () => {
+  try {
+    localStorage.removeItem(TEMPLATES_KEY);
+    return true;
+  } catch (error) {
+    console.error("[EventTemplates] Error clearing templates:", error);
+    return false;
+  }
+};
+
+/**
+ * Check if template name already exists
+ * @param {String} templateName - Name to check
+ * @returns {Boolean} True if name exists
+ */
+export const templateNameExists = (templateName) => {
+  try {
+    const templates = getTemplates();
+    return templates.some(
+      (t) => t.name.toLowerCase() === templateName.toLowerCase()
+    );
+  } catch (error) {
+    console.error("[EventTemplates] Error checking template name:", error);
+    return false;
+  }
+};


### PR DESCRIPTION
## PR Description

### Summary

This PR introduces Event Templates to the Event Creation workflow, allowing organizers to save reusable event configurations and quickly create future events from those templates.
## Fixes #5653 
### Changes Made

#### New Utilities

* Added template storage utilities for:

  * saving templates
  * loading templates
  * deleting templates
  * validating template names

#### New Hook

* Added `useEventTemplates` hook for template management and localStorage synchronization.

#### New Components

* `TemplatePicker`

  * Browse saved templates
  * Load templates
  * Delete templates

* `TemplateNamePrompt`

  * Collect template names before saving

#### Event Creation Integration

Added:

* Save as Template button
* Use Template button
* Template selection modal
* Template naming modal

### Features

* Save current form as a reusable template
* Load existing templates into the event creation form
* Delete saved templates
* Duplicate-name validation
* Graceful handling of corrupted localStorage data
* Existing validation and event creation workflow remain unchanged

### Storage

Templates are stored locally using:

```text
eventra_event_templates
```

No backend changes or additional dependencies were introduced.

### Testing

Verified:

* Template save flow
* Template load flow
* Template deletion flow
* Empty-state handling
* Existing draft persistence
* Existing form validation
* Successful project build

### Result

Organizers can now create reusable templates for common event types such as:

* Workshops
* Hackathons
* Meetups
* Seminars

reducing repetitive setup work and improving the event creation experience.
