### PR TITLE
fix: memoize calculateCompletion result in EditProfile to avoid redundant field iteration on every render

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom"; // 🔥 FIX: Required for Modal Portal
 import { useAuth } from "../../context/AuthContext";
 import { useNavigate } from "react-router-dom";
@@ -203,7 +203,7 @@ const EditProfile = () => {
     return Math.round((filled / 10) * 100);
   };
 
-  const completionPercentage = calculateCompletion();
+  const completionPercentage = useMemo(() => calculateCompletion(), [form, user]);
 
   const addSkill = (skill) => {
     const trimmedSkill = skill.trim();


### PR DESCRIPTION
## Summary
Fixes unnecessary re-execution of calculateCompletion on every render in EditProfile by wrapping it in useMemo.

## Problem
calculateCompletion was called as a plain function on every render. On a profile form with rapid onChange events, it iterated over all fields and recomputed the completion percentage on every single keystroke regardless of whether form or user changed.

## Fix
I Added useMemo to the React import and wrapped the calculateCompletion call with useMemo([form, user]). The percentage now only recomputes when form or user actually changes.

## Changes
- src/components/user/EditProfile.js — added useMemo import, wrapped calculateCompletion in useMemo

Closes #7426 