### PR TITLE
[Critical] fix: const registrationLocks shadows ES module import causing SyntaxError

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -55,8 +55,6 @@ import { logAbuseAttempt } from "../../utils/abuseLogger";
 
 export const MAX_NOTES_CHARS = 500;
 
-// Registration lock map to prevent concurrent registrations for the same event
-const registrationLocks = new Map();
 const registrationLimiter = createRateLimiter({
   maxTokens: 3,
   refillRate: 0.2, // roughly 1 token every 5 seconds


### PR DESCRIPTION
**Issue:** A local const registrationLocks = new Map() declaration shadows the ES module import of the same name on the preceding line, causing a parse-time SyntaxError. The module can never be loaded.

**Cause:** Line 50 imports registrationLocks from the utils module; line 59 redeclares the same identifier as a local const in the same module scope.

import registrationLocks from "../../utils/registrationLocks";
// ...
const registrationLocks = new Map();  // SyntaxError: Identifier already declared

**Fix:** Remove the conflicting local declaration. The imported singleton is used everywhere via incr and set/delete.

Closes #7557
