### PR TITLE
fix: add missing React icon imports in Features page

### DIFF
--- a/src/Pages/About/Features.js
+++ b/src/Pages/About/Features.js
@@ -1,5 +1,14 @@
 import { motion, useReducedMotion } from "framer-motion";
 import { Link } from "react-router-dom";
+import { 
+  FaStar, 
+  FaQrcode, 
+  FaChartLine, 
+  FaUsers, 
+  FaLock, 
+  FaGlobe, 
+  FaArrowRight 
+} from "react-icons/fa";
 
 // 🎯 Safe: Extracted common classes to avoid repetition
 const ICON_CLASSES = "text-indigo-500 dark:text-indigo-400 text-2xl";


### PR DESCRIPTION
## Description

This PR fixes multiple ESLint/build errors in `Features.js` caused by undefined React icon components used in JSX without proper imports.

### Issues Resolved #6008 

* Added missing `FaStar` import
* Added missing `FaQrcode` import
* Added missing `FaChartLine` import
* Added missing `FaUsers` import
* Added missing `FaLock` import
* Added missing `FaGlobe` import
* Added missing `FaArrowRight` import

### Updated File

```text id="yz0uyx"
src/Pages/About/Features.js
```

### Errors Fixed

```bash id="08afl7"
'FaStar' is not defined        react/jsx-no-undef
'FaQrcode' is not defined      react/jsx-no-undef
'FaChartLine' is not defined   react/jsx-no-undef
'FaUsers' is not defined       react/jsx-no-undef
'FaLock' is not defined        react/jsx-no-undef
'FaGlobe' is not defined       react/jsx-no-undef
'FaArrowRight' is not defined  react/jsx-no-undef
```

### Result

* ESLint passes successfully
* Build completes without JSX undefined-component errors
* Features page icons render correctly

### Verification

```bash id="blv7pc"
npx eslint src/Pages/About/Features.js
npm run build
```
