### PR TITLE
[Bug] : notificationQueue silently drops the entire batch if IndexedDB read fails

### DIFF
--- a/src/utils/notificationQueue.js
+++ b/src/utils/notificationQueue.js
@@ -169,6 +169,8 @@ const flushBatch = async () => {
     logger.info(`[NotificationQueue] Flushed batch of ${batch.length} notification(s).`);
   } catch (err) {
     logger.error("[NotificationQueue] Unexpected error during flush:", err);
+    // Put the batch back into pendingBatch so it isn't permanently dropped
+    pendingBatch.unshift(...batch);
   } finally {
     isFlushing = false;
   }


### PR DESCRIPTION
### Description
This PR fixes a critical logic flaw in src/utils/notificationQueue.js that led to silent data loss. If idbGet or JSON.parse threw an error while flushing the batch, the caught exception would silently exit the function, permanently dropping the spliced batch of notifications.
### Changes
- Updated the catch block to unshift the batch back into pendingBatch, ensuring notifications are not lost during IndexedDB read failures.
Fixes #7180