### PR TITLE
fix: close AudioContext in QuestCenter sound player to prevent context leaks

### DIFF
--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -138,6 +138,17 @@ const playClaimSound = () => {
       osc2.start(triggerTime);
       osc2.stop(triggerTime + 0.25);
     });
+
+    // Close the audio context after all notes finish playing to prevent resource leakage
+    setTimeout(() => {
+      try {
+        if (ctx.state !== "closed") {
+          ctx.close();
+        }
+      } catch (err) {
+        console.warn("Failed to close AudioContext:", err);
+      }
+    }, 1500);
   } catch (error) {
     console.warn("Web Audio API not allowed or supported on this context:", error);
   }


### PR DESCRIPTION
I am contributing on behalf of GSSoc’26.

This PR adds a `setTimeout` to clean up and close the instantiated `AudioContext` after the chime notes finish playing, preventing hardware context leaks.

Resolves #6901