### PR TITLE
fix: replace CommonJS require with dynamic import in errorLogger.js

### DIFF
--- a/src/utils/errorLogger.js
+++ b/src/utils/errorLogger.js
@@ -6,36 +6,39 @@ import { logger } from "./logger";
 // (e.g. the dependency was skipped during npm install), every call below
 // is a no-op — the app continues working without remote error reporting.
 let Sentry = null;
-const runtimeEnv =
-  typeof import.meta !== "undefined" && import.meta.env
-    ? import.meta.env
-    : typeof process !== "undefined" && process.env
-      ? process.env
-      : {};
 
 if (isSentryEnabled && typeof window !== "undefined") {
-  try {
-    const SentryModule = require("@sentry/browser");
-    Sentry = SentryModule;
+  (async () => {
+    try {
+      const SentryModule = await import("@sentry/browser");
+      Sentry = SentryModule.default || SentryModule;
 
-    Sentry.init({
-      dsn: SENTRY_DSN,
-      integrations: [
-        typeof SentryModule.browserTracingIntegration === "function"
-          ? SentryModule.browserTracingIntegration()
-          : null,
-        typeof SentryModule.replayIntegration === "function"
-          ? SentryModule.replayIntegration()
-          : null,
-      ].filter(Boolean),
-      tracesSampleRate: 0.25,
-      replaysSessionSampleRate: 0.1,
-      replaysOnErrorSampleRate: 1.0,
-      environment: runtimeEnv.MODE || runtimeEnv.NODE_ENV || "development",
-    });
-  } catch {
-    // Sentry SDK unavailable — local-only logging will still work
-  }
+      const runtimeEnv =
+        typeof import.meta !== "undefined" && import.meta.env
+          ? import.meta.env
+          : typeof process !== "undefined" && process.env
+            ? process.env
+            : {};
+
+      Sentry.init({
+        dsn: SENTRY_DSN,
+        integrations: [
+          typeof SentryModule.browserTracingIntegration === "function"
+            ? SentryModule.browserTracingIntegration()
+            : null,
+          typeof SentryModule.replayIntegration === "function"
+            ? SentryModule.replayIntegration()
+            : null,
+        ].filter(Boolean),
+        tracesSampleRate: 0.25,
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1.0,
+        environment: runtimeEnv.MODE || runtimeEnv.NODE_ENV || "development",
+      });
+    } catch {
+      // Sentry SDK unavailable — local-only logging will still work
+    }
+  })();
 }
 
 function buildErrorEntry(error, errorInfo, extra = {}) {


### PR DESCRIPTION
﻿## Summary

errorLogger.js uses equire("@sentry/browser") (line 18) but the project has "type": "module" in package.json, making all .js files ES modules where equire is not defined. The try/catch silently swallows the ReferenceError, so Sentry never initializes.

## Changes

Replaced the CommonJS equire("@sentry/browser") + 	ry/catch block with an async IIFE using dynamic import("@sentry/browser"). Runtime env resolution moved inside the IIFE since it's only needed for Sentry.init config.

## Behavior

- **@sentry/browser installed:** Dynamic import resolves, Sentry.init() runs with the same config (DSN, integrations, sample rates)
- **@sentry/browser not installed:** Dynamic import rejects, caught by try/catch, Sentry stays null — local-only logging continues as before
- **Existing guard:** logError already checks if (Sentry) before calling Sentry methods, so no further changes needed there

Fixes #7089
