### PR TITLE
perf: merge filter(Boolean).filter() into single pass in conflictDetection

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -217,8 +217,8 @@ export const suggestAlternativeEvents = (
   // filter(Boolean) drops null/undefined entries before accessing .event?.id.
   const safeRegistered = (registeredEvents || []).filter(Boolean);
   const registeredIds = new Set(safeRegistered.map((reg) => reg.event?.id || reg.id));
-  const availableEvents = allEvents.filter(Boolean).filter((event) => {
-    return event.id !== targetEvent.id && !registeredIds.has(event.id);
+  const availableEvents = allEvents.filter((event) => {
+    return event && event.id !== targetEvent.id && !registeredIds.has(event.id);
   });
 
   // Keep only events that don't conflict with existing registrations

--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -179,11 +179,15 @@ export const getTopFeedbackTags = (eventId, limit = 5) => {
 export const getRecommendationStats = (eventId) => {
   try {
     const feedback = getEventFeedback(eventId);
-    const recommendations = feedback.map((f) => f.recommend).filter((r) => r !== undefined);
-
-    const recommendCount = recommendations.filter((r) => r === true).length;
-    const notRecommendCount = recommendations.filter((r) => r === false).length;
-    const total = recommendations.length;
+    const { recommendCount, notRecommendCount, total } = feedback.reduce(
+      (acc, f) => {
+        if (f.recommend === true) acc.recommendCount++;
+        else if (f.recommend === false) acc.notRecommendCount++;
+        if (f.recommend !== undefined) acc.total++;
+        return acc;
+      },
+      { recommendCount: 0, notRecommendCount: 0, total: 0 }
+    );
 
     const percentage = total > 0 ? Math.round((recommendCount / total) * 100) : 0;
 


### PR DESCRIPTION
Fixes #7574

Merges .filter(Boolean).filter() chain into a single .filter() pass, reducing array iterations and intermediate allocation.