### PR TITLE
fix: store session recovery key in memory only

### DIFF
--- a/src/context/SessionRecoveryContext.js
+++ b/src/context/SessionRecoveryContext.js
@@ -126,23 +126,21 @@ const isCryptoAvailable = () =>
 // Session key management — unchanged from the original implementation
 // ---------------------------------------------------------------------------
 
+// In-memory only — never written to sessionStorage or localStorage
+let _inMemorySessionKey = null;
+
 const getOrCreateSessionKey = () => {
-  if (typeof window === "undefined" || !window.sessionStorage) {
-    return null;
-  }
+  if (typeof window === "undefined") return null;
   try {
-    let key = sessionStorage.getItem(RECOVERY_KEY_NAME);
-    if (!key) {
-      // Generate 32 random bytes and encode as hex for use as the PBKDF2 password
+    if (!_inMemorySessionKey) {
       const raw = crypto.getRandomValues(new Uint8Array(32));
-      key = Array.from(raw)
+      _inMemorySessionKey = Array.from(raw)
         .map((b) => b.toString(16).padStart(2, "0"))
         .join("");
-      sessionStorage.setItem(RECOVERY_KEY_NAME, key);
     }
-    return key;
+    return _inMemorySessionKey;
   } catch (e) {
-    logger.error("Failed to manage session-bound recovery key:", e);
+    logger.error("Failed to generate in-memory session key:", e);
     return null;
   }
 };


### PR DESCRIPTION
## Description
Replaced sessionStorage-based session recovery key with an in-memory
module-level variable. Previously the PBKDF2 password was stored in
sessionStorage["eventra_session_recovery_key"], making it readable by
any same-origin JavaScript alongside the salt and ciphertext — rendering
the AES-GCM encryption trivially reversible.

The key now lives exclusively in `_inMemorySessionKey` and is never
written to any browser storage. It is cleared naturally on page/tab close.

Fixes #5714

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings