### PR TITLE
[Critical] fix: use ref to prevent stale values in useFormValidation.enhanced debounced validation

### DIFF
--- a/src/hooks/useFormValidation.enhanced.js
+++ b/src/hooks/useFormValidation.enhanced.js
@@ -48,6 +48,8 @@ export const useFormValidation = (
   const timeoutRefs = useRef({});
   const validationCacheRef = useRef({});
   const isMountedRef = useRef(true);
+  const valuesRef = useRef(values);
+  useEffect(() => { valuesRef.current = values; }, [values]);
 
   /**
    * Clear debounce timeout for a field
@@ -223,8 +225,9 @@ export const useFormValidation = (
         }
 
         timeoutRefs.current[name] = setTimeout(async () => {
+          const currentValues = valuesRef.current;
           const error = await validateField(name, fieldValue, {
-            ...values,
+            ...currentValues,
             [name]: fieldValue,
           });
           if (isMountedRef.current) {
@@ -245,13 +248,13 @@ export const useFormValidation = (
       setTouched((prev) => ({ ...prev, [name]: true }));
 
       if (validationRules[name] && validateOnBlur) {
-        const error = await validateField(name, value, values);
+        const error = await validateField(name, value, valuesRef.current);
         if (isMountedRef.current) {
           setErrors((prev) => ({ ...prev, [name]: error }));
         }
       }
     },
-    [validationRules, values, validateField, validateOnBlur],
+    [validationRules, validateField, validateOnBlur],
   );
 
   /**


### PR DESCRIPTION
**Issue**
The debounced `handleChange` and `handleBlur` callbacks capture `values` from their closure at creation time. Since these callbacks are recreated on every values change (they have `values` in their dependency array), a scheduled timeout still holds `values` from a previous render. Cross-field validators (password confirmation, date ranges) receive stale sibling values, causing false validation errors.

**Cause**
In `handleChange`, the timeout closure captures `values` directly:
```
timeoutRefs.current[name] = setTimeout(async () => {
  const error = await validateField(name, fieldValue, {
    ...values,    // stale — captured when timeout was scheduled
    [name]: fieldValue,
  });
  ...
}, debounceMs);
```

**Runtime scenario:**
1. User types "abc" in `password` field. Timeout T1 is scheduled with `values = { password: "abc", confirm: "" }`.
2. User types "abc" in `confirm` field. Timeout T2 is scheduled with fresh `values`.
3. T1 fires using stale `values` where `confirm` is empty — a "passwords must match" check incorrectly fails.

**Fix**
Added a `valuesRef` synced via `useEffect` so the timeout always reads the latest values:
```
const valuesRef = useRef(values);
useEffect(() => { valuesRef.current = values; }, [values]);

// Inside handleChange:
const currentValues = valuesRef.current;
const error = await validateField(name, fieldValue, { ...currentValues, [name]: fieldValue });
```

**Additional context**
The `handleBlur` callback had the same issue and was also fixed. Its dependency array no longer needs `values` since it reads from the ref directly.

**Closes #7631**