### PR TITLE
Fix #6852: docs: Add GSSoC Eventra calendar view synchronization state guide

### DIFF
--- a/docs/gssoc/guide_6852.md
+++ b/docs/gssoc/guide_6852.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra calendar view synchronization state guide
+
+## Overview
+Details synchronizing client state with calendar component renders in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6852