### PR TITLE
Add check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ cp .env.example .env
 1. Start the local development container:
 
 ```bash
-docker-compose up eventra-dev
+docker compose up eventra-dev
 ```
 
 The app will be available at `http://localhost:3000` with hot-reloading enabled.
@@ -151,7 +151,7 @@ The app will be available at `http://localhost:3000` with hot-reloading enabled.
 1. Build and test the production container locally:
 
 ```bash
-docker-compose up --build eventra-prod
+docker compose up --build eventra-prod
 ```
 
 The production-optimized build will be served via Nginx at `http://localhost:8080`.

--- a/README.md
+++ b/README.md
@@ -113,22 +113,20 @@ cd Eventra
 npm install
 ```
 
-1. Create your env file:
+2. Create your env file:
 
 ```bash
 cp .env.example .env
 ```
 > **Tip:** If your operating system does not support `cp`, copy the file manually or use `copy .env.example .env` on Windows.
 
-1. Start dev server:
+3. Start dev server:
 
-2. Start dev server:
-
-```bash
 npm run dev
-```
 
 App runs at `http://localhost:3000` (configured in `vite.config.js`).
+
+
 
 ## Docker Development
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Security note: never place private secrets in `REACT_APP_*` or `VITE_*` variable
 | `npm run format` | Run Prettier on source files |
 | `npm run test` | Run unit test suite |
 | `npm run test:e2e` | Run Playwright E2E tests |
+| `npm run check` | Run lint + tests together (CI validation) |
 | `npm run storybook` | Start Storybook |
 | `npm run build-storybook` | Build Storybook static output |
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test": "npm run test:unit",
     "test:unit": "node scripts/run-unit-tests.mjs",
     "test:e2e": "playwright test",
+    "check": "npm run lint && npm run test",
     "lint": "eslint src --max-warnings=250",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,css}\"",


### PR DESCRIPTION
## Description

Adds a single command to run lint and tests together, improving developer experience and preventing CI failures.

## Problem
Contributors currently need to run two separate commands to validate changes before pushing:

```bash
npm run lint
npm run test


This is inconvenient and leads to CI failures when contributors forget to run one of them.

##Solution

Added "check": "npm run lint && npm run test" to package.json scripts.

##Usage

npm run check

##Changes Made

package.json: Added check script that runs lint + tests sequentially
README.md: Updated "Available Scripts" table with new npm run check command

##Checklist

[x] Script runs successfully (npm run check executes both lint and test)
[x] README updated with new command documentation
[x] No breaking changes to existing scripts

##Related Issue
Fixes #7984
