### PR TITLE
Fix #6880: docs: Add GSSoC Eventra frontend router lazy loading split guide

### DIFF
--- a/docs/gssoc/guide_6880.md
+++ b/docs/gssoc/guide_6880.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra frontend router lazy loading split guide
+
+## Overview
+Documents dynamic bundle splitting for dashboards in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6880