### PR TITLE
fix: gate EventFeedbackForm behind auth check and scope submission key to userId

### DIFF
--- a/src/components/feedback/EventFeedbackForm.jsx
+++ b/src/components/feedback/EventFeedbackForm.jsx
@@ -1,36 +1,58 @@
-import { Star, MessageSquare, Send, CheckCircle } from "lucide-react";
+import { Star, MessageSquare, Send, CheckCircle, LogIn } from "lucide-react";
 import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { Loader2 } from "lucide-react";
 import { toast } from "react-toastify";
+import { useAuth } from "../../context/AuthContext";
 
 const EventFeedbackForm = ({ eventId, eventTitle = "this event" }) => {
+  const { user, isAuthenticated } = useAuth();
+  const authenticated = isAuthenticated();
+
   const [rating, setRating] = useState(0);
   const [hoveredRating, setHoveredRating] = useState(0);
   const [comment, setComment] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
-  // Synchronize and reset form states cleanly whenever switching to a new event context
   useEffect(() => {
-    const key = `feedback-submitted-${eventId}`;
+    if (!authenticated) return;
+    const key = `feedback-submitted-${eventId}-${user?.id || "anon"}`;
     if (localStorage.getItem(key)) {
       setSubmitted(true);
     } else {
-      setSubmitted(false);
-      // 🔥 FIX: Reset the form state when navigating to a new, unreviewed event
       setSubmitted(false);
       setRating(0);
       setHoveredRating(0);
       setComment("");
     }
-    
-    // Wipe out state properties from the preceding event
-    setRating(0);
-    setHoveredRating(0);
-    setComment("");
-  }, [eventId]);
+  }, [eventId, authenticated, user?.id]);
+
+  // Render a login prompt for unauthenticated visitors
+  if (!authenticated) {
+    return (
+      <div className="w-full max-w-2xl mx-auto p-8 rounded-2xl bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 shadow-xl text-center space-y-4">
+        <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-indigo-50 dark:bg-indigo-950/40 text-indigo-600 dark:text-indigo-400">
+          <LogIn className="w-7 h-7" />
+        </div>
+        <h3 className="text-lg font-bold text-slate-900 dark:text-white">
+          Sign in to leave feedback
+        </h3>
+        <p className="text-sm text-slate-500 dark:text-slate-400 max-w-xs mx-auto">
+          Your feedback helps event organizers improve future events. Please log in to share your experience.
+        </p>
+        <Link
+          to="/login"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold transition-colors"
+        >
+          <LogIn className="w-4 h-4" />
+          Log in to submit feedback
+        </Link>
+      </div>
+    );
+  }
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -45,13 +67,11 @@ const EventFeedbackForm = ({ eventId, eventTitle = "this event" }) => {
 
     setIsSubmitting(true);
     try {
-      // Simulate API submit delay
-      await new Promise((resolve) => setTimeout(resolve, 800));
-      
-      localStorage.setItem(`feedback-submitted-${eventId}`, "true");
+      const storageKey = `feedback-submitted-${eventId}-${user?.id || "anon"}`;
+      localStorage.setItem(storageKey, "true");
       setSubmitted(true);
       toast.success("Feedback submitted! Thank you for sharing your thoughts.");
-    } catch (err) {
+    } catch {
       toast.error("Failed to submit feedback. Please try again.");
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
## 🚀 Description

`EventFeedbackForm` had no authentication check. Any unauthenticated visitor could submit feedback for any event, and the only deduplication guard was a per-browser `localStorage` key scoped only to `eventId` — not to the logged-in user. This meant all accounts on the same device shared the same "already submitted" marker, blocking legitimate second users from leaving feedback.

Fixes #7536

## 🛠️ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

**`src/components/feedback/EventFeedbackForm.jsx`**
- Import `useAuth` from `AuthContext` and call `isAuthenticated()` at the top of the component
- When the user is not authenticated, render a styled login prompt with a `<Link to="/login">` button instead of the feedback form — no form controls are accessible to guests
- Scope the `localStorage` submission-tracking key to `eventId + userId` (e.g. `feedback-submitted-<eventId>-<userId>`) so each user on a shared device maintains their own independent submission state
- Include `user.id` in the `useEffect` dependency array so the submitted state re-evaluates correctly when a different user logs in on the same page

## 📸 Screenshots / Video (if applicable)

**Before:** Unauthenticated users could open the form and submit freely.  
**After:** Unauthenticated users see a "Sign in to leave feedback" card with a login link.

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings