### PR TITLE
devops: add Content-Security-Policy headers to netlify, nginx, and Vercel middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -71,6 +71,7 @@ const SECURITY_HEADERS = {
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Permissions-Policy": "camera=(), microphone=(), geolocation=(), display-capture=()",
+  "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; frame-src 'self' https://accounts.google.com",
 };
 
 const addSecurityHeaders = (headers) => {

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,6 +24,7 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=(), payment=(), usb=(), bluetooth=()"
     Cross-Origin-Opener-Policy = "same-origin-allow-popups"
     Cross-Origin-Resource-Policy = "same-site"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; frame-src 'self' https://accounts.google.com"
 
 [[headers]]
   for = "/"

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,8 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; frame-src 'self' https://accounts.google.com";
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
Fixes #7614

Adds \Content-Security-Policy\ to netlify.toml, nginx.conf, and Vercel Edge Middleware.

**Why it matters:** All three deployment targets set HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy — but none set CSP, the most powerful defense-in-depth against XSS. A single XSS vulnerability anywhere in the application allows an attacker to execute arbitrary scripts, exfiltrate auth tokens, and perform UI redressing. CSP restricts which origins scripts, styles, and connections the browser trusts, stopping XSS even if injection occurs.