### PR TITLE
fix: implement in-memory store fallback resilience when IndexedDB is blocked

### DIFF
--- a/src/utils/indexedDB.js
+++ b/src/utils/indexedDB.js
@@ -1,57 +1,80 @@
 import { get, set, del, clear } from 'idb-keyval';
 
+// In-memory cache fallback when IndexedDB is blocked (e.g., in private windows)
+const memoryCache = new Map();
+let isIndexedDbFunctional = true;
+
 /**
- * Saves a serializable payload to IndexedDB securely.
+ * Saves a serializable payload to IndexedDB securely, falling back to in-memory store if disabled.
  * @param {string} key 
  * @param {any} val 
  * @returns {Promise<void>}
  */
 export const saveToOfflineCache = async (key, val) => {
-  try {
-    await set(key, val);
-  } catch (err) {
-    console.error(`[IndexedDB] Failed to save key "${key}":`, err);
+  if (isIndexedDbFunctional) {
+    try {
+      await set(key, val);
+      return;
+    } catch (err) {
+      console.warn(`[IndexedDB] Blocked or failed to save key "${key}". Falling back to memory:`, err);
+      isIndexedDbFunctional = false;
+    }
   }
+  memoryCache.set(key, val);
 };
 
 /**
- * Retrieves a payload from IndexedDB.
+ * Retrieves a payload from IndexedDB, falling back to in-memory store if disabled.
  * @param {string} key 
  * @param {any} fallback 
  * @returns {Promise<any>}
  */
 export const getFromOfflineCache = async (key, fallback = null) => {
-  try {
-    const val = await get(key);
-    return val !== undefined ? val : fallback;
-  } catch (err) {
-    console.error(`[IndexedDB] Failed to read key "${key}":`, err);
-    return fallback;
+  if (isIndexedDbFunctional) {
+    try {
+      const val = await get(key);
+      return val !== undefined ? val : fallback;
+    } catch (err) {
+      console.warn(`[IndexedDB] Blocked or failed to read key "${key}". Falling back to memory:`, err);
+      isIndexedDbFunctional = false;
+    }
   }
+  const memVal = memoryCache.get(key);
+  return memVal !== undefined ? memVal : fallback;
 };
 
 /**
- * Deletes a specific key from IndexedDB.
+ * Deletes a specific key from IndexedDB, falling back to in-memory store if disabled.
  * @param {string} key 
  * @returns {Promise<void>}
  */
 export const removeFromOfflineCache = async (key) => {
-  try {
-    await del(key);
-  } catch (err) {
-    console.error(`[IndexedDB] Failed to delete key "${key}":`, err);
+  if (isIndexedDbFunctional) {
+    try {
+      await del(key);
+      return;
+    } catch (err) {
+      console.warn(`[IndexedDB] Blocked or failed to delete key "${key}". Falling back to memory:`, err);
+      isIndexedDbFunctional = false;
+    }
   }
+  memoryCache.delete(key);
 };
 
 /**
- * Clears the entire IndexedDB cache for this origin.
+ * Clears the entire IndexedDB cache for this origin, falling back to in-memory store if disabled.
  * Use cautiously.
  * @returns {Promise<void>}
  */
 export const clearOfflineCache = async () => {
-  try {
-    await clear();
-  } catch (err) {
-    console.error(`[IndexedDB] Failed to clear cache:`, err);
+  if (isIndexedDbFunctional) {
+    try {
+      await clear();
+      return;
+    } catch (err) {
+      console.warn(`[IndexedDB] Blocked or failed to clear cache. Falling back to memory:`, err);
+      isIndexedDbFunctional = false;
+    }
   }
+  memoryCache.clear();
 };


### PR DESCRIPTION
Closes #6465 

# Summary
Provides an in-memory storage fallback for offline cache when browser IndexedDB is disabled.

# Changes Made
- Wrapped cache routines with database functional state flags.
- Switched to memory Map fallbacks on exceptions.

# Testing
- Simulated block exceptions on caching calls and verified memory storage continues.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
