### PR TITLE
Fix: add DOMPurify input sanitization to prevent stored XSS via event descriptions

### DIFF
--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -9,6 +9,7 @@ import {
 import {
   parseTimeToMinutes,
 } from "../utils/eventCreationUtils";
+import { sanitizeHtml } from "../utils/sanitizeHtml";
 import { logger } from "../utils/logger";
 import { useAuth } from "../context/AuthContext";
 
@@ -51,12 +52,16 @@ export const useEventForm = () => {
     error: submitError, 
     success: submitSuccess 
   } = useFormSubmit(async (eventData) => {
+    const sanitized = {
+      ...eventData,
+      description: sanitizeHtml(eventData.description || ""),
+    };
     if (!API_ENDPOINTS.EVENTS.CREATE) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       return { id: "mock-event-id", success: true };
     }
 
-    const response = await apiUtils.post(API_ENDPOINTS.EVENTS.CREATE, eventData);
+    const response = await apiUtils.post(API_ENDPOINTS.EVENTS.CREATE, sanitized);
     const result = response.data;
     
     if (!(response.status === 200 && result?.success)) {
@@ -151,8 +156,13 @@ export const useEventForm = () => {
     if (!data.isVirtual && !data.location?.name?.trim()) {
       newErrors.location = "Location name is required for in-person events";
     }
-    if (data.isVirtual && !data.virtualLink?.trim()) {
-      newErrors.virtualLink = "Virtual link is required for online events";
+    if (data.isVirtual) {
+      const link = data.virtualLink?.trim();
+      if (!link) {
+        newErrors.virtualLink = "Virtual link is required for online events";
+      } else if (!/^https:\/\//i.test(link)) {
+        newErrors.virtualLink = "Virtual link must use HTTPS protocol";
+      }
     }
 
     if (data.capacity) {

--- a/src/utils/sanitizeHtml.js
+++ b/src/utils/sanitizeHtml.js
@@ -31,14 +31,12 @@ const ALLOWED_ATTR = [
  * - ALLOWED_TAGS: strict whitelist
  * - ALLOWED_ATTR: strict attribute whitelist
  * - ALLOW_DATA_ATTR: false prevents data-* exfiltration
- * - FORCE_BODY: ensures well-formed fragment output
  * - RETURN_TRUSTED_TYPE: false keeps return value as string
  */
 const PURIFY_CONFIG = {
   ALLOWED_TAGS,
   ALLOWED_ATTR,
   ALLOW_DATA_ATTR: false,
-  FORCE_BODY: true,
 };
 
 /**


### PR DESCRIPTION
## Summary
Add defense-in-depth input sanitization to prevent stored XSS via event descriptions.

## Changes
- **useEventForm.js**: Sanitize event description via DOMPurify before API submission
- **useEventForm.js**: Add HTTPS-only URL validation for virtual event links
- **sanitizeHtml.js**: Remove `FORCE_BODY: true` from DOMPurify config to prevent `<html><body>` wrapping

Closes #6264
