### PR TITLE
fix: resolve sentiment scoring bounds validations and parameter parsing checks

### DIFF
--- a/src/utils/sentiment.js
+++ b/src/utils/sentiment.js
@@ -45,28 +45,32 @@ export const analyzeSentiment = (text) => {
  * Gets a descriptive label and an emoji representation based on the sentiment score
  */
 export const getSentimentDisplay = (score) => {
-  if (score >= 1.5) {
+  // Ensure score is a valid, parsed float number
+  const parsedScore = typeof score === 'number' && isFinite(score) ? score : parseFloat(score);
+  const validatedScore = isNaN(parsedScore) ? 0 : parsedScore;
+
+  if (validatedScore >= 1.5) {
     return {
       emoji: "🌟",
       label: "Excited / Highly Positive",
       color: "text-green-500 dark:text-green-400 animate-bounce"
     };
   }
-  if (score > 0.2) {
+  if (validatedScore > 0.2) {
     return {
       emoji: "🙂",
       label: "Happy / Positive",
       color: "text-emerald-500 dark:text-emerald-400"
     };
   }
-  if (score < -1.5) {
+  if (validatedScore < -1.5) {
     return {
       emoji: "😢",
       label: "Frustrated / Highly Negative",
       color: "text-red-500 dark:text-red-400 animate-pulse"
     };
   }
-  if (score < -0.2) {
+  if (validatedScore < -0.2) {
     return {
       emoji: "🙁",
       label: "Muted / Negative",


### PR DESCRIPTION
Closes #6458 


# Summary
Sanitizes the input parameters of the sentiment display formatting utility.

# Changes Made
- Added type assertions to prevent NaN scores.

# Testing
- Executed `node --loader ./tests/loaders/jsExtension.mjs tests/sentiment.test.mjs` and verified success.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
