### PR TITLE
[critical] Restore trusted client IP extraction for x-real-ip header

### DIFF
--- a/api/lib/getClientIp.js
+++ b/api/lib/getClientIp.js
@@ -1,0 +1,15 @@
+export function getClientIp(req) {
+  if (!req) return "unknown";
+
+  const realIp = req.headers?.["x-real-ip"];
+  if (realIp && typeof realIp === "string") {
+    const trimmed = realIp.trim();
+    if (trimmed) return trimmed;
+  }
+
+  if (req.socket?.remoteAddress) {
+    return req.socket.remoteAddress;
+  }
+
+  return "unknown";
+}


### PR DESCRIPTION
## Summary

The \pi/lib/getClientIp.js\ file was removed during the migration from the \pi/\ directory to the \src/\ layout. This broke the existing client IP extraction contract used by the test suite.

## What was fixed

- Recreated \pi/lib/getClientIp.js\ with the original \getClientIp\ named export
- The function extracts \x-real-ip\ header (trusted proxy header), normalizes it (trims whitespace), and returns the client IP
- Falls back to \socket.remoteAddress\ when no trusted header is present
- Returns \unknown\ only when no reliable client IP source exists

## Acceptance criteria

- \
ode --test tests/clientIp.test.mjs\ passes
- \x-real-ip\ with whitespace padding is correctly trimmed and returned
- Direct socket address fallback works when no proxy header is set
- Header spoofing protection is not weakened

## Related Issues

Closes #6328