### PR TITLE
Fix #6850: docs: Add GSSoC Eventra user email verification activation guide

### DIFF
--- a/docs/gssoc/guide_6850.md
+++ b/docs/gssoc/guide_6850.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra user email verification activation guide
+
+## Overview
+Documents the signup token generation and verification flow in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6850