### PR TITLE
fix: explicit return false on cancel in handleDeleteTemplate and useCallback on handleSubmit in useFormSubmit

### DIFF
--- a/src/hooks/useEventTemplates.js
+++ b/src/hooks/useEventTemplates.js
@@ -124,6 +124,8 @@ export const useEventTemplates = () => {
             return false;
           }
         }
+
+        return false;
       } catch (error) {
         logger.error("[Templates] Error deleting template:", error);
         toast.error("An error occurred while deleting the template.");

--- a/src/hooks/useFormSubmit.js
+++ b/src/hooks/useFormSubmit.js
@@ -2,7 +2,7 @@
  * @fileoverview useFormSubmit - Generic form submission handler hook
  * @module hooks/useFormSubmit
  */
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { pushToQueue } from "../utils/offlineQueue";
 import { getPublicErrorMessage, FORM_ERRORS } from "../utils/errorMessages";
 
@@ -52,7 +52,7 @@ export function useFormSubmit(submitFn, offlineOptions = {}) {
     };
   }, []);
 
-  const handleSubmit = async (data) => {
+  const handleSubmit = useCallback(async (data) => {
     if (isInFlight.current) return;
 
     isInFlight.current = true;
@@ -71,10 +71,10 @@ export function useFormSubmit(submitFn, offlineOptions = {}) {
           typeof offlineOptions.createQueueItem === "function"
             ? offlineOptions.createQueueItem(data, err)
             : {
-                actionType: offlineOptions.actionType || "FORM_SUBMISSION",
-                endpoint: offlineOptions.endpoint,
-                payload: data,
-              };
+              actionType: offlineOptions.actionType || "FORM_SUBMISSION",
+              endpoint: offlineOptions.endpoint,
+              payload: data,
+            };
 
         const queued = await pushToQueue(queueItem, offlineOptions.userId || null);
         if (queued) {
@@ -94,7 +94,7 @@ export function useFormSubmit(submitFn, offlineOptions = {}) {
         setIsSubmitting(false);
       }
     }
-  };
+  }, [submitFn, offlineOptions]);
 
   return { handleSubmit, isSubmitting, error, success };
 }


### PR DESCRIPTION
## Summary
Two small hook fixes grouped together — one fixes an implicit undefined return,
the other stabilises a callback reference.

## Bug 1 — useEventTemplates.js
handleDeleteTemplate returned undefined when the user cancelled the confirm
dialog instead of an explicit false. Added return false after the confirm
block for a consistent boolean contract.

## Bug 2 — useFormSubmit.js
handleSubmit was a plain async function recreated on every render. Added
useCallback to the React import and wrapped handleSubmit with
useCallback([submitFn, offlineOptions]) to produce a stable reference for
consumers.

## Changes
- src/hooks/useEventTemplates.js — added return false after window.confirm block
- src/hooks/useFormSubmit.js — added useCallback import, wrapped handleSubmit

Closes #7911 