### PR TITLE
fix: remove stable dropdownRef from CustomFloatingSelect useEffect dependency array

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -186,7 +186,7 @@ const CustomFloatingSelect = ({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [dropdownRef]);
+  }, []);
 
   const handleSelect = (optionValue) => {
     const selectedOption = options.find((opt) => opt.value === optionValue);


### PR DESCRIPTION
## Summary
Fixes CustomFloatingSelect in FeedbackPage where dropdownRef was incorrectly
listed as a useEffect dependency. Refs are stable references and should never
be reactive dependencies.

## Problem
[dropdownRef] in the deps array implied the effect would re-run when the ref
changes — it never does. This is misleading to maintainers and incorrect per
React documentation.

## Fix
I Replaced [dropdownRef] with [] so the effect clearly registers once on mount
and cleans up on unmount with no reactive dependencies.

## Changes
- src/Pages/Feedback/FeedbackPage.js — removed dropdownRef from useEffect
  dependency array in CustomFloatingSelect

Closes #7768