### PR TITLE
docs: add HUSKY_SETUP.md documenting pre-commit hooks with Husky and …

### DIFF
--- a/HUSKY_SETUP.md
+++ b/HUSKY_SETUP.md
@@ -1,0 +1,49 @@
+# Pre-commit Hooks: Husky + lint-staged
+
+This project uses [Husky](https://typicode.github.io/husky) and [lint-staged](https://github.com/lint-staged/lint-staged) to automatically lint and format code before every commit.
+
+## How it works
+
+When you run `git commit`, Husky triggers the `pre-commit` hook which runs `lint-staged`. Only **staged files** are checked, keeping the process fast.
+
+### What runs on commit
+
+| File type | Actions |
+|-----------|---------|
+| `*.js, *.jsx, *.ts, *.tsx` | ESLint --fix, Prettier --write |
+| `*.css, *.json, *.md` | Prettier --write |
+
+If ESLint finds errors that cannot be auto-fixed, the commit is **blocked** until they are resolved.
+
+## Setup (automatic)
+
+After cloning and running `npm install`, Husky is automatically configured via the `prepare` script.
+
+```bash
+npm install   # husky is set up automatically
+```
+
+## Manual trigger
+
+You can manually run the checks at any time:
+
+```bash
+# Lint all files
+npm run lint
+
+# Auto-fix lint issues
+npm run lint:fix
+
+# Format all files
+npm run format
+```
+
+## Bypass (not recommended)
+
+In rare cases where you need to skip the hook:
+
+```bash
+git commit --no-verify -m "your message"
+```
+
+> ⚠️ Use `--no-verify` only when absolutely necessary. It bypasses all pre-commit checks.


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3055

## Rationale for this change
Husky and lint-staged were already installed and configured in the project 
but lacked documentation, making it unclear to contributors that pre-commit 
hooks were active.

## What changes are included in this PR?
- Added HUSKY_SETUP.md documenting the pre-commit hook setup
- Documents what runs on commit (ESLint + Prettier per file type)
- Explains automatic setup via npm install
- Documents manual trigger commands
- Notes how to bypass in emergencies with warning
- Existing config verified:
  - .husky/pre-commit runs npx lint-staged
  - lint-staged config in package.json covers JS/JSX/TS/TSX/CSS/JSON/MD
  - lint-staged v17 and husky installed in devDependencies

## Are these changes tested?
Pre-commit hooks verified working — running git commit triggers lint-staged 
on staged files automatically.

## Are there any user-facing changes?
No — developer experience improvement only.