### PR TITLE
fix: align password validation strength criteria with backend policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12638,18 +12638,6 @@
         "source-map": "~0.6.1"
       }
     },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/eslint": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
@@ -26354,6 +26342,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -26852,20 +26854,6 @@
       "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,8 +1,8 @@
 import axios from "axios";
-import { ENV } from "./env";
-import { syncServerTimeFromHeader } from "../utils/timeSync";
-import { getCSRFToken } from "../utils/csrfToken";
-import { logger } from "../utils/logger";
+import { ENV } from "./env.js";
+import { syncServerTimeFromHeader } from "../utils/timeSync.js";
+import { getCSRFToken } from "../utils/csrfToken.js";
+import { logger } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
 // Base API URL

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,10 +1,10 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
-import en from "./locales/en.json";
-import es from "./locales/es.json";
-import hi from "./locales/hi.json";
-import te from "./locales/te.json";
+import en from "./locales/en.json" with { type: "json" };
+import es from "./locales/es.json" with { type: "json" };
+import hi from "./locales/hi.json" with { type: "json" };
+import te from "./locales/te.json" with { type: "json" };
 
 i18n
   .use(LanguageDetector)

--- a/src/utils/asyncValidators.js
+++ b/src/utils/asyncValidators.js
@@ -4,7 +4,7 @@
  * Can be composed with sync validators in useFormValidation
  */
 
-import { apiUtils } from "../config/api";
+import { apiUtils } from "../config/api.js";
 
 /**
  * Generic async validator factory
@@ -155,8 +155,8 @@ export const validatePasswordStrength = async (password) => {
       minLength: password.length >= 8,
       hasUppercase: /[A-Z]/.test(password),
       hasLowercase: /[a-z]/.test(password),
-      hasNumber: /[0-9]/.test(password),
-      hasSpecial: /[!@#$%^&*]/.test(password),
+      hasNumber: /\d/.test(password),
+      hasSpecial: /[!@#$%^&*(),.?":{}|<>]/.test(password),
     };
 
     const allMet = Object.values(requirements).every(Boolean);

--- a/src/utils/validationApi.js
+++ b/src/utils/validationApi.js
@@ -1,4 +1,4 @@
-import { apiUtils } from "../config/api";
+import { apiUtils } from "../config/api.js";
 
 const DEFAULT_TIMEOUT_MS = 8000;
 const DEFAULT_RETRIES = 1;

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,4 +1,4 @@
-import { createDebouncedValidator } from "./utils/debounceUtils";
+import { createDebouncedValidator } from "./utils/debounceUtils.js";
 import {
   checkEmailAvailability,
   checkPhoneValidation,
@@ -6,8 +6,8 @@ import {
   createValidationResponse,
   normalizeValidationApiResponse,
   requestValidation,
-} from "./utils/validationApi";
-import i18n from "./i18n/i18n";
+} from "./utils/validationApi.js";
+import i18n from "./i18n/i18n.js";
 
 const t = (key) => i18n.t(key);
 
@@ -47,7 +47,17 @@ export const validate = {
     return EMAIL_REGEX.test(val) || "Invalid email format";
   },
 
-  password: (val) => val.length >= 8 || "Password must be at least 8 characters",
+  password: (val) => {
+    if (!val || val.length < 8) return "Password must be at least 8 characters";
+    const hasUpper = /[A-Z]/.test(val);
+    const hasLower = /[a-z]/.test(val);
+    const hasNumber = /\d/.test(val);
+    const hasSpecial = /[!@#$%^&*(),.?":{}|<>]/.test(val);
+    if (!hasUpper || !hasLower || !hasNumber || !hasSpecial) {
+      return "Password must meet all 5 security criteria: 8+ characters, uppercase, lowercase, number, and special character";
+    }
+    return true;
+  },
 
   required: (val) => (val && val.trim() !== "") || "This field is required",
 
@@ -334,7 +344,7 @@ export const validatePasswordStrength = async (password, options = {}) => {
     [!requireUppercase || /[A-Z]/.test(password), messages.uppercase || "Password must include an uppercase letter"],
     [!requireLowercase || /[a-z]/.test(password), messages.lowercase || "Password must include a lowercase letter"],
     [!requireNumber || /\d/.test(password), messages.number || "Password must include a number"],
-    [!requireSpecial || /[^A-Za-z0-9]/.test(password), messages.special || "Password must include a special character"],
+    [!requireSpecial || /[!@#$%^&*(),.?":{}|<>]/.test(password), messages.special || "Password must include a special character"],
   ];
 
   const failedCheck = checks.find(([passed]) => !passed);

--- a/tests/passwordValidation.test.mjs
+++ b/tests/passwordValidation.test.mjs
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { validate } from "../src/validation.js";
+
+describe("validate.password", () => {
+  it("should return true for a valid strong password", () => {
+    const res = validate.password("SecurePass123!");
+    assert.strictEqual(res, true);
+  });
+
+  it("should fail for a password shorter than 8 characters", () => {
+    const res = validate.password("Sec1!");
+    assert.strictEqual(res, "Password must be at least 8 characters");
+  });
+
+  it("should fail if missing an uppercase letter", () => {
+    const res = validate.password("securepass123!");
+    assert.match(res, /meet all 5 security criteria/i);
+  });
+
+  it("should fail if missing a lowercase letter", () => {
+    const res = validate.password("SECUREPASS123!");
+    assert.match(res, /meet all 5 security criteria/i);
+  });
+
+  it("should fail if missing a number", () => {
+    const res = validate.password("SecurePass!");
+    assert.match(res, /meet all 5 security criteria/i);
+  });
+
+  it("should fail if missing a special character", () => {
+    const res = validate.password("SecurePass123");
+    assert.match(res, /meet all 5 security criteria/i);
+  });
+});


### PR DESCRIPTION
### Problem
The synchronous frontend password validator (`validate.password` in `src/validation.js`) only checked if the password length was at least 8 characters. However, the backend (`api/auth/signup.js`) enforced 5 security criteria (8+ characters, uppercase letter, lowercase letter, number, and a special character from a specific set). This created a validation inconsistency where a user could submit a password that passed client-side checks but was rejected by the server.

### Solution
- Updated the synchronous frontend password validator to check all 5 security criteria, matching the backend's criteria and error message.
- Updated `validatePasswordStrength` in both `src/validation.js` and `src/utils/asyncValidators.js` to use the same special character regex pattern as the backend.
- Fixed missing `.js` extensions on local imports inside config and validation utility files to allow native ES modules execution in tests.
- Added comprehensive unit tests in `tests/passwordValidation.test.mjs` to verify each security rule individually.

---
*I am contributing to this project on behalf of GSSoc'26.*
Closes #7796