### PR TITLE
fix(security): patch client-side prefix scan bypass vulnerability in env validator

### DIFF
--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -128,10 +128,13 @@ for (const [varName, config] of Object.entries(FORMAT_VALIDATED_VARS)) {
   }
 }
 
-console.log("\nScanning VITE_* variables for credential leaks...");
-const viteVars = Object.keys(process.env).filter((k) => k.startsWith("VITE_"));
+console.log("\nScanning client variables for credential leaks...");
+// Security Fix: Scan BOTH Vite and React App prefixes to prevent bypass leaks
+const clientVars = Object.keys(process.env).filter(
+  (k) => k.startsWith("VITE_") || k.startsWith("REACT_APP_")
+);
 
-for (const key of viteVars) {
+for (const key of clientVars) {
   if (ALLOWED_EXCEPTIONS.has(key)) continue;
 
   const value = process.env[key] || "";
@@ -180,6 +183,6 @@ if (criticalErrors.length > 0 || hasErrors) {
 }
 
 console.log(
-  `\n[validate-env] Environment check passed. Scanned ${viteVars.length} VITE_* variable(s).\n`
+  `\n[validate-env] Environment check passed. Scanned ${clientVars.length} client variable(s).\n`
 );
 process.exit(0);


### PR DESCRIPTION
## Description
This PR resolves a critical scan bypass vulnerability within the build-time environment variable sanitation script (`scripts/validate-env.js`). I am contributing this security patch as part of GSSoC 2026!

**Motivation and Context:**
Previously, the security iteration loop only aggregated variables starting with the `VITE_` prefix. However, legacy/hybrid setups in the application utilize `REACT_APP_` variables (as evidenced by `ALLOWED_EXCEPTIONS`). This meant any sensitive credential erroneously prefixed with `REACT_APP_` would completely bypass the scanner and silently leak into the production client bundle. 

**Changes:**
* Refactored the `viteVars` target array into a comprehensive `clientVars` array.
* Expanded the variable filter to explicitly scan both `k.startsWith("VITE_")` and `k.startsWith("REACT_APP_")` prefixes.
* Updated standard out logging to reflect total "client variables" scanned.

Fixes #7470 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
*N/A - DevOps/Build script fix.*

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports