### PR TITLE
fix(security): add dev warning when CSRF token is missing for mutating requests

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -219,6 +219,8 @@ API.interceptors.request.use((config) => {
     const csrf = getCSRFToken();
     if (csrf) {
       config.headers["X-CSRF-Token"] = csrf;
+    } else if (process.env.NODE_ENV !== "production") {
+      console.warn("[CSRF] Token missing for mutating request:", method, config.url);
     }
   }
 


### PR DESCRIPTION
## 📋 Description

Adds a development-time warning when a mutating request (POST/PUT/PATCH/DELETE)
is sent without a CSRF token.

Previously, if both the CSRF meta tag and cookie were absent, the request
continued without an `X-CSRF-Token` header and without any visibility to
developers. This made it difficult to detect missing CSRF protection during
development.

## 🔗 Linked Issue

Closes #7274

## ✏️ Testing

1. Remove the CSRF meta tag and CSRF cookie.
2. Trigger a POST/PUT/PATCH/DELETE request.
3. Verify a console warning appears in development mode.
4. Verify requests with a valid CSRF token continue to work normally.

## ✅ Changes Made

- Added a development-only warning when `getCSRFToken()` returns null.
- Preserved existing request behavior.
- No warnings are shown in production builds.

## 📝 Additional Notes

This change improves developer visibility into missing CSRF protection without
changing runtime behavior for end users.