### PR TITLE
fix: replace fake text/plain blob with real jsPDF ticket generation

### DIFF
--- a/src/utils/exportTicketToPdf.js
+++ b/src/utils/exportTicketToPdf.js
@@ -1,34 +1,24 @@
-// Mock implementation for exporting an event ticket to PDF
-// Requires a PDF library like html2pdf.js or jspdf in a full implementation
-
 import { logger } from "./logger.js";
+import { jsPDF } from "jspdf";
 
 export const exportTicketToPdf = async (event, userData) => {
-  logger.log("Generating Scannable PDF Ticket for:", event?.title);
-  
-  // Create a synthetic blob to simulate downloading a PDF file
-  const mockPdfContent = `
-    Eventra Ticket: ${event?.title || 'Unknown Event'}
-    Attendee: ${userData?.name || 'Guest'}
-    Location: ${event?.location || 'Virtual'}
-    Date: ${event?.date || new Date().toLocaleDateString()}
-    ---------------------------------------------------
-    [MOCK QR CODE AND SCANNABLE BARCODE GOES HERE]
-  `;
+  logger.log("Generating PDF Ticket for:", event?.title);
 
-  const blob = new Blob([mockPdfContent], { type: "text/plain" }); // Using text/plain for mock
-  const url = URL.createObjectURL(blob);
-  
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = `Eventra_Ticket_${event?.id || 'event'}.pdf`;
-  document.body.appendChild(a);
-  a.click();
-  
-  setTimeout(() => {
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  }, 100);
+  const doc = new jsPDF();
+
+  doc.setFontSize(20);
+  doc.text("Eventra Ticket", 105, 20, { align: "center" });
+
+  doc.setFontSize(14);
+  doc.text(`Event: ${event?.title || "Unknown Event"}`, 20, 50);
+  doc.text(`Attendee: ${userData?.name || "Guest"}`, 20, 65);
+  doc.text(`Location: ${event?.location || "Virtual"}`, 20, 80);
+  doc.text(`Date: ${event?.date || new Date().toLocaleDateString()}`, 20, 95);
+
+  doc.setFontSize(10);
+  doc.text("Thank you for registering with Eventra!", 105, 120, { align: "center" });
+
+  doc.save(`Eventra_Ticket_${event?.id || "event"}.pdf`);
 
   return true;
 };


### PR DESCRIPTION
## Description

`src/utils/exportTicketToPdf.js` was creating a `Blob` with `type: "text/plain"`
and saving it with a `.pdf` extension. Any PDF reader would fail to open it.

Replaced the mock implementation with a real PDF using `jsPDF` (already in
`package.json` at v4.2.1), consistent with how `EventTicket.js` and
`EventBadgeGenerator.jsx` use it elsewhere in the project.

Fixes #7690

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
const blob = new Blob([mockPdfContent], { type: "text/plain" });
a.download = `Eventra_Ticket_${event?.id}.pdf`;
```
After:
```js
const doc = new jsPDF();
doc.text(`Event: ${event?.title}`, 20, 50);
doc.save(`Eventra_Ticket_${event?.id}.pdf`);
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings