### PR TITLE
fix: return empty string for invalid input in getOptimizedImageUrl instead of falsy value

### DIFF
--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -22,7 +22,7 @@
  * @returns {string}
  */
 export const getOptimizedImageUrl = (originalUrl, options = {}) => {
-  if (!originalUrl || typeof originalUrl !== "string") return originalUrl;
+  if (!originalUrl || typeof originalUrl !== "string") return "";
 
   // If already a Cloudinary URL, return as is
   if (originalUrl.includes("res.cloudinary.com")) {


### PR DESCRIPTION
Closes #7707.

Summary of What Has Been Done:
getOptimizedImageUrl returned the original falsy value (null, undefined, 0, false) when input was not a valid string URL. Callers that use the return value as a string URL break at runtime with TypeError.

Changes Made:
- Changed `return originalUrl` to `return ""` in the invalid-input guard.
- All falsy inputs (null, undefined, 0, false) now return an empty string instead of their original value.
- Empty string is a valid, handleable value that callers can check and skip rendering for.
- Files changed: `src/utils/imageOptimizer.js` (1 file, +1/-1 lines).

Impact it Made:
- All callers receive a string instead of undefined/null, preventing TypeError in downstream code.
- Consistent with how other URL-building utilities in the codebase handle invalid input.