### PR TITLE
fix: replace window.location.href with useNavigate 

### DIFF
--- a/src/context/SessionRecoveryContext.js
+++ b/src/context/SessionRecoveryContext.js
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { safeJsonParse } from "../utils/safeJsonParse";
 import { logger } from "../utils/logger";
 import { sanitizeSessionState } from "../utils/sessionSanitization";
@@ -158,6 +159,7 @@ export const useSessionRecovery = () => {
 };
 
 export const SessionRecoveryProvider = ({ children }) => {
+  const navigate = useNavigate();
   const [hasSession, setHasSession] = useState(false);
   const [sessionData, setSessionData] = useState(null);
   const [isOnline, setIsOnline] = useState(true);
@@ -252,7 +254,7 @@ export const SessionRecoveryProvider = ({ children }) => {
             );
             localStorage.removeItem(SESSION_KEY);
             if (typeof window !== "undefined" && window.location) {
-              window.location.href = "/login";
+              navigate("/login");
             }
             return;
           }

--- a/src/hooks/useModelContext.js
+++ b/src/hooks/useModelContext.js
@@ -3,6 +3,7 @@
  * @module hooks/useModelContext
  */
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 /**
  * A custom React hook that registers Eventra's tools with the browser's
@@ -25,6 +26,8 @@ import { useEffect } from "react";
  * }
  */
 export const useModelContext = () => {
+  const navigate = useNavigate();
+
   useEffect(() => {
     if (typeof window !== "undefined" && navigator.modelContext) {
       navigator.modelContext.provideContext({
@@ -39,7 +42,7 @@ export const useModelContext = () => {
               }
             },
             execute: async ({ query }) => {
-              window.location.href = `/events?search=${encodeURIComponent(query)}`;
+              navigate(`/events?search=${encodeURIComponent(query)}`);
               return { success: true, message: `Searching for ${query}` };
             }
           },
@@ -48,7 +51,7 @@ export const useModelContext = () => {
             description: "Get information about Eventra APIs",
             inputSchema: { type: "object", properties: {} },
             execute: async () => {
-              window.location.href = "/api-docs";
+              navigate("/api-docs");
               return { success: true, message: "Navigating to API documentation" };
             }
           }


### PR DESCRIPTION


**Closes:** #6359

## Summary of Changes
- **`src/hooks/useModelContext.js`**: Replaced direct assignments to `window.location.href` with the `useNavigate` hook for the `search_events` and `get_api_docs` actions.
- **`src/context/SessionRecoveryContext.js`**: Replaced `window.location.href = "/login"` with `navigate("/login")` when a mismatched device fingerprint is detected during session recovery.
- These changes ensure that programmatic navigation uses React Router correctly, avoiding full page reloads that dump the current application state, Redux/Zustand contexts, and offline sync queues. 

## Testing Instructions
1. Pull this branch (`fix-6359`).
2. Verify that the application builds and runs successfully.
3. Test the Session Recovery behavior: simulate an offline fingerprint mismatch or force the recovery state to trigger a redirect to `/login` and confirm it does not cause a hard reload of the browser tab.
4. If applicable, test the AI Model context tools to ensure they trigger client-side navigation.
