### PR TITLE
fix: remove JWT sessionStorage references from AuthContext

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -49,7 +49,6 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
     setToken(null);
     document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; SameSite=Strict";
-    sessionStorage.removeItem("token");
     syncSecureStorage.removeItem("user");
     localStorage.removeItem("user");
     return true;
@@ -58,7 +57,7 @@ export const AuthProvider = ({ children }) => {
   const clearExpiredSession = useCallback(() => {
     // 🔥 FIX: Check if a user was actually logged in before blasting them with an "Expired" toast.
     // Anonymous users (who trigger a 401 on mount) shouldn't see this.
-    const hadPreviousSession = !!localStorage.getItem("user") || !!sessionStorage.getItem("token");
+    const hadPreviousSession = !!localStorage.getItem("user");
 
     console.warn("[AuthContext] Session expiration detected. Clearing session state immediately.");
     clearSession();


### PR DESCRIPTION
## Description
Removed all sessionStorage references for JWT token in AuthContext.
JWT should never be stored in sessionStorage as it is readable by
any same-origin JavaScript, creating an XSS attack vector.

Fixes #5711

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings