### PR TITLE
[Critical] Fix capacity validator rejecting all registrations when maxAttendees is 0

### DIFF
--- a/api/lib/capacityValidator.js
+++ b/api/lib/capacityValidator.js
@@ -14,7 +14,7 @@
  * Resolves the effective capacity for an event.
  *
  * @param {Object} event - Event record
- * @returns {number} Non-negative capacity. 0 means "no capacity configured".
+ * @returns {number} Non-negative capacity. 0 or unset means "no capacity configured".
  */
 export function resolveCapacity(event) {
   if (!event) return 0;
@@ -29,9 +29,8 @@ export function resolveCapacity(event) {
 /**
  * Evaluates whether one more registration fits within capacity.
  *
- * A capacity of 0 is treated as "unlimited" because the codebase uses 0 to mean
- * unconfigured. Callers that require an explicit limit should validate capacity
- * at event-creation time.
+ * A capacity of 0 or unset is treated as "unlimited". Callers that require an
+ * explicit limit should validate capacity at event-creation time.
  *
  * @param {Object} params
  * @param {Object} params.event - Event record (provides capacity)
@@ -64,8 +63,8 @@ export function checkCapacity({ event, currentCount, requestedSeats = 1 }) {
     };
   }
 
-  // Unlimited when no capacity configured.
-  if (event.maxAttendees === undefined && event.capacity === undefined) {
+  // Unlimited when no capacity configured, or capacity is explicitly 0.
+  if (capacity <= 0) {
     return {
       allowed: true,
       capacity: 0,


### PR DESCRIPTION
## Description
**What is the issue?**
When an event organizer sets `maxAttendees: 0`, the capacity validator rejects **every registration** with "Event is at full capacity". The comment in the code says 0 = unlimited, but the code contradicts this.

**What is causing the issue?**
`resolveCapacity` returns 0 for both "unconfigured" and "explicitly 0", but `checkCapacity` only treats `undefined` as unlimited:
```js
if (event.maxAttendees === undefined && event.capacity === undefined) {
    return { allowed: true, ... }; // Only triggers for undefined
}
// count + seats > 0 is always true when capacity=0
```

**What is the fix?**
Change the unlimited guard from checking `undefined` to checking `capacity <= 0`:
```js
if (capacity <= 0) {
    return { allowed: true, capacity: 0, currentCount: count, remaining: Infinity };
}
```

## Changes
- `api/lib/capacityValidator.js:68`: Changed unchecked to `capacity <= 0`
- Updated JSDoc comments to reflect corrected behavior

## Closes
Closes #7883
