### PR TITLE
fix: sanitize before validate in prepareSafeSearchQuery to stop safe queries being incorrectly rejected

### DIFF
--- a/src/utils/inputSanitization.js
+++ b/src/utils/inputSanitization.js
@@ -93,14 +93,15 @@ export const validateSearchQuery = (query = '') => {
  * @returns {string} - Safe query for API, or empty string if invalid
  */
 export const prepareSafeSearchQuery = (rawQuery = '') => {
-  const validation = validateSearchQuery(rawQuery);
+  const sanitized = sanitizeSearchQuery(rawQuery);
+
+  const validation = validateSearchQuery(sanitized);
   if (!validation.isValid) {
-     
-    console.warn(`[Security] Invalid search query: ${validation.error}`);
+    console.warn(`[Security] Invalid search query after sanitization: ${validation.error}`);
     return '';
   }
 
-  return sanitizeSearchQuery(rawQuery);
+  return sanitized;
 };
 
 /**


### PR DESCRIPTION
## Summary
Fixes prepareSafeSearchQuery in inputSanitization.js where validateSearchQuery
ran before sanitizeSearchQuery, causing queries with strippable special
characters to be rejected and return empty results instead of sanitized results.

## Problem
validateSearchQuery checked the raw user input for characters like $, {, [, ;
and returned isValid: false. sanitizeSearchQuery would have safely stripped
those same characters. Because validation ran first, common technical search
terms like [React] or C# were blocked entirely.

## Fix
I swapped the order to sanitize first, then validate the sanitized output.
The validator now acts as a final consistency check on already-clean input
rather than blocking input that the sanitizer handles correctly.

## Changes
- src/utils/inputSanitization.js — moved sanitizeSearchQuery call before
  validateSearchQuery in prepareSafeSearchQuery, validate now runs on
  sanitized output

Closes #8306 