### PR TITLE
fix: memoize calculateCompletion and filteredSuggestions in EditProfile to avoid unnecessary recomputation on every render

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom"; // 🔥 FIX: Required for Modal Portal
 import { useAuth } from "../../context/AuthContext";
 import { useNavigate } from "react-router-dom";
@@ -203,7 +203,7 @@ const EditProfile = () => {
     return Math.round((filled / 10) * 100);
   };
 
-  const completionPercentage = calculateCompletion();
+  const completionPercentage = useMemo(() => calculateCompletion(), [form, user]);
 
   const addSkill = (skill) => {
     const trimmedSkill = skill.trim();
@@ -295,14 +295,18 @@ const EditProfile = () => {
     }
   };
 
-  const filteredSuggestions = allSkillSuggestions
-    .filter(
-      (suggestion) =>
-        currentSkillInput &&
-        suggestion.toLowerCase().includes(currentSkillInput.toLowerCase()) &&
-        !form.skills.some((s) => s.toLowerCase() === suggestion.toLowerCase())
-    )
-    .slice(0, 7);
+  const filteredSuggestions = useMemo(
+    () =>
+      allSkillSuggestions
+        .filter(
+          (suggestion) =>
+            currentSkillInput &&
+            suggestion.toLowerCase().includes(currentSkillInput.toLowerCase()) &&
+            !form.skills.some((s) => s.toLowerCase() === suggestion.toLowerCase())
+        )
+        .slice(0, 7),
+    [currentSkillInput, form.skills]
+  );
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900 py-10 px-4">


### PR DESCRIPTION
## Summary
Fixes two unmemoized computations in EditProfile.js that ran on every render
regardless of whether their inputs had changed.

## Problem 1 — calculateCompletion
Called as a plain function on every render. Iterates over all profile fields
on every keystroke even when form and user have not changed.

## Problem 2 — filteredSuggestions
Filtered 43 skill suggestions on every render. Only depends on
currentSkillInput and form.skills but ran on all unrelated state updates too.

## Fix
- Added useMemo to the React import
- Wrapped calculateCompletion result in useMemo([form, user])
- Wrapped filteredSuggestions in useMemo([currentSkillInput, form.skills])

## Changes
- src/components/user/EditProfile.js

Closes #7426  #7429 