### PR TITLE
devops: add cache-control and security headers to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,34 @@
 # Netlify Configuration File
-# Fixes build issues caused by CI=true treating warnings as errors, and configures SPA redirects.
 
 [build]
-  command = "CI=false npm run build"
+  command = "npm run build"
   publish = "build"
 
 [build.environment]
   NODE_VERSION = "22"
+
+[[headers]]
+  for = "/assets/*"
+
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=(), payment=(), usb=(), bluetooth=()"
+    Cross-Origin-Opener-Policy = "same-origin-allow-popups"
+    Cross-Origin-Resource-Policy = "same-site"
+
+[[headers]]
+  for = "/"
+  [headers.values]
+    Link = "</.well-known/api-catalog>; rel=\"api-catalog\", </apiDocs>; rel=\"service-doc\""
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Fixes #5774

## Summary

Netlify config had no headers section at all � no Cache-Control for static assets and no security headers.

Added:
- Immutable caching for /assets/* files (max-age=31536000)
- Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy headers
- Link header for API catalog discovery
- Removed CI=false flag which was silencing all build warnings
