### PR TITLE
fix: eliminate duplicate render and export false positives #6709

### DIFF
--- a/scripts/scan-issues.js
+++ b/scripts/scan-issues.js
@@ -12,24 +12,48 @@ function getFiles(dir) {
   return r;
 }
 
+// Helper to strip out comments and string literals to prevent regex false positives
+function cleanCodeForRegex(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')  // Remove multi-line comments
+    .replace(/\/\/.*/g, '')            // Remove single-line comments
+    .replace(/'[^'\\]*(?:\\.[^'\\]*)*'/g, '')   // Remove single-quoted strings safely
+    .replace(/"[^"\\]*(?:\\.[^"\\]*)*"/g, '')   // Remove double-quoted strings safely
+    .replace(/`[\s\S]*?`/g, '');       // Remove template literals
+}
+
 const files = getFiles('src');
 const issues = [];
 
 for (const f of files) {
   const code = fs.readFileSync(f, 'utf8');
-  const rel = f.replace(process.cwd() + path.sep, '');
-  
-  // Check for duplicate render() in class components
-  const renderMatches = [...code.matchAll(/^\s*render\s*\(\s*\)\s*\{/gm)];
+  let rel = path.relative(process.cwd(), f);
+  rel = rel.split(path.sep).join('/');
+  const cleanCode = cleanCodeForRegex(code);
+
+// To fix separate classes legitimately having render(), we split by 'class ' keyword 
+// and check if any individual class body contains more than one render() definition
+const classes = cleanCode.split(/\bclass\s+/);
+let hasDuplicateRender = false;
+
+// Skip the first split element as it's the code before any class definition
+for (let i = 1; i < classes.length; i++) {
+  const renderMatches = [...classes[i].matchAll(/\brender\s*\(\s*\)\s*\{/g)];
   if (renderMatches.length > 1) {
-    issues.push('DUPLICATE_RENDER: ' + rel);
+    hasDuplicateRender = true;
+    break;
   }
+}
+
+if (hasDuplicateRender) {
+  issues.push('DUPLICATE_RENDER: ' + rel);
+}
   
-  // Check for duplicate export default
-  const exportMatches = [...code.matchAll(/^export default /gm)];
-  if (exportMatches.length > 1) {
-    issues.push('DUPLICATE_EXPORT: ' + rel);
-  }
+// Check for duplicate export default on code stripped of comments and strings
+const exportMatches = [...cleanCode.matchAll(/\bexport\s+default\b/g)];
+if (exportMatches.length > 1) {
+  issues.push('DUPLICATE_EXPORT: ' + rel);
+}
 }
 
 console.log('Issues found:', issues.length);


### PR DESCRIPTION
## Description
This PR resolves issue #6709 where the linter script incorrectly triggered false positives for duplicate `render()` methods and `export default` statements. 

Previously, the script used flat string-matching regular expressions over raw file contents. This caused it to erroneously flag keywords appearing inside single-line comments, multi-line comments, string literals, and template strings. It also falsely flagged files containing multiple valid ES6 classes that each legitimately implemented a `render()` method.

**Changes introduced:**
- Added a lightweight helper function (`cleanCodeForRegex`) to strip out block comments, inline comments, string literals, and template strings safely before processing.
- Refactored the `render()` check to isolate class definitions by splitting on the `\bclass\s+` boundary, ensuring individual class scopes are evaluated independently.
- Updated the string-cleaning regex logic to be highly performant and secure against Catastrophic Backtracking.

Fixes #6709

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
