### PR TITLE
perf(p2p): optimize IndexedDB cache lookups using fileId index

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -12,7 +12,7 @@
 
 // --- IndexedDB Cache Configuration ---
 const DB_NAME = "eventra_p2p_cache";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = "file_chunks";
 
 let dbInstance = null;
@@ -24,8 +24,14 @@ const getDB = () => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     request.onupgradeneeded = (e) => {
       const db = e.target.result;
+      let store;
       if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME, { keyPath: "chunkId" });
+        store = db.createObjectStore(STORE_NAME, { keyPath: "chunkId" });
+      } else {
+        store = e.target.transaction.objectStore(STORE_NAME);
+      }
+      if (!store.indexNames.contains("fileId")) {
+        store.createIndex("fileId", "fileId", { unique: false });
       }
     };
     request.onsuccess = (e) => {
@@ -62,8 +68,9 @@ export async function isFileCached(fileId) {
     return new Promise((resolve) => {
       const transaction = db.transaction(STORE_NAME, "readonly");
       const store = transaction.objectStore(STORE_NAME);
+      const index = store.index("fileId");
       
-      const request = store.openCursor();
+      const request = index.openCursor(IDBKeyRange.only(fileId));
       let chunksCount = 0;
       let totalChunks = 0;
       
@@ -72,10 +79,8 @@ export async function isFileCached(fileId) {
       request.onsuccess = (e) => {
         const cursor = e.target.result;
         if (cursor) {
-          if (cursor.value.fileId === fileId) {
-            chunksCount++;
-            totalChunks = cursor.value.totalChunks;
-          }
+          chunksCount++;
+          totalChunks = cursor.value.totalChunks;
           cursor.continue();
         } else {
           resolve(chunksCount > 0 && chunksCount === totalChunks);
@@ -95,8 +100,9 @@ export async function getCachedFile(fileId) {
     return new Promise((resolve) => {
       const transaction = db.transaction(STORE_NAME, "readonly");
       const store = transaction.objectStore(STORE_NAME);
+      const index = store.index("fileId");
 
-      const request = store.openCursor();
+      const request = index.openCursor(IDBKeyRange.only(fileId));
       const chunks = [];
       
       attachIdbReadHandlers(transaction, request, resolve, null, "getCachedFile");
@@ -104,9 +110,7 @@ export async function getCachedFile(fileId) {
       request.onsuccess = (e) => {
         const cursor = e.target.result;
         if (cursor) {
-          if (cursor.value.fileId === fileId) {
-            chunks.push(cursor.value);
-          }
+          chunks.push(cursor.value);
           cursor.continue();
         } else {
           // Sort chunks by index


### PR DESCRIPTION
## Description
This PR addresses an O(N) database performance bottleneck in the WebRTC chunk cache layer (`p2pFileTransfer.js`). 

Previously, checking if a file was cached (`isFileCached`) or retrieving its chunks (`getCachedFile`) executed a full-table scan using `store.openCursor()`. Because no IndexedDB index was created on `fileId`, the browser had to iterate through every single chunk of every cached file stored in the client database. As the cache grows, this results in significant thread blocking and slow connection start times.

### Changes:
- Created a non-unique `fileId` index mapping on `STORE_NAME` during the IndexedDB schema creation/upgrade phase.
- Refactored `isFileCached` and `getCachedFile` to open cursors bounded specifically to the target file's ID range (`IDBKeyRange.only(fileId)`) on the new index instead of scanning the root store.

Fixes #7439

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
