### PR TITLE
fix: memoize sorted bookmarks in SavedEventsPage with useMemo to prevent unnecessary resort on every render

### DIFF
--- a/src/Pages/SavedEventsPage.jsx
+++ b/src/Pages/SavedEventsPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Download } from "lucide-react";
 import EmptyState from "../components/common/EmptyState";
@@ -11,8 +11,11 @@ const SavedEventsPage = () => {
   const [sortBy, setSortBy] = useState("savedAt");
   const [exporting, setExporting] = useState(false);
 
-  const sorted = [...bookmarks].sort((a, b) =>
-    sortBy === "savedAt" ? b.savedAt - a.savedAt : new Date(a.date) - new Date(b.date)
+  const sorted = useMemo(
+    () => [...bookmarks].sort((a, b) =>
+      sortBy === "savedAt" ? b.savedAt - a.savedAt : new Date(a.date) - new Date(b.date)
+    ),
+    [bookmarks, sortBy]
   );
 
   const handleExportCSV = () => {


### PR DESCRIPTION
## Summary
Fixes unnecessary resorting of the bookmarks array on every render in SavedEventsPage.jsx by wrapping the sorted computation in useMemo.

## Problem
sorted was defined as a plain const using [...bookmarks].sort(). This ran a full spread and sort on every render, including renders triggered by the exporting state toggling during the 800ms CSV export feedback window. The sort result only depends on bookmarks and sortBy.

## Fix
I Wrapped sorted in useMemo with [bookmarks, sortBy] as dependencies. The sort now only runs when the data it depends on actually changes. Added useMemo to the existing React import.

## Changes
- src/Pages/SavedEventsPage.jsx — memoized sorted array with useMemo

Closes #6988 