### PR TITLE
Fix #6868: docs: Add GSSoC Eventra admin audit log tracking database schema guide

### DIFF
--- a/docs/gssoc/guide_6868.md
+++ b/docs/gssoc/guide_6868.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra admin audit log tracking database schema guide
+
+## Overview
+Details the schema for logging administrative actions in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6868