### PR TITLE
Perf: reduce recommendationEngine tech overlap from O(N*M) to O(N+M)

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -184,7 +184,8 @@ export const calculateRecommendationScore = (
     addScore("Preferred event type", 10, "Fits your preferred event format");
   }
 
-  const techOverlap = eventTags.filter((tag) => profileTech.includes(tag));
+  const profileTechSet = new Set(profileTech);
+  const techOverlap = eventTags.filter((tag) => profileTechSet.has(tag));
   addScore(
     "Tech stack overlap",
     Math.min(techOverlap.length * 5, 12),


### PR DESCRIPTION
## Summary
Replace O(N*M) profileTech.includes(tag) in filter with O(N+M) Set lookup.

## Changes
- Build a Set from profileTech before filtering
- Use Set.has() instead of Array.includes() in the filter predicate

Closes #6248
