### PR TITLE
fix: scope event drafts to current user

### DIFF
--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -10,6 +10,7 @@ import {
   parseTimeToMinutes,
 } from "../utils/eventCreationUtils";
 import { logger } from "../utils/logger";
+import { useAuth } from "../context/AuthContext";
 
 // 🎯 Constants for better maintainability
 const MAX_CAPACITY = 100000;
@@ -24,6 +25,8 @@ const DEBOUNCE_DELAY = 1000;
  * Handles form state, validation, draft persistence, and submission.
  */
 export const useEventForm = () => {
+  const { user } = useAuth();
+  const scopedDraftKey = `${DRAFT_KEY}_${user?.id || "guest"}`;
   // 📊 State Management
   const [formData, setFormData] = useState(initialFormData);
   const [errors, setErrors] = useState({});
@@ -68,7 +71,7 @@ export const useEventForm = () => {
   useEffect(() => {
     const checkForDraft = () => {
       try {
-        const saved = localStorage.getItem(DRAFT_KEY);
+        const saved = localStorage.getItem(scopedDraftKey);
         if (saved) {
           setShowRestoreModal(true);
         }
@@ -96,7 +99,7 @@ export const useEventForm = () => {
         const saveable = { ...formDataRef.current };
         delete saveable.banner;
         delete saveable.bannerPreview;
-        localStorage.setItem(DRAFT_KEY, JSON.stringify(saveable));
+        localStorage.setItem(scopedDraftKey, JSON.stringify(saveable));
       } catch (error) {
         logger.error("Failed to save draft:", error);
       }
@@ -180,7 +183,7 @@ export const useEventForm = () => {
   const resetForm = useCallback(() => {
     setFormData(initialFormData);
     setErrors({});
-    localStorage.removeItem(DRAFT_KEY);
+    localStorage.removeItem(scopedDraftKey);
   }, []);
 
   const handleInputChange = useCallback((e) => {
@@ -262,7 +265,7 @@ export const useEventForm = () => {
 
   const handleRestoreDraft = useCallback(() => {
     try {
-      const saved = localStorage.getItem(DRAFT_KEY);
+      const saved = localStorage.getItem(scopedDraftKey);
       if (saved) {
         setFormData((prev) => ({ ...prev, ...JSON.parse(saved) }));
         toast.success("Draft restored!");
@@ -275,7 +278,7 @@ export const useEventForm = () => {
   }, []);
 
   const handleDiscardDraft = useCallback(() => {
-    localStorage.removeItem(DRAFT_KEY);
+    localStorage.removeItem(scopedDraftKey);
     setShowRestoreModal(false);
   }, []);
 


### PR DESCRIPTION
Fixes #5717

This PR scopes event drafts to the currently authenticated user instead of using a single global localStorage key.

Previously, drafts were stored under a shared `DRAFT_KEY`, allowing another user on the same device to see and restore a different user's draft data.

Changes:

* Added user-scoped draft keys using `user.id`
* Updated draft save logic to use the scoped key
* Updated draft restore logic to use the scoped key
* Updated draft deletion/reset logic to use the scoped key
* Added a guest fallback when no authenticated user is available

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Screenshots / Video

N/A

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings
