### PR TITLE
fix: only store minimal event metadata in recentEvents to prevent Quo…

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -450,7 +450,7 @@ const addToRecentEvents = (event) => {
 
   const filtered = existing.filter((e) => e.id !== event.id);
 
-  const updated = [event, ...filtered].slice(0, 6);
+  const updated = [{ id: event.id, title: event.title || event.name, date: event.date }, ...filtered].slice(0, 6);
 
   localStorage.setItem("recentEvents", JSON.stringify(updated));
 


### PR DESCRIPTION
### Describe the bug
In `src/components/user/EventsTab.js`, the `addToRecentEvents` function pushed the *entire* `event` object directly into `localStorage`. Because `event` objects often contain massive base64 image strings, viewing just 3-4 events instantly maxed out the browser's 5MB localStorage limit and crashed the app.

### Proposed changes
- Mapped the event payload to only include minimal metadata (`id`, `title`, `date`) before pushing to local storage.

Fixes #8105