### PR TITLE
perf: replace Array.concat with push in leaderboard pagination loop

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -185,7 +185,7 @@ export default async function handler(req, res) {
 
       for (const result of remainingResults) {
         if (result.status === "fulfilled" && result.value.length > 0) {
-          allPrs = allPrs.concat(result.value);
+          allPrs.push(...result.value);
         }
       }
     }


### PR DESCRIPTION
Fixes #5833

## Summary

\llPrs = allPrs.concat(result.value)\ in the pagination loop creates a new array on every page (O(N�) copies). Replaced with \llPrs.push(...result.value)\ for in-place O(N) append.
