### PR TITLE
fix: ensure loading state is shown during async conflict checks in EventRegistration

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -413,22 +413,37 @@ const EventRegistration = () => {
       return;
     }
 
-    const isFull = await checkEventCapacity(eventId, event);
-    if (isFull) {
-      const { getGlobalWaitlist } = await import("../../utils/waitlistUtils");
-      const records = getGlobalWaitlist();
-      const onWaitlist = records.some(
-        (r) => r.userId === user.id && r.eventId === parseInt(eventId) && r.status === "waiting"
-      );
-      if (onWaitlist) {
-        toast.error(t("eventRegistration.toastAlreadyWaitlisted"));
+    setSubmitting(true);
+    isSubmittingRef.current = true;
+
+    try {
+      const isFull = await checkEventCapacity(eventId, event);
+      if (isFull) {
+        const { getGlobalWaitlist } = await import("../../utils/waitlistUtils");
+        const records = getGlobalWaitlist();
+        const onWaitlist = records.some(
+          (r) => r.userId === user.id && r.eventId === parseInt(eventId) && r.status === "waiting"
+        );
+        if (onWaitlist) {
+          toast.error(t("eventRegistration.toastAlreadyWaitlisted"));
+          setSubmitting(false);
+          isSubmittingRef.current = false;
+          return;
+        }
+      }
+
+      if (await checkAndHandleConflicts()) {
+        setSubmitting(false);
+        isSubmittingRef.current = false;
         return;
       }
+
+      proceedWithRegistration();
+    } catch (err) {
+      setSubmitting(false);
+      isSubmittingRef.current = false;
+      toast.error("An error occurred during submission");
     }
-
-    if (await checkAndHandleConflicts()) return;
-
-    proceedWithRegistration();
   }, [isAuthenticated, user, navigate, registrationPath, validateAll, eventId, event, checkEventCapacity, checkAndHandleConflicts, proceedWithRegistration]);
 
   // Handle conflict modal actions


### PR DESCRIPTION
## Summary
- I discovered that during event registration, the "Register" button's loading spinner wouldn't appear immediately if the app had to perform a schedule conflict check over the network.
- This caused a frustrating delay where the user would click the button and nothing would happen for a second or two, often leading to double-clicks.
- I moved the `setSubmitting(true)` call to the very beginning of the `handleSubmit` function so that the button immediately disables and shows the loader while the async API calls run in the background.

Fixes #7112

## Validation
- Clicked "Complete Registration" on an event.
- Verified that the button immediately grays out and shows the spinning `Loader2` while it checks for capacity and schedule conflicts.
- Ensured the loader properly turns off if a conflict is found and the conflict modal appears.

## Note
- This small UX tweak makes the registration flow feel way snappier!
