### PR TITLE
fix: add open to ConfirmModal ESC effect deps to deactivate listener during AnimatePresence exit animation

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -61,10 +61,11 @@ const stagger = {
 
 function ConfirmModal({ open, title, message, onConfirm, onCancel }) {
   useEffect(() => {
+    if (!open) return;
     const handleEsc = (e) => { if (e.key === "Escape") onCancel(); };
     document.addEventListener("keydown", handleEsc);
     return () => document.removeEventListener("keydown", handleEsc);
-  }, [onCancel]);
+  }, [open, onCancel]);
 
   if (!open) return null;
 


### PR DESCRIPTION
## Summary
Fixes the ConfirmModal ESC key listener remaining active during the AnimatePresence exit animation by adding open to the useEffect dependency array.

## Problem
When the modal closed via handleConfirmDelete, AnimatePresence kept ConfirmModal mounted for the exit animation. During this transition open was false but the ESC listener was still registered. A keypress during the animation called onCancel on an already-closing modal.

## Fix
I Added if (!open) return guard and added open to the effect's dependency array. The listener is now only active when the modal is actually open, and is torn down as soon as open becomes false — before the exit animation completes.

## Changes
- src/components/admin/AdminDashboard.js — added open guard and dependency to ConfirmModal ESC useEffect

Closes #7409 