### PR TITLE
Fix: Unhandled Exception in WebRTC Data Channel (#6350)

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -436,7 +436,13 @@ export class P2PFileTransferCoordinator {
     };
 
     this.channel.onmessage = async (e) => {
-      const chunkMsg = JSON.parse(e.data);
+      let chunkMsg;
+      try {
+        chunkMsg = JSON.parse(e.data);
+      } catch (err) {
+        console.error("Failed to parse incoming P2P message:", err);
+        return;
+      }
       this.receivedChunks.push(chunkMsg);
 
       const progress = Math.round((this.receivedChunks.length / chunkMsg.totalChunks) * 100);


### PR DESCRIPTION
This PR resolves issue #6350 by wrapping the JSON.parse call inside the onmessage WebRTC Data Channel listener with a robust try-catch block. This prevents malformed packets sent by malicious or desynced peers from crashing the local coordinator client.