### PR TITLE
Remove unused deprecated LanguageSwitcher.jsx wrapper

### DIFF
--- a/src/components/common/LanguageSwitcher.jsx
+++ b/src/components/common/LanguageSwitcher.jsx
@@ -1,6 +1,0 @@
-import LanguageSelector from "../LanguageSelector";
-
-/** @deprecated Use LanguageSelector instead */
-export default function LanguageSwitcher(props) {
-  return <LanguageSelector {...props} />;
-}


### PR DESCRIPTION
## Summary
- Removes the deprecated LanguageSwitcher.jsx component (6 lines)
- It was just a thin wrapper around LanguageSelector and was no longer imported anywhere

## Related issue
Closes #8265

## GSSoC
Part of GSSoC 2026 contributions.