### PR TITLE
fix: resolve rateLimiter clock drift and backward time token draining

### DIFF
--- a/src/utils/rateLimiter.js
+++ b/src/utils/rateLimiter.js
@@ -27,7 +27,7 @@ export function createRateLimiter({
 
   function refill() {
     const now = Date.now();
-    const elapsed = (now - lastRefill) / 1000;
+    const elapsed = Math.max(0, (now - lastRefill) / 1000);
     tokens = Math.min(maxTokens, tokens + elapsed * refillRate);
     lastRefill = now;
   }


### PR DESCRIPTION
Closes #6488 


# Summary
Fixes token draining caused by system clock adjustments in the rate limiter.

# Changes Made
- Clamped elapsed time calculation to non-negative values.

# Testing
- Executed unit tests: `node --loader ./tests/loaders/jsExtension.mjs tests/rateLimitUtils.test.mjs`
- All tests passed.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
