### PR TITLE
fix(playwright): resolve ESM compatibility and improve e2e reporting

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     timeout: 15000
   },
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -16,7 +16,10 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [
+    ['html'],
+    ['list']
+  ],
   /* Shared settings for all the projects below. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -36,7 +39,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run start',
+    command: 'npm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/tests/e2e/http_cookie.spec.js
+++ b/tests/e2e/http_cookie.spec.js
@@ -2,7 +2,7 @@
  * Implement tests to verify server sets and clears auth cookies,
  * and that the client can restore a session via profile endpoint.
  */
-const { test, expect } = require('@playwright/test');
+import { test, expect } from '@playwright/test';
 
 test.describe('HttpOnly cookie auth', () => {
   test('server should set auth cookie on login (placeholder)', async ({ page }) => {

--- a/tests/e2e/login.spec.js
+++ b/tests/e2e/login.spec.js
@@ -1,4 +1,4 @@
-const { test } = require('@playwright/test');
+import { test } from '@playwright/test';
 
 test('placeholder: login flow e2e', async () => {
   test.info().skip('Implement a headful login simulation or use test account envs');

--- a/tests/e2e/oauth.spec.js
+++ b/tests/e2e/oauth.spec.js
@@ -2,7 +2,7 @@
  * - verify popup timeout handling
  * - verify fallback redirect works
  */
-const { test } = require('@playwright/test');
+import { test } from '@playwright/test';
 
 test('OAuth popup timeout placeholder', async () => {
   test.info().skip('Implement OAuth provider simulation and popup assertions');


### PR DESCRIPTION
## Summary

Updated Playwright E2E tests to use ES module syntax and improved Playwright configuration for better CI visibility and test stability.
## Fixes #6281
## Changes

* Replaced CommonJS `require()` imports with ESM `import` syntax in:

  * `login.spec.js`
  * `oauth.spec.js`
  * `http_cookie.spec.js`
* Added `['list']` reporter alongside `['html']`
* Disabled `fullyParallel` execution to reduce flaky auth/session-related test behavior
* Updated Playwright webServer command to use `npm run dev`

## Reason

The repository is configured as an ES module project (`"type": "module"`), but several Playwright test files were still using CommonJS imports.

This created:

* ESM/CommonJS inconsistency
* compatibility issues in strict ESM environments
* reduced maintainability across the E2E suite

The reporting and execution updates also improve:

* CI terminal visibility
* debugging clarity
* E2E execution stability

## Validation

* Verified Playwright configuration loads correctly
* Verified E2E tests execute successfully
* Verified HTML and terminal reporters generate expected output
