### PR TITLE
perf: cache event tags in recommendationEngine to avoid redundant computation

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -61,6 +61,19 @@ const getPopularityScore = (event) => {
   return Math.min((attendees / capacity) * 10, 10);
 };
 
+const _tagCache = new Map();
+
+const _getCachedTags = (event) => {
+  const id = getEventId(event);
+  if (!id) return [];
+  if (_tagCache.has(id)) return _tagCache.get(id);
+  const tags = getEventTags(event);
+  _tagCache.set(id, tags);
+  return tags;
+};
+
+const clearTagCache = () => _tagCache.clear();
+
 const getSimilarityScore = (candidate, interactedEvents) => {
   if (!interactedEvents.length) return 0;
 
@@ -80,7 +93,7 @@ const getSimilarityScore = (candidate, interactedEvents) => {
       score += 5;
     }
 
-    const overlap = getEventTags(event).filter((tag) => candidateTags.has(tag));
+    const overlap = _getCachedTags(event).filter((tag) => candidateTags.has(tag));
     score += Math.min(overlap.length * 3, 12);
 
     return Math.max(bestScore, score);
@@ -270,6 +283,7 @@ export const buildPersonalizedRecommendations = ({
   includeInteracted = false,
   limit = 8,
 } = {}) => {
+  clearTagCache();
   const interactionProfile = buildInteractionProfile({
     registeredEvents,
     bookmarkedEvents,


### PR DESCRIPTION
## Summary
Added a tag cache to avoid recomputing getEventTags() N*M times during recommendation scoring.

## Changes
- Added _tagCache Map that caches getEventTags results per event ID
- Added clearTagCache() called at the start of buildPersonalizedRecommendations
- getSimilarityScore now uses _getCachedTags() instead of getEventTags()
- Reduces string operations from (N candidates) * (M interacted events) to N + M

Closes #6567