### PR TITLE
feat: add social media sharing buttons to event pages

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -26,6 +26,7 @@ import { getEventStatus } from "../../utils/eventUtils";
 import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import AddToCalendar from "../../components/common/AddToCalendar";
+import SocialShareButtons from "../../components/common/SocialShareButtons";
 import {
   addBookmarkedEvent,
   isEventBookmarked,
@@ -379,6 +380,11 @@ const EventCard = ({ event }) => {
           </div>
         );
       })()}
+
+      {/* Social Sharing */}
+      <div className="px-5 py-3 border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 flex justify-center">
+        <SocialShareButtons event={event} layout="inline" />
+      </div>
 
       {/* CTA */}
       <div className="px-5 py-4 flex gap-3 mt-auto">

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -19,13 +19,13 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { toast } from "react-toastify";
-import { addEventToGoogleCalendar } from "../../utils/calendarUtils";
 import LazyImage from "../../components/common/LazyImage";
 import ShareModal from "../../components/common/ShareModal";
 import StatusBadge from "../../components/common/StatusBadge";
 import { getEventStatus } from "../../utils/eventUtils";
 import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
+import AddToCalendar from "../../components/common/AddToCalendar";
 import {
   addBookmarkedEvent,
   isEventBookmarked,
@@ -236,17 +236,7 @@ const EventCard = ({ event }) => {
           </svg>
         </button>
 
-        <a
-          href={addEventToGoogleCalendar(event)}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          title="Add to Google Calendar"
-          aria-label={`Add ${event.title} to Google Calendar`}
-          className="rounded-full border border-gray-200 bg-white/90 p-2 shadow backdrop-blur-sm hover:border-indigo-200 dark:border-gray-700 dark:bg-gray-800/90 dark:hover:border-indigo-500 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-500"
-        >
-          <Calendar size={14} className="text-gray-600 dark:text-gray-300" aria-hidden="true" />
-        </a>
+        <AddToCalendar event={event} iconOnly={true} />
       </div>
 
       {/* Header */}

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -23,8 +23,8 @@ import { useAuth } from "../../context/AuthContext";
 import { exportToCSV, exportToJSON } from "../../utils/exportUtils";
 import { ROLES } from "../../config/roles";
 import { marked } from "marked";
-import ShareMenu from "../../components/common/ShareMenu";
 import ShareModal from "../../components/common/ShareModal";
+import SocialShareButtons from "../../components/common/SocialShareButtons";
 import { generateEventSharingData } from "../../utils/shareUtils";
 import { downloadICSFile, generateGoogleCalendarLink, generateOutlookLink } from "../../utils/calendarExporter";
 import useRecentlyViewed from "../../hooks/useRecentlyViewed";
@@ -551,11 +551,7 @@ const EventDetails = () => {
               {/* Share & Add to Calendar */}
               <div className="rounded-3xl bg-slate-50 p-5 dark:bg-gray-800 space-y-4">
                 <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">Share & Add to Calendar</h3>
-                <ShareMenu shareData={generateEventSharingData({ ...event, title: event.title, description: event.description, date: event.date, id: event.id })} position="top-left">
-                  <button className="w-full inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2.5 text-sm font-semibold text-gray-800 dark:text-gray-100 shadow-sm hover:bg-indigo-50 dark:hover:bg-indigo-900/30 hover:border-indigo-300 dark:hover:border-indigo-600 transition-all duration-200" aria-label="Share this event">
-                    <Share2 size={15} className="text-indigo-500" /> Share Event
-                  </button>
-                </ShareMenu>
+                <SocialShareButtons event={event} layout="grid" />
 
                 <div className="flex flex-col gap-2">
                   <button onClick={() => { downloadICSFile(event); toast.success("Calendar invite downloaded!"); }} className="w-full inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2.5 text-sm font-semibold text-gray-800 dark:text-gray-100 shadow-sm hover:bg-green-50 dark:hover:bg-green-900/20 hover:border-green-300 dark:hover:border-green-700 transition-all duration-200" aria-label="Download .ics calendar invite">

--- a/src/components/common/AddToCalendar.jsx
+++ b/src/components/common/AddToCalendar.jsx
@@ -47,7 +47,7 @@ const downloadIcal = (event) => {
   URL.revokeObjectURL(url);
 };
 
-export default function AddToCalendar({ event, className = '' }) {
+export default function AddToCalendar({ event, className = '', iconOnly = false }) {
   const [open, setOpen] = useState(false);
   const [added, setAdded] = useState('');
 
@@ -75,13 +75,20 @@ export default function AddToCalendar({ event, className = '' }) {
     <div className={`relative inline-block ${className}`}>
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+        className={iconOnly 
+          ? "rounded-full border border-gray-200 bg-white/90 p-2 shadow backdrop-blur-sm hover:border-indigo-200 dark:border-gray-700 dark:bg-gray-800/90 dark:hover:border-indigo-500 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-500 cursor-pointer"
+          : "flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"}
         aria-haspopup="true"
         aria-expanded={open}
+        title="Add to Calendar"
       >
-        <Calendar className="w-4 h-4" />
-        Add to Calendar
-        <ChevronDown className={`w-4 h-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+        <Calendar className={iconOnly ? "w-3.5 h-3.5 text-gray-600 dark:text-gray-300" : "w-4 h-4"} />
+        {!iconOnly && (
+          <>
+            Add to Calendar
+            <ChevronDown className={`w-4 h-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+          </>
+        )}
       </button>
 
       {open && (

--- a/src/components/common/SocialShareButtons.jsx
+++ b/src/components/common/SocialShareButtons.jsx
@@ -1,0 +1,94 @@
+import React, { useMemo, useCallback } from "react";
+import { Copy, Facebook, Linkedin, Mail, MessageCircle, Send, Twitter } from "lucide-react";
+import { toast } from "react-toastify";
+import { isValidShareUrl } from "../../utils/shareUtils";
+
+const SocialShareButtons = ({ event, layout = "grid" }) => {
+  const shareData = useMemo(() => {
+    if (!event || !event.id) return null;
+
+    const shareUrl = `${window.location.origin}/events/${event.id}`;
+    if (!isValidShareUrl(shareUrl)) return null;
+    
+    const shareText = `Check out this event: ${event.title}`;
+
+    return {
+      shareUrl,
+      links: {
+        twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`,
+        linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`,
+        whatsapp: `https://wa.me/?text=${encodeURIComponent(`${shareText} ${shareUrl}`)}`,
+        facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
+        telegram: `https://t.me/share/url?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareText)}`,
+        email: `mailto:?subject=${encodeURIComponent(event.title)}&body=${encodeURIComponent(`${shareText}\n\n${shareUrl}`)}`,
+      },
+    };
+  }, [event]);
+
+  const copyLink = useCallback(async () => {
+    if (!shareData?.shareUrl) return;
+
+    try {
+      if (!navigator?.clipboard) {
+        throw new Error("Clipboard API unavailable.");
+      }
+
+      await navigator.clipboard.writeText(shareData.shareUrl);
+      toast.success("Link copied to clipboard");
+    } catch (error) {
+      console.error("Failed to copy share link:", error);
+      toast.error("Could not copy the link");
+    }
+  }, [shareData]);
+
+  if (!shareData) return null;
+
+  const buttonClasses = "flex items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm font-medium transition-all hover:scale-[1.02] shadow-sm";
+
+  if (layout === "inline") {
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        <a href={shareData.links.twitter} target="_blank" rel="noopener noreferrer" className="p-2 bg-black text-white rounded-full hover:bg-slate-800 transition-colors" title="Share on Twitter/X">
+          <Twitter size={14} />
+        </a>
+        <a href={shareData.links.linkedin} target="_blank" rel="noopener noreferrer" className="p-2 bg-blue-700 text-white rounded-full hover:bg-blue-800 transition-colors" title="Share on LinkedIn">
+          <Linkedin size={14} />
+        </a>
+        <a href={shareData.links.whatsapp} target="_blank" rel="noopener noreferrer" className="p-2 bg-green-600 text-white rounded-full hover:bg-green-700 transition-colors" title="Share on WhatsApp">
+          <MessageCircle size={14} />
+        </a>
+        <a href={shareData.links.facebook} target="_blank" rel="noopener noreferrer" className="p-2 bg-blue-600 text-white rounded-full hover:bg-blue-700 transition-colors" title="Share on Facebook">
+          <Facebook size={14} />
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`grid ${layout === "grid" ? "grid-cols-2" : "grid-cols-1"} gap-3`}>
+      <a href={shareData.links.twitter} target="_blank" rel="noopener noreferrer" className={`${buttonClasses} bg-black text-white hover:bg-slate-800`}>
+        <Twitter size={16} /> Twitter/X
+      </a>
+      <a href={shareData.links.linkedin} target="_blank" rel="noopener noreferrer" className={`${buttonClasses} bg-blue-700 text-white hover:bg-blue-800`}>
+        <Linkedin size={16} /> LinkedIn
+      </a>
+      <a href={shareData.links.whatsapp} target="_blank" rel="noopener noreferrer" className={`${buttonClasses} bg-green-600 text-white hover:bg-green-700`}>
+        <MessageCircle size={16} /> WhatsApp
+      </a>
+      <a href={shareData.links.facebook} target="_blank" rel="noopener noreferrer" className={`${buttonClasses} bg-blue-600 text-white hover:bg-blue-700`}>
+        <Facebook size={16} /> Facebook
+      </a>
+      <a href={shareData.links.telegram} target="_blank" rel="noopener noreferrer" className={`${buttonClasses} ${layout === "grid" ? "col-span-2" : ""} bg-sky-500 text-white hover:bg-sky-600`}>
+        <Send size={16} /> Telegram
+      </a>
+      <a href={shareData.links.email} className={`${buttonClasses} ${layout === "grid" ? "col-span-2" : ""} bg-slate-100 text-slate-800 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700`}>
+        <Mail size={16} /> Email
+      </a>
+      <button type="button" onClick={copyLink} className={`${buttonClasses} ${layout === "grid" ? "col-span-2" : ""} bg-violet-600 text-white hover:bg-violet-700`}>
+        <Copy size={16} /> Copy Link
+      </button>
+    </div>
+  );
+};
+
+export default SocialShareButtons;


### PR DESCRIPTION
## Description

This PR adds social media sharing buttons directly on the event discovery and event details pages. A new reusable \SocialShareButtons\ component handles inline sharing to Twitter, LinkedIn, WhatsApp, Facebook, Telegram, Email, and Clipboard.

Fixes #7986

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using npm test and verified they pass
- [x] I have run npm run lint and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports