### PR TITLE
fix: call backend logout endpoint to invalidate HttpOnly session cookie

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -340,7 +340,12 @@ export const AuthProvider = ({ children }) => {
 
 
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    try {
+      await authService.logout();
+    } catch (error) {
+      console.warn("[AuthContext] Backend logout failed, proceeding with local clear", error);
+    }
     clearSession();
     setAuthRequestState({ loading: false, error: null });
   }, [clearSession, setAuthRequestState]);


### PR DESCRIPTION
Fixes #7944

### Description
The \clearSession\ function in \AuthContext.js\ previously only attempted to clear the token from \document.cookie\. Since the application transitioned to using \HttpOnly\ cookies for security, client-side JavaScript cannot delete these cookies, resulting in the user remaining authenticated on the backend even after logging out.
This PR updates the \logout\ function to make an asynchronous call to the backend \uthService.logout()\ endpoint before clearing local session state, ensuring the \HttpOnly\ cookie is properly invalidated by the server.

### Changes Made
- Modified \logout\ in \AuthContext.js\ to be an \sync\ function.
- Added \wait authService.logout()\ with fallback error handling.