### PR TITLE
fix: add missing safeJsonParse import and fix broken logout confirmation in AdminDashboard

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -43,6 +43,7 @@ import {
   deleteAdminEvent,
   fetchAdminStats,
 } from "../../services/adminService";
+import { safeJsonParse } from "../../utils/safeJsonParse";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 20 },
@@ -304,6 +305,14 @@ const AdminDashboard = () => {
 
   const handleConfirmDelete = async () => {
     const { type, id } = confirmModal;
+    setConfirmModal({ open: false, type: "", id: null });
+
+    if (type === "logout") {
+      logout();
+      navigate("/login", { replace: true });
+      return;
+    }
+
     try {
       if (type === "user") {
         await deleteAdminUser(id);
@@ -320,7 +329,6 @@ const AdminDashboard = () => {
     } catch (error) {
       toast.error(error.message || `Failed to delete ${type}.`);
     }
-    setConfirmModal({ open: false, type: "", id: null });
   };
 
   const confirmDelete = (type, id) => setConfirmModal({ open: true, type, id });


### PR DESCRIPTION
## Summary
Fixes two bugs in AdminDashboard.js — a ReferenceError on capacity increase and a silent no-op logout confirmation.

## Changes

### Bug 1 — Missing safeJsonParse import
handleIncreaseCapacity used safeJsonParse without importing it, causing a ReferenceError crash when admins tried to increase event capacity.
Added: import { safeJsonParse } from "../../utils/safeJsonParse"

### Bug 2 — Logout modal does nothing
handleConfirmDelete had no branch for type === "logout". Confirming the logout modal closed it silently and left the admin logged in.
Added a logout branch that calls logout() and redirects to /login with replace: true.

## Files Changed
- src/components/admin/AdminDashboard.js — added safeJsonParse import and logout case

Closes #6191 