### PR TITLE
fix: useNotifications variable used before const declaration (TDZ risk)

### DIFF
--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -5,30 +5,30 @@ import { safeJsonParse } from "../utils/safeJsonParse";
 const STORAGE_KEY = "eventra_notifications";
 
 export const useNotifications = () => {
-  const [notifications, setNotifications] = useState([]);
+   const [notifications, setNotifications] = useState([]);
 
-  useEffect(() => {
-    idbGet(STORAGE_KEY)
-      .then((stored) => {
-        if (stored) {
-          const parsed = safeJsonParse(stored, []);
-          setNotifications(parsed);
-        }
-      })
-      .catch((error) => {
-        logger.error("Failed to fetch notifications from indexedDB", error);
-        setNotifications([]);
-      })
-      .finally(() => {
-        // Allow the persistence effect to run only after the initial
-        // load has settled — prevents wiping IndexedDB on mount.
-        didLoadRef.current = true;
-      });
-  }, []);
+   // Track whether the initial load from IndexedDB has completed so we
+   // don't immediately overwrite persisted data with an empty array on mount.
+   const didLoadRef = useRef(false);
 
-  // Track whether the initial load from IndexedDB has completed so we
-  // don't immediately overwrite persisted data with an empty array on mount.
-  const didLoadRef = useRef(false);
+   useEffect(() => {
+     idbGet(STORAGE_KEY)
+       .then((stored) => {
+         if (stored) {
+           const parsed = safeJsonParse(stored, []);
+           setNotifications(parsed);
+         }
+       })
+       .catch((error) => {
+         logger.error("Failed to fetch notifications from indexedDB", error);
+         setNotifications([]);
+       })
+       .finally(() => {
+         // Allow the persistence effect to run only after the initial
+         // load has settled — prevents wiping IndexedDB on mount.
+         didLoadRef.current = true;
+       });
+   }, []);
 
   useEffect(() => {
     if (!didLoadRef.current) return;


### PR DESCRIPTION
Fixes #5880

Summary:
- didLoadRef was used (line 25) before its const declaration (line 31), creating a temporal dead zone risk
- Moved const didLoadRef = useRef(false) above the first useEffect that references it
- Maintains the same cross-tab notification synchronization behavior
