### PR TITLE
fix: scope event registration locks

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -60,6 +60,7 @@ const EventRegistration = () => {
   const [registered, setRegistered] = useState(false);
   const [waitlistPosition, setWaitlistPosition] = useState(-1);
   const isSubmittingRef = useRef(false);
+  const registrationLocksRef = useRef(new Map());
 
   // Conflict detection state
   const [showConflictModal, setShowConflictModal] = useState(false);
@@ -262,7 +263,7 @@ const EventRegistration = () => {
 
     setShowConflictModal(false);
 
-    registrationLocks.set(eventId, true);
+    registrationLocksRef.current.set(eventId, true);
     isSubmittingRef.current = true;
     setSubmitting(true);
 
@@ -282,7 +283,7 @@ const EventRegistration = () => {
         toast.error(err.message || t("eventRegistration.toastRegistrationError"));
         return;
       } finally {
-        registrationLocks.delete(eventId);
+        registrationLocksRef.current.delete(eventId);
         isSubmittingRef.current = false;
         setSubmitting(false);
       }
@@ -368,7 +369,7 @@ const EventRegistration = () => {
 
       toast.error(failureMessage);
     } finally {
-      registrationLocks.delete(eventId);
+      registrationLocksRef.current.delete(eventId);
       isSubmittingRef.current = false;
       setSubmitting(false);
     }
@@ -408,7 +409,7 @@ const EventRegistration = () => {
       return;
     }
 
-    if (registrationLocks.has(eventId)) {
+    if (registrationLocksRef.current.has(eventId)) {
       toast.error(t("eventRegistration.toastAnotherInProgress"));
       return;
     }


### PR DESCRIPTION
## Summary

- add a component-local registration lock map for `EventRegistration`
- route the submit/start/delete/duplicate-guard paths through the ref-backed map
- preserve the existing submit-state and waitlist cleanup behavior

Fixes #7077

## Root Cause

`EventRegistration.js` referenced `registrationLocks` directly, but that variable was never declared in the component module. The similarly named map in `useEventRegistration.js` is private to that hook file, so the page could throw `ReferenceError: registrationLocks is not defined` during registration.

## Testing

- `rg -n "registrationLocks" src/Pages/Events/EventRegistration.js src/hooks/useEventRegistration.js`
- `./node_modules/.bin/eslint src/Pages/Events/EventRegistration.js`
- `git diff --check`

## Notes

The full `npm run lint -- src/Pages/Events/EventRegistration.js` command still invokes the repo script as `eslint src ...`, so it scans all of `src` and fails on pre-existing unrelated parse errors in files such as `src/Pages/Home/components/Hero.js`, `src/components/events/SpatialSeatSelector.jsx`, and `src/components/visual/CollaborationNetworkMap.jsx`. Direct ESLint on the touched file has no errors; it only reports existing hook dependency warnings in `EventRegistration.js`.
