### PR TITLE
fix: memoize filteredSuggestions in EditProfile to avoid redundant skill array filtering on every render

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -295,14 +295,18 @@ const EditProfile = () => {
     }
   };
 
-  const filteredSuggestions = allSkillSuggestions
-    .filter(
-      (suggestion) =>
-        currentSkillInput &&
-        suggestion.toLowerCase().includes(currentSkillInput.toLowerCase()) &&
-        !form.skills.some((s) => s.toLowerCase() === suggestion.toLowerCase())
-    )
-    .slice(0, 7);
+  const filteredSuggestions = useMemo(
+    () =>
+      allSkillSuggestions
+        .filter(
+          (suggestion) =>
+            currentSkillInput &&
+            suggestion.toLowerCase().includes(currentSkillInput.toLowerCase()) &&
+            !form.skills.some((s) => s.toLowerCase() === suggestion.toLowerCase())
+        )
+        .slice(0, 7),
+    [currentSkillInput, form.skills]
+  );
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 py-10 px-4">


### PR DESCRIPTION
## Summary
Fixes unnecessary recomputation of filteredSuggestions on every render in EditProfile by wrapping it in useMemo.

## Problem
filteredSuggestions filtered all 43 skill suggestions on every render regardless of whether currentSkillInput or form.skills had changed. On a form with rapid onChange events this caused frequent unnecessary array operations.

## Fix
I Wrapped filteredSuggestions in useMemo with currentSkillInput and form.skills as dependencies. The filter now only runs when its inputs actually change. useMemo was already imported from a related fix in the same file.

## Changes
- src/components/user/EditProfile.js — wrapped filteredSuggestions in useMemo

Closes #7429