### PR TITLE
fix: correct file path in components.css header comment

### DIFF
--- a/src/components/styles/components.css
+++ b/src/components/styles/components.css
@@ -1,5 +1,5 @@
 /* ===== EVENTRA - CONSOLIDATED COMPONENTS CSS ===== */
-/* File: src/styles/components.css */
+/* File: src/components/styles/components.css */
 /* Description: Global styles for search, collaboration, hero, features & more */
 /* Last Updated: 2026 */
 


### PR DESCRIPTION
## Summary

Fixed the file path in the header comment of `components.css`. The comment said `src/styles/components.css` but the actual path is `src/components/styles/components.css`.

## Change
`src/components/styles/components.css:2` — corrected comment (1 line).

---
_Contributed under GSSoC 2026_

Closes #8277