### PR TITLE
Fix: CPU Exhaustion DoS via Unbounded Password Length (#6337)

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -39,6 +39,8 @@ const validateLoginInput = (usernameOrEmail, password) => {
   
   if (!password) {
     errors.push("Password is required");
+  } else if (password.length > 100) {
+    errors.push("Password exceeds maximum allowed length");
   }
   
   return errors;


### PR DESCRIPTION
This PR resolves issue #6337 by rejecting passwords longer than 100 characters in the login validation logic before handing them over to `bcrypt.compare`. This prevents adversaries from burning server CPU cycles by providing exceptionally long strings.