### PR TITLE
feat: expand advanced filtering with tags and skill levels

### DIFF
--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -84,6 +84,18 @@ const useEventListing = () => {
       });
     }
 
+    if (advancedFilters?.skillLevels?.length) {
+      advancedFilters.skillLevels.forEach((level) => {
+        params.append("skillLevel", level.toLowerCase());
+      });
+    }
+
+    if (advancedFilters?.tags?.length) {
+      advancedFilters.tags.forEach((tag) => {
+        params.append("tag", tag);
+      });
+    }
+
     const sortValue = SORT_MAPPING[sortType];
     if (sortValue) {
       params.append("sort", sortValue);

--- a/src/components/common/AdvancedFilterPanel.jsx
+++ b/src/components/common/AdvancedFilterPanel.jsx
@@ -9,6 +9,8 @@ import {
   EVENT_CATEGORIES,
   EVENT_MODES,
   EVENT_STATUS_OPTIONS,
+  EVENT_SKILL_LEVELS,
+  EVENT_TAGS,
   FILTER_PRESETS,
   hasActiveFilters,
   getDefaultFilters,
@@ -31,6 +33,8 @@ const AdvancedFilterPanel = ({
     category: true,
     mode: true,
     status: true,
+    skillLevel: true,
+    tags: false,
     location: false,
     price: false,
     date: false,
@@ -53,6 +57,14 @@ const AdvancedFilterPanel = ({
 
   const handleStatusChange = (statuses) => {
     onFiltersChange({ ...filters, statuses });
+  };
+
+  const handleSkillLevelChange = (skillLevels) => {
+    onFiltersChange({ ...filters, skillLevels });
+  };
+
+  const handleTagsChange = (tags) => {
+    onFiltersChange({ ...filters, tags });
   };
 
   const handleLocationChange = (event) => {
@@ -227,6 +239,52 @@ const AdvancedFilterPanel = ({
                   statuses={EVENT_STATUS_OPTIONS}
                   selectedStatuses={filters.statuses || []}
                   onStatusChange={handleStatusChange}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Skill Level Filter Section */}
+          <div>
+            <button
+              onClick={() => toggleSection("skillLevel")}
+              className="w-full flex items-center justify-between py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100"
+            >
+              <span>Skill Level</span>
+              <ChevronDown
+                size={16}
+                className={`transition-transform ${expandedSections.skillLevel ? "rotate-180" : ""}`}
+              />
+            </button>
+            {expandedSections.skillLevel && (
+              <div className="mt-3">
+                <CategoryFilter
+                  categories={EVENT_SKILL_LEVELS}
+                  selectedCategories={filters.skillLevels || []}
+                  onCategoryChange={handleSkillLevelChange}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Tags Filter Section */}
+          <div>
+            <button
+              onClick={() => toggleSection("tags")}
+              className="w-full flex items-center justify-between py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100"
+            >
+              <span>Tags</span>
+              <ChevronDown
+                size={16}
+                className={`transition-transform ${expandedSections.tags ? "rotate-180" : ""}`}
+              />
+            </button>
+            {expandedSections.tags && (
+              <div className="mt-3">
+                <CategoryFilter
+                  categories={EVENT_TAGS.map(t => ({ id: t, label: t }))}
+                  selectedCategories={filters.tags || []}
+                  onCategoryChange={handleTagsChange}
                 />
               </div>
             )}

--- a/src/utils/advancedFilterUtils.js
+++ b/src/utils/advancedFilterUtils.js
@@ -24,6 +24,16 @@ export const EVENT_MODES = [
   { id: "hybrid", label: "Hybrid", icon: "Cpu" },
 ];
 
+export const EVENT_SKILL_LEVELS = [
+  { id: "beginner", label: "Beginner" },
+  { id: "intermediate", label: "Intermediate" },
+  { id: "advanced", label: "Advanced" },
+];
+
+export const EVENT_TAGS = [
+  "React", "Node", "Design", "AI", "Business", "Startup", "Finance", "Marketing"
+];
+
 // Event status options
 export const EVENT_STATUS_OPTIONS = [
   { id: "upcoming", label: "Upcoming", color: "blue" },
@@ -265,6 +275,26 @@ export const filterByStatus = (events, selectedStatuses) => {
   });
 };
 
+export const filterBySkillLevel = (events, selectedSkillLevels) => {
+  if (!Array.isArray(events)) return [];
+  if (!selectedSkillLevels || selectedSkillLevels.length === 0) return events;
+  return events.filter((event) => {
+    if (!event) return false;
+    const level = normalizeFilterValue(event.skillLevel || "beginner");
+    return selectedSkillLevels.some(selected => normalizeFilterValue(selected) === level);
+  });
+};
+
+export const filterByTags = (events, selectedTags) => {
+  if (!Array.isArray(events)) return [];
+  if (!selectedTags || selectedTags.length === 0) return events;
+  return events.filter((event) => {
+    if (!event || !Array.isArray(event.tags)) return false;
+    const eventTags = event.tags.map(normalizeFilterValue);
+    return selectedTags.some(tag => eventTags.includes(normalizeFilterValue(tag)));
+  });
+};
+
 /**
  * Apply all filters to events
  * @param {Array} events - Array of events to filter
@@ -296,6 +326,14 @@ export const applyAdvancedFilters = (events, filters = {}) => {
 
   if (filters.statuses && filters.statuses.length > 0) {
     filtered = filterByStatus(filtered, filters.statuses);
+  }
+
+  if (filters.skillLevels && filters.skillLevels.length > 0) {
+    filtered = filterBySkillLevel(filtered, filters.skillLevels);
+  }
+
+  if (filters.tags && filters.tags.length > 0) {
+    filtered = filterByTags(filtered, filters.tags);
   }
 
   return filtered;
@@ -375,6 +413,8 @@ export const hasActiveFilters = (filters = {}) => {
     (filters.categories && filters.categories.length > 0) ||
     (filters.modes && filters.modes.length > 0) ||
     (filters.statuses && filters.statuses.length > 0) ||
+    (filters.skillLevels && filters.skillLevels.length > 0) ||
+    (filters.tags && filters.tags.length > 0) ||
     (filters.location && filters.location.trim() !== "") ||
     (filters.priceRange &&
       (filters.priceRange.min > 0 || filters.priceRange.max < Infinity)) ||
@@ -393,6 +433,8 @@ export const getDefaultFilters = () => ({
   categories: [],
   modes: [],
   statuses: [],
+  skillLevels: [],
+  tags: [],
   location: "",
   priceRange: null,
   dateRange: null,
@@ -404,6 +446,8 @@ export const normalizeAdvancedFilters = (filters = {}) => ({
   categories: Array.isArray(filters.categories) ? filters.categories : [],
   modes: Array.isArray(filters.modes) ? filters.modes : [],
   statuses: Array.isArray(filters.statuses) ? filters.statuses : [],
+  skillLevels: Array.isArray(filters.skillLevels) ? filters.skillLevels : [],
+  tags: Array.isArray(filters.tags) ? filters.tags : [],
   location: typeof filters.location === "string" ? filters.location : "",
   priceRange: filters.priceRange
     ? {
@@ -429,6 +473,8 @@ export const serializeAdvancedFilters = (filters = {}) => {
   if (normalized.categories.length) payload.categories = normalized.categories;
   if (normalized.modes.length) payload.modes = normalized.modes;
   if (normalized.statuses.length) payload.statuses = normalized.statuses;
+  if (normalized.skillLevels.length) payload.skillLevels = normalized.skillLevels;
+  if (normalized.tags.length) payload.tags = normalized.tags;
   if (normalized.location.trim()) payload.location = normalized.location.trim();
   if (normalized.priceRange) payload.priceRange = normalized.priceRange;
   if (


### PR DESCRIPTION
## Description

This PR expands the advanced filtering system on the events page to support filtering by tags and skill levels. It adds \EVENT_TAGS\ and \EVENT_SKILL_LEVELS\ to the filter options and integrates them into the \AdvancedFilterPanel\ UI. The local filtering logic and API query params generation in \useEventListing\ are also updated to apply these new filters correctly.

Fixes #7989

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using npm test and verified they pass
- [x] I have run npm run lint and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports