### PR TITLE
Fix: DoS via Unbounded IP Rate-Limiting Map (#6333)

### DIFF
--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -17,11 +17,19 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 const ipRateLimitMap = new Map();
 
+const MAX_RATE_LIMIT_ENTRIES = 5000;
+
 const isRateLimited = (ip) => {
   const now = Date.now();
   const entry = ipRateLimitMap.get(ip);
 
   if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    if (!entry && ipRateLimitMap.size >= MAX_RATE_LIMIT_ENTRIES) {
+      const oldestKey = ipRateLimitMap.keys().next().value;
+      if (oldestKey !== undefined) {
+        ipRateLimitMap.delete(oldestKey);
+      }
+    }
     ipRateLimitMap.set(ip, { count: 1, windowStart: now });
     return false;
   }


### PR DESCRIPTION
This PR resolves issue #6333 by adding a strict upper limit (5000 entries) to the in-memory `ipRateLimitMap` used in `api/leaderboard.js`. If the limit is reached, it evicts the oldest entry to prevent memory exhaustion and DoS from IP spoofing.