### PR TITLE
feat: add reusable SkeletonGrid component and integrate into EventCar…

### DIFF
--- a/src/components/common/SkeletonGrid.jsx
+++ b/src/components/common/SkeletonGrid.jsx
@@ -1,0 +1,38 @@
+import { memo, useMemo } from "react";
+import SkeletonEventCard from "./SkeletonEventCard";
+
+/**
+ * SkeletonGrid
+ *
+ * A reusable responsive skeleton grid that shows animated placeholder cards
+ * while content is loading. Matches the exact layout of the event card grid.
+ *
+ * @param {number}  count    - Number of skeleton cards to show (default: 6)
+ * @param {string}  viewMode - "grid" or "list" (default: "grid")
+ * @param {React.ComponentType} CardSkeleton - Skeleton card component to render
+ */
+const SkeletonGrid = ({
+  count = 6,
+  viewMode = "grid",
+  CardSkeleton = SkeletonEventCard,
+}) => {
+  const skeletonItems = useMemo(
+    () => Array.from({ length: count }, (_, i) => `skeleton-${i + 1}`),
+    [count]
+  );
+
+  const gridClassName =
+    viewMode === "grid"
+      ? "grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+      : "grid gap-6 grid-cols-1 max-w-4xl mx-auto";
+
+  return (
+    <div className={gridClassName} aria-busy="true" aria-label="Loading events...">
+      {skeletonItems.map((key) => (
+        <CardSkeleton key={key} />
+      ))}
+    </div>
+  );
+};
+
+export default memo(SkeletonGrid);


### PR DESCRIPTION
## Which issue does this PR close?
Closes #3047

## Rationale for this change
The events listing page showed skeleton cards during loading but the 
skeleton grid logic was inline and not reusable across the app.

## What changes are included in this PR?
- Created reusable SkeletonGrid component at src/components/common/SkeletonGrid.jsx
  - Accepts count prop (default 6) for number of skeleton cards
  - Accepts viewMode prop ("grid" or "list") for responsive layout
  - Accepts CardSkeleton prop for custom skeleton card component
  - Responsive: 1 column mobile, 2 tablet, 3 desktop
  - aria-busy and aria-label for accessibility
- Refactored EventCardSection to use SkeletonGrid instead of inline grid
- Removed redundant skeletonItems memo from EventCardSection

## Are these changes tested?
Manually tested — 6 skeleton cards appear correctly during events page 
loading in both grid and list view modes.

## Are there any user-facing changes?
No visual change — skeleton grid looks identical, now just reusable.