### PR TITLE
Fix: Potential SSRF Edge-Case / Token Leak (#6352)

### DIFF
--- a/api/github-proxy.js
+++ b/api/github-proxy.js
@@ -119,7 +119,8 @@ async function handler(req, res) {
     return res.status(400).json({ error: "Invalid GitHub API path" });
   }
 
-  const url = new URL(normalizedPath, "https://api.github.com");
+  const url = new URL("https://api.github.com");
+  url.pathname = normalizedPath;
   Object.entries(queryParams).forEach(([key, value]) => {
     if (!ALLOWED_QUERY_PARAMS.has(key)) return;
     if (Array.isArray(value)) {


### PR DESCRIPTION
This PR resolves issue #6352. The proxy endpoint now safely constructs the upstream URL by initializing the URL object with a hardcoded https://api.github.com base before directly assigning the validated pathname string. This completely eliminates protocol/host smuggling edge cases caused by differences between regex engine and URL parser behavior.