### PR TITLE
perf: use stable key in highlightMatch instead of array index

### DIFF
--- a/src/utils/highlightMatch.js
+++ b/src/utils/highlightMatch.js
@@ -46,7 +46,7 @@ const highlightMatch = (text, query) => {
   return parts.map((part, index) =>
     part.toLowerCase() === query.toLowerCase() ? (
       <span
-        key={index}
+        key={`${part}-${index}`}
         className="
           bg-yellow-200
           dark:bg-yellow-500/30


### PR DESCRIPTION
Fixes #5874

Summary:
- parts.map() used array index as React key prop: key={index}
- When text or query changes, parts array is rebuilt and same index for different segments causes incorrect DOM reuse (stale highlights, janky transitions)
- Changed to key={`${part}-${index}`} for a stable key combining content + position
