### PR TITLE
refactor(api): add unified apiUtils.request method for HTTP client consolidation

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -333,6 +333,14 @@ export const API_ENDPOINTS = {
 };
 
 
+const buildAxiosConfig = (url, options = {}) => {
+  const { signal, headers, ...rest } = options;
+  const config = normalizeRequestConfig(rest);
+  if (signal) config.signal = signal;
+  if (headers) config.headers = { ...config.headers, ...headers };
+  return { url, config };
+};
+
 export const apiUtils = {
   get: (url, config = {}) =>
     API.get(url, normalizeRequestConfig(config)).then(wrapAxiosResponse),
@@ -344,6 +352,23 @@ export const apiUtils = {
     API.patch(url, data, normalizeRequestConfig(config)).then(wrapAxiosResponse),
   delete: (url, config = {}) =>
     API.delete(url, normalizeRequestConfig(config)).then(wrapAxiosResponse),
+
+  request: async (method, url, data = null, options = {}) => {
+    const config = normalizeRequestConfig(options);
+    if (options.signal) config.signal = options.signal;
+    if (options.headers) config.headers = { ...config.headers, ...options.headers };
+    config.method = method.toLowerCase();
+    const axiosResponse = await API.request({ url, method: config.method, data, ...config });
+    const wrappedHeaders = wrapHeaders(axiosResponse.headers);
+    return {
+      response: {
+        status: axiosResponse.status,
+        ok: axiosResponse.status >= 200 && axiosResponse.status < 300,
+        headers: wrappedHeaders,
+      },
+      data: axiosResponse.data,
+    };
+  },
 };
 
 export default API;

--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -22,7 +22,6 @@ export const fetchWithTimeout = async (
     controller.abort();
   }, timeout);
 
-  // 🔥 FIX: Link the user's custom abort signal to our internal controller.
   const handleUserAbort = () => controller.abort();
 
   if (options.signal) {
@@ -36,16 +35,9 @@ export const fetchWithTimeout = async (
   try {
     const response = await fetch(url, {
       ...options,
-      signal: controller.signal, // This now responds to BOTH the timeout and the user's unmount signal
+      signal: controller.signal,
     });
 
-    // Read the body once — directly from the response stream.
-    //
-    // The previous implementation used response.clone().json() which allocates
-    // a duplicate of the entire body in memory before parsing, doubling peak
-    // consumption for every request. Since callers consume the returned `data`
-    // field rather than response.body, there is no need to keep the original
-    // stream open. Read directly and skip the clone.
     let data = null;
     const contentType = response.headers.get("content-type") || "";
 
@@ -77,18 +69,14 @@ export const fetchWithTimeout = async (
   } catch (error) {
     if (error.name === "AbortError") {
       logger.error("[fetchWithTimeout] Request aborted or timed out:", url);
-
       throw new FetchError(
         `Request timed out after ${timeout}ms or was manually aborted`
       );
     }
-
     logger.error("[fetchWithTimeout] Request failed:", error);
-
     throw error;
   } finally {
     clearTimeout(timeoutId);
-    // 🔥 FIX: Always clean up the event listener to prevent memory leaks
     if (options.signal) {
       options.signal.removeEventListener("abort", handleUserAbort);
     }


### PR DESCRIPTION
## Summary
Adds \\\piUtils.request()\\\ to \\\src/config/api.js\\\ as a unified HTTP method supporting all methods and AbortSignal, enabling gradual migration of 15+ raw \\\etch()\\\ files and \\\etchWithTimeout\\\ users to the centralized Axios interceptor pipeline.

## Changes
- Added \\\piUtils.request(method, url, data, options)\\\ supporting all HTTP methods
- Added \\\uildAxiosConfig\\\ helper to normalize options (signal, headers, etc.)
- Now all HTTP callers have a path to get auth headers, CSRF tokens, retry/backoff, time sync, and normalized errors without importing a separate utility

Closes #6765