### PR TITLE
fix(routes): inject localized Suspense in AppRoutes to prevent layout thrashing

### DIFF
--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -40,12 +40,23 @@ const AppRoutes = () => {
           path="/dashboard/achievements"
           element={
             <ProtectedRoute>
-              <UserAchievements />
+              {/* 🔥 FIX: Added localized Suspense to prevent top-level router layout thrashing */}
+              <Suspense fallback={<RouteFallback />}>
+                <UserAchievements />
+              </Suspense>
             </ProtectedRoute>
           }
         />
 
-      <Route path="*" element={<NotFoundPage />} />
+      {/* 🔥 FIX: Added localized Suspense for 404 page */}
+      <Route 
+        path="*" 
+        element={
+          <Suspense fallback={<RouteFallback />}>
+            <NotFoundPage />
+          </Suspense>
+        } 
+      />
     </Routes>
   </Suspense>
   );


### PR DESCRIPTION
## Description
This PR resolves a layout thrashing issue in the main router by localizing Suspense boundaries for standalone lazy-loaded routes.

**Changes made:**
- **Localized Suspense:** Wrapped the `<UserAchievements />` and `<NotFoundPage />` elements in their own `<Suspense fallback={<RouteFallback />}>` boundaries. This ensures that when the network fetches these chunks, only the specific page content suspends, preventing the top-level router from unmounting the entire layout tree.

Fixes #5876

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX/Performance optimization (Prevents layout flickering)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code