### PR TITLE
fix: fix ReferenceError in offlineQueue setQueue()

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -434,8 +434,8 @@ export const setQueue = async (newQueue) => {
 
         newQueue.forEach((item) => store.put(item));
 
-        transaction.oncomplete = () => resolve();
-        transaction.onerror = () => reject(transaction.error);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
       };
       clearReq.onerror = () => reject(clearReq.error);
     });


### PR DESCRIPTION
Fixes #6806

Replaced the undefined `transaction` variable with `tx` to allow the background queue to clear properly after sync.
