### PR TITLE
[Critical] Add error logging to empty catch blocks in storage/index.js

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,3 +1,4 @@
+import { logger } from "../utils/logger";
 import { safeParseJson } from "../utils/jsonUtils";
 
 const STORAGE_TYPES = {
@@ -8,7 +9,8 @@ const STORAGE_TYPES = {
 function getStorage(type) {
   try {
     return type === STORAGE_TYPES.SESSION ? sessionStorage : localStorage;
-  } catch {
+  } catch (e) {
+    logger.warn("[storage] Storage API not available:", e);
     return null;
   }
 }
@@ -20,7 +22,8 @@ export const storage = {
       if (!store) return fallback;
       const raw = store.getItem(key);
       return raw !== null ? safeParseJson(raw, raw) : fallback;
-    } catch {
+    } catch (e) {
+      logger.warn("[storage.get] Failed to read key:", key, e);
       return fallback;
     }
   },
@@ -31,7 +34,9 @@ export const storage = {
       if (!store) return;
       const raw = typeof value === "string" ? value : JSON.stringify(value);
       store.setItem(key, raw);
-    } catch {}
+    } catch (e) {
+      logger.warn("[storage.set] Failed to write key:", key, e);
+    }
   },
 
   remove(key, type = STORAGE_TYPES.LOCAL) {
@@ -39,7 +44,9 @@ export const storage = {
       const store = getStorage(type);
       if (!store) return;
       store.removeItem(key);
-    } catch {}
+    } catch (e) {
+      logger.warn("[storage.remove] Failed to remove key:", key, e);
+    }
   },
 
   clear(type = STORAGE_TYPES.LOCAL) {
@@ -47,7 +54,9 @@ export const storage = {
       const store = getStorage(type);
       if (!store) return;
       store.clear();
-    } catch {}
+    } catch (e) {
+      logger.warn("[storage.clear] Failed to clear storage:", e);
+    }
   },
 
   keys(type = STORAGE_TYPES.LOCAL) {
@@ -55,7 +64,8 @@ export const storage = {
       const store = getStorage(type);
       if (!store) return [];
       return Object.keys(store);
-    } catch {
+    } catch (e) {
+      logger.warn("[storage.keys] Failed to enumerate keys:", e);
       return [];
     }
   },


### PR DESCRIPTION
## Summary

All six `catch` blocks in `src/storage/index.js` were empty, silently swallowing every error during localStorage/sessionStorage operations. This made storage-related bugs extremely difficult to debug since there was zero evidence an operation failed.

## Changes

**`src/storage/index.js`** — Added `import { logger } from "../utils/logger"` and descriptive `logger.warn()` calls to every catch block:

```diff
-  } catch {
-    return null;
+  } catch (e) {
+    logger.warn("[storage] Storage API not available:", e);
+    return null;
   }
```

Similar fix applied to all five other catch blocks with context-specific messages:
- `[storage.get] Failed to read key:` — includes the key name
- `[storage.set] Failed to write key:` — includes the key name
- `[storage.remove] Failed to remove key:` — includes the key name
- `[storage.clear] Failed to clear storage:` — generic clear failure
- `[storage.keys] Failed to enumerate keys:` — enumeration failure

## Why this is critical

When localStorage throws (quota exceeded, security restrictions, private browsing mode), the operation silently fails with no indication. Developers and users see no console warning, no error toast, and have no way to detect that data operations are failing. The `logger` utility is already used across 20+ files in the codebase and is the standard pattern for error reporting.

## Testing

- Existing test suite passes with no regressions
- The `logger` utility is well-tested and used throughout the codebase
- All return values (`null`, `fallback`, `[]`) remain unchanged — only logging was added

Closes #6928
