### PR TITLE
fix: prevent lastSeenFollowers null pointer crash

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -223,7 +223,7 @@ class SseMultiplexer {
   handleBroadcastMessage(msg) {
     if (!isValidBroadcastMessage(msg) || msg.tabId === this.tabId) return;
 
-    if (this.isLeader && this.lastSeenFollowers) {
+    if (this.isLeader && this.lastSeenFollowers instanceof Map) {
       this.lastSeenFollowers.set(msg.tabId, Date.now());
     }
 


### PR DESCRIPTION
Fixes #6826

Added an `instanceof Map` check before interacting with `lastSeenFollowers` to prevent null pointer crashes on leader tab re-elections.