### PR TITLE
fix: replace redundant u.createdAt || u.createdAt with meaningful fallback in AdminDashboard users table

### DIFF
--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -546,7 +546,7 @@ const AdminDashboard = () => {
                                   <span key={r} style={{ marginRight: '4px' }}><StatusBadge status={r} /></span>
                                 ))}
                               </td>
-                              <td className="ad-muted">{u.createdAt || u.createdAt}</td>
+                              <td className="ad-muted">{u.createdAt || u.joinedAt || "—"}</td>
                               <td><StatusBadge status={u.status || "Active"} /></td>
                               <td>
                                 <div className="ad-action-btns">


### PR DESCRIPTION
## Summary
Fixes a copy-paste error in the AdminDashboard users table where the Joined column used u.createdAt || u.createdAt — both sides identical — providing no fallback when createdAt is missing.

## Problem
u.createdAt || u.createdAt evaluates to u.createdAt regardless of its value. If createdAt is null or undefined, the cell renders blank with no indication to the admin.

## Fix
I Replaced with u.createdAt || u.joinedAt || "—" to try the primary field, fall back to an alternative date field, and display a dash sentinel if neither is present.

## Changes
- src/components/admin/AdminDashboard.js — fixed redundant fallback in Joined column of users table

Closes #7411 