### PR TITLE
feat: restore CollaborationNetworkMap controls

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import useReducedMotion from "../../hooks/useReducedMotion";
 import {
   Globe,
   Users,
@@ -208,6 +209,7 @@ const ConnectionParticle = ({ path, color, delay }) => (
 
 // ============ MAIN COMPONENT ============
 export default function CollaborationNetworkMap() {
+  const prefersReducedMotion = useReducedMotion();
   const [activeHub, setActiveHub] = useState(null);
   const [pinnedHub, setPinnedHub] = useState(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -374,6 +376,19 @@ export default function CollaborationNetworkMap() {
                 </select>
               </div>
 
+              <select
+                value={selectedRegion}
+                onChange={(e) => setSelectedRegion(e.target.value)}
+                className="rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-700 focus:outline-none"
+                aria-label="Filter by region"
+              >
+                {REGIONS.map((region) => (
+                  <option key={region} value={region}>
+                    {region === "All" ? "All Regions" : region}
+                  </option>
+                ))}
+              </select>
+
               <label className="flex items-center gap-2 text-slate-700">
                 <input
                   type="checkbox"
@@ -382,6 +397,17 @@ export default function CollaborationNetworkMap() {
                   className=" h-5 w-5 rounded-lg border-slate-300 focus:ring-2 focus:ring-violet-500 cursor-pointer"
                 />
                 <span>Connections</span>
+              </label>
+
+              <label className="flex items-center gap-2 text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={particlesEnabled}
+                  onChange={(e) => setParticlesEnabled(e.target.checked)}
+                  disabled={prefersReducedMotion}
+                  className="h-5 w-5 rounded-lg border-slate-300 focus:ring-2 focus:ring-violet-500 cursor-pointer"
+                />
+                <span>Animated particles</span>
               </label>
             </div>
           </div>
@@ -490,7 +516,7 @@ export default function CollaborationNetworkMap() {
                       strokeWidth={Math.max(0.8, getConnectionWidth(conn.intensity))}
                       strokeLinecap="round"
                     />
-                    {particlesEnabled && (
+                    {particlesEnabled && !prefersReducedMotion && (
                       <ConnectionParticle path={pathD} color={color} delay={idx * 0.4} />
                     )}
                   </g>

--- a/tests/collaborationNetworkMapControls.test.mjs
+++ b/tests/collaborationNetworkMapControls.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("src/components/visual/CollaborationNetworkMap.jsx", "utf8");
+
+assert.match(source, /value=\{selectedRegion\}/);
+assert.match(source, /setSelectedRegion\(e\.target\.value\)/);
+assert.match(source, /checked=\{particlesEnabled\}/);
+assert.match(source, /setParticlesEnabled\(e\.target\.checked\)/);
+assert.match(source, /useReducedMotion/);
+
+console.log("collaboration network map controls contract passed");


### PR DESCRIPTION
## 🚀 Description

This PR restores the dormant region and particle controls in CollaborationNetworkMap while respecting reduced-motion preferences.

### Root Cause

The component maintained region and particle state, but no UI controls updated either value.

Before:

```js
const [selectedRegion, setSelectedRegion] = useState("All");
const [particlesEnabled, setParticlesEnabled] = useState(false);
```

### Changes Made

* Added an accessible region filter wired to REGIONS.
* Added an animated-particles toggle.
* Disabled particle animation when reduced motion is requested.
* Added a regression contract for both controls.

### Validation

✅ Relevant issue has been resolved.

Executed:

```bash
node --loader ./tests/loaders/jsExtension.mjs tests/collaborationNetworkMapControls.test.mjs
npm run lint
VITE_API_URL=http://localhost:8080/api npm run build
```

Notes:

* Remaining warnings are unrelated and tracked separately.
* No new errors were introduced.

✅ Build verification completed.

### Files Modified

* `src/components/visual/CollaborationNetworkMap.jsx`
* `tests/collaborationNetworkMapControls.test.mjs`

### Issue

Fixes #6777

---

## 🛠️ Type of Change

* [x] Code cleanup
* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A — controls follow the existing filter-row visual style.

---

## ✅ Checklist

* [x] Changes are limited to the assigned issue
* [x] No unintended functionality changes introduced
* [x] Self-reviewed
* [x] Relevant validation completed
* [x] Existing behavior preserved