### PR TITLE
fix(security): make CanAccess fail closed when no roles or permissions specified

### DIFF
--- a/src/components/auth/CanAccess.js
+++ b/src/components/auth/CanAccess.js
@@ -4,6 +4,18 @@ const CanAccess = ({ roles = [], permissions = [], children, fallback = null }) 
   const { hasAnyRole, hasAnyPermission, isAuthenticated } = useAuth();
 
   if (!isAuthenticated()) return fallback;
+
+  // Fail-closed: no constraints = deny. Prevents silent misconfiguration.
+  if (roles.length === 0 && permissions.length === 0) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        '[CanAccess] No roles or permissions specified — access denied. ' +
+        'Pass at least one role or permission to allow access.'
+      );
+    }
+    return fallback;
+  }
+
   if (roles.length > 0 && !hasAnyRole(...roles)) return fallback;
   if (permissions.length > 0 && !hasAnyPermission(...permissions)) return fallback;
 


### PR DESCRIPTION
## Summary
Fixes #7270

The `CanAccess` component previously failed open — when used without
any `roles` or `permissions` props, it would render protected children
for every authenticated user including those with no privileges (e.g. attendees).

## Root Cause
The existing checks only ran when the respective arrays were non-empty:
```js
if (roles.length > 0 && !hasAnyRole(...roles)) return fallback;
if (permissions.length > 0 && !hasAnyPermission(...permissions)) return fallback;
```
With both arrays empty (the default), all checks were skipped and `children` was returned unconditionally.

## Fix
Added a fail-closed guard before the existing checks. If both `roles`
and `permissions` are empty, access is denied and `fallback` is returned.
A `console.warn` fires in development to catch misconfigured usages early.

## Behavior Change
| Usage | Before | After |
|---|---|---|
| `<CanAccess roles={["ADMIN"]}>` | ✅ checks role | ✅ checks role |
| `<CanAccess permissions={["DELETE_USER"]}>` | ✅ checks permission | ✅ checks permission |
| `<CanAccess>` (no props) | ❌ renders for everyone | ✅ returns fallback |

## Testing
- Wrap any component with `<CanAccess>` and no props — confirm it renders `fallback`
- Check browser console in dev mode for the warning
- Existing role/permission-gated routes should be unaffected