### PR TITLE
[Bug] getRelativeTime() rejects numeric timestamps — returns null for valid Unix epoch inputs

### DIFF
--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -1,9 +1,6 @@
 const RELATIVE_TIME_FALLBACK = "—";
 
 export function getRelativeTime(dateInput) {
-  if (typeof dateInput === 'number') {
-    return null;
-  }
   if (dateInput === null || dateInput === undefined) {
     return RELATIVE_TIME_FALLBACK;
   }


### PR DESCRIPTION
## Description
Fixes #8084 — getRelativeTime() returned 
ull for numeric inputs, even though 
ew Date() accepts numeric timestamps (ms since epoch). Any caller passing a number got null instead of a relative time string.

## Change
Removed the incorrect 	ypeof number guard.

Closes #8084