### PR TITLE
feat: add reusable Tooltip component with aria-describedby and keyboa…

### DIFF
--- a/src/components/navbar/CursorToggle.jsx
+++ b/src/components/navbar/CursorToggle.jsx
@@ -1,25 +1,26 @@
 import { MousePointer } from "lucide-react";
+import Tooltip from "../common/Tooltip";
 
 const CursorToggle = ({ cursorEnabled, toggleCursor }) => {
   return (
-    <button
-      type="button"
-      onClick={toggleCursor}
-      aria-pressed={cursorEnabled}
-      aria-label="Toggle background cursor effects"
-      title={
-        cursorEnabled
-          ? "Turn off background cursor effects"
-          : "Turn on background cursor effects"
-      }
-      className={`h-9 w-9 rounded-full border transition-colors flex items-center justify-center shadow-none focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
-        cursorEnabled
-          ? "border-primary/40 bg-primary/10 text-primary"
-          : "border-border bg-card-bg text-text-light hover:bg-bg-secondary"
-      }`}
+    <Tooltip
+      content={cursorEnabled ? "Turn off cursor effects" : "Turn on cursor effects"}
+      position="bottom"
     >
-      <MousePointer className="h-4 w-4" aria-hidden="true" />
-    </button>
+      <button
+        type="button"
+        onClick={toggleCursor}
+        aria-pressed={cursorEnabled}
+        aria-label="Toggle background cursor effects"
+        className={`h-9 w-9 rounded-full border transition-colors flex items-center justify-center shadow-none focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+          cursorEnabled
+            ? "border-primary/40 bg-primary/10 text-primary"
+            : "border-border bg-card-bg text-text-light hover:bg-bg-secondary"
+        }`}
+      >
+        <MousePointer className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3058

## Rationale for this change
Icon-only buttons like cursor toggle relied solely on title attributes which 
don't work on mobile/touch devices and have poor screen reader support.

## What changes are included in this PR?
- Created reusable Tooltip component at src/components/common/Tooltip.jsx:
  - Supports top, bottom, left, right positions
  - Uses aria-describedby for proper screen reader association
  - Works on both mouse hover and keyboard focus/blur
  - Animated with fade-in and zoom-in transitions
  - Dark mode compatible
  - No new dependencies — pure React + Tailwind
- Integrated Tooltip into CursorToggle navbar button
- Tooltip shows contextual label based on current state

## Are these changes tested?
Manually tested — tooltip appears on hover and keyboard focus, disappears on 
blur, correct aria-describedby association verified in DevTools.

## Are there any user-facing changes?
Yes — users now see styled tooltips on icon buttons instead of relying on 
browser native title popups which don't work on touch devices.