### PR TITLE
fix: switch pr-size-labeler to pull_request_target for fork write access

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,11 +1,12 @@
 name: PR Size Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   label:
@@ -15,6 +16,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Calculate PR Size


### PR DESCRIPTION
Fixes #7103

## Problem
The `pull_request` trigger gives a read-only `GITHUB_TOKEN` for PRs from
forks. The `permissions: pull-requests: write` block has no effect because
the token is restricted at the source. This causes every fork PR to fail:

GraphQL: Resource not accessible by integration (addLabelsToLabelable)
GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)

## Fix
**3-line change — no logic altered:**

1. Trigger changed from `pull_request` to `pull_request_target` — runs in
   the context of the base repo, so `GITHUB_TOKEN` gets write permissions
   and the existing `permissions` block now takes effect.

2. Added `contents: read` to the permissions block — required for
   `actions/checkout` under `pull_request_target`.

3. Checkout `ref` set to `refs/pull/${{ github.event.pull_request.number }}/merge`
   — ensures `git diff origin/base...HEAD` computes the correct diff even
   though the workflow now runs against the base repo's code.

All label names, thresholds, diff logic, and the `|| true` guard on label
removal are completely unchanged.

## Security
No untrusted code is executed. The workflow only reads diff statistics and
calls the GitHub Labels API to assign a size label. It never installs
dependencies or runs code from the PR branch.