### PR TITLE
perf: add production guard to logger warn/error and use import.meta.env

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,6 +1,5 @@
  
-const isDevelopment =
-  typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production";
+const isDevelopment = import.meta.env.DEV;
 
 const formatMessage = (level, message) => {
   return `[${level.toUpperCase()}] ${message}`;
@@ -20,11 +19,15 @@ export const logger = {
   },
 
   warn: (...args) => {
-    console.warn(formatMessage("warn", args[0]), ...args.slice(1));
+    if (isDevelopment) {
+      console.warn(formatMessage("warn", args[0]), ...args.slice(1));
+    }
   },
 
   error: (...args) => {
-    console.error(formatMessage("error", args[0]), ...args.slice(1));
+    if (isDevelopment) {
+      console.error(formatMessage("error", args[0]), ...args.slice(1));
+    }
   },
 };
 // ... rest of your code


### PR DESCRIPTION
Fixes #7615

Adds \isDevelopment\ guard to \warn\ and \error\ methods. Replaces \process.env.NODE_ENV\ with \import.meta.env.DEV\.

**Why it matters:** \warn\ and \error\ logged unconditionally while \log\ and \info\ were already guarded — inconsistent. In production, these console calls inflate the bundle (not tree-shaken) and leak internal application state via browser devtools to any user who opens the console. Using \import.meta.env.DEV\ is also more reliable than \process.env.NODE_ENV\ in Vite builds since Vite uses \define\ to replace it at build time.