### PR TITLE
[Bug] : Syntax Error in SpatialSeatSelector.jsx useCallback breaks application build

### DIFF
--- a/src/components/events/SpatialSeatSelector.jsx
+++ b/src/components/events/SpatialSeatSelector.jsx
@@ -359,7 +359,7 @@ const SpatialSeatSelector = ({
       seatLabel: `${el.label} - ${label}`,
       tier: tier,
     });
-  };
+  }, [readOnly, onSelectSeat]);
 
   return (
     <div className="ssp-container">


### PR DESCRIPTION
### Description
This PR fixes a critical parsing syntax error in src/components/events/SpatialSeatSelector.jsx. The useCallback hook was incorrectly terminated with }; instead of }, [readOnly, onSelectSeat]);. This caused the Vite build to completely fail in production environments.
### Changes
- Replaced }; with the correct dependency array closing }, [readOnly, onSelectSeat]);.
Fixes #7185