### PR TITLE
fix: add SSR guard to urlBase64ToUint8Array and error handling for QuotaExceededError in writeNotificationPreferences

### DIFF
--- a/src/utils/notificationPreferences.js
+++ b/src/utils/notificationPreferences.js
@@ -98,10 +98,18 @@ export const readNotificationPreferences = () => {
 export const writeNotificationPreferences = (preferences) => {
   if (typeof window === "undefined") return preferences;
   const normalized = normalizeNotificationPreferences(preferences);
-  window.localStorage.setItem(NOTIFICATION_PREFERENCES_KEY, JSON.stringify(normalized));
-  window.dispatchEvent(
-    new CustomEvent("eventra-notification-preferences", { detail: normalized })
-  );
+  try {
+    window.localStorage.setItem(NOTIFICATION_PREFERENCES_KEY, JSON.stringify(normalized));
+    window.dispatchEvent(
+      new CustomEvent("eventra-notification-preferences", { detail: normalized })
+    );
+  } catch {
+    // localStorage may be full or blocked — dispatch the event anyway
+    // so in-memory consumers stay in sync even if persistence fails
+    window.dispatchEvent(
+      new CustomEvent("eventra-notification-preferences", { detail: normalized })
+    );
+  }
   return normalized;
 };
 
@@ -147,6 +155,7 @@ export const playNotificationSound = (soundKey) => {
 };
 
 export const urlBase64ToUint8Array = (base64String) => {
+  if (typeof window === "undefined") return new Uint8Array();
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
   const rawData = window.atob(base64);


### PR DESCRIPTION
## Summary
Two defensive fixes in notificationPreferences.js — one prevents a
ReferenceError in SSR environments, the other prevents an unhandled
QuotaExceededError from crashing preference saves.

## Bug 1 — urlBase64ToUint8Array SSR crash
I added typeof window === "undefined" early return with an empty Uint8Array
to match the SSR guard pattern used by every other function in the file.

## Bug 2 — writeNotificationPreferences missing error handling
I wrapped localStorage.setItem in try/catch. The CustomEvent dispatch is
preserved in both branches so in-memory notification consumers stay in
sync with the normalized preferences even when storage is full or blocked.

## Changes
- src/utils/notificationPreferences.js
  — added SSR guard to urlBase64ToUint8Array
  — wrapped localStorage.setItem in try/catch in writeNotificationPreferences
  — moved dispatchEvent into both try and catch paths

Closes #8319 