### PR TITLE
fix: resolve stale ref cleanup warning in useFormValidation hook

### DIFF
--- a/src/hooks/useFormValidation.enhanced.js
+++ b/src/hooks/useFormValidation.enhanced.js
@@ -359,10 +359,11 @@ export const useFormValidation = (
    */
   useEffect(() => {
     isMountedRef.current = true;
+    const currentTimeouts = timeoutRefs.current;
     return () => {
       isMountedRef.current = false;
-      Object.keys(timeoutRefs.current).forEach((fieldName) => {
-        clearFieldTimeout(fieldName);
+      Object.keys(currentTimeouts).forEach((fieldName) => {
+        clearTimeout(currentTimeouts[fieldName]);
       });
     };
   }, [clearFieldTimeout]);


### PR DESCRIPTION
## Summary

Resolves a React Hook warning in the enhanced form validation hook by avoiding direct access to a mutable ref inside an effect cleanup function.

## Changes Made

* Applied React's recommended ref-capture pattern within the effect.
* Captured the current ref value before returning the cleanup function.
* Updated cleanup logic to use the captured reference instead of directly accessing `timeoutRefs.current`.

## Why

The hook contained the following warning:

```text
The ref value 'timeoutRefs.current' will likely have changed by the time this effect cleanup function runs.
```

Since refs are mutable, directly referencing `timeoutRefs.current` inside a cleanup function can lead to less predictable behavior and triggers React Hook lint warnings.

Using a captured reference improves clarity and aligns with React Hook best practices while preserving existing functionality.

## Verification

* ESLint warning resolved.
* Timeout cleanup behavior preserved.
* No validation logic changes.
* No API changes.
* No functional regressions observed.

## Files Modified

```text
src/hooks/useFormValidation.enhanced.js
```

Fixes #5756
