### PR TITLE
Fix #6876: docs: Add GSSoC Eventra SEO meta tags Open Graph properties guide

### DIFF
--- a/docs/gssoc/guide_6876.md
+++ b/docs/gssoc/guide_6876.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra SEO meta tags Open Graph properties guide
+
+## Overview
+Explains dynamic meta tag injection for event page previews in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6876