### PR TITLE
fix: replace process.env.REACT_APP_* with import.meta.env for Vite compatibility

### DIFF
--- a/src/Pages/HealthCheckPage.jsx
+++ b/src/Pages/HealthCheckPage.jsx
@@ -13,8 +13,8 @@
 
 import { useEffect } from "react";
 
-const APP_VERSION = process.env.REACT_APP_VERSION || "1.0.0";
-const BUILD_TIME = process.env.REACT_APP_BUILD_TIME || new Date().toISOString();
+const APP_VERSION = import.meta.env.VITE_APP_VERSION || import.meta.env.REACT_APP_VERSION || "1.0.0";
+const BUILD_TIME = import.meta.env.VITE_APP_BUILD_TIME || import.meta.env.REACT_APP_BUILD_TIME || new Date().toISOString();
 
 const HealthCheckPage = () => {
   // Update the document title so monitor screenshots are unambiguous

--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -14,16 +14,17 @@ import {
   Eye,
   Languages,
 } from "lucide-react";
-import {
 import { safeJsonParse } from "../../../utils/safeJsonParse";
+import {
   fetchRepository,
   fetchContributors,
   fetchPullRequests,
 } from "../../../utils/githubApiClient";
+import { ENV } from "../../../config/env";
 
 const fetchStat = fetchRepository;
 
-const repoPath = process.env.REACT_APP_GITHUB_REPO || "SandeepVashishtha/Eventra";
+const repoPath = ENV.GITHUB_REPO;
 const [GITHUB_USER, GITHUB_REPO] = repoPath.split("/");
 
 const LS_KEY = "eventra:repoStats";
@@ -71,8 +72,6 @@ export default function GitHubStats() {
 
     (async () => {
       try {
-        // Fire all three requests in parallel — none depends on the others,
-        // so sequential awaits would triple the load time unnecessarily.
         const [repoResult, contributorsResult, prResult] =
           await Promise.allSettled([
             fetchStat(GITHUB_USER, GITHUB_REPO),
@@ -80,10 +79,6 @@ export default function GitHubStats() {
             fetchStat(GITHUB_USER, GITHUB_REPO, { per_page: 1 }),
           ]);
 
-        // Repository data is required; bail out if it failed
-        // repoResult.status === "rejected"
-        // contributorsResult.status === "rejected"
-        // prResult.status === "rejected"
         if (repoResult.status === "rejected") {
           const cached = readCache();
           if (cached) {
@@ -95,7 +90,6 @@ export default function GitHubStats() {
         }
         const repoData = repoResult.value;
 
-        // Contributor count — graceful fallback on failure
         let contribCount = "—";
         if (contributorsResult.status === "fulfilled") {
           const contributors = contributorsResult.value;
@@ -106,7 +100,6 @@ export default function GitHubStats() {
           contribCount = "—";
         }
 
-        // Pull request count — graceful fallback on failure
         let prCount = "—";
         if (prResult.status === "fulfilled") {
           const pullRequests = prResult.value;
@@ -116,7 +109,6 @@ export default function GitHubStats() {
         } else if (prResult.status === "rejected") {
           prCount = "—";
         } else {
-         //console.warn("Failed to fetch pull request count:", prResult.reason);
         }
 
         const next = {
@@ -141,7 +133,6 @@ export default function GitHubStats() {
           setIsLoading(false);
         }
       } catch {
-        //console.warn("GitHub stats fetch failed", err);
         if (!cached && mounted) {
           setStats((s) => ({ ...s, stars: "—", forks: "—", issues: "—" }));
           setIsLoading(false);
@@ -221,14 +212,12 @@ export default function GitHubStats() {
   ], [stats]);
 
   return (
-    // UPDATED: Section background
     <section className="py-16 bg-white dark:bg-black ">
       <div className="max-w-7xl mx-auto px-6">
         <motion.h2
           initial={{ opacity: 0, y: -30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
-          // UPDATED: Title text color with responsive sizing
           className="text-3xl sm:text-4xl font-extrabold text-center text-gray-900 dark:text-gray-100 mb-8 sm:mb-10 px-4"
         >
           Project Statistics
@@ -248,19 +237,14 @@ export default function GitHubStats() {
                   target="_blank" rel="noopener noreferrer"
                   whileHover={{ scale: 1.1, rotate: 1 }}
                   whileTap={{ scale: 0.95 }}
-                  // UPDATED: Card background, border, and responsive sizing
                   className="group flex flex-col items-center justify-center bg-white dark:bg-gray-800 rounded-2xl px-3 py-4 sm:px-6 sm:py-6 md:px-8 shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700 relative overflow-hidden"
                 >
-                  {/* Glow effect */}
-                  {/* UPDATED: Glow effect for dark mode */}
                   <div className="absolute inset-0 bg-black/5 opacity-0 group-hover:opacity-100 transition duration-700 blur-3xl rounded-2xl"></div>
 
                   <div className="z-10 flex flex-col items-center space-y-2 sm:space-y-3">
-                    {/* UPDATED: Icon wrapper background with responsive sizing */}
                     <div className="p-2 sm:p-3 md:p-4 bg-gray-50 dark:bg-gray-700 rounded-full shadow-inner [&>svg]:w-7 [&>svg]:h-7 sm:[&>svg]:w-9 sm:[&>svg]:h-9 md:[&>svg]:w-10 md:[&>svg]:h-10">
                       {icon}
                     </div>
-                    {/* UPDATED: Text colors with responsive sizing */}
                     <p className="text-base sm:text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100 text-center break-words px-1">
                       {value}
                     </p>
@@ -269,7 +253,6 @@ export default function GitHubStats() {
                     </p>
                   </div>
 
-                  {/* UPDATED: Icon color */}
                   <ExternalLink
                     size={16}
                     className="absolute top-3 right-3 text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 transition duration-300"

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -718,7 +718,7 @@ const AdminDashboard = () => {
             <p className="ad-footer-copyright">© {new Date().getFullYear()} Eventra. Admin Control Panel.</p>
             <div className="ad-footer-links">
               <Link to="/helpcenter" className="ad-footer-link">Help Center</Link>
-              <a href={`https://github.com/${process.env.REACT_APP_GITHUB_REPO || 'sandeepvashishtha/Eventra'}`} target="_blank" rel="noopener noreferrer" className="ad-footer-link">GitHub</a>
+              <a href={`https://github.com/${import.meta.env.VITE_GITHUB_REPO || import.meta.env.REACT_APP_GITHUB_REPO || 'sandeepvashishtha/Eventra'}`} target="_blank" rel="noopener noreferrer" className="ad-footer-link">GitHub</a>
               <Link to="/privacy" className="ad-footer-link">Privacy Policy</Link>
               <Link to="/terms" className="ad-footer-link">Terms of Service</Link>
             </div>

--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -125,7 +125,7 @@ export const generateEventSharingData = (event, baseUrl = null) => {
   }
 
   // Determine the correct base URL for sharing
-  const rawPublicUrl = process.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech";
+  const rawPublicUrl = import.meta.env.VITE_PUBLIC_URL || import.meta.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech";
 
   // If baseUrl is provided, use it, otherwise detect
   if (!baseUrl) {


### PR DESCRIPTION
Fixes #7608

Replaces \process.env.REACT_APP_GITHUB_REPO\, \REACT_APP_PUBLIC_URL\, \REACT_APP_VERSION\, and \REACT_APP_BUILD_TIME\ with \import.meta.env.VITE_*\ equivalents.

**Why it matters:** Vite only exposes \VITE_\-prefixed env vars to client code. \REACT_APP_\ references silently resolve to \undefined\ at runtime, causing hardcoded fallback strings (repo name, public URL, version) to be permanently compiled into the production bundle. This leaks internal infrastructure details, makes config changes require a full redeploy, and breaks if the project is ever forked or deployed to a different domain.