### PR TITLE
fix(react): resolve unmounted state memory leaks and AbortError false-positives in ShareMenu

### DIFF
--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -1,7 +1,7 @@
-import { Facebook, Linkedin, MessageCircle, Send } from "lucide-react";
 import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Share2, Copy, Mail, Check } from 'lucide-react';
+// Consolidated lucide-react imports for code cleanliness
+import { Facebook, Linkedin, MessageCircle, Send, Share2, Copy, Mail, Check } from 'lucide-react';
 import { generateSharingUrl, copyToClipboard } from '../../../utils/shareUtils';
 import { toast } from 'react-toastify';
 import './ShareMenu.css';
@@ -29,6 +29,7 @@ const ShareMenu = ({
   const [calculatedPosition, setCalculatedPosition] = useState('bottom');
   const menuRef = useRef(null);
   const buttonRef = useRef(null);
+  const timeoutRef = useRef(null); // Ref to track timeouts and prevent memory leaks
 
   const toggleMenu = () => {
     if (!isOpen && buttonRef.current) {
@@ -80,8 +81,11 @@ const ShareMenu = ({
     copyToClipboard(url);
     setCopied(true);
     
-    // Reset copied status after 2 seconds
-    setTimeout(() => {
+    // Clear any existing timeouts to prevent memory leaks
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    
+    // Reset copied status after 2 seconds safely
+    timeoutRef.current = setTimeout(() => {
       setCopied(false);
     }, 2000);
   };
@@ -99,15 +103,20 @@ const ShareMenu = ({
       })
       .then(()=>setIsOpen(false))
       .catch((err) => {
-        console.error('Error sharing:', err);
-        toast.error("Failed to share event", { autoClose: 2000 });
+        // Ignore AbortError caused by users intentionally closing the native share dialog
+        if (err.name !== 'AbortError') {
+          console.error('Error sharing:', err);
+          toast.error("Failed to share event", { autoClose: 2000 });
+        }
       });
       return;
     }
     if (platform === 'copy') {
       copyToClipboard(url);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
       return;
     }
 
@@ -120,6 +129,13 @@ const ShareMenu = ({
     setIsOpen(false);
   };
   
+  // Handle component unmount memory leak cleanup
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
   // Handle click outside to close menu
   useEffect(() => {
     const handleClickOutside = (event) => {


### PR DESCRIPTION
## Description
This PR resolves a core React memory leak, improves Web Share API error handling, and cleans up duplicate dependencies within the `ShareMenu.js` component. I am contributing this architecture patch as part of GSSoC 2026!

**Motivation and Context:**
1. **Memory Leak Fix:** The clipboard copy actions utilized a `setTimeout` to reset state, but lacked an unmount cleanup phase. This caused React to throw memory leak warnings if the user navigated away before the timeout resolved.
2. **AbortError Fix:** The `navigator.share` Promise blindly caught all errors. Consequently, when a user intentionally closed the OS native share sheet, the browser's `AbortError` triggered a false-positive "Failed to share event" toast.

**Changes:**
* Implemented a `timeoutRef` to track and securely clear active timeouts inside a `useEffect` cleanup hook upon component unmount.
* Added explicit `err.name !== 'AbortError'` validation in the `navigator.share` catch block to prevent false-positive error toasts.
* Consolidated duplicate `lucide-react` imports to resolve linter warnings.
* Retained all original functionality and component comments.

Fixes #7475 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance Optimization
- [x] UX Improvement

## Screenshots / Video (if applicable)
*N/A - React logic/memory fix.*

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports