### PR TITLE
Fix: DoS via Unbounded User ID Rate-Limiting Map (#6334)

### DIFF
--- a/api/ai-recommendations.js
+++ b/api/ai-recommendations.js
@@ -56,12 +56,20 @@ const evictStaleEntries = () => {
   }
 };
 
+const MAX_RATE_LIMIT_ENTRIES = 5000;
+
 const checkRateLimit = (userId) => {
   evictStaleEntries();
   const now = Date.now();
   const entry = rateLimitMap.get(userId);
 
   if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    if (!entry && rateLimitMap.size >= MAX_RATE_LIMIT_ENTRIES) {
+      const oldestKey = rateLimitMap.keys().next().value;
+      if (oldestKey !== undefined) {
+        rateLimitMap.delete(oldestKey);
+      }
+    }
     rateLimitMap.set(userId, { count: 1, windowStart: now });
     return true;
   }

--- a/api/leaderboard.js
+++ b/api/leaderboard.js
@@ -17,11 +17,19 @@ const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 5;
 const ipRateLimitMap = new Map();
 
+const MAX_RATE_LIMIT_ENTRIES = 5000;
+
 const isRateLimited = (ip) => {
   const now = Date.now();
   const entry = ipRateLimitMap.get(ip);
 
   if (!entry || now - entry.windowStart >= RATE_LIMIT_WINDOW_MS) {
+    if (!entry && ipRateLimitMap.size >= MAX_RATE_LIMIT_ENTRIES) {
+      const oldestKey = ipRateLimitMap.keys().next().value;
+      if (oldestKey !== undefined) {
+        ipRateLimitMap.delete(oldestKey);
+      }
+    }
     ipRateLimitMap.set(ip, { count: 1, windowStart: now });
     return false;
   }


### PR DESCRIPTION
This PR resolves issue #6334 by enforcing a maximum size on the `rateLimitMap` used in `api/ai-recommendations.js`. Once the cache hits 5000 entries, the oldest records are evicted, preventing uncontrolled memory growth from distinct tokens on warm server instances.