### PR TITLE
fix: resolve missing isDarkMode memo dependency

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -198,7 +198,17 @@ export const ThemeProvider = ({ children }) => {
       reducedMotion,
       setReducedMotion,
     }),
-    [theme, resolvedTheme, setTheme, toggleTheme, activeThemeId, isCustomizerOpen, customHsl, reducedMotion]
+    [
+      theme,
+      resolvedTheme,
+      isDarkMode,
+      setTheme,
+      toggleTheme,
+      activeThemeId,
+      isCustomizerOpen,
+      customHsl,
+      reducedMotion,
+    ]
   );
 
   return (


### PR DESCRIPTION
# PR Title

fix: resolve missing isDarkMode dependency in ThemeContext memoization

## Description

This PR fixes a React Hook dependency warning in `ThemeContext.js` caused by a missing `isDarkMode` dependency in a `useMemo` hook.
### Fixes #6094 
### Root Cause

The memoized theme object referenced `isDarkMode` internally without including it in the dependency array.

This created potential risks including:

* stale memoized theme state
* inconsistent UI theme updates
* delayed or broken dark mode synchronization

### Changes Made

* Added `isDarkMode` to the relevant `useMemo` dependency array
* Aligned memoization dependencies with referenced values
* Preserved existing theme behavior

### Updated File

```text id="g9g5ak"
src/context/ThemeContext.js
```

### Warning Fixed

```bash id="w9sz8j"
React Hook useMemo has a missing dependency: 'isDarkMode'
```

### Result

* React Hook dependency warning resolved
* Theme switching behavior remains synchronized
* Memoized theme state stays React-compliant and stable

### Verification

```bash id="frsxnp"
npx eslint src/context/ThemeContext.js
npm run build
```
