### PR TITLE
fix: prevent sanitizeInputText from escaping forward slashes

### DIFF
--- a/src/utils/inputSanitization.js
+++ b/src/utils/inputSanitization.js
@@ -112,11 +112,10 @@ export const sanitizeInputText = (text = '') => {
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
-    "'": '&#x27;',
-    '/': '&#x2F;'
+    "'": '&#x27;'
   };
 
-  return text.replace(/[&<>"'/]/g, (match) => htmlEscapes[match]);
+  return text.replace(/[&<>"']/g, (match) => htmlEscapes[match]);
 };
 
 /**


### PR DESCRIPTION
Fixes #6831

Forward slashes are no longer escaped, preventing URL corruption in user-submitted content.