### PR TITLE
test: stabilize SSE multiplexer channel cleanup

### DIFF
--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -173,7 +173,10 @@ const runTests = async () => {
   assert.equal(analyticsSource.closed, true);
 
   // Test 5: Heartbeat mechanisms (PING/PONG and pruning)
-  // Override sseMultiplexer.channel to use MockBroadcastChannel because of ES Module import hoisting
+  // Replace the import-time channel so the test controls every active mock channel.
+  // Leaving the old channel open lets status broadcasts loop back into the same
+  // singleton through a stale listener, which creates recursive warning noise.
+  sseMultiplexer.channel?.close();
   sseMultiplexer.channel = new globalThis.BroadcastChannel("eventra_sse_multiplexer");
   sseMultiplexer.channel.onmessage = (e) => sseMultiplexer.handleBroadcastMessage(e.data);
 
@@ -271,6 +274,9 @@ const runTests = async () => {
   } finally {
     Math.random = originalRandom;
     sseMultiplexer.stopHeartbeatChecks();
+    sseMultiplexer.channel?.close();
+    followerChannel?.close();
+    channels.clear();
     if (sseMultiplexer.heartbeatInterval) {
       clearInterval(sseMultiplexer.heartbeatInterval);
       sseMultiplexer.heartbeatInterval = null;


### PR DESCRIPTION
## Summary
- Close the import-time mock BroadcastChannel before replacing it in `sseMultiplexer.test.mjs`.
- Clean up the active multiplexer channel, follower channel, and mock channel registry at the end of the test.
- Prevent recursive SSE status rebroadcast warnings during the unit suite.

## Verification
- `node tests/sseMultiplexer.test.mjs`
- `npm run test:unit`Z
