### PR TITLE
fix: correct .tech to .in domain fallbacks in env.js and shareUtils.js

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -16,7 +16,7 @@ const optionalEnvVars = {
   },
   PUBLIC_URL: {
     keys: ["VITE_PUBLIC_URL", "REACT_APP_PUBLIC_URL"],
-    fallback: "https://eventra.sandeepvashishtha.tech",
+    fallback: "https://eventra.sandeepvashishtha.in",
   },
   SENTRY_DSN: {
     keys: ["VITE_SENTRY_DSN", "REACT_APP_SENTRY_DSN"],

--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -125,7 +125,7 @@ export const generateEventSharingData = (event, baseUrl = null) => {
   }
 
   // Determine the correct base URL for sharing
-  const rawPublicUrl = ENV.PUBLIC_URL || "eventra.sandeepvashishtha.tech";
+  const rawPublicUrl = ENV.PUBLIC_URL || "eventra.sandeepvashishtha.in";
   const deployedOrigin = rawPublicUrl.startsWith("http")
     ? rawPublicUrl.replace(/\/$/, "")
     : `https://${rawPublicUrl}`;


### PR DESCRIPTION
## Summary

Changed `eventra.sandeepvashishtha.tech` to `eventra.sandeepvashishtha.in` in two files. The `.tech` domain is not the actual deployed site — the real site uses `.in`.

## Files changed
- `src/config/env.js:19` — fallback PUBLIC_URL
- `src/utils/shareUtils.js:128` — fallback for share link generation

This fixes share links pointing to the wrong domain when `PUBLIC_URL` env var is not set.

---
_Contributed under GSSoC 2026_

Closes #8275