### PR TITLE
fix(security): hash userId before using as localStorage key in useBookmarks

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -4,6 +4,18 @@
  */
 import { useState, useEffect, useCallback, useRef } from "react";
 
+// Simple synchronous hash to avoid exposing raw userId (email) in localStorage keys.
+const hashUserId = (userId) => {
+  if (!userId || userId === "guest") return "guest";
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    const chr = userId.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+};
+
 /**
  * A custom React hook that manages bookmarked events for a user,
  * persisting them to localStorage keyed by userId.
@@ -41,7 +53,7 @@ const toBookmarkEntry = (event) => ({
 });
 
 const useBookmarks = (userId = "guest") => {
-  const storageKey = `bookmarks_${userId}`;
+  const storageKey = `bookmarks_${hashUserId(userId)}`;
 
   const [bookmarks, setBookmarks] = useState(() => {
     try {


### PR DESCRIPTION
## 📋 Description
`useBookmarks.js` was using raw `userId` (often the user's email address) directly
as a localStorage key — resulting in keys like `bookmarks_user@example.com`.
Any same-origin JavaScript could enumerate localStorage keys and extract email
addresses of all users who had bookmarked events on that device.

Fixed by adding a synchronous `hashUserId()` function that converts the raw userId
into an opaque hash before using it as the storage key.

Before: `bookmarks_user@example.com`
After:  `bookmarks_1x3k9z`

## 🔗 Linked Issue
Closes #7272

## 🛠️ Type of Change
- [x] 🐛 Bug fix (non-breaking)
- [x] 🔒 Security fix

## 🧪 Testing
**Environment:**
- OS: macOS
- Browser / Node.js: Chrome / Node 18

**Steps to reproduce / verify:**
1. Log in with an email-based account and bookmark any event
2. Open DevTools → Application → Local Storage
3. Confirm the key is now an opaque hash, not the raw email address

## 📸 Screenshots / Recording
N/A — code-level fix, no UI change

## ✅ Self-Review Checklist
**Code Quality**
- [x] Self-review done; code follows project style and naming conventions
- [x] Hard-to-understand areas are commented
- [x] No new warnings, console errors, or leftover debug logs

**Testing**
- [x] Changes tested locally and work as expected
- [x] Existing tests pass