### PR TITLE
feat(chatbot): render markdown and sanitize HTML in assistant responses

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -20,6 +20,16 @@ import {
 import useLocalStorage from "../hooks/useLocalStorage";
 import { quickPrompts, getAssistantReply, INITIAL_MESSAGES } from "../config/chatbotKnowledge";
 import { useFocusTrap } from "../hooks/useFocusTrap";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+// Configure DOMPurify to force all links to open in a new tab securely
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if ("target" in node) {
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
 
 const ICON_MAP = {
   CalendarDays,
@@ -384,7 +394,16 @@ export default function Chatbot() {
                         : "bg-slate-100 dark:bg-slate-800/80 backdrop-blur-sm text-slate-800 dark:text-slate-100 rounded-bl-sm border border-slate-200/30 dark:border-slate-700/20"
                     }`}
                   >
-                    {message.content}
+                    {message.role === "user" ? (
+                      message.content
+                    ) : (
+                      <div
+                        className="chatbot-markdown"
+                        dangerouslySetInnerHTML={{
+                          __html: DOMPurify.sanitize(marked.parse(message.content))
+                        }}
+                      />
+                    )}
                   </motion.div>
                 </div>
               ))}

--- a/src/index.css
+++ b/src/index.css
@@ -1188,3 +1188,47 @@ html:not(.dark) ::placeholder {
   }
 }
 
+/* Chatbot Message Markdown Styles */
+.chatbot-markdown {
+  word-break: break-word;
+}
+.chatbot-markdown p:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+.chatbot-markdown p {
+  margin: 0;
+}
+.chatbot-markdown ul, .chatbot-markdown ol {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+.chatbot-markdown ul {
+  list-style-type: disc;
+}
+.chatbot-markdown ol {
+  list-style-type: decimal;
+}
+.chatbot-markdown li {
+  margin-bottom: 0.25rem;
+}
+.chatbot-markdown strong {
+  font-weight: 700;
+}
+.chatbot-markdown em {
+  font-style: italic;
+}
+.chatbot-markdown a {
+  color: #3b82f6;
+  text-decoration: underline;
+  font-weight: 600;
+}
+.dark .chatbot-markdown a {
+  color: #60a5fa;
+}
+.chatbot-markdown a:hover {
+  color: #2563eb;
+}
+.dark .chatbot-markdown a:hover {
+  color: #93c5fd;
+}
+


### PR DESCRIPTION
## Description
This pull request integrates Markdown rendering and secure HTML sanitization inside the chatbot message bubbles ([Chatbot.jsx](file:///d:/work/Eventra/src/components/Chatbot.jsx)).

Previously, simulated assistant suggestions containing lists, bold text headers, or links rendered as plain, unformatted strings. 

**Key Changes:**
- **Markdown & Sanitization integration**: Imported `marked` and `DOMPurify` to parse assistant messages synchronously into styled HTML elements.
- **Link Security Hook**: Declared a DOMPurify hook that intercepts parsed anchor tags (`<a>`) and forces them to securely open in a new tab (`target="_blank" rel="noopener noreferrer"`).
- **CSS Styling (.chatbot-markdown)**: Appended global styles to [index.css](file:///d:/work/Eventra/src/index.css) to correctly render bullets, lists, spacing, and accessible link colors for both light and dark mode viewports.

Fixes #6166

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Screenshots / Video (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `npm run lint` and resolved any new errors or warnings
