### PR TITLE
fix: add AbortController to useAnalytics to prevent memory leaks on u…

### DIFF
--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -8,11 +8,12 @@ const useAnalytics = () => {
 
   useEffect(() => {
     if (!token) { setLoading(false); return; }
+    const controller = new AbortController();
     const fetchAnalytics = async () => {
       try {
         const res = await fetch(
-          `${process.env.REACT_APP_API_URL}/analytics/summary`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          (process.env.REACT_APP_API_URL || "") + "/analytics/summary",
+          { headers: { Authorization: `Bearer ${token}` }, signal: controller.signal }
         );
         if (!res.ok) throw new Error("API unavailable");
         const data = await res.json();
@@ -24,6 +25,7 @@ const useAnalytics = () => {
       }
     };
     fetchAnalytics();
+    return () => controller.abort();
   }, [token]);
 
   return { analytics, loading };


### PR DESCRIPTION
### Describe the bug
The newly added `src/hooks/useAnalytics.js` fetched data asynchronously but lacked an `AbortController`. If a user quickly navigated away from the dashboard before the network request resolved, React threw a state update warning on an unmounted component, leading to memory leaks. Additionally, a missing `API_URL` check led to malformed endpoint requests.

### Proposed changes
- Implemented an `AbortController` in the `useEffect` cleanup hook to cancel in-flight requests.
- Added a fallback empty string for `REACT_APP_API_URL` to prevent `undefined/` URL paths.

Fixes #8107