### PR TITLE
perf: replace Array.concat with push in EventDetails pagination loops

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -246,7 +246,7 @@ const EventDetails = () => {
                                 const totalPages = response.data?.totalPages || 1;
                                 
                                 if (Array.isArray(data)) {
-                                  allRegistrants = allRegistrants.concat(data);
+                                  allRegistrants.push(...data);
                                 }
                                 
                                 if (page >= totalPages || data.length < limit) {
@@ -284,7 +284,7 @@ const EventDetails = () => {
                                 const totalPages = response.data?.totalPages || 1;
                                 
                                 if (Array.isArray(data)) {
-                                  allRegistrants = allRegistrants.concat(data);
+                                  allRegistrants.push(...data);
                                 }
                                 
                                 if (page >= totalPages || data.length < limit) {


### PR DESCRIPTION
Fixes #5830

## Summary

Two pagination while-loops used \llRegistrants = allRegistrants.concat(data)\ which creates a new array copying all previous elements on every iteration (O(N�) memory churn). Replaced with \.push(...data)\ to append in-place (O(N)).
