### PR TITLE
fix: restore :where() specificity fix for dark mode text inheritance

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1369,14 +1369,6 @@ main {
   color-scheme: dark;
 }
 
-.dark p,
-.dark span,
-.dark h1,
-.dark h2,
-.dark h3,
-.dark h4,
-.dark h5,
-.dark h6,
-.dark label {
+:where(.dark p, .dark span, .dark h1, .dark h2, .dark h3, .dark h4, .dark h5, .dark h6, .dark label) {
   color: inherit;
 }


### PR DESCRIPTION
## Description
This PR resolves the invisible text contrast bug in the global footer by lowering the CSS specificity of the dark theme text inheritance rules.

Closes #7875

### What changed?
Replaced the explicit `.dark` descendant selectors for typography elements (`p`, `span`, `h1` through `h6`, `label`) with the `:where()` pseudo-class function inside `src/App.css`.

### Why does this fix it?
The previous explicit selectors had a specificity weight that aggressively overrode localized text colors applied within the footer component. By wrapping these global selectors in `:where()`, their specificity is neutralized to 0. This maintains the baseline dark mode inheritance across the app but allows nested components (like the dark footer wrapper) to properly apply and render their own high-contrast text utility classes.

## Type of change
* [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
<img width="633" height="318" alt="image" src="https://github.com/user-attachments/assets/958be1bc-f672-4d15-8445-49f9d98d4ee4" />

## Checklist
* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports