### PR TITLE
feat: add role-based context redaction utility for API responses

### DIFF
--- a/src/utils/roleRedactor.js
+++ b/src/utils/roleRedactor.js
@@ -1,0 +1,23 @@
+
+export const redactSensitiveData = (data, userScopes) => {
+  if (!data || typeof data !== 'object') return data;
+  if (userScopes?.includes('admin:all') || userScopes?.includes('event:write')) return data;
+  
+  const redacted = Array.isArray(data) ? [...data] : { ...data };
+  
+  if (!Array.isArray(redacted)) {
+    delete redacted.revenue;
+    delete redacted.hostEmail;
+    delete redacted.privateNotes;
+    
+    Object.keys(redacted).forEach(key => {
+      if (typeof redacted[key] === 'object') {
+        redacted[key] = redactSensitiveData(redacted[key], userScopes);
+      }
+    });
+  } else {
+    return redacted.map(item => redactSensitiveData(item, userScopes));
+  }
+  
+  return redacted;
+};


### PR DESCRIPTION
### Describe the feature
The backend often returns rich event objects that include sensitive metadata (like total revenue and private notes). While visually hidden, this data remains accessible in the React DevTools or Redux state.

### Proposed changes
- Built `roleRedactor.js` as a frontend redaction layer.
- Automatically traverses API responses and strips sensitive keys recursively unless the user holds `admin:all` or `event:write` token scopes.

Fixes #8114