### PR TITLE
fix: add synchronous ref guard in claimXP to prevent duplicate toast and confetti on rapid double-click

### DIFF
--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -146,6 +146,7 @@ const playClaimSound = () => {
 // ─── Main QuestCenter component ────────────────────────────────────────────────
 export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
   const confettiRef = useRef(null);
+  const claimedGuardRef = useRef({});
   const [activeTab, setActiveTab] = useState('daily');
 
   // Initialise quest progress from localStorage or fresh defaults
@@ -227,12 +228,15 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
   // ─── Claim handler ───────────────────────────────────────────────────────────
   const claimXP = (questId, xp, isWeekly) => {
     const claimedKey = isWeekly ? 'weeklyClaimed' : 'dailyClaimed';
-    
-    // 🔥 FIX 1: Moved the check INSIDE the functional setState.
-    // Checking the closure 'state' allows spam-click double-claiming exploits.
-    // Checking 'prev' guarantees atomic verification.
+    const guardKey = `${claimedKey}:${questId}`;
+
+    // Synchronous guard — blocks side effects on rapid double-click
+    // before React has had a chance to re-render with updated claimed state
+    if (claimedGuardRef.current[guardKey]) return;
+    claimedGuardRef.current[guardKey] = true;
+
     setState(prev => {
-      if (prev[claimedKey][questId]) return prev; // Already claimed, block exploit
+      if (prev[claimedKey][questId]) return prev;
 
       return {
         ...prev,


### PR DESCRIPTION
## Summary
Fixes a bug where rapidly double-clicking the Claim XP button triggered duplicate toast notifications, confetti, and sound despite XP only being added once.

## Problem
The functional setState updater in claimXP correctly blocked double XP addition atomically. However toast, fireConfetti, playClaimSound, and setClaimFlash were called outside the updater with no guard. Since React has not re-rendered between rapid clicks, the already-claimed state is not visible to the closure, so all side effects fired on every click.

## Fix
Added claimedGuardRef (useRef) checked synchronously at the top of claimXP. Refs are synchronous and do not require a re-render, so a second rapid click is blocked immediately. The functional updater check is preserved as a second layer of defence for correctness in async scenarios.

## Changes
- src/components/gamification/QuestCenter.jsx — added claimedGuardRef and guard check in claimXP

Closes #6168 