### PR TITLE
fix: prevent silent session wipe on network errors during auth validation

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -155,9 +155,26 @@ export const AuthProvider = ({ children }) => {
         } else {
           clearSession();
         }
-      } catch {
+      } catch (err) {
         if (!isMountedRef.current) return;
-        clearSession();
+        
+        const isAuthError = err?.status === 401 || err?.status === 403;
+        if (isAuthError) {
+          clearSession();
+        } else {
+          console.warn("[AuthContext] Network error during session validation. Preserving local session.");
+          try {
+            const cachedUser = syncSecureStorage.getItem("user");
+            if (cachedUser) {
+              setUser(JSON.parse(cachedUser));
+              setToken("cookie-managed");
+            } else {
+              clearSession();
+            }
+          } catch {
+            clearSession();
+          }
+        }
       } finally {
         if (isMountedRef.current) {
           setLoading(false);


### PR DESCRIPTION
## Summary
- I noticed that if the backend was temporarily unreachable (e.g. 502 Bad Gateway or network timeout), the app would silently wipe the user's entire session and log them out on page load.
- I updated the `validateSession` catch block in `AuthContext` to specifically check for 401/403 authorization errors before clearing the session.
- If it's a generic network error, I now recover the local display profile from `syncSecureStorage` so the app doesn't log the user out unnecessarily during brief outages.

Fixes #7110

## Validation
- I tested this by manually turning off my backend server and reloading the app while logged in.
- I confirmed that the app preserves my session and gracefully handles the network error instead of immediately booting me back to the login screen.

## Note
- This makes the app much more resilient for users on spotty mobile connections!
