### PR TITLE
fix: remove stray useEffect closure in EventConflictModal

### DIFF
--- a/src/components/EventConflictModal.jsx
+++ b/src/components/EventConflictModal.jsx
@@ -77,10 +77,6 @@ const EventConflictModal = ({
     };
   }, [isOpen, onCancel]);
 
-  // Focus trapping is now handled by useFocusTrap above.
-  // The hook handles Tab wrapping and Escape key automatically.
-  }, [isOpen]);
-
   // 🔥 FIX: Safe date formatter to prevent RangeError crashes if event data is malformed
   const safeFormatDate = (dateStr) => {
     if (!dateStr) return "TBD";


### PR DESCRIPTION
## Description

This PR fixes a parsing/build failure in `EventConflictModal.jsx` caused by a duplicate trailing `useEffect` closure.

### Issue Resolved #6014

Removed stray invalid syntax:

```js id="6y5v3m"
}, [isOpen]);
```

which existed after an already completed `useEffect` block.

### Root Cause

The component contained leftover malformed hook syntax, resulting in:

```bash id="a8g0ei"
Parsing error: Unexpected token )
```

### Updated File

```text id="4i7n5q"
src/components/EventConflictModal.jsx
```

### Result

* ESLint passes successfully
* Build completes without parser failures
* Modal component compiles correctly

### Verification

```bash id="ijx3tb"
npx eslint src/components/EventConflictModal.jsx
npm run build
```
