### PR TITLE
Fix #6872: docs: Add GSSoC Eventra security token refresh validation flow guide

### DIFF
--- a/docs/gssoc/guide_6872.md
+++ b/docs/gssoc/guide_6872.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra security token refresh validation flow guide
+
+## Overview
+Outlines refresh token rotation policies and security scopes in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6872