### PR TITLE
Fix IDOR in event registration endpoint with ownership verification

### DIFF
--- a/api/lib/authorizeOwnership.js
+++ b/api/lib/authorizeOwnership.js
@@ -1,0 +1,97 @@
+/**
+ * Resource ownership authorization helpers.
+ *
+ * Prevents Insecure Direct Object Reference (IDOR) vulnerabilities by verifying
+ * that the authenticated caller owns (or is otherwise permitted to access) the
+ * resource identified by the request, before any data is returned or mutated.
+ *
+ * The registration endpoints previously returned and mutated records based on
+ * the URL id alone, so any authenticated user could read or modify another
+ * attendee's registration by guessing or incrementing the id. These helpers
+ * centralise the ownership check so every endpoint enforces it consistently.
+ */
+
+/**
+ * Determines whether a user may act on a resource.
+ *
+ * Access is granted when the user owns the resource or holds an elevated role
+ * (admin / organizer). Comparison is type-tolerant so string and numeric ids
+ * (e.g. "5001" vs 5001) match correctly.
+ *
+ * @param {Object} params
+ * @param {string|number} params.userId - Authenticated user's id
+ * @param {Array<string>} [params.userRoles] - Roles held by the user
+ * @param {string|number} params.resourceOwnerId - Owner id stored on the resource
+ * @param {Array<string>} [params.allowedRoles] - Roles that bypass ownership
+ * @returns {boolean} true when access is permitted
+ */
+export function canAccessResource({
+  userId,
+  userRoles = [],
+  resourceOwnerId,
+  allowedRoles = ["admin", "organizer"],
+}) {
+  if (userId === undefined || userId === null) {
+    return false;
+  }
+  if (resourceOwnerId === undefined || resourceOwnerId === null) {
+    return false;
+  }
+
+  // Elevated roles may access any resource.
+  if (Array.isArray(userRoles)) {
+    for (const role of userRoles) {
+      if (allowedRoles.includes(role)) {
+        return true;
+      }
+    }
+  }
+
+  // Ownership check, tolerant of string vs numeric id types.
+  return String(userId) === String(resourceOwnerId);
+}
+
+/**
+ * Enforces ownership for a request, writing a 401/403 response when denied.
+ *
+ * @param {Object} params
+ * @param {Object} params.user - Authenticated user ({ id, roles })
+ * @param {Object} params.resource - Resource being accessed (must expose an owner id)
+ * @param {string} [params.ownerField] - Field on the resource holding the owner id
+ * @param {Array<string>} [params.allowedRoles] - Roles that bypass ownership
+ * @param {Object} params.res - Response object exposing status()/json()
+ * @returns {boolean} true when the caller may proceed, false when a response was sent
+ */
+export function enforceOwnership({
+  user,
+  resource,
+  ownerField = "userId",
+  allowedRoles = ["admin", "organizer"],
+  res,
+}) {
+  if (!user || user.id === undefined || user.id === null) {
+    res.status(401).json({ error: "Authentication required" });
+    return false;
+  }
+
+  if (!resource) {
+    res.status(404).json({ error: "Resource not found" });
+    return false;
+  }
+
+  const allowed = canAccessResource({
+    userId: user.id,
+    userRoles: user.roles || [],
+    resourceOwnerId: resource[ownerField],
+    allowedRoles,
+  });
+
+  if (!allowed) {
+    // 403, not 404: the resource exists but the caller is not permitted.
+    // A deliberate uniform message avoids leaking which ids are valid.
+    res.status(403).json({ error: "You do not have access to this resource" });
+    return false;
+  }
+
+  return true;
+}

--- a/api/registrations/[id].js
+++ b/api/registrations/[id].js
@@ -1,0 +1,107 @@
+/**
+ * Registration detail endpoint (GET / PUT / DELETE) with IDOR protection.
+ *
+ * Previously these operations trusted the URL id alone, so any authenticated
+ * user could read or modify another attendee's registration by guessing or
+ * incrementing the id, exposing phone, email and address. This handler verifies
+ * that the caller owns the registration (or holds an organizer/admin role)
+ * before returning or mutating any data.
+ */
+
+import { enforceOwnership } from "../lib/authorizeOwnership.js";
+
+/**
+ * Registration handler.
+ *
+ * @param {Object} req - Request with method, body, and an authenticated user
+ * @param {Object} res - Response exposing status()/json()
+ * @param {Object} [deps] - Injected dependencies for testability
+ * @param {Function} [deps.getRegistrationById] - async (id) => registration | null
+ * @param {Function} [deps.updateRegistration] - async (id, patch) => registration
+ * @param {Function} [deps.deleteRegistration] - async (id) => void
+ * @param {Function} [deps.getRegistrationId] - (req) => string (id extraction)
+ */
+export default async function registrationHandler(req, res, deps = {}) {
+  const {
+    getRegistrationById,
+    updateRegistration,
+    deleteRegistration,
+    getRegistrationId = (request) =>
+      request.params?.id ?? request.query?.id,
+  } = deps;
+
+  // The caller must be authenticated. In production this is populated by the
+  // auth middleware; tests inject it directly.
+  const user = req.user;
+  if (!user || user.id === undefined || user.id === null) {
+    res.status(401).json({ error: "Authentication required" });
+    return;
+  }
+
+  const registrationId = getRegistrationId(req);
+  if (!registrationId) {
+    res.status(400).json({ error: "Registration id is required" });
+    return;
+  }
+
+  if (typeof getRegistrationById !== "function") {
+    res.status(503).json({ error: "Registration service unavailable" });
+    return;
+  }
+
+  let registration;
+  try {
+    registration = await getRegistrationById(registrationId);
+  } catch {
+    res.status(500).json({ error: "Internal server error" });
+    return;
+  }
+
+  if (!registration) {
+    res.status(404).json({ error: "Registration not found" });
+    return;
+  }
+
+  // Core IDOR guard: verify ownership before any read or write.
+  if (!enforceOwnership({ user, resource: registration, ownerField: "userId", res })) {
+    return;
+  }
+
+  const method = req.method || "GET";
+
+  try {
+    if (method === "GET") {
+      res.status(200).json({ registration });
+      return;
+    }
+
+    if (method === "PUT" || method === "PATCH") {
+      if (typeof updateRegistration !== "function") {
+        res.status(503).json({ error: "Registration service unavailable" });
+        return;
+      }
+      // Never allow the owner id to be reassigned through an update.
+      const patch = { ...(req.body || {}) };
+      delete patch.userId;
+      delete patch.id;
+
+      const updated = await updateRegistration(registrationId, patch);
+      res.status(200).json({ registration: updated });
+      return;
+    }
+
+    if (method === "DELETE") {
+      if (typeof deleteRegistration !== "function") {
+        res.status(503).json({ error: "Registration service unavailable" });
+        return;
+      }
+      await deleteRegistration(registrationId);
+      res.status(204).json({});
+      return;
+    }
+
+    res.status(405).json({ error: "Method not allowed" });
+  } catch {
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/tests/registrationOwnership.test.mjs
+++ b/tests/registrationOwnership.test.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+
+const { canAccessResource, enforceOwnership } = await import(
+  "../api/lib/authorizeOwnership.js"
+);
+const handlerModule = await import("../api/registrations/[id].js");
+const registrationHandler = handlerModule.default;
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+// --- canAccessResource: owner matches ---
+{
+  assert.equal(
+    canAccessResource({ userId: 5, resourceOwnerId: 5 }),
+    true,
+    "owner can access"
+  );
+  assert.equal(
+    canAccessResource({ userId: "5001", resourceOwnerId: 5001 }),
+    true,
+    "string/number ids match"
+  );
+  assert.equal(
+    canAccessResource({ userId: 7, resourceOwnerId: 8 }),
+    false,
+    "non-owner denied"
+  );
+}
+
+// --- canAccessResource: elevated roles bypass ownership ---
+{
+  assert.equal(
+    canAccessResource({
+      userId: 1,
+      userRoles: ["admin"],
+      resourceOwnerId: 999,
+    }),
+    true,
+    "admin bypasses ownership"
+  );
+  assert.equal(
+    canAccessResource({
+      userId: 1,
+      userRoles: ["user"],
+      resourceOwnerId: 999,
+    }),
+    false,
+    "ordinary role does not bypass ownership"
+  );
+}
+
+// --- canAccessResource: missing ids deny ---
+{
+  assert.equal(
+    canAccessResource({ userId: null, resourceOwnerId: 5 }),
+    false,
+    "null userId denied"
+  );
+  assert.equal(
+    canAccessResource({ userId: 5, resourceOwnerId: undefined }),
+    false,
+    "missing owner denied"
+  );
+}
+
+// --- enforceOwnership: writes 403 for non-owner ---
+{
+  const res = makeRes();
+  const allowed = enforceOwnership({
+    user: { id: 2, roles: ["user"] },
+    resource: { userId: 1 },
+    res,
+  });
+  assert.equal(allowed, false, "non-owner blocked");
+  assert.equal(res.statusCode, 403, "403 returned");
+}
+
+const owner = { id: 5001, roles: ["user"] };
+const attacker = { id: 6002, roles: ["user"] };
+const registration = {
+  id: "reg-1",
+  userId: 5001,
+  email: "owner@example.com",
+  phone: "555-0100",
+};
+
+const deps = {
+  getRegistrationById: async (id) =>
+    id === "reg-1" ? { ...registration } : null,
+  updateRegistration: async (id, patch) => ({ ...registration, ...patch }),
+  deleteRegistration: async () => undefined,
+  getRegistrationId: (req) => req.params.id,
+};
+
+// --- owner can GET their registration ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    { method: "GET", user: owner, params: { id: "reg-1" } },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 200, "owner GET returns 200");
+  assert.equal(res.body.registration.email, "owner@example.com");
+}
+
+// --- attacker cannot GET another user's registration (IDOR blocked) ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    { method: "GET", user: attacker, params: { id: "reg-1" } },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 403, "attacker GET blocked with 403");
+  assert.equal(res.body.registration, undefined, "no data leaked to attacker");
+}
+
+// --- attacker cannot PUT another user's registration ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    {
+      method: "PUT",
+      user: attacker,
+      params: { id: "reg-1" },
+      body: { phone: "555-9999" },
+    },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 403, "attacker PUT blocked with 403");
+}
+
+// --- owner PUT cannot reassign ownership ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    {
+      method: "PUT",
+      user: owner,
+      params: { id: "reg-1" },
+      body: { phone: "555-0101", userId: 9999 },
+    },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 200, "owner PUT succeeds");
+  assert.equal(
+    res.body.registration.userId,
+    5001,
+    "userId cannot be reassigned via update"
+  );
+  assert.equal(res.body.registration.phone, "555-0101", "allowed field updated");
+}
+
+// --- unauthenticated request rejected ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    { method: "GET", params: { id: "reg-1" } },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 401, "missing user returns 401");
+}
+
+// --- unknown registration returns 404 ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    { method: "GET", user: owner, params: { id: "missing" } },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 404, "unknown registration returns 404");
+}
+
+// --- admin can access any registration ---
+{
+  const res = makeRes();
+  await registrationHandler(
+    { method: "GET", user: { id: 1, roles: ["admin"] }, params: { id: "reg-1" } },
+    res,
+    deps
+  );
+  assert.equal(res.statusCode, 200, "admin can access any registration");
+}
+
+console.log("registration ownership (IDOR) tests passed ✓");


### PR DESCRIPTION
## Summary
Adds server-side ownership verification to the registration detail endpoint. Previously GET/PUT on `/api/registrations/:id` trusted the URL id alone, so any authenticated user could read or modify another attendee's registration by guessing or incrementing the id, exposing phone, email and address.

## Detailed Technical Analysis
This is a classic Insecure Direct Object Reference (IDOR). The handler fetched the record by id and returned or updated it without checking that `req.user.id` matched `registration.userId`. Sequential numeric ids make enumeration trivial, turning every registration into publicly readable and writable data for any logged-in account.

## Real-World Scenarios
- User A registers for an event and is assigned registrationId 5001
- User B authenticates, sends `GET /api/registrations/5001`, and receives User A's full record including phone, email and address
- User B sends `PUT /api/registrations/5001` and overwrites User A's data
- User B increments through ids to harvest every attendee's personal data

## Complete Implementation
- `api/lib/authorizeOwnership.js`: `canAccessResource` and `enforceOwnership` helpers granting access only to the resource owner or elevated roles (admin/organizer), with type-tolerant id comparison ("5001" vs 5001) and a uniform 403
- `api/registrations/[id].js`: GET/PUT/DELETE handler that loads the record, verifies ownership before any read or write, strips `userId`/`id` from update patches so ownership cannot be reassigned, and returns 401/403/404 appropriately
- Tests covering owner access, attacker denial on GET and PUT, ownership-reassignment prevention, admin override, unauthenticated rejection, and unknown-id 404

## Testing Strategy
1. Owner can GET their own registration (200)
2. Non-owner GET is blocked with 403 and no data leaks
3. Non-owner PUT is blocked with 403
4. Owner PUT cannot reassign `userId` (privilege-escalation guard)
5. Unauthenticated request returns 401
6. Unknown id returns 404
7. Admin/organizer roles can access any registration
8. String and numeric ids compare correctly

All new tests pass with the project's `npm run test:unit` Node runner.

## Related Standards
- OWASP: Insecure Direct Object Reference Prevention
- CWE-639: Authorization Bypass Through User-Controlled Key
- OWASP API Security Top 10: API1 Broken Object Level Authorization

Fixes #6522

/assign anshul23102