### PR TITLE
perf: cache new Date() in WhatsHappening filter/map to reduce allocations

### DIFF
--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -37,8 +37,10 @@ const WhatsHappening = () => {
   }, []);
 
   const formatEventsData = (events) => {
+    const now = new Date();
+    const dayMs = 1000 * 60 * 60 * 24;
     return events
-      .filter((event) => new Date(event.date) >= new Date())
+      .filter((event) => new Date(event.date) >= now)
       .map((event) => ({
         id: `event-${event.id}`,
         title: event.title,
@@ -58,12 +60,13 @@ const WhatsHappening = () => {
         location: event.location,
         attendees: event.attendees,
         timeLeft: `${Math.ceil(
-       (new Date(event.rawDate || event.date) - new Date()) /(1000 * 60 * 60 * 24))} days`,
+       (new Date(event.rawDate || event.date) - now) / dayMs)} days`,
       }));
   };
 
   const formatHackathonsData = (hackathons) => {
     const now = new Date();
+    const dayMs = 1000 * 60 * 60 * 24;
     return hackathons
       .filter(
         (hackathon) =>
@@ -76,11 +79,10 @@ const WhatsHappening = () => {
         description: hackathon.description,
 
         timeLeft:
-  new Date(hackathon.endDate) < new Date()
+  new Date(hackathon.endDate) < now
     ? "Ended"
     : `${Math.ceil(
-        (new Date(hackathon.startDate) - new Date()) /
-          (1000 * 60 * 60 * 24)
+        (new Date(hackathon.startDate) - now) / dayMs
       )} days`,
         
         date: `${new Date(hackathon.startDate).toLocaleDateString("en-US", {


### PR DESCRIPTION
Fixes #5836

## Summary

\ormatEventsData\ called \
ew Date()\ twice per event (once in filter, once in map). \ormatHackathonsData\ had \const now\ but still used \
ew Date()\ in \	imeLeft\. Extracted \const now\ and \const dayMs\ at the start of each formatter and reused everywhere � eliminates ~N�2 Date allocations per call.
