### PR TITLE
feat: add scroll-to-bottom button alongside scroll-to-top

### DIFF
--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import BackToTopButton from "./common/BackToTopButton";
+import ScrollToBottomButton from "./common/ScrollToBottomButton";
 
 export default function ScrollToTopButton() {
   const [isChatbotOpen, setIsChatbotOpen] = useState(false);
@@ -9,31 +10,39 @@ export default function ScrollToTopButton() {
     const handleChatbotState = () => {
       setIsChatbotOpen(document.querySelector('[data-chatbot-open]') !== null);
     };
-    
+
     // Check initially and set up observer
     handleChatbotState();
-    
-    // 🔥 FIX: Removed `subtree: true`. 
-    // Observing the entire DOM subtree causes massive CPU layout thrashing on every React render.
-    // Since the Chatbot uses createPortal to append directly to the body, we only need to observe direct children.
+
+    // Only observe direct body children — avoids CPU thrashing on every React render
     const observer = new MutationObserver(handleChatbotState);
-    observer.observe(document.body, { childList: true }); 
-    
+    observer.observe(document.body, { childList: true });
+
     return () => {
       observer.disconnect();
     };
   }, []);
 
-  const positionClass = isChatbotOpen 
+  // Scroll-to-top sits at bottom-24; scroll-to-bottom stacks above it at bottom-36
+  const upPositionClass = isChatbotOpen
     ? "bottom-[calc(1rem+var(--safe-area-bottom))] left-[calc(1rem+var(--safe-area-left))] sm:bottom-24 sm:left-6"
     : "bottom-[calc(1rem+var(--safe-area-bottom))] right-[calc(1rem+var(--safe-area-right))] sm:bottom-24 sm:right-6";
 
-  return <BackToTopButton threshold={50} positionClass={positionClass} />;
+  const downPositionClass = isChatbotOpen
+    ? "bottom-[calc(1rem+var(--safe-area-bottom))] left-[calc(1rem+var(--safe-area-left))] sm:bottom-36 sm:left-6"
+    : "bottom-[calc(1rem+var(--safe-area-bottom))] right-[calc(1rem+var(--safe-area-right))] sm:bottom-36 sm:right-6";
+
+  return (
+    <>
+      <ScrollToBottomButton threshold={50} positionClass={downPositionClass} />
+      <BackToTopButton threshold={50} positionClass={upPositionClass} />
+    </>
+  );
 }
 
 // Accessible landmark container router focus shifting utility helper
 export const shiftLandmarkFocus = (elementId) => {
-  // 🔥 FIX: Added SSR guard to prevent ReferenceError crashes in Node/Next.js/Testing environments
+  // SSR guard to prevent ReferenceError crashes in Node/Next.js/Testing environments
   if (typeof document === "undefined") return;
 
   const container = document.getElementById(elementId);
@@ -41,10 +50,10 @@ export const shiftLandmarkFocus = (elementId) => {
     container.setAttribute("tabindex", "-1");
     container.focus();
 
-    // 🔥 FIX: Clean up the tabindex after focus is lost so we don't permanently pollute the DOM
-    container.addEventListener('blur', function cleanup() {
-      container.removeAttribute('tabindex');
-      container.removeEventListener('blur', cleanup);
+    // Clean up the tabindex after focus is lost so we don't permanently pollute the DOM
+    container.addEventListener("blur", function cleanup() {
+      container.removeAttribute("tabindex");
+      container.removeEventListener("blur", cleanup);
     });
   }
 };

--- a/src/components/common/ScrollToBottomButton.jsx
+++ b/src/components/common/ScrollToBottomButton.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+/**
+ * ScrollToBottomButton
+ *
+ * Mirrors BackToTopButton in style and structure (resolves #5985).
+ *
+ * Visibility logic (inverse of scroll-to-top):
+ *   - Visible when the user is near the TOP (scrollY <= threshold)
+ *   - Hidden once the user has scrolled past the threshold
+ *
+ * This means both buttons are never on screen at the same time,
+ * keeping the UI clean without being visually noisy.
+ */
+const ScrollToBottomButton = ({ threshold = 50, positionClass = "bottom-6 right-6" }) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      // Show only when near the top — hide once scrolled past threshold
+      setVisible(window.scrollY <= threshold);
+    };
+
+    // Set correct initial state on mount
+    handleScroll();
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [threshold]);
+
+  const scrollToBottom = () => {
+    const bottom = document.documentElement.scrollHeight;
+    if (window.lenis) {
+      window.lenis.scrollTo(bottom, { immediate: false });
+    } else {
+      window.scrollTo({ top: bottom, behavior: "smooth" });
+    }
+  };
+
+  const visibilityClass = visible
+    ? "opacity-100 translate-y-0"
+    : "opacity-0 translate-y-10 pointer-events-none";
+
+  const buttonClassName = [
+    "fixed z-50 p-3 rounded-full",
+    "bg-indigo-600 hover:bg-indigo-700 text-white",
+    "shadow-lg hover:shadow-xl",
+    "transition-all duration-300",
+    "focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2",
+    "active:scale-95",
+    positionClass,
+    visibilityClass,
+  ].join(" ");
+
+  return (
+    <button
+      onClick={scrollToBottom}
+      aria-label="Scroll to bottom"
+      title="Scroll to bottom"
+      className={buttonClassName}
+    >
+      <ChevronDown size={22} />
+    </button>
+  );
+};
+
+export default ScrollToBottomButton;


### PR DESCRIPTION
Fixes #5985

## Changes
- Added `src/components/common/ScrollToBottomButton.jsx` — mirrors
  BackToTopButton exactly in style (indigo-600, rounded-full, p-3,
  same transitions). Visible near the top, hidden after scrolling past
  threshold. Respects window.lenis if present.
- Updated `ScrollToTopButton.jsx` to render both buttons stacked
  vertically (↓ at bottom-36, ↑ at bottom-24). Both are chatbot-aware
  and shift position when the chatbot FAB is open.
- No changes to App.jsx required.

## Behaviour
- At top of page: ↓ button visible, ↑ button hidden
- Scrolled down: ↑ button visible, ↓ button hidden
- Never both visible at the same time — no visual noise