### PR TITLE
perf(visual): fix WebGL context memory leak and layout thrashing in FluidCursor

### DIFF
--- a/src/components/visual/FluidCursor.js
+++ b/src/components/visual/FluidCursor.js
@@ -1,8 +1,38 @@
+/**
+ * @fileoverview FluidCursor - WebGL-based fluid cursor animation for Eventra
+ * @module components/visual/FluidCursor
+ */
 "use client";
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useState } from "react";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 
+/**
+ * A React component that renders a WebGL-powered fluid simulation
+ * as a cursor trail effect on the page. Creates a colorful, interactive
+ * fluid animation that follows mouse and touch movements.
+ *
+ * Automatically disabled on:
+ * - Mobile/touch devices (viewport ≤ 768px or coarse pointer)
+ * - When `prefers-reduced-motion` accessibility setting is enabled
+ * - When explicitly disabled via the `enabled` prop
+ *
+ * Uses HTML5 Canvas and WebGL (with WebGL2 fallback to WebGL1) for rendering.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {boolean} [props.enabled=true] - Whether the fluid cursor animation is active
+ *
+ * @returns {JSX.Element|null} A fixed-position canvas overlay, or null if disabled
+ *
+ * @example
+ * // Enable fluid cursor (default)
+ * <FluidCursor />
+ *
+ * @example
+ * // Conditionally enable based on user preference
+ * <FluidCursor enabled={userPreferences.fluidCursor} />
+ */
 const FluidCursor = ({ enabled = true }) => {
   const canvasRef = useRef(null);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
@@ -26,8 +56,9 @@ const FluidCursor = ({ enabled = true }) => {
     return () => mediaQuery.removeListener(updateViewportState);
   }, []);
 
+  // 🔥 FIX 3: Added prefersReducedMotion to the dependency array
   useEffect(() => {
-    if (!enabled || isMobileViewport) {
+    if (!enabled || isMobileViewport || prefersReducedMotion) {
       return undefined;
     }
 
@@ -1124,7 +1155,6 @@ const FluidCursor = ({ enabled = true }) => {
       };
     }
 
-
     function updatePointerDownData(pointer, id, posX, posY) {
       pointer.id = id;
       pointer.down = true;
@@ -1166,12 +1196,16 @@ const FluidCursor = ({ enabled = true }) => {
     // Uses document.elementFromPoint to see through the pointer-events-none canvas
     // and detect the actual DOM element beneath it.
     function isExcludedZone(clientX, clientY, target) {
-      if (target && (target.closest("nav") !== null || target.closest("footer") !== null || target.closest("a") !== null || target.closest("button") !== null)) {
-        return true;
+      if (target && typeof target.closest === 'function') {
+        if (target.closest("nav") !== null || target.closest("footer") !== null || target.closest("a") !== null || target.closest("button") !== null) {
+          return true;
+        }
       }
-      const el = document.elementFromPoint(clientX, clientY);
-      if (!el) return false;
-      return el.closest("nav") !== null || el.closest("footer") !== null;
+      // 🔥 FIX 2: Removed document.elementFromPoint to prevent massive Layout Thrashing.
+      // Since the canvas is pointer-events-none, window.onmousemove already receives 
+      // the true underlying DOM element as e.target. Calling elementFromPoint 60x a second
+      // forces synchronous layout recalculations and tanks rendering FPS.
+      return false;
     }
 
     // Skip click splat when mouse is over navbar or footer
@@ -1218,7 +1252,7 @@ const FluidCursor = ({ enabled = true }) => {
       }
     };
 
-    const handleTouchEnd = (e) => {
+    const handleTouchEnd = () => {
       let pointer = pointers[0];
       pointer.down = false;
     };
@@ -1240,8 +1274,18 @@ const FluidCursor = ({ enabled = true }) => {
       if (animationFrameId) {
         cancelAnimationFrame(animationFrameId);
       }
+      
+      // 🔥 FIX 1: Prevent WebGL Context Exhaustion (Memory Leak)
+      // We must explicitly ask the browser to destroy the active WebGL context.
+      // Otherwise, toggling the cursor leaves orphaned contexts in memory until the browser crashes.
+      if (gl) {
+        const loseContextExt = gl.getExtension('WEBGL_lose_context');
+        if (loseContextExt) {
+          loseContextExt.loseContext();
+        }
+      }
     };
-  }, [enabled, isMobileViewport]);
+  }, [enabled, isMobileViewport, prefersReducedMotion]);
 
   if (!enabled || isMobileViewport || prefersReducedMotion) {
     return null;


### PR DESCRIPTION
## Description
This PR addresses critical performance bottlenecks and a hardware-crashing memory leak within the `FluidCursor` WebGL component.

**Changes made:**
- **Context Exhaustion Fix:** Toggling the cursor or changing accessbility preferences was previously leaving orphaned WebGL contexts in browser memory. Modified the `useEffect` cleanup block to explicitly fetch and invoke the `WEBGL_lose_context` extension, safely destroying the context and freeing GPU memory.
- **Layout Thrashing Fix:** The `isExcludedZone` function was executing `document.elementFromPoint()` on every single `mousemove` frame. This forces the browser to halt the render pipeline and calculate synchronous layout reflows ~60 times a second. Since the canvas is natively `pointer-events-none`, `e.target` already holds the target DOM element. Removed `elementFromPoint` to restore standard 60fps rendering.
- **Dependency Tracking:** Added the missing `prefersReducedMotion` variable to the `useEffect` dependency array so the simulation dynamically tears down when accessibility settings change.

Fixes #5721 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance optimization

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code