### PR TITLE
fix: remove duplicate strict-dynamic CSP header causing blank screen …

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -62,7 +62,6 @@
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
-          "value": "default-src 'self'; script-src 'self' 'strict-dynamic' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
         },
         {
           "key": "Vary",


### PR DESCRIPTION
## Description
This PR removes the redundant and misconfigured `strict-dynamic` Content Security Policy header from `vercel.json` to resolve the fatal production rendering crash.

Fixes #7955

### What changed?
Deleted the duplicate CSP key value block in `vercel.json` that enforced `script-src 'self' 'strict-dynamic'`. The configuration now cleanly falls back to the primary, properly configured host-based allowlist.

### Why does this fix it?
Deploying a `strict-dynamic` directive without generating cryptographic nonces caused the browser to block the core React Javascript bundle and third-party authentication scripts. Removing this conflicting rule allows the application to mount and execute the DOM correctly, eliminating the white screen of death.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings