### PR TITLE
[Critical] fix: add clipboard API guard with textarea fallback in ContributorGuide

### DIFF
--- a/src/Pages/Leaderboard/ContributorGuide.js
+++ b/src/Pages/Leaderboard/ContributorGuide.js
@@ -148,11 +148,25 @@ const ContributorGuide = () => {
     },
   ];
 
-  const copyCommand = (cmd, id) => {
-    navigator.clipboard.writeText(cmd).then(() => {
+  const copyCommand = async (cmd, id) => {
+    try {
+      if (navigator?.clipboard) {
+        await navigator.clipboard.writeText(cmd);
+      } else {
+        const textArea = document.createElement("textarea");
+        textArea.value = cmd;
+        textArea.style.position = "fixed";
+        textArea.style.opacity = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textArea);
+      }
       setCopied(id);
       setTimeout(() => setCopied(""), 2000);
-    }).catch(() => {});
+    } catch (err) {
+      console.warn("Failed to copy command:", err);
+    }
   };
 
   return (


### PR DESCRIPTION
**Issue**
The `copyCommand` function calls `navigator.clipboard.writeText(cmd)` without checking if the Clipboard API is available. When clipboard access is denied or unavailable (HTTP context, older browsers, blocked permissions), the promise rejects and the error is silently swallowed by `.catch(() => {})`. The user sees no feedback and believes the command was copied.

**Cause**
Direct clipboard API call with no guard:
```
const copyCommand = (cmd, id) => {
  navigator.clipboard.writeText(cmd).then(() => {
    setCopied(id);
    setTimeout(() => setCopied(""), 2000);
  }).catch(() => {});
};
```

**Fix**
Added a guard checking `navigator?.clipboard` with a textarea fallback using `document.execCommand('copy')`:
```
const copyCommand = async (cmd, id) => {
  try {
    if (navigator?.clipboard) {
      await navigator.clipboard.writeText(cmd);
    } else {
      const textArea = document.createElement("textarea");
      textArea.value = cmd;
      textArea.style.position = "fixed";
      textArea.style.opacity = "0";
      document.body.appendChild(textArea);
      textArea.select();
      document.execCommand("copy");
      document.body.removeChild(textArea);
    }
    setCopied(id);
    setTimeout(() => setCopied(""), 2000);
  } catch (err) {
    console.warn("Failed to copy command:", err);
  }
};
```

**Additional context**
`navigator.clipboard` is only available in secure contexts (HTTPS or localhost). The existing `copyToClipboard` utility in `shareUtils.js:174` already handles this correctly with the same textarea fallback pattern. The fix aligns `ContributorGuide.js` with that established pattern.

**Closes #7632**