### PR TITLE
fix: remove meaningless aria-label="button" on Clear Search button in SearchEmptyState

### DIFF
--- a/src/components/common/SearchEmptyState.jsx
+++ b/src/components/common/SearchEmptyState.jsx
@@ -88,7 +88,7 @@ const SearchEmptyState = ({
             hover:bg-blue-700
             shadow-sm
           "
-          aria-label="button"
+
         >
           <X size={16} aria-hidden="true" />
           Clear Search


### PR DESCRIPTION
## Summary

Removed the meaningless `aria-label="button"` from the Clear Search button in `SearchEmptyState.jsx`.

## Why

- The element is already a `<button>`, so its role is announced by default.
- `aria-label` overrides the visible text for screen readers — they would hear "button" instead of "Clear Search".
- The visible label "Clear Search" is perfectly sufficient.

## Change
`src/components/common/SearchEmptyState.jsx` — removed `aria-label="button"` (1 line).

---
_Contributed under GSSoC 2026_

Closes #8267