### PR TITLE
fix: add null and type guard to sanitizeFilename to prevent TypeError crash on missing or invalid filename

### DIFF
--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -1,4 +1,5 @@
 export function sanitizeFilename(name) {
+  if (!name || typeof name !== "string") return "file";
   return name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
 }
 


### PR DESCRIPTION
## Summary
Fixes a TypeError crash in sanitizeFilename when called with null, undefined, or a non-string filename.

## Problem
sanitizeFilename called name.replace() with no validation. Both exportToCSV and exportToJSON pass the filename argument through to sanitizeFilename directly. Omitting the filename or passing a non-string crashed the entire export with TypeError before any file was created.

## Fix
Added if (!name || typeof name !== "string") return "file"; at the top of sanitizeFilename. Falls back to the safe filename "file" for any invalid input, allowing the export to complete correctly.

## Changes
- src/utils/exportUtils.js — added null and type guard to sanitizeFilename

Closes #6962 