### PR TITLE
fix(transition): resolve page transition flash by disabling on slow connections and using popLayout

### DIFF
--- a/src/components/common/PageTransition.jsx
+++ b/src/components/common/PageTransition.jsx
@@ -1,5 +1,20 @@
 import { useLocation } from "react-router-dom";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+// Connection speed detection utility
+const checkSlowConnection = () => {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return false;
+  const connection =
+    navigator.connection ||
+    navigator.mozConnection ||
+    navigator.webkitConnection;
+  if (!connection) return false;
+  return (
+    connection.saveData ||
+    ["slow-2g", "2g", "3g"].includes(connection.effectiveType)
+  );
+};
 
 // Route-type based transition picker
 const getVariants = (pathname) => {
@@ -51,17 +66,23 @@ const getTransition = (pathname) => {
 const PageTransition = ({ children }) => {
   const location = useLocation();
   const prefersReducedMotion = useReducedMotion();
+  const [isSlow, setIsSlow] = useState(false);
 
-  const variants = prefersReducedMotion
-    ? reducedMotionVariants
-    : getVariants(location.pathname);
+  useEffect(() => {
+    setIsSlow(checkSlowConnection());
+  }, []);
 
-  const transition = prefersReducedMotion
-    ? { duration: 0.15 }
-    : getTransition(location.pathname);
+  const skipAnimation = prefersReducedMotion || isSlow;
+
+  if (skipAnimation) {
+    return <>{children}</>;
+  }
+
+  const variants = getVariants(location.pathname);
+  const transition = getTransition(location.pathname);
 
   return (
-    <AnimatePresence mode="wait" initial={false}>
+    <AnimatePresence mode="popLayout" initial={false}>
       <motion.div
         key={location.pathname}
         variants={variants}


### PR DESCRIPTION
## Description
This PR resolves the page transition flash issue by doing two things:
1. Skips page transitions entirely when the user prefers reduced motion OR is on a slow connection (e.g. 3G/2G or save-data mode). This ensures that on slow networks, the new page's skeleton loader mounts immediately without waiting for a slow exit animation to finish first.
2. Changes the `<AnimatePresence>` transition mode from `wait` to `popLayout`. This overlaps the exit and enter animations (crossfading them) so there is no blank frame or timing gap between page changes.

Fixes #6730

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
