### PR TITLE
fix: prevent infinite API fetch loop in EventRegistration component

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -227,7 +227,7 @@ const EventRegistration = () => {
     return () => {
       isCancelled = true;
     };
-  }, [eventId, user, isAuthenticated, setValues, location.pathname]);
+  }, [eventId, user?.id, isAuthenticated, setValues, location.pathname]);
 
   const checkEventCapacity = useCallback(async (id, currentEvent) => {
     try {


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR replaces the raw `user` object dependency in the `EventRegistration` `useEffect` hook with `user?.id`, avoiding redundant API calls and potential backend rate limits.

Resolves #6882