### PR TITLE
fix: resolve activityTracker localStorage write crash and boundary checks

### DIFF
--- a/src/utils/activityTracker.js
+++ b/src/utils/activityTracker.js
@@ -1,9 +1,32 @@
 // 🔥 FIX: In-memory queue and lock to prevent localStorage race conditions
 let isUpdating = false;
 let interestQueue = [];
+const MAX_QUEUE_SIZE = 100;
+
+// Helper to check if localStorage is available and writable
+const isStorageAvailable = () => {
+  try {
+    const testKey = "__storage_test__";
+    if (typeof localStorage === "undefined" || typeof localStorage.setItem !== "function") {
+      return false;
+    }
+    localStorage.setItem(testKey, testKey);
+    if (typeof localStorage.removeItem === "function") {
+      localStorage.removeItem(testKey);
+    }
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 const processInterestQueue = () => {
   if (isUpdating || interestQueue.length === 0) return;
+  if (!isStorageAvailable()) {
+    // If localStorage is unavailable, clear the queue to prevent memory leak
+    interestQueue = [];
+    return;
+  }
   isUpdating = true;
 
   try {
@@ -28,6 +51,12 @@ const processInterestQueue = () => {
       }
     }
 
+    // Keep interests size reasonable
+    if (interests.length > 50) {
+      interests = interests.slice(-50);
+      modified = true;
+    }
+
     if (modified) {
       localStorage.setItem(
         "eventra_user_profile",
@@ -46,15 +75,20 @@ const processInterestQueue = () => {
 };
 
 export const trackUserInterest = (interest) => {
-  if (!interest) return;
-  interestQueue.push(interest);
+  if (typeof interest !== "string" || !interest.trim() || interest.length > 100) return;
+  if (interestQueue.length >= MAX_QUEUE_SIZE) {
+    interestQueue.shift(); // Evict oldest entry
+  }
+  interestQueue.push(interest.trim());
   processInterestQueue();
 };
 
 export const clearActivityHistory = () => {
   try {
-    localStorage.removeItem("eventra_user_profile");
     interestQueue = [];
+    if (isStorageAvailable()) {
+      localStorage.removeItem("eventra_user_profile");
+    }
   } catch (error) {
     console.error("Failed to clear activity history:", error);
   }


### PR DESCRIPTION
Closes #6470 

# Summary
Applies input sanitization, storage checks, and memory limits to the client activity tracker.

# Changes Made
- Added storage availability verification helper.
- Enforced a queue size ceiling of 100.

# Testing
- Executed unit tests: `node --loader ./tests/loaders/jsExtension.mjs tests/activityTracker.test.mjs`
- Tests passed.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
