### PR TITLE
Fix offline queue session snapshot initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "preview": "vite preview",
     "validate-env": "node scripts/validate-env.js",
     "test": "npm run test:unit",
-    "test:unit": "node --test tests/eventPaginationUtils.test.mjs tests/routeSearchUtils.test.mjs tests/userNameUtils.test.mjs tests/relativeTime.test.mjs tests/safeJsonParse.test.mjs tests/registerUtils.test.mjs tests/bookmarkUtils.test.mjs tests/auth.test.mjs tests/eventDraftUtils.test.mjs tests/exportCsv.test.mjs tests/hackathonFilterUtils.test.mjs tests/colorTokens.test.mjs tests/themeConsistency.test.mjs tests/sseMultiplexer.test.mjs tests/cspReporting.test.mjs tests/readTimeUtils.test.mjs tests/secureStorage.test.mjs tests/conflictDetection.test.mjs tests/eventRecommendationsResponsive.test.mjs tests/spatialSeatSelectorAccessibility.test.mjs tests/navbar.keyboard.test.mjs",
+    "test:unit": "node --test tests/eventPaginationUtils.test.mjs tests/routeSearchUtils.test.mjs tests/userNameUtils.test.mjs tests/relativeTime.test.mjs tests/safeJsonParse.test.mjs tests/registerUtils.test.mjs tests/bookmarkUtils.test.mjs tests/auth.test.mjs tests/eventDraftUtils.test.mjs tests/exportCsv.test.mjs tests/hackathonFilterUtils.test.mjs tests/offlineQueue.test.mjs tests/colorTokens.test.mjs tests/themeConsistency.test.mjs tests/sseMultiplexer.test.mjs tests/cspReporting.test.mjs tests/readTimeUtils.test.mjs tests/secureStorage.test.mjs tests/conflictDetection.test.mjs tests/eventRecommendationsResponsive.test.mjs tests/spatialSeatSelectorAccessibility.test.mjs tests/navbar.keyboard.test.mjs",
     "test:e2e": "playwright test",
     "check": "npm run lint && npm run test",
     "lint": "eslint src --max-warnings=250",

--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -9,6 +9,7 @@ import { API_ENDPOINTS } from '../config/api';
 
 import { logger } from "../utils/logger";
 import { getQueueIndexedDB, setQueue, clearQueue, filterQueueByOwnership, validateQueueSession } from '../utils/offlineQueue';
+import { ensureSessionSnapshot } from "../utils/sessionSnapshot";
 // isTokenValid import removed; authentication is now checked via isAuthenticated()
 // from AuthContext, which handles both token-based and cookie-managed sessions.
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
@@ -261,10 +262,7 @@ const useOfflineSync = () => {
       // SECURITY (Issue #5727): Re-validate session IDs — actions queued under a
       // previous session must not replay under a new session even if the userId
       // matches (e.g. same user, different device/tab login cycle).
-      const currentSession =
-        typeof sessionStorage !== "undefined"
-          ? sessionStorage.getItem("session_id") || null
-          : null;
+      const currentSession = ensureSessionSnapshot(currentUserId);
       const sessionValidatedQueue = validateQueueSession(validatedQueue, currentSession);
 
       if (sessionValidatedQueue.length === 0 && validatedQueue.length > 0) {

--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -3,7 +3,8 @@
 // ---------------------------------------------------------------------------
 import { safeJsonParse } from "./safeJsonParse.js";
 import { logger } from "./logger.js";
-import offlineSyncConfig from "../config/offlineSyncConfig.json";
+import { ensureSessionSnapshot } from "./sessionSnapshot.js";
+import offlineSyncConfig from "../config/offlineSyncConfig.json" with { type: "json" };
 
 const QUEUE_KEY = "eventra_offline_queue";
 const DB_NAME = "eventra_offline_db";
@@ -343,10 +344,7 @@ export const pushToQueue = async (item, userId = null) => {
       offlineSyncConfig.defaultConflictStrategy,
     // SECURITY: Attach user ID to validate ownership on replay
     userId: userId || null,
-    sessionId:
-      typeof sessionStorage !== "undefined"
-        ? sessionStorage.getItem("session_id") || null
-        : null,
+    sessionId: ensureSessionSnapshot(userId),
   };
 
   // Guard against oversized payloads before they reach localStorage.
@@ -553,7 +551,8 @@ export const filterQueueByOwnership = (queue, currentUserId) => {
  *  1. filterQueueByOwnership — userId must match the current authenticated user.
  *  2. validateQueueSession   — sessionId must match the current session.
  *
- * Items with a null/missing sessionId are dropped to be safe (no session = unknown origin).
+ * Legacy items with a null/missing sessionId are migrated to the current
+ * session after ownership validation has already confirmed the user match.
  *
  * @param {Array}  queue          - Ownership-filtered offline queue
  * @param {string} currentSession - Current session ID from sessionStorage
@@ -567,13 +566,14 @@ export const validateQueueSession = (queue, currentSession) => {
     return [];
   }
 
-  return queue.filter((item) => {
+  return queue.reduce((validatedItems, item) => {
     if (!item.sessionId) {
       logger.warn(
-        `[Security] Dropping queued action ${item.id}: no sessionId stored. ` +
-          "Cannot verify session ownership."
+        `[OfflineQueue] Migrating queued action ${item.id}: no sessionId stored. ` +
+          "Binding legacy item to the current verified session."
       );
-      return false;
+      validatedItems.push({ ...item, sessionId: currentSession });
+      return validatedItems;
     }
     if (item.sessionId !== currentSession) {
       logger.warn(
@@ -581,10 +581,11 @@ export const validateQueueSession = (queue, currentSession) => {
           `stored sessionId does not match current session. ` +
           "This prevents stale-session cross-user action replay."
       );
-      return false;
+      return validatedItems;
     }
-    return true;
-  });
+    validatedItems.push(item);
+    return validatedItems;
+  }, []);
 };
 
 // ---------------------------------------------------------------------------
@@ -737,10 +738,7 @@ export const processQueue = async (currentUserId, fetchFn, options = {}) => {
 
   // SECURITY (Issue #5727): Re-validate session ID so actions queued under a
   // previous session cannot replay under a new session, even if the userId matches.
-  const currentSession =
-    typeof sessionStorage !== "undefined"
-      ? sessionStorage.getItem("session_id") || null
-      : null;
+  const currentSession = ensureSessionSnapshot(currentUserId);
   const sessionValidated = validateQueueSession(validated, currentSession);
   if (sessionValidated.length === 0) {
     await clearQueue();

--- a/src/utils/sessionSnapshot.js
+++ b/src/utils/sessionSnapshot.js
@@ -1,0 +1,82 @@
+const SESSION_ID_KEY = "session_id";
+const SESSION_USER_KEY = "session_user_id";
+
+const getSessionStorage = () => {
+  if (typeof window !== "undefined" && window.sessionStorage) {
+    return window.sessionStorage;
+  }
+  if (typeof sessionStorage !== "undefined") {
+    return sessionStorage;
+  }
+  return null;
+};
+
+const createSessionId = () => {
+  if (typeof crypto !== "undefined") {
+    if (typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    if (typeof crypto.getRandomValues === "function") {
+      const values = new Uint32Array(4);
+      crypto.getRandomValues(values);
+      return `session-${Date.now()}-${Array.from(values).join("-")}`;
+    }
+  }
+  return `session-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+};
+
+export const getCurrentSessionSnapshot = () => {
+  try {
+    return getSessionStorage()?.getItem(SESSION_ID_KEY) || null;
+  } catch {
+    return null;
+  }
+};
+
+export const rotateSessionSnapshot = (userId = null) => {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  const sessionId = createSessionId();
+  const normalizedUserId = userId == null ? "" : String(userId);
+
+  try {
+    storage.setItem(SESSION_ID_KEY, sessionId);
+    storage.setItem(SESSION_USER_KEY, normalizedUserId);
+    return sessionId;
+  } catch {
+    return getCurrentSessionSnapshot();
+  }
+};
+
+export const ensureSessionSnapshot = (userId = null) => {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+
+  const normalizedUserId = userId == null ? "" : String(userId);
+
+  try {
+    const existingSessionId = storage.getItem(SESSION_ID_KEY);
+    const storedUserId = storage.getItem(SESSION_USER_KEY) || "";
+
+    if (existingSessionId && storedUserId === normalizedUserId) {
+      return existingSessionId;
+    }
+
+    return rotateSessionSnapshot(userId);
+  } catch {
+    return null;
+  }
+};
+
+export const clearSessionSnapshot = () => {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(SESSION_ID_KEY);
+    storage.removeItem(SESSION_USER_KEY);
+  } catch {
+    // Storage may be unavailable in private browsing contexts.
+  }
+};

--- a/tests/offlineQueue.test.mjs
+++ b/tests/offlineQueue.test.mjs
@@ -28,9 +28,24 @@ global.localStorage = {
   },
 };
 
+const _sessionStore = {};
+global.sessionStorage = {
+  getItem: (key) => (key in _sessionStore ? _sessionStore[key] : null),
+  setItem: (key, val) => {
+    _sessionStore[key] = String(val);
+  },
+  removeItem: (key) => {
+    delete _sessionStore[key];
+  },
+  clear: () => {
+    for (const k of Object.keys(_sessionStore)) delete _sessionStore[k];
+  },
+};
+
 // Stub out window.indexedDB so openDB() rejects cleanly
 global.window = {
   indexedDB: null,
+  sessionStorage: global.sessionStorage,
 };
 global.indexedDB = null;
 
@@ -49,13 +64,22 @@ Object.defineProperty(global, "crypto", {
 });
 
 // Import module AFTER stubs are in place
-const { getQueue, pushToQueue, setQueue, clearQueue } = await import(
+const {
+  getQueue,
+  pushToQueue,
+  setQueue,
+  clearQueue,
+  validateQueueSession,
+  processQueue,
+} = await import(
   "../src/utils/offlineQueue.js"
 );
+const { ensureSessionSnapshot } = await import("../src/utils/sessionSnapshot.js");
 
 // ── Helper ──────────────────────────────────────────────────────────────────
 function reset() {
   localStorage.clear();
+  sessionStorage.clear();
 }
 
 // ── getQueue ────────────────────────────────────────────────────────────────
@@ -85,6 +109,82 @@ assert.equal(getQueue().length, 1, "pushToQueue() stores one item");
 assert.equal(getQueue()[0].eventId, "evt-a", "pushToQueue() stores correct eventId");
 assert.ok(getQueue()[0].timestamp, "pushToQueue() attaches a timestamp");
 assert.equal(getQueue()[0].retryCount, 0, "pushToQueue() initialises retryCount to 0");
+
+// ── session snapshot initialization ───────────────────────────────────────
+reset();
+const queuedWithSession = await pushToQueue(
+  { eventId: "evt-session", payload: { user: "Session User" } },
+  "user-1"
+);
+const sessionBackedQueue = getQueue();
+assert.equal(queuedWithSession, true, "pushToQueue() succeeds with session snapshot");
+assert.ok(
+  sessionStorage.getItem("session_id"),
+  "pushToQueue() initializes session_id when it is missing"
+);
+assert.equal(
+  sessionBackedQueue[0].sessionId,
+  sessionStorage.getItem("session_id"),
+  "queued item stores the initialized session snapshot"
+);
+assert.equal(
+  sessionStorage.getItem("session_user_id"),
+  "user-1",
+  "session snapshot is bound to the current user"
+);
+
+const firstSessionId = sessionStorage.getItem("session_id");
+const secondSessionId = ensureSessionSnapshot("user-2");
+assert.notEqual(
+  secondSessionId,
+  firstSessionId,
+  "ensureSessionSnapshot() rotates when the authenticated user changes"
+);
+
+const migratedLegacyItems = validateQueueSession(
+  [{ id: "legacy-1", userId: "user-2", payload: { legacy: true } }],
+  secondSessionId
+);
+assert.equal(
+  migratedLegacyItems[0].sessionId,
+  secondSessionId,
+  "validateQueueSession() migrates legacy queued items without sessionId"
+);
+
+assert.deepEqual(
+  validateQueueSession(
+    [{ id: "stale-1", userId: "user-2", sessionId: "old-session" }],
+    secondSessionId
+  ),
+  [],
+  "validateQueueSession() still rejects stale session snapshots"
+);
+
+reset();
+localStorage.setItem(
+  "eventra_offline_queue",
+  JSON.stringify([
+    {
+      id: "legacy-replay",
+      actionType: "REGISTER_EVENT",
+      userId: "user-3",
+      endpoint: "/api/events/register",
+      payload: { eventId: "evt-legacy" },
+      retryCount: 0,
+    },
+  ])
+);
+
+let replayedRequest = null;
+const replayResult = await processQueue("user-3", async (url, options) => {
+  replayedRequest = { url, options };
+  return { ok: true, status: 200 };
+});
+
+assert.equal(replayResult.processed, 1, "processQueue() processes legacy item after migration");
+assert.equal(replayResult.succeeded, 1, "processQueue() succeeds for migrated legacy item");
+assert.equal(replayedRequest.url, "/api/events/register", "legacy item is replayed to its endpoint");
+assert.deepEqual(getQueue(), [], "processQueue() clears queue after successful replay");
 
 // ── pushToQueue queue-limit enforcement ─────────────────────────────────────
 reset();


### PR DESCRIPTION
## Description
- Add a session snapshot helper to initialize, rotate, and read offline replay session IDs
- Attach a guaranteed session snapshot when offline queue items are created
- Migrate legacy queued items without session IDs after ownership validation instead of dropping them
- Use the same snapshot initialization during reconnect replay paths

## Tests
- `node --test tests/offlineQueue.test.mjs`

## Notes
- Full `npm run test:unit` currently reaches the new offline queue test, then fails on missing local dependencies (`fuse.js`, `axios`) in this environment.
- `npx eslint ...` could not complete because `node_modules` is not installed and ESLint could not resolve `globals`.

Fixes #8171

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)