### PR TITLE
perf: memoize seat event handlers in SpatialSeatSelector

### DIFF
--- a/src/components/events/SpatialSeatSelector.jsx
+++ b/src/components/events/SpatialSeatSelector.jsx
@@ -340,13 +340,12 @@ const SpatialSeatSelector = ({
     e.currentTarget.releasePointerCapture(e.pointerId);
   };
 
-  // Check if a specific seat index on an element is selected
-  const isSeatSelected = (elId, idx) => {
+  const isSeatSelected = useCallback((elId, idx) => {
     return selectedSeat && selectedSeat.elementId === elId && selectedSeat.seatIndex === idx;
-  };
+  }, [selectedSeat]);
 
   // Selection callback
-  const handleSeatClick = (el, seat, seatIdx) => {
+  const handleSeatClick = useCallback((el, seat, seatIdx) => {
     if (readOnly) return;
     const isOccupied = el.assignedAttendees[seatIdx];
     if (isOccupied) return;
@@ -732,6 +731,28 @@ const Seat = ({ el, seat, allSeats, isSelected, readOnly, onSelect, onHover, con
     onHover(null);
   };
 
+  const handleMouseEnter = useCallback((e) => {
+    const bbox = e.currentTarget.getBoundingClientRect();
+    const vrect = containerRef.current.getBoundingClientRect();
+    onHover({
+      el,
+      seatIdx: seat.index,
+      label: seatLabel,
+      tier: seatTier,
+      occupiedBy: isOccupied || null,
+      x: bbox.left - vrect.left + bbox.width / 2,
+      y: bbox.top - vrect.top - 10,
+    });
+  }, [containerRef, el, onHover, seat.index, seatLabel, seatTier, isOccupied]);
+
+  const handleMouseLeave = useCallback(() => {
+    onHover(null);
+  }, [onHover]);
+
+  const handleClick = useCallback(() => {
+    onSelect(el, seat, seat.index);
+  }, [el, onSelect, seat]);
+
   return (
     <g
       id={`seat-element-${el.id}-${seat.index}`}
@@ -739,24 +760,12 @@ const Seat = ({ el, seat, allSeats, isSelected, readOnly, onSelect, onHover, con
       tabIndex={tabIndex}
       role={role}
       aria-label={ariaLabel}
-      onClick={() => onSelect(el, seat, seat.index)}
+      onClick={handleClick}
       onKeyDown={handleKeyDown}
       onFocus={handleFocus}
       onBlur={handleBlur}
-      onMouseEnter={(e) => {
-        const bbox = e.currentTarget.getBoundingClientRect();
-        const vrect = containerRef.current.getBoundingClientRect();
-        onHover({
-          el,
-          seatIdx: seat.index,
-          label: seatLabel,
-          tier: seatTier,
-          occupiedBy: isOccupied || null,
-          x: bbox.left - vrect.left + bbox.width / 2,
-          y: bbox.top - vrect.top - 10,
-        });
-      }}
-      onMouseLeave={() => onHover(null)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       style={{ cursor: isOccupied ? "not-allowed" : "pointer" }}
     >
       <circle cx={seat.x} cy={seat.y + 3} r={11} fill="rgba(0, 0, 0, 0.45)" />


### PR DESCRIPTION
## Summary
Memoizes seat event handlers in SpatialSeatSelector to prevent unnecessary re-renders of all 200+ seat elements on every state change.

## Changes
- Wrapped handleSeatClick and isSeatSelected in useCallback at parent level
- Created stable handleMouseEnter, handleMouseLeave, handleClick with useCallback inside Seat component
- Prevents inline arrow function recreation on every render, which was defeating MemoizedSeat

Closes #6793