### PR TITLE
Fix #6865: docs: Add GSSoC Eventra image upload resizing utility guide

### DIFF
--- a/docs/gssoc/guide_6865.md
+++ b/docs/gssoc/guide_6865.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra image upload resizing utility guide
+
+## Overview
+Explains compressing and resizing uploaded event poster images in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6865