### PR TITLE
fix(ci): update .gitignore to build/ and add release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+        env:
+          NODE_ENV: production
+          JWT_SECRET: "mock-jwt-secret-for-ci-build-verification-only"
+
+      - name: Archive build directory
+        run: tar -czf build.tar.gz build
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .vscode
 
 node_modules
-build
+build/
 .DS_Store
 
 # Secret Files - DO NOT COMMIT


### PR DESCRIPTION
Issue #4689

Walkthrough of Changes 
This walkthrough documents the changes made to ensure build assets are fully ignored in future developments and automated by a new GitHub Actions release workflow.

Changes Made
Configuration Files
.gitignore
Changed the ignore pattern for build files from build to build/ to be specific and standard.
.github/workflows/release.yml
Created a new GitHub Actions workflow that compiles the production build, packages it into a tarball, and uploads it to GitHub release assets whenever a release is published.