### PR TITLE
Fix: Unhandled JSON Parser Crash on Advanced Filters (#6349)

### DIFF
--- a/src/utils/advancedFilterUtils.js
+++ b/src/utils/advancedFilterUtils.js
@@ -453,7 +453,11 @@ export const decodeAdvancedFilters = (value) => {
   }
 
   try {
-    return normalizeAdvancedFilters(JSON.parse(decodeURIComponent(value)));
+    const parsed = JSON.parse(decodeURIComponent(value));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return getDefaultFilters();
+    }
+    return normalizeAdvancedFilters(parsed);
   } catch {
     return getDefaultFilters();
   }


### PR DESCRIPTION
This PR resolves issue #6349 by explicitly validating that the parsed URL JSON payload is a plain object type before passing it to 
ormalizeAdvancedFilters. This prevents fatal crashes caused by users opening malicious links with primitive JSON values (like booleans or numbers) embedded in the filter parameter.