### PR TITLE
fix: refactor scan-issues.js to use async I/O

### DIFF
--- a/scripts/scan-issues.js
+++ b/scripts/scan-issues.js
@@ -1,12 +1,12 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 
-function getFiles(dir) {
+async function getFiles(dir) {
   let r = [];
-  for (const f of fs.readdirSync(dir)) {
+  for (const f of await fs.readdir(dir)) {
     const full = path.join(dir, f);
-    const stat = fs.statSync(full);
-    if (stat.isDirectory() && f !== 'node_modules') r = r.concat(getFiles(full));
+    const stat = await fs.stat(full);
+    if (stat.isDirectory() && f !== 'node_modules') r = r.concat(await getFiles(full));
     else if (f.endsWith('.js') || f.endsWith('.jsx')) r.push(full);
   }
   return r;
@@ -22,39 +22,46 @@ function cleanCodeForRegex(src) {
     .replace(/`[\s\S]*?`/g, '');       // Remove template literals
 }
 
-const files = getFiles('src');
-const issues = [];
+async function main() {
+  const files = await getFiles('src');
+  const issues = [];
 
-for (const f of files) {
-  const code = fs.readFileSync(f, 'utf8');
-  let rel = path.relative(process.cwd(), f);
-  rel = rel.split(path.sep).join('/');
-  const cleanCode = cleanCodeForRegex(code);
+  for (const f of files) {
+    const code = await fs.readFile(f, 'utf8');
+    let rel = path.relative(process.cwd(), f);
+    rel = rel.split(path.sep).join('/');
+    const cleanCode = cleanCodeForRegex(code);
 
-// To fix separate classes legitimately having render(), we split by 'class ' keyword 
-// and check if any individual class body contains more than one render() definition
-const classes = cleanCode.split(/\bclass\s+/);
-let hasDuplicateRender = false;
+    // To fix separate classes legitimately having render(), we split by 'class ' keyword
+    // and check if any individual class body contains more than one render() definition
+    const classes = cleanCode.split(/\bclass\s+/);
+    let hasDuplicateRender = false;
 
-// Skip the first split element as it's the code before any class definition
-for (let i = 1; i < classes.length; i++) {
-  const renderMatches = [...classes[i].matchAll(/\brender\s*\(\s*\)\s*\{/g)];
-  if (renderMatches.length > 1) {
-    hasDuplicateRender = true;
-    break;
+    // Skip the first split element as it's the code before any class definition
+    for (let i = 1; i < classes.length; i++) {
+      const renderMatches = [...classes[i].matchAll(/\brender\s*\(\s*\)\s*\{/g)];
+      if (renderMatches.length > 1) {
+        hasDuplicateRender = true;
+        break;
+      }
+    }
+
+    if (hasDuplicateRender) {
+      issues.push('DUPLICATE_RENDER: ' + rel);
+    }
+
+    // Check for duplicate export default on code stripped of comments and strings
+    const exportMatches = [...cleanCode.matchAll(/\bexport\s+default\b/g)];
+    if (exportMatches.length > 1) {
+      issues.push('DUPLICATE_EXPORT: ' + rel);
+    }
   }
+
+  console.log('Issues found:', issues.length);
+  issues.forEach(i => console.log(i));
 }
 
-if (hasDuplicateRender) {
-  issues.push('DUPLICATE_RENDER: ' + rel);
-}
-  
-// Check for duplicate export default on code stripped of comments and strings
-const exportMatches = [...cleanCode.matchAll(/\bexport\s+default\b/g)];
-if (exportMatches.length > 1) {
-  issues.push('DUPLICATE_EXPORT: ' + rel);
-}
-}
-
-console.log('Issues found:', issues.length);
-issues.forEach(i => console.log(i));
+main().catch(err => {
+  console.error('scan-issues failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fixes #6712

Replaces `fs.readdirSync`, `fs.statSync`, and `fs.readFileSync` with
`fs.promises` equivalents and wraps execution in `async main()`.
Keeps the event loop unblocked on large codebases and adds a `.catch`
handler for clean CI failure reporting. Detection logic is unchanged.