### PR TITLE
Fix #6844: docs: Add GSSoC Eventra user role permission levels guide

### DIFF
--- a/docs/gssoc/guide_6844.md
+++ b/docs/gssoc/guide_6844.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra user role permission levels guide
+
+## Overview
+Details role permission structures for hosts, attendees, and admins in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6844