### PR TITLE
fix: add onError handler to ShareModal event image to hide broken icon when image fails to load

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -125,6 +125,9 @@ const ShareModal = ({ isOpen, onClose, event }) => {
                   alt={shareData.title}
                   className="h-full w-full object-cover"
                   loading="lazy"
+                  onError={(e) => {
+                    e.currentTarget.style.display = "none";
+                  }}
                 />
               </div>
 


### PR DESCRIPTION
## Summary
Fixes a broken image icon appearing in the ShareModal event preview card when the event image is missing or returns an error.

## Problem
The img element had no onError handler. A null, undefined, or broken image URL caused the browser to display a broken image icon inside the modal preview, making the UI look unpolished.

## Fix
I Added an onError handler that sets e.currentTarget.style.display = "none" when the image fails to load. This hides the broken element cleanly without requiring a placeholder asset.

## Changes
- src/components/common/ShareModal.jsx — added onError handler to event preview img

Closes #7392