### PR TITLE
fix: resolve broken social media previews by using absolute brand image URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <meta property="og:description" content="A premium, modern platform for organizing and attending events, hackathons, and projects." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://eventra.vercel.app/" />
-    <meta property="og:image" content="/Eventra.png" />
+    <meta property="og:image" content="https://eventra.sandeepvashishtha.in/logo_transparent.png" />
 
     <!-- Google Sign In -->
     <meta

--- a/src/Pages/Home/HomePage.jsx
+++ b/src/Pages/Home/HomePage.jsx
@@ -10,7 +10,7 @@ import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 // ─── CONSTANTS ──────────────────────────────────────────────────────────────
 const SITE_URL = "https://eventra.vercel.app";
-const SITE_IMAGE = `${SITE_URL}/Eventra.png`;
+const SITE_IMAGE = "https://eventra.sandeepvashishtha.in/logo_transparent.png";
 const SITE_TITLE = "Eventra | Discover & Join Tech Events";
 const SITE_DESCRIPTION =
   "Eventra is an open-source platform to discover, join, and host tech events, hackathons, and workshops in your community.";

--- a/src/components/SEOHead.jsx
+++ b/src/components/SEOHead.jsx
@@ -13,7 +13,7 @@ import { useEffect } from "react";
 export default function SEOHead({
   title,
   description,
-  image,
+  image = "https://eventra.sandeepvashishtha.in/logo_transparent.png",
   url,
   type = "website",
 }) {


### PR DESCRIPTION
### 🐛 Bug Fix: Resolved Broken Social Media Preview (`og:image`)

### 📝 Description
Social media crawlers require absolute URLs to render metadata preview cards. Relative paths cause these cards to appear blank. This PR converts the brand logo and fallback configurations to use absolute production URLs.

### 🛠️ Changes Made
- **index.html**: Updated `og:image` content to the absolute production URL.
- **HomePage.jsx**: Switched `SITE_IMAGE` constant to the absolute URL.
- **SEOHead.jsx**: Added the absolute URL as a default fallback parameter for the `image` prop across all secondary dynamic pages.

Closes #6837