### PR TITLE
fix: rename onClick parameter to e in ShareModal to fix no-shadow violation on event prop

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -109,7 +109,7 @@ const ShareModal = ({ isOpen, onClose, event }) => {
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 12 }}
             transition={{ duration: 0.2 }}
-            onClick={(event) => event.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between border-b border-slate-100 pb-3 dark:border-slate-800/40">
               <h2 id="share-modal-title" className="text-xl font-black tracking-tight text-slate-900 dark:text-white">


### PR DESCRIPTION
## Summary
Fixes a no-shadow ESLint violation in ShareModal.jsx where the onClick arrow function parameter event shadowed the component's event prop.

## Problem
The inner motion.div used onClick={(event) => event.stopPropagation()}. The parameter name event matches the component prop of the same name. Inside the callback, any reference to event silently resolves to the click object rather than the prop — a silent trap for future developers.

## Fix
I Renamed the parameter from event to e, the conventional short form for DOM event objects, which does not conflict with any prop name.

## Changes
- src/components/common/ShareModal.jsx — renamed onClick parameter from event to e

Closes #7388 