### PR TITLE
fix: guard mock credentials with NODE_ENV check to prevent production auth bypass

### DIFF
--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -36,14 +36,16 @@ export const handlers = [
   }),
 
   http.post(`${API_URL}/api/auth/login`, async ({ request }) => {
-    const body = await request.json();
-    if (body.email === "test@eventra.com" && body.password === "password123") {
-      return HttpResponse.json({
-        token: "mock-jwt-token",
-        user: { id: "1", name: "Test User", email: "test@eventra.com" },
-      });
+    if (process.env.NODE_ENV !== 'production') {
+      const body = await request.json();
+      if (body.email === "test@eventra.com" && body.password === "password123") {
+        return HttpResponse.json({
+          token: "mock-jwt-token",
+          user: { id: "1", name: "Test User", email: "test@eventra.com" },
+        });
+      }
+      return new HttpResponse(null, { status: 401 });
     }
-    return new HttpResponse(null, { status: 401 });
   }),
 
   http.post(`${API_URL}/api/auth/signup`, async ({ request }) => {


### PR DESCRIPTION
Fixes #7579

Wraps mock login handler logic in NODE_ENV check so test
credentials can't be used if MSW is accidentally enabled
in production.