### PR TITLE
perf: cache new Date() once in MyCalendar instead of 3x per day cell

### DIFF
--- a/src/Pages/Calendar/MyCalendar.jsx
+++ b/src/Pages/Calendar/MyCalendar.jsx
@@ -167,6 +167,7 @@ const MyCalendar = () => {
       .sort((a, b) => new Date(a.event.date) - new Date(b.event.date));
   };
 
+  const today = new Date();
   const selectedEvents = getSelectedDateEvents();
   const timelineEvents = getFilteredAllEvents();
 
@@ -352,9 +353,9 @@ const MyCalendar = () => {
                           const dayEvents = getEventsForDate(day);
                           const selected = isSelected(day);
                           const isToday =
-                            new Date().getDate() === day &&
-                            new Date().getMonth() === currentMonth &&
-                            new Date().getFullYear() === currentYear;
+                            today.getDate() === day &&
+                            today.getMonth() === currentMonth &&
+                            today.getFullYear() === currentYear;
 
                           return (
                             <button


### PR DESCRIPTION
Fixes #5835

## Summary

Each day cell in the calendar grid created \
ew Date()\ three times to check if it represents today, resulting in ~84-93 redundant Date allocations per render. Cached \const today = new Date()\ once at the top of the component and reused it in all cell comparisons.
