### PR TITLE
fix(utils): patch parameter pollution and pagination freeze in buildPaginatedUrl

### DIFF
--- a/src/utils/eventFetchUtils.js
+++ b/src/utils/eventFetchUtils.js
@@ -4,7 +4,7 @@
  * The backend accepts optional `page` (0-indexed) and `size` query params.
  * When the backend returns a Spring-style Page envelope the response looks like:
  *
- *   { content: [...], totalElements: N, totalPages: P, number: 0, size: 20 }
+ * { content: [...], totalElements: N, totalPages: P, number: 0, size: 20 }
  *
  * When it returns a plain array (no pagination metadata), all results arrived
  * in one shot — totalElements is inferred from the array length and only one
@@ -54,8 +54,21 @@ export const SERVER_PAGE_SIZE = 20;
 export function buildPaginatedUrl(baseUrl, page, size) {
   if (!baseUrl) return baseUrl;
 
-  const separator = baseUrl.includes("?") ? "&" : "?";
-  return `${baseUrl}${separator}page=${page}&size=${size}`;
+  // 🔥 FIX: Prevent URL Parameter Pollution and Pagination Freezing.
+  // The old logic used string concatenation which blindly appended duplicate 'page' parameters
+  // (e.g., ?category=tech&page=0&page=1). Backend frameworks (like Spring) often extract the
+  // *first* instance of a parameter, permanently freezing the UI on page 0.
+  const [urlWithoutHash, hash] = baseUrl.split("#");
+  const [path, queryString] = urlWithoutHash.split("?");
+
+  const params = new URLSearchParams(queryString || "");
+  
+  // .set() explicitly overwrites existing keys, eliminating duplicate parameter pollution
+  params.set("page", page);
+  params.set("size", size);
+
+  const newUrl = `${path}?${params.toString()}`;
+  return hash ? `${newUrl}#${hash}` : newUrl;
 }
 
 /**


### PR DESCRIPTION
## Description
This PR resolves a silent architectural bug that causes client-side pagination to permanently freeze under specific filtering conditions.

**Changes made:**
- **URL Parameter Pollution Fix:** The `buildPaginatedUrl` utility previously relied on raw string concatenation (`&page=x&size=y`). If a URL was passed that already contained a pagination state, it would duplicate the keys (e.g., `?page=0&page=1`). Because backend frameworks like Spring extract the first occurrence of a parameter, this caused subsequent page requests to constantly evaluate as `page 0`, freezing the UI. 
- **Hash Safe Parsing:** The parsing logic has been upgraded to utilize `URLSearchParams` and safely split hash fragments (`#`), guaranteeing that `.set()` explicitly overwrites existing keys rather than appending duplicates, while perfectly preserving routing hashes.

Fixes #5701

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Functional stability improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code