### PR TITLE
fix: scope secureStorage.clear() to Eventra-prefixed keys only

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -373,13 +373,24 @@ export const syncSecureStorage = {
   },
 
   /**
-   * Clears all localStorage data for the current origin.
-   * Use with caution: this removes ALL keys, not just Eventra's.
+   * Clears all Eventra-managed keys from localStorage.
+   *
+   * Iterates only over keys starting with the Eventra prefix ('eventra:')
+   * so data from other applications on the same origin is never touched.
    */
   clear: () => {
     try {
       pendingWrites.clear();
-      localStorage.clear();
+      writeQueue.clear();
+
+      const prefix = "eventra:";
+      const toRemove = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (k && k.startsWith(prefix)) toRemove.push(k);
+      }
+      toRemove.forEach((k) => localStorage.removeItem(k));
+
       _keyPromise = null;
     } catch (error) {
       console.error('[secureStorage] clear failed:', error);


### PR DESCRIPTION
﻿## Summary

syncSecureStorage.clear() called localStorage.clear() which removes ALL keys for the entire origin, potentially destroying data from other applications on the same subdomain. The JSDoc already acknowledged this risk but didn't fix it.

## Changes

Replaced localStorage.clear() with prefix-scoped iteration:
1. Scan all localStorage keys
2. Collect only keys starting with eventra:
3. Remove only those keys

This ensures that:
- Other applications on the same origin keep their data intact
- Eventra keys that were missed by the previous clear() approach are still removed
- The method is safe to call in shared-deployment scenarios

Fixes #7095
