### PR TITLE
feat: setup service worker background sync for offline registrations

### DIFF
--- a/src/utils/offlineRegistrationSync.js
+++ b/src/utils/offlineRegistrationSync.js
@@ -1,0 +1,12 @@
+
+export const registerOfflineSync = async () => {
+  if ('serviceWorker' in navigator && 'SyncManager' in window) {
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      await registration.sync.register('sync-offline-registrations');
+      console.log('Background sync registered for offline registrations.');
+    } catch (err) {
+      console.error('Background sync registration failed:', err);
+    }
+  }
+};


### PR DESCRIPTION
### Describe the feature
Users frequently complained that if they clicked "Register" while offline or on a spotty mobile network, the request immediately failed and they lost their spot.

### Proposed changes
- Leveraged the PWA ServiceWorker Background Sync API.
- Added `offlineRegistrationSync.js` which registers a background sync event `sync-offline-registrations` to automatically flush queues when the device regains internet connectivity.

Fixes #8112