### PR TITLE
fix(seo): actively remove stale meta tags during SPA route transitions

### DIFF
--- a/src/components/SEOHead.jsx
+++ b/src/components/SEOHead.jsx
@@ -21,10 +21,17 @@ export default function SEOHead({
     // Set document title
     document.title = title ? `${title} | Eventra` : "Eventra - Event Management";
 
-    // Helper to set or create a meta tag
+    // Helper to set, create, or remove a meta tag
     const setMeta = (attr, key, content) => {
-      if (!content) return;
       let el = document.querySelector(`meta[${attr}="${key}"]`);
+      
+      // 🔥 FIX: If the new page doesn't have this content, destroy the old tag
+      // to prevent stale data from leaking across SPA routes.
+      if (!content) {
+        if (el) el.remove();
+        return;
+      }
+      
       if (!el) {
         el = document.createElement("meta");
         el.setAttribute(attr, key);
@@ -40,24 +47,27 @@ export default function SEOHead({
     setMeta("property", "og:title", title);
     setMeta("property", "og:description", description);
     setMeta("property", "og:type", type);
-    if (image) setMeta("property", "og:image", image);
-    if (url) setMeta("property", "og:url", url);
+    setMeta("property", "og:image", image); // 🔥 FIX: Removed 'if (image)' so cleanup runs if it's missing
+    setMeta("property", "og:url", url);
 
     // Twitter Card
     setMeta("name", "twitter:card", image ? "summary_large_image" : "summary");
     setMeta("name", "twitter:title", title);
     setMeta("name", "twitter:description", description);
-    if (image) setMeta("name", "twitter:image", image);
+    setMeta("name", "twitter:image", image);
 
     // Canonical URL
+    let link = document.querySelector('link[rel="canonical"]');
     if (url) {
-      let link = document.querySelector('link[rel="canonical"]');
       if (!link) {
         link = document.createElement("link");
         link.setAttribute("rel", "canonical");
         document.head.appendChild(link);
       }
       link.setAttribute("href", url);
+    } else {
+      // 🔥 FIX: Destroy the old canonical link if the new page doesn't have one
+      if (link) link.remove();
     }
   }, [title, description, image, url, type]);
 


### PR DESCRIPTION
## Description
This PR resolves a critical SEO data leakage bug where old meta tags were persisting across route changes in the SPA.

**Changes made:**
- **Meta Tag Cleanup:** Updated the `setMeta` helper function. Instead of returning early when `content` is falsy, it now queries the DOM and actively calls `.remove()` on the element. This ensures that missing props clear out legacy tags.
- **Canonical Link Cleanup:** Applied the same destruction logic to the `<link rel="canonical">` element, ensuring it is removed if a new route does not supply a URL.
- **Refactored Execution:** Removed the conditional `if (image)` wrappers around the `setMeta` calls, allowing the new cleanup logic inside `setMeta` to handle removal naturally.

Fixes #5955

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] SEO Optimization

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code