### PR TITLE
fix: prevent stale event data race condition during rapid navigation

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -53,11 +53,21 @@ const EventDetails = () => {
     const requestId = ++latestRequestIdRef.current;
     const isLatestRequest = () => latestRequestIdRef.current === requestId;
 
+    // FIX (#5077): AbortController cancels the in-flight network request when
+    // the user navigates away before it completes, preventing the response
+    // from a stale request from ever reaching setState.
+    const controller = new AbortController();
+
+    // Guard: only reset state for the latest request. A stale in-flight
+    // request must not clobber the loading state started by a newer one.
+    if (!isLatestRequest()) return;
     setFetchLoading(true);
     setFetchError(null);
 
     try {
-      const res = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
+      const res = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId), {
+        signal: controller.signal,
+      });
       if (!isLatestRequest()) return;
       if (res.ok && res.data) {
         const raw = res.data?.data ?? res.data;
@@ -65,7 +75,10 @@ const EventDetails = () => {
       } else {
         throw new Error(res.data?.message || `Event not found (${res.status})`);
       }
-    } catch {
+    } catch (err) {
+      // AbortError means the request was intentionally cancelled — do not
+      // update state or show an error to the user.
+      if (err?.name === 'AbortError') return;
       if (!isLatestRequest()) return;
       // Fall back to bundled mock data when the API is unreachable
       const fallback = mockEvents.find((item) => String(item.id) === eventId);
@@ -79,10 +92,17 @@ const EventDetails = () => {
         setFetchLoading(false);
       }
     }
+
+    // Return the abort function so the useEffect cleanup can cancel the request
+    return () => controller.abort();
   }, [eventId]);
 
   useEffect(() => {
-    loadEvent();
+    // loadEvent returns an abort function; wire it up as the cleanup so
+    // navigating away mid-request cancels the in-flight fetch (#5077).
+    let cancel;
+    loadEvent().then((abortFn) => { cancel = abortFn; });
+    return () => { if (cancel) cancel(); };
   }, [loadEvent]);
 
   // Safely handle localStorage cache updates via hook

--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -108,6 +108,11 @@ const EventDetailsPage = () => {
       latestRequestIdRef.current === requestId && !controller.signal.aborted;
 
     const fetchEvent = async () => {
+      // Guard: only update state if this is still the latest request.
+      // Without this check, a stale request starting after a newer one has
+      // already begun would unconditionally reset loading/error state,
+      // causing the race condition described in issue #5077.
+      if (!isLatestRequest()) return;
       setLoading(true);
       setCacheInfo(null);
       setError(null);


### PR DESCRIPTION
Fixes #5077

## What
Closes the race condition where rapidly navigating between events could cause a stale request to overwrite the current event's state.

### `EventDetailsPage.js`
- Added an `isLatestRequest()` guard at the very top of `fetchEvent()` — if this request is already stale when it starts executing, it exits immediately without touching `setLoading`, `setCacheInfo`, or `setError`. Previously these fired unconditionally, letting a slow stale request reset the loading state of a newer one mid-flight.

### `EventDetails.js`
- Same guard added before `setFetchLoading(true)` / `setFetchError(null)`.
- Added `AbortController` to the `apiUtils.get()` call so the underlying network request is actively cancelled (not just ignored) when the user navigates away.
- `loadEvent` now returns an abort function; the `useEffect` cleanup calls it, so navigating away mid-request cancels the fetch immediately.
- Added `AbortError` handling in the catch block so cancelled requests don't trigger the mock-data fallback or error state.

## Why
Both components had `latestRequestIdRef` guards on the final `setState` calls, but the initial state resets (`setLoading(true)`, `setError(null)`) ran unconditionally. A stale request that started before cleanup fired would reset these, causing flickering and potentially letting a slow response from Event A overwrite the state for Event B.

## Type of Change
- [x] 🐛 Bug fix (non-breaking)