### PR TITLE
fix(accessibility): add missing aria-labels to PriceRangeSlider inputs

### DIFF
--- a/src/components/common/PriceRangeSlider.jsx
+++ b/src/components/common/PriceRangeSlider.jsx
@@ -67,6 +67,7 @@ const PriceRangeSlider = ({
         {/* Min slider — visual updates on onChange, parent notified on release */}
         <input
           type="range"
+          aria-label="Minimum Price"
           min={minLimit}
           max={maxLimit}
           value={min}
@@ -81,6 +82,7 @@ const PriceRangeSlider = ({
         {/* Max slider — visual updates on onChange, parent notified on release */}
         <input
           type="range"
+          aria-label="Maximum Price"
           min={minLimit}
           max={maxLimit}
           value={max}

--- a/tests/priceRangeSliderIntegrity.test.mjs
+++ b/tests/priceRangeSliderIntegrity.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const sourcePath = "src/components/common/PriceRangeSlider.jsx";
+const source = readFileSync(sourcePath, "utf8");
+
+assert.match(
+  source,
+  /aria-label="Minimum Price"/,
+  "PriceRangeSlider must have an aria-label for the minimum price input"
+);
+
+assert.match(
+  source,
+  /aria-label="Maximum Price"/,
+  "PriceRangeSlider must have an aria-label for the maximum price input"
+);
+
+console.log("PriceRangeSlider integrity tests passed");


### PR DESCRIPTION
## Summary
This PR adds descriptive `aria-label` attributes to the dual range inputs in `PriceRangeSlider` to resolve screen reader accessibility gaps.

## Root Cause
The `<input type="range">` elements in the `PriceRangeSlider` component lacked descriptive ARIA labels, making them indistinguishable to screen readers.

## Changes Made
- Added `aria-label="Minimum Price"` to the min price range slider input in `src/components/common/PriceRangeSlider.jsx`.
- Added `aria-label="Maximum Price"` to the max price range slider input in `src/components/common/PriceRangeSlider.jsx`.
- Added a static code integrity test in `tests/priceRangeSliderIntegrity.test.mjs` to ensure the component maintains its ARIA labels.

## Tests Added
- `tests/priceRangeSliderIntegrity.test.mjs`

## Validation Results
- **Lint**: PASS
- **Tests**: PASS (122 unit test files ran successfully)
- **Build**: PASS

Closes #6736
