### PR TITLE
fix(security): enforce ownership + session validation in offline queue replay

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -7,7 +7,7 @@ import { toast } from 'react-toastify';
 import { useAuth } from '../context/AuthContext';
 import { API_ENDPOINTS } from '../config/api';
 import { logger } from "../utils/logger";
-import { getQueueIndexedDB, setQueue, clearQueue, filterQueueByOwnership } from '../utils/offlineQueue';
+import { getQueueIndexedDB, setQueue, clearQueue, filterQueueByOwnership, validateQueueSession } from '../utils/offlineQueue';
 // isTokenValid import removed; authentication is now checked via isAuthenticated()
 // from AuthContext, which handles both token-based and cookie-managed sessions.
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
@@ -242,6 +242,32 @@ const useOfflineSync = () => {
         return;
       }
 
+      // SECURITY (Issue #5727): Re-validate session IDs — actions queued under a
+      // previous session must not replay under a new session even if the userId
+      // matches (e.g. same user, different device/tab login cycle).
+      const currentSession =
+        typeof sessionStorage !== "undefined"
+          ? sessionStorage.getItem("session_id") || null
+          : null;
+      const sessionValidatedQueue = validateQueueSession(validatedQueue, currentSession);
+
+      if (sessionValidatedQueue.length === 0 && validatedQueue.length > 0) {
+        logger.warn(
+          "[Security] Clearing offline queue: all actions have stale session IDs. " +
+            "This prevents stale-session cross-user action replay."
+        );
+        await clearQueue();
+        toast.warning(
+          "Offline actions from a previous login session have been cleared for security.",
+          { autoClose: 5000 }
+        );
+        return;
+      }
+
+      if (sessionValidatedQueue.length === 0) {
+        return;
+      }
+
       // Cookie-managed sessions authenticate via the HttpOnly session cookie
       // sent automatically by the browser. Do not forward the "cookie-managed"
       // sentinel string as a Bearer token value; pass null instead so the
@@ -251,7 +277,7 @@ const useOfflineSync = () => {
       isSyncing.current = true;
 
       try {
-        toast.info(`Syncing ${validatedQueue.length} cached offline action(s)...`, {
+        toast.info(`Syncing ${sessionValidatedQueue.length} cached offline action(s)...`, {
           autoClose: 2000,
         });
 
@@ -259,7 +285,7 @@ const useOfflineSync = () => {
         let successCount = 0;
         let droppedCount = 0;
 
-        for (const item of validatedQueue) {
+        for (const item of sessionValidatedQueue) {
           // Halt the zombie loop immediately if the session changed or component unmounted.
           // This prevents making requests with stale tokens and protects IndexedDB from being falsely overwritten below.
           if (conflictController.signal.aborted) {

--- a/src/hooks/useOfflineSync.test.js
+++ b/src/hooks/useOfflineSync.test.js
@@ -4,7 +4,7 @@ import useOfflineSync from "./useOfflineSync";
 import { getQueueIndexedDB, setQueue, clearQueue } from "../utils/offlineQueue";
 
 jest.mock("../context/AuthContext", () => ({
-  useAuth: () => ({ token: "mock-valid-token", user: { id: "mock-user-id" } }),
+  useAuth: () => ({ token: "mock-valid-token", user: { id: "mock-user-id" }, isAuthenticated: () => true, loading: false }),
 }));
 
 jest.mock("../utils/tokenUtils", () => ({
@@ -16,6 +16,7 @@ jest.mock("../utils/offlineQueue", () => ({
   setQueue: jest.fn(),
   clearQueue: jest.fn(),
   filterQueueByOwnership: jest.fn((queue) => queue),
+  validateQueueSession: jest.fn((queue) => queue),
 }));
 
 
@@ -48,6 +49,10 @@ describe("useOfflineSync", () => {
     jest
       .requireMock("../utils/offlineQueue")
       .filterQueueByOwnership.mockImplementation((queue) => queue);
+
+    jest
+      .requireMock("../utils/offlineQueue")
+      .validateQueueSession.mockImplementation((queue) => queue);
   });
 
   afterEach(() => {
@@ -134,5 +139,151 @@ describe("useOfflineSync", () => {
     // Verify setQueue was called to preserve the item
     expect(setQueue).toHaveBeenCalledWith(queue);
     expect(clearQueue).not.toHaveBeenCalled();
+  });
+
+  // ── Security: Issue #5727 — cross-user action replay prevention ───────────
+
+  it("[Security] does not replay queued actions that belong to a different user", async () => {
+    // Queue contains items from user-A only
+    const queue = [
+      { id: "x1", userId: "user-A", retryCount: 0, payload: { name: "stale-action" } },
+    ];
+    getQueueIndexedDB.mockResolvedValue(queue);
+
+    // filterQueueByOwnership drops all items since current user is mock-user-id, not user-A
+    jest
+      .requireMock("../utils/offlineQueue")
+      .filterQueueByOwnership.mockImplementation((_queue, currentUserId) =>
+        _queue.filter((item) => item.userId === currentUserId)
+      );
+
+    const TestComponent = () => {
+      useOfflineSync();
+      return null;
+    };
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<TestComponent />);
+    });
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    // Fetch must NOT have been called — user-A's action should not run under mock-user-id's session
+    expect(global.fetch).not.toHaveBeenCalled();
+    // Queue should be cleared since all items were foreign
+    expect(clearQueue).toHaveBeenCalled();
+  });
+
+  it("[Security] does not replay actions with a stale session ID", async () => {
+    const queue = [
+      { id: "s1", userId: "mock-user-id", sessionId: "old-session-xyz", retryCount: 0, payload: { name: "stale-session-action" } },
+    ];
+    getQueueIndexedDB.mockResolvedValue(queue);
+
+    // validateQueueSession drops all items because their sessionId doesn't match the current session
+    jest
+      .requireMock("../utils/offlineQueue")
+      .validateQueueSession.mockImplementation((_queue, _currentSession) =>
+        _queue.filter((item) => item.sessionId === _currentSession)
+      );
+
+    // Simulate a different current session
+    const originalSessionStorage = global.sessionStorage;
+    Object.defineProperty(window, "sessionStorage", {
+      value: { getItem: jest.fn(() => "new-session-abc") },
+      configurable: true,
+    });
+
+    const TestComponent = () => {
+      useOfflineSync();
+      return null;
+    };
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<TestComponent />);
+    });
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    // Fetch must NOT be called — stale session items should be dropped
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(clearQueue).toHaveBeenCalled();
+
+    Object.defineProperty(window, "sessionStorage", {
+      value: originalSessionStorage,
+      configurable: true,
+    });
+  });
+
+  it("[Security] filterQueueByOwnership is always called during replay — not optional", async () => {
+    const queue = [
+      { id: "f1", userId: "mock-user-id", retryCount: 0, payload: { name: "normal-action" } },
+    ];
+    getQueueIndexedDB.mockResolvedValue(queue);
+
+    const { filterQueueByOwnership } = jest.requireMock("../utils/offlineQueue");
+
+    const TestComponent = () => {
+      useOfflineSync();
+      return null;
+    };
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<TestComponent />);
+    });
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    // filterQueueByOwnership MUST have been called — it is not optional
+    expect(filterQueueByOwnership).toHaveBeenCalled();
+    // It must be called with the current user's ID
+    expect(filterQueueByOwnership).toHaveBeenCalledWith(queue, "mock-user-id");
+  });
+
+  it("[Security] validateQueueSession is always called during replay", async () => {
+    const queue = [
+      { id: "v1", userId: "mock-user-id", sessionId: "sess-abc", retryCount: 0, payload: { name: "action" } },
+    ];
+    getQueueIndexedDB.mockResolvedValue(queue);
+
+    const { validateQueueSession } = jest.requireMock("../utils/offlineQueue");
+
+    const TestComponent = () => {
+      useOfflineSync();
+      return null;
+    };
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<TestComponent />);
+    });
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    // validateQueueSession MUST have been called in all replay paths
+    expect(validateQueueSession).toHaveBeenCalled();
   });
 });

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -520,6 +520,55 @@ export const filterQueueByOwnership = (queue, currentUserId) => {
   return validatedQueue;
 };
 
+/**
+ * SECURITY (Issue #5727): Validate that the current session is still valid and
+ * belongs to the same user before replaying queued actions.
+ *
+ * The offline queue stores a `sessionId` snapshot taken from sessionStorage at
+ * the time the action was enqueued. When connectivity restores, the session may
+ * have changed (user logged out and a different user logged in). This function
+ * compares the stored session ID against the current sessionStorage value and
+ * rejects items whose session no longer matches.
+ *
+ * IMPORTANT: This is an additional defence layer on top of filterQueueByOwnership.
+ * Both checks must pass for an item to be replayed:
+ *  1. filterQueueByOwnership — userId must match the current authenticated user.
+ *  2. validateQueueSession   — sessionId must match the current session.
+ *
+ * Items with a null/missing sessionId are dropped to be safe (no session = unknown origin).
+ *
+ * @param {Array}  queue          - Ownership-filtered offline queue
+ * @param {string} currentSession - Current session ID from sessionStorage
+ * @returns {Array} Items whose stored sessionId matches the current session
+ */
+export const validateQueueSession = (queue, currentSession) => {
+  if (!currentSession) {
+    logger.warn(
+      "[Security] No current session ID available — dropping all queued actions as a safety precaution."
+    );
+    return [];
+  }
+
+  return queue.filter((item) => {
+    if (!item.sessionId) {
+      logger.warn(
+        `[Security] Dropping queued action ${item.id}: no sessionId stored. ` +
+          "Cannot verify session ownership."
+      );
+      return false;
+    }
+    if (item.sessionId !== currentSession) {
+      logger.warn(
+        `[Security] Dropping queued action ${item.id}: ` +
+          `stored sessionId does not match current session. ` +
+          "This prevents stale-session cross-user action replay."
+      );
+      return false;
+    }
+    return true;
+  });
+};
+
 // ---------------------------------------------------------------------------
 // Processing Pipeline — exponential backoff, retry, and replay
 // ---------------------------------------------------------------------------
@@ -634,12 +683,29 @@ export const processQueueItem = async (item, fetchFn, options = {}) => {
  * 4. Removes permanently failed items after MAX_RETRY_COUNT
  * 5. Dispatches eventra-offline-queue-processed custom event
  *
- * @param {string}   currentUserId - User ID for ownership validation
+ * @param {string}   currentUserId - User ID for ownership validation (REQUIRED — replay is
+ *                                   blocked if this is missing or falsy to prevent cross-user
+ *                                   action execution)
  * @param {function} fetchFn       - Async HTTP fetch function
  * @param {object}   [options]     - { signal, onConflict }
  * @returns {Promise<{processed: number, succeeded: number, dropped: number, remaining: number}>}
+ * @throws {Error} If currentUserId is not provided (mandatory security guard)
  */
 export const processQueue = async (currentUserId, fetchFn, options = {}) => {
+  // SECURITY (Issue #5727): currentUserId is MANDATORY. Replay must never proceed
+  // without a verified user identity — omitting it would allow actions queued by
+  // User A to execute under User B's authenticated session.
+  if (!currentUserId) {
+    logger.error(
+      "[Security] processQueue called without currentUserId — replay blocked. " +
+        "Always pass the authenticated user's ID to prevent cross-user action execution."
+    );
+    throw new Error(
+      "[OfflineQueue] currentUserId is required to process the queue. " +
+        "Replay is blocked without a verified user identity."
+    );
+  }
+
   const { signal } = options;
 
   const queue = await getQueueIndexedDB();
@@ -651,11 +717,23 @@ export const processQueue = async (currentUserId, fetchFn, options = {}) => {
     return { processed: 0, succeeded: 0, dropped: 0, remaining: 0 };
   }
 
+  // SECURITY (Issue #5727): Re-validate session ID so actions queued under a
+  // previous session cannot replay under a new session, even if the userId matches.
+  const currentSession =
+    typeof sessionStorage !== "undefined"
+      ? sessionStorage.getItem("session_id") || null
+      : null;
+  const sessionValidated = validateQueueSession(validated, currentSession);
+  if (sessionValidated.length === 0) {
+    await clearQueue();
+    return { processed: 0, succeeded: 0, dropped: 0, remaining: 0 };
+  }
+
   const succeeded = [];
   const dropped = [];
   const failed = [];
 
-  for (const item of validated) {
+  for (const item of sessionValidated) {
     if (signal?.aborted) break;
 
     if (item.retryCount >= MAX_RETRY_COUNT) {
@@ -690,7 +768,7 @@ export const processQueue = async (currentUserId, fetchFn, options = {}) => {
   notifyQueueProcessed({ succeeded: succeeded.length, dropped: dropped.length, remaining });
 
   return {
-    processed: validated.length,
+    processed: sessionValidated.length,
     succeeded: succeeded.length,
     dropped: dropped.length,
     remaining,


### PR DESCRIPTION
Fixes #5727

## What
- Added `validateQueueSession()` to drop queue items whose stored `sessionId` doesn't match the current session
- `processQueue()` now throws if `currentUserId` is missing (mandatory, not optional)
- Both `filterQueueByOwnership` + `validateQueueSession` are now called in all replay paths (`processQueue` and `useOfflineSync`)

## Why
User A could queue actions offline, log out, User B logs in → queue replays under User B's session. The ownership filter existed but wasn't enforced in `processQueue`, and session ID was never re-validated on replay.

## Tests
Added 4 security tests in `useOfflineSync.test.js`:
- Cross-user items are not replayed
- Stale session items are dropped
- `filterQueueByOwnership` is always called with current user ID
- `validateQueueSession` is always called in the replay path