### PR TITLE
fix(a11y): implement form control linkage, ARIA error states, and negative capacity bounds in EventBasicInfo

### DIFF
--- a/src/components/common/EventCreation/EventBasicInfo.jsx
+++ b/src/components/common/EventCreation/EventBasicInfo.jsx
@@ -1,35 +1,47 @@
 import React from "react";
 import { motion } from "framer-motion";
-import { Calendar, FileText, Tag, Users } from "lucide-react";
+// Removed unused Calendar import to clean up dead code
+import { FileText, Tag, Users } from "lucide-react";
 import { categories } from "../../../constants/eventDefaults";
 import CharacterCounter from "../CharacterCounter";
 
-const FormField = ({ label, icon: Icon, error, children, required, hint }) => (
-  <div className="space-y-2">
-    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-      {Icon && <Icon className="w-5 h-5 text-indigo-500 inline-block mr-2" />}
-      {label}
-      {required && <span className="text-red-600 ml-1">*</span>}
-    </label>
-    {children}
-    {hint && <p className="text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
-    {error && (
-      <motion.p 
-        initial={{ opacity: 0, y: -5 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="text-red-500 text-sm flex items-center gap-1"
-      >
-        <span role="img" aria-label="error">⚠️</span>
-        {error}
-      </motion.p>
-    )}
-  </div>
-);
+// Deep Fix 1: Added htmlFor prop to properly bind labels to inputs for screen readers
+const FormField = ({ htmlFor, label, icon: Icon, error, children, required, hint }) => {
+  const errorId = `${htmlFor}-error`;
+  
+  return (
+    <div className="space-y-2">
+      <label htmlFor={htmlFor} className="block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+        {Icon && <Icon className="w-5 h-5 text-indigo-500 inline-block mr-2" aria-hidden="true" />}
+        {label}
+        {required && <span className="text-red-600 ml-1" aria-hidden="true">*</span>}
+        {required && <span className="sr-only"> (Required)</span>}
+      </label>
+      
+      {children}
+      
+      {hint && <p id={`${htmlFor}-hint`} className="text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
+      
+      {error && (
+        <motion.p 
+          id={errorId}
+          initial={{ opacity: 0, y: -5 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-red-500 text-sm flex items-center gap-1"
+          role="alert" // Deep Fix 2: Alert role for screen reader announcements
+        >
+          <span role="img" aria-label="error">⚠️</span>
+          {error}
+        </motion.p>
+      )}
+    </div>
+  );
+};
 
 const EventBasicInfo = ({ formData, handleInputChange, errors }) => {
   return (
     <div className="space-y-6">
-      <FormField label="Event Title" icon={FileText} error={errors.title} required>
+      <FormField htmlFor="title-input" label="Event Title" icon={FileText} error={errors.title} required>
         <input
           type="text"
           id="title-input"
@@ -37,13 +49,15 @@ const EventBasicInfo = ({ formData, handleInputChange, errors }) => {
           value={formData.title}
           onChange={handleInputChange}
           maxLength={200}
-          aria-describedby="title-counter"
+          // Deep Fix 3: Proper ARIA invalidation and description mapping
+          aria-invalid={!!errors.title}
+          aria-describedby={`title-counter ${errors.title ? 'title-input-error' : ''}`.trim()}
           placeholder="Give your event a catchy title"
           className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 
                    text-gray-900 dark:text-gray-100 focus:outline-none 
                    focus:ring-2 focus:ring-indigo-500 focus:border-transparent
                    transition-all duration-200 ${
-                     errors.title ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+                     errors.title ? "border-red-500 focus:ring-red-500" : "border-gray-300 dark:border-gray-600"
                    }`}
         />
         <div className="flex justify-end mt-1">
@@ -51,16 +65,19 @@ const EventBasicInfo = ({ formData, handleInputChange, errors }) => {
         </div>
       </FormField>
 
-      <FormField label="Category" icon={Tag} error={errors.category} required>
+      <FormField htmlFor="category-input" label="Category" icon={Tag} error={errors.category} required>
         <select
+          id="category-input"
           name="category"
           value={formData.category}
           onChange={handleInputChange}
+          aria-invalid={!!errors.category}
+          aria-describedby={errors.category ? "category-input-error" : undefined}
           className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 
                    text-gray-900 dark:text-gray-100 focus:outline-none 
                    focus:ring-2 focus:ring-indigo-500 focus:border-transparent
                    transition-all duration-200 ${
-                     errors.category ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+                     errors.category ? "border-red-500 focus:ring-red-500" : "border-gray-300 dark:border-gray-600"
                    }`}
         >
           <option value="">Select a category</option>
@@ -72,7 +89,7 @@ const EventBasicInfo = ({ formData, handleInputChange, errors }) => {
         </select>
       </FormField>
 
-      <FormField label="Description" icon={FileText} error={errors.description} required>
+      <FormField htmlFor="description-input" label="Description" icon={FileText} error={errors.description} required>
         <textarea
           id="description-input"
           name="description"
@@ -80,13 +97,14 @@ const EventBasicInfo = ({ formData, handleInputChange, errors }) => {
           onChange={handleInputChange}
           rows={5}
           maxLength={500}
-          aria-describedby="description-counter"
+          aria-invalid={!!errors.description}
+          aria-describedby={`description-counter ${errors.description ? 'description-input-error' : ''}`.trim()}
           placeholder="Tell people what your event is about..."
           className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 
                    text-gray-900 dark:text-gray-100 focus:outline-none 
                    focus:ring-2 focus:ring-indigo-500 focus:border-transparent
                    transition-all duration-200 resize-none ${
-                     errors.description ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+                     errors.description ? "border-red-500 focus:ring-red-500" : "border-gray-300 dark:border-gray-600"
                    }`}
         />
         <div className="flex justify-end mt-1">
@@ -95,16 +113,28 @@ const EventBasicInfo = ({ formData, handleInputChange, errors }) => {
       </FormField>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <FormField label="Capacity" icon={Users} error={errors.capacity}>
+        <FormField htmlFor="capacity-input" label="Capacity" icon={Users} error={errors.capacity}>
           <input
             type="number"
+            id="capacity-input"
             name="capacity"
             value={formData.capacity}
             onChange={handleInputChange}
             placeholder="Unlimited"
-            className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 
+            // Deep Fix 4: Data integrity locks (prevents negative capacities and 'e' symbols)
+            min="1"
+            onKeyDown={(e) => {
+              if (['e', 'E', '+', '-'].includes(e.key)) {
+                e.preventDefault();
+              }
+            }}
+            aria-invalid={!!errors.capacity}
+            aria-describedby={errors.capacity ? "capacity-input-error" : undefined}
+            className={`w-full border rounded-lg p-3 
                      bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 
-                     focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                     focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-all duration-200 ${
+                       errors.capacity ? "border-red-500 focus:ring-red-500" : "border-gray-300 dark:border-gray-600"
+                     }`}
           />
         </FormField>
       </div>


### PR DESCRIPTION
## Description
This PR resolves critical WCAG accessibility failures and data integrity loopholes within the `EventBasicInfo` form component. I am contributing this architecture patch as part of GSSoC 2026!

**Motivation and Context:**
1. **Accessibility (WCAG 1.3.1 & 3.3.1):** The `<label>` elements were entirely detached from their corresponding inputs, breaking screen reader association and click-to-focus UX. Furthermore, when inputs errored out, they silently lacked the `aria-invalid` flag, leaving visually impaired users unaware of validation failures.
2. **Data Integrity:** The Capacity input permitted negative numbers and string math characters (e.g., `-50` or `1e3`), which could corrupt backend limits.
3. **Dead Code:** There was an unused library import.

**Changes:**
* Upgraded the `FormField` component to accept and bind an `htmlFor` prop explicitly to the nested label.
* Wired dynamic `aria-invalid={!!error}` checks and strictly mapped `aria-describedby` IDs to all `<input>`, `<select>`, and `<textarea>` nodes to announce error content dynamically.
* Hardened the Capacity input with a strict `min="1"` constraint and an `onKeyDown` interception to reject mathematical string characters (`e`, `E`, `+`, `-`).
* Removed unused `Calendar` import.

Fixes #7498 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility patch (WCAG Compliance)
- [x] Data Validation Enhancement

## Screenshots / Video (if applicable)
*N/A - ARIA semantics and native validation attributes.*

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports