### PR TITLE
security: restrict data: URIs and block unsafe attributes in sanitizeHtml

### DIFF
--- a/src/utils/sanitizeHtml.js
+++ b/src/utils/sanitizeHtml.js
@@ -38,6 +38,8 @@ const PURIFY_CONFIG = {
   ALLOWED_ATTR,
   ALLOW_DATA_ATTR: false,
   ADD_ATTR: ["target"],
+  FORBID_ATTR: ["onerror", "onload"],
+  ALLOW_UNKNOWN_PROTOCOLS: false,
 };
 
 let purifyInstance;
@@ -71,6 +73,23 @@ const getDOMPurify = () => {
       if ("target" in node) {
         node.setAttribute("target", "_blank");
         node.setAttribute("rel", "noopener noreferrer");
+      }
+
+      // Hardening: validate href/src data: URIs and block svg/scripts
+      if (node.hasAttribute("src")) {
+        const src = node.getAttribute("src").trim();
+        if (/^\s*data:/i.test(src)) {
+          const isSafeDataUri = /^\s*data:\s*image\/(png|jpeg|jpg|gif|webp)\s*;base64,/i.test(src);
+          if (!isSafeDataUri) {
+            node.removeAttribute("src");
+          }
+        }
+      }
+      if (node.hasAttribute("href")) {
+        const href = node.getAttribute("href").trim();
+        if (/^\s*data:/i.test(href)) {
+          node.removeAttribute("href");
+        }
       }
     });
     hookRegistered = true;

--- a/tests/sanitizeHtml.test.mjs
+++ b/tests/sanitizeHtml.test.mjs
@@ -30,6 +30,13 @@ try {
   const cleanAttrHtml = sanitizeHtml(badAttrHtml);
   assert.equal(cleanAttrHtml, "<div>Click Me</div>", "Should strip custom data-attributes and onclick event handlers");
 
+  // Test Case 4b: Explicitly strip javascript: URIs and onerror/onload event handlers
+  const maliciousUrls = '<a href="javascript:alert(1)">Link</a><img src="data:image/svg+xml;utf8,<svg onload=alert(1)></svg>" onerror="alert(1)">';
+  const cleanMalicious = sanitizeHtml(maliciousUrls);
+  assert.ok(!cleanMalicious.includes("javascript:"), "Should strip javascript: protocols");
+  assert.ok(!cleanMalicious.includes("onerror"), "Should strip onerror handler");
+  assert.ok(!cleanMalicious.includes("onload"), "Should strip onload handler");
+
   // Test Case 5: sanitizeMarkdown simple pass-through without markdown parser
   assert.equal(sanitizeMarkdown(null), "", "Null markdown returns empty string");
   assert.equal(sanitizeMarkdown("### Title"), "### Title", "Should fall back to sanitizeHtml when no markdown parser is provided");


### PR DESCRIPTION
### Problem
Although the custom HTML sanitizer (`src/utils/sanitizeHtml.js`) configured DOMPurify to exclude standard script/style tags, it allowed `data:` URIs for any image format (including SVG `data:image/svg+xml` which can embed inline scripts like `<svg onload=alert(1)>`). Additionally, it was missing explicit guards against `onerror` and `onload` attribute variations.

### Solution
- Configured DOMPurify with `FORBID_ATTR: ['onerror', 'onload']` and `ALLOW_UNKNOWN_PROTOCOLS: false`.
- Registered a post-attributes hook to inspect all `src` and `href` attributes starting with `data:` protocol. It restricts data URIs strictly to safe, base64-encoded image types (PNG, JPEG, GIF, WEBP) and strips everything else.
- Added comprehensive unit tests in `tests/sanitizeHtml.test.mjs` to verify rejection of malicious data URIs and handlers.

---
*I am contributing to this project on behalf of GSSoc'26.*
Closes #7797