### PR TITLE
fix: remove unused import NOTIFICATION_CATEGORIES in NotificationDropdown.jsx

### DIFF
--- a/src/components/notifications/NotificationDropdown.jsx
+++ b/src/components/notifications/NotificationDropdown.jsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import { Bell, CheckCheck, ExternalLink, Settings } from "lucide-react";
 import { useNotification } from "../../context/NotificationContext";
-import { NOTIFICATION_CATEGORIES } from "../../utils/notificationPreferences";
 import EmptyState from "../common/EmptyState";
 import NotificationItem from "./NotificationItem";
 


### PR DESCRIPTION
## Summary

Removed unused `NOTIFICATION_CATEGORIES` import in `NotificationDropdown.jsx`. The component filters notifications via `preferences?.categories?.[category]?.inApp` directly, making this import dead code.

## Change
`src/components/notifications/NotificationDropdown.jsx` — removed 1 unused import line.

---
_Contributed under GSSoC 2026_

Closes #8271