### PR TITLE
Fix: Ephemeral Session Invalidity (#6342)

### DIFF
--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -67,10 +67,19 @@ export const verifyAuth = (handler) => {
         : usersById.has(userId);
 
       if (!userExists) {
-        return res.status(401).set(corsHeaders).json({
-          error: "Unauthorized: Session invalidated. Please log in again.",
-          sessionInvalidated: true,
-        });
+        // Issue #6342: Reconstruct the ephemeral user from the trusted token claims
+        // so that cold starts or multi-instance scaling don't invalidate existing,
+        // cryptographically valid sessions.
+        const reconstructedUser = {
+          id: decoded.id,
+          email: decoded.email,
+          username: decoded.username || decoded.email,
+          roles: decoded.roles || ["USER"],
+          permissions: [], // Permissions will be computed dynamically anyway
+          isActive: true
+        };
+        users.set(decoded.email.toLowerCase(), reconstructedUser);
+        usersById.set(decoded.id, reconstructedUser);
       }
     }
 
@@ -78,3 +87,4 @@ export const verifyAuth = (handler) => {
     return handler(req, res);
   };
 };
+


### PR DESCRIPTION
This PR resolves issue #6342 by reconstructing the ephemeral user object in memory if the provided JWT is cryptographically valid but the \users\ Map is empty (e.g. after a serverless cold start). This ensures that existing sessions are not arbitrarily invalidated by infrastructure scaling.