### PR TITLE
Fix: missing try/catch on localStorage.getItem in AuthContext

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -57,7 +57,12 @@ export const AuthProvider = ({ children }) => {
   const clearExpiredSession = useCallback(() => {
     // 🔥 FIX: Check if a user was actually logged in before blasting them with an "Expired" toast.
     // Anonymous users (who trigger a 401 on mount) shouldn't see this.
-    const hadPreviousSession = !!localStorage.getItem("user");
+    let hadPreviousSession = false;
+    try {
+      hadPreviousSession = !!localStorage.getItem("user");
+    } catch {
+      // localStorage unavailable (private browsing, quota exceeded, etc.)
+    }
 
     console.warn("[AuthContext] Session expiration detected. Clearing session state immediately.");
     clearSession();


### PR DESCRIPTION
## Summary
Wrap localStorage.getItem call in try/catch to prevent crashes when localStorage is unavailable.

## Changes
- Catch DOMException thrown in private browsing, quota-exceeded, or policy-blocked scenarios
- Default to no previous session on read failure

Closes #6246
