### PR TITLE
fix: differentiate between unconfigured and zero capacity

### DIFF
--- a/api/lib/capacityValidator.js
+++ b/api/lib/capacityValidator.js
@@ -65,7 +65,7 @@ export function checkCapacity({ event, currentCount, requestedSeats = 1 }) {
   }
 
   // Unlimited when no capacity configured.
-  if (capacity === 0) {
+  if (event.maxAttendees === undefined && event.capacity === undefined) {
     return {
       allowed: true,
       capacity: 0,


### PR DESCRIPTION
### Description
This PR resolves a logic bug in `api/lib/capacityValidator.js`. The capacity check previously treated an explicit capacity of `0` as "unlimited" (bypassing capacity constraints), which prevented organizers from temporarily pausing or capping events manually.

### Changes
- Updated `checkCapacity` to differentiate between `undefined` (unconfigured/unlimited) and strictly `0` (sold out/paused).

Fixes #7477