### PR TITLE
fix(auth): preserve signup response roles

### DIFF
--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { API_ENDPOINTS, apiUtils } from "../../config/api";
+import { ROLES } from "../../config/roles";
 import { useAuth } from "../../context/AuthContext";
 import { FormFieldWrapper, ValidationMessage } from "../forms";
 import PasswordStrengthIndicator from "./PasswordStrengthIndicator";
@@ -9,6 +10,22 @@ import { User, AtSign, Lock, Eye, EyeOff, Zap } from "lucide-react";
 import { validate, validateEmailAvailability, validatePasswordStrength } from "../../validation";
 
 const getResultMessage = (result, fallback) => (result?.isValid ? "" : result?.message || fallback);
+
+export const normalizeSignupRoles = (data) => {
+  const responseRoles = Array.isArray(data?.roles)
+    ? data.roles.filter((role) => typeof role === "string" && role.trim())
+    : [];
+
+  if (responseRoles.length > 0) {
+    return responseRoles;
+  }
+
+  if (typeof data?.role === "string" && data.role.trim()) {
+    return [data.role];
+  }
+
+  return [ROLES.ATTENDEE];
+};
 
 const parseSignupResponse = async (response) => {
   if (typeof response?.text === "function") {
@@ -251,14 +268,15 @@ const SignupForm = () => {
         return;
       }
 
+      const sessionRoles = normalizeSignupRoles(data);
       const sessionUser = {
         id: data?.id,
         firstName: data?.firstName ?? formData.firstName.trim(),
         lastName: data?.lastName ?? formData.lastName.trim(),
         email: data?.email ?? formData.email.trim(),
         username: data?.username ?? formData.email.trim(),
-        role: data?.role ?? "USER",
-        roles: data?.role ? [data.role] : ["USER"],
+        role: sessionRoles[0],
+        roles: sessionRoles,
         permissions: data?.permissions ?? [],
       };
 

--- a/src/components/auth/__tests__/SignupForm.test.jsx
+++ b/src/components/auth/__tests__/SignupForm.test.jsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
-import SignupForm from "../SignupForm";
+import SignupForm, { normalizeSignupRoles } from "../SignupForm";
 import { apiUtils } from "../../../config/api";
 import {
   validateEmailAvailability,
@@ -135,6 +135,19 @@ afterEach(() => {
 });
 
 describe("SignupForm integration", () => {
+  it("preserves server-assigned signup roles arrays", () => {
+    expect(
+      normalizeSignupRoles({
+        role: "ATTENDEE",
+        roles: ["ORGANIZER"],
+      }),
+    ).toEqual(["ORGANIZER"]);
+  });
+
+  it("falls back to a valid app role when signup response has no roles", () => {
+    expect(normalizeSignupRoles({})).toEqual(["ATTENDEE"]);
+  });
+
   it("blocks submission and marks required fields invalid", async () => {
     renderSignup();
 


### PR DESCRIPTION
## 📝 Description

This PR fixes the signup session role normalization bug from issue #4806.

After a successful signup, `SignupForm` now:

- prefers a non-empty `data.roles` array returned by the backend
- falls back to a singular `data.role` when needed
- falls back to the valid app role `ATTENDEE` instead of the nonexistent `USER`
- stores the normalized primary role and roles array in the auth session

This prevents newly signed-up users from losing server-assigned roles such as `ORGANIZER` during the first client session.

## 🔗 Linked Issue

Closes #4806

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking)
- [ ] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor (no functional effect)
- [ ] 📖 Documentation update
- [ ] 🎨 UI / Style update
- [ ] ⚙️ CI / Workflow change
- [ ] 🔒 Security fix

## 🧪 Testing

**Environment:**
- OS: macOS
- Node.js: v26.0.0
- npm: 11.12.1

**Steps to reproduce / verify:**
1. Mock a signup response with `roles: ["ORGANIZER"]` and no singular `role`.
2. Verify `normalizeSignupRoles` preserves the backend roles array.
3. Verify missing role data falls back to `ATTENDEE`.
4. Run targeted auth form tests and lint for the changed files.

**Commands run:**

```bash
npx vitest run src/components/auth/__tests__/SignupForm.test.jsx
npx eslint src/components/auth/SignupForm.js src/components/auth/__tests__/SignupForm.test.jsx --max-warnings=20
git diff --check
```

Results:
- `SignupForm.test.jsx`: 11 tests passed
- Targeted ESLint: 0 errors, existing warnings only
- `git diff --check`: passed

Baseline notes:
- `npm run lint` currently fails on unrelated existing repository errors in files outside this PR, including `src/Pages/Home/components/Hero.js`, `src/components/events/SpatialSeatSelector.jsx`, and `src/components/visual/CollaborationNetworkMap.jsx`.
- `npm test` currently has unrelated existing failing test files outside this PR.
- `npm run build` currently fails on the same unrelated parse errors outside this PR.

## 📸 Screenshots / Recording

Not applicable. This is an auth session data normalization fix with unit coverage.

## ✅ Self-Review Checklist

**Code Quality**
- [x] Self-review done; code follows project style and naming conventions
- [x] Hard-to-understand areas are commented
- [x] No new warnings, console errors, or leftover debug logs

**Testing**
- [x] Changes tested locally and work as expected
- [x] Existing test baseline checked; unrelated baseline failures are noted above
- [x] New tests added for the role normalization regression

**Documentation & Standards**
- [x] README / docs / JSDoc updated if needed
- [x] Commits follow Conventional Commits format
- [x] Branch named with correct prefix (`fix/`)

**GSSoC Compliance**
- [x] I was assigned to the linked issue before opening this PR
- [x] No AI-generated boilerplate or copy-pasted code included without full understanding
- [x] No trivial changes (whitespace-only, minor typos) made for point farming

## 📋 Additional Notes

Raised as part of GSSoC 2026. Please add or keep the appropriate GSSoC label if it is missing.

---
_GSSoC'26 · Mentor: [@Ayushh-Sharmaa](https://github.com/Ayushh-Sharmaa)_
