### PR TITLE
Fix: Authentication Brute-Force Bypass via IP Spoofing in login.js (#6339)

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -108,10 +108,10 @@ async function handler(req, res) {
     // -----------------------------------------------------------------------
 
     const clientIp =
-  req.headers?.["x-forwarded-for"]?.split(",")[0]?.trim()
-  || req.headers?.["x-real-ip"]
-  || req.socket?.remoteAddress
-  || null;
+      req.headers?.[\"x-vercel-forwarded-for\"]
+      || req.headers?.[\"x-real-ip\"]
+      || req.socket?.remoteAddress
+      || null;
 
 if (clientIp) {
   loginRateLimiter.evictStale();
@@ -241,3 +241,4 @@ if (clientIp) {
 
 export default handler;
 export { users };
+


### PR DESCRIPTION
This PR resolves issue #6339 by explicitly preferring the \x-vercel-forwarded-for\ header to fetch the true client IP. This prevents attackers from spoofing their IP address via custom \X-Forwarded-For\ headers to bypass the login brute-force rate limiter.