### PR TITLE
[Critical] Fix silent NaN-prone fallback in checkEventCapacity

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -260,12 +260,19 @@ const useEventRegistration = (eventIdParam) => {
       const freshRes = await eventService.getEventDetails(id);
       if (freshRes.status === 200) {
         const freshEvent = freshRes.data;
-        return freshEvent.attendees >= freshEvent.maxAttendees;
+        const capacity = freshEvent.maxAttendees ?? 0;
+        const attendees = freshEvent.attendees ?? 0;
+        return attendees >= capacity;
       }
-    } catch {
-      return currentEvent.attendees >= currentEvent.maxAttendees;
+      const capacity = currentEvent?.maxAttendees ?? 0;
+      const attendees = currentEvent?.attendees ?? 0;
+      return attendees >= capacity;
+    } catch (error) {
+      console.error("[checkEventCapacity] Failed to check capacity:", error);
+      const capacity = currentEvent?.maxAttendees ?? 0;
+      const attendees = currentEvent?.attendees ?? 0;
+      return attendees >= capacity;
     }
-    return false;
   }, []);
 
   const checkAndHandleConflicts = useCallback(async () => {


### PR DESCRIPTION
## Description
**What is the issue?**
`checkEventCapacity` has three problems:
1. **Empty `catch {}`** — API errors silently swallowed with zero logging
2. **NaN-prone fallback** — `currentEvent.attendees >= currentEvent.maxAttendees` becomes `undefined >= undefined` (false), reporting full events as "not full"
3. **Silent `return false`** — non-200 responses fall through to "not full"

**What is the fix?**
Add null guards, error logging, and proper non-200 handling:
```js
const capacity = freshEvent.maxAttendees ?? 0;
const attendees = freshEvent.attendees ?? 0;
return attendees >= capacity;
```

## Changes
- `src/hooks/useEventRegistration.js:258-274`: Added nullish coalescing, error logging, and non-200 fallback

## Closes
Closes #7881
