### PR TITLE
[Critical] Fix pagination total-estimation formula creating phantom pages

### DIFF
--- a/api/events/search.js
+++ b/api/events/search.js
@@ -61,7 +61,7 @@ export default async function searchEventsHandler(req, res, deps = {}) {
       typeof countEvents === "function"
         ? await countEvents({ query })
         : // Best-effort fallback when no count function is provided.
-          offset + items.length + (items.length === pageSize ? pageSize : 0);
+          offset + items.length + (items.length === pageSize ? 1 : 0);
 
     res.status(200).json(
       buildPageResponse({ items, total, page, pageSize })


### PR DESCRIPTION
## Description
**What is the issue?**
The pagination total-estimation fallback formula in `search.js` double-counts the current page's items, creating phantom pages. For page=1 with 20 items and pageSize=20, the formula yields 40 (2 pages) when there may only be 21 items.

**What is causing the issue?**
```js
offset + items.length + (items.length === pageSize ? pageSize : 0);
```
Result: `0 + 20 + 20 = 40` — overestimates by 20.

**What is the fix?**
Replace `pageSize` with `1`:
```js
offset + items.length + (items.length === pageSize ? 1 : 0);
```
Result: `0 + 20 + 1 = 21` — at most 1 extra item estimated.

## Changes
- `api/events/search.js:64`: Changed `pageSize` to `1` in fallback formula

## Closes
Closes #7882
