### PR TITLE
fix: set vercel framework to vite instead of create-react-app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "buildCommand": "npm run lint && GENERATE_SOURCEMAP=false npm run build",
   "outputDirectory": "build",
-  "framework": "create-react-app",
+  "framework": "vite",
   "env": {
     "REACT_APP_API_URL": "/api"
   },


### PR DESCRIPTION
Fixes #5838

## Summary

\ercel.json\ had \"framework": "create-react-app"\ but the project uses Vite (no react-scripts, uses vite.config.js). This causes Vercel to apply CRA-specific build optimizations, caching, and server configuration that don't match the actual toolchain. Changed to \"vite"\.
