### PR TITLE
[Critical] fix: replace deprecated exitBeforeEnter with mode=wait in AnimatePresence

### DIFF
--- a/src/Pages/Events/LiveInteractionHub.jsx
+++ b/src/Pages/Events/LiveInteractionHub.jsx
@@ -31,7 +31,7 @@ const LiveInteractionHub = () => {
             ))}
           </Tab.List>
           <Tab.Panels className="p-6">
-            <AnimatePresence exitBeforeEnter>
+            <AnimatePresence mode="wait">
               {selectedIndex === 0 && (
                 <motion.div
                   key="qa"


### PR DESCRIPTION
## Issue
`AnimatePresence` in `LiveInteractionHub` uses the deprecated `exitBeforeEnter` prop which is removed in framer-motion v12+.

## Cause
In `src/Pages/Events/LiveInteractionHub.jsx` line 34, the code uses:
```jsx
<AnimatePresence exitBeforeEnter>
```

The `exitBeforeEnter` prop was replaced by `mode="wait"` in framer-motion v6. It currently works with a deprecation warning. On the next framer-motion upgrade, the prop will be ignored entirely, causing all three tab panels (Q&A, Poll, Whiteboard) to animate simultaneously — overlapping content during transitions.

## Fix
Replace the deprecated prop with the modern equivalent:

```diff
- <AnimatePresence exitBeforeEnter>
+ <AnimatePresence mode="wait">
```

## Additional Context
`mode="wait"` is fully backwards-compatible with all currently used framer-motion versions. The fix is a single prop rename with zero behavioral change.

Closes #7459
