### PR TITLE
Fix #6840: docs: Add GSSoC Eventra ticket booking concurrency lock guide

### DIFF
--- a/docs/gssoc/guide_6840.md
+++ b/docs/gssoc/guide_6840.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra ticket booking concurrency lock guide
+
+## Overview
+Explains the optimistic concurrency locking for seat reservation in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6840