### PR TITLE
Fix: add edge-level rate limiting for API routes and clean vercel config

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -114,8 +114,6 @@ async function handler(req, res) {
   || null;
 
 if (clientIp) {
-  loginRateLimiter.evictStale();
-
   if (!loginRateLimiter.check(clientIp)) {
     return corsResponse(req, res, 429, {
       success: false,

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -196,8 +196,6 @@ async function handler(req, res) {
       || req.socket?.remoteAddress
       || "unknown";
 
-    signupRateLimiter.evictStale();
-
     if (!signupRateLimiter.check(clientIp)) {
       return corsResponse(req, res, 429, {
         error: "Too many signup attempts. Please try again later.",

--- a/api/lib/rateLimit.js
+++ b/api/lib/rateLimit.js
@@ -9,11 +9,16 @@
  * @param {number} windowMs  — sliding window in milliseconds (default 60s)
  * @param {number} maxRequests — max requests per window per key (default 10)
  * @returns {{ check: (key: string) => boolean, evictStale: () => void, reset: (key: string) => void }}
+ *
+ * Note: evictStale() is called automatically from check() and no longer
+ * needs to be invoked externally.
  */
 export const createRateLimiter = (windowMs = 60_000, maxRequests = 10) => {
   const store = new Map();
   let lastEvictionAt = 0;
 
+  // Inline periodic eviction: called at most once per windowMs from check().
+  // The guard avoids the O(number of keys) Map iteration on every request.
   const evictStale = () => {
     const now = Date.now();
     if (now - lastEvictionAt < windowMs) return;
@@ -27,8 +32,12 @@ export const createRateLimiter = (windowMs = 60_000, maxRequests = 10) => {
 
   /**
    * Returns true if the request is allowed, false if rate-limited.
+   * Automatically handles stale entry eviction on each call using a
+   * guard that limits the O(n) Map iteration to at most once per windowMs.
+   * Callers should no longer invoke evictStale() externally.
    */
   const check = (key) => {
+    evictStale();
     const now = Date.now();
     const entry = store.get(key);
 

--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------
+// Vercel Edge Middleware — runs on every request before the destination
+// handler (rewrite, serverless function, or static file).
+//
+// The /api/:path* rewrite sends all API traffic directly to the external
+// Azure backend, bypassing the serverless auth & rate-limit functions in
+// /api/*.js. This middleware restores edge-level abuse protection for
+// those proxied requests.
+// ---------------------------------------------------------------------------
+
+const API_RATE_LIMIT = 60;        // max requests
+const API_RATE_WINDOW_MS = 60_000; // per window
+
+const ipRateMap = new Map();
+let lastEvictionAt = 0;
+
+const evictStale = () => {
+  const now = Date.now();
+  if (now - lastEvictionAt < API_RATE_WINDOW_MS) return;
+  lastEvictionAt = now;
+  const cutoff = now - API_RATE_WINDOW_MS;
+  for (const [ip, entries] of ipRateMap) {
+    const valid = entries.filter((t) => t > cutoff);
+    if (valid.length === 0) ipRateMap.delete(ip);
+    else ipRateMap.set(ip, valid);
+  }
+};
+
+const isRateLimited = (ip) => {
+  evictStale();
+  const now = Date.now();
+  const cutoff = now - API_RATE_WINDOW_MS;
+  const timestamps = ipRateMap.get(ip) || [];
+  const valid = timestamps.filter((t) => t > cutoff);
+
+  if (valid.length >= API_RATE_LIMIT) return true;
+
+  valid.push(now);
+  ipRateMap.set(ip, valid);
+  return false;
+};
+
+export const config = {
+  matcher: "/api/:path*",
+};
+
+export default async function middleware(request) {
+  const url = new URL(request.url);
+
+  // Skip preflight — let the backend handle CORS
+  if (request.method === "OPTIONS") {
+    return;
+  }
+
+  // Per-IP rate limiting at the edge
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    request.headers.get("x-real-ip") ||
+    "unknown";
+
+  if (isRateLimited(ip)) {
+    return new Response(
+      JSON.stringify({ error: "Too many requests. Please try again later." }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": "60",
+          "Access-Control-Allow-Origin": url.origin,
+          "Access-Control-Allow-Credentials": "true",
+        },
+      },
+    );
+  }
+
+  // Allow the request to proceed to the rewrite destination
+  return;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -61,6 +61,10 @@
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+        },
+        {
+          "key": "Vary",
+          "value": "Origin"
         }
       ]
     },
@@ -74,41 +78,11 @@
       ]
     },
     {
-      "source": "/api/(.*)",
-      "headers": [
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "https://eventra.sandeepvashishtha.tech"
-        },
-        {
-          "key": "Access-Control-Allow-Credentials",
-          "value": "true"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET, POST, PUT, PATCH, DELETE, OPTIONS"
-        },
-        {
-          "key": "Access-Control-Allow-Headers",
-          "value": "Content-Type, Authorization"
-        }
-      ]
-    },
-    {
       "source": "/assets/(.*)",
       "headers": [
         {
           "key": "Cache-Control",
           "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    },
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Accept-Encoding",
-          "value": "gzip, br"
         }
       ]
     }


### PR DESCRIPTION
## Summary\n\nThe \/api/*\ rewrite proxies directly to an Azure backend, bypassing the serverless auth and rate-limit functions. This fix adds Vercel Edge Middleware with per-IP rate limiting as the first line of defense.\n\n## Changes\n- Add \middleware.js\: Vercel Edge Middleware with per-IP sliding-window rate limiting (60 req/min) for \/api/*\ routes\n- Remove \/api/(.*)\ CORS headers from \ercel.json\ to let the backend manage its own CORS policy\n- Remove incorrect \Accept-Encoding\ response header (it's a request header)\n- Add \Vary: Origin\ header for proper CDN caching behavior across origins\n\n## Related Issue\n

Closes #6213