### PR TITLE
Fix: remove dead code and fix stale closure in EventConflictModal

### DIFF
--- a/src/components/EventConflictModal.jsx
+++ b/src/components/EventConflictModal.jsx
@@ -63,23 +63,23 @@ const EventConflictModal = ({
     };
   }, [isOpen]);
 
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
+
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') {
-        onCancel();
+        onCancelRef.current();
       }
     };
-    if (isOpen) {
-      window.addEventListener('keydown', handleKeyDown);
-    }
+    window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isOpen, onCancel]);
+  }, [isOpen]);
 
   // Focus trapping is now handled by useFocusTrap above.
   // The hook handles Tab wrapping and Escape key automatically.
-  }, [isOpen]);
 
   // 🔥 FIX: Safe date formatter to prevent RangeError crashes if event data is malformed
   const safeFormatDate = (dateStr) => {


### PR DESCRIPTION
## Summary
Fix two issues in EventConflictModal.jsx:
1. Remove orphaned useEffect closing delimiter that causes syntax error
2. Fix stale closure in keydown handler using useRef pattern

## Changes
- Delete orphaned }, [isOpen]); from line 82
- Add onCancelRef to capture latest onCancel without re-triggering the effect
- Add/remove listener unconditionally based on isOpen dependency

Closes #6244
Closes #6252
