### PR TITLE
fix: normalize activity level to lowercase before comparison to fix badge styling

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -697,11 +697,11 @@ export default function CollaborationNetworkMap() {
 
                     <div
                       className={`flex items-center gap-1 px-3 py-1 rounded-full text-xs font-semibold
-                      ${(activeHub || pinnedHub).activity === "critical"
+                      ${(activeHub || pinnedHub).activity?.toLowerCase() === "critical"
                         ? "bg-red-100 text-red-600"
-                        : (activeHub || pinnedHub).activity === "high"
+                        : (activeHub || pinnedHub).activity?.toLowerCase() === "high"
                         ? "bg-orange-100 text-orange-600"
-                        : (activeHub || pinnedHub).activity === "medium"
+                        : (activeHub || pinnedHub).activity?.toLowerCase() === "medium"
                         ? "bg-yellow-100 text-yellow-700"
                         : "bg-green-100 text-green-600"
                       }`}


### PR DESCRIPTION
## Description

In `src/components/visual/CollaborationNetworkMap.jsx`, the HUBS data
stores activity values as capitalized strings: "Critical", "High", "Medium".
However, the popup card CSS class conditionals at lines 700–704 compared
against lowercase strings: "critical", "high", "medium".

Since JavaScript `===` is case-sensitive, these comparisons never matched.
Every hub — including Critical ones — always fell through to the final else
branch and rendered with the green "Low" style badge.

Fixed by calling `.toLowerCase()` on the activity value before comparing,
so "Critical" correctly matches "critical".

Fixes #7693

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
(activeHub || pinnedHub).activity === "critical"
```
After:
```js
(activeHub || pinnedHub).activity?.toLowerCase() === "critical"
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings