### PR TITLE
chore: include playwright executable to prevent CI prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "globals": "17.6.0",
         "jsdom": "^29.1.1",
         "lint-staged": "^17.0.7",
+        "playwright": "1.60.0",
         "postcss": "8.5.15",
         "prettier": "^3.2.5",
         "storybook": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",
     "@playwright/test": "1.60.0",
+    "playwright": "1.60.0",
     "@storybook/addon-a11y": "^10.4.1",
     "@storybook/addon-docs": "^10.4.1",
     "@storybook/addon-onboarding": "^10.4.1",


### PR DESCRIPTION
Closes #6354

This PR adds the base `playwright` package to `devDependencies`. This resolves the interactive prompt (`Ok to proceed? (y)`) that currently causes `npx playwright` commands to block or fail in the non-interactive GitHub Actions CI/CD environment when the runner attempts to install missing executables.