### PR TITLE
fix(a11y): implement fieldset legend grouping and improved input hit-targets for duration selector

### DIFF
--- a/src/components/common/EventCreation/components/EventDurationSelector.jsx
+++ b/src/components/common/EventCreation/components/EventDurationSelector.jsx
@@ -9,30 +9,37 @@ export default function EventDurationSelector({ isMultiDay, onChange }) {
       viewport={{ once: true }}
       transition={{ duration: 0.5 }}
     >
-      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-        <Calendar className="w-5 h-5 text-indigo-500 inline-block mr-2" />
-        Event Duration
-      </label>
-      <div className="flex gap-6">
-        <label className="flex items-center text-gray-700 dark:text-white gap-2">
-          <input
-            type="radio"
-            name="eventType"
-            checked={!isMultiDay}
-            onChange={() => onChange(false)}
-          />
-          Single-day Event
-        </label>
-        <label className="flex items-center text-gray-700 dark:text-white gap-2">
-          <input
-            type="radio"
-            name="eventType"
-            checked={isMultiDay}
-            onChange={() => onChange(true)}
-          />
-          Multi-day Event
-        </label>
-      </div>
+      <fieldset className="space-y-3">
+        {/* Deep Fix: Legend for proper screen reader grouping */}
+        <legend className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 flex items-center">
+          <Calendar className="w-5 h-5 text-indigo-500 inline-block mr-2" aria-hidden="true" />
+          Event Duration
+        </legend>
+        
+        <div className="flex gap-4">
+          <label className={`flex-1 flex items-center p-4 border rounded-xl cursor-pointer transition-all ${!isMultiDay ? "border-indigo-600 bg-indigo-50 dark:bg-indigo-900/20 ring-1 ring-indigo-600" : "border-gray-300 dark:border-gray-600"}`}>
+            <input
+              type="radio"
+              name="eventType"
+              className="w-4 h-4 text-indigo-600 focus:ring-indigo-500"
+              checked={!isMultiDay}
+              onChange={() => onChange(false)}
+            />
+            <span className="ml-3 font-medium text-gray-700 dark:text-gray-300">Single-day Event</span>
+          </label>
+
+          <label className={`flex-1 flex items-center p-4 border rounded-xl cursor-pointer transition-all ${isMultiDay ? "border-indigo-600 bg-indigo-50 dark:bg-indigo-900/20 ring-1 ring-indigo-600" : "border-gray-300 dark:border-gray-600"}`}>
+            <input
+              type="radio"
+              name="eventType"
+              className="w-4 h-4 text-indigo-600 focus:ring-indigo-500"
+              checked={isMultiDay}
+              onChange={() => onChange(true)}
+            />
+            <span className="ml-3 font-medium text-gray-700 dark:text-gray-300">Multi-day Event</span>
+          </label>
+        </div>
+      </fieldset>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Description
This PR addresses WCAG 1.3.1 accessibility violations by grouping radio inputs into a semantic `fieldset` and improves mobile UX by expanding click targets. I am contributing this as part of GSSoC 2026!

**Motivation and Context:**
The radio buttons were floating without a container legend, making them contextually invisible to screen readers, and the small click targets hampered mobile usability.

**Changes:**
* Wrapped inputs in a `<fieldset>` with an accessible `<legend>`.
* Converted standard label/input layouts into full-width card-style containers for better touch target accessibility.
* Retained all existing documentation comments and logic.

Fixes #7510

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings