### PR TITLE
fix: swap req/res args in corsResponse rate-limit path

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -103,10 +103,10 @@ async function handler(req, res) {
     loginRateLimiter.evictStale();
 
     if (!loginRateLimiter.check(clientIp)) {
-      return corsResponse(res, 429, {
+      return corsResponse(req, res, 429, {
         error: "Too many login attempts. Please try again later.",
         retryAfter: 60,
-      }, req);
+      });
     }
 
     // -----------------------------------------------------------------------

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -145,10 +145,10 @@ async function handler(req, res) {
     signupRateLimiter.evictStale();
 
     if (!signupRateLimiter.check(clientIp)) {
-      return corsResponse(res, 429, {
+      return corsResponse(req, res, 429, {
         error: "Too many signup attempts. Please try again later.",
         retryAfter: 60,
-      }, req);
+      });
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #5801

Fixed the swapped `req`/`res` arguments in two `corsResponse` calls:

- `api/auth/login.js` line 106 — rate-limit 429 path
- `api/auth/signup.js` line 148 — rate-limit 429 path

Both call sites were passing `(res, 429, data, req)` instead of `(req, res, 429, data)`, which would throw a TypeError when rate limiting triggered. The function signature is `corsResponse(req, res, status, data)` — every other call in these files already uses the correct order.

Let me know if everything looks good!