### PR TITLE
fix: move useNotifications to top of NotificationBell component to follow React hook ordering convention

### DIFF
--- a/src/components/common/NotificationBell.jsx
+++ b/src/components/common/NotificationBell.jsx
@@ -5,8 +5,8 @@ import "./NotificationBell.css";
 
 const NotificationBell = () => {
   const [open, setOpen] = useState(false);
-
   const wrapperRef = useRef(null);
+  const { notifications, unreadCount, markAllAsRead } = useNotifications();
 
   // Close on Escape key
   useEffect(() => {
@@ -29,12 +29,6 @@ const NotificationBell = () => {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [open]);
-
-  const {
-    notifications,
-    unreadCount,
-    markAllAsRead,
-  } = useNotifications();
 
   return (
     <div className="notification-wrapper" ref={wrapperRef}>


### PR DESCRIPTION
## Summary
Fixes hook ordering in NotificationBell.jsx by moving the useNotifications call to the top of the component alongside other hook declarations, before any useEffect calls.

## Problem
useNotifications() was called after two useEffect hooks. React convention requires all hook calls to appear at the top level before effects. The misplaced call made the component's data dependencies non-obvious and could trigger hook ordering lint warnings.

## Fix
I Moved the useNotifications destructuring above both useEffect hooks. No functional behaviour changes — hook call order on every render is identical since both useEffect hooks are still called unconditionally.

## Changes
- src/components/common/NotificationBell.jsx — reordered hook declarations

Closes #7396 