### PR TITLE
fix: remove redundant today variable inside validateForm that shadows outer scope in HostHackathon

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -107,7 +107,6 @@ const HostHackathon = () => {
     }
 
     // Date validations
-    const today = new Date().toISOString().split("T")[0];
     if (data.startDate && data.startDate < today) {
       newErrors.startDate = "Start date cannot be in the past!";
     }


### PR DESCRIPTION
## Summary
Fixes a no-shadow ESLint violation in HostHackathon.js by removing a redundant today variable redeclared inside validateForm.

## Problem
today was declared at component scope and again inside validateForm with the exact same value. The inner declaration shadowed the outer one unnecessarily, triggering the no-shadow lint rule.

## Fix
Removed the inner const today declaration. validateForm now reads today from the component scope via closure, which is always correct and available.

## Changes
- src/Pages/Hackathons/HostHackathon.js — removed shadowing today redeclaration in validateForm

Closes #6204 