### PR TITLE
fix: resolve eventDraftUtils unit test failure in Node environment

### DIFF
--- a/src/utils/eventDraftUtils.js
+++ b/src/utils/eventDraftUtils.js
@@ -3,7 +3,11 @@ import { safeJsonParse } from "./safeJsonParse.js";
 const STORAGE_KEY = "event_creation_draft";
 
 const isStorageAvailable = () => {
-  return typeof window !== "undefined" && !!window.localStorage;
+  try {
+    return typeof localStorage !== "undefined" && localStorage !== null;
+  } catch (e) {
+    return false;
+  }
 };
 
 export const saveDraft = (formData) => {
@@ -19,7 +23,7 @@ export const getDraft = () => {
   if (!isStorageAvailable()) return null;
   try {
     const draft = localStorage.getItem(STORAGE_KEY);
-    return draft ? safeJsonParse(draft, {}) : null;
+    return draft ? safeJsonParse(draft, null) : null;
   } catch (error) {
     console.error("Error loading draft:", error);
     return null;

--- a/tests/eventDraftUtils.edge.test.mjs
+++ b/tests/eventDraftUtils.edge.test.mjs
@@ -18,7 +18,7 @@ const { saveDraft, getDraft, clearDraft } = await import(
 assert.equal(getDraft(), null, "returns null when no draft exists");
 
 localStorage.setItem("event_creation_draft", "{not-json");
-assert.deepEqual(getDraft(), {}, "returns empty object for malformed draft JSON");
+assert.equal(getDraft(), null, "returns null for malformed draft JSON");
 
 saveDraft({ title: "Draft event", step: 2 });
 assert.deepEqual(getDraft(), { title: "Draft event", step: 2 });

--- a/tests/eventDraftUtils.test.mjs
+++ b/tests/eventDraftUtils.test.mjs
@@ -50,5 +50,5 @@ saveDraft(null);
 assert.equal(getDraft(), null);
 
 // Edge Case: Gracefully handling corrupted/non-JSON storage strings
-store["eventra_event_draft"] = "{malformed-json";
+store["event_creation_draft"] = "{malformed-json";
 assert.equal(getDraft(), null, "should return null for corrupted draft storage");


### PR DESCRIPTION
## Description
This PR resolves the `CI / build-and-test (22.x)` check failure caused by the `eventDraftUtils` test suite.

### Proposed Changes
- **Environment Compatibility**: Refactored `isStorageAvailable` in `src/utils/eventDraftUtils.js` to safely probe the global `localStorage` object, ensuring compatibility with Node.js unit tests (where `window` is `undefined`).
- **Mismatched Storage Keys**: Aligned the storage key in the unit tests (`tests/eventDraftUtils.test.mjs`) from `"eventra_event_draft"` to the actual storage key `"event_creation_draft"`.
- **Parsing Mismatch & Fallbacks**: Aligned the fallback return value in `getDraft` from `{}` to `null` when a JSON parsing failure occurs, ensuring correct handling of corrupted storage strings as expected by the test assertions.
- **Test Alignment**: Updated assertions in `tests/eventDraftUtils.edge.test.mjs` and `tests/eventDraftUtils.test.mjs` to consistently expect `null` on JSON parsing errors.

## Verification
- Executed `npm test` locally: all 64 unit tests now pass successfully (0 failures).
