### PR TITLE
[Bug] : JSX Tag Mismatch in CollaborationNetworkMap.jsx prevents production build

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -414,7 +414,7 @@ export default function CollaborationNetworkMap() {
 
           {/* Stats Summary */}
           <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
-            className="flex items-center gap-4 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:shadow-md p-6 shadow-lg"
+            <div className="flex items-center gap-4 rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:shadow-md p-6 shadow-lg">
               <Users size={18} />
               <div>
                 <span className="block text-2xl font-bold text-emerald-400">


### PR DESCRIPTION
### Description
This PR resolves a JSX closing tag mismatch in src/components/visual/CollaborationNetworkMap.jsx which was throwing a compilation error during npm run build. A <div> tag was missing before the className attribute, causing the JSX parser to mismatch the subsequent </div> tag against the parent <section> tag.
### Changes
- Added missing <div to properly structure the stats grid.
Fixes #7184