### PR TITLE
fix: persist session recovery encryption key to sessionStorage

### DIFF
--- a/src/context/SessionRecoveryContext.js
+++ b/src/context/SessionRecoveryContext.js
@@ -135,10 +135,16 @@ const getOrCreateSessionKey = () => {
   if (typeof window === "undefined") return null;
   try {
     if (!_inMemorySessionKey) {
-      const raw = crypto.getRandomValues(new Uint8Array(32));
-      _inMemorySessionKey = Array.from(raw)
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
+      const stored = sessionStorage.getItem("eventra_session_key");
+      if (stored) {
+        _inMemorySessionKey = stored;
+      } else {
+        const raw = crypto.getRandomValues(new Uint8Array(32));
+        _inMemorySessionKey = Array.from(raw)
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        sessionStorage.setItem("eventra_session_key", _inMemorySessionKey);
+      }
     }
     return _inMemorySessionKey;
   } catch (e) {


### PR DESCRIPTION
Fixes #7947

### Description
In \SessionRecoveryContext.js\, the encryption key \_inMemorySessionKey\ was generated randomly but never persisted. This caused the key to reset on every page reload, making it impossible to decrypt the existing \eventra_session_state\ stored in \localStorage\ and effectively breaking the session recovery feature across reloads.
This PR fixes the issue by reading the key from \sessionStorage\ and saving newly generated keys back to \sessionStorage\.

### Changes Made
- Updated \getOrCreateSessionKey\ to retrieve the key from \sessionStorage\ under the key \eventra_session_key\.
- Updated the key generation logic to persist the new key to \sessionStorage\.