### PR TITLE
fix: complete PWA lifecycle (install prompt, update banner, periodic sync)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { toast } from "react-toastify";
 import Navbar from "./components/navbar/Navbar";
 import OfflineBanner from "./components/common/OfflineBanner";
 import OfflineConflictModal from "./components/common/OfflineConflictModal";
+import UpdateAvailableBanner from "./components/common/UpdateAvailableBanner";
 import ScrollToTop from "./components/ScrollToTop";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
@@ -285,6 +286,7 @@ function App() {
                 </ErrorBoundary>
                 )}
               </div>
+              <UpdateAvailableBanner />
             </SessionRecoveryProvider>
           </MyEventsProvider>
         </NotificationProvider>

--- a/src/components/common/InstallAppButton.jsx
+++ b/src/components/common/InstallAppButton.jsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import { Download } from "lucide-react";
+
+export default function InstallAppButton() {
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+  const [isInstallable, setIsInstallable] = useState(false);
+
+  useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+      setIsInstallable(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handler);
+    };
+  }, []);
+
+  const handleInstall = async () => {
+    if (!deferredPrompt) return;
+
+    deferredPrompt.prompt();
+    const result = await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    setIsInstallable(false);
+  };
+
+  if (!isInstallable) return null;
+
+  return (
+    <button
+      onClick={handleInstall}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-semibold hover:opacity-90 transition-opacity"
+      aria-label="Install app"
+    >
+      <Download size={14} />
+      Install
+    </button>
+  );
+}

--- a/src/components/common/UpdateAvailableBanner.jsx
+++ b/src/components/common/UpdateAvailableBanner.jsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from "react";
+import { RefreshCw, X } from "lucide-react";
+
+export default function UpdateAvailableBanner() {
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  useEffect(() => {
+    const handler = () => {
+      setUpdateAvailable(true);
+    };
+
+    window.addEventListener("sw-update-available", handler);
+
+    return () => {
+      window.removeEventListener("sw-update-available", handler);
+    };
+  }, []);
+
+  const handleRefresh = () => {
+    window.location.reload();
+  };
+
+  const handleDismiss = () => {
+    setUpdateAvailable(false);
+  };
+
+  if (!updateAvailable) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-3 bg-blue-600 text-white px-4 py-3 rounded-xl shadow-lg">
+      <span className="text-sm font-medium">New version available!</span>
+      <button
+        onClick={handleRefresh}
+        className="flex items-center gap-1.5 bg-white text-blue-600 px-3 py-1.5 rounded-lg text-xs font-semibold hover:bg-blue-50 transition-colors"
+      >
+        <RefreshCw size={14} />
+        Refresh
+      </button>
+      <button
+        onClick={handleDismiss}
+        className="text-white/80 hover:text-white transition-colors"
+        aria-label="Dismiss"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -5,6 +5,7 @@ import DesktopNavbar from "./DesktopNavbar";
 import MobileNavbar from "./MobileNavbar";
 import CursorToggle from "./CursorToggle";
 import AuthButtons from "./AuthButtons";
+import InstallAppButton from "../common/InstallAppButton";
 import ProfileMenu from "./ProfileMenu";
 import useBodyScrollLock from "./hooks/useBodyScrollLock";
 import useKeyboardShortcuts from "../../hooks/useKeyboardShortcuts";
@@ -117,6 +118,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
               ) : (
                 <AuthButtons />
               )}
+              <InstallAppButton />
               <CursorToggle cursorEnabled={cursorEnabled} toggleCursor={toggleCursor} />
             </div>
 

--- a/src/hooks/useInstallPrompt.js
+++ b/src/hooks/useInstallPrompt.js
@@ -1,0 +1,38 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+  const [isInstallable, setIsInstallable] = useState(false);
+
+  useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+      setIsInstallable(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handler);
+    };
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!deferredPrompt) return false;
+
+    deferredPrompt.prompt();
+    const result = await deferredPrompt.userChoice;
+    setDeferredPrompt(null);
+    setIsInstallable(false);
+
+    return result.outcome === "accepted";
+  }, [deferredPrompt]);
+
+  const dismissInstall = useCallback(() => {
+    setDeferredPrompt(null);
+    setIsInstallable(false);
+  }, []);
+
+  return { isInstallable, promptInstall, dismissInstall };
+}

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -89,6 +89,13 @@ function registerValidSW(swUrl, config) {
           window.dispatchEvent(new CustomEvent('sw-cache-updated', { detail: event.data }));
         }
       });
+
+      if ('periodicSync' in registration && registration.periodicSync) {
+        registration.periodicSync.register('eventra-data-sync', {
+          minInterval: 24 * 60 * 60 * 1000,
+        }).catch(() => {});
+      }
+
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
@@ -97,14 +104,8 @@ function registerValidSW(swUrl, config) {
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
             if (navigator.serviceWorker.controller) {
-              // At this point, the updated precached content has been fetched,
-              // but the previous service worker will still serve the older
-              // content until all client tabs are closed.
-              log(
-                'New content is available and will be used when all tabs for this page are closed. See https://cra.link/pwa.'
-              );
+              window.dispatchEvent(new CustomEvent('sw-update-available', { detail: { registration } }));
 
-              // Execute callback
               if (config && config.onUpdate) {
                 config.onUpdate(registration);
               }


### PR DESCRIPTION
Closes #6766

## Changes
- Dispatch custom \sw-update-available\ event when a new service worker is detected
- Create \useInstallPrompt\ hook for handling the beforeinstallprompt event
- Create \InstallAppButton\ component added to the navbar
- Create \UpdateAvailableBanner\ component for new-version notifications
- Register periodic sync for 24-hour background data refresh
- App shell caching already handled by CRA/Workbox build pipeline