### PR TITLE
feat: automated 15-minute inactive session timeout for shared devices

### DIFF
--- a/src/hooks/useSessionTimeout.js
+++ b/src/hooks/useSessionTimeout.js
@@ -1,0 +1,12 @@
+
+import { useEffect } from 'react';
+export function useSessionTimeout(logoutFn, timeoutMs = 900000) {
+  useEffect(() => {
+    let timer;
+    const resetTimer = () => { clearTimeout(timer); timer = setTimeout(logoutFn, timeoutMs); };
+    window.addEventListener('mousemove', resetTimer);
+    window.addEventListener('keydown', resetTimer);
+    resetTimer();
+    return () => { window.removeEventListener('mousemove', resetTimer); window.removeEventListener('keydown', resetTimer); clearTimeout(timer); };
+  }, [logoutFn, timeoutMs]);
+}


### PR DESCRIPTION
### Description
For enhanced security on shared public devices (e.g., library computers or hackathon labs), Eventra sessions should not persist indefinitely if a user walks away. This PR implements an automated 15-minute inactivity timeout.

### Changes
- Created `useSessionTimeout.js` hook.
- Implemented global event listeners (`mousemove`, `keydown`) to clear auth and redirect upon expiration.

Fixes #7493