### PR TITLE
perf: enable CSS minification via esbuild in vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -79,9 +79,9 @@ export default defineConfig(({ mode }) => {
       outDir: "build",
       sourcemap: false,
       minify: "esbuild",
-      // Disable CSS minification — lightningcss (Vite 8 default) cannot parse
-      // the custom Tailwind `short` screen: (max-height: 520px) media query.
-      cssMinify: false,
+      // Use esbuild for CSS minification instead of the default lightningcss,
+      // which cannot parse the custom Tailwind `short` screen media query.
+      cssMinify: "esbuild",
       chunkSizeWarningLimit: 1500,
       rollupOptions: {
         output: {


### PR DESCRIPTION
Fixes #5771

## Summary

CSS minification was completely disabled (cssMinify: false) because lightningcss (Vite 8 default) cannot parse a custom Tailwind "short" screen with max-height: 520px. This caused production CSS bundles to ship 20-30% larger than necessary.

Changed to cssMinify: "esbuild" � esbuild's CSS minifier handles the problematic media query correctly and provides significant CSS size reduction.
