### PR TITLE
fix: resolve Safari Date parsing issue in ReminderChecker

### DIFF
--- a/src/components/reminders/ReminderChecker.js
+++ b/src/components/reminders/ReminderChecker.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { toast } from "react-toastify";
 import { popDueReminders } from "../../utils/reminderUtils";
+import { parseEventDateTimeLocal } from "../../utils/timezoneUtils";
 
 const CHECK_INTERVAL_MS = 30 * 1000;
 const CHANNEL_NAME = "eventra_reminders_sync_channel";
@@ -9,7 +10,7 @@ const showBrowserNotification = (reminder) => {
   if (typeof window === "undefined" || !("Notification" in window)) return;
   if (Notification.permission !== "granted") return;
 
-  const eventDate = new Date(`${reminder.event.date} ${reminder.event.time || "12:00 AM"}`);
+  const eventDate = parseEventDateTimeLocal(reminder.event.date, reminder.event.time) || new Date();
 
   new Notification(`Reminder: ${reminder.event.title}`, {
     body: `${reminder.timingLabel} at ${eventDate.toLocaleTimeString([], {


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR adopts the `parseEventDateTimeLocal` utility in `ReminderChecker.js` to ensure date parsing compatibility across all modern browsers including Safari/iOS.

Resolves #6894