### PR TITLE
Add explicit radix parameter to all parseInt calls across 9 files

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -159,7 +159,7 @@ export default function ModernAbout() {
                 >
                   <h3 className="text-black dark:text-white text-xl sm:text-2xl font-bold mb-1">
                     {s.value.includes("+") ? (
-                      <CountUp start={0} end={parseInt(s.value)} duration={3} suffix="+" enableScrollSpy scrollSpyOnce />
+                      <CountUp start={0} end={parseInt(s.value, 10)} duration={3} suffix="+" enableScrollSpy scrollSpyOnce />
                     ) : (
                       s.value
                     )}

--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -124,7 +124,7 @@ const ApiDocs = () => {
       
       switch (selectedEndpoint) {
         case "/mock-api/hackathons": {
-          const limitVal = parseInt(params.limit) || 5;
+          const limitVal = parseInt(params.limit, 10) || 5;
           const statusVal = params.status || "all";
           const allHackathons = [
             { id: 1, title: "CodeFest 2025", startDate: "2025-09-20", endDate: "2025-09-25", participants: 150, status: "completed" },
@@ -178,8 +178,8 @@ const ApiDocs = () => {
           break;
         }
         case "/mock-api/leaderboard": {
-          const limitVal = parseInt(params.limit) || 10;
-          const pageVal = parseInt(params.page) || 1;
+          const limitVal = parseInt(params.limit, 10) || 10;
+          const pageVal = parseInt(params.page, 10) || 1;
           const allLeaderboard = [
             { rank: 1, username: "coder123", points: 500 },
             { rank: 2, username: "dev_ankita", points: 230 },

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -152,9 +152,9 @@ const EventsPage = () => {
       savedFilters = {};
     }
 
-    const page = parseInt(searchParams.get("page")) || 1;
+    const page = parseInt(searchParams.get("page"), 10) || 1;
     const perPage =
-      parseInt(searchParams.get("perPage")) || savedFilters.perPage || 6;
+      parseInt(searchParams.get("perPage"), 10) || savedFilters.perPage || 6;
     const filter =
       searchParams.get("filter") || savedFilters.filterType || "all";
     const sort = searchParams.get("sort") || savedFilters.sortType || "Newest";

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -99,7 +99,7 @@ const WhatsHappening = () => {
         link: `/hackathons/${hackathon.id}`,
         featured:
           hackathon.prize &&
-          parseInt(hackathon.prize.replace(/[$,]/g, "")) > 30000,
+          parseInt(hackathon.prize.replace(/[$,]/g, ""), 10) > 30000,
         location: hackathon.location,
         prize: hackathon.prize,
         participants: hackathon.participants,

--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -58,7 +58,7 @@ export default function Chatbot() {
     try {
       const lastActive = localStorage.getItem("eventra_chatbot_last_active");
       const twoHours = 2 * 60 * 60 * 1000;
-      if (lastActive && Date.now() - parseInt(lastActive) > twoHours) {
+      if (lastActive && Date.now() - parseInt(lastActive, 10) > twoHours) {
         setMessages(INITIAL_MESSAGES);
       }
       localStorage.setItem("eventra_chatbot_last_active", Date.now().toString());

--- a/src/components/common/ProjectSubmission.js
+++ b/src/components/common/ProjectSubmission.js
@@ -52,7 +52,7 @@ const ProjectSubmission = ({ onClose, onSubmit }) => {
     const { name, value, type } = e.target;
     setFormData((prev) => ({
       ...prev,
-      [name]: type === "number" ? parseInt(value) || 0 : value,
+      [name]: type === "number" ? parseInt(value, 10) || 0 : value,
     }));
   };
 

--- a/src/components/events/FloorPlan/PropertiesPanel.jsx
+++ b/src/components/events/FloorPlan/PropertiesPanel.jsx
@@ -98,7 +98,7 @@ export default function PropertiesPanel({
           <div className="fp-slider-group">
             <input type="range" min="0" max="360" step="15" className="fp-slider"
               value={activeElement.rotation}
-              onChange={(e) => onUpdateSelected("rotation", parseInt(e.target.value))} />
+              onChange={(e) => onUpdateSelected("rotation", parseInt(e.target.value, 10))} />
             <span className="fp-slider-value">{activeElement.rotation}°</span>
           </div>
         </div>
@@ -110,9 +110,9 @@ export default function PropertiesPanel({
               max={activeElement.type === "stage" ? 600 : 300} className="fp-slider"
               value={activeElement.width}
               onChange={(e) => {
-                onUpdateSelected("width", parseInt(e.target.value));
+                onUpdateSelected("width", parseInt(e.target.value, 10));
                 if (activeElement.type === "round-table") {
-                  onUpdateSelected("height", parseInt(e.target.value));
+                  onUpdateSelected("height", parseInt(e.target.value, 10));
                 }
               }} />
             <span className="fp-slider-value">{activeElement.width}px</span>
@@ -125,7 +125,7 @@ export default function PropertiesPanel({
             <div className="fp-slider-group">
               <input type="range" min="20" max={activeElement.type === "stage" ? 400 : 200} className="fp-slider"
                 value={activeElement.height}
-                onChange={(e) => onUpdateSelected("height", parseInt(e.target.value))} />
+                onChange={(e) => onUpdateSelected("height", parseInt(e.target.value, 10))} />
               <span className="fp-slider-value">{activeElement.height}px</span>
             </div>
           </div>
@@ -146,7 +146,7 @@ export default function PropertiesPanel({
             <div className="fp-slider-group">
               <input type="range" min="2" max="12" className="fp-slider"
                 value={activeElement.seatsCount}
-                onChange={(e) => onUpdateSelected("seatsCount", parseInt(e.target.value))} />
+                onChange={(e) => onUpdateSelected("seatsCount", parseInt(e.target.value, 10))} />
               <span className="fp-slider-value">{activeElement.seatsCount}</span>
             </div>
           </div>

--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -56,7 +56,7 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
             const seatsCountVal = updates.seatsCount;
             const freshAssigned = {};
             Object.keys(el.assignedAttendees).forEach((k) => {
-              if (parseInt(k) < seatsCountVal) {
+              if (parseInt(k, 10) < seatsCountVal) {
                 freshAssigned[k] = el.assignedAttendees[k];
               }
             });

--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -77,8 +77,8 @@ export const addEventToGoogleCalendar = (event) => {
     // Assuming time format like "10:00 AM"
     const timeParts = event.time.match(/(\d+):(\d+)\s*([APap][Mm])/);
     if (timeParts) {
-      let hours = parseInt(timeParts[1]);
-      const minutes = parseInt(timeParts[2]);
+      let hours = parseInt(timeParts[1], 10);
+      const minutes = parseInt(timeParts[2], 10);
       const period = timeParts[3].toUpperCase();
       
       // Convert to 24-hour format


### PR DESCRIPTION
Add ,10 radix to parseInt calls across the codebase to prevent octal/hex interpretation.

Closes #6406
Closes #6407
Closes #6408
Closes #6409
Closes #6410
Closes #6411
Closes #6412
Closes #6413
Closes #6414