### PR TITLE
Fix: add CSRF token to Axios request interceptor — state-changing endpoints were unprotected

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { ENV } from "./env";
 import { syncServerTimeFromHeader } from "../utils/timeSync";
+import { getCSRFToken } from "../utils/csrfToken";
 
 // ---------------------------------------------------------------------------
 // Base API URL
@@ -202,9 +203,15 @@ API.interceptors.request.use((config) => {
   if (isDev) {
     console.debug(`[API ${config.method?.toUpperCase()}]`, buildApiUrl(config.url || ""));
   }
-  
+
   const method = config.method?.toUpperCase();
-  
+  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    const token = getCSRFToken();
+    if (token) {
+      config.headers["X-CSRF-Token"] = token;
+    }
+  }
+
   return config;
 });
 


### PR DESCRIPTION
## Summary
Wire the existing `getCSRFToken()` CSRF token utility into the Axios request interceptor to protect state-changing endpoints.

## Changes
- Import `getCSRFToken` from `src/utils/csrfToken.js`
- Add CSRF token to `X-CSRF-Token` header on POST, PUT, PATCH, DELETE requests
- The `csrfToken.js` utility already existed but was never integrated into the Axios layer

Closes #6263
