### PR TITLE
fix: add catch block to handleExportCSV in SavedEventsPage to show error toast on export failure

### DIFF
--- a/src/Pages/SavedEventsPage.jsx
+++ b/src/Pages/SavedEventsPage.jsx
@@ -4,6 +4,7 @@ import { Download } from "lucide-react";
 import EmptyState from "../components/common/EmptyState";
 import useBookmarks from "../hooks/useBookmarks";
 import { exportToCSV } from "../utils/exportUtils";
+import { toast } from "react-toastify";
 
 const SavedEventsPage = () => {
   const navigate = useNavigate();
@@ -20,6 +21,8 @@ const SavedEventsPage = () => {
     setExporting(true);
     try {
       exportToCSV(sorted, `eventra-saved-events-${new Date().toISOString().slice(0, 10)}`);
+    } catch {
+      toast.error("Failed to export saved events. Please try again.");
     } finally {
       // Brief visual feedback before resetting
       setTimeout(() => setExporting(false), 800);


### PR DESCRIPTION
## Summary
Fixes silent export failure in SavedEventsPage where exportToCSV errors were swallowed by try/finally with no user feedback.

## Problem
handleExportCSV used try/finally with no catch. Any error thrown by exportToCSV was silently discarded. The button flashed "Exporting..." then reset without showing any message, leaving the user with no idea the export failed.

## Fix
I Added a catch block that calls toast.error with a descriptive message. Also added the missing toast import from react-toastify which was not imported in this file.

## Changes
- src/Pages/SavedEventsPage.jsx — added catch block and toast import to handleExportCSV

Closes #6983 