### PR TITLE
fix: fixed middleware.js

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -6,39 +6,37 @@
 // Azure backend, bypassing the serverless auth & rate-limit functions in
 // /api/*.js. This middleware restores edge-level abuse protection for
 // those proxied requests.
+//
+// Rate limiting uses @vercel/kv (Redis) so the counter is shared across
+// all global Edge nodes. The previous in-memory Map was per-process and
+// silently ineffective in a distributed Edge environment.
+//
+// Setup:
+//   1. npx vercel link && npx vercel env pull
+//   2. vercel kv create <store-name>   (sets KV_REST_API_URL / KV_REST_API_TOKEN)
 // ---------------------------------------------------------------------------
 
-const API_RATE_LIMIT = 60;        // max requests
-const API_RATE_WINDOW_MS = 60_000; // per window
+import { kv } from "@vercel/kv";
 
-const ipRateMap = new Map();
-let lastEvictionAt = 0;
+const API_RATE_LIMIT = 60;         // max requests
+const API_RATE_WINDOW_S = 60;      // per window in seconds (Redis TTL unit)
 
-const evictStale = () => {
-  const now = Date.now();
-  if (now - lastEvictionAt < API_RATE_WINDOW_MS) return;
-  lastEvictionAt = now;
-  const cutoff = now - API_RATE_WINDOW_MS;
-  for (const [ip, entries] of ipRateMap) {
-    const valid = entries.filter((t) => t > cutoff);
-    if (valid.length === 0) ipRateMap.delete(ip);
-    else ipRateMap.set(ip, valid);
+// ---------------------------------------------------------------------------
+// Distributed rate limiter using Redis INCR + EXPIRE (atomic sliding window)
+// ---------------------------------------------------------------------------
+
+const isRateLimited = async (ip) => {
+  const key = `rl:${ip}`;
+  // INCR is atomic — safe across concurrent Edge invocations
+  const count = await kv.incr(key);
+  if (count === 1) {
+    // First request in this window: set expiry so key auto-evicts
+    await kv.expire(key, API_RATE_WINDOW_S);
   }
+  return count > API_RATE_LIMIT;
 };
 
-const isRateLimited = (ip) => {
-  evictStale();
-  const now = Date.now();
-  const cutoff = now - API_RATE_WINDOW_MS;
-  const timestamps = ipRateMap.get(ip) || [];
-  const valid = timestamps.filter((t) => t > cutoff);
-
-  if (valid.length >= API_RATE_LIMIT) return true;
-
-  valid.push(now);
-  ipRateMap.set(ip, valid);
-  return false;
-};
+// ---------------------------------------------------------------------------
 
 export const config = {
   matcher: "/api/:path*",
@@ -58,14 +56,14 @@ export default async function middleware(request) {
     request.headers.get("x-real-ip") ||
     "unknown";
 
-  if (isRateLimited(ip)) {
+  if (await isRateLimited(ip)) {
     return new Response(
       JSON.stringify({ error: "Too many requests. Please try again later." }),
       {
         status: 429,
         headers: {
           "Content-Type": "application/json",
-          "Retry-After": "60",
+          "Retry-After": String(API_RATE_WINDOW_S),
           "Access-Control-Allow-Origin": url.origin,
           "Access-Control-Allow-Credentials": "true",
         },


### PR DESCRIPTION
## Fix: Replace In-Memory Rate Limiter with Distributed Redis KV

### Problem
The Edge middleware rate limiter used an in-memory `Map` (`ipRateMap`) to track request counts per IP. Because Vercel Edge runs across isolated global nodes, this map is never shared — each node starts with an empty counter. A client hitting different Edge nodes (or newly spun-up instances) could trivially exceed the 60 req/min limit without ever being blocked.

### Fix
Replaced the in-memory `Map` with `@vercel/kv` (Redis), giving all Edge nodes a single shared counter.

**Before:**
```js
const ipRateMap = new Map();
// per-process, invisible to every other Edge node
```

**After:**
```js
import { kv } from "@vercel/kv";

const count = await kv.incr(key);   // atomic, globally consistent
if (count === 1) await kv.expire(key, API_RATE_WINDOW_S);
```

fixes #6510 

`INCR` is atomic — no race conditions under concurrent requests. Redis TTL replaces the manual `evictStale()` loop.

### Changes
- `middleware.js` — swap `Map` + eviction logic for `kv.incr` / `kv.expire`; mark `isRateLimited` async
- Rate limit (60 req/min) and all response shapes are unchanged

### Setup Required
```bash
npm install @vercel/kv
npx vercel kv create <store-name>   # sets KV_REST_API_URL + KV_REST_API_TOKEN
npx vercel env pull                 # pull env for local dev
```

### Type of Change
- [x] Bug fix (restores rate limiting to actually work in a distributed Edge environment)

opened this PR as a GSSoC'26 contributor