### PR TITLE
[Critical] fix: dead apiUtils.post block crashes all event registrations

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -339,20 +339,7 @@ const useEventRegistration = (eventIdParam) => {
     };
 
     try {
-      await apiUtils.post(
-        endpoint,
-        {
-          ...formData,
-          additionalInfo: formData.additionalInfo.slice(0, MAX_NOTES_CHARS),
-          priority: formData.priority,
-          eventId: parseInt(eventId),
-        },
-        token
-      );
-      const isEventFull = event ? event.attendees >= event.maxAttendees : false;
-      // Fixed: Removed local const isEventFull to prevent scope error in catch block.
-      // Now using the hook-level isEventFull variable.
-      if (isEventFull) {
+      if (event && event.attendees >= event.maxAttendees) {
         await eventService.waitlistForEvent(eventId, payload);
       } else {
         await eventService.registerForEvent(eventId, payload);


### PR DESCRIPTION
**Issue:** Dead code block in proceedWithRegistration references undefined piUtils and endpoint variables, throwing a ReferenceError before the actual registration logic can execute. Every registration attempt crashes.

**Cause:** A leftover piUtils.post(endpoint, ...) block was placed before the real registration code, but neither piUtils nor endpoint are defined or imported in the module scope.

**Fix:** Remove the dead code block entirely:

`diff
-    const endpoint = API_ENDPOINTS.EVENTS?.REGISTER
-        ? API_ENDPOINTS.EVENTS.REGISTER(eventId)
-        : /api/events//register;
-
-    try {
-      const response = await apiUtils.post(
-        endpoint,
-        { ...formData, priority: formData.priority, eventId: parseInt(eventId) },
-        { headers: { 'X-Registration-Source': 'event-page' } }
-      );
-      // ...dead response handling...
-    }
-    // ...dead catch block...
`

**Additional context:** Also removed a local const isEventFull that shadowed the hook-level variable of the same name, despite a nearby comment claiming it had already been removed.

Closes #7554