### PR TITLE
perf: cache Fuse instances in searchUtils to avoid rebuilding index on every search

### DIFF
--- a/src/utils/searchUtils.mjs
+++ b/src/utils/searchUtils.mjs
@@ -1,5 +1,7 @@
 import Fuse from "fuse.js";
 
+const fuseCache = new WeakMap();
+
 /**
  * Normalizes text for searching: lowercase, remove accents, and strip special chars.
  */
@@ -58,24 +60,29 @@ export const getRouteSearchResults = (items, query, keys, options = {}) => {
     }, item);
   };
 
-  const normalizedQuery = normalizeSearchText(query);
-  const queryTokens = normalizedQuery.split(" ").filter(Boolean);
+   const normalizedQuery = normalizeSearchText(query);
+   const queryTokens = normalizedQuery.split(" ").filter(Boolean);
 
-  const fuse = new Fuse(items, {
-    keys: searchKeys,
-    threshold: 0.4,
-    distance: 100,
-    ignoreLocation: true,
-    findAllMatches: true,
-    includeScore: true,
-    useExtendedSearch: true,
-    ...options,
-  });
+   // Get or create Fuse instance for this items array
+   let fuse = fuseCache.get(items);
+   if (!fuse) {
+     fuse = new Fuse(items, {
+       keys: searchKeys,
+       threshold: 0.4,
+       distance: 100,
+       ignoreLocation: true,
+       findAllMatches: true,
+       includeScore: true,
+       useExtendedSearch: true,
+       ...options,
+     });
+     fuseCache.set(items, fuse);
+   }
 
-  const fuseResults = fuse.search(query).map((result) => ({
-    ...result.item,
-    _searchScore: result.score,
-  }));
+   const fuseResults = fuse.search(query).map((result) => ({
+     ...result.item,
+     _searchScore: result.score,
+   }));
 
   const matchedIds = new Set(fuseResults.map((item) => item.id));
 


### PR DESCRIPTION
Fixes #5882

Summary:
- getRouteSearchResults created a new Fuse instance on every call, rebuilding the search index (O(n*k)) each time
- Added a WeakMap cache keyed by the items array to reuse Fuse instances when the same array is passed
- Eliminates redundant index builds while maintaining correctness when items change
