### PR TITLE
fix: implement real setTheme/toggleTheme and resolve system preference in ThemeContext

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -48,7 +48,7 @@ const safeStorage = {
 const getInitialTheme = () => safeStorage.getItem("theme", "system");
 
 export const ThemeProvider = ({ children }) => {
-  const [theme] = useState("light");
+  const [theme, setThemeState] = useState(getInitialTheme);
 
   // States to preserve existing codebase drawer flow without breaking
   const [activeThemeId, setActiveThemeId] = useState(() => {
@@ -78,9 +78,23 @@ export const ThemeProvider = ({ children }) => {
     return saved !== null ? saved === "true" : prefersReduced;
   });
 
-  const resolvedTheme = "light";
-  const setTheme = useCallback(() => {}, []);
-  const toggleTheme = useCallback(() => {}, []);
+  const resolvedTheme = theme === "system" ? getSystemTheme() : theme;
+  const isDarkMode = resolvedTheme === "dark";
+
+  const setTheme = useCallback((newTheme) => {
+    setThemeState(newTheme);
+    if (newTheme === "system") {
+      safeStorage.removeItem("theme");
+    } else {
+      safeStorage.setItem("theme", newTheme);
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const next = resolvedTheme === "dark" ? "light" : "dark";
+    setThemeState(next);
+    safeStorage.setItem("theme", next);
+  }, [resolvedTheme]);
 
   // Apply themes, custom HSL variable overrides, and sync storage
   useEffect(() => {
@@ -131,7 +145,7 @@ export const ThemeProvider = ({ children }) => {
       }
       metaTheme.setAttribute("content", themeColor);
     }
-  }, [activeThemeId, customHsl]);
+  }, [activeThemeId, customHsl, theme, resolvedTheme]);
 
   // Sync OS-level reduced motion preference changes
   useEffect(() => {
@@ -185,7 +199,7 @@ export const ThemeProvider = ({ children }) => {
     () => ({
       theme,
       resolvedTheme,
-      isDarkMode: false,
+      isDarkMode,
       setTheme,
       isCustomizerOpen,
       setIsCustomizerOpen,


### PR DESCRIPTION
Fixes #5871

Summary:
- ThemeContext setTheme/toggleTheme were no-ops, theme stuck to light
- Destructured setter from useState with getInitialTheme()
- Computed resolvedTheme from theme with system preference fallback
- Implemented real setTheme/toggleTheme with localStorage persistence
- Added theme/resolvedTheme to DOM-sync effect deps
- Exposed computed isDarkMode instead of hardcoded false
