### PR TITLE
Fix: Add missing rel="noopener noreferrer" to external links for secu…

### DIFF
--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -240,7 +240,7 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
                   <a
                     href="https://example.com"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="p-2.5 text-gray-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg border border-white/5 hover:border-indigo-500/20 transition-all"
                     title="Website"
                   >
@@ -249,7 +249,7 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
                   <a
                     href="https://linkedin.com"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="p-2.5 text-gray-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg border border-white/5 hover:border-indigo-500/20 transition-all"
                     title="LinkedIn"
                   >
@@ -258,7 +258,7 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
                   <a
                     href="https://twitter.com"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="p-2.5 text-gray-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg border border-white/5 hover:border-indigo-500/20 transition-all"
                     title="Twitter"
                   >
@@ -267,7 +267,7 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
                   <a
                     href="https://github.com"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     className="p-2.5 text-gray-400 hover:text-indigo-400 hover:bg-indigo-500/10 rounded-lg border border-white/5 hover:border-indigo-500/20 transition-all"
                     title="GitHub"
                   >

--- a/src/stories/Configure.mdx
+++ b/src/stories/Configure.mdx
@@ -50,7 +50,7 @@ export const RightArrow = () => <svg
       <a
         className="sb-action-link"
         href="https://storybook.js.org/docs/configure/styling-and-css/?renderer=react&ref=configure"
-        target="_blank"
+        target="_blank" rel="noopener noreferrer"
       >Learn more<RightArrow /></a>
     </div>
     <div className="sb-section-item">
@@ -63,7 +63,7 @@ export const RightArrow = () => <svg
       <a
         className="sb-action-link"
         href="https://storybook.js.org/docs/writing-stories/decorators/?renderer=react&ref=configure#context-for-mocking"
-        target="_blank"
+        target="_blank" rel="noopener noreferrer"
       >Learn more<RightArrow /></a>
     </div>
     <div className="sb-section-item">
@@ -76,7 +76,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/configure/images-and-assets/?renderer=react&ref=configure"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
     </div>
@@ -99,7 +99,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/writing-docs/autodocs/?renderer=react&ref=configure"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
       <div className="sb-grid-item">
@@ -109,7 +109,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/sharing/publish-storybook/?renderer=react&ref=configure#publish-storybook-with-chromatic"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
       <div className="sb-grid-item">
@@ -120,7 +120,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/sharing/design-integrations/?renderer=react&ref=configure#embed-storybook-in-figma-with-the-plugin"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
       <div className="sb-grid-item">
@@ -131,7 +131,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/writing-tests/?renderer=react&ref=configure"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
       <div className="sb-grid-item">
@@ -141,7 +141,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/writing-tests/accessibility-testing/?renderer=react&ref=configure"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
       <div className="sb-grid-item">
@@ -151,7 +151,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://storybook.js.org/docs/configure/theming/?renderer=react&ref=configure"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Learn more<RightArrow /></a>
       </div>
     </div>
@@ -164,7 +164,7 @@ export const RightArrow = () => <svg
     <a
         className="sb-action-link"
         href="https://storybook.js.org/addons/?ref=configure"
-        target="_blank"
+        target="_blank" rel="noopener noreferrer"
       >Discover all addons<RightArrow /></a>
   </div>
   <div className='sb-addon-img'>
@@ -180,7 +180,7 @@ export const RightArrow = () => <svg
       <a
         className="sb-action-link"
         href="https://github.com/storybookjs/storybook"
-        target="_blank"
+        target="_blank" rel="noopener noreferrer"
       >Star on GitHub<RightArrow /></a>
     </div>
     <div className="sb-section-item">
@@ -191,7 +191,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://discord.gg/storybook"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Join Discord server<RightArrow /></a>
       </div>
     </div>
@@ -203,7 +203,7 @@ export const RightArrow = () => <svg
         <a
           className="sb-action-link"
           href="https://www.youtube.com/@chromaticui"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Watch on YouTube<RightArrow /></a>
       </div>
     </div>
@@ -214,7 +214,7 @@ export const RightArrow = () => <svg
       <a
           className="sb-action-link"
           href="https://storybook.js.org/tutorials/?ref=configure"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
         >Discover tutorials<RightArrow /></a>
     </div>
 </div>
@@ -386,3 +386,4 @@ export const RightArrow = () => <svg
   }
   `}
 </style>
+


### PR DESCRIPTION
## Description
This PR addresses a minor security and best-practice issue by adding the missing `rel="noopener noreferrer"` attribute to external links utilizing `target="_blank"`. 

Adding this attribute prevents potential "reverse tabnabbing" attacks, where a newly opened malicious tab could gain partial access to the original tab's `window.opener` object to hijack the user's session.

**Files updated:**
- `src/components/events/VirtualBoothModal.jsx`
- `src/stories/Configure.mdx`

Fixes #7627 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)
N/A - Behind the scenes HTML attribute fix.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment
