### PR TITLE
fix: remove duplicate variable declarations in Hero.js

### DIFF
--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -116,8 +116,6 @@ const Hero = () => {
   const MotionLink = motion(Link);
   
   useDocumentTitle("Eventra | Home");
-  const controls = useAnimation();
-  const prefersReducedMotion = useReducedMotion();
 
   const containerRef = useRef(null);
 


### PR DESCRIPTION
Fixes #7547

## Problem
`Hero.js` had duplicate `const` declarations:
- `controls` declared twice (lines 71 and 119)
- `prefersReducedMotion` declared twice (lines 70 and 120)

This caused a parse error preventing the home page from loading.

## Fix
Removed duplicate declarations on lines 119-120, keeping the original declarations at lines 70-71.

## Testing
- App runs without parse errors
- Home page loads correctly