### PR TITLE
fix: prevent infinite API fetch loop in useEventRegistration

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -448,7 +448,7 @@ const useEventRegistration = (eventIdParam) => {
     return () => {
       isCancelled = true;
     };
-  }, [eventId, user, isAuthenticated, setValues, location.pathname]);
+  }, [eventId, user?.id, isAuthenticated, setValues, location.pathname]);
 
   const checkEventCapacity = useCallback(async (id, currentEvent) => {
     try {


### PR DESCRIPTION
Fixes #6808

Changed the useEffect dependency from the `user` object to `user?.id` to prevent continuous API refetching when the context object reference changes.