### PR TITLE
fix: update initialValueRef synchronously during render to eliminate stale ref reads in useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -4,10 +4,7 @@ import { logger } from "../utils/logger";
 
 const useLocalStorage = (key, initialValue) => {
   const initialValueRef = useRef(initialValue);
-
-  useEffect(()=>{
-    initialValueRef.current = initialValue;
-  },[initialValue]);
+  initialValueRef.current = initialValue; //sync update — always current during render
 
   // 🔥 FIX: Track when WE fired the event so we don't react to ourselves
   const isInternalWrite = useRef(false);


### PR DESCRIPTION
## Summary
Fixes a stale ref bug in useLocalStorage where initialValueRef lagged one render behind when initialValue changed.

## Problem
initialValueRef.current was updated inside a useEffect which runs after render. Between the re-render and the effect firing, readValue used the old initialValue as fallback, returning stale data.

## Fix
Removed the useEffect. Added a direct synchronous assignment initialValueRef.current = initialValue right after useRef. Refs updated synchronously during render are always current and this is the standard React pattern for tracking mutable values without triggering re-renders.

## Changes
- src/hooks/useLocalStorage.js — replaced useEffect ref update with synchronous assignment

Closes #6158