### PR TITLE
Fix: remove mock data fallback in hackathonService — users saw fabricated events on API failure

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -159,6 +159,7 @@ const HackathonHub = () => {
   const [searchQuery, setSearchQuery] = useState("");
 const debouncedSearchQuery = useDebounce(searchQuery, 300);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [isScrollVisible, setIsScrollVisible] = useState(false);
   const [filters, setFilters] = useState({
     difficulty: "",
@@ -181,25 +182,27 @@ const debouncedSearchQuery = useDebounce(searchQuery, 300);
     cardsSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
+  const loadHackathons = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await fetchHackathons();
+      setHackathons(data);
+      const tags = [
+        ...new Set(
+          data.flatMap((hackathon) => hackathon.techStack || []),
+        ),
+      ];
+      setAvailableTags(tags);
+    } catch (err) {
+      setError(err.message || "Failed to load hackathons");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
   // Fetch hackathons and wire page listeners
   useEffect(() => {
-    let isMounted = true;
-    
-    const loadHackathons = async () => {
-      setIsLoading(true);
-      const data = await fetchHackathons();
-      if (isMounted) {
-        setHackathons(data);
-        const tags = [
-          ...new Set(
-            data.flatMap((hackathon) => hackathon.techStack || []),
-          ),
-        ];
-        setAvailableTags(tags);
-        setIsLoading(false);
-      }
-    };
-    
     loadHackathons();
 
     const handleScroll = () => {
@@ -594,7 +597,18 @@ const debouncedSearchQuery = useDebounce(searchQuery, 300);
         {/* Hackathons Grid */}
         <SectionErrorBoundary label="Hackathons">
         <AnimatePresence mode="wait">
-         {isLoading ? (
+         {error ? (
+            <div className="col-span-full text-center py-16">
+              <p className="text-red-500 text-lg font-semibold mb-2">Failed to load hackathons</p>
+              <p className="text-gray-400 text-sm mb-4">{error}</p>
+              <button
+                onClick={() => { setError(null); loadHackathons(); }}
+                className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition"
+              >
+                Retry
+              </button>
+            </div>
+          ) : isLoading ? (
   <div className="grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
     {[...Array(6)].map((_, i) => (
       <HackathonCardSkeleton key={`skeleton-${i}`} />

--- a/src/services/hackathonService.js
+++ b/src/services/hackathonService.js
@@ -1,22 +1,12 @@
 import { apiUtils, API_ENDPOINTS } from "../config/api";
-import mockHackathons from "../Pages/Hackathons/hackathonMockData.json";
 
 export const fetchHackathons = async () => {
-  try {
-    const response = await apiUtils.get(API_ENDPOINTS.HACKATHONS.LIST);
-    
-    // axios returns response.data directly, not response.json()
-    const data = response.data;
-    
-    if (Array.isArray(data) && data.length > 0) {
-      return data;
-    }
-  } catch (error) {
-    console.warn(
-      "Failed to fetch hackathons from API, falling back to mock data",
-      error
-    );
+  const response = await apiUtils.get(API_ENDPOINTS.HACKATHONS.LIST);
+  const data = response.data;
+
+  if (Array.isArray(data) && data.length > 0) {
+    return data;
   }
-  
-  return mockHackathons;
+
+  throw new Error("Hackathons API returned no data");
 };


### PR DESCRIPTION
## Summary
Remove the critical mock data fallback in hackathonService that silently fabricated hackathon data on API failure, causing users to make real decisions (registrations, travel plans) based on fake events.

## Changes
- **hackathonService.js**: Remove the `|| mockHackathons` fallback. Now throws on API failure/no-data.
- **HackathonPage.js**: Add proper error state with retry button. Refactor `loadHackathons` to be reusable (via `useCallback`) and accessible from the retry button.
- Remove `mockHackathons` import.
- Remove the unused `isMounted` guard pattern since `loadHackathons` is now safe to call from event handlers.

Closes #6265
