### PR TITLE
fix: resolve redundant API calls and lack of caching in useBookmarks

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -57,11 +57,12 @@ const useBookmarks = (userId = "guest") => {
   const storageKeyRef = useRef(storageKey);
   storageKeyRef.current = storageKey;
 
+  const isInitialSave = useRef(true);
   const isInitialLoad = useRef(true);
 
   useEffect(() => {
-    if (isInitialLoad.current) {
-      isInitialLoad.current = false;
+    if (isInitialSave.current) {
+      isInitialSave.current = false;
       return;
     }
     try {
@@ -72,6 +73,10 @@ const useBookmarks = (userId = "guest") => {
   }, [bookmarks]);
 
   useEffect(() => {
+    if (isInitialLoad.current) {
+      isInitialLoad.current = false;
+      return;
+    }
     try {
       const stored = localStorage.getItem(storageKey);
       if (!stored) { setBookmarks([]); return; }
@@ -81,6 +86,11 @@ const useBookmarks = (userId = "guest") => {
       setBookmarks([]);
     }
   }, [storageKey]);
+
+  // Cache bookmarks in a Set for O(1) lookups
+  const bookmarksSet = useMemo(() => {
+    return new Set(bookmarks.map(e => e.id));
+  }, [bookmarks]);
 
   /**
    * Toggles bookmark state for an event.
@@ -119,8 +129,8 @@ const useBookmarks = (userId = "guest") => {
    * Returns true if an event with the given id is currently bookmarked.
    */
   const isBookmarked = useCallback(
-    (id) => bookmarks.some((e) => e.id === id),
-    [bookmarks],
+    (id) => bookmarksSet.has(id),
+    [bookmarksSet],
   );
 
   /**


### PR DESCRIPTION
## Summary
- I discovered that `useBookmarks` was making a redundant call to `localStorage.getItem` immediately on initial mount in its `useEffect`, despite already initializing the state correctly in `useState`. This was essentially a redundant Web Storage API call that could slow down the initial render slightly.
- Furthermore, the `isBookmarked` function was performing an O(N) array scan every time it was called, which could become slow for users with many bookmarks.

## Fix
- Added an `isInitialLoad` check to the `localStorage` loading `useEffect` to completely skip the redundant read operation on mount.
- Implemented a `bookmarksSet` cache using `useMemo` to convert the `isBookmarked` array scan into a near-instant O(1) set lookup, significantly optimizing performance when rendering lists of events.

Fixes #7116

## Validation
- Ran the unit tests for `useBookmarks` and verified they all pass.
- Verified that event cards correctly display their bookmark status and the performance is smooth even with many events rendered.
