### PR TITLE
feat: add edge-native geolocation blocking middleware for restricted …

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -80,7 +80,16 @@ const addSecurityHeaders = (headers) => {
   }
 };
 
+const BLOCKED_COUNTRIES = ['CU', 'IR', 'KP', 'SY', 'RU'];
+
 export default async function middleware(request) {
+  const country = request.geo?.country || 'US';
+  if (BLOCKED_COUNTRIES.includes(country)) {
+    return new Response(JSON.stringify({ error: "Unavailable For Legal Reasons" }), {
+      status: 451,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
   const url = new URL(request.url);
 
   // Skip preflight — let the backend handle CORS


### PR DESCRIPTION
Resolves #7895

**Changes:**
- Enhanced `middleware.js` to parse `request.geo.country` provided by Vercel's Edge network.
- Requests originating from a configurable array of restricted countries are now immediately rejected at the edge with a `451 Unavailable For Legal Reasons` response before hitting the backend.