### PR TITLE
refactor: scope Navbar DOM queries to navRef instead of document

### DIFF
--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -24,7 +24,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
   }, []);
 
   const handleSearchFocus = useCallback(() => {
-    const searchInput = document.querySelector(
+    const searchInput = navRef.current?.querySelector(
       'input[type="text"], input[type="search"]'
     );
 
@@ -32,7 +32,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
   }, []);
 
   const handleNewEvent = useCallback(() => {
-    const createEventBtn = document.querySelector(
+    const createEventBtn = navRef.current?.querySelector(
       '[aria-label*="Create Event"], [aria-label*="create"]'
     );
 


### PR DESCRIPTION
Fixes #5879

Summary:
- handleSearchFocus and handleNewEvent used document.querySelector() to find DOM elements
- Scoped queries to navRef.current.querySelector() to limit search to the navbar subtree
- Avoids O(document) scans and prevents accidentally finding elements outside the navbar
