### PR TITLE
fix: add Bearer prefix to Authorization header in HostHackathon to fix 401 on submission

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -175,7 +175,7 @@ const HostHackathon = () => {
         },
         {
           headers: {
-            Authorization: token
+            Authorization: `Bearer ${token}`
           }
         }
       );


### PR DESCRIPTION
## Summary
Fixes a 401 Unauthorized error on hackathon submission caused by a malformed Authorization header missing the Bearer prefix.

## Problem
The apiUtils.post call in HostHackathon.js set Authorization: token. JWT middleware requires Authorization: Bearer <token>. Sending a bare token caused every submission to fail with 401 even for fully authenticated users.

## Fix
Changed Authorization: token to Authorization: `Bearer ${token}`.

## Changes
- src/Pages/Hackathons/HostHackathon.js — fixed Authorization header format

Closes #6194