### PR TITLE
[Critical] fix: await persistSession in login to prevent phantom logouts on reload

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -307,7 +307,7 @@ export const AuthProvider = ({ children }) => {
         // body. There is no longer a missing-token failure path here.
         const { sessionToken, sessionUser } = extractSession(res, data, usernameOrEmail);
 
-        const persisted = persistSession(sessionToken, sessionUser);
+        const persisted = await persistSession(sessionToken, sessionUser);
         if (!persisted) return false;
 
         setAuthRequestState({ loading: false, error: null });


### PR DESCRIPTION
## Issue
Missing `await` in `login()` causes session persistence to complete asynchronously after the function returns, producing phantom logouts on page reload.

## Cause
In `src/context/AuthContext.js` line 310, `persistSession(sessionToken, sessionUser)` is called without `await`:
```
const persisted = persistSession(sessionToken, sessionUser);
if (!persisted) return false;
```
`persistSession` is async and returns a Promise. A Promise is always truthy, so the `if (!persisted)` guard never fires. If the underlying storage write (IndexedDB/localStorage) fails — common in Safari private browsing or quota-exceeded scenarios — `login()` still reports success. The user sees a successful login, but on the next page reload the session is gone and they are redirected to the login page.

## Fix
Add `await` before `persistSession` so the function awaits the storage write and properly handles failures:

```diff
- const persisted = persistSession(sessionToken, sessionUser);
+ const persisted = await persistSession(sessionToken, sessionUser);
  if (!persisted) return false;
```

## Additional Context
This is a subtle timing bug that primarily affects users in private browsing mode or with full storage. The fix is a single `await` keyword addition and has no side effects.

Closes #7456
