### PR TITLE
Fix #6893: docs: Add GSSoC Eventra docker multi stage dev pipeline guide

### DIFF
--- a/docs/gssoc/guide_6893.md
+++ b/docs/gssoc/guide_6893.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra docker multi stage dev pipeline guide
+
+## Overview
+Outlines the multi-stage Docker build pipeline for Eventra development.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6893