### PR TITLE
fix: prevent URL corruption by removing forward slash from input sanitization

### DIFF
--- a/src/utils/inputSanitization.js
+++ b/src/utils/inputSanitization.js
@@ -119,9 +119,8 @@ export const sanitizeInputText = (text = '') => {
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
-    "'": '&#x27;',
-    '/': '&#x2F;'
+    "'": '&#x27;'
   };
 
-  return text.replace(/[&<>"'/]/g, (match) => htmlEscapes[match]);
+  return text.replace(/[&<>"']/g, (match) => htmlEscapes[match]);
 };

--- a/tests/sanitizeInputText.test.mjs
+++ b/tests/sanitizeInputText.test.mjs
@@ -24,7 +24,7 @@ assert.ok(sanitized.includes("&lt;"), "opening bracket escaped");
 assert.ok(sanitized.includes("&gt;"), "closing bracket escaped");
 assert.ok(sanitized.includes("&quot;"), "double quotes escaped");
 assert.ok(sanitized.includes("&#x27;"), "single quotes escaped");
-assert.ok(sanitized.includes("&#x2F;"), "slashes escaped");
+assert.ok(sanitized.includes("/slash/"), "slashes preserved");
 
 const onlySpecial = "&<>\"'/";
 const sanitizedOnly = sanitizeInputText(onlySpecial);


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR removes forward slash (`/`) from the HTML escape map in `inputSanitization.js` to prevent URL and path string corruption in user descriptions, and updates the test suite to match the corrected behaviour.

Resolves #6867