### PR TITLE
fix: added SSR guard to useInstallPrompt to prevent window crash on server

### DIFF
--- a/src/hooks/useInstallPrompt.js
+++ b/src/hooks/useInstallPrompt.js
@@ -5,6 +5,8 @@ export function useInstallPrompt() {
   const [isInstallable, setIsInstallable] = useState(false);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+
     const handler = (e) => {
       e.preventDefault();
       setDeferredPrompt(e);


### PR DESCRIPTION
Closes #7706.

Summary of What Has Been Done:
useInstallPrompt registered a window.addEventListener listener in useEffect without a typeof window guard. In SSR environments (Node.js, Next.js), window is undefined and the code crashes.

Changes Made:
- Added `if (typeof window === "undefined") return;` as the first line of the useEffect.
- Consistent with usePageVisibility and useReducedMotion which already guard window access.
- Files changed: `src/hooks/useInstallPrompt.js` (1 file, +3/-1 lines).

Impact it Made:
- Makes the hook safe to import in SSR/serverless React environments.
- Prevents runtime crashes when the component is server-rendered.