### PR TITLE
fix(accessibility): add missing type=button attribute to CopyLinkButton

### DIFF
--- a/src/components/common/CopyLinkButton.jsx
+++ b/src/components/common/CopyLinkButton.jsx
@@ -39,6 +39,7 @@ const CopyLinkButton = () => {
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
       className={`inline-flex items-center gap-2 px-4 py-2 rounded-xl font-medium transition-all duration-300 shadow-md hover:shadow-lg ${
         copied

--- a/tests/copyLinkButtonIntegrity.test.mjs
+++ b/tests/copyLinkButtonIntegrity.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sourcePath = "src/components/common/CopyLinkButton.jsx";
+const source = readFileSync(sourcePath, "utf8");
+
+assert.match(
+  source,
+  /type="button"/,
+  "CopyLinkButton must have explicit type='button' attribute"
+);
+
+assert.match(
+  source,
+  /aria-label="Copy event link"/,
+  "CopyLinkButton must have accessiblity aria-label"
+);
+
+console.log("CopyLinkButton integrity tests passed");


### PR DESCRIPTION
## Summary
This PR adds the missing explicit `type="button"` attribute to the `CopyLinkButton` component to ensure it does not default to `type="submit"` and cause accidental form submissions in parent containers.

## Root Cause
The `<button>` element inside `CopyLinkButton.jsx` lacked a `type` attribute, defaulting it to `type="submit"` under standard HTML behavior when nested inside a form.

## Changes Made
- Added `type="button"` to the `<button>` element in `src/components/common/CopyLinkButton.jsx`.
- Added a static code integrity test in `tests/copyLinkButtonIntegrity.test.mjs` to ensure the component maintains `type="button"` and its accessibility attributes.

## Tests Added
- `tests/copyLinkButtonIntegrity.test.mjs`

## Validation Results
- **Lint**: PASS
- **Tests**: PASS (122 unit test files ran successfully)
- **Build**: PASS

Closes #6734
