### PR TITLE
[Bug] Hardcoded Cloudinary demo cloud name in imageOptimizer.js

### DIFF
--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -35,7 +35,10 @@ export const getOptimizedImageUrl = (originalUrl, options = {}) => {
   if (height) transformations += `,h_${height},c_fill`;
 
   // Use Cloudinary fetch API for real format conversion
-  const cloudName = import.meta.env?.VITE_CLOUDINARY_CLOUD_NAME || "demo";
+  const cloudName = import.meta.env?.VITE_CLOUDINARY_CLOUD_NAME;
+  if (!cloudName) {
+    return originalUrl;
+  }
 
   // Only apply to absolute HTTP/HTTPS URLs that Cloudinary can fetch.
   // Relative paths (/images/hero.jpg), blob: URLs, and data: URIs cannot


### PR DESCRIPTION
## Description
Fixes #8006 — src/utils/imageOptimizer.js silently fell back to Cloudinary's public demo cloud when VITE_CLOUDINARY_CLOUD_NAME was not set. The demo cloud is publicly writable, shared across all apps, and subject to strict rate limits.

## Change
Return the original URL unchanged when no Cloudinary cloud name is configured.

Closes #8006