### PR TITLE
fix: stabilize listing dependency handling in EventsPage hooks

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -121,6 +121,7 @@ const EventsPage = () => {
   }
 
   const listing = useEventListing();
+  const { isLoading } = listing;
   const cardSectionRef = useRef();
   const hasHydratedFilters = useRef(false);
   const [filtersHydrated, setFiltersHydrated] = useState(false);
@@ -248,7 +249,7 @@ const EventsPage = () => {
 
   // Scroll to card section after loading when a route search is active
   useEffect(() => {
-    if (!listing.isLoading && routeSearchQuery) {
+    if (!isLoading && routeSearchQuery) {
       setTimeout(() => {
         cardSectionRef.current?.scrollIntoView({
           behavior: "smooth",
@@ -256,7 +257,7 @@ const EventsPage = () => {
         });
       }, 100);
     }
-  }, [listing.isLoading, routeSearchQuery]);
+  }, [isLoading, routeSearchQuery]);
 
   const scrollToCard = () => {
     cardSectionRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -328,7 +329,7 @@ const EventsPage = () => {
 
         <SectionErrorBoundary label="Events">
      {renderCardSection(
-  listing.isLoading,
+  isLoading,
   listing.loadError,
   listing.fetchEvents,
   listing.paginatedEvents,


### PR DESCRIPTION
## Description

This PR addresses a React Hook dependency warning in `EventsPage.js` involving `listing`.
### Fixes #6132
### Root Cause

The `useEffect` hook referenced `listing` internally without including it in the dependency array, creating potential stale closure and synchronization risks.

Because `listing` influences event rendering and filtering behavior, the dependency handling required careful validation to avoid introducing:

* repeated renders
* unnecessary effect execution
* unstable listing synchronization
* fetch/update loops

### Changes Made

* Reviewed hook dependency flow surrounding `listing`
* Updated dependency handling safely
* Preserved existing event listing behavior and rendering flow

### Updated File

```text id="2exqjq"
src/Pages/Events/EventsPage.js
```

### Warning Fixed

```bash id="frubvk"
React Hook useEffect has a missing dependency: 'listing'
```

### Result

* React Hook dependency warning resolved
* Event listing behavior remains stable
* No render loops or excessive effect execution introduced

### Verification

```bash id="z79l4w"
npx eslint src/Pages/Events/EventsPage.js
npm run build
```
