### PR TITLE
feat: add saved filter presets for event filtering

### DIFF
--- a/src/Pages/Events/EventFiltersToolbar.js
+++ b/src/Pages/Events/EventFiltersToolbar.js
@@ -1,7 +1,8 @@
-import { Grid, List, Search, X, RotateCcw, Sparkles, Filter, ChevronDown, Check } from "lucide-react";
+import { Grid, List, Search, X, RotateCcw, Sparkles, Filter, Save, Pencil, Trash2, Upload, RefreshCcw } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import StyledDropdown from "../../components/StyledDropdown";
 import AdvancedFilterPanel from "../../components/common/AdvancedFilterPanel";
+import useEventFilterPresets from "../../hooks/useEventFilterPresets";
 
 const CATEGORY_OPTIONS = [
   { id: "all", label: "All Categories" },
@@ -34,9 +35,23 @@ const EventFiltersToolbar = ({
   searchQuery,
   onSearchChange,
   onResetFilters,
+  currentFilterConfig,
+  onApplyPreset,
 }) => {
   const [localQuery, setLocalQuery] = useState(searchQuery || "");
+  const [presetName, setPresetName] = useState("");
+  const [editingPresetId, setEditingPresetId] = useState("");
+  const [editingPresetName, setEditingPresetName] = useState("");
   const debounceRef = useRef(null);
+  const {
+    presets,
+    presetError,
+    clearPresetError,
+    savePreset,
+    renamePreset,
+    updatePreset,
+    deletePreset,
+  } = useEventFilterPresets();
 
   useEffect(() => {
     setLocalQuery(searchQuery || "");
@@ -65,6 +80,37 @@ const EventFiltersToolbar = ({
     }
 
     onSearchChange?.("");
+  };
+
+  const handleSavePreset = () => {
+    const result = savePreset(presetName, currentFilterConfig);
+    if (!result.error) {
+      setPresetName("");
+    }
+  };
+
+  const handleStartRename = (preset) => {
+    clearPresetError();
+    setEditingPresetId(preset.id);
+    setEditingPresetName(preset.name);
+  };
+
+  const handleRenamePreset = (presetId) => {
+    const result = renamePreset(presetId, editingPresetName);
+    if (!result.error) {
+      setEditingPresetId("");
+      setEditingPresetName("");
+    }
+  };
+
+  const handleDeletePreset = (preset) => {
+    if (
+      window.confirm(
+        `Delete the "${preset.name}" filter preset? This cannot be undone.`,
+      )
+    ) {
+      deletePreset(preset.id);
+    }
   };
 
   const hasAnyFilterActive =
@@ -133,6 +179,135 @@ const EventFiltersToolbar = ({
         isOpen={isAdvancedFiltersOpen}
         onToggleOpen={() => onToggleAdvancedFilters?.((isOpen) => !isOpen)}
       />
+
+      <section className="rounded-2xl border border-slate-800 bg-slate-900/45 p-4 shadow-inner">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h4 className="flex items-center gap-2 text-sm font-bold text-slate-100">
+              <Save size={16} className="text-indigo-300" />
+              Saved Presets
+            </h4>
+            <p className="mt-1 text-xs text-slate-500">
+              Save this filter setup and apply it again later.
+            </p>
+          </div>
+
+          <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
+            <label htmlFor="event-filter-preset-name" className="sr-only">
+              Preset name
+            </label>
+            <input
+              id="event-filter-preset-name"
+              type="text"
+              value={presetName}
+              onChange={(event) => {
+                clearPresetError();
+                setPresetName(event.target.value);
+              }}
+              placeholder="Preset name"
+              className="min-w-0 rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30"
+            />
+            <button
+              type="button"
+              onClick={handleSavePreset}
+              className="inline-flex items-center justify-center gap-1.5 rounded-xl border border-indigo-500/50 bg-indigo-600 px-3 py-2 text-xs font-bold uppercase tracking-wider text-white shadow-lg shadow-indigo-500/10 transition hover:bg-indigo-500"
+            >
+              <Save size={14} />
+              Save Preset
+            </button>
+          </div>
+        </div>
+
+        {presetError && (
+          <p className="mt-3 rounded-xl border border-red-500/20 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-300">
+            {presetError}
+          </p>
+        )}
+
+        <div className="mt-4 space-y-2">
+          {presets.length === 0 ? (
+            <p className="rounded-xl border border-dashed border-slate-800 px-3 py-3 text-sm text-slate-500">
+              No saved presets yet.
+            </p>
+          ) : (
+            presets.map((preset) => {
+              const isEditing = editingPresetId === preset.id;
+
+              return (
+                <div
+                  key={preset.id}
+                  className="flex flex-col gap-3 rounded-xl border border-slate-800 bg-slate-950/40 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 flex-1">
+                    {isEditing ? (
+                      <input
+                        type="text"
+                        value={editingPresetName}
+                        onChange={(event) => {
+                          clearPresetError();
+                          setEditingPresetName(event.target.value);
+                        }}
+                        className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30"
+                        aria-label={`Rename ${preset.name}`}
+                      />
+                    ) : (
+                      <p className="truncate text-sm font-semibold text-slate-100">
+                        {preset.name}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onApplyPreset?.(preset.filters)}
+                      className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1.5 text-xs font-semibold text-emerald-300 transition hover:bg-emerald-500/20"
+                    >
+                      <Upload size={13} />
+                      Apply
+                    </button>
+                    {isEditing ? (
+                      <button
+                        type="button"
+                        onClick={() => handleRenamePreset(preset.id)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1.5 text-xs font-semibold text-indigo-300 transition hover:bg-indigo-500/20"
+                      >
+                        <Save size={13} />
+                        Save
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => handleStartRename(preset)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-slate-700 bg-slate-900 px-2.5 py-1.5 text-xs font-semibold text-slate-300 transition hover:text-white"
+                      >
+                        <Pencil size={13} />
+                        Edit
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => updatePreset(preset.id, currentFilterConfig)}
+                      className="inline-flex items-center gap-1 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2.5 py-1.5 text-xs font-semibold text-amber-300 transition hover:bg-amber-500/20"
+                    >
+                      <RefreshCcw size={13} />
+                      Update
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeletePreset(preset)}
+                      className="inline-flex items-center gap-1 rounded-lg border border-red-500/30 bg-red-500/10 px-2.5 py-1.5 text-xs font-semibold text-red-300 transition hover:bg-red-500/20"
+                    >
+                      <Trash2 size={13} />
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </section>
 
       {/* 2. Interactive Search & Timing row */}
       <div className="flex flex-col lg:flex-row items-stretch lg:items-center justify-between gap-4">

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from "react";
+import { useRef, useEffect, useMemo, useState } from "react";
 import { useSearchParams, useLocation } from "react-router-dom";
 import VirtualizedEventGrid from "../../components/common/VirtualizedEventGrid"; 
 import EventHero from "./EventHero";
@@ -27,6 +27,14 @@ import {
 } from "../../utils/advancedFilterUtils";
 
 const FILTER_STORAGE_KEY = "eventra:event-filters:v1";
+
+const ExploreEventsSkeleton = () => (
+  <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" aria-label="Loading events">
+    {Array.from({ length: 6 }, (_, index) => (
+      <EventCardSkeleton key={index} />
+    ))}
+  </div>
+);
 
 const renderCardSection = (
   isLoading,
@@ -145,6 +153,8 @@ const EventsPage = () => {
       parseInt(searchParams.get("perPage"), 10) || savedFilters.perPage || 6;
     const filter =
       searchParams.get("filter") || savedFilters.filterType || "all";
+    const category =
+      searchParams.get("category") || savedFilters.categoryFilter || "all";
     const sort = searchParams.get("sort") || savedFilters.sortType || "Newest";
     const view = searchParams.get("view") || savedFilters.viewMode || "grid";
     const urlAdvancedFilters = searchParams.get("filters");
@@ -160,6 +170,7 @@ const EventsPage = () => {
       listing.setSearchQuery(initialSearch);
     }
     listing.setFilterType(filter);
+    listing.setCategoryFilter(category);
     listing.setSortType(sort);
     listing.setViewMode(view);
     listing.setEventsPerPage(perPage);
@@ -178,6 +189,7 @@ const EventsPage = () => {
     if (listing.eventsPerPage !== 6) params.perPage = listing.eventsPerPage;
     if (listing.searchQuery) params.search = listing.searchQuery;
     if (listing.filterType !== "all") params.filter = listing.filterType;
+    if (listing.categoryFilter !== "all") params.category = listing.categoryFilter;
     if (listing.sortType !== "Newest") params.sort = listing.sortType;
     if (listing.viewMode !== "grid") params.view = listing.viewMode;
     if (hasActiveAdvancedFilters(listing.advancedFilters)) {
@@ -191,6 +203,7 @@ const EventsPage = () => {
         JSON.stringify({
           searchQuery: listing.searchQuery,
           filterType: listing.filterType,
+          categoryFilter: listing.categoryFilter,
           sortType: listing.sortType,
           viewMode: listing.viewMode,
           perPage: listing.eventsPerPage,
@@ -205,6 +218,7 @@ const EventsPage = () => {
     listing.eventsPerPage,
     listing.searchQuery,
     listing.filterType,
+    listing.categoryFilter,
     listing.sortType,
     listing.viewMode,
     listing.advancedFilters,
@@ -261,6 +275,37 @@ const EventsPage = () => {
     setLocalSearchInput("");
   };
 
+  const currentFilterConfig = useMemo(
+    () => ({
+      searchQuery: localSearchInput,
+      filterType: listing.filterType,
+      categoryFilter: listing.categoryFilter,
+      sortType: listing.sortType,
+      viewMode: listing.viewMode,
+      advancedFilters: listing.advancedFilters,
+    }),
+    [
+      localSearchInput,
+      listing.filterType,
+      listing.categoryFilter,
+      listing.sortType,
+      listing.viewMode,
+      listing.advancedFilters,
+    ],
+  );
+
+  const applyFilterPreset = (filters) => {
+    const search = filters?.searchQuery || "";
+    setLocalSearchInput(search);
+    listing.setSearchQuery(search);
+    listing.setFilterType(filters?.filterType || "all");
+    listing.setCategoryFilter(filters?.categoryFilter || "all");
+    listing.setSortType(filters?.sortType || "Newest");
+    listing.setViewMode(filters?.viewMode || "grid");
+    listing.setAdvancedFilters(filters?.advancedFilters || getDefaultFilters());
+    listing.setSafePage(1);
+  };
+
   return (
     <div className="flex flex-col min-h-screen bg-gradient-to-b from-blue-50 via-indigo-50/30 to-white dark:bg-slate-950 text-slate-900 dark:text-gray-100 overflow-x-hidden">
       <EventHero
@@ -295,6 +340,8 @@ const EventsPage = () => {
             priceStats={listing.priceStats}
             dateRangeStats={listing.dateRangeStats}
             onResetFilters={clearSearchAndFilters}
+            currentFilterConfig={currentFilterConfig}
+            onApplyPreset={applyFilterPreset}
           />
         </div>
 

--- a/src/hooks/useEventFilterPresets.js
+++ b/src/hooks/useEventFilterPresets.js
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  createFilterPreset,
+  EVENT_FILTER_PRESETS_STORAGE_KEY,
+  readFilterPresets,
+  removeFilterPreset,
+  renameFilterPreset,
+  updateFilterPreset,
+  writeFilterPresets,
+} from "../utils/eventFilterPresets.js";
+
+const createPresetId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+export const useEventFilterPresets = ({
+  storageKey = EVENT_FILTER_PRESETS_STORAGE_KEY,
+  storage = globalThis.localStorage,
+} = {}) => {
+  const [presets, setPresets] = useState([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setPresets(readFilterPresets(storage, storageKey));
+  }, [storage, storageKey]);
+
+  const persist = useCallback(
+    (nextPresets) => {
+      const persisted = writeFilterPresets(nextPresets, storage, storageKey);
+      setPresets(persisted);
+      return persisted;
+    },
+    [storage, storageKey],
+  );
+
+  const savePreset = useCallback(
+    (name, filters) => {
+      const result = createFilterPreset(
+        presets,
+        name,
+        filters,
+        createPresetId,
+      );
+      setError(result.error || "");
+      if (!result.error) {
+        persist(result.presets);
+      }
+      return result;
+    },
+    [persist, presets],
+  );
+
+  const renamePreset = useCallback(
+    (presetId, name) => {
+      const result = renameFilterPreset(presets, presetId, name);
+      setError(result.error || "");
+      if (!result.error) {
+        persist(result.presets);
+      }
+      return result;
+    },
+    [persist, presets],
+  );
+
+  const updatePreset = useCallback(
+    (presetId, filters) => {
+      const nextPresets = updateFilterPreset(presets, presetId, filters);
+      setError("");
+      persist(nextPresets);
+      return nextPresets;
+    },
+    [persist, presets],
+  );
+
+  const deletePreset = useCallback(
+    (presetId) => {
+      const nextPresets = removeFilterPreset(presets, presetId);
+      setError("");
+      persist(nextPresets);
+      return nextPresets;
+    },
+    [persist, presets],
+  );
+
+  return {
+    presets,
+    presetError: error,
+    clearPresetError: () => setError(""),
+    savePreset,
+    renamePreset,
+    updatePreset,
+    deletePreset,
+  };
+};
+
+export default useEventFilterPresets;

--- a/src/utils/eventFilterPresets.js
+++ b/src/utils/eventFilterPresets.js
@@ -1,0 +1,239 @@
+import { normalizeAdvancedFilters, serializeAdvancedFilters } from "./advancedFilterUtils.js";
+
+export const EVENT_FILTER_PRESETS_STORAGE_KEY = "eventra:event-filter-presets:v1";
+
+const FILTER_TYPES = new Set(["all", "live", "upcoming", "past"]);
+const CATEGORY_FILTERS = new Set([
+  "all",
+  "hackathons",
+  "tech talks",
+  "web-development",
+  "ai-ml",
+  "devops-cloud",
+  "web3-blockchain",
+  "mobile",
+  "design-ux",
+  "cultural",
+]);
+const SORT_TYPES = new Set(["Newest", "Upcoming"]);
+const VIEW_MODES = new Set(["grid", "list"]);
+
+export const getDefaultEventFilterConfig = () => ({
+  searchQuery: "",
+  filterType: "all",
+  categoryFilter: "all",
+  sortType: "Newest",
+  viewMode: "grid",
+  advancedFilters: normalizeAdvancedFilters(),
+});
+
+const normalizeSlug = (value) =>
+  String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export const normalizePresetName = (name) =>
+  String(name || "").replace(/\s+/g, " ").trim();
+
+const normalizeCategoryFilter = (value) => {
+  const raw = String(value || "").trim();
+  if (CATEGORY_FILTERS.has(raw)) return raw;
+
+  const slug = normalizeSlug(raw);
+  if (CATEGORY_FILTERS.has(slug)) return slug;
+  if (slug === "technology") return "tech talks";
+  if (slug === "online") return "all";
+  return "all";
+};
+
+const normalizePriceRange = (price) => {
+  if (!price) return null;
+  if (typeof price === "string" && normalizeSlug(price) === "free") {
+    return { min: 0, max: 0 };
+  }
+  if (typeof price === "object") {
+    return {
+      min: Number(price.min) || 0,
+      max: price.max === Infinity ? Infinity : Number(price.max) || 0,
+    };
+  }
+  return null;
+};
+
+export const normalizeEventFilterConfig = (filters = {}) => {
+  const defaults = getDefaultEventFilterConfig();
+  const advancedInput = filters.advancedFilters || {};
+  const legacyPriceRange = normalizePriceRange(filters.price);
+  const legacyLocation =
+    typeof filters.location === "string" ? filters.location.trim() : "";
+
+  const advancedFilters = normalizeAdvancedFilters({
+    ...advancedInput,
+    location: advancedInput.location || legacyLocation,
+    priceRange: advancedInput.priceRange || legacyPriceRange,
+    dateRange:
+      typeof filters.dateRange === "object"
+        ? filters.dateRange
+        : advancedInput.dateRange,
+  });
+
+  const filterType = FILTER_TYPES.has(filters.filterType)
+    ? filters.filterType
+    : defaults.filterType;
+  const sortType = SORT_TYPES.has(filters.sortType)
+    ? filters.sortType
+    : defaults.sortType;
+  const viewMode = VIEW_MODES.has(filters.viewMode)
+    ? filters.viewMode
+    : defaults.viewMode;
+
+  return {
+    searchQuery:
+      typeof filters.searchQuery === "string" ? filters.searchQuery : "",
+    filterType,
+    categoryFilter: normalizeCategoryFilter(
+      filters.categoryFilter || filters.category,
+    ),
+    sortType,
+    viewMode,
+    advancedFilters: serializeAdvancedFilters(advancedFilters),
+  };
+};
+
+export const normalizeFilterPreset = (preset) => {
+  if (!preset || typeof preset !== "object") return null;
+
+  const id = String(preset.id || "").trim();
+  const name = normalizePresetName(preset.name);
+  if (!id || !name) return null;
+
+  return {
+    id,
+    name,
+    filters: normalizeEventFilterConfig(preset.filters),
+  };
+};
+
+export const normalizeFilterPresets = (value) => {
+  if (!Array.isArray(value)) return [];
+
+  const seenIds = new Set();
+  return value.reduce((presets, preset) => {
+    const normalized = normalizeFilterPreset(preset);
+    if (!normalized || seenIds.has(normalized.id)) return presets;
+    seenIds.add(normalized.id);
+    presets.push(normalized);
+    return presets;
+  }, []);
+};
+
+export const readFilterPresets = (
+  storage = globalThis.localStorage,
+  key = EVENT_FILTER_PRESETS_STORAGE_KEY,
+) => {
+  if (!storage?.getItem) return [];
+
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    const payload = Array.isArray(parsed) ? parsed : parsed?.presets;
+    const presets = normalizeFilterPresets(payload);
+
+    if (!Array.isArray(payload)) {
+      storage.removeItem?.(key);
+      return [];
+    }
+
+    return presets;
+  } catch {
+    storage.removeItem?.(key);
+    return [];
+  }
+};
+
+export const writeFilterPresets = (
+  presets,
+  storage = globalThis.localStorage,
+  key = EVENT_FILTER_PRESETS_STORAGE_KEY,
+) => {
+  const normalized = normalizeFilterPresets(presets);
+  if (!storage?.setItem) return normalized;
+  storage.setItem(key, JSON.stringify(normalized));
+  return normalized;
+};
+
+export const createFilterPreset = (
+  presets,
+  name,
+  filters,
+  idFactory = () => `preset-${Date.now()}`,
+) => {
+  const normalizedName = normalizePresetName(name);
+  const existing = normalizeFilterPresets(presets);
+
+  if (!normalizedName) {
+    return { presets: existing, error: "Preset name is required." };
+  }
+
+  const duplicate = existing.some(
+    (preset) => preset.name.toLowerCase() === normalizedName.toLowerCase(),
+  );
+  if (duplicate) {
+    return {
+      presets: existing,
+      error: "A preset with this name already exists.",
+    };
+  }
+
+  const preset = {
+    id: idFactory(),
+    name: normalizedName,
+    filters: normalizeEventFilterConfig(filters),
+  };
+
+  return { presets: [...existing, preset], preset, error: "" };
+};
+
+export const renameFilterPreset = (presets, presetId, name) => {
+  const normalizedName = normalizePresetName(name);
+  const existing = normalizeFilterPresets(presets);
+
+  if (!normalizedName) {
+    return { presets: existing, error: "Preset name is required." };
+  }
+
+  const duplicate = existing.some(
+    (preset) =>
+      preset.id !== presetId &&
+      preset.name.toLowerCase() === normalizedName.toLowerCase(),
+  );
+  if (duplicate) {
+    return {
+      presets: existing,
+      error: "A preset with this name already exists.",
+    };
+  }
+
+  return {
+    presets: existing.map((preset) =>
+      preset.id === presetId ? { ...preset, name: normalizedName } : preset,
+    ),
+    error: "",
+  };
+};
+
+export const updateFilterPreset = (presets, presetId, filters) => {
+  const existing = normalizeFilterPresets(presets);
+  return existing.map((preset) =>
+    preset.id === presetId
+      ? { ...preset, filters: normalizeEventFilterConfig(filters) }
+      : preset,
+  );
+};
+
+export const removeFilterPreset = (presets, presetId) =>
+  normalizeFilterPresets(presets).filter((preset) => preset.id !== presetId);

--- a/tests/eventFilterPresets.test.mjs
+++ b/tests/eventFilterPresets.test.mjs
@@ -1,0 +1,122 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import {
+  createFilterPreset,
+  getDefaultEventFilterConfig,
+  normalizeEventFilterConfig,
+  readFilterPresets,
+  removeFilterPreset,
+  renameFilterPreset,
+  updateFilterPreset,
+  writeFilterPresets,
+} from "../src/utils/eventFilterPresets.js";
+
+const createStorage = () => {
+  const values = new Map();
+  return {
+    getItem: (key) => (values.has(key) ? values.get(key) : null),
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+    has: (key) => values.has(key),
+  };
+};
+
+const filters = {
+  searchQuery: "react",
+  filterType: "upcoming",
+  categoryFilter: "web-development",
+  sortType: "Upcoming",
+  viewMode: "list",
+  advancedFilters: {
+    modes: ["online"],
+    location: "Remote",
+    priceRange: { min: 0, max: 0 },
+  },
+};
+
+describe("eventFilterPresets", () => {
+  it("saves presets with normalized filter values", () => {
+    const result = createFilterPreset([], " Tech Events ", filters, () => "preset-1");
+
+    assert.equal(result.error, "");
+    assert.equal(result.preset.name, "Tech Events");
+    assert.deepEqual(result.preset.filters, normalizeEventFilterConfig(filters));
+  });
+
+  it("rejects empty and duplicate preset names", () => {
+    const first = createFilterPreset([], "Free Online", filters, () => "preset-1");
+    const empty = createFilterPreset(first.presets, "   ", filters, () => "preset-2");
+    const duplicate = createFilterPreset(first.presets, "free online", filters, () => "preset-3");
+
+    assert.equal(empty.error, "Preset name is required.");
+    assert.equal(duplicate.error, "A preset with this name already exists.");
+    assert.equal(empty.presets.length, 1);
+    assert.equal(duplicate.presets.length, 1);
+  });
+
+  it("persists presets to local storage and loads them back", () => {
+    const storage = createStorage();
+    const saved = createFilterPreset([], "Remote React", filters, () => "preset-1");
+
+    writeFilterPresets(saved.presets, storage, "presets");
+    const loaded = readFilterPresets(storage, "presets");
+
+    assert.deepEqual(loaded, saved.presets);
+  });
+
+  it("applies legacy preset fields into supported filter state", () => {
+    const normalized = normalizeEventFilterConfig({
+      category: "Technology",
+      location: "Online",
+      dateRange: "this_week",
+      price: "free",
+      filterType: "unsupported",
+      viewMode: "board",
+    });
+
+    assert.equal(normalized.categoryFilter, "tech talks");
+    assert.equal(normalized.filterType, "all");
+    assert.equal(normalized.viewMode, "grid");
+    assert.equal(normalized.advancedFilters.location, "Online");
+    assert.deepEqual(normalized.advancedFilters.priceRange, { min: 0, max: 0 });
+    assert.equal(normalized.advancedFilters.dateRange, undefined);
+  });
+
+  it("updates an existing preset with current filters", () => {
+    const saved = createFilterPreset([], "Initial", filters, () => "preset-1");
+    const nextFilters = {
+      ...getDefaultEventFilterConfig(),
+      searchQuery: "cloud",
+      categoryFilter: "devops-cloud",
+    };
+
+    const updated = updateFilterPreset(saved.presets, "preset-1", nextFilters);
+
+    assert.equal(updated[0].name, "Initial");
+    assert.equal(updated[0].filters.searchQuery, "cloud");
+    assert.equal(updated[0].filters.categoryFilter, "devops-cloud");
+  });
+
+  it("renames and deletes presets", () => {
+    const saved = createFilterPreset([], "Initial", filters, () => "preset-1");
+    const renamed = renameFilterPreset(saved.presets, "preset-1", "Renamed");
+    const deleted = removeFilterPreset(renamed.presets, "preset-1");
+
+    assert.equal(renamed.error, "");
+    assert.equal(renamed.presets[0].name, "Renamed");
+    assert.deepEqual(deleted, []);
+  });
+
+  it("recovers from corrupted storage by clearing the bad value", () => {
+    const storage = createStorage();
+    storage.setItem("presets", "{bad json");
+
+    const loaded = readFilterPresets(storage, "presets");
+
+    assert.deepEqual(loaded, []);
+    assert.equal(storage.has("presets"), false);
+  });
+});
+
+console.log("eventFilterPresets tests passed");


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>📝 Description</h2><p>Implemented the <strong>Saved Filter Presets</strong> feature for event filtering to improve usability for users who frequently reuse the same filter combinations.</p><h3>What changed</h3><ul><li><p>Added preset utilities in <code inline="">eventFilterPresets.js</code> for:</p><ul><li><p>Saving presets</p></li><li><p>Loading presets</p></li><li><p>Updating presets</p></li><li><p>Deleting presets</p></li><li><p>Name validation</p></li><li><p>Duplicate-name handling</p></li><li><p>Legacy filter normalization</p></li><li><p>Corrupted localStorage recovery</p></li></ul></li><li><p>Added reusable <code inline="">useEventFilterPresets</code> hook to centralize preset state management and actions.</p></li><li><p>Added a <strong>Saved Presets</strong> section in <code inline="">EventFiltersToolbar.js</code> with support for:</p><ul><li><p>Save Preset</p></li><li><p>Apply Preset</p></li><li><p>Edit/Rename Preset</p></li><li><p>Update Preset</p></li><li><p>Delete Preset</p></li></ul></li><li><p>Integrated preset persistence and application logic into <code inline="">EventsPage.js</code>, including category filter synchronization.</p></li><li><p>Added automated tests in <code inline="">eventFilterPresets.test.mjs</code> covering preset CRUD operations, validation, persistence, and recovery behavior.</p></li><li><p>Fixed a local lint blocker in <code inline="">EventsPage.js</code> by defining the missing <code inline="">ExploreEventsSkeleton</code>.</p></li></ul><h3>Why</h3><p>Users often apply the same combinations of filters when browsing events. Reconfiguring filters repeatedly is time-consuming and negatively impacts user experience. Saved Filter Presets allow users to quickly store and reuse their preferred filter configurations with a single click.</p><h2>🔗 Linked Issue</h2><p>Closes #7234 ;</p><h2>🏷️ Type of Change</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> 🐛 Bug fix (non-breaking)</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> ✨ New feature (non-breaking)</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 💥 Breaking change</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> ♻️ Refactor (no functional effect)</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 📖 Documentation update</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 🎨 UI / Style update</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> ⚙️ CI / Workflow change</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> 🔒 Security fix</p></li></ul><h2>🧪 Testing</h2><p><strong>Environment:</strong></p><ul><li><p>OS: Windows 11</p></li><li><p>Browser / Node.js: Node.js (project test environment)</p></li></ul><p><strong>Steps to reproduce / verify:</strong></p><ol><li><p>Open the Events page and configure filters.</p></li><li><p>Save the current filter combination as a preset.</p></li><li><p>Refresh the page and verify the preset persists.</p></li><li><p>Apply, rename, update, and delete presets.</p></li><li><p>Verify filter values update correctly after applying a preset.</p></li><li><p>Run:</p><pre><code class="language-bash">node --loader ./tests/loaders/jsExtension.mjs tests/eventFilterPresets.test.mjs
</code></pre></li><li><p>Confirm all preset-related tests pass.</p></li></ol><h2>📸 Screenshots / Recording</h2>
Before | After
-- | --
No way to save frequently used filters | Saved Presets section with save, apply, update, rename, and delete functionality

<h2>✅ Self-Review Checklist</h2><p><strong>Code Quality</strong></p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Self-review done; code follows project style and naming conventions</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Hard-to-understand areas are commented where necessary</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> No new warnings, console errors, or leftover debug logs</p></li></ul><p><strong>Testing</strong></p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Changes tested locally and work as expected</p></li><li class="task-list-item"><p><input type="checkbox" disabled=""> Existing tests pass (note failures in Additional Notes)</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> New tests added for new functionality where applicable</p></li></ul><p><strong>Documentation &amp; Standards</strong></p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" disabled=""> README / docs / JSDoc updated if needed</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Commits follow Conventional Commits format</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Branch named with correct prefix (<code inline="">feat/</code>, <code inline="">fix/</code>, <code inline="">docs/</code>, etc.)</p></li></ul><p><strong>GSSoC Compliance</strong></p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I was assigned to the linked issue before opening this PR</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> No AI-generated boilerplate or copy-pasted code included without full understanding</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> No trivial changes (whitespace-only, minor typos) made for point farming</p></li></ul><h2>📋 Additional Notes</h2><ul><li><p>Presets currently persist using localStorage.</p></li><li><p>Backend/user-profile synchronization was not implemented because there does not appear to be an existing API surface for storing filter presets.</p></li><li><p>Preset-related tests pass successfully.</p></li><li><p><code inline="">npm run test:unit</code> still reports unrelated existing failures in:</p><ul><li><p><code inline="">eventDetails</code></p></li><li><p><code inline="">eventRegistrationAdditionalInfo</code></p></li><li><p><code inline="">githubStatsParallel</code></p></li><li><p><code inline="">sseMultiplexer</code></p></li></ul></li><li><p><code inline="">npm run build</code> is currently blocked by unrelated pre-existing syntax errors in:</p><ul><li><p><code inline="">Hero.js</code></p></li><li><p><code inline="">CollaborationNetworkMap.jsx</code></p></li><li><p><code inline="">SpatialSeatSelector.jsx</code></p></li></ul></li></ul><p>These issues are outside the scope of this PR.</p></body></html><!--EndFragment-->
</body>
</html>