### PR TITLE
fix(p2p): prevent InvalidStateError by queuing early remote ICE candi…

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -199,6 +199,7 @@ export class P2PFileTransferCoordinator {
     this.isInitiator = false;
     this.onMessageListener = null;
     this.currentState = null;
+    this.queuedRemoteCandidates = [];
   }
 
   updateState(state, progress = 0, speed = "-", peer = null, count = 1) {
@@ -261,10 +262,14 @@ export class P2PFileTransferCoordinator {
         case "P2P_ICE":
           // Received ICE candidate
           if (msg.to === peerId && this.pc) {
-            try {
-              await this.pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
-            } catch (err) {
-              console.error("Error adding ICE candidate:", err);
+            if (this.pc.remoteDescription && this.pc.remoteDescription.type) {
+              try {
+                await this.pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
+              } catch (err) {
+                console.error("Error adding ICE candidate:", err);
+              }
+            } else {
+              this.queuedRemoteCandidates.push(msg.candidate);
             }
           }
           break;
@@ -333,6 +338,7 @@ export class P2PFileTransferCoordinator {
     this.updateState("connecting", 0, "-", targetPeerId, 1);
     
     this.pc = new RTCPeerConnection();
+    this.queuedRemoteCandidates = [];
     
     // Create data channel
     this.channel = this.pc.createDataChannel("file-transfer");
@@ -368,6 +374,7 @@ export class P2PFileTransferCoordinator {
     this.updateState("connecting", 0, "-", senderId, 1);
 
     this.pc = new RTCPeerConnection();
+    this.queuedRemoteCandidates = [];
 
     this.pc.ondatachannel = (e) => {
       this.channel = e.channel;
@@ -387,6 +394,7 @@ export class P2PFileTransferCoordinator {
     };
 
     await this.pc.setRemoteDescription(new RTCSessionDescription(offer));
+    await this.processQueuedCandidates();
     const answer = await this.pc.createAnswer();
     await this.pc.setLocalDescription(answer);
 
@@ -403,6 +411,20 @@ export class P2PFileTransferCoordinator {
   async handleAnswer(answer) {
     if (this.pc) {
       await this.pc.setRemoteDescription(new RTCSessionDescription(answer));
+      await this.processQueuedCandidates();
+    }
+  }
+
+  // Process any ICE candidates that were queued before the remote description was applied
+  async processQueuedCandidates() {
+    if (!this.pc || !this.pc.remoteDescription) return;
+    while (this.queuedRemoteCandidates.length > 0) {
+      const candidate = this.queuedRemoteCandidates.shift();
+      try {
+        await this.pc.addIceCandidate(new RTCIceCandidate(candidate));
+      } catch (err) {
+        console.error("Error adding queued ICE candidate:", err);
+      }
     }
   }
 


### PR DESCRIPTION
## Description
This PR resolves a connection race condition in the WebRTC peer-to-peer file sharing coordinator (`p2pFileTransfer.js`). 

Previously, incoming remote ICE candidates received via the signaling `BroadcastChannel` were applied immediately to the `RTCPeerConnection`. Under normal network latency, these candidate descriptors often arrived before `setRemoteDescription` resolved on the connection object, causing the browser to throw an `InvalidStateError` (remote description is null) and terminate the connection handshake. This prevented successful peer-to-peer sharing and triggered unnecessary fallbacks to the server.

### Changes:
- Added a `queuedRemoteCandidates` buffer in `P2PFileTransferCoordinator` to track early-arriving remote candidates.
- Updated the `P2P_ICE` message listener to check `this.pc.remoteDescription`. If it is not yet set, incoming candidates are stored in the queue.
- Implemented `processQueuedCandidates()` to flush and apply the buffered ICE candidates immediately after `setRemoteDescription` resolves on both the initiator (`handleAnswer`) and recipient (`handleOffer`) pathways.

Fixes #7441

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
