### PR TITLE
Fix #6861: docs: Add GSSoC Eventra local storage fallback cache guide

### DIFF
--- a/docs/gssoc/guide_6861.md
+++ b/docs/gssoc/guide_6861.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra local storage fallback cache guide
+
+## Overview
+Details using in-memory state fallbacks if localStorage is blocked in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6861