### PR TITLE
fix: clean up duplicate imports and redundant timeout handling in NotificationSettings

### DIFF
--- a/src/Pages/NotificationSettings.jsx
+++ b/src/Pages/NotificationSettings.jsx
@@ -1,9 +1,8 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Bell, BellOff, Check, Mail, Monitor, Save, Volume2 } from "lucide-react";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { useNotification } from "../context/NotificationContext";
 import { NOTIFICATION_CATEGORIES, NOTIFICATION_SOUNDS } from "../utils/notificationPreferences";
-import React, { useEffect, useRef, useState } from "react";
 
 const digestOptions = [
   { value: "instant", label: "Instant" },
@@ -54,22 +53,22 @@ const NotificationSettings = () => {
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-  if (statusMessage) {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
+    if (statusMessage) {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        setStatusMessage("");
+      }, 4000);
     }
 
-    timeoutRef.current = setTimeout(() => {
-      setStatusMessage('');
-    }, 4000);
-  }
-
-  return () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-  };
-}, [statusMessage]);
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [statusMessage]);
 
   const enabledCategoryCount = useMemo(
     () =>
@@ -98,7 +97,6 @@ const NotificationSettings = () => {
 
   const showStatusMessage = (message) => {
     setStatusMessage(message);
-    setTimeout(() => setStatusMessage(""), 4000);
   };
 
   const handlePushToggle = async (enabled) => {


### PR DESCRIPTION
## Summary

This PR performs a small code-quality cleanup in NotificationSettings.
## Fixes #5662 
### Changes Made

* Removed duplicate React hook imports.
* Consolidated React imports into a single statement.
* Removed redundant timeout logic from `showStatusMessage()`.
* Retained the existing `useEffect()` as the single source of timeout management.

### Why

The component contained duplicate hook imports and two separate mechanisms responsible for clearing status messages.

This cleanup:

* Simplifies the implementation.
* Prevents unnecessary timer creation.
* Improves maintainability.
* Preserves existing behavior.

### Verification

* ESLint passes successfully.
* Build completes successfully.
* Status messages continue to clear automatically after 4 seconds.
* No functional changes were introduced.
