### PR TITLE
fix(ui): resolve modal scroll lock destruction and keyboard a11y traps

### DIFF
--- a/src/components/CommunityEvent.js
+++ b/src/components/CommunityEvent.js
@@ -94,23 +94,35 @@ const CommunityEvent = () => {
   const prefersReducedMotion = useReducedMotion();
   const [selectedEvent, setSelectedEvent] = useState(null);
   
-      useEffect(() => {
-        if (selectedEvent) {
-          document.body.style.overflow = "hidden";
-        } else {
-           document.body.style.overflow = "auto";
-        }
+  // 🔥 FIX: Safe scroll locking that caches and restores the original CSS value
+  useEffect(() => {
+    if (selectedEvent) {
+      const originalStyle = window.getComputedStyle(document.body).overflow;
+      document.body.style.overflow = "hidden";
+      
+      return () => {
+        document.body.style.overflow = originalStyle;
+      };
+    }
+  }, [selectedEvent]);
 
-        return () => {
-          document.body.style.overflow = "unset";
-        };
-      }, [selectedEvent]);
+  // 🔥 FIX: Added Escape key listener to satisfy A11y dialog closing requirements
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape" && selectedEvent) {
+        setSelectedEvent(null);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedEvent]);
 
   return (
     <div
       className={`
         relative overflow-hidden
-        bg-linear-to-b from-blue-50 via-indigo-50/30 to-white 
+        /* 🔥 FIX: Changed bg-linear-to-b to bg-gradient-to-b for correct Tailwind execution */
+        bg-gradient-to-b from-blue-50 via-indigo-50/30 to-white 
         dark:from-slate-950 dark:via-slate-900 dark:to-black
         ${darkTheme.textPrimary}
         min-h-[80vh]


### PR DESCRIPTION
## Description
This PR resolves critical accessibility and layout state bugs within the `CommunityEvent` modal, and fixes a silent CSS rendering failure.

**Changes made:**
- **Safe Scroll Locking:** Refactored the `useEffect` scroll lock to capture `window.getComputedStyle(document.body).overflow` before applying `"hidden"`. It now securely restores the exact original value upon unmount/close, preventing global CSS destruction.
- **Accessibility (A11y):** Implemented an `Escape` keydown listener bound to the `window` to allow keyboard users to dismiss the modal, adhering to WAI-ARIA dialog standards.
- **UI Correction:** Fixed the invalid `bg-linear-to-b` class to `bg-gradient-to-b` to restore the intended background gradient.

Fixes #5916 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility (a11y) improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code