### PR TITLE
fix: remove empty dead code if block left from debugging in FeedbackPage validateForm

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -379,9 +379,6 @@ const FeedbackPage = () => {
 
     setErrors(newErrors);
 
-    // Log for debugging
-    if (Object.keys(newErrors).length > 0) {
-    }
 
     return Object.keys(newErrors).length === 0;
   };


### PR DESCRIPTION
## Summary
Removes a leftover empty if block from the validateForm function in FeedbackPage.js that was never cleaned up after debugging.

## Problem
An empty if block with a Log for debugging comment existed in validateForm with no body. It performed no operation and added noise and confusion to the codebase.

## Fix
Deleted the empty if block and its comment entirely.

## Changes
- src/Pages/Feedback/FeedbackPage.js — removed empty dead code if block from validateForm

Closes #5657 