### PR TITLE
fix: await proceedWithRegistration in handleSubmit to prevent silent unhandled promise rejection

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -629,9 +629,9 @@ const useEventRegistration = (eventIdParam) => {
       toast.info("This event is full. You will be added to the waitlist.");
     }
 
-    if (await checkAndHandleConflicts()) return;
+      if (await checkAndHandleConflicts()) return;
 
-    proceedWithRegistration();
+    await proceedWithRegistration();
   }, [isAuthenticated, user, navigate, registrationPath, validateAll, eventId, event, checkEventCapacity, checkAndHandleConflicts, proceedWithRegistration]);
 
   // Handle conflict modal actions


### PR DESCRIPTION
## Summary
Fixes a fire-and-forget async call in handleSubmit that silently dropped unhandled promise rejections from proceedWithRegistration.

## Problem
proceedWithRegistration is async but was called without await in handleSubmit. Any error escaping its internal try/catch became a silent unhandled rejection with no user feedback and potentially leaving the submitting state unresolved.

## Fix
I Added await before proceedWithRegistration(). handleSubmit is already declared async so no further changes are needed.

## Changes
- src/hooks/useEventRegistration.js — added await to proceedWithRegistration call in handleSubmit

Closes #6972 