### PR TITLE
fix: add safe fallback for getRelativeTime on environments lacking In…

### DIFF
--- a/src/utils/dateFormatter.js
+++ b/src/utils/dateFormatter.js
@@ -111,6 +111,7 @@ export function getRelativeTime(date) {
     if (Math.abs(diffMin) >= 1) return rtf.format(diffMin, "minute");
     return rtf.format(diffSec, "second");
   } catch {
-    return "";
+    const d = date instanceof Date ? date : new Date(date);
+    return isNaN(d.getTime()) ? "" : d.toLocaleString();
   }
 }


### PR DESCRIPTION
Resolves #7887

**Changes:**
- Updated the error fallback logic in `src/utils/dateFormatter.js` inside `getRelativeTime()`.
- Instead of returning an empty string `""` on older browsers (like older iOS Safari versions), it now falls back to standard `.toLocaleString()` to ensure times remain visible.