### PR TITLE
fix: fall back to private/loopback IP in getClientIp instead of returning unknown

### DIFF
--- a/api/lib/getClientIp.js
+++ b/api/lib/getClientIp.js
@@ -33,5 +33,18 @@ export function getClientIp(req) {
     if (addr && !isPrivateIp(addr)) return addr;
   }
 
+  // Fallback: if no public IP was found but we have private IPs, return them
+  if (forwarded && typeof forwarded === "string") {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  if (realIp && typeof realIp === "string") {
+    const trimmed = realIp.trim();
+    if (trimmed) return trimmed;
+  }
+  if (req.socket?.remoteAddress) {
+    return req.socket.remoteAddress;
+  }
+
   return "unknown";
 }

--- a/tests/getClientIp.test.mjs
+++ b/tests/getClientIp.test.mjs
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getClientIp } from "../api/lib/getClientIp.js";
+
+describe("getClientIp", () => {
+  it("should return public IP from x-forwarded-for if present", () => {
+    const req = {
+      headers: {
+        "x-forwarded-for": "203.0.113.195, 70.41.3.18",
+      },
+    };
+    assert.equal(getClientIp(req), "203.0.113.195");
+  });
+
+  it("should return public IP from x-real-ip if x-forwarded-for is missing/private", () => {
+    const req = {
+      headers: {
+        "x-forwarded-for": "127.0.0.1",
+        "x-real-ip": "203.0.113.196",
+      },
+    };
+    assert.equal(getClientIp(req), "203.0.113.196");
+  });
+
+  it("should return public IP from remoteAddress if headers are missing/private", () => {
+    const req = {
+      headers: {
+        "x-real-ip": "10.0.0.1",
+      },
+      socket: {
+        remoteAddress: "203.0.113.197",
+      },
+    };
+    assert.equal(getClientIp(req), "203.0.113.197");
+  });
+
+  it("should fall back to private IP from x-forwarded-for if only private/loopback is available", () => {
+    const req = {
+      headers: {
+        "x-forwarded-for": "127.0.0.1",
+      },
+    };
+    assert.equal(getClientIp(req), "127.0.0.1");
+  });
+
+  it("should fall back to private IP from socket if no headers are present", () => {
+    const req = {
+      socket: {
+        remoteAddress: "::1",
+      },
+    };
+    assert.equal(getClientIp(req), "::1");
+  });
+
+  it("should return 'unknown' if no request details or IP can be resolved", () => {
+    assert.equal(getClientIp(null), "unknown");
+    assert.equal(getClientIp({}), "unknown");
+  });
+});


### PR DESCRIPTION
### Problem
Previously, the `getClientIp` utility would filter out private/loopback IPs. While this is appropriate for resolving public client addresses behind proxies, it caused all requests from local development/private networks to fall through to `'unknown'`. This meant the server-side rate limiter treated all local development clients as a single user, exhausting the rate limit threshold rapidly.

### Solution
- Updated `getClientIp` to return the private/loopback IP address as a fallback if no public IP can be resolved.
- Added comprehensive unit tests in `tests/getClientIp.test.mjs` to verify the fallback logic.

---
*I am contributing to this project on behalf of GSSoc'26.*
Closes #7801