### PR TITLE
Fix: missing try/catch on localStorage.getItem in CollaborationHub

### DIFF
--- a/src/components/CollaborationHub.js
+++ b/src/components/CollaborationHub.js
@@ -41,7 +41,12 @@ const CollaborationHub = () => {
   };
 
   const [collaborationOpportunities, setCollaborationOpportunities] = useState(() => {
-    const saved = localStorage.getItem('eventra_collaboration_opportunities');
+    let saved;
+    try {
+      saved = localStorage.getItem('eventra_collaboration_opportunities');
+    } catch {
+      // localStorage unavailable (private browsing, quota exceeded, etc.)
+    }
     if (saved) {
       try {
         return JSON.parse(saved);


### PR DESCRIPTION
## Summary
Wrap localStorage.getItem in try/catch in the useState lazy initializer to prevent crashes when localStorage is unavailable.

## Changes
- Catch DOMException thrown in private browsing, quota-exceeded, or policy-blocked scenarios
- Default to initial mock data on read failure

Closes #6253
