### PR TITLE
fix: extract inputRefs useRef calls to top-level declarations to comply with react-hooks/rules-of-hooks

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -36,17 +36,28 @@ const HostHackathon = () => {
   });
   const today = new Date().toISOString().split("T")[0]; // YYYY-MM-DD
 
+  const hackathonNameRef = useRef(null);
+  const organizerNameRef = useRef(null);
+  const emailRef = useRef(null);
+  const locationRef = useRef(null);
+  const startDateRef = useRef(null);
+  const endDateRef = useRef(null);
+  const descriptionRef = useRef(null);
+  const participantLimitRef = useRef(null);
+  const prizeDetailsRef = useRef(null);
+  const websiteRef = useRef(null);
+
   const inputRefs = {
-    hackathonName: useRef(null),
-    organizerName: useRef(null),
-    email: useRef(null),
-    location: useRef(null),
-    startDate: useRef(null),
-    endDate: useRef(null),
-    description: useRef(null),
-    participantLimit: useRef(null),
-    prizeDetails: useRef(null),
-    website: useRef(null),
+    hackathonName: hackathonNameRef,
+    organizerName: organizerNameRef,
+    email: emailRef,
+    location: locationRef,
+    startDate: startDateRef,
+    endDate: endDateRef,
+    description: descriptionRef,
+    participantLimit: participantLimitRef,
+    prizeDetails: prizeDetailsRef,
+    website: websiteRef,
   };
 
   const handleChange = (e) => {


### PR DESCRIPTION
## Summary
Fixes a Rules of Hooks violation in HostHackathon.js where useRef was called inside an object literal instead of at the top level of the component.

## Problem
Ten useRef calls were embedded inside an object literal expression assigned to inputRefs. This violates the React Rules of Hooks and is flagged by react-hooks/rules-of-hooks. Hooks must be called as direct top-level statements, not inside expressions or data structures.

## Fix
Extracted each useRef call into its own top-level const declaration. The inputRefs lookup object is then assembled from the already-created ref variables. All existing usage of inputRefs in handleSubmit and the form JSX continues to work unchanged.

## Changes
- src/Pages/Hackathons/HostHackathon.js — extracted useRef calls to top-level declarations

Closes #6201 