### PR TITLE
fix: resolve PWA update refresh loop by triggering skipWaiting

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -13,3 +13,11 @@ self.addEventListener('fetch', (event) => {
     );
   }
 });
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+ 

--- a/src/components/common/UpdateAvailableBanner.jsx
+++ b/src/components/common/UpdateAvailableBanner.jsx
@@ -3,9 +3,13 @@ import { RefreshCw, X } from "lucide-react";
 
 export default function UpdateAvailableBanner() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [registration, setRegistration] = useState(null);
 
   useEffect(() => {
-    const handler = () => {
+    const handler = (e) => {
+      if (e.detail && e.detail.registration) {
+        setRegistration(e.detail.registration);
+      }
       setUpdateAvailable(true);
     };
 
@@ -17,7 +21,19 @@ export default function UpdateAvailableBanner() {
   }, []);
 
   const handleRefresh = () => {
-    window.location.reload();
+    if (registration && registration.waiting) {
+      registration.waiting.postMessage({ type: "SKIP_WAITING" });
+    }
+    
+    // Listen for the new active service worker and reload
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      window.location.reload();
+    });
+
+    // Fallback reload if controllerchange doesn't fire within 2 seconds
+    setTimeout(() => {
+      window.location.reload();
+    }, 2000);
   };
 
   const handleDismiss = () => {


### PR DESCRIPTION
## Description

This PR resolves the issue where the PWA "New version available!" update banner would enter an infinite refresh loop without successfully activating the new version of the Service Worker. 

Previously, clicking the "Refresh" button inside the update banner simply triggered `window.location.reload()`. Because the waiting Service Worker was not sent a `SKIP_WAITING` instruction, the page reloaded but re-bound to the old Service Worker. This left the user stuck on the old version until they manually closed all open tabs of the site.

**Summary of Changes:**
* **`public/service-worker.js`**: Added a message event listener to intercept `SKIP_WAITING` events and trigger `self.skipWaiting()`.
* **`src/components/common/UpdateAvailableBanner.jsx`**:
  * Captured the Service Worker registration reference passed inside the `sw-update-available` event.
  * Updated the refresh action to post `SKIP_WAITING` to the waiting worker and reload the page only when the new controller assumes control (`controllerchange` event).
  * Added a 2-second fallback reload as a safety check.

Fixes #7932 

## Type of change 

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

*(N/A for background service worker processes)*

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
```