### PR TITLE
fix(a11y): implement temporal event date locking and ARIA state management in EventLocationSection

### DIFF
--- a/src/components/common/EventCreation/EventLocationSection.jsx
+++ b/src/components/common/EventCreation/EventLocationSection.jsx
@@ -1,79 +1,102 @@
 import React from "react";
 import { MapPin, Globe, Calendar, Link2 } from "lucide-react";
 
-const FormField = ({ label, icon: Icon, error, children, required, hint }) => (
-  <div className="space-y-2">
-    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-      {Icon && <Icon className="w-5 h-5 text-indigo-500 inline-block mr-2" />}
-      {label}
-      {required && <span className="text-red-600 ml-1">*</span>}
-    </label>
-    {children}
-    {hint && <p className="text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
-    {error && (
-      <p className="text-red-500 text-sm flex items-center gap-1">
-        <span role="img" aria-label="error">⚠️</span>
-        {error}
-      </p>
-    )}
-  </div>
-);
+// Deep Fix 1: Hardened FormField with strict htmlFor and ARIA alert roles
+const FormField = ({ htmlFor, label, icon: Icon, error, children, required, hint }) => {
+  const errorId = `${htmlFor}-error`;
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor={htmlFor} className="block text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+        {Icon && <Icon className="w-5 h-5 text-indigo-500 inline-block mr-2" aria-hidden="true" />}
+        {label}
+        {required && <span className="text-red-600 ml-1" aria-hidden="true">*</span>}
+        {required && <span className="sr-only"> (Required)</span>}
+      </label>
+      {children}
+      {hint && <p id={`${htmlFor}-hint`} className="text-xs text-gray-500 dark:text-gray-400">{hint}</p>}
+      {error && (
+        <p id={errorId} className="text-red-500 text-sm flex items-center gap-1" role="alert">
+          <span role="img" aria-hidden="true">⚠️</span>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+};
 
 const EventLocationSection = ({ formData, handleInputChange, handleNestedChange, errors }) => {
+  // Deep Fix 2: Calculate today's date dynamically to prevent time-travel event creation
+  const todayString = new Date().toISOString().split('T')[0];
+
   return (
     <div className="space-y-8">
       {/* Type Switcher */}
-      <div className="flex p-1 bg-gray-100 dark:bg-gray-800 rounded-xl max-w-sm">
+      <div className="flex p-1 bg-gray-100 dark:bg-gray-800 rounded-xl max-w-sm" role="group" aria-label="Event Type Selection">
         <button
           type="button"
+          // Deep Fix 3: Added aria-pressed for screen reader state context
+          aria-pressed={!formData.isVirtual}
           onClick={() => handleInputChange({ target: { name: "isVirtual", value: false, type: "checkbox", checked: false } })}
           className={`flex-1 flex items-center justify-center gap-2 py-2 px-4 rounded-lg text-sm font-medium transition-all ${
             !formData.isVirtual ? "bg-white dark:bg-gray-700 shadow-sm text-indigo-600" : "text-gray-500"
           }`}
         >
-          <MapPin className="w-4 h-4" /> In-Person
+          <MapPin className="w-4 h-4" aria-hidden="true" /> In-Person
         </button>
         <button
           type="button"
+          aria-pressed={formData.isVirtual}
           onClick={() => handleInputChange({ target: { name: "isVirtual", value: true, type: "checkbox", checked: true } })}
           className={`flex-1 flex items-center justify-center gap-2 py-2 px-4 rounded-lg text-sm font-medium transition-all ${
             formData.isVirtual ? "bg-white dark:bg-gray-700 shadow-sm text-indigo-600" : "text-gray-500"
           }`}
         >
-          <Globe className="w-4 h-4" /> Virtual
+          <Globe className="w-4 h-4" aria-hidden="true" /> Virtual
         </button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {formData.isVirtual ? (
-          <FormField label="Meeting Link" icon={Link2} error={errors.virtualLink} required>
+          <FormField htmlFor="virtual-link-input" label="Meeting Link" icon={Link2} error={errors.virtualLink} required>
             <input
               type="url"
+              id="virtual-link-input"
               name="virtualLink"
               value={formData.virtualLink}
               onChange={handleInputChange}
+              aria-invalid={!!errors.virtualLink}
+              aria-describedby={errors.virtualLink ? "virtual-link-input-error" : undefined}
               placeholder="https://zoom.us/j/..."
-              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700"
+              className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                errors.virtualLink ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+              }`}
             />
           </FormField>
         ) : (
           <>
-            <FormField label="Venue Name" icon={MapPin} error={errors.location} required>
+            <FormField htmlFor="venue-name-input" label="Venue Name" icon={MapPin} error={errors.location} required>
               <input
                 type="text"
+                id="venue-name-input"
                 value={formData.location.name}
                 onChange={(e) => handleNestedChange("location", "name", e.target.value)}
+                aria-invalid={!!errors.location}
+                aria-describedby={errors.location ? "venue-name-input-error" : undefined}
                 placeholder="e.g., Grand Ballroom, Hotel Plaza"
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700"
+                className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                  errors.location ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+                }`}
               />
             </FormField>
-            <FormField label="City" icon={MapPin}>
+            <FormField htmlFor="city-input" label="City" icon={MapPin}>
               <input
                 type="text"
+                id="city-input"
                 value={formData.location.city}
                 onChange={(e) => handleNestedChange("location", "city", e.target.value)}
                 placeholder="e.g., Mumbai"
-                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700"
+                className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </FormField>
           </>
@@ -82,32 +105,48 @@ const EventLocationSection = ({ formData, handleInputChange, handleNestedChange,
 
       {/* Date and Time */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <FormField label="Date" icon={Calendar} error={errors.date} required>
+        <FormField htmlFor="date-input" label="Date" icon={Calendar} error={errors.date} required>
           <input
             type="date"
+            id="date-input"
             name="date"
             value={formData.date}
+            min={todayString} // Deep Fix 2: Prevent time-travel selection
             onChange={handleInputChange}
-            className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700"
+            aria-invalid={!!errors.date}
+            aria-describedby={errors.date ? "date-input-error" : undefined}
+            className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+              errors.date ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+            }`}
           />
         </FormField>
         <div className="grid grid-cols-2 gap-3">
-          <FormField label="Start Time" error={errors.startTime} required>
+          <FormField htmlFor="start-time-input" label="Start Time" error={errors.startTime} required>
             <input
               type="time"
+              id="start-time-input"
               name="startTime"
               value={formData.startTime}
               onChange={handleInputChange}
-              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700"
+              aria-invalid={!!errors.startTime}
+              aria-describedby={errors.startTime ? "start-time-input-error" : undefined}
+              className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                errors.startTime ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+              }`}
             />
           </FormField>
-          <FormField label="End Time" error={errors.endTime} required>
+          <FormField htmlFor="end-time-input" label="End Time" error={errors.endTime} required>
             <input
               type="time"
+              id="end-time-input"
               name="endTime"
               value={formData.endTime}
               onChange={handleInputChange}
-              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700"
+              aria-invalid={!!errors.endTime}
+              aria-describedby={errors.endTime ? "end-time-input-error" : undefined}
+              className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+                errors.endTime ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+              }`}
             />
           </FormField>
         </div>


### PR DESCRIPTION
## Description
This PR resolves a critical temporal validation flaw and multiple WCAG accessibility violations within the `EventLocationSection` form component. I am contributing this architecture patch as part of GSSoC 2026!

**Motivation and Context:**
1. **Data Integrity Bug:** The native `<input type="date">` allowed the selection of past dates. If unsanitized, this could lead to corrupt event data, immediately fired email reminders, and broken temporal sorting logic on the backend.
2. **Accessibility (WCAG 4.1.2 & 1.3.1):** The In-Person/Virtual switcher utilized `<button>` elements but lacked `aria-pressed` states, leaving screen reader users blind to the current selection. Furthermore, the localized `FormField` elements lacked `htmlFor` bindings and dynamic `aria-invalid` propagation.

**Changes:**
* Bound the `<input type="date">` to a dynamic `min={new Date().toISOString().split('T')[0]}` constraint, firmly locking the date picker to the current day or later.
* Implemented strict `aria-pressed` boolean tracking on the event type switcher buttons.
* Upgraded the `FormField` wrapper to accept and link `htmlFor` props.
* Wired dynamic `aria-invalid` checks and `aria-describedby` error mappings to all location, date, and time inputs.

Fixes #7500

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility patch (WCAG Compliance)
- [x] Data Validation Enhancement

## Screenshots / Video (if applicable)
*N/A - ARIA semantics and native temporal validation attributes.*

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports