### PR TITLE
perf: limit concurrent prefetches to 4 with asyncPool helper

### DIFF
--- a/src/utils/prefetchUtils.js
+++ b/src/utils/prefetchUtils.js
@@ -5,6 +5,27 @@
  */
 
 const prefetchMap = new Map();
+const MAX_CONCURRENT_PREFETCHES = 4;
+
+async function asyncPool(iterable, iteratorFn, concurrency) {
+  const results = [];
+  const executing = new Set();
+
+  for (const [index, item] of iterable.entries()) {
+    const promise = Promise.resolve().then(() => iteratorFn(item, index));
+    results.push(promise);
+    executing.add(promise);
+
+    const clean = () => executing.delete(promise);
+    promise.then(clean, clean);
+
+    if (executing.size >= concurrency) {
+      await Promise.race(executing);
+    }
+  }
+
+  return Promise.all(results);
+}
 
 /**
  * Pre-fetches a dynamic import and caches the result.
@@ -26,9 +47,13 @@ export const prefetchRoute = async (importFn, key) => {
 };
 
 /**
- * Pre-fetches multiple routes in parallel.
+ * Pre-fetches multiple routes with a concurrency limit.
  * @param {Array<Object>} routes - Array of { importFn, key } objects
  */
 export const prefetchRoutes = (routes) => {
-  return Promise.all(routes.map(({ importFn, key }) => prefetchRoute(importFn, key)));
+  return asyncPool(
+    routes,
+    ({ importFn, key }) => prefetchRoute(importFn, key),
+    MAX_CONCURRENT_PREFETCHES
+  );
 };


### PR DESCRIPTION
Fixes #5829

## Summary

\prefetchRoutes\ used \Promise.all\ to fire all prefetch requests simultaneously with no concurrency limit, potentially saturating the browser's connection pool.

Added an \syncPool\ helper that limits concurrent prefetches to 4 at a time. Each batch waits for at least one in-flight prefetch to complete before starting the next, keeping network usage within reasonable bounds.
