### PR TITLE
Fix/sensitive data securestorage

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -1,3 +1,30 @@
+/**
+ * @file useEventRegistration.js
+ * @module hooks/useEventRegistration
+ *
+ * @description
+ * Custom React hook that encapsulates the full event-registration lifecycle.
+ *
+ * Responsibilities:
+ * - Fetches event details from the backend API, with a three-tier fallback:
+ *     1. Live API response (saved to offline cache on success).
+ *     2. Offline cache (`offlineEventCache`) when the network request fails.
+ *     3. Bundled mock data (`hackathonMockData.json`) for hackathon paths
+ *        (`/register/*`) or as a last resort.
+ * - Pre-fills `fullName` and `email` from the authenticated user's profile.
+ * - Validates the registration form via `useFormValidation` (300 ms debounce).
+ * - Detects scheduling conflicts against the user's existing registrations
+ *   and opens a conflict-resolution modal when one is found.
+ * - Checks live event capacity immediately before submission and routes the
+ *   request to the waitlist endpoint when the event is full.
+ * - Uses a module-level `Map` lock (`registrationLocks`) and a ref
+ *   (`isSubmittingRef`) to guard against duplicate concurrent submissions.
+ * - Falls back to an offline queue (`offlineQueue`) when a network/timeout
+ *   error is detected, so the registration syncs automatically once
+ *   connectivity is restored.
+ * - Clears the session-recovery context (`useSessionRecovery`) after a
+ *   successful or already-registered response.
+ */
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { toast } from "react-toastify";
@@ -24,6 +51,25 @@ const MAX_NOTES_CHARS = 500;
 // Registration lock map to prevent concurrent registrations for the same event
 const registrationLocks = new Map();
 
+/**
+ * Derives a user-facing error message from a failed registration API response.
+ *
+ * Priority order:
+ * 1. HTTP 409 with "already registered" / "duplicate" body  → already-registered copy.
+ * 2. HTTP 409 / 423, or body mentioning capacity keywords   → capacity-full copy.
+ * 3. Body mentioning "conflict"                             → server-conflict copy.
+ * 4. Any other non-empty message from the response body     → returned as-is.
+ * 5. Fallback generic copy.
+ *
+ * @private
+ * @param {Object} error - The caught error object, typically from `apiUtils`.
+ * @param {number}  [error.status]        - HTTP status code.
+ * @param {Object}  [error.data]          - Parsed response body.
+ * @param {string}  [error.data.message]  - Message field from the body.
+ * @param {string}  [error.data.error]    - Error field from the body.
+ * @param {string}  [error.message]       - JS Error message (network errors).
+ * @returns {string} A localised, human-readable failure message.
+ */
 const getRegistrationFailureMessage = (error) => {
   const message = error?.data?.message || error?.data?.error || error?.message || "";
   const normalizedMessage = message.toLowerCase();
@@ -47,6 +93,210 @@ const getRegistrationFailureMessage = (error) => {
   return message || "Registration failed. Please try again.";
 };
 
+/**
+ * Manages the complete event-registration flow for a single event page.
+ *
+ * The hook resolves the target event ID from three sources (in priority order):
+ * 1. The `eventIdParam` argument passed directly by the parent component.
+ * 2. The `:eventId` URL segment exposed by React Router.
+ * 3. The `:id` URL segment (legacy route shape).
+ *
+ * @param {string|number} [eventIdParam] - Optional event ID supplied directly
+ *   by the consuming component. When omitted the hook reads the ID from the
+ *   current URL via `useParams()`.
+ *
+ * @returns {{
+ *   event:                  Object|null,
+ *   loading:                boolean,
+ *   submitting:             boolean,
+ *   registered:             boolean,
+ *   isEventFull:            boolean,
+ *   isPastEvent:            boolean,
+ *   formData:               Object,
+ *   errors:                 Object,
+ *   touched:                Object,
+ *   isFormValid:            boolean,
+ *   handleChange:           Function,
+ *   handleBlur:             Function,
+ *   validateAll:            Function,
+ *   setValues:              Function,
+ *   showConflictModal:      boolean,
+ *   conflictData:           { conflicts: Array, suggestions: Array },
+ *   handleSubmit:           Function,
+ *   handleConflictCancel:   Function,
+ *   handleConflictProceed:  Function,
+ *   handleSelectAlternative:Function,
+ *   myEvents:               Array,
+ * }} An object containing event data, form state, and all event handlers
+ *   needed to render a registration page.
+ *
+ * @property {Object|null} event
+ *   The loaded event object, or `null` while the initial fetch is in flight.
+ *   On API failure the object may contain a `cacheInfo` sub-object
+ *   (`{ cachedAt: number, label: string }`) indicating that stale cached
+ *   data is being displayed.
+ *
+ * @property {boolean} loading
+ *   `true` while the initial event fetch is in progress; `false` once data
+ *   (live, cached, or mock) has been applied.
+ *
+ * @property {boolean} submitting
+ *   `true` between the moment the user confirms submission and the moment
+ *   the API call (or offline-queue push) resolves. Use to disable the submit
+ *   button and show a loading indicator.
+ *
+ * @property {boolean} registered
+ *   Becomes `true` after a successful registration, a successful waitlist
+ *   join, an already-registered 409 response, or a successful offline-queue
+ *   push. Use to render a success / confirmation view.
+ *
+ * @property {boolean} isEventFull
+ *   `true` when `event.attendees >= event.maxAttendees`. Submission is still
+ *   permitted; the user will be placed on the waitlist automatically.
+ *
+ * @property {boolean} isPastEvent
+ *   `true` when `getEventStatus(event)` returns `"past"` or `"ended"`.
+ *   Consumers should disable registration and surface an appropriate message.
+ *
+ * @property {Object} formData
+ *   Controlled form values managed by `useFormValidation`:
+ *   - `fullName`       {string} – pre-filled from `user.fullName` when authenticated.
+ *   - `email`          {string} – pre-filled from `user.email` when authenticated.
+ *   - `phone`          {string}
+ *   - `organization`   {string}
+ *   - `designation`    {string}
+ *   - `additionalInfo` {string} – capped at `MAX_NOTES_CHARS` (500) characters.
+ *   - `priority`       {string} – defaults to `"Medium"`.
+ *
+ * @property {Object} errors
+ *   Field-level validation error messages keyed by field name. A key is
+ *   present only when the field has a validation error (string value).
+ *
+ * @property {Object} touched
+ *   Boolean flags keyed by field name; `true` once the field has been
+ *   blurred. Use to conditionally show inline error messages.
+ *
+ * @property {boolean} isFormValid
+ *   `true` when all required fields (`fullName`, `email`, `phone`) pass
+ *   their validation rules and no errors are present.
+ *
+ * @property {Function} handleChange
+ *   `(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void`
+ *   Standard controlled-input onChange handler; updates `formData` and
+ *   triggers debounced field-level validation (300 ms).
+ *
+ * @property {Function} handleBlur
+ *   `(e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void`
+ *   Marks a field as touched and runs immediate validation on blur.
+ *
+ * @property {Function} validateAll
+ *   `() => boolean` – Triggers validation for all fields at once and returns
+ *   `true` if the form is valid. Called internally by `handleSubmit`.
+ *
+ * @property {Function} setValues
+ *   `(updater: Object | ((prev: Object) => Object)) => void`
+ *   Directly sets all form values. Use sparingly (e.g. "reset form").
+ *
+ * @property {boolean} showConflictModal
+ *   `true` when a scheduling conflict with an existing registration has been
+ *   detected. Consumers should render a conflict-resolution modal.
+ *
+ * @property {{ conflicts: Array, suggestions: Array }} conflictData
+ *   Populated when `showConflictModal` is `true`.
+ *   - `conflicts`   – Array of conflicting event objects from `myEvents`.
+ *   - `suggestions` – Alternative events without a schedule clash, fetched
+ *     from the live events list. May be empty when the fetch fails.
+ *
+ * @property {Function} handleSubmit
+ *   `(e: React.FormEvent) => Promise<void>` – Main form-submit handler.
+ *   Steps performed:
+ *   1. Guards against unauthenticated users (redirects to `/login`).
+ *   2. Runs `validateAll()`; aborts with a toast on failure.
+ *   3. Guards against duplicate in-flight submissions (ref + lock map).
+ *   4. Fetches fresh capacity data and informs the user if the event is full.
+ *   5. Checks for scheduling conflicts; opens the conflict modal if found.
+ *   6. Calls `proceedWithRegistration()`.
+ *
+ * @property {Function} handleConflictCancel
+ *   `() => void` – Closes the conflict modal and cancels registration.
+ *   Shows an informational toast.
+ *
+ * @property {Function} handleConflictProceed
+ *   `() => void` – Closes the conflict modal and proceeds with registration
+ *   despite the detected conflict. Delegates to `proceedWithRegistration()`.
+ *
+ * @property {Function} handleSelectAlternative
+ *   `(alternativeEvent: Object) => void` – Closes the conflict modal and
+ *   navigates the user to the registration page for the chosen alternative
+ *   event (`/events/:id/register`).
+ *
+ * @property {Array} myEvents
+ *   The current user's existing registrations, sourced from
+ *   `MyEventsContext`. Used internally for conflict detection and exposed for
+ *   consumers that need to display the user's schedule alongside the form.
+ *
+ * @example
+ * // Basic usage inside a registration page component
+ * import useEventRegistration from "hooks/useEventRegistration";
+ * import ConflictModal from "components/ConflictModal";
+ *
+ * function EventRegistrationPage() {
+ *   const {
+ *     event,
+ *     loading,
+ *     submitting,
+ *     registered,
+ *     isEventFull,
+ *     isPastEvent,
+ *     formData,
+ *     errors,
+ *     touched,
+ *     isFormValid,
+ *     handleChange,
+ *     handleBlur,
+ *     handleSubmit,
+ *     showConflictModal,
+ *     conflictData,
+ *     handleConflictCancel,
+ *     handleConflictProceed,
+ *     handleSelectAlternative,
+ *   } = useEventRegistration(); // reads eventId from the URL automatically
+ *
+ *   if (loading) return <Spinner />;
+ *   if (!event) return <NotFound />;
+ *   if (registered) return <SuccessView isWaitlist={isEventFull} />;
+ *
+ *   return (
+ *     <>
+ *       <form onSubmit={handleSubmit}>
+ *         <input
+ *           name="fullName"
+ *           value={formData.fullName}
+ *           onChange={handleChange}
+ *           onBlur={handleBlur}
+ *         />
+ *         {touched.fullName && errors.fullName && (
+ *           <span>{errors.fullName}</span>
+ *         )}
+ *
+ *         <button type="submit" disabled={submitting || isPastEvent}>
+ *           {isEventFull ? "Join Waitlist" : "Register"}
+ *         </button>
+ *       </form>
+ *
+ *       {showConflictModal && (
+ *         <ConflictModal
+ *           conflicts={conflictData.conflicts}
+ *           suggestions={conflictData.suggestions}
+ *           onCancel={handleConflictCancel}
+ *           onProceed={handleConflictProceed}
+ *           onSelectAlternative={handleSelectAlternative}
+ *         />
+ *       )}
+ *     </>
+ *   );
+ * }
+ */
 const useEventRegistration = (eventIdParam) => {
   const { eventId: routeEventId, id: routeId } = useParams();
   const eventId = eventIdParam || routeEventId || routeId;
@@ -215,7 +465,7 @@ const useEventRegistration = (eventIdParam) => {
 
   const checkAndHandleConflicts = useCallback(async () => {
     if (!event) return false;
-    
+
     const conflictCheck = checkRegistrationConflict(event, myEvents);
     if (conflictCheck.hasConflict) {
       try {

--- a/src/hooks/useReducedMotion.js
+++ b/src/hooks/useReducedMotion.js
@@ -1,5 +1,78 @@
+/**
+ * @file useReducedMotion.js
+ * @module hooks/useReducedMotion
+ *
+ * @description
+ * Custom React hook that reads and reactively tracks the user's
+ * `prefers-reduced-motion` accessibility preference via the
+ * CSS Media Queries Level 5 API.
+ *
+ * The hook is safe to use in server-side rendering (SSR) environments:
+ * it guards every access to `window` and `window.matchMedia` with
+ * `typeof` checks, so it will not throw during Node.js / SSR execution.
+ * In those environments the initial value defaults to `false` (motion
+ * permitted), which is the least-surprising behaviour for a server render.
+ */
 import { useEffect, useState } from "react";
 
+/**
+ * Detects whether the user has requested reduced motion at the OS or
+ * browser level, and re-renders the consuming component automatically
+ * whenever that preference changes at runtime.
+ *
+ * Internally the hook evaluates the CSS media feature
+ * `(prefers-reduced-motion: reduce)` using `window.matchMedia`. The
+ * initial state is resolved synchronously inside the `useState` lazy
+ * initialiser — avoiding a one-frame flash of un-reduced motion on
+ * first render. A `change` event listener is then attached for the
+ * lifetime of the component so that the returned value stays in sync
+ * if the user updates their system preference while the page is open.
+ *
+ * **SSR / non-browser environments**
+ * When `window` or `window.matchMedia` is unavailable the hook returns
+ * `false` (motion permitted) and skips attaching the event listener.
+ * No warnings or errors are produced.
+ *
+ * **Accessibility note**
+ * The [WCAG 2.1 Success Criterion 2.3.3 (Animation from Interactions)](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html)
+ * recommends disabling non-essential motion when this preference is set.
+ * Use the returned flag to conditionally suppress animations, transitions,
+ * parallax effects, and auto-playing carousels.
+ *
+ * @returns {boolean} `true` when the user's current system setting maps to
+ *   `prefers-reduced-motion: reduce`; `false` when the media feature does
+ *   not match or when `window.matchMedia` is unavailable (SSR, old browsers).
+ *
+ * @example
+ * // Conditionally apply a CSS transition based on user preference
+ * import { useReducedMotion } from "hooks/useReducedMotion";
+ *
+ * function AnimatedBanner() {
+ *   const prefersReduced = useReducedMotion();
+ *
+ *   return (
+ *     <div
+ *       style={{
+ *         transition: prefersReduced ? "none" : "transform 0.4s ease",
+ *         transform: isVisible ? "translateY(0)" : "translateY(-20px)",
+ *       }}
+ *     >
+ *       Welcome!
+ *     </div>
+ *   );
+ * }
+ *
+ * @example
+ * // Choose between a motion variant and a static variant of a component
+ * import { useReducedMotion } from "hooks/useReducedMotion";
+ * import MotionCard from "components/MotionCard";
+ * import StaticCard from "components/StaticCard";
+ *
+ * function Card(props) {
+ *   const prefersReduced = useReducedMotion();
+ *   return prefersReduced ? <StaticCard {...props} /> : <MotionCard {...props} />;
+ * }
+ */
 export function useReducedMotion() {
   const [prefersReduced, setPrefersReduced] = useState(() =>
     typeof window !== "undefined" &&

--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -1,4 +1,33 @@
 /* eslint-disable-next-line no-console */
+/**
+ * @file secureStorage.js
+ * @module utils/secureStorage
+ *
+ * @description
+ * AES-GCM encrypted localStorage wrapper built on the Web Crypto API.
+ *
+ * **Security model**
+ * - The AES-256-GCM key is derived with PBKDF2 (100 000 iterations, SHA-256)
+ *   from two random 256-bit values that are generated once per browser and
+ *   persisted in localStorage. Neither value is derived from any public
+ *   constant such as the origin URL.
+ * - Each write uses a fresh random 12-byte IV, so identical values produce
+ *   different ciphertext on every call (preventing pattern analysis).
+ * - No plaintext is ever written to localStorage. In-flight values (between
+ *   the `setItem` call and encryption completion) are held only in the
+ *   `pendingWrites` in-memory Map.
+ * - If the page is closed before encryption completes the data is not
+ *   persisted — data loss is the intentional tradeoff versus silent plaintext
+ *   exposure.
+ * - If Web Crypto is unavailable (non-HTTPS context, very old browser) the
+ *   module degrades gracefully to unencrypted localStorage and
+ *   `isEncryptionActive()` returns `false`.
+ *
+ * **Migration**
+ * Earlier versions of this module wrote a `key + ':plaintext'` fallback entry
+ * to localStorage before async encryption completed. `cleanupPlaintextFallbacks`
+ * runs automatically at module load to remove any such keys left on disk.
+ */
 // ---------------------------------------------------------------------------
 // AES-GCM Encryption Engine (Web Crypto API)
 // ---------------------------------------------------------------------------
@@ -62,7 +91,7 @@ const getOrCreateSecret = (storageKey) => {
 // Both values are initialised eagerly at module load so every call to
 // getDerivedKey() within a page session operates on the same key.
 const DERIVED_KEY_MATERIAL = getOrCreateSecret(MATERIAL_STORAGE_KEY);
-const DERIVED_KEY_SALT     = getOrCreateSecret(SALT_STORAGE_KEY);
+const DERIVED_KEY_SALT = getOrCreateSecret(SALT_STORAGE_KEY);
 
 let _keyPromise = null;
 
@@ -149,62 +178,102 @@ const cryptoSupported = isCryptoAvailable();
 // Encrypted key-value storage wrapper (localStorage — AES-GCM encrypted)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Legacy plaintext-fallback cleanup
+// ---------------------------------------------------------------------------
+// Previous versions of this module wrote `key + ':plaintext'` to localStorage
+// synchronously before encryption completed so that data would survive a
+// page close. This left sensitive values permanently in plaintext whenever
+// the page was closed during the async encryption window.
+//
+// PLAINTEXT_SUFFIX is kept ONLY so that cleanupPlaintextFallbacks() can
+// identify and remove those legacy keys on load. It must NOT be used for
+// any new localStorage write.
+// ---------------------------------------------------------------------------
 
-// In-memory cache for pending writes to prevent race conditions during async encryption
-const pendingWrites = new Map();
-
-/**
- * syncSecureStorage
- *
- * Encrypts values at rest in localStorage using AES-GCM (256-bit) via the
- * Web Crypto API. Each write generates a random IV so identical values
- * produce different ciphertext every time, preventing pattern analysis.
- *
- * The encryption key is derived per-origin using PBKDF2 — no hardcoded
- * secrets exist in source code.
- *
- * Falls back to plain localStorage when Web Crypto is unavailable
- * (non-HTTPS contexts or very old browsers).
- */
 const PLAINTEXT_SUFFIX = ':plaintext';
 
 /**
- * Write plaintext immediately so data survives tab close, then
- * replace with encrypted version asynchronously. If encryption
- * is not supported or the page closes before it completes, the
- * plaintext fallback is available on next load.
+ * Scans localStorage for keys ending in `':plaintext'` left behind by
+ * the previous write strategy and removes them. Called once at module load.
+ *
+ * This is a one-time migration helper. Once all active clients have loaded
+ * this version at least once, there will be no legacy keys left to clean up.
+ *
+ * @private
+ */
+const cleanupPlaintextFallbacks = () => {
+  try {
+    const toRemove = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.endsWith(PLAINTEXT_SUFFIX)) toRemove.push(k);
+    }
+    toRemove.forEach((k) => localStorage.removeItem(k));
+  } catch {
+    // localStorage unavailable — nothing to clean up
+  }
+};
+
+if (typeof window !== 'undefined') {
+  // Best-effort: errors here must never prevent module load
+  try { cleanupPlaintextFallbacks(); } catch { /* ignore */ }
+}
+
+// In-memory cache for pending writes — the sole mechanism for serving reads
+// that arrive while async encryption is in progress. No plaintext is ever
+// written to localStorage, so this Map is the only in-flight plaintext store.
+const pendingWrites = new Map();
+
+/**
+ * Encrypts `value` and writes the ciphertext to localStorage under `key`.
+ *
+ * When Web Crypto is unavailable the raw value is written directly (the
+ * caller's JSDoc documents this degraded mode explicitly).
+ *
+ * Errors from `encryptValue` are intentionally NOT caught here — they
+ * propagate to `setItem`, which returns `false` so the caller knows the
+ * write did not persist. Silently keeping a plaintext fallback on encryption
+ * failure would undermine the entire security model.
+ *
+ * @private
+ * @param {string} key   - localStorage key.
+ * @param {string} value - Plaintext value to encrypt and store.
+ * @returns {Promise<void>}
  */
 const writeWithEncryption = async (key, value) => {
   if (!cryptoSupported) {
     localStorage.setItem(key, value);
     return;
   }
-  try {
-    const encrypted = await encryptValue(value);
-    localStorage.setItem(key, encrypted);
-    localStorage.removeItem(key + PLAINTEXT_SUFFIX);
-  } catch (err) {
-    console.error('[secureStorage] Encryption failed:', err);
-    // Plaintext is already in the fallback key — keep it
-  }
+  const encrypted = await encryptValue(value);
+  localStorage.setItem(key, encrypted);
 };
 
 export const syncSecureStorage = {
   /**
-   * Stores a value encrypted under the given key.
+   * Encrypts `value` and stores it under `key` in localStorage.
    *
-   * Data is written to localStorage synchronously as a plaintext fallback
-   * before encryption begins. If the page closes before encryption
-   * completes, the plaintext fallback survives. On next load, getItemAsync
-   * prefers the fallback if present.
+   * While encryption is in progress the value is held in the in-memory
+   * `pendingWrites` Map so that concurrent `getItem` / `getItemAsync` calls
+   * within the same page session return the correct value immediately.
    *
-   * @param {string} key
-   * @param {string} value
-   * @returns {Promise<boolean>} true on success, false on storage failure
+   * **No plaintext is written to localStorage at any point.** If the page
+   * is closed or navigated away before encryption completes, the data will
+   * not be persisted — this is an intentional tradeoff: data loss is
+   * preferable to permanent plaintext exposure.
+   *
+   * When Web Crypto is unavailable (non-HTTPS / legacy browser) the raw
+   * value is stored directly; `isEncryptionActive()` will return `false`
+   * so callers can surface a warning to the user if needed.
+   *
+   * @param {string} key   - localStorage key.
+   * @param {string} value - Plaintext string to encrypt and store.
+   * @returns {Promise<boolean>} `true` on success; `false` when the write
+   *   could not be persisted (localStorage full, encryption error, etc.).
    */
   setItem: async (key, value) => {
     try {
-      localStorage.setItem(key + PLAINTEXT_SUFFIX, value);
       pendingWrites.set(key, value);
       await writeWithEncryption(key, value);
       pendingWrites.delete(key);
@@ -217,20 +286,23 @@ export const syncSecureStorage = {
   },
 
   /**
-   * Returns the raw stored bytes for the key without decrypting.
+   * Returns the raw stored bytes for the given key without decrypting.
    *
-   * For actual values use getItemAsync().
+   * If a write for this key is currently in progress, the pending
+   * plaintext value is returned from the in-memory Map so callers always
+   * see the latest value within a session.
+   *
+   * For decrypted values use `getItemAsync()`.
    *
    * @param {string} key
-   * @returns {string|null}
+   * @returns {string|null} Raw ciphertext string, in-flight plaintext from
+   *   `pendingWrites`, or `null` when the key does not exist.
    */
   getItem: (key) => {
     try {
       if (pendingWrites.has(key)) {
         return pendingWrites.get(key);
       }
-      const fallback = localStorage.getItem(key + PLAINTEXT_SUFFIX);
-      if (fallback !== null) return fallback;
       return localStorage.getItem(key);
     } catch (error) {
       console.error('[secureStorage] getItem failed:', error);
@@ -241,20 +313,25 @@ export const syncSecureStorage = {
   /**
    * Retrieves and decrypts the value stored under the given key.
    *
-   * Falls back to the plaintext fallback (if available) or to the raw
-   * stored value when decryption fails.
+   * Resolution order:
+   * 1. `pendingWrites` Map — returns the in-flight plaintext immediately if
+   *    a `setItem` for this key is still running.
+   * 2. localStorage ciphertext — decrypted with the derived AES-GCM key.
+   *    If decryption fails (e.g. key material was lost between sessions) the
+   *    raw stored string is returned as a best-effort fallback so callers
+   *    can surface an error rather than silently returning `null`.
+   * 3. When Web Crypto is unavailable the raw stored value is returned
+   *    directly (plaintext was written by `setItem` in degraded mode).
    *
    * @param {string} key
-   * @returns {Promise<string|null>}
+   * @returns {Promise<string|null>} Decrypted value, raw fallback, or `null`
+   *   when the key does not exist or an unrecoverable error occurs.
    */
   getItemAsync: async (key) => {
     try {
       if (pendingWrites.has(key)) {
         return pendingWrites.get(key);
       }
-
-      const fallback = localStorage.getItem(key + PLAINTEXT_SUFFIX);
-      if (fallback !== null) return fallback;
 
       const stored = localStorage.getItem(key);
       if (stored === null) return null;
@@ -275,7 +352,12 @@ export const syncSecureStorage = {
   },
 
   /**
-   * Removes the encrypted blob stored under the given key.
+   * Removes the value stored under the given key.
+   *
+   * Also removes the legacy `key + ':plaintext'` entry if one exists on
+   * disk from a previous version of this module, ensuring no stale
+   * plaintext survives a targeted delete.
+   *
    * @param {string} key
    */
   removeItem: (key) => {


### PR DESCRIPTION
## Description

Fixes a security vulnerability in `syncSecureStorage` where sensitive data was permanently written to localStorage in plaintext under conditions the implementation was designed to prevent.

**Root cause:** `setItem` wrote `localStorage.setItem(key + ':plaintext', value)` synchronously before async AES-GCM encryption began. The `:plaintext` suffix entry was only removed *after* encryption completed. Any page close, tab kill, navigation, or crash during that window left the raw value on disk permanently. The `writeWithEncryption` catch block compounded this by intentionally preserving the plaintext entry on encryption failure. Additionally, both `getItem` and `getItemAsync` unconditionally preferred the `:plaintext` key over the encrypted blob, so even when both existed the encrypted version was never read.

**Changes:**
- `setItem` — removed `localStorage.setItem(key + PLAINTEXT_SUFFIX, value)`. The existing `pendingWrites` Map already serves in-flight reads correctly; the localStorage write was redundant.
- `writeWithEncryption` — removed the `try/catch` that suppressed encryption errors and preserved plaintext as a fallback. Errors now propagate to `setItem`, which returns `false`.
- `getItem` / `getItemAsync` — removed the plaintext-fallback read path. Resolution order is now `pendingWrites` → ciphertext only.
- Added `cleanupPlaintextFallbacks()` — scans localStorage for legacy `:plaintext` keys left by previous versions and removes them. Runs once at module load and is also called implicitly by `removeItem`.
- Added `@file` / `@module` JSDoc with a security model summary and migration note.

**Tradeoff accepted:** If the page is closed before async encryption completes, the data is not persisted. Data loss is the correct tradeoff here over silent permanent plaintext exposure.

Fixes #6436

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

---

## Screenshots / Video (if applicable)

N/A

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports

I am opening this PR as a GSSoC'26 contributor.