### PR TITLE
remove unused jest configuration from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,6 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
-  "jest": {
-    "moduleNameMapper": {
-      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
-      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
-    }
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
## Description
This Pull Request cleans up the repository's dependency configuration to reduce bloat and prevent contributor confusion.
### Changes Made:
- Safely deleted the legacy `"jest": { "moduleNameMapper": ... }` block from `package.json`.
- The project currently utilizes native test runners, making this block entirely redundant.
Fixes #5531