### PR TITLE
fix: remove persistRateLimit side effect from setLockoutUntil updater in applyServerLockout to fix stale state

### DIFF
--- a/src/hooks/useLoginRateLimit.js
+++ b/src/hooks/useLoginRateLimit.js
@@ -112,12 +112,10 @@ function useLoginRateLimit() {
     if (retryMs <= 0) return;
 
     const serverUntil = Date.now() + retryMs;
-    setLockoutUntil((prev) => {
-      const next = Math.max(prev, serverUntil);
-      persistRateLimit(attemptCount, next);
-      return next;
-    });
-  }, [attemptCount]);
+    setLockoutUntil((prev) => Math.max(prev, serverUntil));
+    // persistence is handled automatically by the sync useEffect:
+    // useEffect(() => { persistRateLimit(attemptCount, lockoutUntil); }, [attemptCount, lockoutUntil]);
+  }, []);
 
   /**
    * Clears all attempt tracking and removes the persisted state.


### PR DESCRIPTION
## Summary
Fixes a stale closure bug in useLoginRateLimit where persistRateLimit was called inside a state updater with a potentially stale attemptCount.

## Problem
applyServerLockout called persistRateLimit(attemptCount, next) inside the setLockoutUntil updater. State updaters must be pure. The attemptCount variable was captured from the closure and could be stale by the time the updater ran. The hook already had a dedicated useEffect watching both attemptCount and lockoutUntil that called persistRateLimit correctly.

## Fix
Removed persistRateLimit from inside the updater. Simplified setLockoutUntil to a pure Math.max computation. Removed attemptCount from the useCallback dependency array. Persistence is now handled exclusively by the existing sync useEffect.

## Changes
- src/hooks/useLoginRateLimit.js — removed side effect from state updater, simplified applyServerLockout

Closes #6160 