### PR TITLE
fix(ui): attach missing scroll ref and add type safety to Chatbot

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -176,7 +176,9 @@ export default function Chatbot() {
   }, [messages]);
 
   const sendMessage = (messageText = draft) => {
-    const cleanMessage = messageText.trim();
+    // 🔥 FIX: Guard against React Synthetic Events to prevent fatal .trim() crashes
+    const safeText = typeof messageText === "string" ? messageText : draft;
+    const cleanMessage = safeText.trim();
     if (!cleanMessage || isTyping) return;
 
     // Append User Message, pruning the oldest entries when the cap is exceeded.
@@ -218,7 +220,7 @@ export default function Chatbot() {
             <div
               className="
                 fixed bottom-6 right-6 z-[100]
-                hidden sm:flex               /* hide strip on mobile, show FAB instead */
+                hidden sm:flex              /* hide strip on mobile, show FAB instead */
                 items-center justify-between gap-3
                 w-72 rounded-2xl
                 border border-slate-700
@@ -404,7 +406,9 @@ export default function Chatbot() {
                   </motion.div>
                 </div>
               )}
-
+              
+              {/* 🔥 FIX: Added the missing dummy div to act as the scroll target for messagesEndRef */}
+              <div ref={messagesEndRef} />
             </div>
 
             {/* Footer controls */}


### PR DESCRIPTION
## Description
This PR resolves a broken UX feature where the chatbot failed to auto-scroll, and patches a potential fatal crash in the message submission handler.

**Changes made:**
- **Auto-Scroll Anchor:** Added a `<div ref={messagesEndRef} />` at the bottom of the message list. This gives the existing `useEffect` a physical DOM node to target, restoring the smooth auto-scroll behavior when the AI responds.
- **Type Safety Guard:** Updated `sendMessage` to verify `typeof messageText === "string"`. If an event object or invalid type is passed, it safely falls back to the component's `draft` state, preventing `TypeError` crashes.

Fixes #5903

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX improvement (Restored auto-scrolling)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code