### PR TITLE
Add mandatory pagination to event search endpoint

### DIFF
--- a/api/events/search.js
+++ b/api/events/search.js
@@ -1,0 +1,72 @@
+/**
+ * Event search endpoint with mandatory pagination.
+ *
+ * Previously this endpoint returned every matching event in one response, so a
+ * broad query such as "concert" could return thousands of records, freezing the
+ * client and consuming large amounts of memory. This handler always paginates,
+ * with a default page size of 20 and a hard maximum of 100, and returns a
+ * standard pagination envelope so clients can page through results.
+ *
+ * When the data source supports native paginated queries (preferred), the
+ * injected `searchEvents` performs LIMIT/OFFSET at the database level so the
+ * server never materialises the full result set. A `countEvents` function
+ * supplies the total for pagination metadata.
+ */
+
+import {
+  normalizePagination,
+  buildPageResponse,
+  paginateArray,
+} from "../lib/pagination.js";
+
+/**
+ * Search handler.
+ *
+ * @param {Object} req - Request with method and query
+ * @param {Object} res - Response exposing status()/json()
+ * @param {Object} [deps] - Injected dependencies for testability
+ * @param {Function} [deps.searchEvents] - async ({ query, offset, pageSize }) => events[]
+ *   Should apply LIMIT/OFFSET natively. If it returns the full set, the handler
+ *   slices defensively so the response is paginated either way.
+ * @param {Function} [deps.countEvents] - async ({ query }) => number
+ */
+export default async function searchEventsHandler(req, res, deps = {}) {
+  if (req.method && req.method !== "GET") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const { searchEvents, countEvents } = deps;
+
+  if (typeof searchEvents !== "function") {
+    res.status(503).json({ error: "Search service unavailable" });
+    return;
+  }
+
+  const query = (req.query?.q ?? req.query?.query ?? "").toString().trim();
+  const { page, pageSize, offset } = normalizePagination(req.query || {});
+
+  try {
+    const rows = await searchEvents({ query, offset, pageSize });
+    const safeRows = Array.isArray(rows) ? rows : [];
+
+    // Defensive slice: if the data source ignored offset/pageSize and returned
+    // everything, we still emit at most pageSize items.
+    const items =
+      safeRows.length > pageSize
+        ? paginateArray(safeRows, offset, pageSize)
+        : safeRows;
+
+    const total =
+      typeof countEvents === "function"
+        ? await countEvents({ query })
+        : // Best-effort fallback when no count function is provided.
+          offset + items.length + (items.length === pageSize ? pageSize : 0);
+
+    res.status(200).json(
+      buildPageResponse({ items, total, page, pageSize })
+    );
+  } catch {
+    res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/api/lib/pagination.js
+++ b/api/lib/pagination.js
@@ -1,0 +1,84 @@
+/**
+ * Server-side pagination helpers for list/search endpoints.
+ *
+ * The event search endpoint previously returned every matching row in a single
+ * response. For popular queries this meant thousands of records in one payload,
+ * freezing the browser and consuming large amounts of memory and bandwidth.
+ * These helpers normalise pagination parameters with hard upper bounds so a
+ * single request can never return an unbounded result set.
+ */
+
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 100;
+
+/**
+ * Normalises raw page/pageSize query values into safe integers.
+ *
+ * - page is clamped to >= 1
+ * - pageSize is clamped to [1, MAX_PAGE_SIZE] and defaults to DEFAULT_PAGE_SIZE
+ * - non-numeric input falls back to defaults instead of throwing
+ *
+ * @param {Object} query
+ * @param {string|number} [query.page]
+ * @param {string|number} [query.pageSize]
+ * @returns {{ page: number, pageSize: number, offset: number }}
+ */
+export function normalizePagination(query = {}) {
+  const rawPage = Number.parseInt(query.page, 10);
+  const rawSize = Number.parseInt(query.pageSize, 10);
+
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
+
+  let pageSize = Number.isFinite(rawSize) && rawSize >= 1 ? rawSize : DEFAULT_PAGE_SIZE;
+  if (pageSize > MAX_PAGE_SIZE) {
+    pageSize = MAX_PAGE_SIZE;
+  }
+
+  return {
+    page,
+    pageSize,
+    offset: (page - 1) * pageSize,
+  };
+}
+
+/**
+ * Builds a standard paginated response envelope.
+ *
+ * @param {Object} params
+ * @param {Array} params.items - The page of items
+ * @param {number} params.total - Total matching items across all pages
+ * @param {number} params.page - Current page (1-based)
+ * @param {number} params.pageSize - Items per page
+ * @returns {{ data: Array, pagination: Object }}
+ */
+export function buildPageResponse({ items, total, page, pageSize }) {
+  const totalPages = total <= 0 ? 0 : Math.ceil(total / pageSize);
+
+  return {
+    data: items,
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1 && totalPages > 0,
+    },
+  };
+}
+
+/**
+ * Applies offset pagination to an in-memory array.
+ * Used when the data source cannot paginate natively.
+ *
+ * @param {Array} items
+ * @param {number} offset
+ * @param {number} pageSize
+ * @returns {Array}
+ */
+export function paginateArray(items, offset, pageSize) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.slice(offset, offset + pageSize);
+}

--- a/tests/eventSearchPagination.test.mjs
+++ b/tests/eventSearchPagination.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+
+const {
+  normalizePagination,
+  buildPageResponse,
+  paginateArray,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} = await import("../api/lib/pagination.js");
+const handlerModule = await import("../api/events/search.js");
+const searchEventsHandler = handlerModule.default;
+
+function makeRes() {
+  return {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+// --- normalizePagination defaults and clamping ---
+{
+  const d = normalizePagination({});
+  assert.equal(d.page, 1, "default page 1");
+  assert.equal(d.pageSize, DEFAULT_PAGE_SIZE, "default page size");
+  assert.equal(d.offset, 0, "default offset 0");
+
+  const clamped = normalizePagination({ pageSize: "10000" });
+  assert.equal(clamped.pageSize, MAX_PAGE_SIZE, "page size clamped to max");
+
+  const p3 = normalizePagination({ page: "3", pageSize: "20" });
+  assert.equal(p3.offset, 40, "offset computed from page and size");
+
+  const bad = normalizePagination({ page: "-5", pageSize: "abc" });
+  assert.equal(bad.page, 1, "negative page falls back to 1");
+  assert.equal(bad.pageSize, DEFAULT_PAGE_SIZE, "non-numeric size falls back");
+}
+
+// --- buildPageResponse metadata ---
+{
+  const env = buildPageResponse({
+    items: [1, 2, 3],
+    total: 53,
+    page: 1,
+    pageSize: 20,
+  });
+  assert.deepEqual(env.data, [1, 2, 3], "items echoed in data");
+  assert.equal(env.pagination.totalPages, 3, "53/20 -> 3 pages");
+  assert.equal(env.pagination.hasNextPage, true, "has next page");
+  assert.equal(env.pagination.hasPreviousPage, false, "no previous on page 1");
+
+  const last = buildPageResponse({ items: [], total: 0, page: 1, pageSize: 20 });
+  assert.equal(last.pagination.totalPages, 0, "no results -> 0 pages");
+  assert.equal(last.pagination.hasNextPage, false, "no next when empty");
+}
+
+// --- paginateArray slices correctly ---
+{
+  const arr = Array.from({ length: 100 }, (_, i) => i);
+  assert.deepEqual(paginateArray(arr, 0, 5), [0, 1, 2, 3, 4], "first page");
+  assert.deepEqual(paginateArray(arr, 95, 20), [95, 96, 97, 98, 99], "tail page");
+  assert.deepEqual(paginateArray(null, 0, 5), [], "non-array yields empty");
+}
+
+// --- handler: rejects non-GET ---
+{
+  const res = makeRes();
+  await searchEventsHandler({ method: "POST", query: {} }, res, {
+    searchEvents: async () => [],
+  });
+  assert.equal(res.statusCode, 405, "non-GET rejected");
+}
+
+// --- handler: returns at most pageSize even if source returns everything ---
+{
+  const allEvents = Array.from({ length: 5000 }, (_, i) => ({ id: i }));
+  const res = makeRes();
+  await searchEventsHandler(
+    { method: "GET", query: { q: "concert" } },
+    res,
+    {
+      // Simulate a naive data source that ignores offset/pageSize.
+      searchEvents: async () => allEvents,
+      countEvents: async () => allEvents.length,
+    }
+  );
+  assert.equal(res.statusCode, 200, "search returns 200");
+  assert.equal(
+    res.body.data.length,
+    DEFAULT_PAGE_SIZE,
+    "response capped to default page size despite huge source"
+  );
+  assert.equal(res.body.pagination.total, 5000, "total reported");
+  assert.equal(res.body.pagination.totalPages, 250, "5000/20 -> 250 pages");
+}
+
+// --- handler: honours native pagination and page selection ---
+{
+  let received;
+  const res = makeRes();
+  await searchEventsHandler(
+    { method: "GET", query: { q: "music", page: "3", pageSize: "10" } },
+    res,
+    {
+      searchEvents: async ({ query, offset, pageSize }) => {
+        received = { query, offset, pageSize };
+        return Array.from({ length: pageSize }, (_, i) => ({ id: offset + i }));
+      },
+      countEvents: async () => 100,
+    }
+  );
+  assert.equal(res.statusCode, 200, "paginated search returns 200");
+  assert.deepEqual(
+    received,
+    { query: "music", offset: 20, pageSize: 10 },
+    "offset/pageSize passed to data source"
+  );
+  assert.equal(res.body.data.length, 10, "page contains pageSize items");
+  assert.equal(res.body.pagination.page, 3, "current page echoed");
+  assert.equal(res.body.pagination.hasPreviousPage, true, "has previous on page 3");
+}
+
+// --- handler: missing service fails closed ---
+{
+  const res = makeRes();
+  await searchEventsHandler({ method: "GET", query: {} }, res, {});
+  assert.equal(res.statusCode, 503, "missing searchEvents returns 503");
+}
+
+console.log("event search pagination tests passed ✓");


### PR DESCRIPTION
## Summary
Adds mandatory pagination to the event search endpoint. Previously the endpoint returned every matching event in one response, so a broad query such as "concert" could return thousands of records, freezing the browser and consuming large amounts of memory and bandwidth.

## Detailed Technical Analysis
The search path returned the full result set with no LIMIT. The cost is paid three times: the database materialises every row, the server serialises a multi-megabyte JSON payload, and the client attempts to render thousands of DOM nodes. The fix paginates at the data-source level (LIMIT/OFFSET) and, as a safety net, caps the response size even if the data source ignores the limit.

## Real-World Scenarios
- A user searches a popular term and 5000+ events match
- All 5000 are returned in a single response
- The browser attempts to render them all and becomes unresponsive
- Memory and bandwidth spike on both server and client

## Complete Implementation
- `api/lib/pagination.js`: `normalizePagination` (page >= 1, pageSize clamped to [1, 100], default 20), `buildPageResponse` (standard envelope with `total`, `totalPages`, `hasNextPage`, `hasPreviousPage`), and `paginateArray`
- `api/events/search.js`: search handler that always paginates, passes `offset`/`pageSize` to the data source for native LIMIT/OFFSET, and defensively slices to `pageSize` even if the source returns the full set
- Tests covering parameter clamping, response metadata, the defensive cap against a naive 5000-row source, native pagination passthrough, and the fail-closed path

## Testing Strategy
1. `normalizePagination` defaults, clamps pageSize to 100, computes offset, and rejects bad input
2. `buildPageResponse` reports correct totalPages and next/previous flags
3. `paginateArray` slices first and tail pages and handles non-arrays
4. Handler caps a 5000-row naive source to the default page size
5. Handler passes `offset`/`pageSize` to a native paginating source and echoes the current page
6. Non-GET returns 405 and a missing service returns 503

All new tests pass with the project's `npm run test:unit` Node runner.

## Related Standards
- OWASP: Unrestricted Resource Consumption (API4)
- CWE-400: Uncontrolled Resource Consumption

Fixes #6523

/assign anshul23102