### PR TITLE
fix: resolve broken Place button background color class in whiteboard

### DIFF
--- a/src/components/common/CollaborativeWhiteboard.jsx
+++ b/src/components/common/CollaborativeWhiteboard.jsx
@@ -672,7 +672,7 @@ export default function CollaborativeWhiteboard() {
                   </button>
                   <button
                     type="submit"
-                    className="px-2.5 py-1.5 rounded-lg bg-indigo-650 hover:bg-indigo-700 text-[10px] font-bold text-white shadow-sm"
+                    className="px-2.5 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-[10px] font-bold text-white shadow-sm"
                   >
                     Place
                   </button>

--- a/tests/whiteboardStyles.test.mjs
+++ b/tests/whiteboardStyles.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const filePath = path.resolve("src/components/common/CollaborativeWhiteboard.jsx");
+const content = fs.readFileSync(filePath, "utf8");
+
+// Test that the invalid class "bg-indigo-650" has been removed
+assert.ok(!content.includes("bg-indigo-650"), "Component should not contain invalid class bg-indigo-650");
+
+// Test that the correct class "bg-indigo-600" is present
+assert.ok(content.includes("bg-indigo-600"), "Component should contain correct class bg-indigo-600");
+
+console.log("whiteboardStyles tests passed ✓");


### PR DESCRIPTION
## Summary
This PR fixes the broken background color styling of the "Place" text button in the Collaborative Whiteboard tool, resolving an issue where the button was rendered as transparent/invisible.

## Root Cause
The component `CollaborativeWhiteboard.jsx` had a typo in its Tailwind CSS classes: `bg-indigo-650`. Tailwind CSS does not support `650` as a default shade (colors increment by 100). The invalid class was ignored by the compiler, leading to a transparent background.

## Changes Made
- Updated `src/components/common/CollaborativeWhiteboard.jsx` to replace the invalid `bg-indigo-650` class with the correct `bg-indigo-600` class.
- Added a regression test suite in `tests/whiteboardStyles.test.mjs` to ensure the component does not contain the invalid background class.

## Tests Added
- `tests/whiteboardStyles.test.mjs`: Asserts that `CollaborativeWhiteboard.jsx` does not contain `bg-indigo-650` and contains `bg-indigo-600`.

## Validation Results
- **Lint**: PASS (All eslint checks complete successfully)
- **Tests**: PASS (All 122 unit tests pass, including the new whiteboardStyle test)
- **Build**: PASS (Vite production bundle built successfully with no errors)

## Risk Assessment
Extremely low risk. The change is isolated to a single CSS class string replacement within a specific button inside `CollaborativeWhiteboard.jsx` and does not alter any component state or business logic.

Closes #6732
