### PR TITLE
fix: add JWT verification to logout endpoint

### DIFF
--- a/api/auth/logout.js
+++ b/api/auth/logout.js
@@ -1,1 +1,18 @@
-module.exports = function logout(req, res) { /* FIX: Verify JWT securely before decoding */ return res.status(200).send('Secure Logout'); };
+const jwt = require("jsonwebtoken");
+
+module.exports = function logout(req, res) {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ message: "No valid token provided" });
+    }
+
+    const token = authHeader.split(" ")[1];
+    jwt.verify(token, process.env.JWT_SECRET);
+    req.user = null;
+
+    return res.status(200).json({ message: "Logged out successfully" });
+  } catch (error) {
+    return res.status(401).json({ message: "No valid token provided" });
+  }
+};


### PR DESCRIPTION
Fixes #7569

Previously logout was a no-op returning plaintext. Now verifies the
JWT Bearer token before acknowledging logout, preventing anonymous
logout calls.