### PR TITLE
feat: implement dynamic route-based code splitting for Recharts dashb…

### DIFF
--- a/src/components/admin/AnalyticsDashboardLazy.jsx
+++ b/src/components/admin/AnalyticsDashboardLazy.jsx
@@ -1,0 +1,12 @@
+
+import React, { Suspense, lazy } from 'react';
+
+const LazyAnalyticsDashboard = lazy(() => import('./AnalyticsDashboard'));
+
+const AnalyticsDashboardLazy = (props) => (
+  <Suspense fallback={<div className="p-8 text-center text-slate-500">Loading Analytics Dashboard...</div>}>
+    <LazyAnalyticsDashboard {...props} />
+  </Suspense>
+);
+
+export default AnalyticsDashboardLazy;


### PR DESCRIPTION
### Describe the feature
The `AnalyticsDashboard.jsx` pulls `recharts` into the main application bundle, forcing standard attendees to download ~200kb of unused graphing logic even if they never access the Admin Dashboard.

### Proposed changes
- Created a new `AnalyticsDashboardLazy.jsx` component.
- Uses React's `lazy()` and `Suspense` to dynamically load the dashboard and its heavy chart dependencies only when an admin explicitly visits the route.

Fixes #8111