### PR TITLE
fix: add CSRF meta tag to index.html enabling CSRF protection

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,9 @@
     <meta property="og:url" content="https://eventra.vercel.app/" />
     <meta property="og:image" content="https://eventra.sandeepvashishtha.in/logo_transparent.png" />
 
+    <!-- CSRF Protection -->
+    <meta name="csrf-token" content="%CSRF_TOKEN%" />
+
     <!-- Google Sign In -->
     <meta
       name="google-signin-client_id"


### PR DESCRIPTION
﻿Fixes #7617

Adds <meta name="csrf-token" content="%CSRF_TOKEN%"> to index.html.

**Why it matters:** The csrfToken.js utility first checks for this meta tag to attach the X-CSRF-Token header to POST/PUT/PATCH/DELETE requests. No meta tag existed, so the fallback reads the XSRF-TOKEN cookie via document.cookie — which returns 
ull if the cookie is HttpOnly (as it should be). The result: the X-CSRF-Token header was never attached, making CSRF protection completely non-functional. Any external site could forge authenticated requests on behalf of logged-in users. Adding the meta tag placeholder lets the server inject the token so the client-side CSRF utility actually works.
