### PR TITLE
fix(cors): proxy stream endpoints and correct Vite env variable injection

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "outputDirectory": "build",
   "framework": "vite",
   "env": {
-    "REACT_APP_API_URL": "/api"
+    "VITE_API_URL": "/api"
   },
   "rewrites": [
     {
@@ -23,7 +23,11 @@
       "destination": "https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/api/:path*"
     },
     {
-      "source": "/((?!api/.*).*)",
+      "source": "/stream/:path*",
+      "destination": "https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net/stream/:path*"
+    },
+    {
+      "source": "/((?!api/|stream/).*)",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## 📌 Related Issue Fixes
Closes #8047

***

## 📝 Description
This PR resolves the critical CORS blocking issue on production by configuring Vercel to proxy the stream endpoints directly to the Azure backend, and it fixes a silent environment variable failure.

### 🔹 What has been changed?
* **Environment Variables:** Renamed `REACT_APP_API_URL` to `VITE_API_URL` inside `vercel.json`. 
* **Stream Proxy:** Added a dedicated rewrite rule for `/stream/:path*` mapping to the Azure backend.
* **SPA Fallback:** Updated the catch-all regex from `/((?!api/.*).*)` to `/((?!api/|stream/).*)` to ensure the new stream proxy is not swallowed by the `index.html` fallback.

### 🔹 Why are these changes needed?
1. **The Vite Fix:** Vite explicitly ignores client-side environment variables that lack the `VITE_` prefix. The previous configuration was dead code, preventing the frontend from actually resolving the base API URL.
2. **The CORS Bypass:** The browser was rejecting direct frontend-to-backend requests. By using Vercel's rewrite engine to handle `/stream` routes, the requests are executed server-to-server, successfully bypassing the browser's CORS enforcement.

***

## 🛠️ Type of Change
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Architecture / Configuration update

***

## 📋 Checklist
* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports