### PR TITLE
fix: await startScanner in handleResetScan to surface camera errors after scan result reset

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -370,9 +370,9 @@ export default function TicketScanner() {
     setManualAttendeeName("");
   };
 
-  const handleResetScan = () => {
+  const handleResetScan = async () => {
     setScanResult(null);
-    startScanner(selectedCameraId);
+    await startScanner(selectedCameraId);
   };
 
   const handleEventSelect = (e) => {


### PR DESCRIPTION
## Summary
Fixes handleResetScan in TicketScanner to properly await the async startScanner call so camera restart failures are not silently swallowed.

## Problem
startScanner was called without await in handleResetScan. If the camera failed to restart — permission revoked, device disconnected, library error — the rejection was lost. The scanner status became inconsistent and the user received no feedback.

## Fix
I Made handleResetScan async and added await before startScanner(selectedCameraId). The existing error handling inside startScanner now correctly surfaces failures via toast and sets the error status.

## Changes
- src/components/admin/TicketScanner.jsx — made handleResetScan async, added await on startScanner

Closes #7424 