### PR TITLE
fix: resolve P2P connection timeout and signaling hangs

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -293,14 +293,37 @@ export class P2PFileTransferCoordinator {
 
     // We wait 2.5 seconds to discover nearby peers. If none answer, we fail and trigger fallback.
     return new Promise((resolve) => {
-      setTimeout(() => {
-        if (!this.pc) {
+      const searchTimeout = setTimeout(() => {
+        if (!this.pc || this.currentState === "searching") {
           this.cleanup();
           resolve(false); // No peers found, trigger server fallback
-        } else {
-          resolve(true); // Connected to peer!
         }
       }, 2500);
+
+      // Add a secondary connection safety timer of 5 seconds total
+      const connectionSafetyTimeout = setTimeout(() => {
+        if (this.currentState === "connecting" || this.currentState === "searching") {
+          this.cleanup();
+          resolve(false); // WebRTC connection handshakes timed out, fallback to server
+        } else if (this.currentState === "completed" || this.currentState === "transferring") {
+          resolve(true);
+        }
+      }, 5000);
+
+      // Attach state listener check to resolve immediately if completed
+      const checkInterval = setInterval(() => {
+        if (this.currentState === "completed") {
+          clearTimeout(searchTimeout);
+          clearTimeout(connectionSafetyTimeout);
+          clearInterval(checkInterval);
+          resolve(true);
+        } else if (this.currentState === "failed") {
+          clearTimeout(searchTimeout);
+          clearTimeout(connectionSafetyTimeout);
+          clearInterval(checkInterval);
+          resolve(false);
+        }
+      }, 200);
     });
   }
 


### PR DESCRIPTION
Closes #6474 

# Summary
Implements connection handshake safety timers in the WebRTC file coordinator.

# Changes Made
- Added search and connection safety timeouts in `p2pFileTransfer.js`.
- Ensured resources are cleaned up on failures.

# Testing
- Tested state machine logic to verify it times out and rejects after 5 seconds of hanging.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
