### PR TITLE
fix: use functional updater in HostHackathon handleChange to prevent stale formData closure

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -51,7 +51,7 @@ const HostHackathon = () => {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData({ ...formData, [name]: value });
+    setFormData((prev) => ({ ...prev, [name]: value }));
     setErrors((prev) => ({ ...prev, [name]: "" }));
   };
 


### PR DESCRIPTION
## Summary
Fixes a stale closure bug in HostHackathon where rapid field changes could overwrite each other due to spreading from a stale formData snapshot.

## Problem
handleChange used setFormData({ ...formData, [name]: value }). The formData variable is captured at render time. Rapid consecutive updates before a re-render both spread from the same snapshot, causing the first update to be lost.

## Fix
Changed to setFormData((prev) => ({ ...prev, [name]: value })). The functional updater always receives the latest committed state, eliminating the stale closure risk.

## Changes
- src/Pages/Hackathons/HostHackathon.js — functional updater in handleChange

Closes #6198 