### PR TITLE
feat: event draft auto-save and recovery with timestamps (issue #7673)

### DIFF
--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -184,6 +184,7 @@ const EventCreation = () => {
                   </button>
                   <p className="text-center text-sm text-gray-500 mt-4 italic">
                     Progress is auto-saved as you type ✨
+                    {lastSavedAt && <span className="block text-xs text-gray-400 mt-1">Last saved {formatDraftAge(lastSavedAt)}</span>}
                   </p>
                 </div>
               </form>

--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -17,6 +17,8 @@ import LocationFields from "./components/LocationFields";
 import RegistrationDatesFields from "./components/RegistrationDatesFields";
 import TagsInput from "./components/TagsInput";
 import StatsSection from "./components/StatsSection";
+import { useAutoSaveDraft } from "../../../hooks/useAutoSaveDraft";
+import { formatDraftAge } from "../../../utils/eventDraftUtils";
 import {
   DRAFT_KEY,
   CREATION_STEPS,
@@ -80,8 +82,9 @@ const EventCreation = () => {
   const [newTag, setNewTag] = useState("");
   const [isDraftLoaded, setIsDraftLoaded] = useState(false);
   const [showRestoreModal, setShowRestoreModal] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState(null);
   const [restoreDraftMessage, setRestoreDraftMessage] = useState(
-    "A previously saved event draft was found. Would you like to restore it?"
+    `A previously saved event draft was found${lastSavedAt ? " (saved " + formatDraftAge(lastSavedAt) + ")" : ""}. Would you like to restore it?`
   );
   const location = useLocation();
 
@@ -336,7 +339,8 @@ const EventCreation = () => {
     delete saveable.banner;
     delete saveable.bannerPreview;
 
-    localStorage.setItem(DRAFT_KEY, JSON.stringify(saveable));
+    localStorage.setItem(DRAFT_KEY, JSON.stringify({ data: saveable, savedAt: new Date().toISOString() }));
+    setLastSavedAt(new Date().toISOString());
   }, [formData, isDraftLoaded]);
 
   useEffect(() => {

--- a/src/hooks/useAutoSaveDraft.js
+++ b/src/hooks/useAutoSaveDraft.js
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useCallback } from "react";
+import { saveDraft, clearDraft } from "../utils/eventDraftUtils";
+
+/**
+ * Auto-saves form data to localStorage every `intervalMs` milliseconds.
+ * Also saves on unmount if data has changed.
+ *
+ * @param {object} formData - The form data to save
+ * @param {function} onSave - Called after each successful save with ISO timestamp
+ * @param {number} intervalMs - Auto-save interval in ms (default 30s)
+ * @param {boolean} enabled - Whether auto-save is active
+ */
+export const useAutoSaveDraft = (formData, onSave, intervalMs = 30000, enabled = true) => {
+  const lastSavedRef = useRef(null);
+  const formDataRef = useRef(formData);
+
+  // Keep ref current without triggering re-renders
+  useEffect(() => {
+    formDataRef.current = formData;
+  }, [formData]);
+
+  const save = useCallback(() => {
+    const ok = saveDraft(formDataRef.current);
+    if (ok) {
+      const ts = new Date().toISOString();
+      lastSavedRef.current = ts;
+      onSave?.(ts);
+    }
+  }, [onSave]);
+
+  // Interval-based auto-save
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(save, intervalMs);
+    return () => clearInterval(id);
+  }, [save, intervalMs, enabled]);
+
+  // Save on page unload
+  useEffect(() => {
+    if (!enabled) return;
+    const handleUnload = () => saveDraft(formDataRef.current);
+    window.addEventListener("beforeunload", handleUnload);
+    return () => window.removeEventListener("beforeunload", handleUnload);
+  }, [enabled]);
+
+  return { saveNow: save, clearDraft };
+};

--- a/src/utils/eventDraftUtils.js
+++ b/src/utils/eventDraftUtils.js
@@ -11,23 +11,45 @@ const isStorageAvailable = () => {
 };
 
 export const saveDraft = (formData) => {
-  if (!isStorageAvailable()) return;
+  if (!isStorageAvailable()) return false;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(formData));
+    const payload = {
+      data: formData,
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    return true;
   } catch (error) {
     console.error("Error saving draft:", error);
+    return false;
   }
 };
 
 export const getDraft = () => {
   if (!isStorageAvailable()) return null;
   try {
-    const draft = localStorage.getItem(STORAGE_KEY);
-    return draft ? safeJsonParse(draft, null) : null;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = safeJsonParse(raw, null);
+    if (!parsed) return null;
+    // Support both old format (plain object) and new format (with savedAt)
+    if (parsed.data && parsed.savedAt) return parsed;
+    // Legacy: wrap old format
+    return { data: parsed, savedAt: null };
   } catch (error) {
     console.error("Error loading draft:", error);
     return null;
   }
+};
+
+export const getDraftData = () => {
+  const draft = getDraft();
+  return draft ? draft.data : null;
+};
+
+export const getDraftTimestamp = () => {
+  const draft = getDraft();
+  return draft ? draft.savedAt : null;
 };
 
 export const clearDraft = () => {
@@ -37,4 +59,13 @@ export const clearDraft = () => {
   } catch (error) {
     console.error("Error clearing draft:", error);
   }
+};
+
+export const formatDraftAge = (isoTimestamp) => {
+  if (!isoTimestamp) return null;
+  const diff = Math.floor((Date.now() - new Date(isoTimestamp)) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return new Date(isoTimestamp).toLocaleDateString();
 };


### PR DESCRIPTION
- Add savedAt timestamp to draft payload in eventDraftUtils.js
- Add formatDraftAge helper for human-readable timestamps
- Add getDraftTimestamp and getDraftData helpers
- Add useAutoSaveDraft hook with interval saving and beforeunload handler
- Wire lastSavedAt state into EventCreation auto-save effect
- Show last saved timestamp in recovery modal and auto-save indicator
- Backward compatible with existing draft format

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
