### PR TITLE
Fix: DoS via Infinite scanLogs Array Growth in checkin.js (#6335)

### DIFF
--- a/api/tickets/checkin.js
+++ b/api/tickets/checkin.js
@@ -94,6 +94,7 @@ async function handler(req, res) {
       status: "Duplicate Attempt"
     };
     scanLogs.push(duplicateLog);
+    if (scanLogs.length > 10000) scanLogs.shift();
 
     return corsResponse(req, res, 409, { error: "Attendee is already checked in" });
   }
@@ -116,6 +117,7 @@ async function handler(req, res) {
     status: "Checked In"
   };
   scanLogs.push(checkInLog);
+  if (scanLogs.length > 10000) scanLogs.shift();
 
   return corsResponse(req, res, 200, {
     success: true,


### PR DESCRIPTION
This PR resolves issue #6335 by enforcing a maximum size (10000 entries) on the in-memory `scanLogs` array in `api/tickets/checkin.js`. If the threshold is exceeded, the oldest log is evicted, preventing unbounded memory growth.