### PR TITLE
fix: remove unused Link import from react-router-dom in AdminDashboard

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuth } from "../../context/AuthContext";
-import { useNavigate, Navigate, useLocation, Link } from "react-router-dom";
+import { useNavigate, Navigate, useLocation } from "react-router-dom";
 import {
   Users,
   Calendar,


### PR DESCRIPTION
## Summary
Removes an unused Link import in AdminDashboard.js that was triggering a no-unused-vars ESLint warning.

## Problem
Link was imported from react-router-dom but never used anywhere in the component.

## Fix
Removed Link from the import statement. useNavigate, Navigate, and useLocation remain as they are all actively used.

## Changes
- src/components/admin/AdminDashboard.js — removed unused Link import

Closes #6214 