### PR TITLE
Fix #6857: docs: Add GSSoC Eventra notification template localization guide

### DIFF
--- a/docs/gssoc/guide_6857.md
+++ b/docs/gssoc/guide_6857.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra notification template localization guide
+
+## Overview
+Documents localized email templates for ticket bookings in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6857