### PR TITLE
[Bug] lazyWithRetry never retries again after exhausting attempts

### DIFF
--- a/src/utils/lazyWithRetry.js
+++ b/src/utils/lazyWithRetry.js
@@ -2,9 +2,9 @@
 import { lazy } from "react";
 
 export function lazyWithRetry(importFn, retries = 2, delay = 1000) {
-  let attempt = 0;
-
   const retryImport = async () => {
+    let attempt = 0;
+
     while (attempt <= retries) {
       try {
         return await importFn();


### PR DESCRIPTION
Fixes #8287. Move attempt counter inside retryImport so React can retry lazy-loading after transient failures instead of being permanently stuck.\n\nCloses #8287