### PR TITLE
Fix #6885: docs: Add GSSoC Eventra keyboard accessibility Skip Link implementation guide

### DIFF
--- a/docs/gssoc/guide_6885.md
+++ b/docs/gssoc/guide_6885.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra keyboard accessibility Skip Link implementation guide
+
+## Overview
+Outlines keyboard tab focus and skip links implementation in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6885