### PR TITLE
perf: replace 14-pass string sanitization loop with single combined regex

### DIFF
--- a/src/utils/inputSanitization.js
+++ b/src/utils/inputSanitization.js
@@ -21,28 +21,8 @@ export const sanitizeSearchQuery = (query = '') => {
   // Trim whitespace
   let sanitized = query.trim();
 
-  // Remove/reject NoSQL injection operators
-  const dangerousPatterns = [
-    /\$/g, // NoSQL operators start with $
-    /\{/g, // Object notation
-    /\}/g,
-    /\[/g, // Array notation
-    /\]/g,
-    /;/g, // Statement terminators
-    /'/g, // SQL/NoSQL quotes
-    /`/g, // Backticks
-    /\|/g, // Pipes for command execution
-    /\\/g, // Escape characters
-    /\n/g, // Newlines
-    /\r/g, // Carriage returns
-    /</g,  // HTML tags / XSS
-    />/g,
-  ];
-
-  // Remove dangerous characters
-  dangerousPatterns.forEach(pattern => {
-    sanitized = sanitized.replace(pattern, '');
-  });
+  // Remove dangerous characters in a single pass
+  sanitized = sanitized.replace(/[${}\[\];'`|\\\n\r<>]/g, '');
 
   // Ensure max length to prevent ReDoS attacks
   const MAX_QUERY_LENGTH = 200;


### PR DESCRIPTION
Fixes #5873

Summary:
- sanitizeSearchQuery iterated 14 times over the input string via forEach + replace
- Combined all 14 patterns into a single character class regex: /[${}\[\];'"`|\\\n\r<>]/g
- Removed now-unused dangerousPatterns array (~20 lines of dead code)
