### PR TITLE
fix: validate BroadcastChannel message schema before dispatching

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -7,6 +7,44 @@ const HEARTBEAT_KEY = "eventra_sse_leader_heartbeat";
 // Unique identifier for this tab instance
 const TAB_ID = Math.random().toString(36).substring(2, 9);
 
+const ALLOWED_MESSAGE_TYPES = new Set([
+  "SUBSCRIBE",
+  "UNSUBSCRIBE",
+  "UNSUBSCRIBE_ALL",
+  "QUERY_SUBSCRIBERS",
+  "SUBSCRIBERS_RESPONSE",
+  "SSE_MESSAGE",
+  "SSE_STATUS",
+  "RECONNECT_REQUEST",
+  "PING",
+  "PONG",
+]);
+
+const MESSAGE_REQUIRED_FIELDS = {
+  SUBSCRIBE: ["tabId", "path"],
+  UNSUBSCRIBE: ["tabId", "path"],
+  UNSUBSCRIBE_ALL: ["tabId", "paths"],
+  QUERY_SUBSCRIBERS: ["tabId"],
+  SUBSCRIBERS_RESPONSE: ["tabId", "paths"],
+  SSE_MESSAGE: ["path", "data"],
+  SSE_STATUS: ["path", "status"],
+  RECONNECT_REQUEST: ["path"],
+  PING: ["tabId"],
+  PONG: ["tabId"],
+};
+
+const isValidBroadcastMessage = (msg) => {
+  if (!msg || typeof msg !== "object" || !msg.type) return false;
+  if (!ALLOWED_MESSAGE_TYPES.has(msg.type)) return false;
+  const required = MESSAGE_REQUIRED_FIELDS[msg.type];
+  if (!required) return false;
+  for (const field of required) {
+    if (!(field in msg)) return false;
+    if (field === "paths" && !Array.isArray(msg.paths)) return false;
+  }
+  return true;
+};
+
 class SseMultiplexer {
   constructor() {
     this.tabId = TAB_ID;
@@ -177,7 +215,7 @@ class SseMultiplexer {
   }
 
   handleBroadcastMessage(msg) {
-    if (!msg || msg.tabId === this.tabId) return;
+    if (!isValidBroadcastMessage(msg) || msg.tabId === this.tabId) return;
 
     if (this.isLeader && this.lastSeenFollowers) {
       this.lastSeenFollowers.set(msg.tabId, Date.now());


### PR DESCRIPTION
Fixes #5765

## Summary

The \handleBroadcastMessage\ method processed incoming BroadcastChannel messages without any validation. Any script on the same origin (via XSS or compromised dependency) could inject arbitrary messages.

Added:
- \ALLOWED_MESSAGE_TYPES\ Set defining all valid message types
- \MESSAGE_REQUIRED_FIELDS\ schema specifying required fields per type
- \isValidBroadcastMessage()\ function that validates type, required fields, and array types
- Updated \handleBroadcastMessage\ to silently drop invalid messages