### PR TITLE
fix: add right padding to FAQ answers to prevent chatbot button overl…

### DIFF
--- a/src/Pages/FAQ/FAQPage.js
+++ b/src/Pages/FAQ/FAQPage.js
@@ -467,7 +467,7 @@ function FAQSectionInner() {
         }
 
         .faq-answer-wrapper {
-          padding: 20px 24px;
+          padding: 20px 104px 20px 24px;
           display: flex;
           flex-direction: column;
           gap: 16px;
@@ -669,7 +669,7 @@ function FAQSectionInner() {
           }
 
           .faq-answer-wrapper {
-            padding: 16px 16px;
+            padding: 16px 88px 16px 16px;
           }
 
           .faq-accordion-header h3 {


### PR DESCRIPTION
Fixes #4448

**Root Cause:**
The floating chatbot launcher (Chatbot.jsx line 330) is 56px wide and sits 
fixed on the right edge. The FAQ answer container in `FAQPage.js` had no 
right padding, causing text to render behind the button and get clipped.

**Fix:**
- Added extra right-side padding to the answer container at `FAQPage.js` line 470
- Added matching mobile override at `FAQPage.js` line 672 to handle smaller screens

**Tested:**
- FAQ answer text is fully visible and clears the chatbot button on all screen sizes
- Accordion behavior unchanged
- No other styles affected