### PR TITLE
fix: wrap AuthContext role helpers in useCallback to stabilise useMemo

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -231,12 +231,12 @@ export const AuthProvider = ({ children }) => {
   const hasAnyRole = useCallback((...roleNames) => roleNames.some((r) => hasRole(r)), [hasRole]);
   const hasAnyPermission = useCallback((...ps) => ps.some((p) => hasPermission(p)), [hasPermission]);
 
-  const isAdmin = () => hasRole(ROLES.ADMIN);
-  const isEventManager = () => hasRole(ROLES.ORGANIZER);
-  const isSuperAdmin = () => hasRole(ROLES.SUPER_ADMIN);
-  const isOrganizer = () => hasRole(ROLES.ORGANIZER);
-  const isVolunteer = () => hasRole(ROLES.VOLUNTEER);
-  const isAttendee = () => hasRole(ROLES.ATTENDEE);
+  const isAdmin = useCallback(() => hasRole(ROLES.ADMIN), [hasRole]);
+  const isEventManager = useCallback(() => hasRole(ROLES.ORGANIZER), [hasRole]);
+  const isSuperAdmin = useCallback(() => hasRole(ROLES.SUPER_ADMIN), [hasRole]);
+  const isOrganizer = useCallback(() => hasRole(ROLES.ORGANIZER), [hasRole]);
+  const isVolunteer = useCallback(() => hasRole(ROLES.VOLUNTEER), [hasRole]);
+  const isAttendee = useCallback(() => hasRole(ROLES.ATTENDEE), [hasRole]);
 
   const value = useMemo(() => ({
     user, token, loading, authRequest, login, logout, setUser,


### PR DESCRIPTION
## Description

`AuthContext` wraps its context value in `useMemo`, but six role-helper functions (`isAdmin`, `isEventManager`, `isSuperAdmin`, `isOrganizer`, `isVolunteer`, `isAttendee`) were defined as plain inline arrow functions. Since their references changed on every render, the `useMemo` dependency check always failed producing a new context object every render and causing every `useAuth()` consumer across the app to re-render
unnecessarily.

The fix wraps all six in `useCallback` with `[hasRole]` as the dependency, matching the pattern already used by the other helpers (`isAuthenticated`, `hasRole`, `hasPermission`, etc.) in the same file.

Fixes #8284 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
