### PR TITLE
docs(storybook): add missing outline variant to Button stories

### DIFF
--- a/src/components/Button.stories.jsx
+++ b/src/components/Button.stories.jsx
@@ -5,7 +5,8 @@ export default {
   component: Button,
   tags: ["autodocs"],
   argTypes: {
-    variant: { control: "select", options: ["primary", "secondary", "danger"] },
+    // 🔥 FIX: Added the missing "outline" variant to the Storybook controls
+    variant: { control: "select", options: ["primary", "secondary", "danger", "outline"] },
     size: { control: "select", options: ["small", "medium", "large"] },
   },
 };
@@ -30,6 +31,15 @@ export const Danger = {
   args: {
     children: "Delete Event",
     variant: "danger",
+    size: "medium",
+  },
+};
+
+// 🔥 FIX: Added the missing Outline story so developers can actually see it in the docs
+export const Outline = {
+  args: {
+    children: "Outline Button",
+    variant: "outline",
     size: "medium",
   },
 };


### PR DESCRIPTION
## Description
This PR resolves configuration drift between the `Button` component and its Storybook documentation by adding the missing `outline` variant.

**Changes made:**
- **Control Panel Sync:** Added `"outline"` to the `variant` options array in `argTypes` so it can be dynamically tested via the Storybook UI.
- **Story Export:** Added a dedicated `Outline` story export to ensure the variant is properly documented and available for visual testing.

Fixes #5888

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code