### PR TITLE
fix: validate JWT structure before trusting eyJ-prefixed QR code

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -194,7 +194,7 @@ export default function TicketScanner() {
     try {
       ticketData = JSON.parse(decodedText);
     } catch {
-      if (decodedText.startsWith("eyJ")) {
+      if (decodedText.startsWith("eyJ") && decodedText.split(".").length === 3) {
         const activeEvent = events.find(e => String(e.id) === String(selectedEventId));
         ticketData = {
           ticketId: decodedText,


### PR DESCRIPTION
## Description

In `src/components/admin/TicketScanner.jsx` at line 197, the `handleScanSuccess`
function was accepting any string starting with "eyJ" as a valid JWT ticket.
"eyJ" is just base64 for `{"` — any arbitrary string beginning with it would
bypass the invalid QR rejection and be sent to `validateTicket()`.

Fixed by adding a proper JWT structure check — the string must have exactly
3 dot-separated parts (header.payload.signature) to be treated as a valid ticket.

Fixes #7689

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
if (decodedText.startsWith("eyJ")) {
```
After:
```js
if (decodedText.startsWith("eyJ") && decodedText.split(".").length === 3) {
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings