### PR TITLE
fix: update invalid Discord invite link on leaderboard page

### DIFF
--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -855,7 +855,7 @@ const timeLeft = useCountdown(
           <motion.button
             whileHover={{ scale: 1.03 }}
             whileTap={{ scale: 0.98 }}
-            onClick={() => window.open("https://discord.gg/eventra", "_blank", "noopener,noreferrer")}
+            onClick={() => window.open("https://discord.gg/6MQ9r5nHT", "_blank", "noopener,noreferrer")}
             className="px-6 sm:px-8 py-3 rounded-full font-semibold text-white bg-[#5865F2] hover:bg-[#4752C4] shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-[#5865F2] focus:ring-offset-2 dark:focus:ring-offset-black"
           >
             <MessageCircle className="w-4 h-4" aria-hidden="true" />


### PR DESCRIPTION
## Description
The "Join Discord" button on the GSSoC Leaderboard page was using an invalid Discord invite link `https://discord.gg/eventra` which showed an "Invalid Invite" error on Discord. 

Fixes #7678 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports