### PR TITLE
Fix #6889: docs: Add GSSoC Eventra event draft auto save handler mechanics guide

### DIFF
--- a/docs/gssoc/guide_6889.md
+++ b/docs/gssoc/guide_6889.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra event draft auto save handler mechanics guide
+
+## Overview
+Details debounce and state persist mechanisms for event drafts in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6889