### PR TITLE
fix: use server-side env var GITHUB_REPO instead of REACT_APP_GITHUB_…

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -2,7 +2,7 @@ import { getClientIp } from "./lib/getClientIp.js";
 import { fetchWithTimeout } from "./lib/fetchWithTimeout.js";
 import { buildCorsHeaders } from "./auth/cors.js";
 
-const GITHUB_REPO = process.env.REACT_APP_GITHUB_REPO || "SandeepVashishtha/Eventra";
+const GITHUB_REPO = process.env.GITHUB_REPO || "SandeepVashishtha/Eventra";
 
 const POINTS = {
   gssoclevel1: 3,


### PR DESCRIPTION
Closes #5409

## Description

Changes `process.env.REACT_APP_GITHUB_REPO` to `process.env.GITHUB_REPO` in `api/leaderboard.js`.

`REACT_APP_*` is a Create React App convention — those vars are replaced at build time for the frontend only and are not available in Vercel serverless Node.js runtime. Using `GITHUB_REPO` (without the prefix) is the correct approach for server-side env vars.

Fixes #5409

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings