### PR TITLE
fix: resolve stale closure bug in useOfflineSync hook interval

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -38,15 +38,21 @@ const useOfflineSync = () => {
   const isSyncing = useRef(false);
   const isLockPending = useRef(false); // 🔥 FIX: Protects against asynchronous race conditions during Web Lock acquisition
   const conflictControllerRef = useRef(new AbortController());
+  const heartbeatIntervalRef = useRef(null);
+  const syncLockAborted = useRef(false);
 
   // Clean up controller on full unmount
   useEffect(() => {
     return () => {
       conflictControllerRef.current.abort();
+      if (heartbeatIntervalRef.current) {
+        clearInterval(heartbeatIntervalRef.current);
+      }
     };
   }, []);
 
   useEffect(() => {
+    syncLockAborted.current = false;
   /**
    * resolveConflict
    *
@@ -367,7 +373,7 @@ const useOfflineSync = () => {
       }
 
       const heartbeatInterval = setInterval(() => {
-        if (syncLockAborted) { clearInterval(heartbeatInterval); return; }
+        if (syncLockAborted.current) { clearInterval(heartbeatInterval); return; }
         try {
           localStorage.setItem(LOCK_KEY, JSON.stringify({ timestamp: Date.now(), tabId: currentTabId }));
         } catch (e) {}
@@ -436,8 +442,6 @@ const useOfflineSync = () => {
 
     let idleId = null;
     let timeoutId = null;
-    const heartbeatIntervalRef = { current: null };
-    let syncLockAborted = false;
 
     if (navigator.onLine) {
       if (typeof window.requestIdleCallback === "function") {
@@ -464,7 +468,7 @@ const useOfflineSync = () => {
       
       // Signal the sync lock heartbeat to stop — it runs outside React's
       // lifecycle and won't be caught by the normal finally block on unmount.
-      syncLockAborted = true;
+      syncLockAborted.current = true;
       if (heartbeatIntervalRef.current) {
         clearInterval(heartbeatIntervalRef.current);
         heartbeatIntervalRef.current = null;


### PR DESCRIPTION
## Summary
- Fixed a subtle state closure issue in `useOfflineSync` where the `syncLockAborted` and `heartbeatIntervalRef` variables were scoped as standard block-level mutable variables (`let`) inside the `useEffect`. Because they were evaluated asynchronously across nested async closures and intervals (such as the heartbeat `setInterval` for cross-tab locking), it could lead to potential race conditions or stale reads if the effect unmounted during an active lock acquisition.

## Fix
- Refactored `syncLockAborted` and `heartbeatIntervalRef` to use React's `useRef` hook.
- This ensures that references to these variables in asynchronous closures remain stable and up-to-date across component re-renders and unmounts. The interval will now correctly read the `syncLockAborted.current` state to reliably halt itself without memory leaks.

Fixes #7118

## Validation
- Ran the `useOfflineSync` unit tests which passed perfectly.
- Confirmed that cross-tab web lock fallback using LocalStorage does not leak intervals on unmount.
