### PR TITLE
fix: catch individual fetch errors in Contributors Promise.all map

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -182,12 +182,26 @@ const ContributorsInner = () => {
 
       const enhanced = await Promise.all(
         allContributors.map(async (c) => {
-          const profile = await fetchGitHubProfile(c.login);
-          return {
-            ...c,
-            ...profile,
-            role: getRoleByGitHubActivity({ ...c, ...profile }),
-          };
+          try {
+            const profile = await fetchGitHubProfile(c.login);
+            return {
+              ...c,
+              ...profile,
+              role: getRoleByGitHubActivity({ ...c, ...profile }),
+            };
+          } catch (err) {
+            console.error(`Failed to load profile for ${c.login || "unknown"}:`, err);
+            return {
+              ...c,
+              followers: 0,
+              public_repos: 0,
+              name: c.login || "Contributor",
+              bio: "Open source contributor",
+              company: null,
+              location: null,
+              role: getRoleByGitHubActivity(c),
+            };
+          }
         }),
       );
 


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR wraps the GitHub profile fetch call inside the `Promise.all` mapper in a `try-catch` block, making the list load resilient to individual profile fetch errors.

Resolves #6886