### PR TITLE
fix: resolve markdown lint errors in README and docs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cp .env.example .env
 
 1. Start dev server:
 
-3. Start dev server:
+2. Start dev server:
 
 ```bash
 npm run dev

--- a/docs/CONFLICT_RESOLVER_README.md
+++ b/docs/CONFLICT_RESOLVER_README.md
@@ -162,7 +162,7 @@ npm test -- conflictDetection.test.js
 - Verify non-conflicting alternatives exist
 - Check `conflictData.suggestions` in modal props
 
-## That's It!
+## That's It
 
 The system is production-ready. Start with the examples, customize to your needs, write tests, ship it.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -70,8 +70,8 @@ git checkout -b feature/short-description
   - `docs/` for documentation updates (e.g., `docs/fix-contributing-format`)
   - `enhancement/` for visual/behavior improvements (e.g., `enhancement/dashboard-empty-state`)
 
-3. Make your changes in small, reviewable commits.
-4. Run quality checks locally:
+1. Make your changes in small, reviewable commits.
+2. Run quality checks locally:
 
 ```bash
 npm run lint

--- a/docs/EVENT_CONFLICT_RESOLVER.md
+++ b/docs/EVENT_CONFLICT_RESOLVER.md
@@ -245,7 +245,7 @@ getEventUTCRange(event, fallbackDuration?, timezone?)
 
 #### Detailed Function Signatures
 
-**checkRegistrationConflict**
+### checkRegistrationConflict
 ```javascript
 /**
  * @param {object} newEvent - Event to check for conflicts
@@ -256,7 +256,7 @@ getEventUTCRange(event, fallbackDuration?, timezone?)
  */
 ```
 
-**suggestAlternativeEvents**
+### suggestAlternativeEvents
 ```javascript
 /**
  * @param {object} targetEvent - Event user tried to register for


### PR DESCRIPTION
Fixes markdown-lint CI errors introduced in recent upstream merges.

**Changes:**
- `README.md` line 111 — fixed ordered list item prefix (3→2)
- `docs/EVENT_CONFLICT_RESOLVER.md` line 248 — changed bold emphasis 
  `**checkRegistrationConflict**` to heading `### checkRegistrationConflict`
- `docs/EVENT_CONFLICT_RESOLVER.md` line 259 — changed bold emphasis 
  `**suggestAlternativeEvents**` to heading `### suggestAlternativeEvents`
- `docs/CONTRIBUTING.md` lines 73-74 — fixed ordered list prefixes (3→1, 4→2)
- `docs/CONFLICT_RESOLVER_README.md` line 165 — removed trailing `!` 
  from heading "That's It!"

**No functional or code changes — markdown formatting fixes only.**