### PR TITLE
Fix: use req.authToken in logout handler for cookie token extraction

### DIFF
--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -168,15 +168,27 @@ async function handler(req, res) {
 
   try {
     // -----------------------------------------------------------------------
-    // Extract token from Authorization header (req.user populated by verifyAuth)
+    // Extract token from req.authToken (populated by verifyAuth middleware)
+    // Falls back to Authorization header extraction for direct API callers.
     // -----------------------------------------------------------------------
 
-    const authHeader = req.headers?.authorization || req.headers?.Authorization;
-    const token = extractToken(authHeader);
+    const token = req.authToken || (() => {
+      const authHeader = req.headers?.authorization || req.headers?.Authorization;
+      return extractToken(authHeader);
+    })();
 
     if (!token) {
       return corsResponse(req, res, 401, { 
         error: "Authentication required. No token provided." 
+      });
+    }
+
+    // Validate that the token matches the authenticated user (defense-in-depth)
+    const decoded = jwt.verify(token, getJwtSecret());
+
+    if (decoded.id !== req.user.id || decoded.email !== req.user.email) {
+      return corsResponse(req, res, 401, {
+        error: "Token does not match authenticated session.",
       });
     }
 

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -75,6 +75,7 @@ export const verifyAuth = (handler) => {
     }
 
     req.user = decoded;
+    req.authToken = token;
     return handler(req, res);
   };
 };


### PR DESCRIPTION
## Summary\n\nThe logout endpoint was extracting tokens only from the Authorization header, missing users authenticated via cookies. This is a security issue because cookie-authenticated sessions cannot be properly invalidated on logout.\n\n## Changes\n- **api/middleware/auth.js**: Store the raw token string on \
eq.authToken\ after successful verification\n- **api/auth/logout.js**: Use \
eq.authToken\ (with fallback to header extraction) and add defense-in-depth token verification\n\n## Related Issue\n

Closes #6205