### PR TITLE
fix(auth): prevent user recreation from JWT claims in authentication middleware

### DIFF
--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -44,43 +44,31 @@ export const verifyAuth = (handler) => {
       return res.status(401).set(corsHeaders).json({ error: "Unauthorized: Invalid token" });
     }
 
-    // 3. Verify the user referenced by the JWT still exists in the user store.
-    //
-    //    CONTEXT: user records are held in a module-scoped in-memory Map that
-    //    resets on every serverless cold start. A JWT issued before a cold start
-    //    is still cryptographically valid (signature + expiry check pass), but
-    //    the user it references no longer exists in the current instance. Without
-    //    this check, protected endpoints would accept the orphaned token and then
-    //    fail later with confusing errors when they try to look up the user.
-    //
-    //    This check is intentionally lightweight: it only confirms the user
-    //    record is present in the current process. It does NOT replace a
-    //    persistent database — that architectural fix is tracked separately.
-    //    If the users Map is empty (cold start) this returns 401 with a clear
-    //    message so the client can prompt re-authentication.
-    const userEmail = decoded?.email;
+    // 3. Verify the user referenced by the JWT still exists and is active.
+    // Never reconstruct users from token claims; revocation must be honored.
     const userId = decoded?.id;
+    const normalizedEmail = typeof decoded?.email === "string" ? decoded.email.toLowerCase() : null;
 
-    if (userEmail || userId) {
-      const userExists = userEmail
-        ? users.has(userEmail.toLowerCase())
-        : usersById.has(userId);
+    if (!userId && !normalizedEmail) {
+      return res
+        .status(401)
+        .set(corsHeaders)
+        .json({ error: "Unauthorized: Invalid token payload" });
+    }
 
-      if (!userExists) {
-        // Issue #6342: Reconstruct the ephemeral user from the trusted token claims
-        // so that cold starts or multi-instance scaling don't invalidate existing,
-        // cryptographically valid sessions.
-        const reconstructedUser = {
-          id: decoded.id,
-          email: decoded.email,
-          username: decoded.username || decoded.email,
-          roles: decoded.roles || ["USER"],
-          permissions: [], // Permissions will be computed dynamically anyway
-          isActive: true
-        };
-        users.set(decoded.email.toLowerCase(), reconstructedUser);
-        usersById.set(decoded.id, reconstructedUser);
-      }
+    let user = null;
+    if (userId && usersById.has(userId)) {
+      user = usersById.get(userId);
+    } else if (normalizedEmail && users.has(normalizedEmail)) {
+      user = users.get(normalizedEmail);
+    }
+
+    if (!user) {
+      return res.status(401).set(corsHeaders).json({ error: "Unauthorized: User not found" });
+    }
+
+    if (user.isActive === false) {
+      return res.status(401).set(corsHeaders).json({ error: "Unauthorized: User inactive" });
     }
 
     req.user = decoded;

--- a/tests/authMiddleware.test.mjs
+++ b/tests/authMiddleware.test.mjs
@@ -1,0 +1,140 @@
+import "./helpers/authTestEnv.mjs";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+import { verifyAuth } from "../api/middleware/auth.js";
+import { getJwtSecret } from "../api/auth/jwt-config.js";
+import { users, usersById, usersByUsername } from "../api/auth/signup.js";
+import { AUTH_TEST_ALLOWED_ORIGIN } from "./helpers/authTestEnv.mjs";
+
+const makeToken = (payload) => jwt.sign(payload, getJwtSecret(), { expiresIn: "1h" });
+
+const createRequest = (token) => ({
+  method: "GET",
+  headers: {
+    authorization: `Bearer ${token}`,
+    origin: AUTH_TEST_ALLOWED_ORIGIN,
+  },
+  cookies: {},
+});
+
+const createResponse = () => ({
+  statusCode: 200,
+  body: null,
+  headers: {},
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  set(key, value) {
+    if (typeof key === "object") {
+      Object.assign(this.headers, key);
+    } else {
+      this.headers[key] = value;
+    }
+    return this;
+  },
+  json(body) {
+    this.body = body;
+    return this;
+  },
+});
+
+const protectedHandler = verifyAuth(async (req, res) => {
+  return res.status(200).json({ ok: true, userId: req.user.id });
+});
+
+const resetUserStores = () => {
+  users.clear();
+  usersById.clear();
+  usersByUsername.clear();
+};
+
+const seedUser = ({ id, email, isActive = true }) => {
+  const user = {
+    id,
+    email,
+    username: email,
+    roles: ["USER"],
+    permissions: [],
+    isActive,
+  };
+
+  users.set(email.toLowerCase(), user);
+  usersById.set(id, user);
+  usersByUsername.set(email.toLowerCase(), user);
+
+  return user;
+};
+
+resetUserStores();
+
+// Baseline: active users with valid token can access protected endpoints.
+{
+  const user = seedUser({ id: "active-user", email: "active@example.com", isActive: true });
+  const token = makeToken({ id: user.id, email: user.email, roles: user.roles });
+  const req = createRequest(token);
+  const res = createResponse();
+
+  await protectedHandler(req, res);
+
+  assert.equal(res.statusCode, 200, "Active user should be authorized");
+  assert.equal(res.body?.ok, true);
+}
+
+// Deleted user: a previously valid token must now be rejected.
+{
+  const user = seedUser({ id: "deleted-user", email: "deleted@example.com", isActive: true });
+  const token = makeToken({ id: user.id, email: user.email, roles: user.roles });
+
+  users.delete(user.email.toLowerCase());
+  usersById.delete(user.id);
+  usersByUsername.delete(user.email.toLowerCase());
+
+  const req = createRequest(token);
+  const res = createResponse();
+  await protectedHandler(req, res);
+
+  assert.equal(res.statusCode, 401, "Deleted user token must be rejected");
+  assert.equal(res.body?.error, "Unauthorized: User not found");
+  assert.equal(
+    users.has(user.email.toLowerCase()),
+    false,
+    "Middleware must not recreate deleted users"
+  );
+  assert.equal(usersById.has(user.id), false, "Deleted user ID must remain absent");
+}
+
+// Inactive user: valid token cannot bypass account suspension.
+{
+  const user = seedUser({ id: "inactive-user", email: "inactive@example.com", isActive: false });
+  const token = makeToken({ id: user.id, email: user.email, roles: user.roles });
+
+  const req = createRequest(token);
+  const res = createResponse();
+  await protectedHandler(req, res);
+
+  assert.equal(res.statusCode, 401, "Inactive user token must be rejected");
+  assert.equal(res.body?.error, "Unauthorized: User inactive");
+}
+
+// Cold start: empty in-memory stores must not accept orphaned tokens.
+{
+  resetUserStores();
+
+  const token = makeToken({
+    id: "cold-start-user",
+    email: "coldstart@example.com",
+    roles: ["USER"],
+  });
+
+  const req = createRequest(token);
+  const res = createResponse();
+  await protectedHandler(req, res);
+
+  assert.equal(res.statusCode, 401, "Cold-start orphaned token must be rejected");
+  assert.equal(res.body?.error, "Unauthorized: User not found");
+  assert.equal(users.size, 0, "Middleware must not reconstruct users during cold start");
+}
+
+resetUserStores();
+console.log("authMiddleware tests passed.");


### PR DESCRIPTION
## Description

This PR fixes an authentication security issue where the middleware would automatically reconstruct a user from JWT claims when the corresponding user record was not found in the active user store.

### Changes made

- Removed JWT-claim-based user reconstruction from the authentication middleware.
- Enforced strict user validation using the current user store.
- Added `401 Unauthorized` responses for:

  - Missing users
  - Inactive users
  - Malformed token payloads
- Added regression tests covering:

  - Valid active user authentication
  - Deleted user scenarios
  - Inactive user scenarios
  - Cold-start/empty-store scenarios

This ensures that deleted, deactivated, or revoked accounts cannot regain access through stale JWT claims and that authorization decisions are based on the current account state.

Fixes #6548 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
Not applicable 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
