### PR TITLE
fix(ui): resolve hook import crash and tooltip overlap in FeedbackButton

### DIFF
--- a/src/components/FeedbackButton.js
+++ b/src/components/FeedbackButton.js
@@ -1,7 +1,8 @@
 import { MessageSquare } from "lucide-react";
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
-import useReducedMotion from "../hooks/useReducedMotion";
+// 🔥 FIX: Changed from default import to named import to prevent fatal TypeError crash
+import { useReducedMotion } from "../hooks/useReducedMotion";
 
 const FeedbackButton = () => {
   const prefersReducedMotion = useReducedMotion();
@@ -10,7 +11,8 @@ const FeedbackButton = () => {
     <motion.div
       layout
       transition={prefersReducedMotion ? {} : { type: "spring", stiffness: 300, damping: 30 }}
-      className={"fixed left-[1.625rem] z-[100] translate-y-1/2 bottom-6 fixed-floating-widget transition-opacity duration-300"}
+      // 🔥 FIX: Removed translate-y-1/2 which was pushing the button off the bottom of mobile screens
+      className={"fixed left-[1.625rem] z-[100] bottom-6 fixed-floating-widget transition-opacity duration-300"}
       initial={{ opacity: 0, scale: 0 }}
       animate={{ opacity: 1, scale: 1 }}
     >
@@ -28,9 +30,10 @@ const FeedbackButton = () => {
           <MessageSquare className="text-2xl text-black" />
         </motion.div>
 
-        <div className="pointer-events-none absolute left-full mr-3 whitespace-nowrap rounded-lg bg-white border border-black/15 px-3 py-2 text-sm text-black opacity-0 shadow-md transition-opacity duration-300 group-hover:opacity-100">
+        {/* 🔥 FIX: Changed mr-3 to ml-3. Since it's positioned left-full (on the right), it needs left margin to not overlap the button */}
+        <div className="pointer-events-none absolute left-full ml-3 whitespace-nowrap rounded-lg bg-white border border-black/15 px-3 py-2 text-sm text-black opacity-0 shadow-md transition-opacity duration-300 group-hover:opacity-100">
           Share your feedback
-          <div className=" absolute right-full top-1/2 -translate-y-1/2 transform border-4 border-transparent border-r-white"></div>
+          <div className="absolute right-full top-1/2 -translate-y-1/2 transform border-4 border-transparent border-r-white"></div>
         </div>
       </Link>
     </motion.div>


### PR DESCRIPTION
## Description
This PR resolves a fatal rendering crash and cleans up the UI spacing for the global `FeedbackButton`.

**Changes made:**
- **Crash Prevention:** Corrected the `useReducedMotion` import from a default import to a named import (`{ useReducedMotion }`), matching the hook's actual export signature and preventing a `TypeError`.
- **Tooltip Spacing:** Changed the tooltip margin from `mr-3` to `ml-3`. Because the tooltip is positioned at `left-full` (popping out to the right), it requires left-margin to avoid squishing into the button.
- **Viewport Clipping:** Removed the `translate-y-1/2` class from the parent container so the button sits exactly at `bottom-6` without being pushed off the screen on mobile devices.

Fixes #5943

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UX/UI improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code