### PR TITLE
[Bug] Malformed import block in GitHubStats.jsx causes module parse failure

### DIFF
--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 
 import { safeJsonParse } from "../../../utils/safeJsonParse";
+import {
   fetchRepository,
   fetchContributors,
   fetchPullRequests,


### PR DESCRIPTION
## Description
Fixes #8005 — The import block in src/Pages/Home/components/GitHubStats.jsx was syntactically malformed. Lines 19-22 were missing the import { keyword, making etchRepository an unexpected identifier.

## Change
Added the missing import { keyword before etchRepository.

Closes #8005