### PR TITLE
Fix: Prototype Pollution Risk in ErrorBoundary (#6351)

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -45,7 +45,11 @@ function attemptStateRecovery() {
   try {
     const savedState = sessionStorage.getItem("eventra_component_state_backup");
     if (savedState) {
-      window.__EVENTRA_RECOVERED_STATE__ = JSON.parse(savedState);
+      const parsed = JSON.parse(savedState, (key, value) => {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+        return value;
+      });
+      window.__EVENTRA_RECOVERED_STATE__ = parsed;
       sessionStorage.removeItem("eventra_component_state_backup");
       return true;
     }


### PR DESCRIPTION
This PR resolves issue #6351 by implementing a custom JSON reviver function when parsing the savedState from sessionStorage. The reviver safely intercepts and discards any __proto__, constructor, or prototype keys before they can be assigned to the global window.__EVENTRA_RECOVERED_STATE__ object.