### PR TITLE
Fix: Lack of Idempotency Keys on Critical State Mutations (#7663)

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -222,6 +222,17 @@ API.interceptors.request.use((config) => {
     } else if (process.env.NODE_ENV !== "production") {
       console.warn("[CSRF] Token missing for mutating request:", method, config.url);
     }
+    
+    // Add idempotency key for critical state mutations
+    if (!config.headers["Idempotency-Key"]) {
+      config.headers["Idempotency-Key"] = typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+          });
+    }
   }
 
   return config;

--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -32,6 +32,22 @@ export const fetchWithTimeout = async (
     }
   }
 
+  const method = (options.method || "GET").toUpperCase();
+  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+    const headers = new Headers(options.headers || {});
+    if (!headers.has("Idempotency-Key")) {
+      const idempotencyKey = typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            const r = Math.random() * 16 | 0;
+            const v = c === 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+          });
+      headers.set("Idempotency-Key", idempotencyKey);
+    }
+    options.headers = headers;
+  }
+
   try {
     const response = await fetch(url, {
       ...options,


### PR DESCRIPTION
This PR adds client-side generation of an `Idempotency-Key` (UUID) for all mutating API requests (POST, PUT, PATCH, DELETE) in `api.js` and `fetchWithTimeout.js` to prevent duplicate submissions on retries.

Fixes #7663