### PR TITLE
fix: align sentiment display score thresholds with test contract

### DIFF
--- a/src/utils/sentiment.js
+++ b/src/utils/sentiment.js
@@ -45,28 +45,28 @@ export const analyzeSentiment = (text) => {
  * Gets a descriptive label and an emoji representation based on the sentiment score
  */
 export const getSentimentDisplay = (score) => {
-  if (score >= 3.0) {
+  if (score > 1.5) {
     return {
       emoji: "🌟",
       label: "Excited / Highly Positive",
       color: "text-green-500 dark:text-green-400 animate-bounce"
     };
   }
-  if (score >= 1.5) {
+  if (score >= 0.2) {
     return {
       emoji: "🙂",
       label: "Happy / Positive",
       color: "text-emerald-500 dark:text-emerald-400"
     };
   }
-  if (score <= -3.0) {
+  if (score < -1.5) {
     return {
       emoji: "😢",
       label: "Frustrated / Highly Negative",
       color: "text-red-500 dark:text-red-400 animate-pulse"
     };
   }
-  if (score <= -1.5) {
+  if (score <= -0.2) {
     return {
       emoji: "🙁",
       label: "Muted / Negative",


### PR DESCRIPTION
This pull request updates the sentiment display thresholds in the `getSentimentDisplay` function to provide more nuanced sentiment categorization. The changes adjust the score ranges for each sentiment label, making the transitions between categories smoother and more representative of the underlying sentiment score.

**Sentiment display logic updates:**

* Adjusted the threshold for "Excited / Highly Positive" from `score >= 3.0` to `score > 1.5`, and for "Happy / Positive" from `score >= 1.5` to `score >= 0.2`, allowing more scores to be considered positive.
* Changed the threshold for "Frustrated / Highly Negative" from `score <= -3.0` to `score < -1.5`, and for "Muted / Negative" from `score <= -1.5` to `score <= -0.2`, broadening the range for negative sentiments.

Closes #8188 