### PR TITLE
fix: remove unused React default import from ConfirmationModal to fix no-unused-vars ESLint warning

### DIFF
--- a/src/components/common/ConfirmationModal.js
+++ b/src/components/common/ConfirmationModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useRef } from "react";
 import "./ConfirmationModal.css";
 
 const FOCUSABLE_SELECTOR = [


### PR DESCRIPTION
## Summary
Removes the unused React default import from ConfirmationModal.js which triggered a no-unused-vars ESLint warning.

## Problem
React was imported as a default export alongside the named hooks. The modern JSX transform (React 17+) handles JSX compilation automatically without needing React in scope. The import was dead code and flagged by ESLint.

## Fix
I Removed React from the import. Named hooks useEffect, useId, and useRef are preserved unchanged.

## Changes
- src/components/common/ConfirmationModal.js — removed unused React default import

Closes #7394 