### PR TITLE
fix: remove unstable errors and formData.tags deps from useCallback handlers in useEventForm

### DIFF
--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -461,14 +461,13 @@ export const useEventForm = () => {
         [name]: type === "checkbox" ? checked : value,
       }));
     }
-    if (errors[name]) {
-      setErrors((prev) => {
-        const newErrs = { ...prev };
-        delete newErrs[name];
-        return newErrs;
-      });
-    }
-  }, [errors]);
+    setErrors((prev) => {
+      if (!prev[name]) return prev;
+      const newErrs = { ...prev };
+      delete newErrs[name];
+      return newErrs;
+    });
+  }, []);
 
   const handleNestedChange = useCallback((category, field, value) => {
     setFormData((prev) => ({
@@ -478,25 +477,23 @@ export const useEventForm = () => {
         [field]: value,
       },
     }));
-    if (errors[category]) {
-      setErrors((prev) => {
-        const newErrs = { ...prev };
-        delete newErrs[category];
-        return newErrs;
-      });
-    }
-  }, [errors]);
+    setErrors((prev) => {
+      if (!prev[category]) return prev;
+      const newErrs = { ...prev };
+      delete newErrs[category];
+      return newErrs;
+    });
+  }, []);
 
   const addTag = useCallback(() => {
     const tag = newTag.trim().toLowerCase().replace(/[^a-z0-9]/g, "");
-    if (tag && !formData.tags.includes(tag)) {
-      setFormData((prev) => ({
-        ...prev,
-        tags: [...prev.tags, tag],
-      }));
-      setNewTag("");
-    }
-  }, [newTag, formData.tags]);
+    if (!tag) return;
+    setFormData((prev) => {
+      if (prev.tags.includes(tag)) return prev;
+      return { ...prev, tags: [...prev.tags, tag] };
+    });
+    setNewTag("");
+  }, [newTag]);
 
   const removeTag = useCallback((tagToRemove) => {
     setFormData((prev) => ({


### PR DESCRIPTION
## Summary
Fixes three useCallback handlers in useEventForm that had unnecessary state
values in their dependency arrays, causing new function references on every
validation update or tag change.

## Problems Fixed

### Bug 1 — errors in handleInputChange and handleNestedChange deps
Both handlers checked errors[name] before calling setErrors. Since setErrors
accepts a functional updater, the guard can be moved inside — reading from
prev instead of a closed-over errors snapshot. This removes errors from both
deps arrays and makes both handlers stable.

### Bug 2— formData.tags in addTag deps
addTag read formData.tags to check for duplicates. Moving the check inside
the setFormData functional updater (if (prev.tags.includes(tag)) return prev)
removes formData.tags from the deps. addTag now only depends on [newTag].

## Changes
- src/hooks/useEventForm.js

Closes #7908