### PR TITLE
feat: leaderboard gamification tiers based on point thresholds

### DIFF
--- a/src/Pages/Leaderboard/components/LeaderboardTable.jsx
+++ b/src/Pages/Leaderboard/components/LeaderboardTable.jsx
@@ -36,6 +36,9 @@ function TableRow({ c, rank, badge, streak, index }) {
             {rank}
           </span>
           <RankMovementIndicator liveDifference={streak?.rankDifference} />
+          {c.points > 1000 && <span className="ml-2 text-xs bg-gradient-to-r from-blue-400 to-purple-500 text-white px-2 py-0.5 rounded-full font-bold shadow-sm">DIAMOND</span>}
+          {c.points > 500 && c.points <= 1000 && <span className="ml-2 text-xs bg-yellow-500 text-white px-2 py-0.5 rounded-full font-bold shadow-sm">GOLD</span>}
+          {c.points > 100 && c.points <= 500 && <span className="ml-2 text-xs bg-gray-400 text-white px-2 py-0.5 rounded-full font-bold shadow-sm">SILVER</span>}
         </div>
       </td>
 


### PR DESCRIPTION
### Description
This PR enhances the newly introduced open-source Leaderboard by introducing dynamic gamification tiers. Contributors are visually rewarded with tiered tags (Silver, Gold, Diamond) based on their accumulated point thresholds.

### Changes
- Added threshold-based tier logic directly to the `LeaderboardTable.jsx` component to dynamically render highly visible achievement badges.

Fixes #7489