### PR TITLE
[Bug] ICS calendar file uses literal backslash-r-backslash-n instead of actual CRLF

### DIFF
--- a/src/utils/calendarUrlUtils.js
+++ b/src/utils/calendarUrlUtils.js
@@ -269,7 +269,7 @@ export const generateIcsFileBlobUrl = (event, timezone) => {
     `LOCATION:${(event.location || '').replace(/,/g, '\\,')}`,
     'END:VEVENT',
     'END:VCALENDAR'
-  ].join('\\r\\n');
+  ].join('\r\n');
 
   try {
     const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });


### PR DESCRIPTION
## Description
Fixes #8083 — The .ics calendar file content was joined with the literal 4-character string \r\n (backslash, r, backslash, n) instead of actual CRLF control characters. This made every generated .ics file unparseable by RFC 5545 compliant calendar apps.

## Change
Changed ].join('\\r\\n') to ].join('\r\n') on line 272.

Closes #8083