### PR TITLE
fix: remove unused useCallback import in NavbarLinks

### DIFF
--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState, useEffect} from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { ChevronDown } from "lucide-react";
 import { NAV_ITEMS } from "./constants/navItems";


### PR DESCRIPTION
## Summary

This PR removes an unused `useCallback` import from `NavbarLinks.jsx` to address an ESLint `no-unused-vars` warning.

## Changes Made

### NavbarLinks.jsx

* Removed unused `useCallback` import from React

## Result

* Eliminates ESLint warning for unused import
* Removes dead code
* No functional or UI changes

Solves #5237
