### PR TITLE
fix: overhaul error handling and boundary consistency

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -36,8 +36,6 @@ function sanitizeUrl(url) {
     return url;
   }
 }
-  return id;
-}
 
 /**
  * Attempt to recover component state from sessionStorage

--- a/src/components/common/SectionErrorBoundary.jsx
+++ b/src/components/common/SectionErrorBoundary.jsx
@@ -30,6 +30,22 @@ class SectionErrorBoundary extends React.Component {
   componentDidCatch(error, errorInfo) {
     const { label = "Unknown Section" } = this.props;
     logError(error, errorInfo, { section: label });
+
+    // Persist section-level failures separately so they can be reviewed
+    // even after a page reload (the main ErrorBoundary only stores top-level crashes).
+    try {
+      const key = "eventra_section_errors";
+      const existing = JSON.parse(localStorage.getItem(key) || "[]");
+      existing.unshift({
+        section: label,
+        message: error?.message || String(error),
+        timestamp: new Date().toISOString(),
+        url: window.location.href,
+      });
+      localStorage.setItem(key, JSON.stringify(existing.slice(0, 15)));
+    } catch (_) {
+      // Never crash inside the error boundary
+    }
   }
 
   handleReset() {

--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -16,6 +16,7 @@ import {
 } from "../../utils/offlineEventCache";
 import { pushToQueue } from "../../utils/offlineQueue";
 import { logger } from "../../utils/logger";
+import { logError } from "../../utils/errorLogger";
 import hackathonsData from "../../Pages/Hackathons/hackathonMockData.json";
 
 const MAX_NOTES_CHARS = 500;
@@ -159,7 +160,7 @@ const useEventRegistration = (eventIdParam) => {
         }
       } catch (error) {
         if (isCancelled) return;
-        console.error("Failed to load event details:", error);
+        logError(error, null, { hook: "useEventRegistration", action: "loadEvent", eventId });
         const cached = getCachedEventDetail(eventId);
         if (cached?.event) {
           applyLoadedEvent({
@@ -226,7 +227,7 @@ const useEventRegistration = (eventIdParam) => {
           suggestions,
         });
       } catch (err) {
-        logger.error("Failed to fetch alternative events", err);
+        logError(err, null, { hook: "useEventRegistration", action: "fetchAlternatives" });
         setConflictData({
           conflicts: conflictCheck.conflicts,
           suggestions: [],

--- a/src/utils/errorLogger.js
+++ b/src/utils/errorLogger.js
@@ -94,3 +94,17 @@ export const clearErrorLog = () => {
     localStorage.removeItem("eventra_feature_errors");
   } catch (_) {}
 };
+
+export const getSectionErrors = () => {
+  try {
+    return JSON.parse(localStorage.getItem("eventra_section_errors") || "[]");
+  } catch (_) {
+    return [];
+  }
+};
+
+export const clearSectionErrors = () => {
+  try {
+    localStorage.removeItem("eventra_section_errors");
+  } catch (_) {}
+};

--- a/src/utils/globalErrorHandler.js
+++ b/src/utils/globalErrorHandler.js
@@ -1,9 +1,43 @@
 import { logError } from "./errorLogger.js";
 
+// Track recent errors to avoid flooding logs with identical stack traces
+// that happen in rapid succession (e.g. a render loop).
+const recentErrors = new Map();
+const DEDUP_WINDOW_MS = 3000;
+
+function isDuplicate(fingerprint) {
+  const now = Date.now();
+  const lastSeen = recentErrors.get(fingerprint);
+  if (lastSeen && now - lastSeen < DEDUP_WINDOW_MS) {
+    return true;
+  }
+  recentErrors.set(fingerprint, now);
+
+  // Housekeep stale entries so the map doesn't grow without bound
+  if (recentErrors.size > 50) {
+    for (const [key, ts] of recentErrors) {
+      if (now - ts > DEDUP_WINDOW_MS) recentErrors.delete(key);
+    }
+  }
+  return false;
+}
+
+function buildFingerprint(error) {
+  if (!error) return "unknown";
+  const msg = typeof error === "string" ? error : error.message || "";
+  const stack = error.stack || "";
+  // Use the first stack frame + message as the dedup key
+  const firstFrame = stack.split("\n").slice(0, 2).join("|");
+  return `${msg}::${firstFrame}`;
+}
+
 export const initializeGlobalErrorHandling = () => {
   if (typeof window === "undefined") return;
 
   window.onerror = (message, source, lineno, colno, error) => {
+    const fp = buildFingerprint(error || message);
+    if (isDuplicate(fp)) return;
+
     console.error("[GlobalError]", error || message);
     if (error) {
       logError(error, null, { source, lineno, colno });
@@ -12,8 +46,12 @@ export const initializeGlobalErrorHandling = () => {
 
   window.onunhandledrejection = (event) => {
     const reason = event.reason;
+    const wrapped = reason instanceof Error ? reason : new Error(String(reason));
+    const fp = buildFingerprint(wrapped);
+    if (isDuplicate(fp)) return;
+
     console.error("[UnhandledPromiseRejection]", reason);
-    logError(reason instanceof Error ? reason : new Error(String(reason)), null, {
+    logError(wrapped, null, {
       type: "unhandled_promise_rejection",
     });
   };


### PR DESCRIPTION
Closes #5779

---

Went through all the error handling code and found a bunch of issues that needed cleaning up.

**What was broken:**

The `ErrorBoundary.jsx` had dead code from a merge that never got cleaned up — a stray `return id;` and extra closing brace sitting outside any function body. This was causing parse errors and would crash the entire boundary on import in certain build configurations.

`SectionErrorBoundary` was logging errors to the console via `logError` but not persisting them anywhere useful. If a section like the navbar or footer crashed, you'd only know if you happened to have devtools open at that moment.

The `globalErrorHandler` had no dedup logic at all, so if a component threw in a render loop you'd get hundreds of identical error entries flooding both the console and localStorage.

API hooks were inconsistent — `useEventRegistration` used raw `console.error` in some catch blocks and `logger.error` in others, bypassing the centralized error reporting pipeline entirely.

**What this fixes:**

- Removed the dead code in ErrorBoundary so it actually parses correctly
- SectionErrorBoundary now writes section-level crashes to `eventra_section_errors` in localStorage with the section label, timestamp, and URL — added matching `getSectionErrors()`/`clearSectionErrors()` exports to errorLogger
- globalErrorHandler deduplicates errors within a 3-second window using a fingerprint based on the message + first stack frame, so render loops don't spam the log
- Standardized useEventRegistration to route all catch blocks through `logError` with proper context tags

Tested locally, the boundary renders correctly and handles errors as expected.