### PR TITLE
fix: guard CountdownTimer resolveDeadline fallback against 12-hour time strings that produce Invalid Date

### DIFF
--- a/src/components/common/CountdownTimer.jsx
+++ b/src/components/common/CountdownTimer.jsx
@@ -16,7 +16,15 @@ import { resolveEventInstant } from "../../utils/timezoneUtils";
  */
 const resolveDeadline = (date, time, timezone) => {
   const resolved = resolveEventInstant(date, time, timezone);
-  return resolved || new Date(`${date}T${time}`);
+  if (resolved) return resolved;
+
+  // Fallback: only attempt naive ISO construction for 24-hour "HH:MM" format.
+  // 12-hour strings like "10:00 AM" are not valid ISO 8601 and produce Invalid Date.
+  if (time && /^\d{1,2}:\d{2}$/.test(time.trim())) {
+    return new Date(`${date}T${time}`);
+  }
+
+  return null;
 };
 
 const calculateTimeLeft = (deadline) => {


### PR DESCRIPTION
## Summary
Fixes events falsely showing "Registration Closed" in CountdownBadge and CountdownTimer when a 12-hour time string like "10:00 AM" is passed and resolveEventInstant falls through to the naive fallback.

## Problem
resolveDeadline fell back to new Date(`${date}T${time}`). This only works for 24-hour "HH:MM" strings. For 12-hour strings like "10:00 AM", the resulting value is not valid ISO 8601. new Date() returns Invalid Date, calculateTimeLeft returns null, and the component renders "Registration Closed" even for open events.

## Fix
Added a /^\d{1,2}:\d{2}$/ regex check on the time string before attempting the ISO fallback. Non-matching formats return null instead of Invalid Date, keeping the component silent rather than incorrect.

## Changes
- src/components/common/CountdownTimer.jsx — guarded resolveDeadline ISO fallback with 24-hour format check

Closes #7385 