### PR TITLE
fix: added SSR guard to abuseLogger to prevent localStorage crash on server

### DIFF
--- a/src/utils/abuseLogger.js
+++ b/src/utils/abuseLogger.js
@@ -1,4 +1,6 @@
 export const logAbuseAttempt = (type, details = {}) => {
+  if (typeof window === "undefined") return;
+
   try {
     let existing;
     try {


### PR DESCRIPTION
Closes #7705.

Summary of What Has Been Done:
abuseLogger.js called localStorage.getItem/setItem directly without checking if window is defined. In SSR (Node.js, Next.js server components), window is undefined and these calls throw ReferenceError, crashing any code that imports the module.

Changes Made:
- Added `if (typeof window === "undefined") return;` as the first line of logAbuseAttempt.
- Verified no crash in Node.js (SSR simulation).
- Files changed: `src/utils/abuseLogger.js` (1 file, +2 lines).

Impact it Made:
- Makes the module safe to import in SSR/serverless environments.
- Prevents deployment crashes in Next.js or Vercel serverless functions.
- Follows the same typeof window guard pattern used by other localStorage utilities in the codebase (readNotificationPreferences, etc.).