### PR TITLE
fix: guard hardcoded test bearer token with NODE_ENV check

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -87,7 +87,7 @@ const ApiDocs = () => {
     status: "all",
     hackathonId: "1",
     sortBy: "recent",
-    authHeader: "Bearer evt_dev_test_token",
+    authHeader: `Bearer ${process.env.NODE_ENV === 'development' ? "evt_dev_test_token" : "[redacted]"}`,
     role: "all",
     page: "1",
   });


### PR DESCRIPTION
Fixes #7578

Makes the dev test token conditional on NODE_ENV so it's not
shipped in production bundles.