### PR TITLE
fix: enforce cookie-managed session expiry using user.exp

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -220,12 +220,13 @@ export const AuthProvider = ({ children }) => {
 
     expiryToastShownRef.current = false;
 
+    let expSeconds;
     if (token === "cookie-managed") {
-      return;
+      expSeconds = user?.exp;
+    } else {
+      const payload = decodeTokenPayload(token);
+      expSeconds = payload?.exp;
     }
-
-    const payload = decodeTokenPayload(token);
-    const expSeconds = payload?.exp;
 
     let timeoutId;
 
@@ -235,30 +236,37 @@ export const AuthProvider = ({ children }) => {
       const delayMs = Math.max(expiresAtMs - nowMs + 1000, 0);
 
       timeoutId = setTimeout(() => {
-        if (!isTokenValid(token)) {
+        if (token === "cookie-managed" ? Date.now() >= expiresAtMs : !isTokenValid(token)) {
           clearExpiredSession();
         }
       }, delayMs);
     } else {
-      timeoutId = setInterval(() => {
+      // If we have no expiration information, we can only rely on API 401s.
+      // We do not ping blindly every 60s as it's wasteful.
+      // But if there's a token, we check it.
+      if (token !== "cookie-managed") {
+        timeoutId = setInterval(() => {
+          if (!isTokenValid(token)) {
+            clearExpiredSession();
+          }
+        }, 60_000);
+
         if (!isTokenValid(token)) {
           clearExpiredSession();
         }
-      }, 60_000);
-
-      if (!isTokenValid(token)) {
-        clearExpiredSession();
       }
     }
 
     return () => {
-      if (typeof expSeconds === "number") {
-        clearTimeout(timeoutId);
-      } else {
-        clearInterval(timeoutId);
+      if (timeoutId) {
+        if (typeof expSeconds === "number") {
+          clearTimeout(timeoutId);
+        } else {
+          clearInterval(timeoutId);
+        }
       }
     };
-  }, [token, clearExpiredSession]);
+  }, [token, user?.exp, clearExpiredSession]);
 
   const persistSession = useCallback(async (sessionToken, sessionUser) => {
     setToken(sessionToken);
@@ -347,7 +355,13 @@ export const AuthProvider = ({ children }) => {
 
   const isAuthenticated = useCallback(() => {
     if (!user || !token) return false;
-    if (token !== "cookie-managed" && !isTokenValid(token)) {
+    
+    if (token === "cookie-managed") {
+      if (typeof user.exp === "number" && Date.now() >= user.exp * 1000) {
+        clearExpiredSession();
+        return false;
+      }
+    } else if (!isTokenValid(token)) {
       clearExpiredSession();
       return false;
     }


### PR DESCRIPTION
Fixes #7945

### Description
Previously, when the authentication token was set to \cookie-managed\ (HttpOnly model), the frontend's \isAuthenticated\ function and the session expiry timer blindly returned true without checking the actual token expiration time. This caused the UI to permanently show the user as logged in until an API request naturally failed with a 401 error.
This PR fixes the issue by reading the \exp\ property directly from the \user\ profile when the token is \cookie-managed\, ensuring the session expires correctly and the UI updates proactively.

### Changes Made
- Updated the \useEffect\ session expiry timer in \AuthContext.js\ to extract \expSeconds\ from \user?.exp\ for cookie-managed sessions.
- Updated \isAuthenticated\ to check \Date.now() >= user.exp * 1000\ when the token is \cookie-managed\.