### PR TITLE
fix: add missing null and empty data guard to exportToJSON to match exportToCSV behaviour

### DIFF
--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -39,6 +39,7 @@ export function exportToCSV(data, filename) {
 }
 
 export function exportToJSON(data, filename) {
+  if (!data || !data.length) return;
   const jsonString = JSON.stringify(data, null, 2);
   const blob = new Blob([jsonString], { type: 'application/json;charset=utf-8;' });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
Fixes exportToJSON silently downloading a file containing "null" or "[]" when called with no data.

## Problem
exportToCSV has an early return for null or empty data. exportToJSON was missing this guard. Calling it with null or an empty array triggered a download of a useless file containing the literal string "null" or "[]" with no error or warning to the caller.

## Fix
Added if (!data || !data.length) return; at the top of exportToJSON. This mirrors the identical guard already present in exportToCSV and makes both functions behave consistently.

## Changes
- src/utils/exportUtils.js — added null and empty guard to exportToJSON

Closes #6954 