### PR TITLE
security(utils): patch SSRF protocol-relative bypass and parameter pollution

### DIFF
--- a/src/utils/githubApiClient.js
+++ b/src/utils/githubApiClient.js
@@ -2,11 +2,19 @@ import { fetchWithTimeout } from "./fetchWithTimeout";
 const GITHUB_HOST = "github.com";
 
 export const buildGitHubProxyUrl = (path, queryParams = {}) => {
-  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  const params = new URLSearchParams({ path: normalizedPath });
+  // 🔥 FIX 1: Prevent Protocol-Relative SSRF Bypass (e.g. "//evil.com")
+  // Remove ALL leading slashes, then explicitly prepend exactly one.
+  const sanitizedPath = `/${path.replace(/^\/+/, '')}`;
+  const params = new URLSearchParams({ path: sanitizedPath });
 
   Object.entries(queryParams).forEach(([key, value]) => {
     if (value === undefined || value === null || value === "") return;
+    
+    // 🔥 FIX 2: Prevent Parameter Pollution
+    // Block attackers from passing a malicious "path" key in the query string
+    // which would overwrite our secure sanitized path.
+    if (key.toLowerCase() === "path") return;
+    
     params.set(key, String(value));
   });
 


### PR DESCRIPTION
## Description
This PR addresses two critical Security vulnerabilities within the `githubApiClient` utility that could lead to Server-Side Request Forgery (SSRF) and the leakage of backend authentication tokens.

**Changes made:**
- **Protocol-Relative SSRF Patch:** The `buildGitHubProxyUrl` function previously used `path.startsWith("/")` to normalize paths. This permitted protocol-relative URL injections (e.g., `//attacker.com`). When parsed by the backend, this hijacks the domain resolution, forcing the proxy to send secure requests to malicious external servers. The patch now uses a strict regex (`/^\/+/, ''`) to strip all leading slashes before prepending exactly one.
- **Parameter Pollution Patch:** The `queryParams` loop previously used `params.set()` without a blocklist. This allowed callers to inject `{ path: "malicious-path" }` into the function, completely overwriting the target endpoint. The loop now explicitly blocks the `path` key from overriding core parameters.

Fixes #5693 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security vulnerability patch

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code