### PR TITLE
[Critical] Fix undefined registrationLimiter causing ReferenceError in registration flow

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -55,7 +55,7 @@ import { logAbuseAttempt } from "../../utils/abuseLogger";
 
 // Registration lock map to prevent concurrent registrations for the same event
 // const registrationLocks = new Map();
-// registrationLimiter moved to hook scope
+// registrationLimiterRef initialized at hook scope with 3 tokens, 0.3/sec refill
 
 /**
  * Derives a user-facing error message from a failed registration API response.
@@ -98,6 +98,7 @@ const useEventRegistration = (eventIdParam) => {
   const [submitting, setSubmitting] = useState(false);
   const [registered, setRegistered] = useState(false);
   const isSubmittingRef = useRef(false);
+  const registrationLimiterRef = useRef(createRateLimiter({ maxTokens: 3, refillRate: 0.3 }));
 
   // Conflict detection state
   const [showConflictModal, setShowConflictModal] = useState(false);
@@ -296,8 +297,8 @@ const useEventRegistration = (eventIdParam) => {
 
   // Proceed with registration after conflict check or user confirmation
   const proceedWithRegistration = useCallback(async () => {
-    if (!registrationLimiter.tryConsume()) {
-      const retryMs = registrationLimiter.getRetryAfterMs();
+    if (!registrationLimiterRef.current.tryConsume()) {
+      const retryMs = registrationLimiterRef.current.getRetryAfterMs();
 
       logAbuseAttempt("event-registration-rate-limit", {
         eventId,


### PR DESCRIPTION
## Description
**What is the issue?**
`proceedWithRegistration` calls `registrationLimiter.tryConsume()` and `registrationLimiter.getRetryAfterMs()`, but `registrationLimiter` was **never instantiated**. This throws a `ReferenceError: registrationLimiter is not defined` when the user clicks "Register".

**What is causing the issue?**
The file imports `createRateLimiter` (line 1) but the actual instantiation is missing. Line 58 has a stale comment `// registrationLimiter moved to hook scope` but no variable was ever created.

**What is the fix?**
Add a `useRef`-based rate limiter instance at the hook scope:
```js
const registrationLimiterRef = useRef(createRateLimiter({ maxTokens: 3, refillRate: 0.3 }));
```
Update references from `registrationLimiter` to `registrationLimiterRef.current`.

## Changes
- `src/hooks/useEventRegistration.js`: Added `registrationLimiterRef` initialization and updated usages

## Closes
Closes #7880
