### PR TITLE
fix(hackathons): escape JSX apostrophe entity in WorkspaceBootstrapModal

### DIFF
--- a/src/components/hackathons/WorkspaceBootstrapModal.jsx
+++ b/src/components/hackathons/WorkspaceBootstrapModal.jsx
@@ -448,7 +448,7 @@ const WorkspaceBootstrapModal = ({ team, onClose }) => {
               >
                 <div className="p-3 rounded-xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/60">
                   <p className="text-[11px] text-slate-500 dark:text-slate-400 leading-relaxed">
-                    Add GitHub usernames of your teammates. They'll receive a collaboration invitation email.
+                    Add GitHub usernames of your teammates. They&apos;ll receive a collaboration invitation email.
                     {initialHandle && (
                       <span className="block mt-1 text-blue-600 dark:text-blue-400">
                         ✓ Pre-filled <strong>@{initialHandle}</strong> from the contact link.


### PR DESCRIPTION
## PR Description

### Summary

Resolved a JSX entity lint violation in `WorkspaceBootstrapModal.jsx` caused by an unescaped apostrophe inside rendered JSX content.
### FIxes #6482
### Changes

* Escaped the offending apostrophe using a JSX-safe entity
* Preserved rendered UI text exactly
* Restored lint compliance

### Impact

This fix restores:

* ESLint stability
* CI validation compliance
* valid JSX entity handling

### Validation

* Verified `react/no-unescaped-entities` error is resolved
* Verified modal renders correctly
* Verified rendered text remains unchanged visually
