### PR TITLE
fix: add BOM to CSV exports

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -87,7 +87,8 @@ export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv"
     .map((row) => row.map(sanitizeCSVField).join(","))
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const BOM = "\uFEFF";
+  const blob = new Blob([BOM + csvContent], { type: "text/csv;charset=utf-8;" });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement("a");
 
@@ -148,7 +149,8 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
     .map((row) => row.map(sanitizeCSVField).join(","))
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const BOM = "\uFEFF";
+  const blob = new Blob([BOM + csvContent], { type: "text/csv;charset=utf-8;" });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement("a");
 
@@ -213,7 +215,8 @@ export const exportEventsToCSV = (events, filename = "eventra-events.csv") => {
     .map((row) => row.map(sanitizeCSVField).join(","))
     .join("\n");
 
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+  const BOM = "\uFEFF";
+  const blob = new Blob([BOM + csvContent], { type: "text/csv;charset=utf-8;" });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement("a");
 


### PR DESCRIPTION
Fixes #6810


Added UTF-8 BOM (`\uFEFF`) to CSV blobs so that non-ASCII characters and emojis render correctly in Microsoft Excel.