### PR TITLE
refactor: use dynamic import for Sentry to prevent require crashes in ESM

### DIFF
--- a/src/utils/errorLogger.js
+++ b/src/utils/errorLogger.js
@@ -6,28 +6,29 @@ import { SENTRY_DSN, isSentryEnabled } from "../config/env.js";
 let Sentry = null;
 
 if (isSentryEnabled && typeof window !== "undefined") {
-  try {
-    const SentryModule = require("@sentry/browser");
-    Sentry = SentryModule;
+  import("@sentry/browser")
+    .then((SentryModule) => {
+      Sentry = SentryModule;
 
-    Sentry.init({
-      dsn: SENTRY_DSN,
-      integrations: [
-        typeof SentryModule.browserTracingIntegration === "function"
-          ? SentryModule.browserTracingIntegration()
-          : null,
-        typeof SentryModule.replayIntegration === "function"
-          ? SentryModule.replayIntegration()
-          : null,
-      ].filter(Boolean),
-      tracesSampleRate: 0.25,
-      replaysSessionSampleRate: 0.1,
-      replaysOnErrorSampleRate: 1.0,
-      environment: process.env.NODE_ENV || "development",
+      Sentry.init({
+        dsn: SENTRY_DSN,
+        integrations: [
+          typeof SentryModule.browserTracingIntegration === "function"
+            ? SentryModule.browserTracingIntegration()
+            : null,
+          typeof SentryModule.replayIntegration === "function"
+            ? SentryModule.replayIntegration()
+            : null,
+        ].filter(Boolean),
+        tracesSampleRate: 0.25,
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1.0,
+        environment: process.env.NODE_ENV || "development",
+      });
+    })
+    .catch(() => {
+      // Sentry SDK unavailable — local-only logging will still work
     });
-  } catch {
-    // Sentry SDK unavailable — local-only logging will still work
-  }
 }
 
 function buildErrorEntry(error, errorInfo, extra = {}) {


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR replaces the CommonJS `require("@sentry/browser")` call with an asynchronous dynamic `import()` statement, resolving modern ESM loading crashes.

Resolves #6871