### PR TITLE
fix: update og:url domain from vercel.app to sandeepvashishtha.in

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <meta property="og:title" content="Eventra - Platform for Builders" />
     <meta property="og:description" content="A premium, modern platform for organizing and attending events, hackathons, and projects." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://eventra.vercel.app/" />
+    <meta property="og:url" content="https://eventra.sandeepvashishtha.in/" />
     <meta property="og:image" content="https://eventra.sandeepvashishtha.in/logo_transparent.png" />
 
     <!-- CSRF Protection -->


### PR DESCRIPTION
**Summary**
The `og:url` meta tag in `index.html` pointed to `https://eventra.vercel.app/` instead of the actual custom domain `https://eventra.sandeepvashishtha.in/`.

**Change**
Updated `og:url` to use the correct canonical domain, matching `robots.txt` and other references.

Closes #8257