### PR TITLE
[Bug] : Memory leak in p2pFileTransfer.js checkInterval on WebRTC connection timeout

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -300,18 +300,22 @@ export class P2PFileTransferCoordinator {
         }
       }, 2500);
 
+      let checkInterval;
+
       // Add a secondary connection safety timer of 5 seconds total
       const connectionSafetyTimeout = setTimeout(() => {
         if (this.currentState === "connecting" || this.currentState === "searching") {
           this.cleanup();
+          clearInterval(checkInterval);
           resolve(false); // WebRTC connection handshakes timed out, fallback to server
         } else if (this.currentState === "completed" || this.currentState === "transferring") {
+          clearInterval(checkInterval);
           resolve(true);
         }
       }, 5000);
 
       // Attach state listener check to resolve immediately if completed
-      const checkInterval = setInterval(() => {
+      checkInterval = setInterval(() => {
         if (this.currentState === "completed") {
           clearTimeout(searchTimeout);
           clearTimeout(connectionSafetyTimeout);


### PR DESCRIPTION
### Description
This PR fixes a silent memory and CPU leak in src/utils/p2pFileTransfer.js. When a WebRTC connection handshake timed out, the connectionSafetyTimeout fallback would correctly resolve the promise and call cleanup(), but it failed to call clearInterval(checkInterval). This caused the interval to poll every 200ms indefinitely.
### Changes
- Extracted checkInterval to a shared scope.
- Explicitly called clearInterval(checkInterval) inside the safety timeout fallback.
Fixes #7183