### PR TITLE
fix(core): resolve focus race conditions and restore native hash rout…

### DIFF
--- a/src/components/SkipToContent.jsx
+++ b/src/components/SkipToContent.jsx
@@ -11,14 +11,28 @@ import "./styles/SkipToContent.css";
  * @param {string} [props.targetId] - ID of the main content element (default: "main-content")
  */
 export default function SkipToContent({ targetId = "main-content" }) {
-  const handleClick = (e) => {
-    e.preventDefault();
-    const target = document.getElementById(targetId);
-    if (target) {
-      target.setAttribute("tabindex", "-1");
-      target.focus();
-      target.removeAttribute("tabindex");
-    }
+  const handleClick = () => {
+    // 🔥 FIX: Removed e.preventDefault()
+    // We MUST allow the browser to natively update the URL hash so history tracking
+    // and CSS :target selectors function correctly.
+
+    // 🔥 FIX: Defer execution to the next macro-task.
+    // This allows the browser's native anchor jump to process BEFORE we programmatically force focus.
+    setTimeout(() => {
+      const target = document.getElementById(targetId);
+      if (target) {
+        // Enforce focusability on non-interactive elements (like <main>)
+        target.setAttribute("tabindex", "-1");
+        target.focus();
+
+        // 🔥 FIX: Eliminated the synchronous race condition.
+        // We only remove the tabindex AFTER the element natively loses focus.
+        // Removing it synchronously prevents the A11y tree from registering the shift.
+        target.addEventListener("blur", function cleanup() {
+          target.removeAttribute("tabindex");
+        }, { once: true }); // Automatically cleans up the listener
+      }
+    }, 0);
   };
 
   return (


### PR DESCRIPTION
## Description
This PR addresses deep execution-level bugs in the accessibility skip link, restoring functionality for screen reader users and native browser history.

**Changes made:**
- **Resolved Accessibility Race Condition:** Moved the `tabindex` cleanup into an isolated `blur` event listener (`{ once: true }`). This prevents the synchronous execution trap where the attribute was removed before the OS-level Accessibility Tree could process the focus shift.
- **Restored Native History Routing:** Removed `e.preventDefault()`. The component now allows the browser to natively update the URL hash, preserving back/forward history tracking and enabling deep-linking.
- **Execution Deferral:** Wrapped the programmatic focus shift in a `setTimeout(..., 0)` macro-task. This yields the main thread, allowing the browser's native anchor jump to execute first before we rigidly enforce the DOM focus, preventing execution clashing.

Fixes #5959

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Deep Architecture / Accessibility execution fix

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code