### PR TITLE
fix: implement client-side fallback sorting for Title and Price

### DIFF
--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -259,12 +259,30 @@ const useEventListing = () => {
 
   const sortedEvents = useMemo(() => {
     return [...filteredEvents].sort((a, b) => {
+      if (sortType === "Title A-Z") {
+        return (a.title || "").localeCompare(b.title || "");
+      }
+      if (sortType === "Title Z-A") {
+        return (b.title || "").localeCompare(a.title || "");
+      }
+      if (sortType === "Price Low to High") {
+        const priceA = a.price === "Free" || !a.price ? 0 : parseFloat(a.price);
+        const priceB = b.price === "Free" || !b.price ? 0 : parseFloat(b.price);
+        return priceA - priceB;
+      }
+      if (sortType === "Price High to Low") {
+        const priceA = a.price === "Free" || !a.price ? 0 : parseFloat(a.price);
+        const priceB = b.price === "Free" || !b.price ? 0 : parseFloat(b.price);
+        return priceB - priceA;
+      }
+
       const dateA = new Date(a.date || a.startDate);
       const dateB = new Date(b.date || b.startDate);
 
-      if (sortType === "Upcoming") {
+      if (sortType === "Upcoming" || sortType === "Oldest") {
         return dateA - dateB;
       }
+      // Default / Newest
       return dateB - dateA;
     });
   }, [filteredEvents, sortType]);


### PR DESCRIPTION
Fixes #7948

### Description
In \useEventListing.js\, the client-side fallback sorter (\sortedEvents\ memo) only supported the \Upcoming\ and \Newest\ sort options, defaulting everything else to \Newest\ (\dateB - dateA\). This caused Title and Price sorting to appear broken when the frontend was running on mock data or fallback mode.
This PR adds the missing comparison logic for all supported sort types.

### Changes Made
- Updated \sortedEvents\ memo to explicitly handle \Title A-Z\, \Title Z-A\, \Price Low to High\, and \Price High to Low\.
- Handled edge cases where price might be the string 'Free' or missing by treating it as 0.