### PR TITLE
docs: add notifications list API documentation

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -1463,6 +1463,53 @@ Requires a valid Bearer JWT in the `Authorization` header. Any authenticated use
 
 ---
 
+# Notification APIs
+
+## Get Notifications
+
+| Method | Endpoint             |
+| ------ | -------------------- |
+| GET    | `/api/notifications` |
+
+Returns the authenticated user’s notifications sorted by newest first.
+
+### Authentication
+
+Requires Bearer JWT authentication.
+
+### Success Response
+
+Status: `200 OK`
+
+```json
+[
+  {
+    "id": 1,
+    "title": "Welcome Notification",
+    "message": "This is a manual test notification.",
+    "read": false,
+    "createdAt": "2026-06-09T00:38:52.335113"
+  }
+]
+```
+
+### Empty Response
+
+If the authenticated user has no notifications:
+
+```json
+[]
+```
+
+### Notes
+
+* Only notifications belonging to the authenticated user are returned.
+* The response includes read/unread status using the `read` field.
+* Notifications are returned in newest-first order.
+* Pagination is not currently included.
+
+---
+
 # Analytics APIs
 
 ## Get Admin Analytics


### PR DESCRIPTION
## Related Backend Implementation

Related backend implementation: SandeepVashishtha/Eventra-Backend#BACKEND_PR_NUMBER

## Description

This PR updates the API documentation to include the newly added notifications list endpoint.

The documented endpoint allows authenticated users to fetch their own notifications, including read/unread status, sorted by newest first.

## Changes Made

- Documented `GET /api/notifications`
- Added authentication requirement for Bearer JWT
- Added success response example
- Added empty response example
- Added notes about user-specific notification filtering
- Clarified that notifications are returned in newest-first order
- Clarified that pagination is not currently included

## Documented API

| Method | Endpoint | Auth Required |
|--------|----------|---------------|
| GET | `/api/notifications` | Yes |

## Notes

- This PR only updates frontend/docs API documentation
- No frontend source code was modified
- `PUT /api/notifications/{id}/read` is not documented in this PR
- `PUT /api/notifications/read-all` is not documented in this PR
- Notification creation triggers are not documented because they are not part of this backend implementation