### PR TITLE
fix(useOfflineSync): emit eventra-offline-queue-processed after hook replay

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -377,6 +377,23 @@ const useOfflineSync = () => {
         }
       } finally {
         isSyncing.current = false;
+
+        // Emit the unified completion event so UI components (e.g. OfflineManager)
+        // that listen for eventra-offline-queue-processed can reset their sync state.
+        // offlineQueue.processQueue() emits this event via notifyQueueProcessed(),
+        // but useOfflineSync runs its own replay loop independently and previously
+        // never emitted it, leaving the OfflineManager spinner stuck permanently.
+        if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+          window.dispatchEvent(
+            new CustomEvent("eventra-offline-queue-processed", {
+              detail: {
+                succeeded: successCount,
+                dropped: droppedCount,
+                remaining: failedQueue.length,
+              },
+            })
+          );
+        }
       }
     };
 


### PR DESCRIPTION
## Description

The hook-based replay path (executeSync) processed the offline queue
independently but never emitted the completion event that OfflineManager
and other UI components rely on to reset their sync state.

The utility-based path (offlineQueue.processQueue) correctly calls
notifyQueueProcessed() which dispatches this event, but useOfflineSync
never calls processQueue() — it has its own replay loop.

Fix: dispatch eventra-offline-queue-processed in the finally block of
executeSync, passing succeeded/dropped/remaining counts to match the
payload shape emitted by notifyQueueProcessed().

Impact:
- OfflineManager "Sync Now" spinner now stops after sync completes
- Sync banners receive final status updates reliably
- Both replay paths now emit a consistent completion event

Closes #8172

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
