### PR TITLE
fix: revoke blob URL after download click in Settings handleDownloadKey to prevent memory leak

### DIFF
--- a/src/Pages/Settings.js
+++ b/src/Pages/Settings.js
@@ -83,6 +83,7 @@ const Settings = () => {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+    URL.revokeObjectURL(url);
     toast.success("Backup key file downloaded!");
   };
 


### PR DESCRIPTION
## Summary
Fixes a memory leak in Settings.js where handleDownloadKey created a blob
URL for the backup key file download but never called URL.revokeObjectURL,
leaving the blob held in memory for the entire page session.

## Problem
URL.createObjectURL(blob) was called but URL.revokeObjectURL was never
called after the download was triggered. Each download call accumulated
an unreleased blob in memory.

## Fix
I Added URL.revokeObjectURL(url) immediately after link.click() and before
document.body.removeChild(link). The download is already queued by the
browser at the point of click so revoking immediately is safe.

## Changes
- src/Pages/Settings.js — added URL.revokeObjectURL(url) in handleDownloadKey

Closes #7774 