### PR TITLE
fix(admin): add missing Link import to AdminDashboard

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuth } from "../../context/AuthContext";
-import { useNavigate, Navigate, useLocation } from "react-router-dom";
+import { useNavigate, Navigate, useLocation, Link } from "react-router-dom";
 import {
   Users,
   Calendar,


### PR DESCRIPTION
## PR Description

### Summary

Resolved runtime and lint failures in `AdminDashboard.js` caused by missing `Link` imports from `react-router-dom`.

### Changes

* Added missing `Link` import
* Restored valid JSX component resolution
* Preserved existing admin dashboard navigation behavior
### Fixes #6502
### Impact

This fix restores:

* admin dashboard rendering stability
* router component resolution
* lint/build execution

### Validation

* Verified `react/jsx-no-undef` errors are resolved
* Verified dashboard navigation renders correctly
* Verified admin routes function as expected
