### PR TITLE
fix: resolve broken import block in EventsPage.js

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -17,16 +17,15 @@ import { prepareSafeSearchQuery } from "../../utils/inputSanitization";
 import ErrorBoundary from "../../components/common/ErrorBoundary";
 import ErrorMessage from "../../components/common/ErrorMessage";
 import { EventTimeline } from "../../components/EventTimeline";
-import {
 import { safeJsonParse } from "../../utils/safeJsonParse";
+import {
   decodeAdvancedFilters,
   encodeAdvancedFilters,
   getDefaultFilters,
-  hasActiveFilters as hasActiveAdvancedFilters,
+  hasActiveAdvancedFilters,
   normalizeAdvancedFilters,
   serializeAdvancedFilters,
 } from "../../utils/advancedFilterUtils";
-
 const FILTER_STORAGE_KEY = "eventra:event-filters:v1";
 
 const ExploreEventsSkeleton = () => (


### PR DESCRIPTION
Fixes #7821

## Problem
`EventsPage.js` had a malformed import block causing 6 parse errors:
- An empty `import {` on line 20 was never properly closed
- `safeJsonParse` import was inserted inside the unclosed block
- TypeScript-only `as hasActiveAdvancedFilters` syntax used in a `.js` file

## Errors fixed
- Identifier expected (Line 21)
- ',' expected (Line 21)
- ';' expected (Line 21, 26)
- Type assertion expressions can only be used in TypeScript files (Line 25)
- Expression expected (Line 28)
- Unexpected keyword or identifier (Line 28)

## Fix
- Moved `safeJsonParse` import to its own line before the block
- Removed duplicate `as hasActiveAdvancedFilters` alias
- Restored correct import structure

## Testing
- 0 errors in Problems tab after fix
- App compiles without parse errors