### PR TITLE
Fix floating promises in EventsTab — add .catch() to dynamic imports

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -236,7 +236,7 @@ const WaitlistCard = ({ event, index, onLeaveWaitlist }) => {
     if (user) {
       import("../../utils/waitlistUtils").then(({ getQueuePosition }) => {
         setQueuePos(getQueuePosition(event.id, user.id || user.email));
-      });
+      }).catch(() => setQueuePos(-1));
     }
   }, [event.id, user]);
 
@@ -319,8 +319,8 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
             };
           });
           setWaitlistEvents(resolved);
-        });
-      });
+        }).catch(() => setWaitlistEvents([]));
+      }).catch(() => setWaitlistEvents([]));
     } else {
       setWaitlistEvents([]);
     }


### PR DESCRIPTION
Fixes #6420

Three dynamic import().then() calls for waitlistUtils were missing .catch() handlers. If the imports fail, the floating promises would cause unhandled promise rejections.