### PR TITLE
feat: add storybook documentation for layout components

### DIFF
--- a/src/components/Layout/BrandMark.stories.jsx
+++ b/src/components/Layout/BrandMark.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import BrandMark from "./BrandMark";
+
+export default {
+  title: "Layout/BrandMark",
+  component: BrandMark,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <div className="p-4 bg-zinc-100 dark:bg-zinc-800 flex justify-center items-center h-screen">
+          <Story />
+        </div>
+      </BrowserRouter>
+    ),
+  ],
+  argTypes: {
+    compact: { control: "boolean" },
+  },
+};
+
+export const Default = {
+  args: {
+    compact: false,
+  },
+};
+
+export const Compact = {
+  args: {
+    compact: true,
+  },
+};

--- a/src/components/Layout/CursorToggleButton.stories.jsx
+++ b/src/components/Layout/CursorToggleButton.stories.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import CursorToggleButton from "./CursorToggleButton";
+
+export default {
+  title: "Layout/CursorToggleButton",
+  component: CursorToggleButton,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="p-8 bg-zinc-50 dark:bg-zinc-900 flex justify-center items-center h-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    cursorEnabled: { control: "boolean" },
+    isMobile: { control: "boolean" },
+    toggleCursor: { action: "toggled" },
+  },
+};
+
+export const DesktopEnabled = {
+  args: {
+    cursorEnabled: true,
+    isMobile: false,
+  },
+};
+
+export const DesktopDisabled = {
+  args: {
+    cursorEnabled: false,
+    isMobile: false,
+  },
+};
+
+export const MobileEnabled = {
+  args: {
+    cursorEnabled: true,
+    isMobile: true,
+  },
+};
+
+export const MobileDisabled = {
+  args: {
+    cursorEnabled: false,
+    isMobile: true,
+  },
+};

--- a/src/components/Layout/ThemeToggleButton.stories.jsx
+++ b/src/components/Layout/ThemeToggleButton.stories.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import ThemeToggleButton from "./ThemeToggleButton";
+
+export default {
+  title: "Layout/ThemeToggleButton",
+  component: ThemeToggleButton,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="p-8 bg-zinc-50 dark:bg-zinc-900 flex justify-center items-center h-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    isDarkMode: { control: "boolean" },
+    isMobile: { control: "boolean" },
+    toggleTheme: { action: "theme_toggled" },
+    setIsCustomizerOpen: { action: "customizer_opened" },
+  },
+};
+
+export const DesktopLight = {
+  args: {
+    isDarkMode: false,
+    isMobile: false,
+  },
+};
+
+export const DesktopDark = {
+  args: {
+    isDarkMode: true,
+    isMobile: false,
+  },
+};
+
+export const MobileLight = {
+  args: {
+    isDarkMode: false,
+    isMobile: true,
+  },
+};
+
+export const MobileDark = {
+  args: {
+    isDarkMode: true,
+    isMobile: true,
+  },
+};


### PR DESCRIPTION
## Description
This PR resolves an issue with missing component documentation by adding Storybook stories for the newly introduced Layout components.
Closes #6822 
### Changes Made
- Created `BrandMark.stories.jsx` covering both the default and compact variants.
- Created `CursorToggleButton.stories.jsx` covering the fluid/static toggle states across both desktop and mobile layouts.
- Created `ThemeToggleButton.stories.jsx` covering the light/dark mode and customizer trigger states across both desktop and mobile layouts.
- Integrated `react-router-dom` decorators to support inner `<Link>` wrappers cleanly.

### Type of Change
- [x] Documentation / Storybook (adding missing UI library states)
- [ ] Bug fix (non-breaking change which fixes an issue)
