### PR TITLE
devops: merge lint, typecheck, and test into single CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   NODE_VERSION: "22.x"
 
 jobs:
-  lint:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,36 +26,14 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
-
-  typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
       - name: TypeScript check
         run: npx tsc --noEmit --allowJs
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
       - name: Unit tests
         run: npm test 2>&1
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [validate]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Merged lint, typecheck, and test into a single 'validate' job to eliminate redundant npm ci runs.

## Changes
- Combined 3 separate jobs (lint, typecheck, test) into one 'validate' job
- npm ci now runs once instead of 3 times for validation steps
- Build job depends on the single validate job

Closes #6568