### PR TITLE
fix: remove stale imports and duplicate routes from App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,17 +26,14 @@ import Breadcrumbs from "./components/common/Breadcrumbs";
 import {
   AuthFormSkeleton,
   ExploreEventsSkeleton,
-  EventDetailSkeleton,
 } from "./components/common/SkeletonLoaders";
 
 // Route-level lazy splits - loaded only when route is visited
 const Footer = lazy(() => import("./components/Layout/Footer"));
 const Chatbot = lazy(() => import("./components/Chatbot"));
 const AppRoutes = lazy(() => import("./components/AppRoutes"));
-const EventRegistration = lazy(() => import("./Pages/Events/EventRegistration"));
 const SavedEventsPage = lazy(() => import("./Pages/SavedEventsPage"));
 const EventRecommendation = lazy(() => import("./Pages/EventRecommendation/EventRecommendation"));
-const EventDetails = lazy(() => import("./Pages/Events/EventDetails"));
 const ExploreEvents = lazy(() => import("./Pages/Events/EventsPage"));
 
 // Non-critical UI - deferred after first paint
@@ -193,16 +190,7 @@ function App() {
                   <PageTransition>
                     <ErrorBoundary>
                       <Routes location={location} key={location?.pathname || "default"}>
-                        <Route
-                          path="/register/:id"
-                          element={
-                            <ProtectedRoute>
-                              <Suspense fallback={<AuthFormSkeleton />}>
-                                <EventRegistration />
-                              </Suspense>
-                            </ProtectedRoute>
-                          }
-                        />
+                        {/* /explore is a legacy alias for the Events page */}
                         <Route
                           path="/explore"
                           element={
@@ -212,29 +200,25 @@ function App() {
                           }
                         />
                         <Route
-                          path="/events/:id"
+                          path="/event-recommendation"
                           element={
-                            <Suspense fallback={<EventDetailSkeleton />}>
-                              <EventDetails />
+                            <Suspense fallback={null}>
+                              <EventRecommendation />
                             </Suspense>
                           }
                         />
-                        {/* TODO: Implement missing auth/dashboard routes
-                          Pages do not exist:
-                          - ./Pages/auth/Login
-                          - ./Pages/auth/Signup
-                          - ./Pages/dashboard/Dashboard
-                          - ./Pages/Admin/AdminPanel
-                          - ./Pages/user/Profile
-                        */}
-                        <Route
-                          path="/event-recommendation"
-                          element={<Suspense fallback={null}><EventRecommendation /></Suspense>}
-                        />
                         <Route
                           path="/saved-events"
-                          element={<Suspense fallback={null}><SavedEventsPage /></Suspense>}
+                          element={
+                            <ProtectedRoute>
+                              <Suspense fallback={<AuthFormSkeleton />}>
+                                <SavedEventsPage />
+                              </Suspense>
+                            </ProtectedRoute>
+                          }
                         />
+                        {/* All other routes (auth, dashboard, admin, profile, events, etc.)
+                            are handled by AppRoutes → PublicRoutes / ProtectedRoutes */}
                         <Route
                           path="*"
                           element={
@@ -282,7 +266,7 @@ function App() {
                     <Suspense fallback={null}>
                       <FluidCursor enabled={cursorEnabled} />
                     </Suspense>
-                </ErrorBoundary>
+                  </ErrorBoundary>
                 )}
               </div>
             </SessionRecoveryProvider>


### PR DESCRIPTION
Fixes #6313

## Root Cause
App.jsx contained stale lazy imports and duplicate `<Route>` definitions
for pages that had already been migrated into the centralised routing
system (PublicRoutes.js / ProtectedRoutes.js / getAuthRoutes). This
caused Vite to fail at build time when those import paths didn't resolve.

## Changes
- Removed duplicate lazy imports for `EventRegistration` and `EventDetails`
  (both correctly imported in PublicRoutes.js)
- Removed duplicate `/register/:id` and `/events/:id` routes that
  conflicted with PublicRoutes definitions
- Removed the `TODO` comment block — Login, Signup, Dashboard, AdminPanel,
  and Profile all exist on disk and are already wired in ProtectedRoutes.js
  and getAuthRoutes()
- Added `ProtectedRoute` guard to `/saved-events` (was missing auth check)
- Removed unused `EventDetailSkeleton` import

## Verified
All 6 pages named in the issue exist at their correct paths and are
reachable via AppRoutes → PublicRoutes / ProtectedRoutes / AuthRoutes.