### PR TITLE
fix: enforce registration notes length limit

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -42,11 +42,10 @@ import {
   saveCachedEventDetail,
 } from "../../utils/offlineEventCache";
 import { pushToQueue } from "../../utils/offlineQueue";
-import { logger } from "../../utils/logger";
 import { logError } from "../../utils/errorLogger";
 import hackathonsData from "../../Pages/Hackathons/hackathonMockData.json";
 
-const MAX_NOTES_CHARS = 500;
+export const MAX_NOTES_CHARS = 500;
 
 // Registration lock map to prevent concurrent registrations for the same event
 const registrationLocks = new Map();
@@ -305,7 +304,6 @@ const useEventRegistration = (eventIdParam) => {
   const { user, token, isAuthenticated } = useAuth();
   const { addRegistration, myEvents } = useMyEvents();
   const { clearSession } = useSessionRecovery();
-  const isHackathonPath = location.pathname.startsWith("/register");
   const registrationPath = location.pathname;
 
   const [event, setEvent] = useState(null);
@@ -332,7 +330,7 @@ const useEventRegistration = (eventIdParam) => {
     errors,
     touched,
     isFormValid,
-    handleChange,
+    handleChange: handleFormChange,
     handleBlur,
     validateAll,
     setValues,
@@ -349,6 +347,21 @@ const useEventRegistration = (eventIdParam) => {
     validationRules,
     { debounceMs: 300 }
   );
+
+  const handleRegistrationChange = useCallback((event) => {
+    if (event.target.name !== "additionalInfo") {
+      handleFormChange(event);
+      return;
+    }
+
+    handleFormChange({
+      ...event,
+      target: {
+        ...event.target,
+        value: event.target.value.slice(0, MAX_NOTES_CHARS),
+      },
+    });
+  }, [handleFormChange]);
 
   // Load event data from backend API
   useEffect(() => {
@@ -517,6 +530,7 @@ const useEventRegistration = (eventIdParam) => {
         endpoint,
         {
           ...formData,
+          additionalInfo: formData.additionalInfo.slice(0, MAX_NOTES_CHARS),
           priority: formData.priority,
           eventId: parseInt(eventId),
           userId: user.id,
@@ -536,6 +550,7 @@ const useEventRegistration = (eventIdParam) => {
       if (isOfflineFailure) {
         const payload = {
           ...formData,
+          additionalInfo: formData.additionalInfo.slice(0, MAX_NOTES_CHARS),
           eventId: parseInt(eventId),
           userId: user.id,
         };
@@ -649,7 +664,7 @@ const useEventRegistration = (eventIdParam) => {
     errors,
     touched,
     isFormValid,
-    handleChange,
+    handleChange: handleRegistrationChange,
     handleBlur,
     validateAll,
     setValues,

--- a/tests/eventRegistrationNotesLimit.test.mjs
+++ b/tests/eventRegistrationNotesLimit.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("src/hooks/useEventRegistration.js", "utf8");
+
+assert.match(source, /export const MAX_NOTES_CHARS = 500/);
+assert.match(source, /const handleRegistrationChange = useCallback/);
+assert.match(source, /value\.slice\(0, MAX_NOTES_CHARS\)/);
+assert.match(source, /additionalInfo:\s*formData\.additionalInfo\.slice\(0, MAX_NOTES_CHARS\)/);
+
+console.log("event registration notes limit contract passed");


### PR DESCRIPTION
## 🚀 Description

This PR enforces the documented 500-character registration notes limit while preserving optional-field behavior.

### Root Cause

MAX_NOTES_CHARS was documented but unused, so oversized notes could enter online and offline registration payloads.

Before:

```js
const MAX_NOTES_CHARS = 500;
// no enforcement
```

### Changes Made

* Exported MAX_NOTES_CHARS as the single source of truth.
* Clamped additionalInfo through the registration change handler.
* Clamped online and offline queue payloads at the boundary.
* Added a regression contract without making the optional field required.

### Validation

✅ Relevant issue has been resolved.

Executed:

```bash
node --loader ./tests/loaders/jsExtension.mjs tests/eventRegistrationNotesLimit.test.mjs
npm run lint
VITE_API_URL=http://localhost:8080/api npm run build
```

Notes:

* Remaining warnings are unrelated and tracked separately.
* No new errors were introduced.

✅ Build verification completed.

### Files Modified

* `src/hooks/useEventRegistration.js`
* `tests/eventRegistrationNotesLimit.test.mjs`

### Issue

Fixes #6775

---

## 🛠️ Type of Change

* [x] Code cleanup
* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A — validation is enforced inside the registration hook.

---

## ✅ Checklist

* [x] Changes are limited to the assigned issue
* [x] No unintended functionality changes introduced
* [x] Self-reviewed
* [x] Relevant validation completed
* [x] Existing behavior preserved