### PR TITLE
#6009 fix: disable clear conversation button when chat is empty

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -335,7 +335,8 @@ export default function Chatbot() {
                 <button
                   type="button"
                   onClick={handleClearConversation}
-                  className="rounded-lg p-2 text-slate-300 hover:bg-white/10 hover:text-red-400 transition-colors focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                  disabled={messages.length <= 1}
+                  className="rounded-lg p-2 text-slate-300 hover:bg-white/10 hover:text-red-400 transition-colors focus:ring-2 focus:ring-indigo-500 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Clear conversation"
                   aria-label="Clear conversation"
                 >


### PR DESCRIPTION
## Description
This PR fixes a minor UI/UX flaw where the 'Clear conversation' (trash) icon inside the `Chatbot.jsx` component remained active and clickable even when no chat messages were present. 

The button is now dynamically disabled based on the `messages` array length. Additionally, Tailwind utility classes were introduced to visually gray out the button and change the cursor to indicate it is unclickable, preventing confusing interactions.

Fixes #6009

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports