### PR TITLE
docs: add hackathon registration API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1341,6 +1341,42 @@ No response body.
 - **403 Forbidden**: Authenticated user does not have the required role (`ADMIN` or `SUPER_ADMIN`).
 - **404 Not Found**: Hackathon id does not exist.
 
+## Register for Hackathon
+
+| Method | Endpoint |
+|--------|----------|
+| POST | `/api/hackathons/{id}/register` |
+
+Registers the authenticated user for a hackathon by id.
+
+### Authentication
+Protected endpoint. Requires Bearer JWT authentication. Any authenticated user can register.
+
+### Path Parameter
+- `id`: Long, hackathon id
+
+### Request Body
+No request body required.
+
+### Successful Response (201)
+
+```json
+{
+  "registrationId": 1,
+  "hackathonId": 1,
+  "hackathonTitle": "Manual Register Test Hackathon",
+  "userEmail": "hackregisteruser@example.com",
+  "registeredAt": "2026-06-04T23:50:18.742152",
+  "status": "CONFIRMED"
+}
+```
+
+### Error Responses
+- **400 Bad Request**: Registration deadline has passed / registration is closed.
+- **401 Unauthorized**: JWT is missing or invalid.
+- **404 Not Found**: Hackathon id does not exist.
+- **409 Conflict**: User is already registered for the hackathon.
+
 *Note: The backend implementation is handled in the Eventra-Backend repository. This docs PR only syncs API documentation with the backend behavior.*
 
 ---


### PR DESCRIPTION
## Description

This PR updates the API documentation to include the newly added hackathon registration endpoint.

## Related Backend Implementation

Backend implementation: SandeepVashishtha/Eventra-Backend#59

## Changes Made

* Documented `POST /api/hackathons/{id}/register`
* Added authentication and authorization requirements
* Added path parameter details
* Documented that no request body is required
* Added success response example for `201 Created`
* Added possible error responses for `400`, `401`, `404`, and `409`
* Documented duplicate registration prevention
* Documented registration deadline enforcement
* Noted that capacity is not enforced because the current Hackathon model does not include capacity or registered count fields

## Notes

The backend implementation is handled in the Eventra-Backend repository. This PR only syncs the frontend/docs repository API documentation with the backend behavior.
