### PR TITLE
fix: validate event.id in ShareModal useMemo to prevent broken /events/undefined share links

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -32,6 +32,11 @@ const ShareModal = ({ isOpen, onClose, event }) => {
       return null;
     }
 
+    if (!event.id) {
+      console.warn("[ShareModal] event.id is missing — share URL cannot be constructed.");
+      return null;
+    }
+
     const shareUrl = `${window.location.origin}/events/${event.id}`;
     if (!isValidShareUrl(shareUrl)) {
       console.warn("[ShareModal] Rejected invalid share URL:", shareUrl);


### PR DESCRIPTION
## Summary
Fixes broken share links in ShareModal where a missing event.id produced URLs ending in /events/undefined that passed URL validation and were shared across all platforms.

## Problem
The useMemo only checked if event was non-null. A defined event without an id field resulted in a share URL of .../events/undefined. isValidShareUrl passed it since the origin matched. All six share links were built with the broken URL and shown to the user.

## Fix
I Added an event.id check after the existing event null check. Returns null with a console warning when id is missing, preventing URL construction entirely and leaving the modal in its closed/empty state.

## Changes
- src/components/common/ShareModal.jsx — added event.id validation guard in shareData useMemo

Closes #7390 