### PR TITLE
fix(ui): resolve responsive layout overflow of event titles on mobile

### DIFF
--- a/src/Pages/Calendar/CalendarPage.jsx
+++ b/src/Pages/Calendar/CalendarPage.jsx
@@ -385,7 +385,7 @@ const CalendarPage = () => {
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div>
-                          <p className="text-sm font-semibold text-slate-900 dark:text-white">
+                          <p title={event.title} className="text-sm font-semibold text-slate-900 dark:text-white line-clamp-2 break-words min-w-0">
                             {event.title}
                           </p>
                           <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-500 dark:text-slate-400">

--- a/src/Pages/Calendar/MyCalendar.jsx
+++ b/src/Pages/Calendar/MyCalendar.jsx
@@ -423,7 +423,7 @@ const MyCalendar = () => {
                                 <span className="px-2 py-0.5 rounded-md text-[10px] font-black uppercase bg-indigo-100 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300">
                                   {item.event.category || "General"}
                                 </span>
-                                <h4 className="font-extrabold text-sm text-slate-900 dark:text-slate-100 mt-1 truncate">
+                                <h4 title={item.event.title} className="font-extrabold text-sm text-slate-900 dark:text-slate-100 mt-1 line-clamp-2 break-words min-w-0">
                                   {item.event.title}
                                 </h4>
                                 <div className="flex items-center gap-1.5 text-xs text-slate-400 dark:text-slate-500 mt-2">
@@ -533,7 +533,7 @@ const MyCalendar = () => {
                                       Registered: {new Date(item.registeredAt).toLocaleDateString()}
                                     </span>
                                   </div>
-                                  <h4 className="font-extrabold text-base text-slate-900 dark:text-slate-100">
+                                  <h4 title={item.event.title} className="font-extrabold text-base text-slate-900 dark:text-slate-100 line-clamp-2 break-words min-w-0">
                                     {item.event.title}
                                   </h4>
                                   <p className="text-xs text-slate-500 max-w-xl truncate mt-1">

--- a/src/Pages/EventRecommendation/EventRecommendation.jsx
+++ b/src/Pages/EventRecommendation/EventRecommendation.jsx
@@ -429,7 +429,7 @@ const EventRecommendation = () => {
 
                       </div>
 
-                      <h3 className="text-lg font-bold text-text">
+                      <h3 title={event.title} className="text-lg font-bold text-text line-clamp-2 break-words min-w-0">
                         {event.title}
                       </h3>
 
@@ -484,7 +484,7 @@ const EventRecommendation = () => {
                           className="rounded-2xl border border-border p-5 bg-bg"
                         >
 
-                          <h3 className="text-lg font-bold text-text">
+                          <h3 title={event.title} className="text-lg font-bold text-text line-clamp-2 break-words min-w-0">
                             {event.title}
                           </h3>
 
@@ -528,7 +528,7 @@ const EventRecommendation = () => {
                         key={index}
                         className="rounded-2xl border border-border p-5 bg-bg text-left"
                       >
-                        <h3 className="text-lg font-bold text-text">
+                        <h3 title={event.title} className="text-lg font-bold text-text line-clamp-2 break-words min-w-0">
                           {event.title}
                         </h3>
                         <p className="mt-2 text-sm text-text-light">

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -255,7 +255,7 @@ const EventCard = ({ event }) => {
           {randomIcon}
         </div>
 
-        <h3 id={titleId} className="text-gray-900 dark:text-white font-bold text-lg tracking-tight line-clamp-2 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-300 flex-1">
+        <h3 id={titleId} title={event.title} className="text-gray-900 dark:text-white font-bold text-lg tracking-tight line-clamp-2 break-words group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-300 flex-1 min-w-0">
           {event.title}
         </h3>
         <div className="ml-auto flex items-center gap-2">

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -282,7 +282,7 @@ const EventDetails = () => {
                 {event.type}
               </p>
               <div className="mt-4 flex items-center gap-3">
-                <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight">{event.title}</h1>
+                <h1 title={event.title} className="text-4xl sm:text-5xl font-extrabold tracking-tight break-words">{event.title}</h1>
                 <button
                   onClick={handleCopy}
                   className={`p-2 rounded-full transition-colors ${linkCopied 

--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -273,7 +273,8 @@ const EventDetailsPage = () => {
                   </div>
                   <h1
                     id="event-details-title"
-                    className="text-balance text-2xl font-bold leading-tight xs:text-3xl sm:text-4xl"
+                    title={event.title}
+                    className="text-balance text-2xl font-bold leading-tight xs:text-3xl sm:text-4xl break-words"
                   >
                     {event.title}
                   </h1>

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -576,7 +576,7 @@ const EventRegistration = () => {
           </p>
 
           <div className="bg-slate-50/80 dark:bg-slate-950/40 border border-slate-200/40 dark:border-slate-800/50 rounded-3xl p-5 mb-8 text-left">
-            <h3 className="text-lg font-bold text-slate-800 dark:text-slate-200 mb-3 truncate">
+            <h3 title={event.title} className="text-lg font-bold text-slate-800 dark:text-slate-200 mb-3 line-clamp-2 break-words min-w-0">
               {event.title}
             </h3>
 
@@ -722,7 +722,7 @@ const EventRegistration = () => {
             />
             <div className="absolute inset-0 bg-linear-to-t from-black/60 to-transparent"></div>
             <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
-              <h1 className="text-3xl font-bold mb-2">{event.title}</h1>
+              <h1 title={event.title} className="text-3xl font-bold mb-2 break-words">{event.title}</h1>
               <div className="flex flex-wrap gap-4 text-sm">
                 <span className="flex items-center gap-1">
                   <Calendar className="w-4 h-4" />

--- a/src/Pages/Events/RemindersPage.js
+++ b/src/Pages/Events/RemindersPage.js
@@ -128,7 +128,7 @@ const RemindersPage = () => {
                     <div className="p-5">
                       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                         <div>
-                          <h2 className="text-xl font-bold text-gray-950 dark:text-white">
+                          <h2 title={event.title} className="text-xl font-bold text-gray-950 dark:text-white line-clamp-2 break-words min-w-0">
                             {event.title}
                           </h2>
                           <div className="mt-3 space-y-2 text-sm text-gray-600 dark:text-gray-300">

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -353,7 +353,7 @@ const WhatsHappening = () => {
                               </span>
                             </div>
 
-                            <h3 className="text-lg sm:text-xl font-semibold text-slate-900 mb-2 leading-snug group-hover:text-sky-700 transition-colors">
+                            <h3 title={event.title} className="text-lg sm:text-xl font-semibold text-slate-900 mb-2 leading-snug group-hover:text-sky-700 transition-colors line-clamp-2 break-words min-w-0">
                               {event.title}
                             </h3>
                             

--- a/src/Pages/SavedEventsPage.jsx
+++ b/src/Pages/SavedEventsPage.jsx
@@ -86,7 +86,7 @@ const SavedEventsPage = () => {
               key={event.id}
               className="rounded-3xl border border-gray-100 bg-white p-5 shadow-[0_10px_25px_rgba(0,0,0,0.05)] transition-all duration-300 hover:-translate-y-1 hover:border-indigo-200 hover:shadow-xl dark:border-gray-800 dark:bg-gray-900 dark:shadow-[0_10px_25px_rgba(0,0,0,0.3)] dark:hover:border-indigo-700"
             >
-              <h3 className="mb-2 text-lg font-bold tracking-tight text-gray-950 dark:text-slate-100">
+              <h3 title={event.title || event.name} className="mb-2 text-lg font-bold tracking-tight text-gray-950 dark:text-slate-100 line-clamp-2 break-words min-w-0">
                 {event.title || event.name}
               </h3>
               <p className="text-sm text-gray-600 dark:text-slate-400">{event.date}</p>

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -153,7 +153,7 @@ const NotFoundPage = () => {
               >
                 {/* UPDATED: Text colors */}
                 <div className="text-sm text-gray-500 dark:text-white/70">{event.category}</div>
-                <h4 className="font-semibold text-lg mt-1">{event.name}</h4>
+                <h4 title={event.name} className="font-semibold text-lg mt-1 break-words">{event.name}</h4>
                 <Link
                   to="/events"
                   // UPDATED: Link color

--- a/src/components/common/RecentlyViewedEvents.css
+++ b/src/components/common/RecentlyViewedEvents.css
@@ -255,6 +255,8 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/components/events/EventRecommendations.jsx
+++ b/src/components/events/EventRecommendations.jsx
@@ -359,7 +359,7 @@ const EventRecommendations = ({ currentEventId, currentCategory }) => {
                     )}
                   </div>
 
-                  <h4 className="font-extrabold text-sm tracking-tight text-slate-900 dark:text-slate-100 mt-3 line-clamp-1">
+                  <h4 title={event.title} className="font-extrabold text-sm tracking-tight text-slate-900 dark:text-slate-100 mt-3 line-clamp-2 break-words min-w-0">
                     {event.title}
                   </h4>
 

--- a/src/components/user/UserDashboard.css
+++ b/src/components/user/UserDashboard.css
@@ -736,6 +736,8 @@
   font-weight: 600;
   color: var(--text-color);
   margin: 0 0 var(--ud-space-xxs);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* removed dark mode override (handled by CSS variables) */
@@ -878,6 +880,8 @@
   color: var(--text-color);
   margin: 0;
   line-height: 1.3;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* removed dark mode override (handled by CSS variables) */

--- a/src/components/user/UserDashboard.js
+++ b/src/components/user/UserDashboard.js
@@ -347,8 +347,8 @@ export default function UserDashboard() {
                       ) : (
                         upcomingEvents.map(ev => (
                           <div key={ev.id} className="ud-list-item">
-                            <div>
-                              <p className="ud-list-title">{ev.title}</p>
+                            <div className="min-w-0 flex-1">
+                              <p title={ev.title} className="ud-list-title">{ev.title}</p>
                               <p className="ud-list-meta"><Calendar size={12} /> {getSmartDateLabel(ev.date)}</p>
                             </div>
                             <StatusBadge status={ev.participationType} />
@@ -374,8 +374,8 @@ export default function UserDashboard() {
                       ) : (
                         upcomingHackathons.map(h => (
                           <div key={h.id} className="ud-list-item">
-                            <div>
-                              <p className="ud-list-title">{h.title}</p>
+                            <div className="min-w-0 flex-1">
+                              <p title={h.title} className="ud-list-title">{h.title}</p>
                               <p className="ud-list-meta"><Calendar size={12} /> {getSmartDateLabel(h.date)}</p>
                             </div>
                             <StatusBadge status={h.participationType} />
@@ -401,8 +401,8 @@ export default function UserDashboard() {
                       ) : (
                         activeProjects.map(p => (
                           <div key={p.id} className="ud-list-item">
-                            <div>
-                              <p className="ud-list-title">{p.title}</p>
+                            <div className="min-w-0 flex-1">
+                              <p title={p.title} className="ud-list-title">{p.title}</p>
                               <p className="ud-list-meta">Updated: {p.lastUpdate}</p>
                             </div>
                             <StatusBadge status={p.projectStatus} />

--- a/tests/eventTitleOverflow.test.mjs
+++ b/tests/eventTitleOverflow.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Paths to files modified for title overflow
+const paths = {
+  EventCard: path.resolve(__dirname, "../src/Pages/Events/EventCard.js"),
+  WhatsHappening: path.resolve(__dirname, "../src/Pages/Home/components/WhatsHappening.js"),
+  EventRecommendation: path.resolve(__dirname, "../src/Pages/EventRecommendation/EventRecommendation.jsx"),
+  EventRecommendationsComponent: path.resolve(__dirname, "../src/components/events/EventRecommendations.jsx"),
+  SavedEventsPage: path.resolve(__dirname, "../src/Pages/SavedEventsPage.jsx"),
+  CalendarPage: path.resolve(__dirname, "../src/Pages/Calendar/CalendarPage.jsx"),
+  MyCalendar: path.resolve(__dirname, "../src/Pages/Calendar/MyCalendar.jsx"),
+  EventRegistration: path.resolve(__dirname, "../src/Pages/Events/EventRegistration.js"),
+  EventDetails: path.resolve(__dirname, "../src/Pages/Events/EventDetails.js"),
+  EventDetailsPage: path.resolve(__dirname, "../src/Pages/Events/EventDetailsPage.js"),
+  RemindersPage: path.resolve(__dirname, "../src/Pages/Events/RemindersPage.js"),
+  RecentlyViewedEventsCss: path.resolve(__dirname, "../src/components/common/RecentlyViewedEvents.css"),
+  UserDashboardJs: path.resolve(__dirname, "../src/components/user/UserDashboard.js"),
+  UserDashboardCss: path.resolve(__dirname, "../src/components/user/UserDashboard.css"),
+  NotFound: path.resolve(__dirname, "../src/components/NotFound.js"),
+};
+
+describe("Event Title Overflow Prevention Integrity Tests", () => {
+  it("should verify EventCard has break-words, min-w-0, and title attribute", () => {
+    const src = readFileSync(paths.EventCard, "utf8");
+    assert.ok(src.includes("break-words"), "EventCard should wrap long words");
+    assert.ok(src.includes("min-w-0"), "EventCard title should have min-w-0 for flex layout");
+    assert.ok(src.includes("title={event.title}"), "EventCard title should have title attribute");
+  });
+
+  it("should verify WhatsHappening has line-clamp-2, break-words, and title attribute", () => {
+    const src = readFileSync(paths.WhatsHappening, "utf8");
+    assert.ok(src.includes("line-clamp-2"), "WhatsHappening should clamp long titles");
+    assert.ok(src.includes("break-words"), "WhatsHappening should wrap long words");
+    assert.ok(src.includes("title={event.title}"), "WhatsHappening title should have title attribute");
+  });
+
+  it("should verify EventRecommendation page has break-words, clamp, and title attribute", () => {
+    const src = readFileSync(paths.EventRecommendation, "utf8");
+    assert.ok(src.includes("break-words"), "EventRecommendation should wrap long words");
+    assert.ok(src.includes("line-clamp-2"), "EventRecommendation should clamp long titles");
+    assert.ok(src.includes("title={event.title}"), "EventRecommendation should have title attribute");
+  });
+
+  it("should verify EventRecommendations component has break-words, clamp, and title attribute", () => {
+    const src = readFileSync(paths.EventRecommendationsComponent, "utf8");
+    assert.ok(src.includes("break-words"), "EventRecommendations should wrap long words");
+    assert.ok(src.includes("line-clamp-2"), "EventRecommendations should clamp long titles");
+    assert.ok(src.includes("title={event.title}"), "EventRecommendations should have title attribute");
+  });
+
+  it("should verify SavedEventsPage has line-clamp-2, break-words, and title attribute", () => {
+    const src = readFileSync(paths.SavedEventsPage, "utf8");
+    assert.ok(src.includes("line-clamp-2"), "SavedEventsPage should clamp long titles");
+    assert.ok(src.includes("break-words"), "SavedEventsPage should wrap long words");
+    assert.ok(src.includes("title={event.title || event.name}"), "SavedEventsPage should have title attribute");
+  });
+
+  it("should verify CalendarPage has line-clamp-2, break-words, and title attribute", () => {
+    const src = readFileSync(paths.CalendarPage, "utf8");
+    assert.ok(src.includes("line-clamp-2"), "CalendarPage should clamp long titles");
+    assert.ok(src.includes("break-words"), "CalendarPage should wrap long words");
+    assert.ok(src.includes("title={event.title}"), "CalendarPage should have title attribute");
+  });
+
+  it("should verify MyCalendar has line-clamp-2, break-words, and title attributes", () => {
+    const src = readFileSync(paths.MyCalendar, "utf8");
+    assert.ok(src.includes("line-clamp-2"), "MyCalendar should clamp long titles");
+    assert.ok(src.includes("break-words"), "MyCalendar should wrap long words");
+    assert.ok(src.includes("title={item.event.title}"), "MyCalendar should have title attribute");
+  });
+
+  it("should verify EventRegistration has line-clamp-2, break-words, and title attributes", () => {
+    const src = readFileSync(paths.EventRegistration, "utf8");
+    assert.ok(src.includes("line-clamp-2"), "EventRegistration should clamp long titles");
+    assert.ok(src.includes("break-words"), "EventRegistration should wrap long words");
+    assert.ok(src.includes("title={event.title}"), "EventRegistration should have title attribute");
+  });
+
+  it("should verify EventDetails and EventDetailsPage have break-words and title attributes", () => {
+    const srcDetails = readFileSync(paths.EventDetails, "utf8");
+    const srcDetailsPage = readFileSync(paths.EventDetailsPage, "utf8");
+    assert.ok(srcDetails.includes("break-words"), "EventDetails should wrap long words");
+    assert.ok(srcDetails.includes("title={event.title}"), "EventDetails should have title attribute");
+    assert.ok(srcDetailsPage.includes("break-words"), "EventDetailsPage should wrap long words");
+    assert.ok(srcDetailsPage.includes("title={event.title}"), "EventDetailsPage should have title attribute");
+  });
+
+  it("should verify RemindersPage has line-clamp-2, break-words, and title attribute", () => {
+    const src = readFileSync(paths.RemindersPage, "utf8");
+    assert.ok(src.includes("line-clamp-2"), "RemindersPage should clamp long titles");
+    assert.ok(src.includes("break-words"), "RemindersPage should wrap long words");
+    assert.ok(src.includes("title={event.title}"), "RemindersPage should have title attribute");
+  });
+
+  it("should verify RecentlyViewedCss has overflow-wrap and word-break rules", () => {
+    const src = readFileSync(paths.RecentlyViewedEventsCss, "utf8");
+    assert.ok(src.includes("overflow-wrap: anywhere;"), "RecentlyViewedCss should wrap any characters");
+    assert.ok(src.includes("word-break: break-word;"), "RecentlyViewedCss should break words");
+  });
+
+  it("should verify UserDashboard has min-w-0, flex-1, and title attributes", () => {
+    const srcJs = readFileSync(paths.UserDashboardJs, "utf8");
+    const srcCss = readFileSync(paths.UserDashboardCss, "utf8");
+    assert.ok(srcJs.includes("min-w-0 flex-1"), "UserDashboard should have flex wrapping helper");
+    assert.ok(srcJs.includes("title={ev.title}"), "UserDashboard events list should have title attribute");
+    assert.ok(srcJs.includes("title={h.title}"), "UserDashboard hackathons list should have title attribute");
+    assert.ok(srcJs.includes("title={p.title}"), "UserDashboard projects list should have title attribute");
+    assert.ok(srcCss.includes("overflow-wrap: anywhere;"), "UserDashboard CSS should wrap any characters");
+    assert.ok(srcCss.includes("word-break: break-word;"), "UserDashboard CSS should break words");
+  });
+
+  it("should verify NotFound suggestions have break-words and title attributes", () => {
+    const src = readFileSync(paths.NotFound, "utf8");
+    assert.ok(src.includes("break-words"), "NotFound should wrap long words");
+    assert.ok(src.includes("title={event.name}"), "NotFound suggestions should have title attribute");
+  });
+});


### PR DESCRIPTION
## Description

While working on #7127, I noticed that long event titles could break card layouts on smaller screens, especially when a title contained very long words or strings without spaces.

To fix this, I updated the affected event views so titles wrap correctly instead of overflowing their containers. In places where card height needs to stay consistent, I used line clamping to keep the layout stable while still showing the full title through the native tooltip.

I went through the different event-related pages and applied the fix where the issue could actually occur, including event cards, recommendations, calendar views, saved events, dashboards, and event detail pages.

I also added a regression test to help catch future changes that might reintroduce the overflow problem.

## Testing

I verified the change by:

* Checking affected components with very long event titles
* Testing responsive layouts on smaller screen widths
* Confirming titles stay within their containers
* Confirming full titles remain accessible through the `title` attribute
* Running the new overflow test

## Linked Issue

Closes #7127

## Notes

This change only affects title rendering and does not modify event data, business logic, or existing user flows.
