### PR TITLE
Fix search input border and placeholder alignment

### DIFF
--- a/src/components/common/ModernSearchInput.js
+++ b/src/components/common/ModernSearchInput.js
@@ -45,7 +45,7 @@ const ModernSearchInput = ({
         className="relative group"
       >
         <div
-          className={`absolute inset-y-0 left-0 pl-4 flex items-center z-20 pointer-events-none transition-colors duration-300 ${
+          className={`absolute left-4 top-1/2 -translate-y-1/2 flex items-center z-20 pointer-events-none ${
             isFocused ? "text-indigo-500" : "text-gray-400 dark:text-gray-500"
           }`}
         >
@@ -53,7 +53,7 @@ const ModernSearchInput = ({
         </div>
 
         <div
-          className={`flex flex-wrap items-center gap-2 w-full pl-12 pr-12 py-3.5 sm:py-4 text-base text-gray-900 dark:text-gray-100 bg-white dark:bg-slate-900 border  rounded-2xl transition-all duration-300 shadow-lg ${inputClassName}`}
+          className={`flex items-center gap-2 w-full  h-14 sm:h-16 px-4  pl-12 pr-4  text-base text-gray-900 dark:text-gray-100 bg-white dark:bg-slate-900 border  rounded-2xl transition-all duration-300 shadow-lg ${inputClassName}`}
           style={{
             borderColor: isFocused ? "#6366f1" : "",
             borderWidth: isFocused ? "2px" : "1px",
@@ -64,18 +64,23 @@ const ModernSearchInput = ({
         >
           {tags}
           <input
-            ref={searchInputRef}
-            type="text"
-            placeholder={tags && tags.length > 0 ? "" : placeholder}
-            className="flex-1 bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 min-w-[120px] placeholder-gray-400 dark:placeholder-gray-500"
-            style={{ color: "inherit" }}
-            value={value}
-            onChange={onChange}
-            onFocus={handleFocus}
-            autoFocus={autoFocus}
-            onBlur={handleBlur}
-            onKeyDown={onKeyDown}
-          />
+  ref={searchInputRef}
+  type="text"
+  placeholder={tags && tags.length > 0 ? "" : placeholder}
+  className="flex-1 bg-transparent border-none outline-none focus:outline-none focus:ring-0 shadow-none"
+  style={{
+    border: "none",
+    boxShadow: "none",
+    outline: "none",
+    background: "transparent",
+  }}
+  value={value}
+  onChange={onChange}
+  onFocus={handleFocus}
+  autoFocus={autoFocus}
+  onBlur={handleBlur}
+  onKeyDown={onKeyDown}
+/>
         </div>
 
         {showClearButton && value && (


### PR DESCRIPTION
## Description

This PR fixes the search input UI issue where an unwanted border/inner textbox appeared around the placeholder text, resulting in a misaligned and inconsistent search bar design.

Fixes #8161

## Type of change

Please delete options that are not relevant.

- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)
BEFORE
<img width="909" height="141" alt="image" src="https://github.com/user-attachments/assets/14a4da91-96c5-4a2d-8134-5f2ffe896de5" />

AFTER
<img width="798" height="120" alt="image" src="https://github.com/user-attachments/assets/1e589a2a-76ee-4e7d-8b73-57e168d991cc" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
