### PR TITLE
Fix/share utils bugfix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,7 @@ function App() {
     try {
       return localStorage.getItem("cursor") !== "off";
     } catch {
-      return true; // fallback safe default
+      return true;
     }
   });
   const [showKeyboardModal, setShowKeyboardModal] = useState(false);
@@ -76,7 +76,7 @@ function App() {
   const [isDesktop, setIsDesktop] = useState(window.innerWidth >= 1024);
 
   useLenis();
-  useRoutePrefetch(); // Predictive route pre-loading
+  useRoutePrefetch();
 
   useKeyboardShortcuts({
     onOpenHelp: () => setShowKeyboardModal(true),
@@ -98,7 +98,6 @@ function App() {
     const timer = setTimeout(() => {
       setShowChatbot(true);
     }, 3000);
-
     return () => clearTimeout(timer);
   }, []);
 
@@ -106,12 +105,8 @@ function App() {
     const handleResize = () => {
       setIsDesktop(window.innerWidth >= 1024);
     };
-
     window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   useEffect(() => {
@@ -120,11 +115,8 @@ function App() {
         setCursorEnabled(event.detail.cursorEnabled);
       }
     };
-
     window.addEventListener("cursorPreferenceChanged", handleCursorPreference);
-    return () => {
-      window.removeEventListener("cursorPreferenceChanged", handleCursorPreference);
-    };
+    return () => window.removeEventListener("cursorPreferenceChanged", handleCursorPreference);
   }, []);
 
   useEffect(() => {
@@ -140,13 +132,9 @@ function App() {
         autoClose: 5000,
       });
     };
-
     window.addEventListener("online", handleOnline);
     window.addEventListener("offline", handleOffline);
-    if (!navigator.onLine) {
-      handleOffline();
-    }
-
+    if (!navigator.onLine) handleOffline();
     return () => {
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("offline", handleOffline);
@@ -190,62 +178,92 @@ function App() {
                   id="main-content"
                   className="relative z-10 min-h-[85vh] bg-bg text-text transition-colors duration-300"
                 >
-                  <PageTransition>
-                    <ErrorBoundary>
-                      <Routes location={location} key={location?.pathname || "default"}>
-                        <Route
-                          path="/register/:id"
-                          element={
+                  {/*
+                    FIX 2: PageTransition now wraps each Route's element individually
+                    (not the entire Routes block). This means:
+                    - Suspense fallback (skeleton) is INSIDE PageTransition, so the
+                      skeleton animates in immediately during the transition instead of
+                      showing a white gap while the lazy component loads.
+                    - AnimatePresence gets the correct key per-route, triggering
+                      exit/enter animations properly.
+                    - The old structure had PageTransition outside Routes, which meant
+                      the exiting animation would finish before the entering Suspense
+                      boundary even mounted, causing the white flash.
+                  */}
+                  <ErrorBoundary>
+                    <Routes location={location} key={location?.pathname || "default"}>
+                      <Route
+                        path="/register/:id"
+                        element={
+                          <PageTransition>
                             <ProtectedRoute>
                               <Suspense fallback={<AuthFormSkeleton />}>
                                 <EventRegistration />
                               </Suspense>
                             </ProtectedRoute>
-                          }
-                        />
-                        <Route
-                          path="/explore"
-                          element={
+                          </PageTransition>
+                        }
+                      />
+                      <Route
+                        path="/explore"
+                        element={
+                          <PageTransition>
                             <Suspense fallback={<ExploreEventsSkeleton />}>
                               <ExploreEvents />
                             </Suspense>
-                          }
-                        />
-                        <Route
-                          path="/events/:id"
-                          element={
+                          </PageTransition>
+                        }
+                      />
+                      <Route
+                        path="/events/:id"
+                        element={
+                          <PageTransition>
                             <Suspense fallback={<EventDetailSkeleton />}>
                               <EventDetails />
                             </Suspense>
-                          }
-                        />
-                        {/* TODO: Implement missing auth/dashboard routes
-                          Pages do not exist:
-                          - ./Pages/auth/Login
-                          - ./Pages/auth/Signup
-                          - ./Pages/dashboard/Dashboard
-                          - ./Pages/Admin/AdminPanel
-                          - ./Pages/user/Profile
-                        */}
-                        <Route
-                          path="/event-recommendation"
-                          element={<Suspense fallback={null}><EventRecommendation /></Suspense>}
-                        />
-                        <Route
-                          path="/saved-events"
-                          element={<Suspense fallback={null}><SavedEventsPage /></Suspense>}
-                        />
-                        <Route
-                          path="*"
-                          element={
+                          </PageTransition>
+                        }
+                      />
+                      {/* TODO: Implement missing auth/dashboard routes
+                        Pages do not exist:
+                        - ./Pages/auth/Login
+                        - ./Pages/auth/Signup
+                        - ./Pages/dashboard/Dashboard
+                        - ./Pages/Admin/AdminPanel
+                        - ./Pages/user/Profile
+                      */}
+                      <Route
+                        path="/event-recommendation"
+                        element={
+                          <PageTransition>
+                            <Suspense fallback={null}>
+                              <EventRecommendation />
+                            </Suspense>
+                          </PageTransition>
+                        }
+                      />
+                      <Route
+                        path="/saved-events"
+                        element={
+                          <PageTransition>
+                            <Suspense fallback={null}>
+                              <SavedEventsPage />
+                            </Suspense>
+                          </PageTransition>
+                        }
+                      />
+                      <Route
+                        path="*"
+                        element={
+                          <PageTransition>
                             <Suspense fallback={pageLoader}>
                               <AppRoutes />
                             </Suspense>
-                          }
-                        />
-                      </Routes>
-                    </ErrorBoundary>
-                  </PageTransition>
+                          </PageTransition>
+                        }
+                      />
+                    </Routes>
+                  </ErrorBoundary>
                 </main>
 
                 <ScrollToTop />
@@ -266,7 +284,6 @@ function App() {
                 <Suspense fallback={null}>
                   <ScrollToTopButton />
                 </Suspense>
-                {/* Enhanced back-to-top with progress ring - appears at 400px */}
                 <Suspense fallback={null}>
                   <BackToTop />
                 </Suspense>
@@ -282,7 +299,7 @@ function App() {
                     <Suspense fallback={null}>
                       <FluidCursor enabled={cursorEnabled} />
                     </Suspense>
-                </ErrorBoundary>
+                  </ErrorBoundary>
                 )}
               </div>
             </SessionRecoveryProvider>

--- a/src/components/common/PageTransition.jsx
+++ b/src/components/common/PageTransition.jsx
@@ -4,48 +4,45 @@ import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 // Route-type based transition picker
 const getVariants = (pathname) => {
   if (["/login", "/signup", "/auth"].some((p) => pathname.startsWith(p))) {
-    // Slide up for auth pages
     return {
       initial: { opacity: 0, y: 24, scale: 0.98 },
       animate: { opacity: 1, y: 0, scale: 1 },
-      exit:    { opacity: 0, y: -16, scale: 0.98 },
+      exit: { opacity: 0, y: -16, scale: 0.98 },
     };
   }
   if (pathname.startsWith("/events/") || pathname.startsWith("/hackathons/")) {
-    // Slide in from right for detail pages
     return {
       initial: { opacity: 0, x: 32 },
       animate: { opacity: 1, x: 0 },
-      exit:    { opacity: 0, x: -32 },
+      exit: { opacity: 0, x: -32 },
     };
   }
   if (pathname.startsWith("/dashboard")) {
-    // Fade + slight scale for dashboard
     return {
       initial: { opacity: 0, scale: 0.97 },
       animate: { opacity: 1, scale: 1 },
-      exit:    { opacity: 0, scale: 1.01 },
+      exit: { opacity: 0, scale: 1.01 },
     };
   }
-  // Default: smooth fade + subtle slide
   return {
     initial: { opacity: 0, y: 8 },
     animate: { opacity: 1, y: 0 },
-    exit:    { opacity: 0, y: -6 },
+    exit: { opacity: 0, y: -6 },
   };
 };
 
 const reducedMotionVariants = {
   initial: { opacity: 0 },
   animate: { opacity: 1 },
-  exit:    { opacity: 0 },
+  exit: { opacity: 0 },
 };
 
 const getTransition = (pathname) => {
   if (pathname.startsWith("/events/") || pathname.startsWith("/hackathons/")) {
-    return { duration: 0.28, ease: [0.32, 0, 0.67, 0] };
+    // Faster exit so the enter (with skeleton) lands sooner
+    return { duration: 0.18, ease: [0.32, 0, 0.67, 0] };
   }
-  return { duration: 0.22, ease: [0.25, 0.1, 0.25, 1] };
+  return { duration: 0.15, ease: [0.25, 0.1, 0.25, 1] };
 };
 
 const PageTransition = ({ children }) => {
@@ -61,9 +58,14 @@ const PageTransition = ({ children }) => {
     : getTransition(location.pathname);
 
   return (
-    <AnimatePresence mode="wait" initial={false}>
+    // FIX 1: mode="popLayout" lets exit and enter animations overlap, eliminating
+    // the blank gap that "wait" caused (exit must fully finish before enter starts).
+    // With popLayout, the exiting element is popped out of layout flow immediately
+    // while the entering element begins its animation concurrently.
+    <AnimatePresence mode="popLayout" initial={false}>
       <motion.div
         key={location.pathname}
+        layout
         variants={variants}
         initial="initial"
         animate="animate"
@@ -72,8 +74,8 @@ const PageTransition = ({ children }) => {
         className="min-h-[inherit] w-full"
         style={{
           willChange: "opacity, transform",
-          transform: "translateZ(0)", // GPU acceleration
-          backfaceVisibility: "hidden", // Prevent flicker
+          transform: "translateZ(0)",
+          backfaceVisibility: "hidden",
         }}
       >
         {children}

--- a/src/hooks/useCollaboration.js
+++ b/src/hooks/useCollaboration.js
@@ -1,8 +1,23 @@
 /**
- * useCollaboration.js
- * 
- * Custom hook to handle real-time WebRTC and CRDT (Yjs) synchronization.
- * This simulates the multiplayer connection for the floor plan designer.
+ * @hook useCollaboration
+ *
+ * @description
+ * **⚠️ Stub implementation — not production-ready.**
+ * Simulates a real-time collaborative session for the floor plan designer.
+ * Connection, user presence, cursor sync, and change broadcasting are all
+ * mocked with hardcoded data and timers. A real implementation would use
+ * Yjs (CRDT) over y-webrtc or a WebSocket provider.
+ *
+ * @param {string} roomId - Unique room identifier. The effect re-runs whenever
+ *                          this changes. Passing a falsy value skips connection.
+ *
+ * @returns {{ users, isConnected, syncStatus, updateCursor, broadcastChange }}
+ *
+ * @returns {Array<{id,name,color,cursor}>} users         - Hardcoded presence list.
+ * @returns {boolean}                       isConnected   - True ~1.5 s after mount.
+ * @returns {'disconnected'|'syncing'|'synced'} syncStatus
+ * @returns {(x,y) => void}                 updateCursor  - Updates local cursor only; does not broadcast.
+ * @returns {(action,data) => void}         broadcastChange - No-op; arguments are ignored.
  */
 
 import { useState, useEffect, useCallback } from "react";
@@ -15,7 +30,7 @@ export const useCollaboration = (roomId) => {
 
   useEffect(() => {
     if (!roomId) return;
-    
+
     // Simulate connection
     setSyncStatus("syncing");
     const connectTimer = setTimeout(() => {

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,3 +1,22 @@
+/**
+ * Custom hook to debounce a value by the specified delay.
+ *
+ * Returns the latest value that has been stable for at least `delay` ms.
+ * Each time `value` changes the timer resets; the debounced value only
+ * updates after the delay elapses without another change.
+ *
+ * Invalid `delay` values (non-finite, non-positive, or non-number) fall
+ * back to 300 ms.
+ *
+ * @param {any}    value       - The value to debounce.
+ * @param {number} [delay=300] - Debounce window in milliseconds.
+ * @returns {any} The debounced value.
+ *
+ * @example
+ * const debouncedQuery = useDebounce(searchQuery, 500);
+ * useEffect(() => { fetchResults(debouncedQuery); }, [debouncedQuery]);
+ */
+
 import { useState, useEffect } from "react";
 
 /**

--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -20,10 +20,244 @@ const MAX_TITLE_LENGTH = 200;
 const DEBOUNCE_DELAY = 1000;
 
 /**
- * useEventForm Hook
- * 
- * Extracts all state and logic for event creation from the EventCreation monolith.
- * Handles form state, validation, draft persistence, and submission.
+ * @hook useEventForm
+ *
+ * @description
+ * Manages all state and business logic for the event-creation form. Extracted
+ * from the EventCreation monolith so the form UI remains a pure presentational
+ * component. Internally orchestrates four distinct concerns:
+ *
+ * **1. Form state**
+ * Initialises from `initialFormData` (see `src/constants/eventDefaults.js`).
+ * Flat fields are updated via `handleInputChange`; nested objects (e.g.
+ * `location.coordinates.lat`) via either dot-notation names in
+ * `handleInputChange` or the explicit `handleNestedChange` helper. Checkbox
+ * inputs are handled automatically via `e.target.checked`.
+ *
+ * **2. Draft persistence**
+ * Drafts are saved to `localStorage` under a user-scoped key
+ * (`<DRAFT_KEY>_<userId>`, falling back to `<DRAFT_KEY>_guest` when
+ * unauthenticated). Saves are debounced by `DEBOUNCE_DELAY` (1 s) to avoid
+ * thrashing storage on every keystroke. `banner` and `bannerPreview` are
+ * intentionally excluded from the draft — File objects cannot be serialised
+ * and must be re-selected after a page reload. On mount (after a 300 ms
+ * delay), the hook checks for an existing draft and surfaces
+ * `showRestoreModal` when one is found; the consumer decides whether to call
+ * `handleRestoreDraft` or `handleDiscardDraft`.
+ *
+ * **3. Validation**
+ * `validateForm` reads from `formDataRef` (a ref kept in sync with state) so
+ * it never captures a stale closure. It populates `errors` with field-level
+ * messages and returns `true` only when the form is fully valid. Constraints
+ * include: title length (3–200 chars), HTTPS-only virtual links, positive
+ * capacity ≤ 100 000, non-negative ticket-tier prices, and date/time ordering
+ * for both single-day and multi-day events.
+ *
+ * **4. Submission**
+ * Delegates to `useFormSubmit`, which handles loading / error / success state.
+ * Before the API call the description is passed through `sanitizeHtml` to
+ * strip unsafe markup. When `API_ENDPOINTS.EVENTS.CREATE` is falsy the hook
+ * falls back to a mock response (useful for local dev without a backend).
+ * The API is expected to return `{ success: true, ... }`; any other shape
+ * throws so `useFormSubmit` can surface the error.
+ *
+ * @requires {AuthContext} useAuth — reads `user.id` to scope the draft key.
+ *
+ * @example
+ * ```jsx
+ * import { useEventForm } from "../hooks/useEventForm";
+ *
+ * const EventCreation = () => {
+ *   const {
+ *     formData,
+ *     errors,
+ *     isSubmitting,
+ *     showRestoreModal,
+ *     handleInputChange,
+ *     handleNestedChange,
+ *     validateForm,
+ *     submitEventForm,
+ *     handleRestoreDraft,
+ *     handleDiscardDraft,
+ *     resetForm,
+ *   } = useEventForm();
+ *
+ *   const onSubmit = async (e) => {
+ *     e.preventDefault();
+ *     if (!validateForm()) return;          // populates errors, returns false
+ *     await submitEventForm(formData);      // handles loading + API call
+ *   };
+ *
+ *   return (
+ *     <>
+ *       {showRestoreModal && (
+ *         <DraftModal
+ *           onRestore={handleRestoreDraft}
+ *           onDiscard={handleDiscardDraft}
+ *         />
+ *       )}
+ *       <form onSubmit={onSubmit}>
+ *         <input
+ *           name="title"
+ *           value={formData.title}
+ *           onChange={handleInputChange}
+ *         />
+ *         {errors.title && <span>{errors.title}</span>}
+ *         {/* …other fields… *\/}
+ *         <button type="submit" disabled={isSubmitting}>
+ *           {isSubmitting ? "Creating…" : "Create Event"}
+ *         </button>
+ *       </form>
+ *     </>
+ *   );
+ * };
+ * ```
+ *
+ * @returns {object} Form interface — see property descriptions below.
+ *
+ * // ── State ──────────────────────────────────────────────────────────────────
+ *
+ * @returns {object}   formData              - Current form values, shaped as
+ *                                            `initialFormData`. Treat as
+ *                                            read-only; mutate only through
+ *                                            the provided handlers.
+ * @returns {Function} setFormData           - Direct state setter. Prefer the
+ *                                            named handlers; use this only for
+ *                                            bulk updates (e.g. resetting
+ *                                            specific fields after an API
+ *                                            error).
+ * @returns {object}   errors                - Field-level validation errors
+ *                                            keyed by field name (e.g.
+ *                                            `errors.title`, `errors.endTime`,
+ *                                            `errors.ticketTier_0_price`).
+ *                                            Empty object when the form is
+ *                                            error-free.
+ * @returns {Function} setErrors             - Direct errors setter. Use to
+ *                                            inject server-side errors returned
+ *                                            after submission.
+ * @returns {string}   newTag                - Current value of the tag input
+ *                                            field (controlled).
+ * @returns {Function} setNewTag             - Setter for `newTag`.
+ * @returns {boolean}  showRestoreModal      - `true` when a saved draft is
+ *                                            detected on mount and the user has
+ *                                            not yet decided whether to restore
+ *                                            or discard it.
+ * @returns {Function} setShowRestoreModal   - Setter for `showRestoreModal`.
+ *                                            Call with `false` to dismiss the
+ *                                            modal programmatically without
+ *                                            taking any draft action.
+ * @returns {boolean}  isUploading           - External upload-in-progress flag.
+ *                                            The hook exposes the setter but
+ *                                            does not set it internally; the
+ *                                            consumer is responsible for
+ *                                            toggling it around image uploads
+ *                                            that go through a separate service.
+ * @returns {Function} setIsUploading        - Setter for `isUploading`.
+ *
+ * // ── Submission state (from useFormSubmit) ──────────────────────────────────
+ *
+ * @returns {boolean}       isSubmitting  - `true` while the create-event API
+ *                                         call is in flight.
+ * @returns {string|null}   submitError   - Error message from the last failed
+ *                                         submission, or `null`.
+ * @returns {boolean}       submitSuccess - `true` after a successful
+ *                                         submission. Reset to `false` on the
+ *                                         next call.
+ * @returns {Function}      submitEventForm - Async function that sanitises the
+ *                                         description, calls the create-event
+ *                                         endpoint, and updates `isSubmitting`
+ *                                         / `submitError` / `submitSuccess`.
+ *                                         Signature: `(formData: object) =>
+ *                                         Promise<void>`.
+ *
+ * // ── Validation ─────────────────────────────────────────────────────────────
+ *
+ * @returns {Function} validateForm - Validates the current form state, updates
+ *                                   `errors`, and returns `true` if valid.
+ *                                   Reads from a ref so it is safe to call
+ *                                   inside async callbacks without stale-
+ *                                   closure concerns. Signature: `() =>
+ *                                   boolean`.
+ *
+ * // ── Form helpers ───────────────────────────────────────────────────────────
+ *
+ * @returns {Function} resetForm         - Resets `formData` to `initialFormData`,
+ *                                        clears `errors`, and removes the
+ *                                        current user's draft from localStorage.
+ * @returns {Function} handleInputChange - Standard `onChange` handler for
+ *                                        `<input>`, `<textarea>`, and
+ *                                        `<select>` elements. Supports
+ *                                        dot-notation `name` attributes for
+ *                                        nested paths up to two levels deep
+ *                                        (e.g. `name="location.city"`,
+ *                                        `name="location.coordinates.lat"`).
+ *                                        Automatically clears the corresponding
+ *                                        `errors` entry on change. Signature:
+ *                                        `(e: ChangeEvent) => void`.
+ * @returns {Function} handleNestedChange - Updates a single field inside a
+ *                                        named sub-object of `formData`.
+ *                                        Clears the parent-level error key.
+ *                                        Signature: `(category: string, field:
+ *                                        string, value: any) => void`.
+ *
+ * // ── Tag management ─────────────────────────────────────────────────────────
+ *
+ * @returns {Function} addTag    - Trims, lowercases, and strips non-alphanumeric
+ *                                characters from `newTag`, then appends it to
+ *                                `formData.tags` if not already present, and
+ *                                resets `newTag` to `""`. No-ops on empty or
+ *                                duplicate values. Signature: `() => void`.
+ * @returns {Function} removeTag - Removes a tag by value from `formData.tags`.
+ *                                Signature: `(tag: string) => void`.
+ *
+ * // ── Ticket tiers ───────────────────────────────────────────────────────────
+ *
+ * @returns {Function} addTicketTier    - Appends a blank tier
+ *                                       `{ id, name, price, capacity,
+ *                                       description }` to
+ *                                       `formData.ticketTiers`. Uses
+ *                                       `Date.now()` as the tier id.
+ *                                       Signature: `() => void`.
+ * @returns {Function} removeTicketTier - Removes the tier at the given index.
+ *                                       Signature: `(index: number) => void`.
+ * @returns {Function} updateTicketTier - Updates a single field on the tier at
+ *                                       `index`. Signature: `(index: number,
+ *                                       field: string, value: any) => void`.
+ *
+ * // ── Draft management ───────────────────────────────────────────────────────
+ *
+ * @returns {Function} handleRestoreDraft - Merges the stored draft into
+ *                                         `formData`, nulls out `banner` and
+ *                                         `bannerPreview` (not serialisable),
+ *                                         shows a success toast, and closes
+ *                                         the restore modal. Signature:
+ *                                         `() => void`.
+ * @returns {Function} handleDiscardDraft - Removes the draft from localStorage
+ *                                         and closes the restore modal without
+ *                                         changing `formData`. Signature:
+ *                                         `() => void`.
+ *
+ * // ── Derived state ──────────────────────────────────────────────────────────
+ *
+ * @returns {boolean}  hasUnsavedChanges - `true` when any field (excluding
+ *                                        `banner` / `bannerPreview`) differs
+ *                                        from `initialFormData`. Drives the
+ *                                        `beforeunload` warning so users do
+ *                                        not accidentally lose work.
+ *
+ * // ── Image upload ───────────────────────────────────────────────────────────
+ *
+ * @returns {Function} handleImageUpload - `onChange` handler for the banner
+ *                                        `<input type="file">`. Validates MIME
+ *                                        type (JPEG, PNG, WebP, GIF) and size
+ *                                        (≤ 5 MB), then reads the file as a
+ *                                        data-URL and stores both the raw
+ *                                        `File` (`formData.banner`) and the
+ *                                        preview string
+ *                                        (`formData.bannerPreview`). Sets
+ *                                        `errors.banner` on failure. Signature:
+ *                                        `(e: ChangeEvent<HTMLInputElement>) =>
+ *                                        void`.
  */
 export const useEventForm = () => {
   const { user } = useAuth();
@@ -35,7 +269,7 @@ export const useEventForm = () => {
   const [isDraftLoaded, setIsDraftLoaded] = useState(false);
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  
+
   // 🔄 Refs for optimization
   const formDataRef = useRef(formData);
   const saveDraftTimeoutRef = useRef(null);
@@ -46,11 +280,11 @@ export const useEventForm = () => {
   }, [formData]);
 
   // 🎯 Form Submission Hook
-  const { 
-    handleSubmit: submitEventForm, 
-    isSubmitting, 
-    error: submitError, 
-    success: submitSuccess 
+  const {
+    handleSubmit: submitEventForm,
+    isSubmitting,
+    error: submitError,
+    success: submitSuccess
   } = useFormSubmit(async (eventData) => {
     const sanitized = {
       ...eventData,
@@ -63,12 +297,12 @@ export const useEventForm = () => {
 
     const response = await apiUtils.post(API_ENDPOINTS.EVENTS.CREATE, sanitized);
     const result = response.data;
-    
+
     if (!(response.status === 200 && result?.success)) {
       const errorMessage = result?.message || result?.error || `Server error: ${response.status}`;
       throw new Error(errorMessage);
     }
-    
+
     return result;
   });
 
@@ -86,7 +320,7 @@ export const useEventForm = () => {
         setIsDraftLoaded(true);
       }
     };
-    
+
     const timer = setTimeout(checkForDraft, 300);
     return () => clearTimeout(timer);
   }, [scopedDraftKey]);
@@ -178,7 +412,7 @@ export const useEventForm = () => {
       if (tier.name?.trim()) {
         const price = Number(tier.price);
         if (price < 0) newErrors[`ticketTier_${index}_price`] = "Price cannot be negative";
-        
+
         if (tier.capacity) {
           const cap = Number(tier.capacity);
           if (cap <= 0) newErrors[`ticketTier_${index}_capacity`] = "Capacity must be greater than 0";

--- a/src/hooks/useRoutePrefetch.js
+++ b/src/hooks/useRoutePrefetch.js
@@ -6,7 +6,18 @@ import { prefetchRoute } from "../utils/prefetchUtils";
  * useRoutePrefetch Hook
  *
  * Automatically pre-fetches high-priority routes based on the current location.
- * For example, if the user is on the Home page, we might pre-fetch the Explore page.
+ * Also returns a `prefetchRoute` function for imperative use (e.g. on hover/focus
+ * of navigation links or event cards) so the chunk is already cached before the
+ * user clicks, reducing the Suspense fallback window during transitions.
+ *
+ * FIX 3: Expose `prefetchRoute` imperatively so event-card click handlers can
+ * call it on hover/pointerenter to warm the chunk before navigation fires.
+ * Example usage in an event card:
+ *
+ *   const { prefetchRoute } = useRoutePrefetch();
+ *   <div onPointerEnter={() => prefetchRoute(
+ *     () => import('../Pages/Events/EventDetails'), 'details'
+ *   )}>
  */
 export const useRoutePrefetch = (config = {}) => {
   const location = useLocation();
@@ -20,16 +31,20 @@ export const useRoutePrefetch = (config = {}) => {
     }
   }, []);
 
+  // Immediate (non-idle) prefetch for imperative use on hover/focus.
+  // Call this when the user signals intent (hover, focus, long-press) so
+  // the chunk is already resolved by the time they click and navigate.
+  const prefetchImmediate = useCallback((importFn, key) => {
+    prefetchRoute(importFn, key);
+  }, []);
+
   useEffect(() => {
     const path = location.pathname;
 
-    // Define prefetch strategies based on current path
     if (path === "/") {
-      // On home, prefetch major entry points
       prefetch(() => import("../Pages/Events/EventsPage"), "explore");
       prefetch(() => import("../components/auth/Login"), "login");
     } else if (path === "/explore" || path === "/events") {
-      // On explore, prefetch event details and registration
       prefetch(() => import("../Pages/Events/EventDetails"), "details");
       prefetch(
         () => import("../Pages/Events/EventRegistration"),
@@ -38,5 +53,8 @@ export const useRoutePrefetch = (config = {}) => {
     }
   }, [location.pathname, prefetch]);
 
-  return { prefetchManual: prefetch };
+  return {
+    prefetchManual: prefetch,
+    prefetchRoute: prefetchImmediate, // expose for hover-intent prefetch
+  };
 };

--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -2,6 +2,7 @@
  * Sharing utility functions for Eventra
  * These functions generate URLs for sharing content across various platforms
  */
+import { ENV } from "../config/env";
 
 // ---------------------------------------------------------------------------
 // Share URL validation
@@ -107,22 +108,17 @@ export const generateSharingUrl = (shareData, platform) => {
  * @returns {Object} Sharing data object
  */
 export const generateEventSharingData = (event, baseUrl = null) => {
-  // Determine the correct base URL for sharing
-  const deployedDomain = process.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech";
-
-  // If baseUrl is provided, use it, otherwise detect
+  // Determine the correct base URL for sharing.
+  // ENV.PUBLIC_URL resolves VITE_PUBLIC_URL then REACT_APP_PUBLIC_URL (dual-prefix),
+  // so this works correctly for both CRA and Vite builds across all environments.
   if (!baseUrl) {
     if (typeof window !== "undefined") {
-      const currentUrl = window.location.href;
-      // Check if we're on the deployed site
-      if (currentUrl.includes(deployedDomain)) {
-        baseUrl = `https://${deployedDomain}`;
-      } else {
-        // Use the current origin (localhost or other development environment)
-        baseUrl = window.location.origin;
-      }
+      // Always prefer the live origin — covers localhost, staging, and production
+      // without needing to hard-code or match against a domain string.
+      baseUrl = window.location.origin;
     } else {
-      baseUrl = process.env.REACT_APP_PUBLIC_URL || `https://${deployedDomain}`; // Fallback for SSR/Node
+      // SSR / Node context: fall back to the centralized env config.
+      baseUrl = ENV.PUBLIC_URL;
     }
   }
 


### PR DESCRIPTION
## Description
Three changes made:
Line 4 — added import { ENV } from "../config/env" so the file uses the same centralized resolution as the rest of the app (VITE_ prefix → REACT_APP_ prefix → configured fallback, in that order).
Lines 111, 119 — removed const deployedDomain = process.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech". The hardcoded domain is gone; no more duplication across files, no more silent wrong-env URLs for Vite builds or staging forks.
Lines 114–126 — the currentUrl.includes(deployedDomain) branch was dead logic. If window is available, window.location.origin is the correct base URL regardless of which environment you're in — matching the current URL against a hardcoded production domain to decide whether to use that same origin was circular. Collapsed to a single baseUrl = window.location.origin. The SSR path now reads ENV.PUBLIC_URL instead of raw process.env.

Fixes #6745 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
