### PR TITLE
fix(vite): enable JSX parsing for .js files in Rolldown optimizeDeps

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -50,6 +50,11 @@ export default defineConfig(({ mode }) => {
 
     // Pre-bundle heavy deps once → node_modules/.vite/deps
     optimizeDeps: {
+      rolldownOptions: {
+        moduleTypes: {
+          ".js": "jsx",
+        },
+      },
       include: [
         "react",
         "react-dom",


### PR DESCRIPTION
## Summary

Configured Rolldown optimizeDeps to correctly parse JSX inside `.js` files under Vite 8.
## Fixes #6283 
## Changes

Added:

```js id="7h4h89"
rolldownOptions: {
  moduleTypes: {
    ".js": "jsx",
  },
},
```

inside `optimizeDeps` in `vite.config.js`.

## Reason

Vite 8 uses Rolldown for dependency optimization. During optimizeDeps scanning, `.js` files containing JSX were not being parsed correctly, resulting in errors such as:

```txt id="btlnd3"
JSX syntax is disabled
```

This update ensures:

* JSX inside `.js` files is processed correctly
* the dev server starts successfully
* dependency pre-bundling completes without parsing failures

## Validation

* Verified Vite dev server starts successfully
* Verified optimizeDeps completes without JSX parsing errors
* Verified project builds successfully after configuration update
