### PR TITLE
[Bug] Registration end validation uses > instead of >=

### DIFF
--- a/src/utils/eventFormValidation.js
+++ b/src/utils/eventFormValidation.js
@@ -75,7 +75,7 @@ export const validateForm = (formData) => {
       newErrors.registrationStart = "Registration start must be before the event starts";
     }
 
-    if (registrationEnd && !isNaN(eventStart.getTime()) && registrationEnd > eventStart) {
+    if (registrationEnd && !isNaN(eventStart.getTime()) && registrationEnd >= eventStart) {
       newErrors.registrationEnd = "Registration must close before the event starts";
     }
   }


### PR DESCRIPTION
## Description
Fixes #8085 — Registration end validation used > instead of >=, so when egistrationEnd equals eventStart exactly, the error was not flagged. The identical start-time check on line 74 correctly uses >=.

## Change
Changed > to >= on line 78.

Closes #8085