### PR TITLE
fix(hooks): resolve useEffect dependency and ref cleanup warnings in components & contexts

### DIFF
--- a/src/components/user/OnboardingChecklist.jsx
+++ b/src/components/user/OnboardingChecklist.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
@@ -105,7 +105,7 @@ export default function OnboardingChecklist() {
   ]);
 
   // Check storage values and update task statuses
-  const checkTaskStatus = () => {
+  const checkTaskStatus = useCallback(() => {
     // 1. Check user profile / skills in local storage or state
     let interestsDone = false;
     const storedUser = localStorage.getItem("user");
@@ -170,7 +170,7 @@ export default function OnboardingChecklist() {
 
       return updated;
     });
-  };
+  }, [user]);
 
   // Perform checks periodically and on routing
   useEffect(() => {
@@ -180,7 +180,7 @@ export default function OnboardingChecklist() {
     const interval = setInterval(checkTaskStatus, 1500);
 
     return () => clearInterval(interval);
-  }, [user, isDismissed, location]);
+  }, [user, isDismissed, location, checkTaskStatus]);
 
   // Listen to custom reset event to show checklist immediately
   useEffect(() => {
@@ -194,7 +194,7 @@ export default function OnboardingChecklist() {
     return () => {
       window.removeEventListener("eventraOnboardingReset", handleResetEvent);
     };
-  }, []);
+  }, [checkTaskStatus]);
 
   const handleDismiss = () => {
     localStorage.setItem("eventra_onboarding_dismissed", "true");

--- a/src/context/SessionRecoveryContext.js
+++ b/src/context/SessionRecoveryContext.js
@@ -345,9 +345,11 @@ export const SessionRecoveryProvider = ({ children }) => {
   }, [hasSession, clearSession]);
 
   useEffect(() => {
+    const saveTimeout = saveTimeoutRef.current;
+    const activityTimeout = activityTimeoutRef.current;
     return () => {
-      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
-      if (activityTimeoutRef.current) clearTimeout(activityTimeoutRef.current);
+      if (saveTimeout) clearTimeout(saveTimeout);
+      if (activityTimeout) clearTimeout(activityTimeout);
     };
   }, []);
 


### PR DESCRIPTION
## Description
This pull request resolves React Hook dependency (`react-hooks/exhaustive-deps`) and Ref cleanup memory leak warnings in `OnboardingChecklist` and `SessionRecoveryContext`. These issues were triggering build-time linter warnings and potentially causing performance/memory issues.

### Key Changes
1. **`OnboardingChecklist` (`src/components/user/OnboardingChecklist.jsx`):**
   - Wrapped `checkTaskStatus` in a `useCallback` hook with `[user]` as a dependency to prevent redundant function instantiations.
   - Added `checkTaskStatus` to the dependency arrays of the periodic polling `useEffect` and reset listener `useEffect`.
2. **`SessionRecoveryContext` (`src/context/SessionRecoveryContext.js`):**
   - Cached the active timeout references (`saveTimeoutRef.current` and `activityTimeoutRef.current`) into local variables within the scope of the hook's `useEffect`.
   - Used these local variables in the cleanup function to prevent ESLint warnings about mutating/evaluating refs during unmounting.

Fixes # (replace with the issue number if applicable)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Linter runs cleanly with no errors (`npm run lint` or `eslint` checks pass)