### PR TITLE
fix: revoke blob URL after SVG certificate download in UserAchievements to prevent memory leak

### DIFF
--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -178,6 +178,8 @@ export default function UserAchievements() {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    // Free browser memory after download triggers (100ms ensures download starts first)
+    setTimeout(() => URL.revokeObjectURL(url), 100);
     toast.success(t("userAchievements.toastCertificateDownloaded"));
   };
 


### PR DESCRIPTION
## Summary
Fixes a memory leak in UserAchievements where handleDownloadSVG created a blob URL for SVG certificate downloads but never revoked it.

## Problem
URL.createObjectURL allocates browser memory that must be explicitly freed with URL.revokeObjectURL. handleDownloadSVG triggered the download but skipped the revoke step. Each download permanently leaked the allocated memory for the page session lifetime. exportUtils.js correctly handles this with a 100ms setTimeout after the click.

## Fix
Added setTimeout(() => URL.revokeObjectURL(url), 100) after link.click(), matching the existing pattern in exportToCSV and exportToJSON.

## Changes
- src/Pages/UserAchievements.jsx — added URL.revokeObjectURL call after SVG download

Closes #6980 