### PR TITLE
fix: surface dropped offline sync actions

### DIFF
--- a/src/components/common/OfflineBanner.jsx
+++ b/src/components/common/OfflineBanner.jsx
@@ -7,13 +7,13 @@ export default function OfflineBanner() {
   const [status, setStatus] = useState(navigator.onLine ? "online" : "offline");
   const [visible, setVisible] = useState(!navigator.onLine);
   const [queueCount, setQueueCount] = useState(0);
+  const [syncSummary, setSyncSummary] = useState("");
   const timerRef = useRef(null);
 
   useEffect(() => {
-    let timer;
-
     const handleOnline = () => {
       setStatus("online");
+      setSyncSummary("");
       setVisible(true);
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => {
@@ -23,6 +23,7 @@ export default function OfflineBanner() {
 
     const handleOffline = () => {
       setStatus("offline");
+      setSyncSummary("");
       setVisible(true);
     };
 
@@ -34,7 +35,17 @@ export default function OfflineBanner() {
     const handleQueueProcessed = (e) => {
       const { succeeded, dropped, remaining } = e.detail;
       setQueueCount(remaining);
-      if (remaining === 0) {
+      if (dropped > 0) {
+        setSyncSummary(
+          `${dropped} queued action(s) could not be synced. ${succeeded} action(s) synced successfully.`,
+        );
+        setVisible(true);
+      } else {
+        setSyncSummary(
+          succeeded > 0 ? `${succeeded} queued action(s) synced successfully.` : "",
+        );
+      }
+      if (remaining === 0 && dropped === 0) {
         if (timerRef.current) clearTimeout(timerRef.current);
         timerRef.current = setTimeout(() => setVisible(false), 4000);
       }
@@ -70,7 +81,10 @@ export default function OfflineBanner() {
           <>
             <Wifi className="offline-banner-icon text-emerald-400" size={16} />
             <span>
-              Connection restored! {queueCount > 0 ? `Synchronizing ${queueCount} queued action(s)...` : "Offline cache is ready."}
+              {syncSummary ||
+                (queueCount > 0
+                  ? `Synchronizing ${queueCount} queued action(s)...`
+                  : "Connection restored! Offline cache is ready.")}
             </span>
           </>
         )}

--- a/tests/offlineBannerSyncFeedback.test.mjs
+++ b/tests/offlineBannerSyncFeedback.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync("src/components/common/OfflineBanner.jsx", "utf8");
+
+assert.match(source, /syncSummary/);
+assert.match(source, /dropped > 0/);
+assert.match(source, /succeeded/);
+assert.match(source, /queued action\(s\) could not be synced/);
+
+console.log("offline banner sync feedback contract passed");


### PR DESCRIPTION
## 🚀 Description

This PR surfaces dropped offline actions after queue synchronization while preserving the existing offline banner lifecycle.

### Root Cause

OfflineBanner received succeeded and dropped result counts but ignored them, allowing partial failures to appear successful.

Before:

```js
const { succeeded, dropped, remaining } = e.detail;
setQueueCount(remaining);
```

### Changes Made

* Added a synchronization summary state.
* Displayed distinct success and dropped-action outcomes.
* Kept dropped-action feedback visible instead of auto-hiding it as success.
* Removed the unused timer local and added a regression contract.

### Validation

✅ Relevant issue has been resolved.

Executed:

```bash
node --loader ./tests/loaders/jsExtension.mjs tests/offlineBannerSyncFeedback.test.mjs
npm run lint
VITE_API_URL=http://localhost:8080/api npm run build
```

Notes:

* Remaining warnings are unrelated and tracked separately.
* No new errors were introduced.

✅ Build verification completed.

### Files Modified

* `src/components/common/OfflineBanner.jsx`
* `tests/offlineBannerSyncFeedback.test.mjs`

### Issue

Fixes #6776

---

## 🛠️ Type of Change

* [x] Code cleanup
* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## 📸 Screenshots / Video (if applicable)

N/A — feedback uses the existing offline banner presentation.

---

## ✅ Checklist

* [x] Changes are limited to the assigned issue
* [x] No unintended functionality changes introduced
* [x] Self-reviewed
* [x] Relevant validation completed
* [x] Existing behavior preserved