### PR TITLE
fix: use pull_request_target so fork PRs can edit size labels

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Size Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Calculate PR Size


### PR DESCRIPTION
## Summary

Every fork PR fails the `Auto Label PR Size` check with:

```
GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)
GraphQL: Resource not accessible by integration (addLabelsToLabelable)
```

## Root Cause

The workflow uses `pull_request` trigger, which GitHub Actions restricts to a read-only `GITHUB_TOKEN` when the PR originates from a fork. The `permissions: pull-requests: write` declaration is silently ignored for fork PRs under `pull_request`.

## Fix

1. Changed trigger from `pull_request` to `pull_request_target` — the elevated token permissions apply to fork PRs.
2. Added `ref` to the checkout step pointing to the merge ref for the PR — this ensures `git diff origin/base...HEAD` correctly computes the PR's line changes.

## Security

The workflow only runs `git diff` (pure text comparison, no code execution from the PR) and `gh pr edit` to add/remove labels. It does not build, test, or deploy any code from the PR branch, so `pull_request_target` is safe here.
