### PR TITLE
Fix floating promises in EventDetailsPage — add .catch() to dynamic imports

### DIFF
--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -35,7 +35,7 @@ const EventDetailsPage = () => {
     if (userId && event) {
       import("../../utils/waitlistUtils").then(({ getQueuePosition }) => {
         setQueuePosition(getQueuePosition(event.id, userId));
-      });
+      }).catch(() => setQueuePosition(-1));
     } else {
       setQueuePosition(-1);
     }
@@ -45,7 +45,7 @@ const EventDetailsPage = () => {
     if (event) {
       import("../../utils/waitlistUtils").then(({ getEventWaitlist }) => {
         setWaitlistCount(getEventWaitlist(event.id).length);
-      });
+      }).catch(() => setWaitlistCount(0));
     }
   }, [event, waitlistUpdated]);
 


### PR DESCRIPTION
Fixes #6421

Two dynamic import().then() calls for waitlistUtils were missing .catch() handlers. If the imports fail, the floating promises would cause unhandled promise rejections.