### PR TITLE
fix: add IndexedDB compatibility check for SSR and private-window safety in P2P transfer

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -20,22 +20,30 @@ let dbInstance = null;
 // Initialize IndexedDB
 const getDB = () => {
   if (dbInstance) return Promise.resolve(dbInstance);
+  if (typeof window === "undefined" || typeof indexedDB === "undefined" || !indexedDB) {
+    return Promise.reject(new Error("IndexedDB is not supported in this environment"));
+  }
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION);
-    request.onupgradeneeded = (e) => {
-      const db = e.target.result;
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: "chunkId" });
-      }
-    };
-    request.onsuccess = (e) => {
-      dbInstance = e.target.result;
-      resolve(dbInstance);
-    };
-    request.onerror = (e) => {
-      console.error("IndexedDB initialization error:", e);
-      reject(e);
-    };
+    try {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = (e) => {
+        const db = e.target.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME, { keyPath: "chunkId" });
+        }
+      };
+      request.onsuccess = (e) => {
+        dbInstance = e.target.result;
+        resolve(dbInstance);
+      };
+      request.onerror = (e) => {
+        console.error("IndexedDB initialization error:", e);
+        reject(e);
+      };
+    } catch (err) {
+      console.error("IndexedDB open exception:", err);
+      reject(err);
+    }
   });
 };
 


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR adds comprehensive checks for `window` and `indexedDB` availability before initializing the file cache database in `p2pFileTransfer.js`, avoiding crashes in server-side rendered pages and private windows.

Resolves #6897