### PR TITLE
Fix #6898: docs: Add GSSoC Eventra system status logging and metrics guide

### DIFF
--- a/docs/gssoc/guide_6898.md
+++ b/docs/gssoc/guide_6898.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Eventra system status logging and metrics guide
+
+## Overview
+Documents integrating system logger output with monitoring tools in Eventra.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #6898