### PR TITLE
fix: resolve syntax error in waitlistUtils.js addLocalNotification call

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -229,9 +229,6 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
   await addLocalNotification(
     "Waitlist Joined (Offline)",
     `You have been added to the offline waitlist for ${registrationForm.eventTitle || "the event"}. It will sync when you are back online.`
-    "Waitlist Joined",
-    `You have successfully joined the waitlist for ${registrationForm.eventTitle || "the event"
-    }.`
   );
 
   return newEntry;


### PR DESCRIPTION
This pull request makes a small change to the local notification shown when a user joins the waitlist offline. The redundant success notification for joining the waitlist has been removed to avoid duplicate notifications.

* Removed the extra notification for "Waitlist Joined" after adding the user to the offline waitlist in `waitlistUtils.js`.


Closes #8184 