### PR TITLE
fix: verify SSE fallback leadership claims

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -4,6 +4,8 @@ import { ENV } from "../config/env.js";
 const MULTIPLEX_CHANNEL_NAME = "eventra_sse_multiplexer";
 const LOCK_NAME = "eventra_sse_leader_lock";
 const HEARTBEAT_KEY = "eventra_sse_leader_heartbeat";
+const LOCAL_STORAGE_CONFIRM_MIN_MS = 25;
+const LOCAL_STORAGE_CONFIRM_JITTER_MS = 75;
 
 // Unique identifier for this tab instance
 const TAB_ID = Math.random().toString(36).substring(2, 9);
@@ -57,6 +59,8 @@ class SseMultiplexer {
     this.statusListeners = new Set(); // callbacks listening to status changes
     this.lastSeenFollowers = new Map();
     this.tabIdToPaths = new Map();
+    this.localStorageLeadershipToken = null;
+    this.localStorageClaimTimeout = null;
 
     if (typeof window !== "undefined") {
       this.channel = new BroadcastChannel(MULTIPLEX_CHANNEL_NAME);
@@ -102,41 +106,111 @@ class SseMultiplexer {
     const HEARTBEAT_INTERVAL = 3000;
     const HEARTBEAT_TIMEOUT = 7000;
 
+    const readHeartbeat = () => {
+      try {
+        const heartbeat = localStorage.getItem(HEARTBEAT_KEY);
+        return heartbeat ? JSON.parse(heartbeat) : null;
+      } catch {
+        return null;
+      }
+    };
+
+    const hasActiveExternalLeader = (heartbeat, now) =>
+      heartbeat &&
+      heartbeat.tabId !== this.tabId &&
+      now - heartbeat.timestamp < HEARTBEAT_TIMEOUT;
+
     const checkLeader = () => {
       if (this.isLeader) return;
 
       const now = Date.now();
-      const heartbeat = localStorage.getItem(HEARTBEAT_KEY);
-
-      if (heartbeat) {
-        try {
-          const parsed = JSON.parse(heartbeat);
-          if (parsed && now - parsed.timestamp < HEARTBEAT_TIMEOUT && parsed.tabId !== this.tabId) {
-            // Active leader exists
-            return;
-          }
-        } catch {}
-      }
+      const heartbeat = readHeartbeat();
+      if (hasActiveExternalLeader(heartbeat, now)) return;
 
       // Try to claim leadership
-      this.claimLocalStorageLeadership();
+      this.claimLocalStorageLeadership(HEARTBEAT_TIMEOUT);
     };
 
     this.localStorageInterval = setInterval(checkLeader, HEARTBEAT_INTERVAL);
     checkLeader();
   }
 
-  claimLocalStorageLeadership() {
+  claimLocalStorageLeadership(heartbeatTimeout = 7000) {
+    if (this.localStorageClaimTimeout || this.isLeader) return;
+
+    const token = `${this.tabId}:${Date.now()}:${Math.random().toString(36).substring(2, 9)}`;
+    const timestamp = Date.now();
+
+    try {
+      const current = localStorage.getItem(HEARTBEAT_KEY);
+      const parsed = current ? JSON.parse(current) : null;
+      if (
+        parsed &&
+        parsed.tabId !== this.tabId &&
+        timestamp - parsed.timestamp < heartbeatTimeout
+      ) {
+        return;
+      }
+
+      localStorage.setItem(HEARTBEAT_KEY, JSON.stringify({ tabId: this.tabId, token, timestamp }));
+    } catch {
+      this.becomeLocalStorageLeader(token);
+      return;
+    }
+
+    const confirmDelay =
+      LOCAL_STORAGE_CONFIRM_MIN_MS + Math.floor(Math.random() * LOCAL_STORAGE_CONFIRM_JITTER_MS);
+
+    this.localStorageClaimTimeout = setTimeout(() => {
+      this.localStorageClaimTimeout = null;
+
+      try {
+        const heartbeat = JSON.parse(localStorage.getItem(HEARTBEAT_KEY) || "null");
+        if (heartbeat?.tabId !== this.tabId || heartbeat?.token !== token) return;
+      } catch {
+        return;
+      }
+
+      this.becomeLocalStorageLeader(token);
+    }, confirmDelay);
+  }
+
+  becomeLocalStorageLeader(token) {
     this.isLeader = true;
+    this.localStorageLeadershipToken = token;
     logger.log(`[SSE Multiplexer] Tab ${this.tabId} claimed leadership via LocalStorage.`);
 
     // Write an immediate heartbeat so other tabs see the new leader without
     // waiting up to HEARTBEAT_INTERVAL (3 s) for the first interval tick.
     const writeHeartbeat = () => {
       try {
+        const current = JSON.parse(localStorage.getItem(HEARTBEAT_KEY) || "null");
+        if (
+          current?.tabId &&
+          current.tabId !== this.tabId &&
+          Date.now() - current.timestamp < 7000
+        ) {
+          for (const source of this.activeEventSources.values()) {
+            source.close();
+          }
+          this.activeEventSources.clear();
+          this.isLeader = false;
+          this.localStorageLeadershipToken = null;
+          if (this.heartbeatInterval) {
+            clearInterval(this.heartbeatInterval);
+            this.heartbeatInterval = null;
+          }
+          this.stopHeartbeatChecks();
+          return;
+        }
+
         localStorage.setItem(
           HEARTBEAT_KEY,
-          JSON.stringify({ tabId: this.tabId, timestamp: Date.now() })
+          JSON.stringify({
+            tabId: this.tabId,
+            token: this.localStorageLeadershipToken,
+            timestamp: Date.now(),
+          })
         );
       } catch {
         // localStorage unavailable — non-fatal, leadership still held in memory
@@ -495,6 +569,7 @@ class SseMultiplexer {
 
     if (this.localStorageInterval) clearInterval(this.localStorageInterval);
     if (this.heartbeatInterval) clearInterval(this.heartbeatInterval);
+    if (this.localStorageClaimTimeout) clearTimeout(this.localStorageClaimTimeout);
 
     // Remove the heartbeat key from localStorage when this tab was the leader.
     //

--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -6,6 +6,9 @@ const store = {};
 globalThis.window = {
   addEventListener() {},
   removeEventListener() {},
+  location: {
+    origin: "https://api.example.test",
+  },
   localStorage: {
     getItem(key) {
       return store[key] || null;
@@ -18,6 +21,7 @@ globalThis.window = {
     },
   },
 };
+globalThis.localStorage = globalThis.window.localStorage;
 
 // Mock BroadcastChannel for tab coordination
 const channels = new Set();
@@ -220,6 +224,61 @@ const runTests = async () => {
 
   // Stop heartbeat checks
   sseMultiplexer.stopHeartbeatChecks();
+  if (sseMultiplexer.heartbeatInterval) {
+    clearInterval(sseMultiplexer.heartbeatInterval);
+    sseMultiplexer.heartbeatInterval = null;
+  }
+
+  // Test 6: localStorage fallback verifies ownership before accepting leadership
+  delete store.eventra_sse_leader_heartbeat;
+  sseMultiplexer.isLeader = false;
+  sseMultiplexer.localStorageLeadershipToken = null;
+  if (sseMultiplexer.localStorageClaimTimeout) {
+    clearTimeout(sseMultiplexer.localStorageClaimTimeout);
+    sseMultiplexer.localStorageClaimTimeout = null;
+  }
+
+  const originalRandom = Math.random;
+  Math.random = () => 0;
+  try {
+    sseMultiplexer.claimLocalStorageLeadership(0);
+    const firstClaim = JSON.parse(store.eventra_sse_leader_heartbeat);
+    assert.equal(firstClaim.tabId, sseMultiplexer.tabId);
+
+    store.eventra_sse_leader_heartbeat = JSON.stringify({
+      tabId: "competing_tab",
+      token: "competing-token",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    assert.equal(
+      sseMultiplexer.isLeader,
+      false,
+      "A tab must not become leader after another tab overwrites its claim"
+    );
+
+    delete store.eventra_sse_leader_heartbeat;
+    sseMultiplexer.claimLocalStorageLeadership(0);
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    assert.equal(
+      sseMultiplexer.isLeader,
+      true,
+      "A tab should become leader when its claim token survives confirmation"
+    );
+  } finally {
+    Math.random = originalRandom;
+    sseMultiplexer.stopHeartbeatChecks();
+    if (sseMultiplexer.heartbeatInterval) {
+      clearInterval(sseMultiplexer.heartbeatInterval);
+      sseMultiplexer.heartbeatInterval = null;
+    }
+    if (sseMultiplexer.localStorageClaimTimeout) {
+      clearTimeout(sseMultiplexer.localStorageClaimTimeout);
+      sseMultiplexer.localStorageClaimTimeout = null;
+    }
+    delete store.eventra_sse_leader_heartbeat;
+  }
 
   console.log("🟢 All SSE Multiplexer unit tests completed successfully!");
 };


### PR DESCRIPTION
Summary
- add a token confirmation step before a localStorage fallback tab accepts SSE leadership
- stop pending localStorage election claims during teardown
- cover overwritten-claim behavior in the SSE multiplexer regression test

Validation
- node --loader ./tests/loaders/jsExtension.mjs tests/sseMultiplexer.test.mjs
- ./node_modules/.bin/eslint src/utils/sseMultiplexer.js tests/sseMultiplexer.test.mjs (passes with one existing test warning: lockAcquiredCallback is assigned but unused)
- git diff --check

Fixes #7080