### PR TITLE
[Critical] fix: dual registration lock maps allow concurrent submissions

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -86,7 +86,6 @@ const EventRegistration = () => {
   const [registered, setRegistered] = useState(false);
   const [waitlistPosition, setWaitlistPosition] = useState(-1);
   const isSubmittingRef = useRef(false);
-  const registrationLocksRef = useRef(new Map());
 
   // Conflict detection state
   const [showConflictModal, setShowConflictModal] = useState(false);
@@ -290,7 +289,7 @@ const EventRegistration = () => {
 
     setShowConflictModal(false);
 
-    registrationLocksRef.current.set(eventId, true);
+    registrationLocks.set(eventId, true);
     isSubmittingRef.current = true;
     setSubmitting(true);
 
@@ -310,7 +309,7 @@ const EventRegistration = () => {
         toast.error(err.message || t("eventRegistration.toastRegistrationError"));
         return;
       } finally {
-        registrationLocksRef.current.delete(eventId);
+      registrationLocks.delete(eventId);
         isSubmittingRef.current = false;
         setSubmitting(false);
       }
@@ -439,7 +438,7 @@ const EventRegistration = () => {
       return;
     }
 
-    if (registrationLocksRef.current.has(eventId)) {
+    if (registrationLocks.has(eventId)) {
       toast.error(t("eventRegistration.toastAnotherInProgress"));
       return;
     }


### PR DESCRIPTION
**Issue:** EventRegistration.js maintains two separate lock maps — a per-component egistrationLocksRef (useRef) and an imported singleton egistrationLocks — with inconsistent check/set/delete patterns across handleSubmit, proceedWithRegistration, and handleConflictProceed. This defeats double-submit protection and allows concurrent registrations for the same event.

**Cause:**
- handleSubmit checks egistrationLocksRef (line 441) but sets egistrationLocks (line 450).
- proceedWithRegistration sets and cleans up only egistrationLocksRef (lines 293, 400).
- handleConflictProceed checks egistrationLocks (line 498) instead of the ref.

**Fix:** Remove egistrationLocksRef entirely and use the imported singleton everywhere:

`diff
-  const registrationLocksRef = useRef(new Map());
`

`diff
-    registrationLocksRef.current.set(eventId, true);
+    registrationLocks.set(eventId, true);
`

`diff
-    registrationLocksRef.current.delete(eventId);
+    registrationLocks.delete(eventId);
`

`diff
-    if (registrationLocksRef.current.has(eventId)) {
+    if (registrationLocks.has(eventId)) {
`

Closes #7555