### PR TITLE
fix: whitelist safe keys in ErrorBoundary diagnostic report

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -40,9 +40,10 @@ function saveAppStateSnapshot() {
       url: window.location.href,
       localStorage: (() => {
         const snap = {};
+        const ALLOWED = ["my_events_", "bookmarks_", "eventra_theme", "eventra_language", "eventra_preferences"];
         for (let i = 0; i < localStorage.length; i++) {
           const k = localStorage.key(i);
-          if (k && !k.includes("token") && !k.includes("password")) {
+          if (k && ALLOWED.some((safe) => k.startsWith(safe))) {
             snap[k] = localStorage.getItem(k)?.slice(0, 100);
           }
         }
@@ -50,9 +51,10 @@ function saveAppStateSnapshot() {
       })(),
       sessionStorage: (() => {
         const snap = {};
+        const ALLOWED = ["my_events_", "bookmarks_", "eventra_theme", "eventra_language", "eventra_preferences"];
         for (let i = 0; i < sessionStorage.length; i++) {
           const k = sessionStorage.key(i);
-          if (k && !k.includes("token") && !k.includes("password")) {
+          if (k && ALLOWED.some((safe) => k.startsWith(safe))) {
             snap[k] = sessionStorage.getItem(k)?.slice(0, 100);
           }
         }


### PR DESCRIPTION
## Description
Replaced blacklist filter (excluding "token" and "password") with a
whitelist approach in `buildDiagnosticReport`. Previously, sensitive keys
like `eventra_session_recovery_key` (AES key material) and
`eventra:key-salt` (PBKDF2 salt) were included in the clipboard report.
Now only known safe keys are included in the snapshot.

Fixes #5712

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings