### PR TITLE
fix: return empty string for falsy or non-string input in getOptimizedImageUrl to satisfy @returns {string} contract

### DIFF
--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -22,7 +22,7 @@
  * @returns {string}
  */
 export const getOptimizedImageUrl = (originalUrl, options = {}) => {
-  if (!originalUrl || typeof originalUrl !== "string") return originalUrl;
+  if (!originalUrl || typeof originalUrl !== "string") return "";
 
   // If already a Cloudinary URL, return as is
   if (originalUrl.includes("res.cloudinary.com")) {


### PR DESCRIPTION
## Summary
Fixes getOptimizedImageUrl in imageOptimizer.js returning null or undefined
for falsy input, violating its @returns {string} type contract and crashing
callers that chain string methods on the result.

## Problem
The early return guard passed the original argument through unchanged. For
null, undefined, or other falsy non-string values, the function returned a
non-string, breaking the declared return type and causing TypeErrors in
downstream callers.

## Fix
I changed return originalUrl to return "" in the early return guard so the
function always returns a string. This matches the @returns {string} contract
and makes null/undefined image URLs safe to use without extra guards in
callers.

## Changes
- src/utils/imageOptimizer.js — changed early return to return ""

Closes #8291