### PR TITLE
perf: batch IndexedDB put operations in setQueue

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -432,15 +432,10 @@ export const setQueue = async (newQueue) => {
           return;
         }
 
-        let completed = 0;
-        newQueue.forEach((item) => {
-          const putReq = store.put(item);
-          putReq.onsuccess = () => {
-            completed++;
-            if (completed === newQueue.length) resolve();
-          };
-          putReq.onerror = () => reject(putReq.error);
-        });
+        newQueue.forEach((item) => store.put(item));
+
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
       };
       clearReq.onerror = () => reject(clearReq.error);
     });


### PR DESCRIPTION
## Summary
Replaced per-item IndexedDB put() callbacks with a single transaction-level completion handler, reducing N+1 round-trips to a single batch commit.

## Changes
- Removed per-item onsuccess/onerror tracking in setQueue
- Resolve on transaction.oncomplete after calling put() for all items

Closes #6564