### PR TITLE
Fix #6846: docs: Add GSSoC Eventra event search geocoding index guide

### DIFF
--- a/docs/gssoc/guide_6846.md
+++ b/docs/gssoc/guide_6846.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra event search geocoding index guide
+
+## Overview
+Describes geocoding indexing for location-based event queries in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6846