### PR TITLE
perf: add immutable Cache-Control headers for Vite-hashed assets in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -95,6 +95,15 @@
       ]
     },
     {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
Fixes #5772

## Summary

Vite generates content-hashed filenames for all production assets (e.g. index-abc123.js), but vercel.json had no Cache-Control headers for these immutable files. Browsers revalidated them on every visit.

Added a header rule for /assets/(.*) with \public, max-age=31536000, immutable\ to cache hashed assets aggressively. HTML and API routes are unaffected.
