### PR TITLE
docs: add hackathon delete API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1319,6 +1319,28 @@ Content-Type: application/json
 - **403 Forbidden**: Authenticated user does not have the required role (`ORGANIZER`, `ADMIN`, or `SUPER_ADMIN`).
 - **404 Not Found**: Hackathon id does not exist.
 
+## Delete Hackathon
+
+| Method | Endpoint |
+|--------|----------|
+| DELETE | `/api/hackathons/{id}` |
+
+Deletes an existing hackathon by id. Restricted to authorized roles: `ADMIN`, `SUPER_ADMIN`.
+
+### Authentication
+Protected endpoint. Requires Bearer JWT authentication.
+
+### Path Parameter
+- `id`: Long, hackathon id
+
+### Successful Response (204)
+No response body.
+
+### Error Responses
+- **401 Unauthorized**: JWT is missing or invalid.
+- **403 Forbidden**: Authenticated user does not have the required role (`ADMIN` or `SUPER_ADMIN`).
+- **404 Not Found**: Hackathon id does not exist.
+
 *Note: The backend implementation is handled in the Eventra-Backend repository. This docs PR only syncs API documentation with the backend behavior.*
 
 ---


### PR DESCRIPTION
## Description

This PR updates the API documentation to include the newly added hackathon delete endpoint.

## Related Backend Implementation

Backend implementation: SandeepVashishtha/Eventra-Backend#58

## Changes Made

* Documented `DELETE /api/hackathons/{id}`
* Added authentication and authorization requirements
* Added path parameter details
* Documented that no request body is required
* Added success response for `204 No Content`
* Documented that no response body is returned
* Added possible error responses for `401`, `403`, and `404`

## Notes

The backend implementation is handled in the Eventra-Backend repository. This PR only syncs the frontend/docs repository API documentation with the backend behavior.
