### PR TITLE
fix: add ErrorBoundaries to independent complex modals

### DIFF
--- a/src/components/EventConflictModal.jsx
+++ b/src/components/EventConflictModal.jsx
@@ -20,6 +20,8 @@ import { useFocusTrap } from '../hooks/useFocusTrap';
  * @param {Function} props.onSelectAlternative - Callback when user selects an alternative event
  * @param {boolean} props.strictMode - If true, blocks registration (no proceed option)
  */
+import ErrorBoundary from "./common/ErrorBoundary";
+
 const EventConflictModal = ({
   isOpen,
   newEvent,
@@ -271,4 +273,10 @@ const EventConflictModal = ({
   );
 };
 
-export default EventConflictModal;
+export default function SafeEventConflictModal(props) {
+  return (
+    <ErrorBoundary level="feature" label="Event Conflict Modal">
+      <EventConflictModal {...props} />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -5,6 +5,8 @@ import {
 } from "lucide-react";
 import { toast } from "react-toastify";
 
+import ErrorBoundary from "../common/ErrorBoundary";
+
 const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
   const [showChat, setShowChat] = useState(false);
   const [chatMessage, setChatMessage] = useState("");
@@ -403,4 +405,10 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
   );
 };
 
-export default VirtualBoothModal;
+export default function SafeVirtualBoothModal(props) {
+  return (
+    <ErrorBoundary level="feature" label="Virtual Booth Modal">
+      <VirtualBoothModal {...props} />
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
- I noticed that some of our more complex, standalone modals (like `VirtualBoothModal` and `EventConflictModal`) were missing their own Error Boundaries.
- If an edge case error occurred inside one of these modals, it would crash the entire parent page instead of safely containing the error.
- I wrapped the default exports of both modals with our reusable `<ErrorBoundary level="feature" />` component.

Fixes #7114

## Validation
- Temporarily forced an error throw inside `VirtualBoothModal` to test it.
- Confirmed that the modal simply renders the fallback UI ("Something went wrong with this feature") while the rest of the app (the background page) remains fully functional and intact.

## Note
- This is a proactive step to ensure our app's stability, especially since these modals handle a lot of complex state and API data!
