### PR TITLE
fix: memoize setPreference and setCategoryPreference with useCallback in NotificationSettings

### DIFF
--- a/src/Pages/NotificationSettings.jsx
+++ b/src/Pages/NotificationSettings.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Bell, BellOff, Check, Mail, Monitor, Save, Volume2 } from "lucide-react";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { useNotification } from "../context/NotificationContext";
@@ -78,11 +78,11 @@ const NotificationSettings = () => {
     [preferences.categories]
   );
 
-  const setPreference = (key, value) => {
+  const setPreference = useCallback((key, value) => {
     updatePreferences((current) => ({ ...current, [key]: value }));
-  };
+  }, [updatePreferences]);
 
-  const setCategoryPreference = (category, channel, value) => {
+  const setCategoryPreference = useCallback((category, channel, value) => {
     updatePreferences((current) => ({
       ...current,
       categories: {
@@ -93,7 +93,7 @@ const NotificationSettings = () => {
         },
       },
     }));
-  };
+  }, [updatePreferences]);
 
   const showStatusMessage = (message) => {
     setStatusMessage(message);


### PR DESCRIPTION
## Summary
Fixes setPreference and setCategoryPreference in NotificationSettings being
recreated as new function objects on every render by wrapping them in useCallback.

## Problem
Both functions were plain arrow functions that depended only on updatePreferences
— a stable context reference. They were unnecessarily recreated on every render,
passing new onClick references to every button in the settings page on each
state update.

## Fix
I Added useCallback to the React import and wrapped both functions with
useCallback([updatePreferences]). They now produce stable references that
only change if the context updater changes.

## Changes
- src/Pages/NotificationSettings.jsx — added useCallback import, wrapped
  setPreference and setCategoryPreference with useCallback

Closes #7771 