### PR TITLE
fix: replace hardcoded test data in captureLead with real user info from useAuth

### DIFF
--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -5,10 +5,12 @@ import {
 } from "lucide-react";
 import { toast } from "react-toastify";
 import { safeJsonParse } from "../../utils/safeJsonParse";
+import { useAuth } from "../../context/AuthContext";
 
 import ErrorBoundary from "../common/ErrorBoundary";
 
 const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
+  const { user } = useAuth();
   const [showChat, setShowChat] = useState(false);
   const [chatMessage, setChatMessage] = useState("");
   const [chatHistory, setChatHistory] = useState([]);
@@ -22,9 +24,9 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
       const existingLeads = existingLeadsStr ? safeJsonParse(existingLeadsStr, []) : [];
       
       const newLead = {
-        name: "Test Attendee",
+        name: user?.name || user?.email || "Guest",
         action: action,
-        contact: "attendee@example.com",
+        contact: user?.email || "unknown",
         time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
       };
       

--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -697,11 +697,11 @@ export default function CollaborationNetworkMap() {
 
                     <div
                       className={`flex items-center gap-1 px-3 py-1 rounded-full text-xs font-semibold
-                      ${(activeHub || pinnedHub).activity === "critical"
+                      ${(activeHub || pinnedHub).activity?.toLowerCase() === "critical"
                         ? "bg-red-100 text-red-600"
-                        : (activeHub || pinnedHub).activity === "high"
+                        : (activeHub || pinnedHub).activity?.toLowerCase() === "high"
                         ? "bg-orange-100 text-orange-600"
-                        : (activeHub || pinnedHub).activity === "medium"
+                        : (activeHub || pinnedHub).activity?.toLowerCase() === "medium"
                         ? "bg-yellow-100 text-yellow-700"
                         : "bg-green-100 text-green-600"
                       }`}


### PR DESCRIPTION
## Description

In `src/components/events/VirtualBoothModal.jsx`, the `captureLead` function
at lines 25–27 hardcoded:
- `name: "Test Attendee"`
- `contact: "attendee@example.com"`

This function is called on real user actions — job applications and chat
initiations. Sponsors were receiving a lead list entirely populated with
fake test data, making the entire lead-tracking feature non-functional.

Fixed by importing `useAuth` and reading the actual authenticated user's
name and email instead of hardcoded placeholder values.

Fixes #7694

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
name: "Test Attendee",
contact: "attendee@example.com",
```
After:
```js
name: user?.name || user?.email || "Guest",
contact: user?.email || "unknown",
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings