### PR TITLE
fix: add import attribute to JSON config import in offlineQueue.js

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 import { safeJsonParse } from "./safeJsonParse.js";
 import { logger } from "./logger.js";
-import offlineSyncConfig from "../config/offlineSyncConfig.json";
+import offlineSyncConfig from "../config/offlineSyncConfig.json" with { type: "json" };
 
 const QUEUE_KEY = "eventra_offline_queue";
 const DB_NAME = "eventra_offline_db";


### PR DESCRIPTION
This pull request makes a minor update to the way the `offlineSyncConfig.json` file is imported in `src/utils/offlineQueue.js`, specifying the JSON module type for compatibility with modern JavaScript module loaders.

* Updated the import statement for `offlineSyncConfig.json` in `src/utils/offlineQueue.js` to use the `{ type: "json" }` assertion, ensuring proper handling as a JSON module.

Closes #8187