### PR TITLE
fix: add aria-label to notification bell button to meet WCAG 4.1.2 accessibility requirements

### DIFF
--- a/src/components/common/NotificationBell.jsx
+++ b/src/components/common/NotificationBell.jsx
@@ -38,7 +38,7 @@ const NotificationBell = () => {
 
   return (
     <div className="notification-wrapper" ref={wrapperRef}>
-      <button className="notification-bell" onClick={() => setOpen(!open)} aria-expanded={open} aria-haspopup="true">
+      <button className="notification-bell" onClick={() => setOpen(!open)} aria-expanded={open} aria-haspopup="true" aria-label="Notifications">
         <Bell size={22} />
 
         {unreadCount > 0 && (


### PR DESCRIPTION
## Summary
Fixes a missing accessible name on the notification bell button in NotificationBell.jsx.

## Problem
The bell button had aria-expanded and aria-haspopup but no aria-label. Screen readers had no way to identify the button as a notifications control, failing WCAG 2.1 SC 4.1.2 Name, Role, Value.

## Fix
Added aria-label="Notifications" to the button element.

## Changes
- src/components/common/NotificationBell.jsx — added aria-label to bell button

Closes #6173 