### PR TITLE
fix: update Content Security Policy to allow trusted external resources

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -129,12 +129,26 @@ export const config = {
 };
 
 const SECURITY_HEADERS = {
-  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Strict-Transport-Security":
+    "max-age=31536000; includeSubDomains; preload",
+
   "X-Frame-Options": "DENY",
+
   "X-Content-Type-Options": "nosniff",
+
   "Referrer-Policy": "strict-origin-when-cross-origin",
-  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), display-capture=()",
-  "Content-Security-Policy": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; frame-src 'self' https://accounts.google.com",
+
+  "Permissions-Policy":
+    "camera=(), microphone=(), geolocation=(), display-capture=()",
+
+  "Content-Security-Policy":
+  "default-src 'self'; " +
+  "script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; " +
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+  "img-src 'self' data: https:; " +
+  "font-src 'self' https://fonts.gstatic.com; " +
+  "connect-src 'self' https://api.github.com https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net; " +
+  "frame-src 'self' https://accounts.google.com",
 };
 
 const addSecurityHeaders = (headers) => {


### PR DESCRIPTION
## Summary

This PR updates the Content Security Policy (CSP) configuration to allow trusted external resources required by the application while maintaining existing security protections.

## Changes Made

* Added the Azure backend API domain to the `connect-src` directive.
* Preserved existing CSP restrictions for scripts, frames, images, and fonts.
* Ensured API requests to approved backend services are not blocked by CSP.
* Maintained secure default policies and security headers.

## Issue Fixed

The application was generating CSP violations in the browser console because requests to trusted external resources were being blocked by the current policy. This prevented certain resources and API calls from loading correctly.

## Testing

* Opened the application in Google Chrome.
* Verified the CSP header is applied correctly.
* Confirmed requests to the approved backend domain are allowed by the browser.
* Checked the browser console for CSP-related violations.

## Related Issue

Fixes #8058
wports
