### PR TITLE
fix(middleware): add security headers to Vercel Edge Middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -66,6 +66,20 @@ export const config = {
   matcher: "/api/:path*",
 };
 
+const SECURITY_HEADERS = {
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "X-Frame-Options": "DENY",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), display-capture=()",
+};
+
+const addSecurityHeaders = (headers) => {
+  for (const [key, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(key, value);
+  }
+};
+
 export default async function middleware(request) {
   const url = new URL(request.url);
 
@@ -81,16 +95,18 @@ export default async function middleware(request) {
     "unknown";
 
   if (await isRateLimited(ip)) {
+    const responseHeaders = new Headers({
+      "Content-Type": "application/json",
+      "Retry-After": String(API_RATE_WINDOW_S),
+    });
+    addSecurityHeaders(responseHeaders);
+    responseHeaders.set("Access-Control-Allow-Origin", url.origin);
+    responseHeaders.set("Access-Control-Allow-Credentials", "true");
     return new Response(
       JSON.stringify({ error: "Too many requests. Please try again later." }),
       {
         status: 429,
-        headers: {
-          "Content-Type": "application/json",
-          "Retry-After": String(API_RATE_WINDOW_S),
-          "Access-Control-Allow-Origin": url.origin,
-          "Access-Control-Allow-Credentials": "true",
-        },
+        headers: responseHeaders,
       },
     );
   }


### PR DESCRIPTION
## Summary
Adds standard security headers to the Vercel Edge Middleware for defense-in-depth.

## Changes
- Added HSTS (max-age=31536000; includeSubDomains; preload)
- Added X-Frame-Options: DENY (clickjacking protection)
- Added X-Content-Type-Options: nosniff (MIME-sniffing prevention)
- Added Referrer-Policy: strict-origin-when-cross-origin
- Added Permissions-Policy with restricted capabilities
- Extracted addSecurityHeaders() helper to reduce duplication
- Applied headers to 429 rate-limit response

Closes #6743