### PR TITLE
fix(react): resolve WebKit blob race condition, double-click OOM crashes, and unmount leaks in useTicketDownload

### DIFF
--- a/src/components/common/QRTicket/useTicketDownload.js
+++ b/src/components/common/QRTicket/useTicketDownload.js
@@ -3,13 +3,25 @@
  * Hook to download a ticket element as PNG or PDF.
  *
  * Usage:
- *   const { downloading, downloadPNG, downloadPDF } = useTicketDownload(ticketRef, ticketId);
+ * const { downloading, downloadPNG, downloadPDF } = useTicketDownload(ticketRef, ticketId);
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { toast } from "react-toastify";
 
 export function useTicketDownload(ticketRef, ticketId = "ticket") {
   const [downloading, setDownloading] = useState(false);
+  
+  // Deep Fix 1 & 2: Refs for unmounted leak protection and synchronous concurrency locking
+  const isMounted = useRef(true);
+  const isProcessingLock = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
   /** Captures the DOM node to a canvas via html2canvas */
   const captureCanvas = useCallback(async () => {
@@ -27,32 +39,45 @@ export function useTicketDownload(ticketRef, ticketId = "ticket") {
 
   /** Download ticket as PNG */
   const downloadPNG = useCallback(async () => {
-    if (downloading) return;
-    setDownloading(true);
+    // Deep Fix 2: Synchronous lock prevents double-click OOM crashes on mobile
+    if (isProcessingLock.current) return;
+    
+    isProcessingLock.current = true;
+    if (isMounted.current) setDownloading(true);
+    
     try {
       const canvas = await captureCanvas();
       
       // Use toBlob instead of toDataURL to prevent massive base64 memory allocation
       canvas.toBlob((blob) => {
-        if (!blob) return;
+        if (!blob) throw new Error("Canvas rendering failed");
+        
         const url = URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.download = `eventra-ticket-${ticketId}.png`;
         link.href = url;
         link.click();
-        URL.revokeObjectURL(url);
+        
+        // Deep Fix 3: Defer revocation to prevent WebKit/Safari silent download failures
+        setTimeout(() => URL.revokeObjectURL(url), 150);
       }, "image/png");
     } catch (err) {
       console.error("[QRTicket] PNG download failed:", err);
+      toast.error("Failed to generate PNG. Please try again.");
     } finally {
-      setDownloading(false);
+      isProcessingLock.current = false;
+      // Deep Fix 1: Prevent memory leak if modal was closed during async generation
+      if (isMounted.current) setDownloading(false);
     }
-  }, [captureCanvas, downloading, ticketId]);
+  }, [captureCanvas, ticketId]);
 
   /** Download ticket as PDF */
   const downloadPDF = useCallback(async () => {
-    if (downloading) return;
-    setDownloading(true);
+    if (isProcessingLock.current) return;
+    
+    isProcessingLock.current = true;
+    if (isMounted.current) setDownloading(true);
+    
     try {
       const canvas = await captureCanvas();
       const { jsPDF } = await import("jspdf");
@@ -73,10 +98,12 @@ export function useTicketDownload(ticketRef, ticketId = "ticket") {
       pdf.save(`eventra-ticket-${ticketId}.pdf`);
     } catch (err) {
       console.error("[QRTicket] PDF download failed:", err);
+      toast.error("Failed to generate PDF. Please try again.");
     } finally {
-      setDownloading(false);
+      isProcessingLock.current = false;
+      if (isMounted.current) setDownloading(false);
     }
-  }, [captureCanvas, downloading, ticketId]);
+  }, [captureCanvas, ticketId]);
 
   return { downloading, downloadPNG, downloadPDF };
 }


### PR DESCRIPTION
## Description
This PR resolves critical mobile memory management flaws, browser-specific concurrency issues, and unmounted state leaks within the `useTicketDownload` hook. I am contributing this advanced architecture patch as part of GSSoC 2026!

**Motivation and Context:**
1. **WebKit Bug:** The blob URL was being revoked synchronously. Safari/iOS devices often failed to download the image because the memory pointer was destroyed before the OS could execute the file IO stream.
2. **Concurrency Crash:** Asynchronous React state was used as a debounce mechanism. Users double-clicking the download button spawned concurrent `html2canvas` payload threads, crashing mobile browser tabs via Out-Of-Memory (OOM) exceptions.
3. **Memory Leak:** Asynchronous resolution blocks updated state without checking component mount status.

**Changes:**
* Wrapped the `URL.revokeObjectURL` execution in a 150ms `setTimeout` to allow WebKit thread handoffs to complete safely.
* Implemented a synchronous `isProcessingLock` via `useRef` to guarantee absolute thread-locking during heavy canvas processing, preventing double-click crashes.
* Added an `isMounted` ref tied to a cleanup `useEffect` to intercept state updates if the parent modal unmounts.
* Surfaced silent background errors to the user via UI `toast` notifications.

Fixes #7485 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance/Memory Optimization

## Screenshots / Video (if applicable)
*N/A - React hook concurrency logic.*

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports