### PR TITLE
fix(api): resolve route dictionary mismatch and trailing slash bugs

### DIFF
--- a/src/components/MockApiResponse.js
+++ b/src/components/MockApiResponse.js
@@ -1,7 +1,8 @@
 import { Link, useLocation } from "react-router-dom";
 
 const mockResponses = {
-  "/mock-api/hackathons": {
+  // 🔥 FIX: Changed dictionary keys from "/mock-api/..." to "/api/..." to match actual router paths
+  "/api/hackathons": {
     status: 200,
     source: "mock",
     data: [
@@ -14,7 +15,7 @@ const mockResponses = {
       },
     ],
   },
-  "/mock-api/projects": {
+  "/api/projects": {
     status: 200,
     source: "mock",
     data: [
@@ -26,7 +27,7 @@ const mockResponses = {
       },
     ],
   },
-  "/mock-api/contributors": {
+  "/api/contributors": {
     status: 200,
     source: "mock",
     data: [
@@ -38,7 +39,7 @@ const mockResponses = {
       },
     ],
   },
-  "/mock-api/leaderboard": {
+  "/api/leaderboard": {
     status: 200,
     source: "mock",
     data: [
@@ -53,7 +54,11 @@ const mockResponses = {
 
 const MockApiResponse = () => {
   const location = useLocation();
-  const response = mockResponses[location.pathname] || {
+  
+  // 🔥 FIX: Normalize the path by removing any trailing slashes to prevent 404s on exact matches
+  const normalizedPath = location.pathname.replace(/\/$/, "");
+  
+  const response = mockResponses[normalizedPath] || {
     status: 404,
     source: "mock",
     error: "Endpoint not found",


### PR DESCRIPTION
## Description
This PR fixes an endpoint matching bug that was causing all mock API documentation pages to return 404 errors.

**Changes made:**
- **Route Syncing:** Updated the keys in the `mockResponses` dictionary from `/mock-api/...` to `/api/...` so they perfectly match the paths defined in the React Router configuration.
- **Path Normalization:** Added a regex `.replace(/\/$/, "")` to `location.pathname` before checking the dictionary. This ensures that URLs with or without trailing slashes (e.g., `/api/hackathons` vs `/api/hackathons/`) will both successfully resolve the mock data.

Fixes #5945

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Quality of Life / Dev-experience improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code