### PR TITLE
Fix misplaced .project-card CSS rule inside media hover block

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1190,9 +1190,9 @@ html:not(.dark) ::placeholder {
     /* border-indigo-700 */
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
   }
+}
 
-  .project-card,
+.project-card,
 .project-card * {
   color: white !important;
-}
 }


### PR DESCRIPTION
## Summary
- Moved `.project-card, .project-card * { color: white !important; }` outside the `@media (hover: hover)` block in `src/index.css`
- The rule was previously only applied on hover-capable devices, which was likely unintentional

## Related issue
Closes #8263