### PR TITLE
fix(security): Implement signed-cookie rate-limiter for serverless

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -2,6 +2,7 @@
 // Secures the Groq API key from frontend exposure
 
 import { verifyAuth } from "./middleware/auth.js";
+import { rateLimiter } from "./middleware/rateLimiter.js";
 
 // ---------------------------------------------------------------------------
 // Guards
@@ -11,34 +12,8 @@ import { verifyAuth } from "./middleware/auth.js";
 // lets an unauthenticated caller exhaust the API quota in a single request.
 const MAX_PROMPT_LENGTH = 2000;
 
-// Per-user rate limit: at most RATE_LIMIT_MAX_REQUESTS within RATE_LIMIT_WINDOW_MS.
-// This Map lives in process memory. In a multi-instance serverless deployment,
-// each instance maintains its own window, which reduces but does not eliminate
-// the ability to exceed the limit by spreading requests across warm instances.
-// A Redis-backed limiter would enforce a strict global cap if needed later.
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
-const RATE_LIMIT_MAX_REQUESTS = 10;
-const rateLimitMap = new Map();
-
-const checkRateLimit = (userId) => {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-
-  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
-    rateLimitMap.set(userId, { count: 1, windowStart: now });
-    return true;
-  }
-
-  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return false;
-  }
-
-  entry.count += 1;
-  return true;
-};
-
 // ---------------------------------------------------------------------------
-// Handler (wrapped by verifyAuth - requires a valid Eventra JWT)
+// Handler (wrapped by verifyAuth and rateLimiter)
 // ---------------------------------------------------------------------------
 
 async function handler(req, res) {
@@ -61,16 +36,6 @@ async function handler(req, res) {
 
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Method not allowed. Use POST." });
-  }
-
-  // req.user is set by verifyAuth after successful JWT verification
-  const userId = req.user?.id || req.user?.email || "unknown";
-
-  // Per-user rate limiting
-  if (!checkRateLimit(userId)) {
-    return res.status(429).json({
-      error: "Too many requests. Please wait before sending another recommendation request.",
-    });
   }
 
   const apiKey = process.env.GROQ_API_KEY || process.env.REACT_APP_GROQ_API_KEY;
@@ -120,4 +85,4 @@ async function handler(req, res) {
   }
 }
 
-export default verifyAuth(handler);
+export default verifyAuth(rateLimiter(10)(handler));

--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -1,4 +1,5 @@
 import { verifyAuth } from "./middleware/auth.js";
+import { rateLimiter } from "./middleware/rateLimiter.js";
 
 const SAFE_GITHUB_PATH_PATTERNS = [
   /^\/repos\/[^/?#]+\/[^/?#]+$/,
@@ -10,54 +11,6 @@ const SAFE_GITHUB_PATH_PATTERNS = [
 // Only these query parameters are forwarded to the GitHub API.
 // All other caller-supplied parameters are silently dropped.
 const ALLOWED_QUERY_PARAMS = new Set(["per_page", "page", "state", "sort", "direction"]);
-
-// ---------------------------------------------------------------------------
-// Per-user rate limiter
-//
-// Tracks request counts in a module-level Map so the limit is shared across
-// all requests handled by the same warm function instance.
-//
-// Each entry: { count: number, windowStart: number (epoch ms) }
-// Window: 60 seconds | Limit: 60 requests per user per window
-//
-// Note: in-memory state does not persist across cold starts. This is
-// intentional for a stateless Vercel deployment: the limit prevents a single
-// user from exhausting the quota within one warm instance's lifetime. For
-// stronger guarantees, replace with a Redis-backed counter.
-// ---------------------------------------------------------------------------
-
-const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
-const RATE_LIMIT_MAX_REQUESTS = 60;  // requests per window per user
-
-const rateLimitMap = new Map();
-
-const isRateLimited = (userId) => {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-
-  if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
-    rateLimitMap.set(userId, { count: 1, windowStart: now });
-    return false;
-  }
-
-  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return true;
-  }
-
-  entry.count += 1;
-  return false;
-};
-
-// Evict stale entries to prevent unbounded memory growth in long-lived
-// instances. Called after every rate-limit check.
-const evictStaleEntries = () => {
-  const now = Date.now();
-  for (const [key, entry] of rateLimitMap.entries()) {
-    if (now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
-      rateLimitMap.delete(key);
-    }
-  }
-};
 
 const normalizePath = (path) => {
   const rawPath = Array.isArray(path) ? path.join("/") : path;
@@ -78,18 +31,6 @@ const isSafeGitHubPath = (path) => {
 };
 
 async function handler(req, res) {
-  // req.user is populated by the verifyAuth wrapper.
-  const userId = req.user?.id || req.user?.email;
-
-  // Check rate limit before doing any work.
-  if (isRateLimited(userId)) {
-    evictStaleEntries();
-    return res.status(429).json({
-      error: "Too many requests. You may make up to 60 proxy requests per minute.",
-    });
-  }
-  evictStaleEntries();
-
   const { path, ...queryParams } = req.query;
 
   if (!path) {
@@ -138,4 +79,4 @@ async function handler(req, res) {
   }
 }
 
-export default verifyAuth(handler);
+export default verifyAuth(rateLimiter(60)(handler));

--- a/api/middleware/rateLimiter.js
+++ b/api/middleware/rateLimiter.js
@@ -1,0 +1,76 @@
+import crypto from "crypto";
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX_REQUESTS = 60; // default requests per window per user
+const COOKIE_NAME = "eventra-rl";
+const COOKIE_SECRET = process.env.JWT_SECRET || "eventra-rate-limiter-fallback-secret-key-123456";
+
+// Helpers to sign and verify
+function sign(data) {
+  return crypto.createHmac("sha256", COOKIE_SECRET).update(data).digest("hex");
+}
+
+function parseCookies(cookieHeader) {
+  const list = {};
+  if (!cookieHeader) return list;
+  cookieHeader.split(";").forEach(cookie => {
+    const parts = cookie.split("=");
+    list[parts.shift().trim()] = decodeURI(parts.join("="));
+  });
+  return list;
+}
+
+export function rateLimiter(maxRequests = RATE_LIMIT_MAX_REQUESTS) {
+  return (handler) => {
+    return async (req, res) => {
+      // req.user is set by verifyAuth middleware
+      const userId = req.user?.id || req.user?.email || "anonymous";
+      const now = Date.now();
+      const cookies = parseCookies(req.headers.cookie);
+      const rlCookie = cookies[COOKIE_NAME];
+
+      let windowStart = now;
+      let count = 0;
+      let isValid = false;
+
+      if (rlCookie) {
+        const parts = rlCookie.split(":");
+        if (parts.length === 3) {
+          const [cTimestamp, cCount, cSig] = parts;
+          // Verify signature
+          const expectedSig = sign(`${userId}:${cTimestamp}:${cCount}`);
+          if (cSig === expectedSig) {
+            windowStart = parseInt(cTimestamp, 10);
+            count = parseInt(cCount, 10);
+            isValid = true;
+          }
+        }
+      }
+
+      if (isValid && (now - windowStart < RATE_LIMIT_WINDOW_MS)) {
+        if (count >= maxRequests) {
+          return res.status(429).json({
+            error: "Too many requests. Please wait before sending more requests."
+          });
+        }
+        count += 1;
+      } else {
+        windowStart = now;
+        count = 1;
+      }
+
+      // Create new cookie signature
+      const newSig = sign(`${userId}:${windowStart}:${count}`);
+      const cookieValue = `${windowStart}:${count}:${newSig}`;
+
+      // Set cookie in response header
+      const expires = new Date(windowStart + RATE_LIMIT_WINDOW_MS).toUTCString();
+      res.setHeader(
+        "Set-Cookie",
+        `${COOKIE_NAME}=${cookieValue}; Path=/; HttpOnly; SameSite=Lax; Expires=${expires}`
+      );
+
+      return handler(req, res);
+    };
+  };
+}


### PR DESCRIPTION
This PR replaces the stateless in-memory Map rate limiter with a cryptographically signed cookie rate limiter to protect serverless cold starts from limit bypasses.

Fixes #5747

cc @SandeepVashishtha