### PR TITLE
fix(recommendation-engine): add LRU eviction to unbounded tag cache

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -62,17 +62,33 @@ const getPopularityScore = (event) => {
 };
 
 const _tagCache = new Map();
+const _cacheOrder = [];
+const MAX_CACHE_SIZE = 100;
 
 const _getCachedTags = (event) => {
   const id = getEventId(event);
   if (!id) return [];
-  if (_tagCache.has(id)) return _tagCache.get(id);
+  if (_tagCache.has(id)) {
+    const tags = _tagCache.get(id);
+    const idx = _cacheOrder.indexOf(id);
+    if (idx > -1) _cacheOrder.splice(idx, 1);
+    _cacheOrder.push(id);
+    return tags;
+  }
+  if (_cacheOrder.length >= MAX_CACHE_SIZE) {
+    const oldest = _cacheOrder.shift();
+    _tagCache.delete(oldest);
+  }
   const tags = getEventTags(event);
   _tagCache.set(id, tags);
+  _cacheOrder.push(id);
   return tags;
 };
 
-const clearTagCache = () => _tagCache.clear();
+const clearTagCache = () => {
+  _tagCache.clear();
+  _cacheOrder.length = 0;
+};
 
 const getSimilarityScore = (candidate, interactedEvents) => {
   if (!interactedEvents.length) return 0;


### PR DESCRIPTION
## Summary
Adds LRU eviction policy to \_tagCache\ to prevent unbounded memory growth when users browse hundreds of events.

## Changes
- Added \MAX_CACHE_SIZE = 100\ constant
- Added \_cacheOrder\ array to track access order
- Evicts oldest entry when cache exceeds limit before inserting new entry
- Promotes accessed entries to most-recently-used position
- Clears both cache and order array in \clearTagCache()\

Closes #6739