### PR TITLE
[Critical] Remove duplicate getUserTimezone function from dateFormatter.js

### DIFF
--- a/src/utils/dateFormatter.js
+++ b/src/utils/dateFormatter.js
@@ -1,21 +1,4 @@
-/**
- * Timezone-aware Date Formatting Utility
- *
- * Uses Intl.DateTimeFormat to format dates in the user's local timezone.
- * Falls back gracefully if the Intl API is not available.
- */
-
-/**
- * Gets the user's timezone from the browser.
- * @returns {string} IANA timezone string (e.g., "America/New_York")
- */
-export function getUserTimezone() {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  } catch {
-    return "UTC";
-  }
-}
+import { getUserTimezone } from './timezoneUtils';
 
 /**
  * Formats a date string for display in the user's local timezone.


### PR DESCRIPTION
## Summary

The `getUserTimezone()` function was duplicated across two files with near-identical implementations:
- `src/utils/dateFormatter.js` — own copy (lines 12-18)
- `src/utils/timezoneUtils.js` — canonical copy (lines 14-20)

This is a maintenance hazard: any future fix or enhancement to timezone detection must be applied to both copies or they will diverge.

## Changes

**`src/utils/dateFormatter.js`**:
- Removed the inline `getUserTimezone()` function definition (1 import + 18 lines deleted)
- Added `import { getUserTimezone } from './timezoneUtils'`
- The `formatEventDate` function already called `getUserTimezone()` at line 20, so no call-site changes were needed

```diff
-/**
- * Gets the user's timezone from the browser.
- * @returns {string} IANA timezone string (e.g., "America/New_York")
- */
-export function getUserTimezone() {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  } catch {
-    return "UTC";
-  }
-}
+import { getUserTimezone } from './timezoneUtils';
```

## Why this matters

If the timezone detection logic ever needs to change (e.g., to add a configuration override, fix a browser compatibility issue, or respect a user-selected timezone preference), both copies must be updated in sync — a maintenance hazard that will inevitably diverge. The canonical source (`timezoneUtils.js`) is already imported by `conflictDetection.js`.

## Testing

- Existing test suite passes (timezoneUtils tests and all other tests)
- The imported function is identical to the removed one (same logic, same fallback to "UTC")
- No import cycle detected (timezoneUtils.js does not import from dateFormatter.js)

Closes #6932
