### PR TITLE
Use safeParseJson utility across all error boundaries and localStorage reads

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import ModernSearchInput from "../../components/common/ModernSearchInput";
 import CountUpLib from "react-countup";
 import { darkTheme } from "../../components/styles/theme";
+import { safeParseJson } from "../../utils/jsonUtils";
 import { SkeletonBlock } from "../../components/common/SkeletonLoaders";
 const CountUp = CountUpLib.default || CountUpLib;
 
@@ -13,12 +14,8 @@ const CountUp = CountUpLib.default || CountUpLib;
 const SEARCH_HISTORY_KEY = "eventra.events.searchHistory";
 
 const getStoredSearchHistory = () => {
-  try {
-    const stored = JSON.parse(localStorage.getItem(SEARCH_HISTORY_KEY) || "[]");
-    return Array.isArray(stored) ? stored.slice(0, 5) : [];
-  } catch {
-    return [];
-  }
+  const stored = safeParseJson(localStorage.getItem(SEARCH_HISTORY_KEY), []);
+  return Array.isArray(stored) ? stored.slice(0, 5) : [];
 };
 
 const TRENDING_SEARCHES = [

--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Html5Qrcode } from "html5-qrcode";
+import { safeParseJson } from "../../utils/jsonUtils";
 import {
   Camera,
   CameraOff,
@@ -178,7 +179,7 @@ export default function TicketScanner() {
   const addToHistory = useCallback((entry) => {
     setCheckinHistory((prev) => [entry, ...prev].slice(0, 50));
     try {
-      const updated = [entry, ...JSON.parse(localStorage.getItem(HISTORY_CACHE_KEY) || "[]")].slice(0, 50);
+      const updated = [entry, ...safeParseJson(localStorage.getItem(HISTORY_CACHE_KEY), [])].slice(0, 50);
       localStorage.setItem(HISTORY_CACHE_KEY, JSON.stringify(updated));
     } catch { /* ignore */ }
   }, []);

--- a/src/components/common/FeatureErrorBoundary.jsx
+++ b/src/components/common/FeatureErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { logger } from "../../utils/logger";
+import { safeParseJson } from "../../utils/jsonUtils";
 
 /**
  * FeatureErrorBoundary
@@ -39,7 +40,7 @@ class FeatureErrorBoundary extends React.Component {
         message: error?.toString(),
         timestamp: new Date().toISOString(),
       };
-      const existing = JSON.parse(localStorage.getItem("eventra_feature_errors") || "[]");
+      const existing = safeParseJson(localStorage.getItem("eventra_feature_errors"), []);
       existing.unshift(entry);
       localStorage.setItem("eventra_feature_errors", JSON.stringify(existing.slice(0, 10)));
     } catch (_) {}

--- a/src/components/common/SectionErrorBoundary.jsx
+++ b/src/components/common/SectionErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { logError } from "../../utils/errorLogger";
+import { safeParseJson } from "../../utils/jsonUtils";
 
 /**
  * SectionErrorBoundary
@@ -35,7 +36,7 @@ class SectionErrorBoundary extends React.Component {
     // even after a page reload (the main ErrorBoundary only stores top-level crashes).
     try {
       const key = "eventra_section_errors";
-      const existing = JSON.parse(localStorage.getItem(key) || "[]");
+      const existing = safeParseJson(localStorage.getItem(key), []);
       existing.unshift({
         section: label,
         message: error?.message || String(error),

--- a/src/utils/errorLogger.js
+++ b/src/utils/errorLogger.js
@@ -1,4 +1,5 @@
 import { SENTRY_DSN, isSentryEnabled } from "../config/env.js";
+import { safeParseJson } from "./jsonUtils";
 
 // Try to load the real Sentry SDK. If @sentry/browser is not installed
 // (e.g. the dependency was skipped during npm install), every call below
@@ -43,9 +44,9 @@ function buildErrorEntry(error, errorInfo, extra = {}) {
 }
 
 function persistToLocalStorage(entry) {
+  const existing = safeParseJson(localStorage.getItem("eventra_error_log"), []);
+  existing.unshift(entry);
   try {
-    const existing = JSON.parse(localStorage.getItem("eventra_error_log") || "[]");
-    existing.unshift(entry);
     localStorage.setItem("eventra_error_log", JSON.stringify(existing.slice(0, 10)));
   } catch (_) {
   }
@@ -80,13 +81,8 @@ export const logError = (error, errorInfo, extra = {}) => {
   }
 };
 
-export const getErrorLog = () => {
-  try {
-    return JSON.parse(localStorage.getItem("eventra_error_log") || "[]");
-  } catch (_) {
-    return [];
-  }
-};
+export const getErrorLog = () =>
+  safeParseJson(localStorage.getItem("eventra_error_log"), []);
 
 export const clearErrorLog = () => {
   try {
@@ -95,13 +91,8 @@ export const clearErrorLog = () => {
   } catch (_) {}
 };
 
-export const getSectionErrors = () => {
-  try {
-    return JSON.parse(localStorage.getItem("eventra_section_errors") || "[]");
-  } catch (_) {
-    return [];
-  }
-};
+export const getSectionErrors = () =>
+  safeParseJson(localStorage.getItem("eventra_section_errors"), []);
 
 export const clearSectionErrors = () => {
   try {


### PR DESCRIPTION
Replace inline JSON.parse with centralized safeParseJson for consistent error handling.

Closes #6376
Closes #6377
Closes #6378
Closes #6391