### PR TITLE
Fix: DoS via Infinite scanLogs Array Growth in validate.js (#6336)

### DIFF
--- a/api/tickets/validate.js
+++ b/api/tickets/validate.js
@@ -113,6 +113,7 @@ async function handler(req, res) {
       status: "Duplicate Attempt"
     };
     scanLogs.push(duplicateLog);
+    if (scanLogs.length > 10000) scanLogs.shift();
 
     return corsResponse(req, res, 200, {
       valid: true,


### PR DESCRIPTION
This PR resolves issue #6336 by applying a max size to the `scanLogs` array referenced in `api/tickets/validate.js`. Oldest items are shifted out once the array reaches 10000 items, guarding against memory exhaustion.