### PR TITLE
fix: replace duplicate reduced motion logic with useReducedMotion hook

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -3,6 +3,7 @@ import { motion, useInView } from "framer-motion";
 import { useEffect, useState, useRef } from "react";
 
 import useDocumentTitle from "../../hooks/useDocumentTitle";
+import { useReducedMotion } from "../../hooks/useReducedMotion";
 import CountUpLib from "react-countup";
 import SectionErrorBoundary from "../../components/common/SectionErrorBoundary";
 
@@ -66,16 +67,7 @@ const values = [
 
 export default function ModernAbout() {
   useDocumentTitle("Eventra | About");
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setPrefersReducedMotion(mediaQuery.matches);
-
-    const handleChange = (e) => setPrefersReducedMotion(e.matches);
-    mediaQuery.addEventListener("change", handleChange);
-    return () => mediaQuery.removeEventListener("change", handleChange);
-  }, []);
+  const prefersReducedMotion = useReducedMotion();
 
   const anim = (variants) => ({
     initial: "hidden",


### PR DESCRIPTION
Fixes #5805

Replaced the 12-line inline reduced-motion detection logic in `ModernAbout.js` with the existing `useReducedMotion()` hook. This brings ModernAbout in line with the 20+ other components already using the shared hook, and inherits the hook's SSR safety (window existence check) and correct initial state (reads the media query match directly instead of defaulting to false).

- Removed the local `useState` + `useEffect` + `window.matchMedia` duplication
- Added the hook import: `import { useReducedMotion } from "../../hooks/useReducedMotion"`

Let me know if everything looks good!