### PR TITLE
Fix: remove JWT in localStorage from deprecated useAuthStore — critical XSS token theft vector

### DIFF
--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -1,61 +1,26 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
-import { apiUtils, API_ENDPOINTS } from "../config/api";
-import { logger } from "../utils/logger";
+
+let warned = false;
 
 /**
- * useAuthStore
+ * useAuthStore — DEPRECATED
  * 
- * Migration from AuthContext to Zustand for better performance and 
- * selector-based subscriptions.
+ * This store previously persisted JWTs in localStorage, creating a critical
+ * security vulnerability (XSS token theft) and a parallel auth state that
+ * never synced with the canonical AuthContext.
+ * 
+ * Use `useAuth` from `src/context/AuthContext.js` instead.
  */
-export const useAuthStore = create(
-  persist(
-    (set, get) => ({
-      user: null,
-      token: localStorage.getItem("token") || null,
-      isAuthenticated: !!localStorage.getItem("token"),
-      isLoading: false,
-      error: null,
-
-      // Actions
-      login: async (email, password) => {
-        set({ isLoading: true, error: null });
-        try {
-          const response = await apiUtils.post(API_ENDPOINTS.AUTH.LOGIN, { email, password });
-          const { user, token } = response.data;
-          
-          localStorage.setItem("token", token);
-          set({ user, token, isAuthenticated: true, isLoading: false });
-          return { success: true };
-        } catch (error) {
-          const message = error.response?.data?.message || "Login failed";
-          set({ error: message, isLoading: false });
-          return { success: false, message };
-        }
-      },
-
-      logout: () => {
-        localStorage.removeItem("token");
-        set({ user: null, token: null, isAuthenticated: false });
-        logger.info("User logged out");
-      },
-
-      updateProfile: (userData) => {
-        set((state) => ({
-          user: { ...state.user, ...userData }
-        }));
-      },
-
-      setToken: (token) => {
-        localStorage.setItem("token", token);
-        set({ token, isAuthenticated: !!token });
-      },
-    }),
-    {
-      name: "eventra-auth-storage",
-      storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ user: state.user, token: state.token }),
+export const useAuthStore = create(() => ({
+  get user() {
+    if (!warned) {
+      console.warn("[useAuthStore] Deprecated — use useAuth() from AuthContext instead");
+      warned = true;
     }
-  )
-);
+    return null;
+  },
+  get token() { return null; },
+  get isAuthenticated() { return false; },
+  get isLoading() { return false; },
+  get error() { return null; },
+}));


### PR DESCRIPTION
## Summary
Remove the critical JWT-in-localStorage vulnerability from the deprecated `useAuthStore`.

## Changes
- Remove `persist` middleware that stored user + token under `eventra-auth-storage`
- Remove all `localStorage.setItem/getItem/removeItem("token")` calls
- Remove the `login`, `logout`, `setToken`, `updateProfile` action stubs
- Replace with a deprecation stub that warns developers to use `useAuth()` from AuthContext
- Store is unused in the codebase (grep shows zero imports outside its own file)

Closes #6262
