### PR TITLE
Perf: reduce conflictDetection alternative events from O(N*M) to O(N+M)

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -202,10 +202,9 @@ export const suggestAlternativeEvents = (
   const tz = timezone || getUserTimezone();
 
   // Exclude the target event and already-registered events
+  const registeredIds = new Set(registeredEvents.map((reg) => reg.event?.id || reg.id));
   const availableEvents = allEvents.filter((event) => {
-    const isTargetEvent = event.id === targetEvent.id;
-    const isRegistered = registeredEvents.some((reg) => (reg.event?.id || reg.id) === event.id);
-    return !isTargetEvent && !isRegistered;
+    return event.id !== targetEvent.id && !registeredIds.has(event.id);
   });
 
   // Keep only events that don't conflict with existing registrations


### PR DESCRIPTION
## Summary
Replace O(N*M) egisteredEvents.some() inside filter with a pre-built Set for O(N+M) total.

## Changes
- Build egisteredIds Set once before filtering
- Use Set.has() instead of Array.some() for each candidate event

Closes #6249
