### PR TITLE
fix: add REACT_APP_GOOGLE_CLIENT_ID to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ BACKEND_URL=http://localhost:8080
 # Set to false for frontend-only development without running backend
 REACT_APP_USE_REAL_API=false
 
+# Optional: Google OAuth Client ID for Google Sign-In
+# Get yours at: https://console.cloud.google.com > APIs & Services > Credentials
+REACT_APP_GOOGLE_CLIENT_ID=your_google_client_id_here
+
 # Optional: Public repository metadata
 REACT_APP_GITHUB_REPO=SandeepVashishtha/Eventra
 


### PR DESCRIPTION
## Description
REACT_APP_GOOGLE_CLIENT_ID was used for Google OAuth Sign-In but was
missing from .env.example. Every developer who cloned the repo and ran
npm start immediately saw a console warning about an undefined env
variable, with no guidance on how to fix it.

Added the missing variable with a placeholder value and a comment
pointing to Google Cloud Console where the key can be obtained.

Fixes #7524

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
N/A — .env.example is a config template file, no UI changes involved.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports