### PR TITLE
fix: use RETRYABLE_METHODS Set in API retry interceptor

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -226,7 +226,7 @@ API.interceptors.response.use(
     }
 
     const retryCount = config._retryCount || 0;
-    const isNonMutating = config.method?.toUpperCase() === 'GET';
+    const isNonMutating = RETRYABLE_METHODS.has(config.method?.toUpperCase() ?? "");
     const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status);
     
     // Retry only idempotent reads/probes. Do not blind-retry mutations or 429s,


### PR DESCRIPTION
Fixes #5800

Replaced the hardcoded `GET`-only retry check at `src/config/api.js` line 229 with the existing `RETRYABLE_METHODS.has()` call, so HEAD, OPTIONS, and TRACE requests also benefit from built-in retry logic on 502/503/504 responses. The Set was already defined with the correct methods — it just wasn't being used.

Let me know if everything looks good!