### PR TITLE
fix: use optional chaining on event.description.slice to prevent null crash

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -286,7 +286,7 @@ const EventDetails = () => {
       <Helmet>
         <title>{event.title} | Eventra</title>
         <meta property="og:title" content={event.title} />
-        <meta property="og:description" content={event.description.slice(0, 160)} />
+        <meta property="og:description" content={event.description?.slice(0, 160) || ""} />
         <meta property="og:image" content={event.image} />
         <meta property="og:url" content={window.location.href} />
         <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
## Description

In `src/Pages/Events/EventDetails.js` at line 289, the Open Graph meta tag
called `event.description.slice(0, 160)` with no null check. If the API
returns an event where description is null or undefined, this throws:
`TypeError: Cannot read properties of null (reading 'slice')`
and crashes the entire component.

Fixed by using optional chaining and a fallback empty string:
`event.description?.slice(0, 160) || ""`

Fixes #7691

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
<meta property="og:description" content={event.description.slice(0, 160)} />
```
After:
```js
<meta property="og:description" content={event.description?.slice(0, 160) || ""} />
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings