### PR TITLE
fix: prevent unauthorized admin API calls on non-admin mount in AdminDashboard by guarding effects with isAdmin check

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -257,20 +257,23 @@ const AdminDashboard = () => {
   }, []);
 
   useEffect(() => {
+    if (!isAdmin) return;
     loadStats();
-  }, [loadStats]);
+  }, [loadStats, isAdmin]);
 
   useEffect(() => {
+    if (!isAdmin) return;
     if (activeTab === "users") {
       loadUsers(usersPage, searchUser);
     }
-  }, [activeTab, usersPage]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeTab, usersPage, isAdmin]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    if (!isAdmin) return;
     if (activeTab === "events") {
       loadEvents(eventsPage, searchEvent);
     }
-  }, [activeTab, eventsPage]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeTab, eventsPage, isAdmin]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSearchUser = (value) => {
     setSearchUser(value);


### PR DESCRIPTION
## Summary
Fixes unauthorized admin API calls being triggered on mount for non-admin users in AdminDashboard before the Navigate redirect completes.

## Problem
React fires all useEffect callbacks after every render including the first one. The isAdmin conditional return happens during render, but effects run after it. Non-admin users visiting the dashboard URL triggered fetchAdminStats, fetchAdminUsers, and fetchAdminEvents before being redirected — hitting admin-only endpoints without authorization.

## Fix
I Added if (!isAdmin) return guards at the top of the loadStats, loadUsers, and loadEvents effects. Added isAdmin to their dependency arrays so they correctly re-run if auth state changes after mount.

## Changes
- src/components/admin/AdminDashboard.jsx — added isAdmin guard to three useEffect callbacks

Closes #7403 