### PR TITLE
refactor: standardize logging in service worker registration

### DIFF
--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -1,5 +1,6 @@
 // serviceWorkerRegistration.js
 // Registers the PWA service worker with dynamic lifecycle hooks to improve offline access.
+import { logger } from './utils/logger';
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -19,13 +20,6 @@ const runtimeEnv =
 const isDev = runtimeEnv.DEV ?? runtimeEnv.NODE_ENV === 'development';
 const publicBaseUrl = runtimeEnv.BASE_URL || "/";
 const isProd = runtimeEnv.PROD ?? runtimeEnv.NODE_ENV === "production";
-
-const log = (...args) => {
-  if (isDev) {
-    console.log(...args);
-  }
-};
-
 const MAX_SW_RETRIES = 3;
 const SW_RETRY_DELAY = 2000;
 
@@ -66,7 +60,7 @@ export function register(config) {
 
         // Add logging to localhost, welcoming developers
         navigator.serviceWorker.ready.then(() => {
-          log(
+          logger.log(
             'This web app is being served cache-first by a service worker. To learn more, visit https://cra.link/pwa'
           );
         });
@@ -85,7 +79,7 @@ function registerValidSW(swUrl, config) {
     .then((registration) => {
       navigator.serviceWorker.addEventListener('message', (event) => {
         if (event.data && event.data.type === 'CACHE_UPDATED') {
-          log('[Service Worker] Cache updated to version:', event.data.version);
+          logger.log('[Service Worker] Cache updated to version:', event.data.version);
           window.dispatchEvent(new CustomEvent('sw-cache-updated', { detail: event.data }));
         }
       });
@@ -100,7 +94,7 @@ function registerValidSW(swUrl, config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              log(
+              logger.log(
                 'New content is available and will be used when all tabs for this page are closed. See https://cra.link/pwa.'
               );
 
@@ -111,7 +105,7 @@ function registerValidSW(swUrl, config) {
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a "Content is cached for offline use!" message.
-              log('Content is cached for offline use.');
+              logger.log('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -124,7 +118,7 @@ function registerValidSW(swUrl, config) {
     })
     .catch((error) => {
       if (isDev) {
-        console.error(
+        logger.error(
           'Error during service worker registration:',
           error
         );
@@ -156,7 +150,7 @@ function checkValidServiceWorker(swUrl, config) {
       }
     })
     .catch(() => {
-      log('No internet connection found. App is running in offline mode.');
+      logger.log('No internet connection found. App is running in offline mode.');
     });
 }
 
@@ -168,7 +162,7 @@ export function unregister() {
       })
       .catch((error) => {
         if (isDev) {
-          console.error(error.message);
+          logger.error(error.message);
         }
       });
   }

--- a/src/utils/serviceWorkerRegistration.js
+++ b/src/utils/serviceWorkerRegistration.js
@@ -1,14 +1,15 @@
-/* eslint-disable no-console */
+import { logger } from './logger';
+
 export const registerServiceWorker = () => {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
         .register('/service-worker.js')
         .then((registration) => {
-          console.log('[Service Worker] Registered:', registration.scope);
+          logger.log('[Service Worker] Registered:', registration.scope);
         })
         .catch((error) => {
-          console.log('[Service Worker] Registration failed:', error);
+          logger.error('[Service Worker] Registration failed:', error);
         });
     });
   }
@@ -21,7 +22,7 @@ export const unregisterServiceWorker = () => {
         registration.unregister();
       })
       .catch((error) => {
-        console.log('[Service Worker] Unregister failed:', error);
+        logger.error('[Service Worker] Unregister failed:', error);
       });
   }
 };


### PR DESCRIPTION
## Description
This PR resolves an issue with console spam and non-standard logging by standardizing the `serviceWorkerRegistration.js` files to use the centralized `logger.js` utility.
Closes #6820
### Changes Made
- **`src/serviceWorkerRegistration.js`**: Replaced the custom local `log()` wrapper with the centralized `logger.log()` utility. Converted raw `console.error` calls to `logger.error()`.
- **`src/utils/serviceWorkerRegistration.js`**: Removed the `/* eslint-disable no-console */` rule, imported the centralized logger, and replaced `console.log` and `console.log(error)` with `logger.log()` and `logger.error()`.
- Ensures that PWA registration and caching logs are properly managed across development and production environments according to the app's standard logging configuration.

### Type of Change
- [x] Code Refactoring (cleaning up technical debt)
- [ ] Bug fix (non-breaking change which fixes an issue)

### Testing
- Verified that the application still compiles cleanly without ESLint errors regarding console statements.
