### PR TITLE
fix: define missing getInitialTheme and getSystemTheme helpers in ThemeContext to prevent app crash on load

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -38,8 +38,24 @@ const safeStorage = {
   },
 };
 
+const getSystemTheme = () =>
+  typeof window !== "undefined" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+
+const getInitialTheme = () => {
+  const stored = safeStorage.getItem("theme");
+  if (stored === "light" || stored === "dark" || stored === "system") {
+    return stored;
+  }
+  return "system";
+};
+
 export const ThemeProvider = ({ children }) => {
-  const [theme, setThemeState] = useState(() => getInitialTheme());
+
+  export const ThemeProvider = ({ children }) => {
+    const [theme, setThemeState] = useState(() => getInitialTheme());
 
   // States to preserve existing codebase drawer flow without breaking
   const [activeThemeId, setActiveThemeId] = useState(() => {


### PR DESCRIPTION
## Summary
Fixes a critical ReferenceError crash on app load caused by two helper functions being called but never defined in ThemeContext.js.

## Problem
getInitialTheme() and getSystemTheme() were used inside ThemeProvider but were never declared, imported, or defined anywhere in the file. Since ThemeProvider wraps the app root, this crash was immediate and total.

## Fix
Added getSystemTheme to detect OS dark mode preference via window.matchMedia. Added getInitialTheme to read the persisted theme from localStorage with a safe fallback to system. Both are pure functions defined above ThemeProvider.

## Changes
- src/context/ThemeContext.js — added getInitialTheme and getSystemTheme function definitions

Closes #6156 