### PR TITLE
Fix: Missing Authentication State Validation in API Proxies (#7661)

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -87,6 +87,53 @@ export default async function middleware(request) {
     return;
   }
 
+  // Strict Origin Validation
+  const origin = request.headers.get("origin");
+  const host = request.headers.get("host");
+  
+  if (origin) {
+    try {
+      const originUrl = new URL(origin);
+      if (originUrl.host !== host) {
+        return new Response(
+          JSON.stringify({ error: "Forbidden: Invalid origin" }),
+          { status: 403, headers: { "Content-Type": "application/json" } }
+        );
+      }
+    } catch (e) {
+      return new Response(
+        JSON.stringify({ error: "Forbidden: Malformed origin" }),
+        { status: 403, headers: { "Content-Type": "application/json" } }
+      );
+    }
+  }
+
+  // Session validation for API routes
+  if (url.pathname.startsWith("/api/")) {
+    const PUBLIC_PATHS = [
+      "/api/auth/login",
+      "/api/auth/signup",
+      "/api/auth/reset-password",
+      "/api/events",
+      "/api/hackathons",
+      "/api/projects",
+      "/api/validate"
+    ];
+
+    const isPublicPath = PUBLIC_PATHS.some(path => url.pathname.startsWith(path) && (request.method === "GET" || url.pathname.includes("/auth/") || url.pathname.includes("/validate/")));
+
+    if (!isPublicPath) {
+      const cookieHeader = request.headers.get("cookie") || "";
+      const tokenMatch = cookieHeader.match(/(?:^|;\s*)token\s*=\s*([^;]*)/);
+      if (!tokenMatch || !tokenMatch[1]) {
+        return new Response(
+          JSON.stringify({ error: "Unauthorized: Missing active user session" }),
+          { status: 401, headers: { "Content-Type": "application/json" } }
+        );
+      }
+    }
+  }
+
   // Per-IP rate limiting at the edge
   const ip =
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,6 +31,12 @@
     Link = "</.well-known/api-catalog>; rel=\"api-catalog\", </apiDocs>; rel=\"service-doc\""
 
 [[redirects]]
+  from = "/api/*"
+  to = "https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/api/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
This PR adds a strict origin validation and JWT session existence check to the Edge middleware for all protected API routes, addressing the critical security vulnerability identified in #7661. It also introduces the missing `/api/*` proxy block in `netlify.toml` to maintain parity with `vercel.json`.

Fixes #7661