### PR TITLE
fix: add warning and comment to messenger case in generateSharingUrl to make unsupported platform explicit

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -81,6 +81,10 @@ export const generateSharingUrl = (shareData, platform) => {
       return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
 
     case "messenger":
+      // Messenger sharing requires a Facebook App ID (app_id parameter) which
+      // is not available in this client-side configuration.
+      // Callers should hide or disable the Messenger share button.
+      console.warn("[shareUtils] Messenger sharing is not supported — no Facebook App ID configured.");
       return "";
 
     case "linkedin":


### PR DESCRIPTION
## Summary
Fixes the silent empty string return for the messenger platform in generateSharingUrl by adding a console.warn and an explanatory inline comment.

## Problem
The messenger case returned "" with no warning or comment. Callers could not distinguish this from an error or validation failure. The JSDoc listed messenger as supported, creating a false expectation.

## Fix
I Added console.warn explaining Messenger sharing requires a Facebook App ID not available in this configuration. Added inline comment advising callers to hide or disable the Messenger share button. Return value is unchanged to avoid breaking existing callers.

## Changes
- src/utils/shareUtils.js — added warning and comment to messenger case

Closes #6964