### PR TITLE
Fix floating promise in MyEventsContext — add .catch() to dynamic import

### DIFF
--- a/src/context/MyEventsContext.js
+++ b/src/context/MyEventsContext.js
@@ -177,7 +177,7 @@ export const MyEventsProvider = ({ children }) => {
     // Trigger automatic promotion from the waitlist
     import("../utils/waitlistUtils.js").then(({ promoteNextUser }) => {
       promoteNextUser(eventId);
-    });
+    }).catch(() => {});
   }, []);
 
   /**


### PR DESCRIPTION
Fixes #6423

The dynamic import().then() for waitlistUtils.promoteNextUser was missing a .catch() handler. If the import fails, the floating promise would cause an unhandled promise rejection.