### PR TITLE
fix: implement route-level code splitting with Suspense

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -229,10 +229,40 @@ function App() {
                             </ProtectedRoute>
                           } 
                         />
-                        <Route path="/admin" element={<ProtectedRoute><AdminPanel /></ProtectedRoute>} />
-                        <Route path="/event-recommendation" element={<EventRecommendation />} />
-                        <Route path="/saved-events" element={<SavedEventsPage />} />
-                        <Route path="*" element={<AppRoutes />} />
+                        <Route 
+                          path="/admin" 
+                          element={
+                            <ProtectedRoute>
+                              <Suspense fallback={<DashboardHomeSkeleton />}>
+                                <AdminPanel />
+                              </Suspense>
+                            </ProtectedRoute>
+                          } 
+                        />
+                        <Route 
+                          path="/event-recommendation" 
+                          element={
+                            <Suspense fallback={<div>Loading recommendations...</div>}>
+                              <EventRecommendation />
+                            </Suspense>
+                          } 
+                        />
+                        <Route 
+                          path="/saved-events" 
+                          element={
+                            <Suspense fallback={<div>Loading saved events...</div>}>
+                              <SavedEventsPage />
+                            </Suspense>
+                          } 
+                        />
+                        <Route 
+                          path="*" 
+                          element={
+                            <Suspense fallback={<div>Loading...</div>}>
+                              <AppRoutes />
+                            </Suspense>
+                          } 
+                        />
                       </Routes>
                     </ErrorBoundary>
                   </PageTransition>


### PR DESCRIPTION
Closes #5778

- Added Suspense wrappers to lazy-loaded routes in App.jsx to fix missing Suspense boundaries, which prevents runtime errors when those routes are loaded.