### PR TITLE
fix: replace react-hot-toast with react-toastify in Settings to align with project-wide notification library

### DIFF
--- a/src/Pages/Settings.js
+++ b/src/Pages/Settings.js
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { Sun, MousePointer, Bell, ShieldCheck, ArrowRight, Key, Eye, EyeOff, Clipboard, Download, ShieldAlert, RefreshCw, SlidersHorizontal } from "lucide-react";
 import useLocalStorage from "../hooks/useLocalStorage";
 import useDocumentTitle from "../hooks/useDocumentTitle";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 import KeyboardShortcutsHelp from "../components/accessibility/KeyboardShortcutsHelp";
 
 const Settings = () => {


### PR DESCRIPTION
## Summary
Fixes an inconsistent toast library import in Settings.js where react-hot-toast
was used instead of the project-standard react-toastify.

## Problem
Settings.js imported toast from react-hot-toast while all other files use
react-toastify. This caused visual inconsistency in toast notifications on
the settings page and risks a build or runtime crash if react-hot-toast is
not a listed project dependency.

## Fix
I Replaced the import with react-toastify to match every other component in
the codebase. No call-site changes needed as both libraries share the same
toast.success() and toast.error() API surface.

## Changes
- src/Pages/Settings.js — replaced react-hot-toast import with react-toastify

Closes #7776 