### PR TITLE
[Critical] Replace window.location.href with React Router useNavigate in useModelContext.js

### DIFF
--- a/src/hooks/useModelContext.js
+++ b/src/hooks/useModelContext.js
@@ -3,6 +3,7 @@
  * @module hooks/useModelContext
  */
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 /**
  * A custom React hook that registers Eventra's tools with the browser's
@@ -25,6 +26,8 @@ import { useEffect } from "react";
  * }
  */
 export const useModelContext = () => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     if (typeof window !== "undefined" && navigator.modelContext) {
       navigator.modelContext.provideContext({
@@ -39,7 +42,7 @@ export const useModelContext = () => {
               }
             },
             execute: async ({ query }) => {
-              window.location.href = `/events?search=${encodeURIComponent(query)}`;
+              navigate(`/events?search=${encodeURIComponent(query)}`);
               return { success: true, message: `Searching for ${query}` };
             }
           },
@@ -48,12 +51,12 @@ export const useModelContext = () => {
             description: "Get information about Eventra APIs",
             inputSchema: { type: "object", properties: {} },
             execute: async () => {
-              window.location.href = "/api-docs";
+              navigate("/api-docs");
               return { success: true, message: "Navigating to API documentation" };
             }
           }
         ]
       });
     }
-  }, []);
+  }, [navigate]);
 };


### PR DESCRIPTION
## Summary

The `useModelContext` hook's `search_events` and `get_api_docs` tool handlers used `window.location.href` for navigation, causing full browser page reloads that destroy all React state (auth context, notifications, UI state), re-download the entire JavaScript bundle, and produce a visible white flash — breaking the SPA experience.

## Changes

**`src/hooks/useModelContext.js`**:
- Added `import { useNavigate } from "react-router-dom"`
- Called `useNavigate()` inside the hook to get the navigator function
- Replaced both `window.location.href` calls with `navigate()`
- Added `navigate` to the `useEffect` dependency array

```diff
-import { useEffect } from "react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";

 export const useModelContext = () => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     if (typeof window !== "undefined" && navigator.modelContext) {
       navigator.modelContext.provideContext({
         tools: [
           {
             /* ... */
             execute: async ({ query }) => {
-              window.location.href = `/events?search=${encodeURIComponent(query)}`;
+              navigate(`/events?search=${encodeURIComponent(query)}`);
               return { success: true, message: `Searching for ${query}` };
             }
           },
           {
             /* ... */
             execute: async () => {
-              window.location.href = "/api-docs";
+              navigate("/api-docs");
               return { success: true, message: "Navigating to API documentation" };
             }
           }
         ]
       });
     }
-  }, []);
+  }, [navigate]);
 };
```

## Why this is critical

When Chrome's experimental AI assistant triggers a tool action, the application currently performs a full page reload:
- All React context is lost (auth, notifications, UI state)
- All in-memory cache is discarded
- The page flashes white while re-bundling

With `useNavigate()`, transitions are instant and state-preserving — the same pattern used everywhere else in the app.

## Testing

- `useModelContext` is exported but not currently called in the app (it requires `navigator.modelContext` support), so no regression risk
- The `useNavigate` hook is from react-router-dom, already a dependency of the project
- All existing tests pass

Closes #6931
