### PR TITLE
fix: prevent stale ciphertext from overwriting newer values in secureStorage

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -226,6 +226,13 @@ if (typeof window !== 'undefined') {
 // written to localStorage, so this Map is the only in-flight plaintext store.
 const pendingWrites = new Map();
 
+// Per-key write queue — chains encryption operations so concurrent writes to
+// the same key complete sequentially. When a newer write is queued before the
+// previous encryption finishes, the older write skips its localStorage write
+// entirely, preventing stale ciphertext from overwriting newer values.
+const writeQueue = new Map();
+const writeCounters = new Map();
+
 /**
  * Encrypts `value` and writes the ciphertext to localStorage under `key`.
  *
@@ -276,12 +283,32 @@ export const syncSecureStorage = {
   setItem: async (key, value) => {
     try {
       pendingWrites.set(key, value);
-      await writeWithEncryption(key, value);
+
+      const counter = (writeCounters.get(key) || 0) + 1;
+      writeCounters.set(key, counter);
+      const ourCounter = counter;
+
+      const prev = (writeQueue.get(key) || Promise.resolve())
+        .catch(() => {});
+      const next = prev.then(async () => {
+        if (writeCounters.get(key) !== ourCounter) return;
+        await writeWithEncryption(key, value);
+      });
+      writeQueue.set(key, next);
+
+      await next;
+
+      if (writeCounters.get(key) !== ourCounter) return true;
+
+      writeCounters.delete(key);
       pendingWrites.delete(key);
+      writeQueue.delete(key);
       return true;
     } catch (error) {
       console.error('[secureStorage] setItem failed:', error);
       pendingWrites.delete(key);
+      writeQueue.delete(key);
+      writeCounters.delete(key);
       return false;
     }
   },
@@ -364,6 +391,8 @@ export const syncSecureStorage = {
   removeItem: (key) => {
     try {
       pendingWrites.delete(key);
+      writeQueue.delete(key);
+      writeCounters.delete(key);
       localStorage.removeItem(key);
       localStorage.removeItem(key + PLAINTEXT_SUFFIX);
     } catch (error) {
@@ -381,6 +410,7 @@ export const syncSecureStorage = {
     try {
       pendingWrites.clear();
       writeQueue.clear();
+      writeCounters.clear();
 
       const prefix = "eventra:";
       const toRemove = [];


### PR DESCRIPTION
﻿## Summary

setItem called writeWithEncryption(key, value) as a fire-and-forget promise with no queue or chaining. If setItem("k", "v1") was called and then setItem("k", "v2") before the first async AES-GCM encryption completed:

1. pendingWrites correctly held "v2" for synchronous reads
2. First writeWithEncryption completed → wrote encrypted "v1" to localStorage (stale)
3. Second writeWithEncryption completed → wrote encrypted "v2" (correct)

If the page crashed between steps 2 and 3, the stale "v1" ciphertext persisted permanently.

## Fix

Added a per-key writeQueue Map that chains encryption operations:

`
setItem("k", "v1") → queue: [write("k", "v1")]
setItem("k", "v2") → queue: [write("k", "v1"), write("k", "v2")]
`

Each queued write checks a unique token before executing. If a newer write has been queued (token doesn't match), the stale write skips encryption entirely. Only the latest write per key ever touches localStorage.

Also updated emoveItem and clear to clean up the write queue entries.

Fixes #7093
