### PR TITLE
[Critical] fix: add request ID tracking to prevent stale race conditions in event listing

### DIFF
--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -57,6 +57,7 @@ const useEventListing = () => {
 
   const [isAdvancedFiltersOpen, setIsAdvancedFiltersOpen] = useState(false);
   const isInitialMount = useRef(true);
+  const latestRequestRef = useRef(0);
 
   const buildQueryParams = useCallback(() => {
     const params = new URLSearchParams();
@@ -100,6 +101,7 @@ const useEventListing = () => {
   ]);
 
   const fetchEvents = useCallback(async () => {
+    const requestId = ++latestRequestRef.current;
     setIsLoading(true);
     setLoadError("");
 
@@ -109,6 +111,9 @@ const useEventListing = () => {
       const response = await apiUtils.get(
         `${API_ENDPOINTS.EVENTS.LIST}?${query}`,
       );
+
+      // Discard stale responses from earlier requests
+      if (requestId !== latestRequestRef.current) return;
 
       const responseData = response?.data || {};
 


### PR DESCRIPTION
## Issue
`useEventListing` has no request cancellation mechanism, causing stale API responses to overwrite fresh filter results when filters change rapidly.

## Cause
In `src/Pages/Events/useEventListing.js`, the `useEffect` on line 167 simply calls `fetchEvents()` whenever `buildQueryParams` changes — which happens on every filter/sort/page change. Multiple concurrent requests can resolve out of order, and a stale response can overwrite the latest results:

```js
useEffect(() => {
  fetchEvents();
}, [fetchEvents]);
```

There is no `AbortController`, request ID ref, or mounted guard to prevent this.

## Fix
Add a `latestRequestRef` counter that increments on each call. Stale responses are discarded by comparing their captured request ID against the current value:

```diff
+const latestRequestRef = useRef(0);
+
 const fetchEvents = useCallback(async () => {
+  const requestId = ++latestRequestRef.current;
   setIsLoading(true);
   setLoadError("");
   try {
     const query = buildQueryParams();
     const response = await apiUtils.get(`${API_ENDPOINTS.EVENTS.LIST}?${query}`);
+
+    // Discard stale responses from earlier requests
+    if (requestId !== latestRequestRef.current) return;
+
     const responseData = response?.data || {};
```

## Additional Context
This is most noticeable on slow connections when users type search queries character by character. The result flickers between different search terms as responses arrive out of order. The fix uses the same pattern already employed in `EventDetails.js`.

Closes #7458
