### PR TITLE
fix: apply useReducedMotion return value to StarRating motion props to respect user accessibility preference

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 // Star Rating Component
 const StarRating = ({ rating, onRatingChange, error }) => {
   const { t } = useTranslation();
-  useReducedMotion();
+  const prefersReducedMotion = useReducedMotion();
   const [hoveredRating, setHoveredRating] = useState(0);
 
   const handleStarClick = (star) => {
@@ -42,8 +42,8 @@ const StarRating = ({ rating, onRatingChange, error }) => {
             onMouseEnter={() => setHoveredRating(star)}
             onMouseLeave={() => setHoveredRating(0)}
             className="focus:outline-none"
-            whileHover={{ scale: 1.1 }}
-            whileTap={{ scale: 0.95 }}
+            whileHover={prefersReducedMotion ? {} : { scale: 1.1 }}
+            whileTap={prefersReducedMotion ? {} : { scale: 0.95 }}
             aria-label={`Rate ${star} star${star > 1 ? "s" : ""}`}
             title={`Click to rate ${star} star${star > 1 ? "s" : ""
               } (click again to deselect)`}


### PR DESCRIPTION
## Summary
Fixes StarRating in FeedbackPage where useReducedMotion() was called but its
return value was discarded, causing star animations to always fire regardless
of the user's OS reduced motion setting.

## Problem
useReducedMotion() was called without capturing the result. whileHover and
whileTap on star buttons always applied scale animations, violating
prefers-reduced-motion accessibility requirements.

## Fix
I Stored the return value as prefersReducedMotion and conditionally applied it
to whileHover and whileTap props on the star motion.button elements.

## Changes
- src/Pages/Feedback/FeedbackPage.js — captured useReducedMotion return value
  in StarRating, applied conditional motion guards to star buttons

Closes #7766