### PR TITLE
BUG: Fix Parse Error in AuthContext.js (Critical)

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,33 +1,55 @@
 import { createContext, useContext, useEffect, useMemo, useCallback, useRef, useState } from "react";
-import { setOnUnauthorizedHandler, setAuthToken } from "../config/api";
-import { authService } from "../services/authService";
-import { userService } from "../services/userService";
-import { syncSecureStorage } from "../utils/secureStorage";
-import { usePermissions } from "../hooks/usePermissions";
-import { useTokenExpiry } from "../hooks/useTokenExpiry";
-import { isTokenValid } from "../utils/tokenUtils";
+import { setOnUnauthorizedHandler, setAuthToken } from "../config/api.js";
+import { authService } from "../services/authService.js";
+import { userService } from "../services/userService.js";
+import { syncSecureStorage } from "../utils/secureStorage.js";
+import { usePermissions, normalizeRoles } from "../hooks/usePermissions.js";
+import { useTokenExpiry } from "../hooks/useTokenExpiry.js";
+import { isTokenValid } from "../utils/tokenUtils.js";
 import { toast } from "react-toastify";
-import { normalizeRoles } from "../hooks/usePermissions";
-import { ROLES, ROLE_PERMISSIONS } from "../config/roles";
+import { ROLES, ROLE_PERMISSIONS } from "../config/roles.js";
 
+// Create context for Authentication
 const AuthContext = createContext();
 
+/**
+ * Custom hook to consume the AuthContext.
+ * Ensures that it is only used within a valid AuthProvider.
+ * 
+ * @returns {Object} Authentication context state and helper functions.
+ */
 export const useAuth = () => {
   const context = useContext(AuthContext);
-  if (!context) throw new Error("useAuth must be used within an AuthProvider");
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
   return context;
 };
 
+/**
+ * Helper function to extract user details and session state from raw response data.
+ * Merges roles and parses associated permissions and scopes for user authorization checks.
+ * 
+ * @param {Object} data - Raw response data from the API (auth/profile response).
+ * @param {string|null} fallbackEmail - Fallback identifier/email when not present in response.
+ * @returns {Object} Extracted session user details.
+ */
 const extractSession = (data, fallbackEmail) => {
+  // Extract user details from raw API response payload structure
   const rawUser = data?.user ?? data?.data ?? data ?? null;
   const rawRoles = rawUser?.roles ?? (rawUser?.role ? [rawUser.role] : []);
+  
+  // Normalize roles to ensure consistent uppercase format and organization names
   const resolvedRoles = normalizeRoles(rawRoles);
+  
+  // Build user permissions by combining token-based and role-based permissions
   const tokenPermissions = Array.isArray(rawUser?.permissions)
     ? rawUser.permissions.map((p) => String(p))
     : [];
   const rolePermissions = resolvedRoles.flatMap((role) => ROLE_PERMISSIONS[role] || []);
   const permissions = Array.from(new Set([...tokenPermissions, ...rolePermissions]));
 
+  // Resolve scopes based on the normalized user roles
   const scopes =
     rawUser?.scopes ??
     (resolvedRoles.includes(ROLES.SUPER_ADMIN) || resolvedRoles.includes(ROLES.ADMIN)
@@ -36,6 +58,7 @@ const extractSession = (data, fallbackEmail) => {
         ? ["event:write", "event:read", "hackathon:write", "hackathon:read"]
         : ["event:read", "hackathon:read"]);
 
+  // Compile final clean user object representation
   const sessionUser = {
     ...(rawUser || {}),
     firstName: rawUser?.firstName ?? "",
@@ -51,91 +74,95 @@ const extractSession = (data, fallbackEmail) => {
   return { sessionUser };
 };
 
+/**
+ * AuthProvider component wrapper.
+ * Manages the core authenticated state, token management, session expiry timing,
+ * and exposes API calls like login, logout, and security role checking utilities.
+ */
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(null);
   const [loading, setLoading] = useState(true);
   const [authRequest, setAuthRequest] = useState({ loading: false, error: null });
+  
+  // Ref to track mounting status and prevent setting state on unmounted components
   const isMountedRef = useRef(true);
-
-  const isMountedRef = useRef(true);
+  
+  // Ref to track whether session expired toast has already been displayed to prevent spamming
   const expiryToastShownRef = useRef(false);
 
+  // Setup mount/unmount listener to control isMountedRef state
   useEffect(() => {
     isMountedRef.current = true;
-    return () => { isMountedRef.current = false; };
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
+  /**
+   * Helper function to clear all active session state.
+   * Wipes cookie, local storage, API auth headers, and React local state.
+   * 
+   * @returns {boolean} True if state cleared, false if unmounted.
+   */
   const clearSession = useCallback(() => {
     if (!isMountedRef.current) return false;
     setUser(null);
     setToken(null);
     setAuthToken(null);
+    
+    // Invalidate token cookie
     document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; SameSite=Strict";
+    
+    // Clear user metadata from secure/local storage manager
     syncSecureStorage.removeItem("user");
     return true;
   }, []);
 
-  const { clearExpiredSession } = useTokenExpiry({ token, user, onExpired: clearSession });
-  const permissions = usePermissions(user);
+  // Hook to handle periodic token validation and auto-logout on expiration
+  const { clearExpiredSession: handleExpiredSession } = useTokenExpiry({
+    token,
+    user,
+    onExpired: clearSession
+  });
 
-  const normalizeRoles = useCallback((roles = []) =>
-    roles.map((r) => {
-      const n = String(r).toUpperCase();
-      return n === "EVENT_MANAGER" ? ROLES.ORGANIZER : n;
-    }), []);
-
-  const extractSession = useCallback((res, data, fallbackEmail) => {
-    const sessionToken = "cookie-managed";
-    const rawUser = data?.user ?? data?.data ?? data ?? null;
-    const rawRoles = rawUser?.roles ?? (rawUser?.role ? [rawUser.role] : []);
-    const resolvedRoles = normalizeRoles(rawRoles);
-    const tokenPermissions = Array.isArray(rawUser?.permissions)
-      ? rawUser.permissions.map(String) : [];
-    const rolePermissions = resolvedRoles.flatMap((role) => ROLE_PERMISSIONS[role] || []);
-    const perms = Array.from(new Set([...tokenPermissions, ...rolePermissions]));
-    const scopes = rawUser?.scopes ?? (
-      resolvedRoles.includes(ROLES.SUPER_ADMIN) || resolvedRoles.includes(ROLES.ADMIN)
-        ? ["admin:all", "event:write", "event:read", "hackathon:write", "hackathon:read"]
-        : resolvedRoles.includes(ROLES.ORGANIZER)
-          ? ["event:write", "event:read", "hackathon:write", "hackathon:read"]
-          : ["event:read", "hackathon:read"]
-    );
-    return {
-      sessionToken,
-      sessionUser: {
-        ...(rawUser || {}),
-        firstName: rawUser?.firstName ?? "",
-        lastName: rawUser?.lastName ?? "",
-        email: rawUser?.email ?? fallbackEmail ?? "",
-        username: rawUser?.username ?? fallbackEmail ?? "",
-        role: rawUser?.role ?? resolvedRoles[0] ?? "",
-        roles: resolvedRoles,
-        permissions: perms,
-        scopes,
-      },
-    };
-  }, [normalizeRoles]);
+  /**
+   * Handler to cleanly expire the session, notify the user, and redirect them to login.
+   * Utilizes ref to prevent toast duplications.
+   */
   const clearExpiredSession = useCallback(() => {
     let hadPreviousSession = false;
     try {
       hadPreviousSession = !!syncSecureStorage.getItem("user");
-    } catch {}
+    } catch (e) {
+      console.warn("[AuthContext] Failed to read from secure storage during expiry check", e);
+    }
+    
     clearSession();
+    
     if (!hadPreviousSession || expiryToastShownRef.current) return;
     expiryToastShownRef.current = true;
+    
     toast.info("Session expired. Please log in again.", {
       toastId: "session-expired",
       autoClose: 4000,
     });
-    setTimeout(() => window.location.replace("/login"), 1500);
+    
+    setTimeout(() => {
+      window.location.replace("/login");
+    }, 1500);
   }, [clearSession]);
 
+  /**
+   * Effect hook running on mount to validate existing user profile.
+   * Restores user profile and token status from backend session or local secure cache fallback.
+   */
   useEffect(() => {
     const validate = async () => {
       try {
         const res = await userService.getProfile();
         if (!isMountedRef.current) return;
+        
         if (res.ok && res.data) {
           const { sessionUser } = extractSession(res.data, null);
           if (!isMountedRef.current) return;
@@ -146,9 +173,12 @@ export const AuthProvider = ({ children }) => {
         }
       } catch (err) {
         if (!isMountedRef.current) return;
+        
+        // If server returns unauthorized or forbidden, clear cached state
         if (err?.status === 401 || err?.status === 403) {
           clearSession();
         } else {
+          // If network is offline, attempt to fall back to securely cached user details
           try {
             const cachedUser = syncSecureStorage.getItem("user");
             if (cachedUser) {
@@ -157,106 +187,151 @@ export const AuthProvider = ({ children }) => {
             } else {
               clearSession();
             }
-          } catch { clearSession(); }
+          } catch (storageErr) {
+            console.error("[AuthContext] Secure storage fallback read failure:", storageErr);
+            clearSession();
+          }
         }
       } finally {
         if (isMountedRef.current) setLoading(false);
       }
     };
+    
     validate();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-    validateSession();
-  }, [clearSession]);
 
+  // Sync clearExpiredSession method with a ref so api interceptor can safely invoke it without stale closures
   const clearExpiredSessionRef = useRef(clearExpiredSession);
-  useEffect(() => { clearExpiredSessionRef.current = clearExpiredSession; }, [clearExpiredSession]);
   useEffect(() => {
+    clearExpiredSessionRef.current = clearExpiredSession;
+  }, [clearExpiredSession]);
+
+  useEffect(() => {
+    // Intercept 401 errors globally at Axios layer to auto-logout user
     setOnUnauthorizedHandler(() => clearExpiredSessionRef.current());
     return () => setOnUnauthorizedHandler(null);
   }, []);
 
+  /**
+   * Monitor token age and expiry limits dynamically.
+   * Auto-schedules logout timers or fallback verification intervals.
+   */
   useEffect(() => {
     if (!token || token === "cookie-managed") return;
     expiryToastShownRef.current = false;
-    const expSeconds = token === "cookie-managed" ? user?.exp : decodeTokenPayload(token)?.exp;
-    let id;
+    
+    const expSeconds = user?.exp;
+    let timerId;
+    
     if (typeof expSeconds === "number") {
-      id = setTimeout(() => { clearExpiredSession(); },
-        Math.max(expSeconds * 1000 - Date.now() + 1000, 0));
-    } else if (token !== "cookie-managed") {
-      id = setInterval(() => { if (!isTokenValid(token)) clearExpiredSession(); }, 60_000);
+      const msUntilExpiry = expSeconds * 1000 - Date.now() + 1000;
+      timerId = setTimeout(() => {
+        clearExpiredSession();
+      }, Math.max(msUntilExpiry, 0));
+    } else {
+      timerId = setInterval(() => {
+        if (!isTokenValid(token)) clearExpiredSession();
+      }, 60000);
     }
-    return () => { if (typeof expSeconds === "number") clearTimeout(id); else if (id) clearInterval(id); };
+    
+    return () => {
+      if (typeof expSeconds === "number") {
+        clearTimeout(timerId);
+      } else {
+        clearInterval(timerId);
+      }
+    };
   }, [token, user?.exp, clearExpiredSession]);
 
-  const persistSession = useCallback(async (_, sessionUser) => {
-    setToken("cookie-managed");
+  /**
+   * Persists the active session state to local variables and secure cache.
+   * Strips administrative permissions/roles from plain storage to mitigate local XSS exploits.
+   * 
+   * @param {string} sessionToken - The active JWT token identifier or cookie placeholder.
+   * @param {Object} sessionUser - The complete user profile object containing credentials.
+   * @returns {boolean} Successful persistence state.
+   */
+  const persistSession = useCallback(async (sessionToken, sessionUser) => {
+    setToken(sessionToken);
     setUser(sessionUser);
     setAuthToken(sessionToken);
+    
     try {
-      const { roles, permissions: perms, scopes, ...display } = sessionUser;
-      await syncSecureStorage.setItem("user", JSON.stringify(display));
-    } catch (err) {
-      console.error("[AuthContext] Error persisting user:", err);
-    setAuthToken("cookie-managed");
-    try {
+      // Security Contract: Strip authorization keys from display profile object stored in localStorage
       const { roles, permissions, scopes, ...displayProfile } = sessionUser;
       await syncSecureStorage.setItem("user", JSON.stringify(displayProfile));
     } catch (error) {
-      console.error("[AuthContext] Error persisting user profile:", error);
+      console.error("[AuthContext] Error persisting user profile safely:", error);
     }
     return true;
   }, []);
 
+  /**
+   * Explicitly sets the auth session manually (used post-registration or sign-up workflows).
+   */
   const setAuthSession = useCallback((t, u) => persistSession(t, u), [persistSession]);
+
+  /**
+   * Normalizes error payload responses to user-friendly messages.
+   */
   const getAuthErrorMessage = (error, fallbackMessage) =>
     error?.response?.data?.message ||
     error?.response?.data?.error ||
     error?.message ||
     fallbackMessage;
 
+  /**
+   * Initiates authentication login sequence.
+   * 
+   * @param {string} usernameOrEmail - Input credential.
+   * @param {string} password - User password.
+   * @returns {boolean} True if login resolves, false otherwise.
+   */
   const login = useCallback(async (usernameOrEmail, password) => {
     if (!isMountedRef.current) return false;
     setAuthRequest({ loading: true, error: null });
+    
     try {
       const res = await authService.login({ usernameOrEmail, password });
       const data = res.data;
-      if (res.status !== 200) throw new Error(data?.message || data?.error || "Invalid credentials");
+      
+      if (res.status !== 200) {
+        throw new Error(data?.message || data?.error || "Invalid credentials");
+      }
+      
       const { sessionUser } = extractSession(data, usernameOrEmail);
       const persisted = await persistSession("cookie-managed", sessionUser);
       if (!persisted) return false;
+      
       setAuthRequest({ loading: false, error: null });
       return true;
     } catch (error) {
       if (!isMountedRef.current) return false;
-      setAuthRequest({ loading: false, error: getAuthErrorMessage(error, "Login failed. Please try again.") });
+      setAuthRequest({
+        loading: false,
+        error: getAuthErrorMessage(error, "Login failed. Please try again.")
+      });
       return false;
     }
   }, [persistSession]);
 
+  /**
+   * Logs out the user.
+   */
   const logout = useCallback(async () => {
     try {
-      const res = await authService.login({ usernameOrEmail, password });
-      if (res.status !== 200) throw new Error(res.data?.message || res.data?.error || "Invalid credentials");
-      const { sessionToken, sessionUser } = extractSession(res, res.data, usernameOrEmail);
-      if (!(await persistSession(sessionToken, sessionUser))) return false;
-      setAuthRequest({ loading: false, error: null });
-      return true;
+      await authService.logout();
     } catch (error) {
-      if (!isMountedRef.current) return false;
-      const msg = error?.response?.data?.message || error?.response?.data?.error || error?.message || "Login failed";
-      setAuthRequest({ loading: false, error: msg });
-      return false;
+      console.warn("[AuthContext] Backend logout request failed (best-effort error):", error);
     }
-  }, [extractSession, persistSession]);
-
-  const logout = useCallback(async () => {
-    try { await authService.logout(); } catch { /* best-effort */ }
     clearSession();
     setAuthRequest({ loading: false, error: null });
   }, [clearSession]);
 
+  /**
+   * Quick utility helper to verify authentication state.
+   */
   const isAuthenticated = useCallback(() => {
     if (!user || !token) return false;
     if (token === "cookie-managed") {
@@ -271,41 +346,32 @@ export const AuthProvider = ({ children }) => {
     return true;
   }, [user, token, clearExpiredSession]);
 
+  // Compute permissions using the external hook for roles and authorization queries
+  const permissions = usePermissions(user);
+
+  // Memoize context provider values to prevent redundant subscriber re-renders
   const value = useMemo(() => ({
-    user, token, loading, authRequest,
-    login, logout, setAuthSession, setUser,
+    user,
+    token,
+    loading,
+    authRequest,
+    login,
+    logout,
+    setAuthSession,
+    setUser,
     isAuthenticated,
     ...permissions,
-  }), [user, token, loading, authRequest, login, logout, setAuthSession, setUser, isAuthenticated, permissions]);
-  const hasRole = useCallback((roleName) => {
-    if (!user?.roles) return false;
-    const targetRole = String(roleName).toUpperCase();
-    return normalizeRoles(user.roles).includes(targetRole);
-  }, [user]);
-
-  const hasPermission = useCallback((permissionName) => {
-    if (!user?.permissions) return false;
-    return user.permissions.includes(permissionName);
-  }, [user]);
-
-  const hasAnyRole = useCallback((...roleNames) => roleNames.some((r) => hasRole(r)), [hasRole]);
-  const hasAnyPermission = useCallback((...ps) => ps.some((p) => hasPermission(p)), [hasPermission]);
-
-  const isAdmin = () => hasRole(ROLES.ADMIN);
-  const isEventManager = () => hasRole(ROLES.ORGANIZER);
-  const isSuperAdmin = () => hasRole(ROLES.SUPER_ADMIN);
-  const isOrganizer = () => hasRole(ROLES.ORGANIZER);
-  const isVolunteer = () => hasRole(ROLES.VOLUNTEER);
-  const isAttendee = () => hasRole(ROLES.ATTENDEE);
-
-  const value = useMemo(() => ({
-    user, token, loading, authRequest, login, logout, setUser,
-    isAuthenticated, hasRole, hasPermission, hasAnyRole, hasAnyPermission,
-    isAdmin, isEventManager, isSuperAdmin, isOrganizer, isVolunteer, isAttendee,
   }), [
-    user, token, loading, authRequest, login, logout,
-    isAuthenticated, hasRole, hasPermission, hasAnyRole, hasAnyPermission,
-    isAdmin, isEventManager, isSuperAdmin, isOrganizer, isVolunteer, isAttendee,
+    user,
+    token,
+    loading,
+    authRequest,
+    login,
+    logout,
+    setAuthSession,
+    setUser,
+    isAuthenticated,
+    permissions
   ]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## BUG: Fix Parse Error in AuthContext.js (Critical)

Closes #8197 

### Description
This pull request fixes a critical parsing and syntax error in `AuthContext.js` that was preventing the application from compiling or starting. The file contained corrupted blocks (likely from a previous merge conflict), duplicate declarations, a missing closing brace in a `catch` block, and a dangling `useEffect` tail block.

### Changes Made
1. **Deduplicated Declarations**: Removed the duplicate declaration of `isMountedRef` (previously declared on lines 59 and 61).
2. **Fixed Syntax Errors**:
   * Removed a dangling `validateSession(); }, [clearSession]);` code block at lines 169–170 which lay outside of any functional context.
   * Restored the missing closing brace `}` for the `catch` statement in the `persistSession` function on line 200.
3. **Consolidated Shadowed/Duplicate Logic**:
   * Eliminated a duplicate, shadowed definition of `extractSession` inside the provider. The calls in `login` and `validate` now correctly route to the top-level implementation.
   * Removed a duplicate `logout` function (which was accidentally copy-pasted and modified from the `login` function).
4. **Resolved Undefined References**: Updated the `persistSession` parameters from `(_, sessionUser)` to `(sessionToken, sessionUser)` to resolve an undefined variable reference to `sessionToken` inside `setAuthToken(sessionToken)`.
5. **Added Detailed JSDoc & Inline Documentation**: Added descriptive comments for core state persistence (such as security considerations for stripping user roles/scopes in `localStorage` to prevent XSS privilege escalation).

### Verification
Validated that the parse errors are resolved by running a production build:
```bash
$env:VITE_API_URL="http://localhost:5000"; $env:JWT_SECRET="super_secret_key_1234567890123456"; npm run build


