### PR TITLE
security: fix JWT verification bypass by enforcing signature validati…

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -36,9 +36,25 @@ export function isTokenExpired(token) {
   return payload.exp - CLOCK_SKEW_BUFFER <= nowInSeconds;
 }
 
-export function isTokenValid(token) {
+import crypto from "node:crypto"; // Paste this at the very top of your file
+
+export function isTokenValid(token, secret = process.env.JWT_SECRET) {
   if (!token || typeof token !== "string") return false;
-  return !isTokenExpired(token);
+  if (isTokenExpired(token)) return false;
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+
+  const [header, payload, signature] = parts;
+  if (!secret) return false;
+
+  // Re-create the HMAC SHA256 signature using the secret key
+  const expectedSignature = crypto
+    .createHmac("sha256", secret)
+    .update(`${header}.${payload}`)
+    .digest("base64url"); // base64url matches standard JWT encoding formats
+
+  return signature === expectedSignature;
 }
 
 export function getTokenTTL(token) {

--- a/tests/auth.test.mjs
+++ b/tests/auth.test.mjs
@@ -1,14 +1,22 @@
 import assert from "node:assert/strict";
 import { decodeJwtPayload, isTokenExpired, isTokenValid, getTokenTTL } from "../src/utils/auth.js";
 
+import crypto from "node:crypto";
+
+const TEST_SECRET = "test-environmental-secret-key";
+process.env.JWT_SECRET = TEST_SECRET; // Sets the secret for isTokenValid to read
+
 function makeToken(payloadObj) {
   const header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
   const payloadStr = JSON.stringify(payloadObj);
-  const payloadBase64 = Buffer.from(payloadStr).toString("base64")
-    .replace(/=/g, "")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_");
-  return `${header}.${payloadBase64}.signature`;
+  const payloadBase64 = Buffer.from(payloadStr).toString("base64url"); // Cleaner built-in encoding
+  
+  const signature = crypto
+    .createHmac("sha256", TEST_SECRET)
+    .update(`${header}.${payloadBase64}`)
+    .digest("base64url");
+
+  return `${header}.${payloadBase64}.${signature}`;
 }
 
 // Test decodeJwtPayload with invalid formats


### PR DESCRIPTION
## Description

This PR fixes a high-severity security vulnerability where `isTokenValid` was merely checking the token's structural string format and expiration date, but completely ignoring cryptographic signature validation. This allowed a client to forge a JWT payload (e.g., changing roles to "admin"), append a arbitrary string as a signature, and entirely bypass authentication.

The implementation has been rectified to reconstruct and verify the HMAC SHA-256 signature against the application's secret key (`process.env.JWT_SECRET`). Additionally, the mock token helper in the test suite has been updated to sign test tokens cryptographically so that tests reflect real-world verification conditions.

Fixes #7878

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

*N/A (Backend logic security fix, verified via test suite output)*

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings