### PR TITLE
perf: combine duplicate useEffect in PriceRangeSlider to avoid double render

### DIFF
--- a/src/components/common/PriceRangeSlider.jsx
+++ b/src/components/common/PriceRangeSlider.jsx
@@ -24,11 +24,8 @@ const PriceRangeSlider = ({
   // Sync external prop changes (e.g. filter reset from parent) into local state.
   useEffect(() => {
     setMin(minPrice);
-  }, [minPrice]);
-
-  useEffect(() => {
     setMax(maxPrice);
-  }, [maxPrice]);
+  }, [minPrice, maxPrice]);
 
   // Visual-only handlers — update local state on every tick for smooth UI.
   const handleMinChange = (e) => {


### PR DESCRIPTION
Fixes #5878

Summary:
- Two separate useEffects synced minPrice and maxPrice prop changes into local state
- When both props changed simultaneously (e.g. filter reset), this caused two sequential re-renders with an intermediate inconsistent state
- Combined into a single useEffect that sets both min and max in one batched update
