### PR TITLE
[Critical] fix: disconnect MutationObserver in BackToTop cleanup to prevent memory leak

### DIFF
--- a/src/components/common/BackToTop.jsx
+++ b/src/components/common/BackToTop.jsx
@@ -40,19 +40,11 @@ const BackToTop = ({
     if (typeof document !== "undefined" && avoidChatbot) {
       observer.observe(document.body, { childList: true });
     }
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, [handleScroll]);
-
-  useEffect(() => {
     return () => {
-      try {
-        // disconnect observer if present
-        // noop — observer variable not in scope here; rely on GC for simple page lifecycles
-      } catch {
-        // ignore
-      }
+      window.removeEventListener("scroll", handleScroll);
+      observer.disconnect();
     };
-  }, []);
+  }, [handleScroll]);
 
   const scrollToTop = () => {
     if (window.lenis) {


### PR DESCRIPTION
**Issue**
The `BackToTop` component creates a `MutationObserver` to detect chatbot DOM presence but never disconnects it when the component unmounts. The cleanup function only removes the scroll event listener. A second `useEffect` explicitly acknowledges this with a noop comment: "observer variable not in scope here; rely on GC for simple page lifecycles."

**Cause**
The first `useEffect` creates and starts the observer but its cleanup only handles the scroll listener:
```
return () => window.removeEventListener("scroll", handleScroll);
```
The observer variable (`observer`) is in scope at cleanup time but was never disconnected.

**Fix**
Removed the dead second `useEffect` and added `observer.disconnect()` to the first effect's cleanup:
```
return () => {
  window.removeEventListener("scroll", handleScroll);
  observer.disconnect();
};
```

**Additional context**
The observer's callback captures `setIsChatbotOpen` via closure and continues calling `setState` on an unmounted component after `BackToTop` is removed from the tree. On pages with frequent mount/unmount cycles (SPA route transitions), the leaked observer accumulates memory and causes React warnings.

**Closes #7630**