### PR TITLE
Fix floating promise in AdminDashboard — add .catch() to dynamic import

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -132,7 +132,7 @@ const AdminDashboard = () => {
   const loadWaitlist = useCallback((eventId) => {
     import("../../utils/waitlistUtils.js").then(({ getEventWaitlist }) => {
       setWaitlistUsers(getEventWaitlist(eventId));
-    });
+    }).catch(() => setWaitlistUsers([]));
   }, []);
 
   const openWaitlistModal = (event) => {


### PR DESCRIPTION
Fixes #6422

The dynamic import().then() for waitlistUtils.getEventWaitlist was missing a .catch() handler. If the import fails, the floating promise would cause an unhandled promise rejection.