### PR TITLE
[Bug] Keyboard shortcut handler matches bare key even when modifiers are pressed

### DIFF
--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -82,8 +82,8 @@ export const useKeyboardShortcuts = (shortcuts = {}, disabled = false) => {
       if (shift) keyString += "shift+";
       keyString += key.toLowerCase();
 
-      // 1. Direct handler match (e.g. "ctrl+k", "alt+d", or physical key mapping like "r", "c", etc.)
-      const handler = shortcutsRef.current[keyString] || shortcutsRef.current[key.toLowerCase()];
+      // 1. Direct handler match (e.g. "ctrl+k", "alt+d"), or bare key when no modifiers active
+      const handler = shortcutsRef.current[keyString] || (!ctrl && !alt && !shift ? shortcutsRef.current[key.toLowerCase()] : undefined);
 
       if (handler) {
         event.preventDefault();


### PR DESCRIPTION
Fixes #8286. Guard bare key shortcut lookup to only match when no modifiers (Ctrl/Alt/Shift) are active, preventing modifier-key combinations from incorrectly triggering plain letter shortcuts.\n\nCloses #8286