### PR TITLE
fix: move getInitialCheckins and getInitialLiveCount to module scope in AnalyticsDashboard to prevent unnecessary recreation on every rende

### DIFF
--- a/src/components/admin/AnalyticsDashboard.jsx
+++ b/src/components/admin/AnalyticsDashboard.jsx
@@ -116,28 +116,27 @@ function AnalyticsStreamBadge({ status }) {
 
 const LOCAL_STORAGE_KEY = "eventra_checkins";
 
+// Pure initializers — depend only on module-level constants, safe to define outside component
+const getInitialCheckins = () => {
+  const saved = safeJsonParse(localStorage.getItem(LOCAL_STORAGE_KEY), []);
+  if (saved.length > 0) {
+    const merged = [...saved.slice(0, 5), ...MOCK_CHECKINS].slice(0, 5);
+    return merged;
+  }
+  return MOCK_CHECKINS;
+};
+
+const getInitialLiveCount = () => {
+  const saved = safeJsonParse(localStorage.getItem(LOCAL_STORAGE_KEY), []);
+  return 342 + saved.filter((c) => c.status === "Verified").length;
+};
+
 const AnalyticsDashboard = () => {
-  // Merge real scanned check-ins from localStorage (set by TicketScanner) with mock defaults
-  const getInitialCheckins = () => {
-    const saved = safeJsonParse(localStorage.getItem(LOCAL_STORAGE_KEY), []);
-    if (saved.length > 0) {
-      // Merge: show real scanned check-ins first, then pad with mocks if fewer than 5
-      const merged = [...saved.slice(0, 5), ...MOCK_CHECKINS].slice(0, 5);
-      return merged;
-    }
-    return MOCK_CHECKINS;
-  };
-
-  const getInitialLiveCount = () => {
-    const saved = safeJsonParse(localStorage.getItem(LOCAL_STORAGE_KEY), []);
-    return 342 + saved.filter((c) => c.status === "Verified").length;
-  };
-
   const [checkins, setCheckins] = useState(getInitialCheckins);
   const [hourlyData, setHourlyData] = useState(INITIAL_HOURLY_DATA);
   const [liveCount, setLiveCount] = useState(getInitialLiveCount);
   const [activeCheckinsPerMinute, setActiveCheckinsPerMinute] = useState(5.4);
-const [activeTab, setActiveTab] = useState('analytics');
+  const [activeTab, setActiveTab] = useState('analytics');
 
   // Real-time SSE stream — takes priority over local simulation when connected
   const { recentCheckins: streamCheckins, status: streamStatus } = useAnalyticsStream();


### PR DESCRIPTION
## Summary
Fixes unnecessary recreation of two pure initializer functions on every render in AnalyticsDashboard by moving them to module scope above the component.

## Problem
getInitialCheckins and getInitialLiveCount were defined inside the component body but only depend on module-level constants. They were recreated as new function objects on every render despite being pure, stable functions. While useState only calls them once as lazy initializers, their recreation was wasteful and misleading.

## Fix
I Moved both functions above the AnalyticsDashboard component. No functional behaviour changes — they still initialize useState identically on mount.

## Changes
- src/components/admin/AnalyticsDashboard.jsx — moved getInitialCheckins and getInitialLiveCount to module scope

Closes #7413 