### PR TITLE
fix: add missing lucide-react icon imports in MobileDrawer

### DIFF
--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { LogIn, UserPlus, Info, HelpCircle } from "lucide-react";
+import { LogIn, UserPlus, Info, HelpCircle, Sun, Moon, MousePointer } from "lucide-react";
 import NavbarLinks from "./NavbarLinks";
 import { useTheme } from "../../context/ThemeContext";
 


### PR DESCRIPTION
## Description

This PR fixes ESLint/build errors in `MobileDrawer.jsx` caused by missing imports for the `Sun`, `Moon`, and `MousePointer` icons used in JSX.

### Changes Made

* Added missing `Sun` import from `lucide-react`
* Added missing `Moon` import from `lucide-react`
* Added missing `MousePointer` import from `lucide-react`

### File Updated

```text
src/components/navbar/MobileDrawer.jsx
```

### Issue Fixed #5978 

Resolves the following ESLint errors:

```bash
'Sun' is not defined           react/jsx-no-undef
'Moon' is not defined          react/jsx-no-undef
'MousePointer' is not defined  react/jsx-no-undef
```

### Result

* ESLint passes successfully
* Build works correctly
* Mobile drawer icons render properly
