### PR TITLE
fix(routes): inject Suspense boundaries into PublicRoutes to prevent crashes

### DIFF
--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -1,4 +1,4 @@
-import { lazy } from "react";
+import { lazy, Suspense } from "react";
 import { Route } from "react-router-dom";
 import ProtectedRoute from "../auth/ProtectedRoute";
 import ErrorBoundary from "../common/ErrorBoundary";
@@ -35,44 +35,60 @@ const RemindersPage = lazy(() => import("../../Pages/Events/RemindersPage"));
 const MyCalendar = lazy(() => import("../../Pages/Calendar/MyCalendar"));
 const OptimizedImage = lazy(() => import("../common/OptimizedImage"));
 
+// 🔥 FIX: Added Suspense wrapper required for React.lazy() to prevent layout thrashing and crashes
 const withModuleBoundary = (children, boundaryName) => (
   <ErrorBoundary
     variant="section"
     boundaryName={boundaryName}
     title={boundaryName + " needs a reset"}
   >
-    {children}
+    <Suspense fallback={<div className="flex justify-center items-center min-h-[50vh] text-gray-500 animate-pulse">Loading {boundaryName}...</div>}>
+      {children}
+    </Suspense>
   </ErrorBoundary>
 );
 
+// 🔥 FIX: Added helper for naked utility routes
+const withPublicSuspense = (children) => (
+  <Suspense fallback={<div className="flex justify-center items-center min-h-screen text-gray-500 animate-pulse">Loading...</div>}>
+    {children}
+  </Suspense>
+);
+
 export const getPublicRoutes = () => [
-  <Route key="/health" path="/health" element={<HealthCheckPage />} />,
-  <Route key="/" path="/" element={<HomePage />} />,
+  // 🔥 FIX: Wrapped naked utility route with Suspense
+  <Route key="/health" path="/health" element={withPublicSuspense(<HealthCheckPage />)} />,
+  // 🔥 FIX: Wrapped naked HomePage with module boundary for safety
+  <Route key="/" path="/" element={withModuleBoundary(<HomePage />, "Home")} />,
   <Route key="/events" path="/events" element={withModuleBoundary(<EventsPage />, "Events explorer")} />,
   <Route key="/event-details" path="/events/:eventId" element={withModuleBoundary(<EventDetails />, "Event details")} />,
   
   
-  <Route key="/register" path="/events/:eventId/register" element={<ProtectedRoute><EventRegistration /></ProtectedRoute>} />,
+  // 🔥 FIX: Safely wrapped the lazy-loaded EventRegistration inside the ProtectedRoute
+  <Route key="/register" path="/events/:eventId/register" element={<ProtectedRoute>{withModuleBoundary(<EventRegistration />, "Event Registration")}</ProtectedRoute>} />,
   <Route key="/hackathons" path="/hackathons" element={withModuleBoundary(<HackathonPage />, "Hackathon explorer")} />,
   <Route key="/hackathon-details" path="/hackathons/:hackathonId" element={withModuleBoundary(<HackathonDetailsPage />, "Hackathon details")} />,
   <Route key="/hackathons-lifecycle" path="/hackathons/:id/lifecycle" element={withModuleBoundary(<HackathonLifecycle />, "Hackathon lifecycle")} />,
   <Route key="/projects" path="/projects" element={withModuleBoundary(<ProjectsPage />, "Projects explorer")} />,
   <Route key="/leaderboard" path="/leaderboard" element={withModuleBoundary(<LeaderBoard />, "Leaderboard")} />,
   <Route key="/community-event" path="/community-event" element={withModuleBoundary(<CommunityEvent />, "Community Events")} />,
-<Route key="/about" path="/about" element={withModuleBoundary(<AboutPage />, "About")} />,
-<Route key="/faq" path="/faq" element={withModuleBoundary(<FAQPage />, "FAQ")} />,
-<Route key="/contact" path="/contact" element={withModuleBoundary(<ContactUs />, "Contact")} />,
-<Route key="/contributors" path="/contributors" element={withModuleBoundary(<Contributors />, "Contributors")} />,
-<Route key="/contributorguide" path="/contributorguide" element={withModuleBoundary(<ContributorGuide />, "Contributor Guide")} />,
-<Route key="/documentation" path="/documentation" element={withModuleBoundary(<DocumentationPage />, "Documentation")} />,
-<Route key="/terms" path="/terms" element={withModuleBoundary(<Terms />, "Terms")} />,
-<Route key="/privacy" path="/privacy" element={withModuleBoundary(<Privacy />, "Privacy")} />,
-<Route key="/api-docs" path="/api-docs" element={withModuleBoundary(<ApiDocs />, "API Docs")} />,
-<Route key="/helpcenter" path="/helpcenter" element={withModuleBoundary(<HelpCenter />, "Help Center")} />,
-<Route key="/feedback" path="/feedback" element={withModuleBoundary(<FeedbackPage />, "Feedback")} />,
-<Route key="/bookmarks" path="/bookmarks" element={withModuleBoundary(<BookmarkedEvents />, "Bookmarks")} />,
-<Route key="/reminders" path="/reminders" element={withModuleBoundary(<RemindersPage />, "Reminders")} />,
-<Route key="/calendar" path="/calendar" element={withModuleBoundary(<MyCalendar />, "Calendar")} />,
-<Route key="/image-test" path="/image-test" element={<OptimizedImage src="https://images.unsplash.com/photo-1540575861501-7c90b707a27d" alt="Test" />} />,
-<Route key="/submit-project" path="/submit-project" element={withModuleBoundary(<SubmitProject />, "Submit Project")} />,
-  <Route key="/api/hackathons" path="/api/hackathons" element={<MockApiResponse />} />,];
+  <Route key="/about" path="/about" element={withModuleBoundary(<AboutPage />, "About")} />,
+  <Route key="/faq" path="/faq" element={withModuleBoundary(<FAQPage />, "FAQ")} />,
+  <Route key="/contact" path="/contact" element={withModuleBoundary(<ContactUs />, "Contact")} />,
+  <Route key="/contributors" path="/contributors" element={withModuleBoundary(<Contributors />, "Contributors")} />,
+  <Route key="/contributorguide" path="/contributorguide" element={withModuleBoundary(<ContributorGuide />, "Contributor Guide")} />,
+  <Route key="/documentation" path="/documentation" element={withModuleBoundary(<DocumentationPage />, "Documentation")} />,
+  <Route key="/terms" path="/terms" element={withModuleBoundary(<Terms />, "Terms")} />,
+  <Route key="/privacy" path="/privacy" element={withModuleBoundary(<Privacy />, "Privacy")} />,
+  <Route key="/api-docs" path="/api-docs" element={withModuleBoundary(<ApiDocs />, "API Docs")} />,
+  <Route key="/helpcenter" path="/helpcenter" element={withModuleBoundary(<HelpCenter />, "Help Center")} />,
+  <Route key="/feedback" path="/feedback" element={withModuleBoundary(<FeedbackPage />, "Feedback")} />,
+  <Route key="/bookmarks" path="/bookmarks" element={withModuleBoundary(<BookmarkedEvents />, "Bookmarks")} />,
+  <Route key="/reminders" path="/reminders" element={withModuleBoundary(<RemindersPage />, "Reminders")} />,
+  <Route key="/calendar" path="/calendar" element={withModuleBoundary(<MyCalendar />, "Calendar")} />,
+  // 🔥 FIX: Wrapped naked image test route with Suspense
+  <Route key="/image-test" path="/image-test" element={withPublicSuspense(<OptimizedImage src="https://images.unsplash.com/photo-1540575861501-7c90b707a27d" alt="Test" />)} />,
+  <Route key="/submit-project" path="/submit-project" element={withModuleBoundary(<SubmitProject />, "Submit Project")} />,
+  // 🔥 FIX: Wrapped naked mock api route with Suspense
+  <Route key="/api/hackathons" path="/api/hackathons" element={withPublicSuspense(<MockApiResponse />)} />,
+];


### PR DESCRIPTION
## Description
This PR fortifies the public routing configuration by addressing missing React Suspense boundaries and naked component crash risks.

**Changes made:**
- **Module Suspense:** Imported `Suspense` and integrated it into the `withModuleBoundary` helper, ensuring all lazy-loaded public routes have localized loading states and don't cause fatal render crashes.
- **Naked Route Protection:** Created a `withPublicSuspense` helper for utility routes (like `/health`) and wrapped critical naked routes (like `<HomePage />` and `<EventRegistration />`) with `withModuleBoundary` to prevent full-tree crashes on localized errors.

Fixes #5869

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance/UX optimization (Localized Suspense boundaries)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code