### PR TITLE
fix: resolve Unexpected token catch in NotificationContext

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -41,7 +41,7 @@ const ensureServiceWorkerRegistration = async () => {
 
   try {
     return await navigator.serviceWorker.register("/service-worker.js");
-  } catch {
+  } catch (error) {
     return null;
   }
 };
@@ -468,7 +468,7 @@ export const NotificationProvider = ({ children }) => {
       };
       try {
         window.localStorage.setItem(PUSH_SUBSCRIPTION_KEY, JSON.stringify(safeLocalRecord));
-      } catch {
+      } catch (error) {
         // Non-fatal — the subscription is still active; local status just won't persist
       }
 
@@ -483,7 +483,7 @@ export const NotificationProvider = ({ children }) => {
             // Old format with sensitive keys — replace with the safe record
             window.localStorage.setItem(PUSH_SUBSCRIPTION_KEY, JSON.stringify(safeLocalRecord));
           }
-        } catch { /* non-fatal */ }
+        } catch (error) { /* non-fatal */ }
       }
 
       const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.PUSH_SUBSCRIBE;


### PR DESCRIPTION
## Description
This Pull Request resolves a fatal parsing error caused by ES2019 Optional Catch Binding syntax not being supported by the current linter configuration.
### Changes Made:
- Refactored `catch {` to `catch (error) {` across `src/context/NotificationContext.js`.
- Ensures full compatibility with the existing ESLint pipeline without requiring an invasive parser upgrade.
Fixes #5624