### PR TITLE
[Critical] fix: registration lock never released after successful submission in EventRegistration page

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -481,7 +481,12 @@ const EventRegistration = () => {
       return;
     }
 
-    proceedWithRegistration();
+    try {
+      await proceedWithRegistration();
+    } finally {
+      isSubmittingRef.current = false;
+      registrationLocks.delete(eventId);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, user, navigate, registrationPath, validateAll, eventId, event, checkEventCapacity, checkAndHandleConflicts, proceedWithRegistration]);
 


### PR DESCRIPTION
**Issue:** Registration lock (egistrationLocks) acquired in handleSubmit is never released when proceedWithRegistration completes successfully.

**Cause:** handleSubmit acquires the lock via egistrationLocks.set(eventId, true) but the happy path calls proceedWithRegistration, which only cleans up its own per-component egistrationLocksRef map — a completely different store. The imported singleton egistrationLocks entry for that event ID is never deleted.

**Fix:** Wrap proceedWithRegistration() in a 	ry/finally that unconditionally deletes the lock:

`js
try {
  await proceedWithRegistration();
} finally {
  isSubmittingRef.current = false;
  registrationLocks.delete(eventId);
}
`

**Additional context:** The early-return paths (capacity check, conflict detection, error catch) already clean up correctly. Only the happy path was missing cleanup.

Closes #7553