### PR TITLE
fix(ci): optimize npm-security-audit workflow with caching and path filtering

### DIFF
--- a/.github/workflows/npm-security-audit.yml
+++ b/.github/workflows/npm-security-audit.yml
@@ -3,8 +3,18 @@ name: NPM Security Audit
 on:
   push:
     branches: [master, main]
+    paths:
+      - package.json
+      - package-lock.json
+      - yarn.lock
+      - .github/workflows/npm-security-audit.yml
   pull_request:
     branches: [master, main]
+    paths:
+      - package.json
+      - package-lock.json
+      - yarn.lock
+      - .github/workflows/npm-security-audit.yml
   schedule:
     - cron: '0 0 * * 0' # Run weekly on Sundays
 
@@ -20,6 +30,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Run NPM Audit
         run: npm audit --audit-level=high
+
+      - name: Save audit report
+        run: npm audit --json > npm-audit-report.json || true
+
+      - name: Upload audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-report
+          path: npm-audit-report.json
+          retention-days: 30


### PR DESCRIPTION
## Summary
Optimizes the NPM audit CI workflow to run faster and only when relevant.

## Changes
- Added path filters: workflow only triggers when package.json/lock files change
- Added npm cache via setup-node cache: npm
- Uploads JSON audit report as a downloadable artifact (30-day retention)
- Keeps weekly scheduled run as safety net

Closes #6744