### PR TITLE
fix: restore Forgot Password link on login page (#8162)

### DIFF
--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { authService } from '../../services/authService';
 import './Auth.css'; // Keeps their existing styling intact
 
@@ -60,6 +61,12 @@ export default function LoginForm() {
             required 
             placeholder="Enter your password"
           />
+        </div>
+
+        <div style={{ textAlign: 'right', marginTop: '-12px' }}>
+          <Link to="/password-reset" className="auth-link" style={{ fontSize: '0.9rem' }}>
+            Forgot Password?
+          </Link>
         </div>
 
         <button type="submit" disabled={loading} className="btn-submit">


### PR DESCRIPTION
## Description
Fixes #8162

The **"Forgot Password"** link was missing from the login page, preventing users from recovering their accounts.

## Root Cause
The `/login` route renders `AuthPage`, which mounts `LoginForm` (`src/components/auth/LoginForm.js`). That component had no forgot-password link. A legacy `Login.js` still contained the link, but it is no longer the routed component — so the link disappeared from the UI after the update. The recovery flow itself was never broken: the `/password-reset` route and its `PasswordReset` component still exist and work.

## Fix
- Added a **"Forgot Password?"** link in `LoginForm.js` below the password field.
- Points to the existing public `/password-reset` route.
- Styled with the existing `.auth-link` class, so it inherits light/dark theming and stays consistent with the rest of the auth UI.

## Changes
- `src/components/auth/LoginForm.js` — import `Link` from `react-router-dom`; render the forgot-password link.

## Testing
- [x] ESLint passes (0 errors)
- [x] `/password-reset` confirmed as a public route (reachable while logged out)
- [x] Manual: go to **Get Started → Sign in**, confirm the "Forgot Password?" link is visible and navigates to the recovery page
- [x] Verified in light and dark mode

