### PR TITLE
feat: add navigation recovery actions to error fallback

### DIFF
--- a/src/components/common/ErrorFallback.jsx
+++ b/src/components/common/ErrorFallback.jsx
@@ -1,5 +1,8 @@
+import { useNavigate } from "react-router-dom";
 
 export const ErrorFallback = ({ error, resetErrorBoundary }) => {
+  const navigate = useNavigate();
+
   return (
     <div
       role="alert"
@@ -32,14 +35,30 @@ export const ErrorFallback = ({ error, resetErrorBoundary }) => {
         </p>
       )}
 
-      {resetErrorBoundary && (
+      <div className="flex gap-3 flex-wrap justify-center">
+        {resetErrorBoundary && (
+          <button
+            onClick={resetErrorBoundary}
+            className="px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition-colors"
+          >
+            Try Again
+          </button>
+        )}
+
         <button
-          onClick={resetErrorBoundary}
-          className="px-4 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition-colors"
-         aria-label="button">
-          Try again
+          onClick={() => window.location.reload()}
+          className="px-4 py-2 bg-gray-700 text-white text-sm font-medium rounded-lg hover:bg-gray-800 transition-colors"
+        >
+          Reload Page
         </button>
-      )}
+
+        <button
+          onClick={() => navigate("/")}
+          className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          Go Home
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 📝 Description
this pr improves the existing error fallback ui by adding 2 additional recovery options, reload page and go home .

## 🔗 Linked Issue
Closes #6918

## 🏷️ Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor
- [ ] 📖 Documentation update
- [ ] 🎨 UI / Style update
- [ ] ⚙️ CI / Workflow change
- [ ] 🔒 Security fix

## 🧪 How Has This Been Tested?

**Environment**
windows 11 and node.js 22.x 

**Steps**
1. trigger the fallback component.

2. Verify "Try Again" still works , then "reload page" refreshes the applications and also the "go home" navigates to homepage. 


## ✅ Self-Review Checklist

### Code Quality

- [x] I have performed a self-review of my code
- [x] My code follows the project's style guidelines
- [x] My changes generate no new warnings or console errors
- [x] I have removed temporary code and debug logs

### Testing

- [x] I have tested my changes locally
- [ ] Existing tests pass with my changes
- [ ] I have added tests where applicable

### Documentation & Standards

- [ ] Documentation update not required
- [x] My commit messages follow Conventional Commits
- [x] My branch name follows the project's naming convention

### GSSoC Compliance

- [x] I was assigned to this issue before starting work
- [x] This PR reflects my understanding of the changes made
- [x] I have not made trivial changes for point farming