### PR TITLE
fix: remove orphaned nested .dark rule breaking CSS variable declarations in components.css

### DIFF
--- a/src/components/styles/components.css
+++ b/src/components/styles/components.css
@@ -71,9 +71,6 @@ body {
   --color-text-primary: #f9fafb;
   --color-text-secondary: #9ca3af;
   --color-border: #374151;
-  .dark {
-  color: #f9fafb;
-}
   --color-accent: #818cf8;
   --color-accent-hover: #6366f1;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
**Summary**
The `.dark` block in `src/components/styles/components.css` contained an orphaned nested `.dark { color: #f9fafb; }` rule (lines 74-76) that broke CSS variable parsing for the declarations that followed.

**Change**
Removed the 3-line nested rule so that `--color-accent`, `--shadow-*`, etc. are properly parsed as part of the `.dark` block.

Closes #8259