### PR TITLE
fix: mock request socket in clientIp tests for robust execution

### DIFF
--- a/tests/clientIp.test.mjs
+++ b/tests/clientIp.test.mjs
@@ -4,6 +4,7 @@ import { getClientIp } from "../api/lib/getClientIp.js";
 {
   const ip = getClientIp({
     headers: { "x-real-ip": " 203.0.113.7 " },
+    socket: { remoteAddress: "127.0.0.1" },
   });
   assert.equal(ip, "203.0.113.7");
 }


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR resolves the `clientIp.test.mjs` test failures by correctly mocking the `socket.remoteAddress` property on test HTTP request objects.

Resolves #6860