### PR TITLE
fix: wrap analytics and matchmaking hub in DashboardLayout to restore…

### DIFF
--- a/src/Pages/Networking/MatchmakingHub.jsx
+++ b/src/Pages/Networking/MatchmakingHub.jsx
@@ -5,6 +5,9 @@ import { fetchRecommendedConnections } from "../../utils/aiMatchmaking";
 import { Calendar, MessageSquare, Zap, Star } from "lucide-react";
 import { toast } from "react-toastify";
 
+// 1. IMPORT THE MASTER SKIN LAYOUT SHELL
+import DashboardLayout from "../../components/Layout/DashboardLayout"; 
+
 const MatchmakingHub = () => {
   const { eventId = "networking-hub" } = useParams();
   const { user } = useAuth();
@@ -25,69 +28,72 @@ const MatchmakingHub = () => {
   };
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-12">
-      <div className="flex items-center gap-3 mb-8">
-        <div className="p-3 bg-indigo-100 dark:bg-indigo-900/30 rounded-xl">
-          <Zap className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
+    // 2. WRAP EVERYTHING INSIDE THE LAYOUT SHELL
+    <DashboardLayout>
+      <div className="max-w-6xl mx-auto px-4 py-12">
+        <div className="flex items-center gap-3 mb-8">
+          <div className="p-3 bg-indigo-100 dark:bg-indigo-900/30 rounded-xl">
+            <Zap className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">AI Matchmaking Hub</h1>
+            <p className="text-gray-500">Smart networking recommendations based on your profile and event history.</p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">AI Matchmaking Hub</h1>
-          <p className="text-gray-500">Smart networking recommendations based on your profile and event history.</p>
-        </div>
-      </div>
 
-      {loading ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {[...Array(3)].map((_, i) => (
-            <div key={i} className="animate-pulse bg-white dark:bg-gray-800 p-6 rounded-3xl border border-gray-100 dark:border-gray-700 h-64" />
-          ))}
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {connections.map((conn) => (
-            <div key={conn.id} className="bg-white dark:bg-gray-800 p-6 rounded-3xl border border-gray-200 dark:border-gray-700 shadow-sm flex flex-col h-full hover:shadow-xl transition-shadow">
-              <div className="flex items-start justify-between mb-4">
-                <div className="flex items-center gap-4">
-                  <img src={conn.avatar} alt={conn.name} className="w-14 h-14 rounded-full border-2 border-indigo-100 dark:border-indigo-900" />
-                  <div>
-                    <h3 className="font-bold text-lg dark:text-white">{conn.name}</h3>
-                    <p className="text-sm text-gray-500">{conn.role}</p>
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="animate-pulse bg-white dark:bg-gray-800 p-6 rounded-3xl border border-gray-100 dark:border-gray-700 h-64" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {connections.map((conn) => (
+              <div key={conn.id} className="bg-white dark:bg-gray-800 p-6 rounded-3xl border border-gray-200 dark:border-gray-700 shadow-sm flex flex-col h-full hover:shadow-xl transition-shadow">
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex items-center gap-4">
+                    <img src={conn.avatar} alt={conn.name} className="w-14 h-14 rounded-full border-2 border-indigo-100 dark:border-indigo-900" />
+                    <div>
+                      <h3 className="font-bold text-lg dark:text-white">{conn.name}</h3>
+                      <p className="text-sm text-gray-500">{conn.role}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 px-2.5 py-1 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 rounded-full text-xs font-bold">
+                    <Star className="w-3 h-3" /> {conn.matchScore}%
                   </div>
                 </div>
-                <div className="flex items-center gap-1 px-2.5 py-1 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 rounded-full text-xs font-bold">
-                  <Star className="w-3 h-3" /> {conn.matchScore}%
+                
+                <div className="p-3 bg-indigo-50 dark:bg-indigo-900/10 rounded-xl mb-4 text-sm text-indigo-800 dark:text-indigo-300">
+                  <span className="font-semibold block mb-1">Why you match:</span>
+                  {conn.matchReason}
+                </div>
+
+                <div className="flex flex-wrap gap-2 mb-6">
+                  {conn.skills.map(skill => (
+                    <span key={skill} className="text-xs px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-md text-gray-600 dark:text-gray-300">
+                      {skill}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="mt-auto flex gap-3">
+                  <button 
+                    onClick={() => handleSchedule(conn)}
+                    className="flex-1 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-sm font-semibold flex items-center justify-center gap-2 transition-colors"
+                  >
+                    <Calendar className="w-4 h-4" /> Meet
+                  </button>
+                  <button className="flex-1 py-2.5 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 hover:border-indigo-600 text-gray-700 dark:text-gray-300 rounded-xl text-sm font-semibold flex items-center justify-center gap-2 transition-colors">
+                    <MessageSquare className="w-4 h-4" /> Message
+                  </button>
                 </div>
               </div>
-              
-              <div className="p-3 bg-indigo-50 dark:bg-indigo-900/10 rounded-xl mb-4 text-sm text-indigo-800 dark:text-indigo-300">
-                <span className="font-semibold block mb-1">Why you match:</span>
-                {conn.matchReason}
-              </div>
-
-              <div className="flex flex-wrap gap-2 mb-6">
-                {conn.skills.map(skill => (
-                  <span key={skill} className="text-xs px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-md text-gray-600 dark:text-gray-300">
-                    {skill}
-                  </span>
-                ))}
-              </div>
-
-              <div className="mt-auto flex gap-3">
-                <button 
-                  onClick={() => handleSchedule(conn)}
-                  className="flex-1 py-2.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-xl text-sm font-semibold flex items-center justify-center gap-2 transition-colors"
-                >
-                  <Calendar className="w-4 h-4" /> Meet
-                </button>
-                <button className="flex-1 py-2.5 bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 hover:border-indigo-600 text-gray-700 dark:text-gray-300 rounded-xl text-sm font-semibold flex items-center justify-center gap-2 transition-colors">
-                  <MessageSquare className="w-4 h-4" /> Message
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
   );
 };
 

--- a/src/components/Analytics/ComparativeAnalyticsDashboard.jsx
+++ b/src/components/Analytics/ComparativeAnalyticsDashboard.jsx
@@ -4,6 +4,9 @@ import {
   XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
 
+// 1. IMPORT YOUR GLOBAL DASHBOARD LAYOUT ELEMENT
+import DashboardLayout from '../../components/Layout/DashboardLayout';
+
 const eventsData = [
   { name: 'Tech Summit', registrations: 320, attendance: 280, engagement: 87, category: 'Tech' },
   { name: 'Design Conf', registrations: 210, attendance: 175, engagement: 72, category: 'Design' },
@@ -31,81 +34,90 @@ export default function ComparativeAnalyticsDashboard() {
     setSelected(prev => prev.includes(name) ? prev.filter(n => n !== name) : [...prev, name]);
 
   return (
-    <div className="p-6 space-y-8 bg-gray-50 min-h-screen">
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900">Comparative Event Analytics</h1>
-        <p className="text-gray-500 mt-1">Compare performance across multiple events</p>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {eventsData.map(e => (
-          <button key={e.name} onClick={() => toggle(e.name)}
-            className={`px-4 py-1.5 rounded-full text-sm font-medium border transition-all ${
-              selected.includes(e.name)
-                ? 'bg-indigo-600 text-white border-indigo-600'
-                : 'bg-white text-gray-500 border-gray-300'
-            }`}>
-            {e.name}
-          </button>
-        ))}
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div className="bg-green-50 border border-green-200 rounded-xl p-5">
-          <p className="text-sm font-medium text-green-600">Best Performing</p>
-          <p className="text-xl font-bold text-green-800 mt-1">{best.name}</p>
-          <p className="text-sm text-green-600">{best.engagement}% engagement</p>
+    // 2. ENCLOSE YOUR PAGE CODE IN THE WRAPPER ELEMENT
+    <DashboardLayout>
+      {/* Note: I removed bg-gray-50 min-h-screen to let the component adopt the skin base */}
+      <div className="p-6 space-y-8 w-full"> 
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Comparative Event Analytics</h1>
+          <p className="text-gray-500 mt-1">Compare performance across multiple events</p>
         </div>
-        <div className="bg-blue-50 border border-blue-200 rounded-xl p-5">
-          <p className="text-sm font-medium text-blue-600">Total Registrations</p>
-          <p className="text-xl font-bold text-blue-800 mt-1">
-            {filtered.reduce((s, e) => s + e.registrations, 0).toLocaleString()}
-          </p>
+        
+        <div className="flex flex-wrap gap-2">
+          {eventsData.map(e => (
+            <button key={e.name} onClick={() => toggle(e.name)}
+              className={`px-4 py-1.5 rounded-full text-sm font-medium border transition-all ${
+                selected.includes(e.name)
+                  ? 'bg-indigo-600 text-white border-indigo-600'
+                  : 'bg-white text-gray-500 border-gray-300 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700'
+              }`}>
+              {e.name}
+            </button>
+          ))}
         </div>
-        <div className="bg-purple-50 border border-purple-200 rounded-xl p-5">
-          <p className="text-sm font-medium text-purple-600">Avg Attendance Rate</p>
-          <p className="text-xl font-bold text-purple-800 mt-1">{avgAttendance}%</p>
+        
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="bg-green-50 border border-green-200 rounded-xl p-5 dark:bg-green-950/20 dark:border-green-900/50">
+            <p className="text-sm font-medium text-green-600 dark:text-green-400">Best Performing</p>
+            <p className="text-xl font-bold text-green-800 dark:text-green-200 mt-1">{best.name}</p>
+            <p className="text-sm text-green-600 dark:text-green-400">{best.engagement}% engagement</p>
+          </div>
+          <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 dark:bg-blue-950/20 dark:border-blue-900/50">
+            <p className="text-sm font-medium text-blue-600 dark:text-blue-400">Total Registrations</p>
+            <p className="text-xl font-bold text-blue-800 dark:text-blue-200 mt-1">
+              {filtered.reduce((s, e) => s + e.registrations, 0).toLocaleString()}
+            </p>
+          </div>
+          <div className="bg-purple-50 border border-purple-200 rounded-xl p-5 dark:bg-purple-950/20 dark:border-purple-900/50">
+            <p className="text-sm font-medium text-purple-600 dark:text-purple-400">Avg Attendance Rate</p>
+            <p className="text-xl font-bold text-purple-800 dark:text-purple-200 mt-1">{avgAttendance}%</p>
+          </div>
+        </div>
+        
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 dark:bg-gray-900 dark:border-gray-800">
+          <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-4">Registrations vs Attendance</h2>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={filtered}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-800" />
+              <XAxis dataKey="name" tick={{ fontSize: 12 }} className="fill-gray-500" />
+              <YAxis className="fill-gray-500" />
+              <Tooltip />
+              <Legend />
+              <Bar dataKey="registrations" fill="#6366f1" name="Registrations" radius={[4,4,0,0]} />
+              <Bar dataKey="attendance" fill="#22c55e" name="Attendance" radius={[4,4,0,0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 dark:bg-gray-900 dark:border-gray-800">
+          <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-4">Engagement Rate (%)</h2>
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={filtered}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-800" />
+              <XAxis dataKey="name" tick={{ fontSize: 12 }} className="fill-gray-500" />
+              <YAxis domain={[50, 100]} className="fill-gray-500" />
+              <Tooltip formatter={(v) => `${v}%`} />
+              <Line type="monotone" dataKey="engagement" stroke="#f59e0b" strokeWidth={2} dot={{ r: 5 }} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+        
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 dark:bg-gray-900 dark:border-gray-800">
+          <h2 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-4">Growth Trends Over Time</h2>
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={growthData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-gray-200 dark:stroke-gray-800" />
+              <XAxis dataKey="month" className="fill-gray-500" />
+              <YAxis yAxisId="left" className="fill-gray-500" />
+              <YAxis yAxisId="right" orientation="right" className="fill-gray-500" />
+              <Tooltip />
+              <Legend />
+              <Line yAxisId="left" type="monotone" dataKey="registrations" stroke="#6366f1" strokeWidth={2} name="Registrations" />
+              <Line yAxisId="right" type="monotone" dataKey="events" stroke="#ec4899" strokeWidth={2} name="Events Count" />
+            </LineChart>
+          </ResponsiveContainer>
         </div>
       </div>
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-        <h2 className="text-lg font-semibold text-gray-700 mb-4">Registrations vs Attendance</h2>
-        <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={filtered}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-            <YAxis />
-            <Tooltip />
-            <Legend />
-            <Bar dataKey="registrations" fill="#6366f1" name="Registrations" radius={[4,4,0,0]} />
-            <Bar dataKey="attendance" fill="#22c55e" name="Attendance" radius={[4,4,0,0]} />
-          </BarChart>
-        </ResponsiveContainer>
-      </div>
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-        <h2 className="text-lg font-semibold text-gray-700 mb-4">Engagement Rate (%)</h2>
-        <ResponsiveContainer width="100%" height={250}>
-          <LineChart data={filtered}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-            <YAxis domain={[50, 100]} />
-            <Tooltip formatter={(v) => `${v}%`} />
-            <Line type="monotone" dataKey="engagement" stroke="#f59e0b" strokeWidth={2} dot={{ r: 5 }} />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-        <h2 className="text-lg font-semibold text-gray-700 mb-4">Growth Trends Over Time</h2>
-        <ResponsiveContainer width="100%" height={250}>
-          <LineChart data={growthData}>
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="month" />
-            <YAxis yAxisId="left" />
-            <YAxis yAxisId="right" orientation="right" />
-            <Tooltip />
-            <Legend />
-            <Line yAxisId="left" type="monotone" dataKey="registrations" stroke="#6366f1" strokeWidth={2} name="Registrations" />
-            <Line yAxisId="right" type="monotone" dataKey="events" stroke="#ec4899" strokeWidth={2} name="Events Count" />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-    </div>
+    </DashboardLayout>
   );
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves a UI rendering issue where both the AI Matchmaking Hub and the Comparative Event Analytics pages loaded entirely "naked" without the application's global layout skin (side navigation bars, unified page frames, and margins). 

The issue occurred because these paths were rendering straight to the screen as standalone pages without inheriting a parent layout shell structure. Both files have now been securely wrapped inside `<DashboardLayout />`. Additionally, hardcoded, layout-breaking container properties (`bg-gray-50 min-h-screen`) were stripped from the analytics component so it gracefully yields to the system's global canvas styling rules.

Fixes #7871 

## ScreenShot (if applicable)
N/a since it was rendering issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
