### PR TITLE
refactor: restore reminder controls on EventDetails

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -1,7 +1,6 @@
 import "./EventDetails.print.css";
 import CountdownTimer from "../../components/common/CountdownTimer";
 import { useEffect, useState, useCallback, useRef } from "react";
-import React from "react";
 import { Helmet } from "react-helmet-async";
 import { sanitizeMarkdown } from "../../utils/sanitizeHtml";
 import { toast } from "react-toastify";
@@ -15,7 +14,6 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import { logger } from "../../utils/logger";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import CertificateDownload from "../../components/CertificateDownload";
-import EventMaterials from "../../components/common/EventMaterials";
 import EventRecommendations from "../../components/events/EventRecommendations";
 import { EventDetailSkeleton } from "../../components/common/SkeletonLoaders";
 import LazyImage from "../../components/common/LazyImage";
@@ -444,6 +442,10 @@ const EventDetails = () => {
               </Link>
             </div>
           </div>
+
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+            <ReminderControls event={event} canSetReminder={canSetReminder} />
+          </section>
 
           {/* Main Grid */}
           <div className="grid gap-8 lg:grid-cols-[1.25fr_0.75fr] items-start">

--- a/tests/eventDetailsReminderControls.test.mjs
+++ b/tests/eventDetailsReminderControls.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("src/Pages/Events/EventDetails.js", "utf8");
+
+assert.match(source, /<ReminderControls\s+event=\{event\}/);
+assert.match(source, /canSetReminder=\{canSetReminder\}/);
+assert.doesNotMatch(source, /import EventMaterials/);
+
+console.log("event details reminder controls contract passed");


### PR DESCRIPTION
## 🚀 Description

This PR restores reminder controls on EventDetails while preserving existing event detail behavior.

### Root Cause

EventDetails imported ReminderControls and computed reminder eligibility but never rendered the controls.

Before:

```js
const canSetReminder = isEventBookmarked(event.id) || isRegistered(event.id);
// value was never rendered
```

### Changes Made

* Rendered ReminderControls using the existing event and eligibility contract.
* Removed the orphaned EventMaterials and React default imports.
* Added a regression contract for EventDetails reminder integration.
* Preserved existing functionality and behavior.

### Validation

✅ Relevant issue has been resolved.

Executed:

```bash
node --loader ./tests/loaders/jsExtension.mjs tests/eventDetailsReminderControls.test.mjs
npm run lint
VITE_API_URL=http://localhost:8080/api npm run build
```

Notes:

* Remaining warnings are unrelated and tracked separately.
* No new errors were introduced.

✅ Build verification completed.

### Files Modified

* `src/Pages/Events/EventDetails.js`
* `tests/eventDetailsReminderControls.test.mjs`

### Issue

Fixes #6774

---

## 🛠️ Type of Change

* [x] Code cleanup
* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A — the existing ReminderControls component is reused without visual redesign.

---

## ✅ Checklist

* [x] Changes are limited to the assigned issue
* [x] No unintended functionality changes introduced
* [x] Self-reviewed
* [x] Relevant validation completed
* [x] Existing behavior preserved