### PR TITLE
[Critical] fix: use sanitized authToken in offline sync conflict retry path

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -296,10 +296,10 @@ const useOfflineSync = () => {
 
               if (resolution.resolution === "local") {
                 // Retry with force flag
-                res = await postWithBackoff(url, item.payload, token, 0, true, conflictController.signal, item.id);
+                res = await postWithBackoff(url, item.payload, authToken, 0, true, conflictController.signal, item.id);
               } else if (resolution.resolution === "merge") {
                 // Post merged content
-                res = await postWithBackoff(url, resolution.mergedPayload, token, 0, true, conflictController.signal, item.id);
+                res = await postWithBackoff(url, resolution.mergedPayload, authToken, 0, true, conflictController.signal, item.id);
               } else {
                 // Discard local (treated as handled success so we proceed)
                 res = { status: "success" };


### PR DESCRIPTION
## Issue
Offline sync conflict retry path leaks the unsanitized raw `token` variable as a Bearer token value for HttpOnly session users.

## Cause
In `src/hooks/useOfflineSync.js`, line 250 correctly sanitizes the token for cookie-managed sessions:
```
const authToken = token === "cookie-managed" ? null : token;
```

The initial sync attempt on line 282-289 correctly uses `authToken`. However, the conflict resolution retry paths on lines 299 and 302 use the raw `token` variable:
```js
res = await postWithBackoff(url, item.payload, token, 0, true, conflictController.signal, item.id);           // line 299
res = await postWithBackoff(url, resolution.mergedPayload, token, 0, true, conflictController.signal, item.id); // line 302
```

For HttpOnly session users, the raw token value is the sentinel string "cookie-managed". Passing this as a Bearer token causes all conflict retries to fail with 401 Unauthorized.

## Fix
Replace `token` with `authToken` on both lines so conflict retries also benefit from the cookie-managed sentinel sanitization:

```diff
- res = await postWithBackoff(url, item.payload, token, 0, true, conflictController.signal, item.id);
+ res = await postWithBackoff(url, item.payload, authToken, 0, true, conflictController.signal, item.id);
- res = await postWithBackoff(url, resolution.mergedPayload, token, 0, true, conflictController.signal, item.id);
+ res = await postWithBackoff(url, resolution.mergedPayload, authToken, 0, true, conflictController.signal, item.id);
```

## Additional Context
This causes waitlist promotions and registration drops to be silently lost when a conflict occurs during offline sync. The fix is two lines, each replacing a single variable name.

Closes #7457
