### PR TITLE
fix: update sanitizeHtml test expectations for DOMPurify security attributes

### DIFF
--- a/tests/sanitizeHtml.test.mjs
+++ b/tests/sanitizeHtml.test.mjs
@@ -21,8 +21,9 @@ try {
 
   // Test Case 3: Whitelisted tags and attributes
   const goodHtml = '<p class="text-large"><a href="https://example.com" target="_blank">Link</a></p>';
+  const expectedHtml = '<p class="text-large"><a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a></p>';
   const outputHtml = sanitizeHtml(goodHtml);
-  assert.equal(outputHtml, goodHtml, "Should retain whitelisted tags (p, a) and attributes (class, href, target)");
+  assert.equal(outputHtml, expectedHtml, "Should retain whitelisted tags (p, a) and attributes (class, href, target)");
 
   // Test Case 4: Strip illegal attributes
   const badAttrHtml = '<div data-secret="123" onclick="doMalicious()">Click Me</div>';


### PR DESCRIPTION
## Description

This PR fixes a false-negative test failure in `tests/sanitizeHtml.test.mjs` caused by an outdated strict HTML equality assertion.

DOMPurify automatically injects the security attribute `rel="noopener noreferrer"` into links that use `target="_blank"` to protect against reverse tabnabbing attacks. The existing test expected the sanitized HTML output to match the original input exactly, causing the assertion to fail even though the sanitizer was functioning correctly.

### Changes Made

* Updated the expected sanitized HTML output to include the automatically injected `rel="noopener noreferrer"` attribute.
* Aligned the test assertions with DOMPurify's security behavior.
* Preserved existing sanitizer functionality and security protections.
* Eliminated false-negative test failures in CI environments.

Fixes #6430

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have run local unit tests using `npm test` and verified they pass
* [x] I have run `npm run lint` and resolved any new errors or warnings
* [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
