### PR TITLE
feat(whiteboard): sync shape drawing previews to peers in real-time

### DIFF
--- a/src/components/common/CollaborativeWhiteboard.jsx
+++ b/src/components/common/CollaborativeWhiteboard.jsx
@@ -214,6 +214,20 @@ export default function CollaborativeWhiteboard() {
           }));
           break;
 
+        case "WHITEBOARD_SHAPE_PREVIEW":
+          setRemoteActiveStrokes((prev) => {
+            const active = prev[msg.id];
+            if (!active) return prev;
+            return {
+              ...prev,
+              [msg.id]: {
+                ...active,
+                end: msg.end,
+              },
+            };
+          });
+          break;
+
         case "WHITEBOARD_STROKE_DRAW":
           setRemoteActiveStrokes((prev) => {
             const active = prev[msg.id];
@@ -250,6 +264,13 @@ export default function CollaborativeWhiteboard() {
             saveHistory(updated);
             return updated;
           });
+          if (msg.id) {
+            setRemoteActiveStrokes((prev) => {
+              const copy = { ...prev };
+              delete copy[msg.id];
+              return copy;
+            });
+          }
           break;
 
         case "WHITEBOARD_CLEAR":
@@ -321,6 +342,25 @@ export default function CollaborativeWhiteboard() {
     } else {
       // Shape tools (line, rect, circle)
       currentPointsRef.current = [coords.x, coords.y]; // Store starting coordinate anchor
+      const newStroke = {
+        tool,
+        color,
+        lineWidth,
+        start: [coords.x, coords.y],
+        end: [coords.x, coords.y],
+      };
+
+      bcRef.current.postMessage({
+        type: "WHITEBOARD_STROKE_START",
+        id: currentStrokeIdRef.current,
+        stroke: newStroke,
+        from: peerId.current,
+      });
+
+      setRemoteActiveStrokes((prev) => ({
+        ...prev,
+        [currentStrokeIdRef.current]: newStroke,
+      }));
     }
   };
 
@@ -362,6 +402,13 @@ export default function CollaborativeWhiteboard() {
         end: [coords.x, coords.y]
       };
 
+      bcRef.current.postMessage({
+        type: "WHITEBOARD_SHAPE_PREVIEW",
+        id: currentStrokeIdRef.current,
+        end: [coords.x, coords.y],
+        from: peerId.current,
+      });
+
       setRemoteActiveStrokes(prev => ({
         ...prev,
         [currentStrokeIdRef.current]: previewStroke
@@ -400,6 +447,7 @@ export default function CollaborativeWhiteboard() {
         if (finished) {
           bcRef.current.postMessage({
             type: "WHITEBOARD_COMPLETE_STROKE",
+            id: currentStrokeIdRef.current,
             stroke: finished,
             from: peerId.current
           });


### PR DESCRIPTION
## Description
This pull request implements real-time preview synchronization for shape drawing tools (straight lines, rectangles, circles) in the Collaborative Whiteboard component ([CollaborativeWhiteboard.jsx](file:///d:/work/Eventra/src/components/common/CollaborativeWhiteboard.jsx)).

Previously, peer tabs could not see shape outlines as they were actively being sized and dragged on the canvas; shapes only appeared suddenly on remote screens after the mouse button was released. 

**Key Changes:**
- **Broadcasting Shape Lifecycle**: Modified shape drawing start, move, and stop sequences to trigger real-time updates over the BroadcastChannel.
- **Preview Channel Message (`WHITEBOARD_SHAPE_PREVIEW`)**: Added a case to the receiver's message loop to capture intermediate coordinate shifts of the shapes and update active stroke previews locally.
- **Active Previews Cleanup**: Included the stroke `id` property in the final `WHITEBOARD_COMPLETE_STROKE` payload to trigger automatic removal of shape previews from peers' `remoteActiveStrokes` upon shape completion.

Fixes #6167

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `npm run lint` and resolved any new errors or warnings
