### PR TITLE
fix: correct broken import path for CharacterCounter in CollaborationHub.js

### DIFF
--- a/src/components/CollaborationHub.js
+++ b/src/components/CollaborationHub.js
@@ -5,7 +5,7 @@ import { useReducedMotion } from '../hooks/useReducedMotion';
 import useDebounce from '../hooks/useDebounce.js';
 import { toast } from 'react-toastify';
 import './components.css';
-import CharacterCounter from "../../components/common/CharacterCounter";
+import CharacterCounter from "./common/CharacterCounter";
 import { sanitizeInputText } from "../utils/inputSanitization";
 import EventMaterials from "./common/EventMaterials";
 import { Plus, Search, Check, X, Briefcase as BriefcaseIcon, DollarSign, Calendar, Users, Send, MessageCircle } from 'lucide-react';


### PR DESCRIPTION
## Summary

Fixed a broken import path in `CollaborationHub.js`. The import used `../../components/common/CharacterCounter` which resolves to a non-existent path. The correct path is `./common/CharacterCounter`.

This is a **runtime bug** — the component would throw a module-not-found error when the proposal form section renders.

## Change
`src/components/CollaborationHub.js:8` — fixed import path (1 line).

---
_Contributed under GSSoC 2026_

Closes #8279