### PR TITLE
fix: add uid sanitization and error handling to verifyCertificate

### DIFF
--- a/src/Pages/CertificateVerification/CertificateVerifier.jsx
+++ b/src/Pages/CertificateVerification/CertificateVerifier.jsx
@@ -21,12 +21,12 @@ export const CertificateVerifier = () => {
   const [result, setResult] = useState(null);
 
   const handleSearch = async () => {
-    try {
-      const data = await verifyCertificate(uid.trim());
+    const { success, data, error } = await verifyCertificate(uid.trim());
+    if (success) {
       setResult(data);
       toast.success('Certificate verified!');
-    } catch (e) {
-      toast.error('Verification failed');
+    } else {
+      toast.error(error || 'Verification failed');
       setResult(null);
     }
   };

--- a/src/utils/certificateUtils.js
+++ b/src/utils/certificateUtils.js
@@ -1,12 +1,29 @@
+const sanitizeUid = (uid) => {
+  if (typeof uid !== "string") return "";
+  return uid.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 128);
+};
+
 export async function verifyCertificate(uid) {
-  if (!uid) throw new Error('UID is required');
-  const apiBaseUrl = process.env.REACT_APP_API_URL || process.env.VITE_API_URL || '';
-  const response = await fetch(`${apiBaseUrl}/api/verify-certificate/${uid}`);
-  if (!response.ok) {
-    const error = await response.text();
-    throw new Error(error || 'Verification failed');
+  const cleanUid = sanitizeUid(uid);
+  if (!cleanUid) {
+    return { success: false, error: "UID is required" };
   }
-  const data = await response.json();
-  // Expected shape: { name, skills: [], badges: [] }
-  return data;
+
+  const apiBaseUrl = process.env.REACT_APP_API_URL || process.env.VITE_API_URL || "";
+
+  try {
+    const response = await fetch(
+      `${apiBaseUrl}/api/verify-certificate/${encodeURIComponent(cleanUid)}`
+    );
+
+    if (!response.ok) {
+      const error = await response.text().catch(() => "Verification failed");
+      return { success: false, error: error || `Server returned ${response.status}` };
+    }
+
+    const data = await response.json();
+    return { success: true, data };
+  } catch (err) {
+    return { success: false, error: err.message || "Network error during verification" };
+  }
 }


### PR DESCRIPTION
Fixes #5828

## Summary

The \erifyCertificate\ function had two issues:
1. \uid\ was interpolated directly into the fetch URL without sanitization, enabling path traversal
2. No \	ry/catch\ around the fetch � network failures became unhandled promise rejections

Added:
- \sanitizeUid()\ that strips non-alphanumeric chars (max 128)
- \encodeURIComponent()\ for the URL path segment
- \	ry/catch\ returning structured \{ success, data, error }\ instead of throwing
- Updated caller in CertificateVerifier.jsx to use the new return format
