### PR TITLE
Perf: reduce aiMatchmaking compatibility score from O(N*M) to O(N+M)

### DIFF
--- a/src/utils/aiMatchmaking.js
+++ b/src/utils/aiMatchmaking.js
@@ -13,7 +13,8 @@ export const generateCompatibilityScore = (userA, userB) => {
   const skillsA = userA.skills || [];
   const skillsB = userB.skills || [];
   
-  const commonSkills = skillsA.filter(s => skillsB.includes(s));
+  const skillsBSet = new Set(skillsB);
+  const commonSkills = skillsA.filter(s => skillsBSet.has(s));
   score += commonSkills.length * 10;
   
   if (userA.industry === userB.industry) score += 15;


### PR DESCRIPTION
## Summary
Replace O(N*M) skillsB.includes(s) inside filter with O(1) skillsBSet.has(s) to reduce complexity to O(N+M).

## Changes
- Build a Set from skillsB before filtering
- Use Set.has() instead of Array.includes() in the filter predicate

Closes #6247
