### PR TITLE
fix: replace proprietary ud-stat classes with raw Tailwind in Dashboa…

### DIFF
--- a/src/components/common/SkeletonLoaders.jsx
+++ b/src/components/common/SkeletonLoaders.jsx
@@ -383,9 +383,9 @@ export const ProjectCardSkeleton = () => (
 );
 
 export const DashboardStatCardSkeleton = () => (
-  <div aria-hidden="true" className="ud-stat-card">
-    <SkeletonBlock className="ud-stat-icon h-11 w-11 rounded-xl" />
-    <div className="ud-stat-info flex-1">
+  <div aria-hidden="true" className="flex items-center p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 animate-pulse">
+    <SkeletonBlock className="h-14 w-14 rounded-xl flex-shrink-0" />
+    <div className="flex-1 ml-4">
       <SkeletonBlock className="h-3 w-20 mb-2" />
       <SkeletonBlock className="h-8 w-14 mb-2" />
       <SkeletonBlock className="h-3 w-32" />


### PR DESCRIPTION
Resolves #7888

**Changes:**
- Replaced the hardcoded external `ud-stat-*` utility classes with raw Tailwind spacing, flexbox, and color utilities.
- This guarantees the skeleton loader maintains structural stability and prevents Cumulative Layout Shifts (CLS) while waiting for asynchronous stylesheets to load on slower connections.