### PR TITLE
docs: add SECURITY_ARCHITECTURE.md to detail auth flow, token lifecycle, and security controls

### DIFF
--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -1,0 +1,116 @@
+# Eventra Security Architecture
+
+This document describes the security architecture of Eventra, detailing the design, patterns, and protocols enforced to protect the application and its users.
+
+---
+
+## 1. Authentication Flow
+
+Eventra enforces cookie-based authentication using JSON Web Tokens (JWT) stored in secure, `HttpOnly` cookies. The client never handles the raw token directly in Javascript, mitigating Cross-Site Scripting (XSS) token exfiltration risks.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Client as Client Browser
+    participant API as Serverless API Endpoint
+    participant Store as User Store (Memory/DB)
+
+    Client->>API: POST /api/auth/signup or /login (Credentials)
+    API->>Store: Lookup User / Compare Password (BCrypt)
+    Store-->>API: User Verified
+    API->>API: Sign JWT with JWT_SECRET
+    API-->>Client: 200/201 JSON (Set-Cookie: token=JWT; HttpOnly; SameSite=Strict; Secure)
+    
+    Note over Client, API: Subsequent requests carry the cookie automatically
+    
+    Client->>API: GET /api/protected-route (Carries Token Cookie)
+    API->>API: verifyAuth Middleware checks signature and expiry
+    API->>Store: Confirm user is active and exists
+    API-->>Client: 200 JSON (Protected Resource)
+    
+    Client->>API: POST /api/auth/logout
+    API-->>Client: Set-Cookie: token=; Max-Age=0 (Clears Cookie)
+```
+
+---
+
+## 2. Token Lifecycle & Session Management
+
+- **Short Access Token Expiration**: The JWT default lifetime (`JWT_EXPIRES_IN`) is set to `1h` (1 hour). This limits the exposure window of any intercepted session token.
+- **Dynamic Cookie Attributes**:
+  - `HttpOnly`: Access blocked to `document.cookie` from script space.
+  - `SameSite=Strict`: Prevents the cookie from being sent on cross-site requests, mitigating Cross-Site Request Forgery (CSRF).
+  - `Secure`: Cookie only transmitted over HTTPS connections (enforced in production).
+  - `Max-Age`: Computed dynamically based on `JWT_EXPIRES_IN` to ensure cookie and JWT lifetimes match.
+- **Revocation and User Existence Checks**:
+  - The `verifyAuth` middleware does not rely solely on cryptographic validation of the token payload.
+  - On every authenticated request, the middleware looks up the user in the store (`usersById` or `users`) and checks that `user.isActive !== false` before authorizing the request. This ensures suspended or deleted accounts lose access immediately.
+
+---
+
+## 3. Rate Limiting Strategy
+
+Eventra protects resource-intensive API paths (like authentication and LLM recommendation probes) using a dual-layer, sliding-window rate limiter keyed by client IP.
+
+- **Sliding-Window Limiter**: Eliminates the boundary-burst vulnerability inherent to fixed-window systems by tracking exact request timestamps per IP and checking counts dynamically.
+- **Periodic sweeps**: The in-memory cache prunes stale IP buckets to ensure memory consumption remains bounded under long-running processes.
+- **Configurations**:
+  - **Login Route**: Limited to 5 requests per minute per IP.
+  - **Signup Route**: Limited to 3 requests per minute per IP.
+  - **General APIs**: Throttled using Edge Middleware / Vercel KV REST API at the routing boundary.
+
+---
+
+## 4. Content Security Policy (CSP)
+
+Global security headers are defined in `vercel.json` to prevent injection attacks and MIME-sniffing:
+
+- `Content-Security-Policy`: Disallows unauthorized scripts, styles, or frames.
+  - `default-src 'self'`: Default fallback to trusted local origin.
+  - `script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net`: Restricts executable scripts.
+  - `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`: Restricts styling vectors.
+  - `object-src 'none'`: Blocks Flash and Java applets.
+  - `frame-ancestors 'none'`: Prevents clickjacking by blocking rendering in `<iframe>`, `<frame>`, or `<embed>`.
+- `X-Frame-Options: DENY`: Global frame prevention.
+- `X-Content-Type-Options: nosniff`: Enforces correct MIME types to prevent script execution via non-JS file uploads.
+- `Referrer-Policy: strict-origin-when-cross-origin`: Controls referrer leakage.
+
+---
+
+## 5. Input Sanitization Guidelines
+
+Always choose the appropriate helper for the context of user input:
+
+| Helper Function | Target Use Case | Actions Taken |
+| :--- | :--- | :--- |
+| `sanitizeHtml` | Rich Text / Descriptions (for rendering via `dangerouslySetInnerHTML`) | Cleans HTML tags against a whitelist; blocks `javascript:`/`data:` protocols; strips event handlers (`onerror`, `onload`). |
+| `sanitizeInputText` | Plain text inputs (form fields) | Escapes special characters (`<`, `>`, `&`, `"`, `'`) to safe HTML entities. |
+| `sanitizeSearchQuery` | Search queries / API parameters | Strips all HTML, tags, query operators, and truncates queries to 200 characters to prevent ReDoS / NoSQL injection. |
+
+---
+
+## 6. CSRF Protection
+
+For state-changing actions (POST, PUT, PATCH, DELETE), the frontend attaches a unique, session-bound token:
+
+1. The CSRF token is obtained via `getCSRFToken()`.
+2. Frontend requests append the token to the `X-CSRF-Token` header.
+3. The server validates this token against the request session, rejecting mismatched requests with `403 Forbidden`.
+
+---
+
+## 7. Security Policy and Reporting
+
+For vulnerabilities, do not open public GitHub issues. Please refer to our responsible disclosure policy outlined in [SECURITY.md](../SECURITY.md) or email the maintenance team directly.
+
+---
+
+## 8. Developer Security Checklist
+
+Before submitting a Pull Request, ensure:
+
+- [ ] Unescaped user text is never directly written to `dangerouslySetInnerHTML`. Use `sanitizeHtml` or `sanitizeMarkdown`.
+- [ ] No raw tokens or user credentials are printed in logs.
+- [ ] Sensitive files or credentials are not checked into git.
+- [ ] All local imports under `src/` specify correct `.js` extensions.
+- [ ] State-changing endpoints are validated for both authentication and CSRF.


### PR DESCRIPTION
### Problem
Although the project contains standard security controls (JWT authentication, rate limiting, Content Security Policy, HTML/Markdown sanitization, CSRF tokens, secure session storage), it lacked a single developer-facing document summarizing how they are integrated. This made it difficult for new contributors to understand the security posture and could lead to vulnerabilities or redundant utilities.

### Solution
- Created `docs/SECURITY_ARCHITECTURE.md` containing:
  - An authentication sequence diagram showing login, token issuance, verification, and cookie clearing.
  - Explanations of token attributes (HttpOnly, SameSite, Secure) and the user existence check.
  - Sliding-window rate-limiting implementation details.
  - Guidelines for choosing the correct sanitization helper (`sanitizeHtml`, `sanitizeInputText`, or `sanitizeSearchQuery`).
  - CSRF protection flow.
  - A pre-PR security checklist for developers.

---
*I am contributing to this project on behalf of GSSoc'26.*
Closes #7800