### PR TITLE
fix: guard p2pFileTransfer.js against unavailable IndexedDB and WebRTC APIs

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -178,9 +178,15 @@ export async function simulateServerDownload(fileId, fileName, onProgress) {
 const peerId = `peer_${Math.random().toString(36).substring(2, 7)}`;
 let signalingChannel = null;
 
+const isBrowser = typeof window !== "undefined";
+const webrtcAvailable = isBrowser &&
+  typeof RTCPeerConnection !== "undefined" &&
+  typeof RTCSessionDescription !== "undefined" &&
+  typeof RTCIceCandidate !== "undefined";
+
 // Establish P2P Broadcast Channel for multi-tab signaling
 const getSignalingChannel = () => {
-  if (!signalingChannel && typeof window !== "undefined") {
+  if (!signalingChannel && isBrowser) {
     signalingChannel = new BroadcastChannel("eventra_p2p_mesh");
   }
   return signalingChannel;
@@ -287,6 +293,11 @@ export class P2PFileTransferCoordinator {
     this.setupSignaling();
     this.updateState("searching", 0, "-", null, 0);
 
+    if (!webrtcAvailable) {
+      this.updateState("failed");
+      return false;
+    }
+
     // Broadcast file request to other tabs
     this.bc.postMessage({
       type: "P2P_QUERY",
@@ -332,6 +343,10 @@ export class P2PFileTransferCoordinator {
 
   // Initiator builds connection offer to target peer
   async connectToPeer(targetPeerId) {
+    if (!webrtcAvailable) {
+      this.updateState("failed");
+      return;
+    }
     this.isInitiator = true;
     this.updateState("connecting", 0, "-", targetPeerId, 1);
     
@@ -367,6 +382,10 @@ export class P2PFileTransferCoordinator {
 
   // Target peer receives connection offer and replies with answer
   async handleOffer(offer, senderId) {
+    if (!webrtcAvailable) {
+      this.updateState("failed");
+      return;
+    }
     this.isInitiator = false;
     this.updateState("connecting", 0, "-", senderId, 1);
 

--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -20,6 +20,9 @@ let dbInstance = null;
 // Initialize IndexedDB
 const getDB = () => {
   if (dbInstance) return Promise.resolve(dbInstance);
+  if (typeof indexedDB === "undefined") {
+    return Promise.reject(new Error("IndexedDB is not available in this environment"));
+  }
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     request.onupgradeneeded = (e) => {


### PR DESCRIPTION
﻿## Summary

Three crashes in non-browser / restricted-browser environments:

1. **getDB()** accessed indexedDB.open() without checking if indexedDB is defined. Firefox private browsing, SSR/Node.js, and some testing frameworks throw a ReferenceError.

2. **connectToPeer()** and **handleOffer()** created 
ew RTCPeerConnection() without checking if WebRTC APIs are available. Non-browser or restricted-browser environments crash.

## Changes

- getDB(): Added 	ypeof indexedDB === "undefined" guard that rejects with a descriptive error. All three callers already handle rejections via try/catch.

- Added webrtcAvailable boolean at module scope checking: RTCPeerConnection, RTCSessionDescription, and RTCIceCandidate.

- Added early returns to startP2PSearch(), connectToPeer(), and handleOffer() that set state to 'failed' when WebRTC is unavailable, preventing the WebRTC creation code from running.

- Reused existing isBrowser pattern consistently.

Fixes #7097
