### PR TITLE
fix: use authToken instead of currentToken in offline conflict resolution retries

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -331,10 +331,10 @@ const useOfflineSync = () => {
 
               if (resolution.resolution === "local") {
                 // Retry with force flag
-                res = await postWithBackoff(url, item.payload, currentToken, 0, true, conflictController.signal, item.id);
+                res = await postWithBackoff(url, item.payload, authToken, 0, true, conflictController.signal, item.id);
               } else if (resolution.resolution === "merge") {
                 // Post merged content
-                res = await postWithBackoff(url, resolution.mergedPayload, currentToken, 0, true, conflictController.signal, item.id);
+                res = await postWithBackoff(url, resolution.mergedPayload, authToken, 0, true, conflictController.signal, item.id);
               } else {
                 // Discard local (treated as handled success so we proceed)
                 res = { status: "success" };


### PR DESCRIPTION
## 📋 Description

In `useOfflineSync.js`, line 285 correctly converts "cookie-managed" to null:
`const authToken = currentToken === "cookie-managed" ? null : currentToken;`

But conflict resolution retries at lines 334 and 337 were passing raw
`currentToken` instead of resolved `authToken`, sending
`Authorization: Bearer cookie-managed` — causing all conflict retries to
fail with 401 for cookie-managed sessions.

Fixed by replacing `currentToken` with `authToken` at both retry sites.

## 🔗 Linked Issue

Closes #7275

## 🔄 Type of Change
- [x] 🔒 Security fix

## ✏️ Testing
1. Run `grep -n "postWithBackoff.*currentToken" src/hooks/useOfflineSync.js`
2. Confirm no results returned

## ✅ Self-Review Checklist
- [x] Self-review done
- [x] No new warnings or console errors
- [x] Existing tests pass
- [x] I was assigned to the linked issue before opening this PR