### PR TITLE
fix: replace non-existent safeParseJson import with safeJsonParse in TicketScanner to fix check-in history persistence crash

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Html5Qrcode } from "html5-qrcode";
-import { safeParseJson } from "../../utils/jsonUtils";
+import { safeJsonParse } from "../../utils/safeJsonParse";
 import {
   Camera,
   CameraOff,
@@ -179,7 +179,7 @@ export default function TicketScanner() {
   const addToHistory = useCallback((entry) => {
     setCheckinHistory((prev) => [entry, ...prev].slice(0, 50));
     try {
-      const updated = [entry, ...safeParseJson(localStorage.getItem(HISTORY_CACHE_KEY), [])].slice(0, 50);
+      const updated = [entry, ...safeJsonParse(localStorage.getItem(HISTORY_CACHE_KEY), [])].slice(0, 50);
       localStorage.setItem(HISTORY_CACHE_KEY, JSON.stringify(updated));
     } catch { /* ignore */ }
   }, []);


### PR DESCRIPTION
## Summary
Fixes a runtime crash in TicketScanner where check-in history could not be persisted to localStorage due to a wrong import of safeParseJson from a non-existent utility file.

## Problem
safeParseJson was imported from ../../utils/jsonUtils which does not exist in the codebase. The correct utility is safeJsonParse from ../../utils/safeJsonParse. The wrong import caused a TypeError on every scan, silently breaking the history persistence in addToHistory.

## Fix
I Updated the import to use safeJsonParse from safeJsonParse and updated the one call site in addToHistory to match.

## Changes
- src/components/admin/TicketScanner.jsx — fixed import name and call site

Closes #7420 