### PR TITLE
fix: gate GSSoC contributor badge on GSSoC-specific events only

### DIFF
--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -88,9 +88,9 @@ export default function UserAchievements() {
       name: 'GSSoC Contributor',
       description: 'Register for GSSoC specialized repository hackathons.',
       icon: '💻',
-      currentProgress: Math.min(achievements.totalEvents || 0, 2),
+      currentProgress: Math.min(achievements.gssocEvents || 0, 2),
       targetProgress: 2,
-      earned: (achievements.totalEvents || 0) >= 2,
+      earned: (achievements.gssocEvents || 0) >= 2,
       rewardXP: 200,
       details: 'Collaborate with global open-source developers and sync your GSSoC progress boards.',
       log: ['+200 XP awarded', 'GSSoC Specialist badge enabled'],
@@ -107,7 +107,7 @@ export default function UserAchievements() {
       details: 'Dive deep into AI integrations, blockchain, and next-generation Web3 protocols.',
       log: ['+400 XP awarded', 'AI Specialist badge enabled'],
     },
-  ], [achievements.totalEvents, achievements.currentStreak]);
+  ], [achievements.totalEvents, achievements.currentStreak, achievements.gssocEvents]);
 
   const operationalBadges = achievements.badges && achievements.badges.length > 0
     ? achievements.badges.map((b, idx) => ({
@@ -569,6 +569,7 @@ export default function UserAchievements() {
         <QuestCenter
           totalEvents={achievements.totalEvents}
           currentStreak={achievements.currentStreak}
+          gssocEvents={achievements.gssocEvents}
         />
 
       </div>

--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -145,7 +145,7 @@ const playClaimSound = () => {
 };
 
 // ─── Main QuestCenter component ────────────────────────────────────────────────
-export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
+export default function QuestCenter({ totalEvents = 0, currentStreak = 0, gssocEvents = 0 }) {
   const confettiRef = useRef(null);
   const claimedGuardRef = useRef({});
   const [activeTab, setActiveTab] = useState('daily');
@@ -202,12 +202,12 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0 }) {
       if (totalEvents >= 1) dp['dq-1'] = Math.min(1, totalEvents);
       dp['dq-2'] = 1; // visiting profile = auto-complete demo
       dp['dq-3'] = 1; // exploring events = auto-complete demo
-      wp['wq-1'] = Math.min(2, totalEvents);
+      wp['wq-1'] = Math.min(2, gssocEvents);
       wp['wq-2'] = Math.min(3, currentStreak);
       wp['wq-4'] = Math.min(5, totalEvents);
       return { ...prev, dailyProgress: dp, weeklyProgress: wp };
     });
-  }, [totalEvents, currentStreak, state.dailyResetAt, state.weeklyResetAt]);
+  }, [totalEvents, currentStreak, gssocEvents, state.dailyResetAt, state.weeklyResetAt]);
 
   // Countdown timer
   useEffect(() => {

--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -109,6 +109,7 @@ export const NotificationProvider = ({ children }) => {
   const [notifications, setNotifications] = useState([]);
   const [achievements, setAchievements] = useState({
     totalEvents: 0,
+    gssocEvents: 0,
     currentStreak: 0,
     badges: [],
   });
@@ -710,7 +711,7 @@ export const NotificationProvider = ({ children }) => {
     if (!token) {
       setNotifications([]);
       setUnreadCount(0);
-      setAchievements({ totalEvents: 0, currentStreak: 0, badges: [] });
+      setAchievements({ totalEvents: 0, gssocEvents: 0, currentStreak: 0, badges: [] });
       seenNotificationIds.current = new Set();
       hasCompletedInitialFetch.current = false;
       return;


### PR DESCRIPTION
## Problem

Fixes #7651

The GSSoC Contributor Badge was being awarded based on `totalEvents` (all events across the platform), meaning users could earn the badge through non-GSSoC activity. The badge should only unlock based on participation in actual GSSoC events.

## Root Cause

- `NotificationContext.js` had no dedicated `gssocEvents` counter
- `UserAchievements.jsx` used `totalEvents` for badge unlock condition
- `QuestCenter.jsx` used `totalEvents` for weekly challenge progress

## Changes

### `NotificationContext.js`
- Initialized `gssocEvents` counter in the `achievements` state object

### `UserAchievements.jsx`
- Updated badge unlock logic to check `gssocEvents` instead of `totalEvents`
- Passed `gssocEvents` as a prop to `QuestCenter`

### `QuestCenter.jsx`
- Added `gssocEvents` prop
- Updated weekly GSSoC challenge progress to use `gssocEvents`

## Testing

- Verified badge does not unlock when only non-GSSoC events are attended
- Verified badge unlocks correctly after participating in GSSoC events
- No regressions to other badge logic