### PR TITLE
fix: move backend Azure URL to environment variable in setupProxy.js

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,10 +1,16 @@
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
+const PRODUCTION_BACKEND_URL = 'https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net';
+
+const BACKEND_URL = process.env.VITE_API_URL
+  || process.env.REACT_APP_API_URL
+  || PRODUCTION_BACKEND_URL;
+
 module.exports = function(app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net',
+      target: BACKEND_URL,
       changeOrigin: true,
       logLevel: 'debug'
     })


### PR DESCRIPTION
Fixes #5763

## Summary

The Azure Spring Apps backend URL was hardcoded in \src/setupProxy.js\, exposing infrastructure details (region, resource name) and preventing environment-based switching.

Changed the proxy to read from \VITE_API_URL\ or \REACT_APP_API_URL\ environment variables first, with the current hardcoded URL as a final fallback.