### PR TITLE
docs: add hackathon creation API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1090,6 +1090,8 @@ Status: `200 OK`
 
 # Hackathon APIs
 
+*This documentation corresponds to the backend Hackathon API updates.*
+
 ## List Hackathons
 
 | Method | Endpoint |
@@ -1175,6 +1177,76 @@ GET /api/hackathons/1
   "timestamp": "2026-06-02T02:41:32.8274901"
 }
 ```
+
+## Create Hackathon
+
+| Method | Endpoint |
+|--------|----------|
+| POST | `/api/hackathons` |
+
+Creates a new hackathon. Restricted to authorized roles: `ORGANIZER`, `ADMIN`, `SUPER_ADMIN`.
+
+### Authentication
+Protected endpoint. Requires Bearer JWT authentication.
+
+### Request Headers
+
+```bash
+Authorization: Bearer YOUR_JWT_TOKEN
+Content-Type: application/json
+```
+
+### Request Body
+
+```json
+{
+  "title": "CodeSprint 2026",
+  "description": "A beginner-friendly hackathon for building full-stack projects.",
+  "organizer": "Eventra Team",
+  "startDate": "2026-07-10T00:00:00",
+  "endDate": "2026-07-12T00:00:00",
+  "location": "Bhopal",
+  "mode": "Offline",
+  "prizePool": "50000",
+  "registrationDeadline": "2026-07-05T00:00:00",
+  "imageUrl": "https://example.com/hackathon.png"
+}
+```
+
+- `title`: required
+- `description`: required
+- `organizer`: required
+- `startDate`: required
+- `endDate`: required
+- `location`: required
+- `mode`: required
+- `registrationDeadline`: required
+- `prizePool`: optional
+- `imageUrl`: optional
+
+### Successful Response (201)
+
+```json
+{
+  "id": 1,
+  "title": "CodeSprint 2026",
+  "description": "A beginner-friendly hackathon for building full-stack projects.",
+  "organizer": "Eventra Team",
+  "startDate": "2026-07-10T00:00:00",
+  "endDate": "2026-07-12T00:00:00",
+  "location": "Bhopal",
+  "mode": "Offline",
+  "prizePool": "50000",
+  "registrationDeadline": "2026-07-05T00:00:00",
+  "imageUrl": "https://example.com/hackathon.png"
+}
+```
+
+### Error Responses
+
+- **400 Bad Request**: Validation errors for invalid payloads.
+- **401 Unauthorized**: JWT is missing or invalid.
+- **403 Forbidden**: Authenticated user does not have the required role (`ORGANIZER`, `ADMIN`, or `SUPER_ADMIN`).
 
 ---
 


### PR DESCRIPTION
## Description

This PR updates the API documentation to include the newly implemented hackathon creation endpoint.

The documented endpoint allows authorized users to create hackathon records through the backend API.

## Changes Made

* Documented `POST /api/hackathons`
* Added Bearer JWT authentication requirement
* Added role-based authorization notes for `ORGANIZER`, `ADMIN`, and `SUPER_ADMIN`
* Added request body example
* Added `201 Created` success response example
* Added validation and auth-related error notes
* Kept the existing hackathon list/detail documentation unchanged

## Related Backend Work

The backend Hackathon module has been expanded with:

* `GET /api/hackathons`
* `GET /api/hackathons/{id}`
* `POST /api/hackathons`

The create endpoint includes:

* `HackathonCreateRequest` DTO with validation
* Service-layer creation logic
* Role-protected controller endpoint
* Reuse of `HackathonResponse`
* Controller tests for success, unauthenticated access, forbidden access, and validation failures

## CI / Test Fixes Logged

While working on the backend API flow, the following backend CI/build blockers were also identified and handled separately:

* Fixed a pre-existing Analytics service compile issue that blocked Maven compilation
* Added the missing `@ActiveProfiles("test")` annotation to `EventStreamTests`
* Verified the full backend test suite locally with `77 tests run, 0 failures`
* Identified CI workflow env issues where production datasource variables were overriding H2 test configuration
* Updated backend CI workflow configuration separately so Maven tests can use H2 and the required `JWT_SECRET`

## Notes

This PR only updates frontend/docs API documentation. It does not modify frontend UI behavior or backend implementation code.

Related backend implementations:
 SandeepVashishtha/Eventra-Backend#56
 SandeepVashishtha/Eventra-Backend#54
 SandeepVashishtha/Eventra-Backend#53
 SandeepVashishtha/Eventra-Backend#55
