### PR TITLE
[Refactor] Replace hardcoded values and direct process.env access with centralized ENV config

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -87,7 +87,7 @@ const ApiDocs = () => {
     status: "all",
     hackathonId: "1",
     sortBy: "recent",
-    authHeader: `Bearer ${process.env.NODE_ENV === 'development' ? "evt_dev_test_token" : "[redacted]"}`,
+    authHeader: "Bearer [redacted]",
     role: "all",
     page: "1",
   });

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -22,6 +22,7 @@ import {
   ChevronLeft,
   Clock,
 } from "lucide-react";
+import { ENV } from "../../config/env";
 import { exportToCSV, exportToJSON } from "../../utils/exportUtils";
 import {
   AdminListCardSkeleton,
@@ -736,7 +737,7 @@ const AdminDashboard = () => {
             <p className="ad-footer-copyright">© {new Date().getFullYear()} Eventra. Admin Control Panel.</p>
             <div className="ad-footer-links">
               <Link to="/helpcenter" className="ad-footer-link">Help Center</Link>
-              <a href={`https://github.com/${import.meta.env.VITE_GITHUB_REPO || import.meta.env.REACT_APP_GITHUB_REPO || 'sandeepvashishtha/Eventra'}`} target="_blank" rel="noopener noreferrer" className="ad-footer-link">GitHub</a>
+              <a href={`https://github.com/${ENV.GITHUB_REPO}`} target="_blank" rel="noopener noreferrer" className="ad-footer-link">GitHub</a>
               <Link to="/privacy" className="ad-footer-link">Privacy Policy</Link>
               <Link to="/terms" className="ad-footer-link">Terms of Service</Link>
             </div>

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -34,7 +34,8 @@ const resolveEnvApiBaseUrl = () => {
     logger.warn(`VITE_API_URL environment variable is missing in ${process.env.NODE_ENV}. Defaulting to relative API requests.`);
     return "";
   }
-  return "http://localhost:8080";
+  logger.warn("VITE_API_URL not set in development. Defaulting to localhost.");
+  return "";
 };
 
 export const API_BASE_URL = resolveEnvApiBaseUrl();

--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -125,7 +125,7 @@ export const generateEventSharingData = (event, baseUrl = null) => {
   }
 
   // Determine the correct base URL for sharing
-  const rawPublicUrl = import.meta.env.VITE_PUBLIC_URL || import.meta.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech";
+  const rawPublicUrl = ENV.PUBLIC_URL;
 
   // If baseUrl is provided, use it, otherwise detect
   if (!baseUrl) {


### PR DESCRIPTION
## Description
Fixes #8007 — Four files bypassed the centralized src/config/env.js by accessing process.env/import.meta.env directly or using hardcoded fallbacks.

## Files changed
1. src/config/api.js — Removed hardcoded http://localhost:8080 fallback
2. src/utils/shareUtils.js — Replaced direct env chain with ENV.PUBLIC_URL
3. src/components/admin/AdminDashboard.js — Replaced direct env access with ENV.GITHUB_REPO
4. src/Pages/ApiDocs.js — Removed dev token exposure in default auth header

Closes #8007