### PR TITLE
fix: resolve SSE split-brain scenario with robust tab demotion

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -103,23 +103,31 @@ class SseMultiplexer {
     const HEARTBEAT_TIMEOUT = 7000;
 
     const checkLeader = () => {
-      if (this.isLeader) return;
-
       const now = Date.now();
       const heartbeat = localStorage.getItem(HEARTBEAT_KEY);
+
+      let activeLeaderId = null;
 
       if (heartbeat) {
         try {
           const parsed = JSON.parse(heartbeat);
-          if (parsed && now - parsed.timestamp < HEARTBEAT_TIMEOUT && parsed.tabId !== this.tabId) {
-            // Active leader exists
-            return;
+          if (parsed && now - parsed.timestamp < HEARTBEAT_TIMEOUT) {
+            activeLeaderId = parsed.tabId;
           }
         } catch {}
       }
 
-      // Try to claim leadership
-      this.claimLocalStorageLeadership();
+      if (this.isLeader) {
+        // If we are the leader but our heartbeat expired and someone else claimed it
+        if (activeLeaderId && activeLeaderId !== this.tabId) {
+          this.demoteFromLeadership();
+        }
+      } else {
+        // If we are a follower and no active leader exists, claim it
+        if (!activeLeaderId || activeLeaderId === this.tabId) {
+          this.claimLocalStorageLeadership();
+        }
+      }
     };
 
     this.localStorageInterval = setInterval(checkLeader, HEARTBEAT_INTERVAL);
@@ -130,10 +138,21 @@ class SseMultiplexer {
     this.isLeader = true;
     logger.log(`[SSE Multiplexer] Tab ${this.tabId} claimed leadership via LocalStorage.`);
 
-    // Write an immediate heartbeat so other tabs see the new leader without
-    // waiting up to HEARTBEAT_INTERVAL (3 s) for the first interval tick.
+    const HEARTBEAT_TIMEOUT = 7000;
+
     const writeHeartbeat = () => {
+      if (!this.isLeader) return;
       try {
+        // Before overwriting, check if we were usurped while suspended
+        const heartbeat = localStorage.getItem(HEARTBEAT_KEY);
+        if (heartbeat) {
+          const parsed = JSON.parse(heartbeat);
+          if (parsed && parsed.tabId !== this.tabId && Date.now() - parsed.timestamp < HEARTBEAT_TIMEOUT) {
+            this.demoteFromLeadership();
+            return;
+          }
+        }
+
         localStorage.setItem(
           HEARTBEAT_KEY,
           JSON.stringify({ tabId: this.tabId, timestamp: Date.now() })
@@ -144,12 +163,29 @@ class SseMultiplexer {
     };
     writeHeartbeat();
 
-    // Heartbeat loop — keep the entry fresh while leadership is held
     this.heartbeatInterval = setInterval(writeHeartbeat, 2000);
 
     this.startHeartbeatChecks();
     this.queryGlobalSubscribers();
     this.reconcileConnections();
+  }
+
+  demoteFromLeadership() {
+    if (!this.isLeader) return;
+    this.isLeader = false;
+    logger.log(`[SSE Multiplexer] Tab ${this.tabId} demoted from leadership.`);
+
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+
+    this.stopHeartbeatChecks();
+
+    for (const source of this.activeEventSources.values()) {
+      source.close();
+    }
+    this.activeEventSources.clear();
   }
 
   // --- 2. Subscription Management ---


### PR DESCRIPTION
## Description
This PR resolves a critical split-brain scenario and socket exhaustion bug within the background synchronization system's fallback leadership election mechanism.
Closes #5007 
### The Issue
Previously, the `setupLocalStorageElection` logic allowed a background tab to claim leadership but lacked a proper demotion mechanism. If a leader tab was throttled by the browser, its heartbeat would expire and a follower tab would take over. Once the original tab awoke, it remained unaware of its demotion and would execute background syncs concurrently with the new leader, causing duplicate data submissions and exhausting active connections.

### Changes Made
- Refactored `setupLocalStorageElection` in `src/utils/sseMultiplexer.js` to actively monitor the current heartbeat ID on every tick, even if the current tab is the leader.
- Added a `demoteFromLeadership()` method which gracefully clears active heartbeat intervals and closes physical `EventSource` sockets when the tab realizes it has been usurped.
- Added a pre-flight guard in the `writeHeartbeat()` interval to prevent a suspended leader from blindly overwriting a newly elected leader's heartbeat upon waking up.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance Optimization
