### PR TITLE
fix: prepend UTF-8 BOM to exported CSVs for correct Excel encoding

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -87,7 +87,7 @@ export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv"
     .map((row) => row.map(sanitizeCSVField).join(","))
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const blob = new Blob(["\uFEFF" + csvContent], { type: "text/csv;charset=utf-8;" });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement("a");
 
@@ -141,7 +141,7 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
     .map((row) => row.map(sanitizeCSVField).join(","))
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const blob = new Blob(["\uFEFF" + csvContent], { type: "text/csv;charset=utf-8;" });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement("a");
 
@@ -206,7 +206,7 @@ export const exportEventsToCSV = (events, filename = "eventra-events.csv") => {
     .map((row) => row.map(sanitizeCSVField).join(","))
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const blob = new Blob(["\uFEFF" + csvContent], { type: "text/csv;charset=utf-8;" });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement("a");
 


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR prepends a UTF-8 BOM `\uFEFF` to all generated CSV Blobs in `exportCsv.js`, resolving character encoding issues when opening files in Excel.

Resolves #6875