### PR TITLE
fix: correct API Docs footer link from /apiDocs to /api-docs

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -88,7 +88,7 @@ const footerLinks = {
     },
     {
       name: "API Docs",
-      href: "/apiDocs",
+      href: "/api-docs",
       icon: <FaBookOpen size={14} />,
     },
   ],


### PR DESCRIPTION
## Description
The "API Docs" link in the footer was pointing to `/apiDocs`, which does not exist as a route in the application, causing a 404 "Lost in the Cloud?" page on click. The correct route registered in PublicRoutes.jsx is `/api-docs`. This PR corrects the href in Footer.js to match the existing route.

Fixes #6005 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
No response

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
