### PR TITLE
fix: resolve search input text invisible in dark mode

### DIFF
--- a/src/components/common/ModernSearchInput.js
+++ b/src/components/common/ModernSearchInput.js
@@ -73,6 +73,7 @@ const ModernSearchInput = ({
               border: "none",
               outline: "none",
               boxShadow: "none",
+              color: "inherit",
             }}
             value={value}
             onChange={onChange}


### PR DESCRIPTION
## Problem

Fixes #7847

In dark mode, the search input text becomes invisible because global CSS `input` selectors in `index.css` override the text color, making typed text unreadable.

## Root Cause

The global `input` selector was setting `color` explicitly, which overrode the component-level styling in `ModernSearchInput.js`.

## Fix

Added `color: 'inherit'` to the inner input element's inline style in `ModernSearchInput.js`. This ensures the text color inherits from the parent container which correctly responds to the active theme (light/dark).

## Affected Components

`ModernSearchInput` is a shared component used by:
- `EventHero`
- `HackathonHero`
- `Hero`
- `ProjectsPage`

All of these now display search input text correctly in dark mode.

## Testing

- Toggled dark/light mode and verified text is visible in both modes
- No regressions to other input styles