### PR TITLE
Fix floating promises in dynamic imports

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -35,7 +35,7 @@ const EventDetailsPage = () => {
     if (userId && event) {
       import("../../utils/waitlistUtils").then(({ getQueuePosition }) => {
         setQueuePosition(getQueuePosition(event.id, userId));
-      });
+      }).catch(() => setQueuePosition(-1));
     } else {
       setQueuePosition(-1);
     }
@@ -45,7 +45,7 @@ const EventDetailsPage = () => {
     if (event) {
       import("../../utils/waitlistUtils").then(({ getEventWaitlist }) => {
         setWaitlistCount(getEventWaitlist(event.id).length);
-      });
+      }).catch(() => setWaitlistCount(0));
     }
   }, [event, waitlistUpdated]);
 

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -132,7 +132,7 @@ const AdminDashboard = () => {
   const loadWaitlist = useCallback((eventId) => {
     import("../../utils/waitlistUtils.js").then(({ getEventWaitlist }) => {
       setWaitlistUsers(getEventWaitlist(eventId));
-    });
+    }).catch(() => setWaitlistUsers([]));
   }, []);
 
   const openWaitlistModal = (event) => {

--- a/src/components/common/CollaborativeWhiteboard.jsx
+++ b/src/components/common/CollaborativeWhiteboard.jsx
@@ -181,6 +181,8 @@ export default function CollaborativeWhiteboard() {
     // 1. Open Database & Load history
     initDB().then((db) => {
       loadHistory(db);
+    }).catch(() => {
+      console.warn("[Whiteboard] IndexedDB unavailable, starting with empty history");
     });
 
     // 2. Connect BroadcastChannel for real-time signaling P2P

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -236,7 +236,7 @@ const WaitlistCard = ({ event, index, onLeaveWaitlist }) => {
     if (user) {
       import("../../utils/waitlistUtils").then(({ getQueuePosition }) => {
         setQueuePos(getQueuePosition(event.id, user.id || user.email));
-      });
+      }).catch(() => setQueuePos(-1));
     }
   }, [event.id, user]);
 
@@ -319,8 +319,8 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
             };
           });
           setWaitlistEvents(resolved);
-        });
-      });
+        }).catch(() => setWaitlistEvents([]));
+      }).catch(() => setWaitlistEvents([]));
     } else {
       setWaitlistEvents([]);
     }

--- a/src/context/MyEventsContext.js
+++ b/src/context/MyEventsContext.js
@@ -177,7 +177,7 @@ export const MyEventsProvider = ({ children }) => {
     // Trigger automatic promotion from the waitlist
     import("../utils/waitlistUtils.js").then(({ promoteNextUser }) => {
       promoteNextUser(eventId);
-    });
+    }).catch(() => {});
   }, []);
 
   /**


### PR DESCRIPTION
Add .catch() handlers to all dynamic import().then() chains to prevent unhandled promise rejections.

Closes #6419, #6420, #6421, #6422, #6423