### PR TITLE
fix: implement image fallbacks for EventCard and UserProfile 

### DIFF
--- a/src/components/Layout/UserProfileDropdown.jsx
+++ b/src/components/Layout/UserProfileDropdown.jsx
@@ -33,7 +33,11 @@ const UserProfileDropdown = ({
           alt="Profile"
           className="w-8 h-8 rounded-full object-cover ring-2 ring-primary/20"
           loading="lazy"
-          onError={(e) => (e.currentTarget.style.display = "none")}
+          onError={(e) => {
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%239ca3af" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>';
+            e.currentTarget.style.backgroundColor = "#f3f4f6";
+          }}
         />
       ) : (
         <div className="w-8 h-8 rounded-full dark:bg-white/20 bg-gray-300 flex items-center justify-center">
@@ -60,7 +64,11 @@ const UserProfileDropdown = ({
                   src={user.profilePicture}
                   alt="Profile"
                   className="w-12 h-12 rounded-full object-cover ring-2 ring-purple-500/20"
-                  onError={(e) => (e.currentTarget.style.display = "none")}
+                  onError={(e) => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%239ca3af" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>';
+                    e.currentTarget.style.backgroundColor = "#f3f4f6";
+                  }}
                 />
               ) : (
                 <div className="w-12 h-12 rounded-full bg-gradient-to-r from-indigo-800 to-indigo-950 flex items-center justify-center">

--- a/src/components/common/LazyImage.jsx
+++ b/src/components/common/LazyImage.jsx
@@ -46,6 +46,12 @@ const LazyImage = ({
     ? src.replace(/\.(jpe?g|png)$/i, '.webp')
     : null;
 
+  const handleOnError = (e) => {
+    if (onError) onError(e);
+    e.target.onerror = null;
+    e.target.src = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" fill="%23f3f4f6"><rect width="100%" height="100%"/><text x="50%" y="50%" fill="%239ca3af" font-family="sans-serif" font-size="24" text-anchor="middle" dominant-baseline="middle">Image Not Available</text></svg>';
+  };
+
   const img = (
     <img
       ref={imgRef}
@@ -56,7 +62,7 @@ const LazyImage = ({
       loading={loading}
       decoding={decoding}
       onLoad={() => setLoaded(true)}
-      onError={onError}
+      onError={handleOnError}
       className={`lazy-img ${loaded ? 'lazy-img--loaded' : 'lazy-img--loading'} ${className}`}
       style={style}
       {...props}

--- a/src/components/user/UserProfile.js
+++ b/src/components/user/UserProfile.js
@@ -135,7 +135,13 @@ export default function UserProfile() {
                 <img
                   src={profile.avatarBase64 || profile.profilePicture}
                   alt={displayName}
-                  className="upv-avatar-img" loading="lazy"/>
+                  className="upv-avatar-img" loading="lazy"
+                  onError={(e) => {
+                    e.target.onerror = null;
+                    e.target.src = 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%239ca3af" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>';
+                    e.target.style.backgroundColor = "#f3f4f6";
+                  }}
+                />
               ) : (
                 <div className="upv-avatar-placeholder">
                   <span className="upv-avatar-initials">{initials}</span>


### PR DESCRIPTION
## Summary
- I added an `onError` fallback to the `LazyImage` component so we don't show broken image icons on the `EventCard`.
- I also did the same for the avatar image in `UserProfile`.
- If an image fails to load (like a 404), I swap it out with a simple inline SVG placeholder.

Fixes #7106

## Validation
- I tested this locally by passing a fake broken URL to an event and my user profile.
- I saw that my fallback SVGs rendered perfectly without breaking the layout.
- I added `e.target.onerror = null` just in case, to prevent any infinite loops.

## Note
- I used inline SVG data URIs so we don't have to worry about the fallback itself failing to load.
