### PR TITLE
fix: redact localStorage values in ErrorBoundary diagnostic report for production

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -89,7 +89,7 @@ function buildDiagnosticReport(errorId, error, errorInfo) {
       for (let i = 0; i < localStorage.length; i++) {
         const k = localStorage.key(i);
         if (k && !k.includes("token") && !k.includes("password") && !k.includes("eventra:key-material") && !k.includes("eventra:key-salt")) {
-          try { snap[k] = localStorage.getItem(k)?.slice(0, 200); } catch {}
+          try { snap[k] = process.env.NODE_ENV === "production" ? "[redacted]" : (localStorage.getItem(k)?.slice(0, 200)); } catch {}
         }
       }
       return JSON.stringify(snap, null, 2);
@@ -286,7 +286,7 @@ class ErrorBoundary extends React.Component {
         for (let i = 0; i < localStorage.length; i++) {
           const k = localStorage.key(i);
           if (k && !k.includes("token") && !k.includes("password") && !k.includes("eventra:key-material") && !k.includes("eventra:key-salt")) {
-            try { snap[k] = localStorage.getItem(k)?.slice(0, 200); } catch {}
+            try { snap[k] = process.env.NODE_ENV === "production" ? "[redacted]" : (localStorage.getItem(k)?.slice(0, 200)); } catch {}
           }
         }
         return JSON.stringify(snap, null, 2);


### PR DESCRIPTION
Fixes #7581

In production, localStorage values are redacted to only show keys
(no values). Full key/value display is preserved in development.