### PR TITLE
add JSDoc documentation for useEventForm hook

### DIFF
--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -20,10 +20,244 @@ const MAX_TITLE_LENGTH = 200;
 const DEBOUNCE_DELAY = 1000;
 
 /**
- * useEventForm Hook
- * 
- * Extracts all state and logic for event creation from the EventCreation monolith.
- * Handles form state, validation, draft persistence, and submission.
+ * @hook useEventForm
+ *
+ * @description
+ * Manages all state and business logic for the event-creation form. Extracted
+ * from the EventCreation monolith so the form UI remains a pure presentational
+ * component. Internally orchestrates four distinct concerns:
+ *
+ * **1. Form state**
+ * Initialises from `initialFormData` (see `src/constants/eventDefaults.js`).
+ * Flat fields are updated via `handleInputChange`; nested objects (e.g.
+ * `location.coordinates.lat`) via either dot-notation names in
+ * `handleInputChange` or the explicit `handleNestedChange` helper. Checkbox
+ * inputs are handled automatically via `e.target.checked`.
+ *
+ * **2. Draft persistence**
+ * Drafts are saved to `localStorage` under a user-scoped key
+ * (`<DRAFT_KEY>_<userId>`, falling back to `<DRAFT_KEY>_guest` when
+ * unauthenticated). Saves are debounced by `DEBOUNCE_DELAY` (1 s) to avoid
+ * thrashing storage on every keystroke. `banner` and `bannerPreview` are
+ * intentionally excluded from the draft — File objects cannot be serialised
+ * and must be re-selected after a page reload. On mount (after a 300 ms
+ * delay), the hook checks for an existing draft and surfaces
+ * `showRestoreModal` when one is found; the consumer decides whether to call
+ * `handleRestoreDraft` or `handleDiscardDraft`.
+ *
+ * **3. Validation**
+ * `validateForm` reads from `formDataRef` (a ref kept in sync with state) so
+ * it never captures a stale closure. It populates `errors` with field-level
+ * messages and returns `true` only when the form is fully valid. Constraints
+ * include: title length (3–200 chars), HTTPS-only virtual links, positive
+ * capacity ≤ 100 000, non-negative ticket-tier prices, and date/time ordering
+ * for both single-day and multi-day events.
+ *
+ * **4. Submission**
+ * Delegates to `useFormSubmit`, which handles loading / error / success state.
+ * Before the API call the description is passed through `sanitizeHtml` to
+ * strip unsafe markup. When `API_ENDPOINTS.EVENTS.CREATE` is falsy the hook
+ * falls back to a mock response (useful for local dev without a backend).
+ * The API is expected to return `{ success: true, ... }`; any other shape
+ * throws so `useFormSubmit` can surface the error.
+ *
+ * @requires {AuthContext} useAuth — reads `user.id` to scope the draft key.
+ *
+ * @example
+ * ```jsx
+ * import { useEventForm } from "../hooks/useEventForm";
+ *
+ * const EventCreation = () => {
+ *   const {
+ *     formData,
+ *     errors,
+ *     isSubmitting,
+ *     showRestoreModal,
+ *     handleInputChange,
+ *     handleNestedChange,
+ *     validateForm,
+ *     submitEventForm,
+ *     handleRestoreDraft,
+ *     handleDiscardDraft,
+ *     resetForm,
+ *   } = useEventForm();
+ *
+ *   const onSubmit = async (e) => {
+ *     e.preventDefault();
+ *     if (!validateForm()) return;          // populates errors, returns false
+ *     await submitEventForm(formData);      // handles loading + API call
+ *   };
+ *
+ *   return (
+ *     <>
+ *       {showRestoreModal && (
+ *         <DraftModal
+ *           onRestore={handleRestoreDraft}
+ *           onDiscard={handleDiscardDraft}
+ *         />
+ *       )}
+ *       <form onSubmit={onSubmit}>
+ *         <input
+ *           name="title"
+ *           value={formData.title}
+ *           onChange={handleInputChange}
+ *         />
+ *         {errors.title && <span>{errors.title}</span>}
+ *         {/* …other fields… *\/}
+ *         <button type="submit" disabled={isSubmitting}>
+ *           {isSubmitting ? "Creating…" : "Create Event"}
+ *         </button>
+ *       </form>
+ *     </>
+ *   );
+ * };
+ * ```
+ *
+ * @returns {object} Form interface — see property descriptions below.
+ *
+ * // ── State ──────────────────────────────────────────────────────────────────
+ *
+ * @returns {object}   formData              - Current form values, shaped as
+ *                                            `initialFormData`. Treat as
+ *                                            read-only; mutate only through
+ *                                            the provided handlers.
+ * @returns {Function} setFormData           - Direct state setter. Prefer the
+ *                                            named handlers; use this only for
+ *                                            bulk updates (e.g. resetting
+ *                                            specific fields after an API
+ *                                            error).
+ * @returns {object}   errors                - Field-level validation errors
+ *                                            keyed by field name (e.g.
+ *                                            `errors.title`, `errors.endTime`,
+ *                                            `errors.ticketTier_0_price`).
+ *                                            Empty object when the form is
+ *                                            error-free.
+ * @returns {Function} setErrors             - Direct errors setter. Use to
+ *                                            inject server-side errors returned
+ *                                            after submission.
+ * @returns {string}   newTag                - Current value of the tag input
+ *                                            field (controlled).
+ * @returns {Function} setNewTag             - Setter for `newTag`.
+ * @returns {boolean}  showRestoreModal      - `true` when a saved draft is
+ *                                            detected on mount and the user has
+ *                                            not yet decided whether to restore
+ *                                            or discard it.
+ * @returns {Function} setShowRestoreModal   - Setter for `showRestoreModal`.
+ *                                            Call with `false` to dismiss the
+ *                                            modal programmatically without
+ *                                            taking any draft action.
+ * @returns {boolean}  isUploading           - External upload-in-progress flag.
+ *                                            The hook exposes the setter but
+ *                                            does not set it internally; the
+ *                                            consumer is responsible for
+ *                                            toggling it around image uploads
+ *                                            that go through a separate service.
+ * @returns {Function} setIsUploading        - Setter for `isUploading`.
+ *
+ * // ── Submission state (from useFormSubmit) ──────────────────────────────────
+ *
+ * @returns {boolean}       isSubmitting  - `true` while the create-event API
+ *                                         call is in flight.
+ * @returns {string|null}   submitError   - Error message from the last failed
+ *                                         submission, or `null`.
+ * @returns {boolean}       submitSuccess - `true` after a successful
+ *                                         submission. Reset to `false` on the
+ *                                         next call.
+ * @returns {Function}      submitEventForm - Async function that sanitises the
+ *                                         description, calls the create-event
+ *                                         endpoint, and updates `isSubmitting`
+ *                                         / `submitError` / `submitSuccess`.
+ *                                         Signature: `(formData: object) =>
+ *                                         Promise<void>`.
+ *
+ * // ── Validation ─────────────────────────────────────────────────────────────
+ *
+ * @returns {Function} validateForm - Validates the current form state, updates
+ *                                   `errors`, and returns `true` if valid.
+ *                                   Reads from a ref so it is safe to call
+ *                                   inside async callbacks without stale-
+ *                                   closure concerns. Signature: `() =>
+ *                                   boolean`.
+ *
+ * // ── Form helpers ───────────────────────────────────────────────────────────
+ *
+ * @returns {Function} resetForm         - Resets `formData` to `initialFormData`,
+ *                                        clears `errors`, and removes the
+ *                                        current user's draft from localStorage.
+ * @returns {Function} handleInputChange - Standard `onChange` handler for
+ *                                        `<input>`, `<textarea>`, and
+ *                                        `<select>` elements. Supports
+ *                                        dot-notation `name` attributes for
+ *                                        nested paths up to two levels deep
+ *                                        (e.g. `name="location.city"`,
+ *                                        `name="location.coordinates.lat"`).
+ *                                        Automatically clears the corresponding
+ *                                        `errors` entry on change. Signature:
+ *                                        `(e: ChangeEvent) => void`.
+ * @returns {Function} handleNestedChange - Updates a single field inside a
+ *                                        named sub-object of `formData`.
+ *                                        Clears the parent-level error key.
+ *                                        Signature: `(category: string, field:
+ *                                        string, value: any) => void`.
+ *
+ * // ── Tag management ─────────────────────────────────────────────────────────
+ *
+ * @returns {Function} addTag    - Trims, lowercases, and strips non-alphanumeric
+ *                                characters from `newTag`, then appends it to
+ *                                `formData.tags` if not already present, and
+ *                                resets `newTag` to `""`. No-ops on empty or
+ *                                duplicate values. Signature: `() => void`.
+ * @returns {Function} removeTag - Removes a tag by value from `formData.tags`.
+ *                                Signature: `(tag: string) => void`.
+ *
+ * // ── Ticket tiers ───────────────────────────────────────────────────────────
+ *
+ * @returns {Function} addTicketTier    - Appends a blank tier
+ *                                       `{ id, name, price, capacity,
+ *                                       description }` to
+ *                                       `formData.ticketTiers`. Uses
+ *                                       `Date.now()` as the tier id.
+ *                                       Signature: `() => void`.
+ * @returns {Function} removeTicketTier - Removes the tier at the given index.
+ *                                       Signature: `(index: number) => void`.
+ * @returns {Function} updateTicketTier - Updates a single field on the tier at
+ *                                       `index`. Signature: `(index: number,
+ *                                       field: string, value: any) => void`.
+ *
+ * // ── Draft management ───────────────────────────────────────────────────────
+ *
+ * @returns {Function} handleRestoreDraft - Merges the stored draft into
+ *                                         `formData`, nulls out `banner` and
+ *                                         `bannerPreview` (not serialisable),
+ *                                         shows a success toast, and closes
+ *                                         the restore modal. Signature:
+ *                                         `() => void`.
+ * @returns {Function} handleDiscardDraft - Removes the draft from localStorage
+ *                                         and closes the restore modal without
+ *                                         changing `formData`. Signature:
+ *                                         `() => void`.
+ *
+ * // ── Derived state ──────────────────────────────────────────────────────────
+ *
+ * @returns {boolean}  hasUnsavedChanges - `true` when any field (excluding
+ *                                        `banner` / `bannerPreview`) differs
+ *                                        from `initialFormData`. Drives the
+ *                                        `beforeunload` warning so users do
+ *                                        not accidentally lose work.
+ *
+ * // ── Image upload ───────────────────────────────────────────────────────────
+ *
+ * @returns {Function} handleImageUpload - `onChange` handler for the banner
+ *                                        `<input type="file">`. Validates MIME
+ *                                        type (JPEG, PNG, WebP, GIF) and size
+ *                                        (≤ 5 MB), then reads the file as a
+ *                                        data-URL and stores both the raw
+ *                                        `File` (`formData.banner`) and the
+ *                                        preview string
+ *                                        (`formData.bannerPreview`). Sets
+ *                                        `errors.banner` on failure. Signature:
+ *                                        `(e: ChangeEvent<HTMLInputElement>) =>
+ *                                        void`.
  */
 export const useEventForm = () => {
   const { user } = useAuth();
@@ -35,7 +269,7 @@ export const useEventForm = () => {
   const [isDraftLoaded, setIsDraftLoaded] = useState(false);
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  
+
   // 🔄 Refs for optimization
   const formDataRef = useRef(formData);
   const saveDraftTimeoutRef = useRef(null);
@@ -46,11 +280,11 @@ export const useEventForm = () => {
   }, [formData]);
 
   // 🎯 Form Submission Hook
-  const { 
-    handleSubmit: submitEventForm, 
-    isSubmitting, 
-    error: submitError, 
-    success: submitSuccess 
+  const {
+    handleSubmit: submitEventForm,
+    isSubmitting,
+    error: submitError,
+    success: submitSuccess
   } = useFormSubmit(async (eventData) => {
     const sanitized = {
       ...eventData,
@@ -63,12 +297,12 @@ export const useEventForm = () => {
 
     const response = await apiUtils.post(API_ENDPOINTS.EVENTS.CREATE, sanitized);
     const result = response.data;
-    
+
     if (!(response.status === 200 && result?.success)) {
       const errorMessage = result?.message || result?.error || `Server error: ${response.status}`;
       throw new Error(errorMessage);
     }
-    
+
     return result;
   });
 
@@ -86,7 +320,7 @@ export const useEventForm = () => {
         setIsDraftLoaded(true);
       }
     };
-    
+
     const timer = setTimeout(checkForDraft, 300);
     return () => clearTimeout(timer);
   }, [scopedDraftKey]);
@@ -178,7 +412,7 @@ export const useEventForm = () => {
       if (tier.name?.trim()) {
         const price = Number(tier.price);
         if (price < 0) newErrors[`ticketTier_${index}_price`] = "Price cannot be negative";
-        
+
         if (tier.capacity) {
           const cap = Number(tier.capacity);
           if (cap <= 0) newErrors[`ticketTier_${index}_capacity`] = "Capacity must be greater than 0";


### PR DESCRIPTION
## Description
Structure — four named sections in the description (Form state, Draft persistence, Validation, Submission) mirror the four comment blocks already in the implementation. Contributors can jump between the doc and the code without re-orienting.
Non-obvious behaviours explicitly called out:

Draft key is user-scoped (<DRAFT_KEY>_<userId>), falls back to _guest — a footgun for anyone testing unauthenticated
banner/bannerPreview are excluded from drafts (File objects aren't serialisable) — contributors would otherwise wonder why their image disappears on restore
validateForm reads formDataRef, not state, so it's stale-closure-safe inside async callbacks
handleInputChange supports dot-notation names up to two levels (location.coordinates.lat) — not obvious from the name alone
isUploading is consumer-managed; the hook exposes the setter but never sets it internally
addTag strips non-alphanumeric characters before inserting

Fixes #6602 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports

I have opened this PR as a GSSoC'26 contributor.
