### PR TITLE
fix(security): persist reset cooldown in sessionStorage to prevent refresh bypass

### DIFF
--- a/src/components/auth/PasswordReset.js
+++ b/src/components/auth/PasswordReset.js
@@ -3,7 +3,39 @@ import { Link, useNavigate } from 'react-router-dom';
 import { API_ENDPOINTS, apiUtils } from '../../config/api';
 import { motion } from "framer-motion";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
-import { RESET_COOLDOWN_SECONDS, secondsUntilUnlock } from '../../utils/rateLimitUtils';
+import { RESET_COOLDOWN_SECONDS, secondsUntilUnlock, STORAGE_KEY_RESET_LAST_SUBMIT } from '../../utils/rateLimitUtils';
+
+// ---------------------------------------------------------------------------
+// sessionStorage helpers — persist cooldown across page refreshes (Issue #5720)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the last submit timestamp from sessionStorage.
+ * Returns 0 if missing or corrupt so the cooldown is treated as expired.
+ */
+const readLastSubmit = () => {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY_RESET_LAST_SUBMIT);
+    if (raw === null) return 0;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  } catch {
+    return 0;
+  }
+};
+
+/**
+ * Persist the last submit timestamp to sessionStorage.
+ * Fails silently (privacy mode / storage full) — the in-memory ref is the
+ * authoritative source within the same page lifecycle.
+ */
+const writeLastSubmit = (ts) => {
+  try {
+    sessionStorage.setItem(STORAGE_KEY_RESET_LAST_SUBMIT, String(ts));
+  } catch {
+    // best-effort
+  }
+};
 
 const PasswordReset = () => {
   useDocumentTitle("Reset Password | Eventra");
@@ -13,7 +45,10 @@ const PasswordReset = () => {
   const [error, setError] = useState('');
   const [cooldownSeconds, setCooldownSeconds] = useState(0);
 
-  const lastSubmitRef = useRef(0);
+  // FIX (Issue #5720): Seed from sessionStorage so cooldown survives page refresh.
+  // useRef is still used as the authoritative in-memory source within the lifecycle;
+  // sessionStorage provides durability across remounts/refreshes.
+  const lastSubmitRef = useRef(readLastSubmit());
   const intervalRef = useRef(null);
   const navTimerRef = useRef(null);
   const emailInputRef = useRef(null);
@@ -49,6 +84,18 @@ const PasswordReset = () => {
     return () => clearAllTimers(); // Safely clean up everything on unmount
   }, [clearAllTimers]);
 
+  // FIX (Issue #5720): On mount, if a persisted cooldown is still active,
+  // start the countdown timer so the UI reflects the correct remaining time.
+  useEffect(() => {
+    if (lastSubmitRef.current > 0) {
+      const remaining = secondsUntilUnlock(lastSubmitRef.current + RESET_COOLDOWN_SECONDS * 1000);
+      if (remaining > 0) {
+        startCooldownTimer();
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally runs once on mount
+
   const isCoolingDown = () => {
     return Date.now() - lastSubmitRef.current < RESET_COOLDOWN_SECONDS * 1000;
   };
@@ -73,6 +120,7 @@ const PasswordReset = () => {
       const response = await apiUtils.post(API_ENDPOINTS.AUTH.RESET_PASSWORD, { email });
       setMessage(response.data?.message || 'Password reset link sent! Check your email.');
       lastSubmitRef.current = Date.now();
+      writeLastSubmit(lastSubmitRef.current); // FIX (Issue #5720): persist so refresh can't bypass cooldown
       startCooldownTimer();
       navTimerRef.current = setTimeout(() => navigate('/login'), 3000);
     } catch (err) {

--- a/src/components/utils/rateLimitUtils.js
+++ b/src/components/utils/rateLimitUtils.js
@@ -1,0 +1,156 @@
+/**
+ * Shared rate-limiting utilities used by authentication forms.
+ *
+ * These helpers operate entirely in the browser — they are a UX-layer defence
+ * that raises the cost of automated attacks and protects the backend from
+ * being flooded. They do NOT replace server-side rate limiting; both layers
+ * should be present.
+ */
+
+/** sessionStorage key names for persisted rate-limit state. */
+export const STORAGE_KEY_ATTEMPTS = 'eventra:login:attempts';
+export const STORAGE_KEY_LOCKOUT_UNTIL = 'eventra:login:lockoutUntil';
+
+/**
+ * sessionStorage key for the last password-reset submission timestamp (ms).
+ * Persisting this across page refreshes prevents the 60-second cooldown from
+ * being bypassed by simply reloading the page (Issue #5720).
+ */
+export const STORAGE_KEY_RESET_LAST_SUBMIT = 'eventra:resetPwd:lastSubmit';
+
+/** Maximum number of failed login attempts before a lockout is imposed. */
+export const MAX_LOGIN_ATTEMPTS = 5;
+
+/**
+ * Reads persisted rate-limit state from sessionStorage.
+ * Returns zeroed defaults if the data is missing, corrupt, or from a future
+ * lockout that has already expired.
+ *
+ * @returns {{ attempts: number, lockoutUntil: number }}
+ */
+export function readPersistedRateLimit() {
+  try {
+    const rawAttempts = sessionStorage.getItem(STORAGE_KEY_ATTEMPTS);
+    const rawLockout = sessionStorage.getItem(STORAGE_KEY_LOCKOUT_UNTIL);
+
+    const attempts = rawAttempts !== null ? parseInt(rawAttempts, 10) : 0;
+    const lockoutUntil = rawLockout !== null ? parseInt(rawLockout, 10) : 0;
+
+    if (!Number.isFinite(attempts) || attempts < 0) return { attempts: 0, lockoutUntil: 0 };
+
+    // Discard expired lockouts — don't start with a stale "locked" state
+    const validLockout = Number.isFinite(lockoutUntil) && lockoutUntil > Date.now()
+      ? lockoutUntil
+      : 0;
+
+    return { attempts, lockoutUntil: validLockout };
+  } catch {
+    return { attempts: 0, lockoutUntil: 0 };
+  }
+}
+
+/**
+ * Writes current rate-limit state to sessionStorage.
+ * sessionStorage is tab-scoped and cleared when the tab is closed, which
+ * provides the right scope: resist refresh-bypass within a tab session while
+ * not permanently blocking a legitimate user across browser restarts.
+ *
+ * @param {number} attempts
+ * @param {number} lockoutUntil - Unix timestamp (ms), 0 if not locked.
+ */
+export function persistRateLimit(attempts, lockoutUntil) {
+  try {
+    sessionStorage.setItem(STORAGE_KEY_ATTEMPTS, String(attempts));
+    sessionStorage.setItem(STORAGE_KEY_LOCKOUT_UNTIL, String(lockoutUntil));
+  } catch {
+    // sessionStorage may be full or blocked in privacy mode — fail silently.
+    // The in-memory state is still active; this is a best-effort durability layer.
+  }
+}
+
+/**
+ * Removes all persisted rate-limit state from sessionStorage.
+ * Call this on successful login or intentional reset.
+ */
+export function clearPersistedRateLimit() {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY_ATTEMPTS);
+    sessionStorage.removeItem(STORAGE_KEY_LOCKOUT_UNTIL);
+  } catch {
+    // Ignore — clearing is best-effort
+  }
+}
+
+/**
+ * Parses the Retry-After HTTP response header value into milliseconds.
+ * Handles both the integer-seconds form ("30") and the HTTP-date form.
+ *
+ * @param {string|null|undefined} headerValue - Raw Retry-After header value.
+ * @returns {number} Delay in milliseconds, or 0 if unparseable.
+ */
+export function parseRetryAfterMs(headerValue) {
+  if (!headerValue) return 0;
+
+  const trimmed = String(headerValue).trim();
+
+  // Integer seconds form: "30"
+  const asSeconds = parseInt(trimmed, 10);
+  if (!isNaN(asSeconds) && String(asSeconds) === trimmed) {
+    return Math.max(0, asSeconds) * 1000;
+  }
+
+  // HTTP-date form: "Wed, 21 Oct 2025 07:28:00 GMT"
+  const asDate = Date.parse(trimmed);
+  if (!isNaN(asDate)) {
+    return Math.max(0, asDate - Date.now());
+  }
+
+  return 0;
+}
+
+/**
+ * Minimum number of seconds a user must wait between password-reset
+ * submissions. Prevents reset-email spam against a victim address.
+ */
+export const RESET_COOLDOWN_SECONDS = 60;
+
+/**
+ * Returns the exponential backoff delay (in milliseconds) for a given number
+ * of failed attempts. The delay starts after MAX_LOGIN_ATTEMPTS failures and
+ * is capped at 30 seconds so legitimate users are not locked out indefinitely.
+ *
+ * Attempt 5 → 2 s, attempt 6 → 4 s, attempt 7 → 8 s … capped at 30 s.
+ *
+ * @param {number} attempts - Total failed attempts so far (1-based).
+ * @returns {number} Lockout duration in milliseconds.
+ */
+export function getBackoffDelay(attempts) {
+  if (attempts < MAX_LOGIN_ATTEMPTS) return 0;
+  const exponent = attempts - (MAX_LOGIN_ATTEMPTS - 1);
+  return Math.min(30, Math.pow(2, exponent)) * 1000;
+}
+
+/**
+ * Formats a remaining-cooldown duration into a human-readable string.
+ *
+ * @param {number} remainingMs - Remaining time in milliseconds.
+ * @returns {string} E.g. "29s", "1m 4s".
+ */
+export function formatCountdown(remainingMs) {
+  if (remainingMs <= 0) return '0s';
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Returns the number of whole seconds remaining in a lockout period.
+ *
+ * @param {number} lockoutUntil - Unix timestamp (ms) when lockout expires.
+ * @returns {number} Seconds remaining, never negative.
+ */
+export function secondsUntilUnlock(lockoutUntil) {
+  return Math.max(0, Math.ceil((lockoutUntil - Date.now()) / 1000));
+}


### PR DESCRIPTION
Fixes #5720

## What
- Added `STORAGE_KEY_RESET_LAST_SUBMIT = 'eventra:resetPwd:lastSubmit'` constant to `rateLimitUtils.js`
- Added `readLastSubmit()` / `writeLastSubmit()` sessionStorage helpers in `PasswordReset.js`
- `lastSubmitRef` is now seeded from sessionStorage on mount instead of always `0`
- Timestamp is written to sessionStorage on every successful submission
- Added mount `useEffect` to restore the countdown timer UI if a cooldown is still active after refresh

## Why
`lastSubmitRef.current` was a plain React ref — it reset to `0` on every page refresh, completely bypassing the 60-second cooldown and allowing unlimited reset emails to be sent to a victim address. This follows the exact same sessionStorage pattern already used for login rate limiting in `rateLimitUtils.js`.

## Behaviour
- Cooldown now survives F5 / component remount within the same browser tab session
- sessionStorage is tab-scoped, so it clears naturally when the tab closes — legitimate users are never permanently blocked
- Fails silently if sessionStorage is unavailable (private mode) — in-memory ref still enforces the cooldown for the current page lifecycle