### PR TITLE
feat: add custom responsive viewport presets to storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,6 +16,27 @@ const preview = {
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/,
+
+      },
+    },
+    viewport: {
+      viewports: {
+        mobile: {
+          name: 'Mobile (sm)',
+          styles: { width: '640px', height: '800px' },
+        },
+        tablet: {
+          name: 'Tablet (md)',
+          styles: { width: '768px', height: '1024px' },
+        },
+        laptop: {
+          name: 'Laptop (lg)',
+          styles: { width: '1024px', height: '768px' },
+        },
+        desktop: {
+          name: 'Desktop (xl)',
+          styles: { width: '1280px', height: '900px' },
+        },
       },
     },
   },


### PR DESCRIPTION
## Description

This PR introduces custom responsive viewport presets directly into the Storybook toolbar configuration. Currently, Storybook defaults to the developer's live browser window size, making it easy to miss UI breakages across varying device dimensions. 

By adding tailored dimensions (`640px`, `768px`, `1024px`, and `1280px`) that match standard layout breakpoints, developers can now test component responsiveness and visual consistency uniformly with a single click.

Fixes #6316 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots / Video (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports