### PR TITLE
fix: resolve missing scopedDraftKey hook dependencies in useEventForm

### DIFF
--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -84,7 +84,7 @@ export const useEventForm = () => {
     
     const timer = setTimeout(checkForDraft, 300);
     return () => clearTimeout(timer);
-  }, []);
+  }, [scopedDraftKey]);
 
   // 💾 Debounced Draft Saving
   useEffect(() => {
@@ -110,7 +110,7 @@ export const useEventForm = () => {
         clearTimeout(saveDraftTimeoutRef.current);
       }
     };
-  }, [formData, isDraftLoaded]);
+  }, [formData, isDraftLoaded, scopedDraftKey]);
 
   // 🔍 Validation Logic
   const validateForm = useCallback(() => {
@@ -184,7 +184,7 @@ export const useEventForm = () => {
     setFormData(initialFormData);
     setErrors({});
     localStorage.removeItem(scopedDraftKey);
-  }, []);
+  }, [scopedDraftKey]);
 
   const handleInputChange = useCallback((e) => {
     const { name, value, type, checked } = e.target;
@@ -297,12 +297,12 @@ export const useEventForm = () => {
     } finally {
       setShowRestoreModal(false);
     }
-  }, []);
+  }, [scopedDraftKey]);
 
   const handleDiscardDraft = useCallback(() => {
     localStorage.removeItem(scopedDraftKey);
     setShowRestoreModal(false);
-  }, []);
+  }, [scopedDraftKey]);
 
   const hasUnsavedChanges = useMemo(() => {
     return Object.entries(formData).some(([key, value]) => {


### PR DESCRIPTION
## Description

This PR fixes multiple React Hook dependency warnings in `useEventForm.js` related to missing `scopedDraftKey` dependencies.

### Root Cause

Several `useEffect` and `useCallback` hooks referenced `scopedDraftKey` internally without including it in dependency arrays.

This created potential risks including:

* stale closures
* outdated draft persistence state
* inconsistent autosave/restore behavior
### Fixes #6092 
### Changes Made

* Added missing `scopedDraftKey` dependencies to affected hooks
* Aligned dependency arrays with actual referenced values
* Preserved existing draft persistence behavior

### Updated File

```text
src/hooks/useEventForm.js
```

### Warnings Fixed

```bash
React Hook useEffect has a missing dependency: 'scopedDraftKey'
React Hook useCallback has a missing dependency: 'scopedDraftKey'
```

### Result

* React Hook dependency warnings resolved
* Draft state synchronization improved
* Hook behavior remains stable and React-compliant

### Verification

```bash
npx eslint src/hooks/useEventForm.js
npm run build
```
