### PR TITLE
fix: wrap fallbackBadges in useMemo in UserAchievements to prevent unnecessary recomputation on every render

### DIFF
--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNotification } from '../context/NotificationContext';
 import useDocumentTitle from '../hooks/useDocumentTitle';
@@ -46,7 +46,7 @@ export default function UserAchievements() {
   }, [activeShareBadge]);
 
   // Fallback / Normalized list of milestone achievements with progress metrics
-  const fallbackBadges = [
+  const fallbackBadges = useMemo(() => [
     {
       id: 'first-step',
       name: 'First Step',
@@ -107,7 +107,7 @@ export default function UserAchievements() {
       details: 'Dive deep into AI integrations, blockchain, and next-generation Web3 protocols.',
       log: ['+400 XP awarded', 'AI Specialist badge enabled'],
     },
-  ];
+  ], [achievements.totalEvents, achievements.currentStreak]);
 
   const operationalBadges = achievements.badges && achievements.badges.length > 0
     ? achievements.badges.map((b, idx) => ({


### PR DESCRIPTION
## Summary
Fixes unnecessary recomputation of the fallbackBadges array on every render in UserAchievements.jsx by memoizing it with useMemo.

## Problem
fallbackBadges was defined as a plain const inside the component. It was fully reconstructed on every render regardless of whether achievements.totalEvents or achievements.currentStreak had changed. The component has multiple interactive state variables (expandedBadgeId, activeShareBadge, shareStory, sharePlatform) that trigger frequent re-renders, causing this array to be rebuilt each time.

## Fix
I Wrapped fallbackBadges in useMemo with [achievements.totalEvents, achievements.currentStreak] as its dependency array. The array now recomputes only when the actual data it depends on changes. Added useMemo to the existing React import.

## Changes
- src/Pages/UserAchievements.jsx — memoized fallbackBadges with useMemo

Closes #6986 