### PR TITLE
[critical] Align root EventCreation submission with HttpOnly-cookie auth flow

### DIFF
--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "react-toastify";
 import { ArrowRight, Pencil, CheckCircle, AlertCircle, Calendar, Users, MapPin, Ticket as TicketIcon } from "lucide-react";
+import { API_ENDPOINTS, apiUtils } from "../config/api";
 
 import { useEventForm } from "../hooks/useEventForm";
 import EventBasicInfo from "./common/EventCreation/EventBasicInfo";
@@ -52,7 +53,19 @@ const EventCreation = () => {
   };
 
   const handlePublish = async () => {
-    await submitEventForm(formData);
+    const eventData = formData;
+    try {
+      if (!API_ENDPOINTS.EVENTS.CREATE) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        toast.success("🎉 Mock event creation successful!");
+        return;
+      }
+      await apiUtils.post(API_ENDPOINTS.EVENTS.CREATE, eventData);
+      toast.success("🎉 Event published successfully!");
+      setCurrentStep("form");
+    } catch (err) {
+      toast.error(err?.response?.data?.message || "Failed to create event.");
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

The root \src/components/EventCreation.jsx\ was not using the HttpOnly-cookie auth model. The test suite confirmed it was missing the \piUtils\ submission path and mock fallback.

## What was fixed

- Updated \handlePublish\ to use \piUtils.post(API_ENDPOINTS.EVENTS.CREATE, eventData)\ instead of relying solely on the form hook
- Added a mock fallback path when \API_ENDPOINTS.EVENTS.CREATE\ is not configured (local/demo usage)
- Mock path uses \setTimeout\ to simulate submission delay
- Error handling displays user-friendly toast messages

## Acceptance criteria

- \
ode --test tests/eventCreationAuth.test.mjs\ passes
- Event creation uses the shared \piUtils\ client with cookie-based auth
- No \sessionStorage\ token reads for auth
- Mock fallback works when backend endpoint is unavailable
- \piUtils.post\ is called with exactly two arguments (endpoint, eventData)

## Related Issues

Closes #6329