### PR TITLE
[Critical] fix: add missing useMemo import to useBookmarks hook

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -2,7 +2,7 @@
  * @fileoverview useBookmarks - Event bookmarks management hook
  * @module hooks/useBookmarks
  */
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { safeJsonParse } from "../utils/safeJsonParse";
 
 // Simple synchronous hash to avoid exposing raw userId (email) in localStorage keys.


### PR DESCRIPTION
**Issue**
The `useBookmarks` hook calls `useMemo()` on line 105 but never imports it from React. The import only includes `useState`, `useEffect`, `useCallback`, `useRef`. Any component using this hook throws a `ReferenceError: useMemo is not defined` at runtime.

**Cause**
The import on line 5 was written as:
```
import { useState, useEffect, useCallback, useRef } from "react";
```
But `useMemo` is called on line 105:
```
const bookmarksSet = useMemo(() => {
  return new Set(bookmarks.map(e => e.id));
}, [bookmarks]);
```

**Fix**
Added `useMemo` to the React import:
```
import { useState, useEffect, useCallback, useRef, useMemo } from "react";
```

**Additional context**
This causes a runtime crash on any page that uses bookmarks. The `bookmarksSet` is used for O(1) lookups in toggle logic — without it, every access to bookmarks state throws a ReferenceError and the React error boundary catches a blank screen. This was not caught by linting because eslint's `no-unused-vars` only flags unused imports, not missing named imports from bare specifiers.

**Closes #7629**