### PR TITLE
fix: added null guards to generateCompatibilityScore to prevent crashes

### DIFF
--- a/src/utils/aiMatchmaking.js
+++ b/src/utils/aiMatchmaking.js
@@ -6,20 +6,22 @@
  */
 
 export const generateCompatibilityScore = (userA, userB) => {
+  if (!userA || !userB) return 0;
+
   // In a real implementation, this would involve vector embeddings of user profiles,
   // past events attended, and explicit interests.
   let score = 50;
-  
+
   const skillsA = userA.skills || [];
   const skillsB = userB.skills || [];
-  
+
   const skillsBSet = new Set(skillsB);
   const commonSkills = skillsA.filter(s => skillsBSet.has(s));
   score += commonSkills.length * 10;
-  
+
   if (userA.industry === userB.industry) score += 15;
   if (userA.role !== userB.role) score += 5; // e.g. Designer meets Developer
-  
+
   return Math.min(score, 99);
 };
 


### PR DESCRIPTION
Closes #7715.

Summary of What Has Been Done:
generateCompatibilityScore accessed userA.skills and userB.skills without null checks. When either user was null or undefined, this threw TypeError: Cannot read property of null. The function is called in the matchmaking UI without guaranteed non-null user objects.

Changes Made:
- Added `if (!userA || !userB) return 0;` guard at the start of generateCompatibilityScore.
- Returns a safe default score (0) for invalid inputs instead of crashing.
- Files changed: `src/utils/aiMatchmaking.js` (1 file, +6/-4 lines).

Impact it Made:
- Prevents runtime TypeError crashes when user data is missing or still loading.
- Makes the matchmaking flow resilient to partial data.