### PR TITLE
fix: enforce LRU eviction in offlineEventCache.js to prevent quota errors

### DIFF
--- a/src/utils/offlineEventCache.js
+++ b/src/utils/offlineEventCache.js
@@ -82,6 +82,26 @@ export const getCachedEvents = () => {
 // Event detail cache
 // ---------------------------------------------------------------------------
 
+const MAX_CACHE_SIZE = 50;
+
+const enforceLRU = (cached) => {
+  const keys = Object.keys(cached);
+  if (keys.length <= MAX_CACHE_SIZE) return;
+
+  // Sort keys by cachedAt ascending (oldest first)
+  keys.sort((a, b) => {
+    const timeA = new Date(cached[a]?.cachedAt || 0).getTime();
+    const timeB = new Date(cached[b]?.cachedAt || 0).getTime();
+    return timeA - timeB;
+  });
+
+  // Delete oldest entries until we're at or below the limit
+  const numToRemove = keys.length - MAX_CACHE_SIZE;
+  for (let i = 0; i < numToRemove; i++) {
+    delete cached[keys[i]];
+  }
+};
+
 export const saveCachedEventDetail = (event) => {
   if (!event?.id) {
     return false;
@@ -91,6 +111,7 @@ export const saveCachedEventDetail = (event) => {
     cachedAt: new Date().toISOString(),
     event,
   };
+  enforceLRU(cached);
   return writeJson(EVENT_DETAILS_CACHE_KEY, cached);
 };
 
@@ -123,6 +144,7 @@ export const saveAllCachedEventDetails = (events = []) => {
     }
   });
 
+  enforceLRU(cached);
   return writeJson(EVENT_DETAILS_CACHE_KEY, cached);
 };
 


### PR DESCRIPTION
Fixes #7946

### Description
The \saveCachedEventDetail\ function in \offlineEventCache.js\ previously cached detailed event data indefinitely. While stale entries were pruned upon access, there was no maximum size limit or eviction strategy, allowing browsing of many events to quickly exhaust the ~5MB \localStorage\ limit and trigger a \QuotaExceededError\.
This PR introduces a Least Recently Used (LRU) eviction strategy that limits the event details cache to 50 items. Oldest entries (by \cachedAt\) are removed whenever the limit is exceeded.

### Changes Made
- Added \enforceLRU\ helper function to delete oldest cache entries until the size is at or below \MAX_CACHE_SIZE\ (50).
- Called \enforceLRU\ before writing back to localStorage in \saveCachedEventDetail\ and \saveAllCachedEventDetails\.