### PR TITLE
fix: resolve missing aria-labels and remove redundant aria-label attributes

### DIFF
--- a/src/components/CollaborationHub.js
+++ b/src/components/CollaborationHub.js
@@ -451,10 +451,10 @@ const CollaborationHub = () => {
                   </div>
                   
                   <div className="collaboration-actions flex gap-2">
-                    <button className="px-4 py-2 bg-slate-100 dark:bg-slate-800 text-slate-850 dark:text-slate-200 hover:bg-slate-200 rounded-xl text-xs font-bold transition-all" aria-label="button">
+                    <button className="px-4 py-2 bg-slate-100 dark:bg-slate-800 text-slate-850 dark:text-slate-200 hover:bg-slate-200 rounded-xl text-xs font-bold transition-all">
                       View Details
                     </button>
-                    <button className="px-4 py-2 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 rounded-xl text-xs font-bold transition-all" aria-label="button">
+                    <button className="px-4 py-2 border border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 rounded-xl text-xs font-bold transition-all">
                       Schedule Meeting
                     </button>
                   </div>
@@ -501,10 +501,10 @@ const CollaborationHub = () => {
                     </div>
                     
                     <div className="networking-actions flex gap-2">
-                      <button className="flex-1 py-2 px-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-xs font-bold transition-all flex items-center justify-center gap-1" aria-label="button">
+                      <button className="flex-1 py-2 px-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-xs font-bold transition-all flex items-center justify-center gap-1">
                         <Check size={14} /> Accept Connection
                       </button>
-                      <button className="px-3 py-2 border border-slate-200 dark:border-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 rounded-xl text-xs font-bold transition-all" aria-label="button">
+                      <button className="px-3 py-2 border border-slate-200 dark:border-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 rounded-xl text-xs font-bold transition-all">
                         Message
                       </button>
                     </div>
@@ -642,7 +642,7 @@ const CollaborationHub = () => {
                 <span id="skills-hint" className="sr-only">Comma separated list of required skills</span>
               </div>
               
-              <button type="submit" className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-xs font-bold transition-all" aria-label="button">
+              <button type="submit" className="w-full py-3 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-xs font-bold transition-all">
                 Create Collaboration Request
               </button>
             </form>
@@ -671,6 +671,7 @@ const CollaborationHub = () => {
               <button 
                 onClick={() => setSelectedOpportunity(null)}
                 className="absolute top-4 right-4 p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 transition-all text-slate-400 hover:text-slate-900 dark:hover:text-white"
+                aria-label="Close modal"
               >
                 <X size={16} />
               </button>
@@ -773,7 +774,7 @@ const CollaborationHub = () => {
                   <button 
                     type="submit"
                     className="flex-1 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-xs font-bold"
-                   aria-label="button">
+                  >
                     Submit Application
                   </button>
                 </div>


### PR DESCRIPTION
## Summary
- Found a bug where the icon-only `X` button to close the collaboration opportunity modal lacked an `aria-label`, rendering it inaccessible to screen readers.
- Discovered an anti-pattern where multiple buttons that already contained descriptive text (like "Submit Application" or "Message") had `aria-label="button"`, which is redundant and can confuse assistive technologies.

## Fix
- Added an `aria-label="Close modal"` to the `X` icon-only button inside the modal to properly describe its function.
- Scanned the component and stripped out all the redundant `aria-label="button"` properties from text-bearing buttons to keep our accessibility markup clean and strictly compliant with WAI-ARIA standards.

Fixes #7117

## Validation
- Checked the component using a screen reader context extension to ensure the buttons are correctly announced.
- Verified there are no ESLint JSX-A11y warnings remaining for this component regarding interactive controls lacking labels.
