### PR TITLE
fix(forms): apply correct right-padding in FormFieldWrapper (#8100)

### DIFF
--- a/src/components/forms/FormFieldWrapper.jsx
+++ b/src/components/forms/FormFieldWrapper.jsx
@@ -146,7 +146,10 @@ const FormFieldWrapper = ({
           (validationState === "success" || validationState === "valid") && "border-green-500 focus:border-green-500 focus:ring-green-500/20 dark:border-green-400",
           loading && "border-blue-500 dark:border-blue-400",
           prefix && "pl-10",
-          (showStatusIcon || suffix) && "pr-20",
+          // Reserve right padding to match the icons actually rendered: 80px for
+          // both the status icon and a suffix, 40px for just one, none otherwise.
+          showStatusIcon && suffix && "pr-20",
+          (showStatusIcon || suffix) && !(showStatusIcon && suffix) && "pr-10",
           child.props.className,
         ),
       })


### PR DESCRIPTION
## Description

`FormFieldWrapper` reserved `pr-20` (80px) of right-padding whenever `showStatusIcon` **or** `suffix` was set. Since `showStatusIcon` defaults to `true`, **every** input across the app (signup, login, and all other forms) reserved 80px for a single ~20px validation icon — about 44px of dead space, most noticeable on mobile.

This change makes the reserved padding match the icons actually rendered:
- both status icon **and** suffix → `pr-20` (80px)
- exactly one of them → `pr-10` (40px)
- neither → no right padding

Single-line conditional in `src/components/forms/FormFieldWrapper.jsx`; `joinClasses` already filters falsy values so exactly one padding class is emitted.

Fixes #8100

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

<!-- Before/after of an input on /signup showing the tighter right padding -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports