### PR TITLE
fix(react): implement React Portals, scroll-locks, and WCAG alertdialog semantics in DraftRestoreModal

### DIFF
--- a/src/components/common/EventCreation/DraftRestoreModal.jsx
+++ b/src/components/common/EventCreation/DraftRestoreModal.jsx
@@ -1,54 +1,120 @@
-import React from "react";
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { AlertCircle, History, Trash2, ArrowRight } from "lucide-react";
 
 const DraftRestoreModal = ({ show, onRestore, onDiscard }) => {
-  return (
+  const modalRef = useRef(null);
+
+  // Deep Fix 1: Safe Body Scroll Lock
+  useEffect(() => {
+    if (!show) return;
+    const originalStyle = window.getComputedStyle(document.body).overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, [show]);
+
+  // Deep Fix 2: Global Escape Listener & Strict Focus Trap
+  useEffect(() => {
+    if (!show) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onDiscard(); // Default safe action for destructive modals
+      }
+      
+      if (e.key === "Tab" && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    
+    // Auto-focus modal on open for screen readers
+    if (modalRef.current) {
+      modalRef.current.focus();
+    }
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [show, onDiscard]);
+
+  // Prevent SSR hydration mismatch for Portals
+  if (typeof window === "undefined") return null;
+
+  const modalContent = (
     <AnimatePresence>
       {show && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
+        <div 
+          className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="draft-modal-title"
+          aria-describedby="draft-modal-desc"
+        >
           <motion.div
+            ref={modalRef}
+            tabIndex={-1}
             initial={{ opacity: 0, scale: 0.9, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.9, y: 20 }}
-            className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-2xl overflow-hidden"
+            className="w-full max-w-md bg-white dark:bg-gray-800 rounded-2xl shadow-2xl overflow-hidden outline-none"
           >
             <div className="p-6 space-y-4">
               <div className="flex items-center gap-3 text-indigo-600 dark:text-indigo-400">
                 <div className="p-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg">
-                  <History className="w-6 h-6" />
+                  <History className="w-6 h-6" aria-hidden="true" />
                 </div>
-                <h3 className="text-xl font-bold">Unfinished Draft Found</h3>
+                <h3 id="draft-modal-title" className="text-xl font-bold">Unfinished Draft Found</h3>
               </div>
               
-              <p className="text-gray-600 dark:text-gray-400 leading-relaxed">
+              <p id="draft-modal-desc" className="text-gray-600 dark:text-gray-400 leading-relaxed">
                 It looks like you were in the middle of creating an event. Would you like to restore your progress or start fresh?
               </p>
 
               <div className="grid grid-cols-1 gap-3 pt-2">
                 <button
                   onClick={onRestore}
-                  className="flex items-center justify-between p-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl transition-all group"
+                  className="flex items-center justify-between p-4 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl transition-all group focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500"
                 >
                   <div className="flex items-center gap-3">
-                    <History className="w-5 h-5" />
+                    <History className="w-5 h-5" aria-hidden="true" />
                     <span className="font-semibold">Restore Draft</span>
                   </div>
-                  <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
+                  <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" aria-hidden="true" />
                 </button>
                 
                 <button
                   onClick={onDiscard}
-                  className="flex items-center gap-3 p-4 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-xl transition-all"
+                  className="flex items-center gap-3 p-4 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-xl transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500"
                 >
-                  <Trash2 className="w-5 h-5 text-red-500" />
+                  <Trash2 className="w-5 h-5 text-red-500" aria-hidden="true" />
                   <span className="font-semibold">Discard and Start Fresh</span>
                 </button>
               </div>
             </div>
             
             <div className="px-6 py-4 bg-gray-50 dark:bg-gray-800/50 border-t border-gray-100 dark:border-gray-700 flex items-center gap-2 text-xs text-gray-500">
-              <AlertCircle className="w-4 h-4" />
+              <AlertCircle className="w-4 h-4" aria-hidden="true" />
               <span>Restoring will overwrite any current changes.</span>
             </div>
           </motion.div>
@@ -56,6 +122,9 @@ const DraftRestoreModal = ({ show, onRestore, onDiscard }) => {
       )}
     </AnimatePresence>
   );
+
+  // Deep Fix 3: React Portal to escape DOM parent clipping
+  return createPortal(modalContent, document.body);
 };
 
 export default DraftRestoreModal;


### PR DESCRIPTION
## Description
This PR resolves critical UI clipping vulnerabilities, background scroll leaks, and WCAG accessibility failures within the `DraftRestoreModal` component. I am contributing this architecture patch as part of GSSoC 2026!

**Motivation and Context:**
1. **DOM Trapping:** The modal was rendering inline. If a parent container utilized `overflow: hidden` or `transform`, the modal would visually clip, ignoring its z-index.
2. **Scroll Leak:** The background DOM remained fully scrollable while the modal was open.
3. **Accessibility:** As a destructive action prompt, the modal lacked strict `alertdialog` roles, an `Escape` key fallback, and Tab focus trapping.

**Changes:**
* Wrapped the core component return in `ReactDOM.createPortal` to safely mount the modal directly to `document.body`, escaping all localized CSS stacking contexts.
* Added a dynamic `useEffect` to safely cache and lock `document.body.style.overflow`.
* Implemented `role="alertdialog"` with corresponding `aria-labelledby` maps.
* Added a global `window` event listener to capture `Escape` and fire the safe `onDiscard` handler, along with a strict `Tab` trap loop.

Fixes #7494

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility patch (WCAG Compliance)
- [x] UX/UI Enhancement

## Screenshots / Video (if applicable)
*N/A - React Portal implementation and DOM lifecycle logic.*

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports