### PR TITLE
fix: preserve event registration redirects after authentication

### DIFF
--- a/src/components/auth/AuthPage.js
+++ b/src/components/auth/AuthPage.js
@@ -35,10 +35,10 @@ const AuthPage = () => {
     if (isAuthenticated()) {
       // 🔥 FIX 1B: The Infinite Redirect Guard
       // Prevents redirecting authenticated users back into an auth-loop.
-      const safeRedirectPath = 
-        rawRedirectPath.includes('/login') || rawRedirectPath.includes('/register')
-          ? '/dashboard' 
-          : rawRedirectPath;
+      // Only redirect to dashboard for actual auth routes, not event registration pages
+      const authRoutes = ['/login', '/register', '/signup', '/unauthorized', '/password-reset'];
+      const isAuthRoute = authRoutes.includes(rawRedirectPath);
+      const safeRedirectPath = isAuthRoute ? '/dashboard' : rawRedirectPath;
 
       navigate(safeRedirectPath, { replace: true });
     }


### PR DESCRIPTION
## Description
This PR fixes an auth redirect issue where users were sent to `/dashboard` after login instead of returning to the event registration page they originally requested.

### Changes made
- Replaced substring matching with exact auth route matching
- Preserved redirects to event registration pages after login
- Kept existing redirects for auth pages such as `/login` and `/register`

Fixes #7407 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)
Not applicable 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
