### PR TITLE
fix: handle bookmarked events background in light mode

### DIFF
--- a/src/Pages/Events/BookmarkedEvents.js
+++ b/src/Pages/Events/BookmarkedEvents.js
@@ -28,14 +28,19 @@ const BookmarkedEvents = () => {
   );
 
   return (
-    <div className="min-h-screen dark:from-slate-950 dark:via-slate-950 dark:to-gray-950 text-slate-900 dark:text-gray-100 pt-12 pb-16 bg-gradient-to-br from-[#f5f7ff] via-[#eef2ff] to-[#f3e8ff] " style={{
-    backgroundImage: "url('/assets/bookmarkbg.png')",
+    <div
+  className="min-h-screen bg-gray-50 dark:from-slate-950 dark:via-slate-950 dark:to-gray-950 text-slate-900 dark:text-gray-100 pt-12 pb-16"
+  style={{
+    backgroundImage: document.documentElement.classList.contains("dark")
+      ? "url('/assets/bookmarkbg.png')"
+      : "none",
     backgroundSize: "cover",
     backgroundPosition: "center",
     backgroundRepeat: "no-repeat",
     minHeight: "100vh",
-    width:"100vw"
-  }}>
+    width: "100vw"
+  }}
+>
       <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between mb-8">
           <div>


### PR DESCRIPTION
## Description
This PR fixes the theme visibility issue on the Bookmarked Events page where a fixed dark background image was being applied even in light mode.

The background styling has been updated to respect the active theme, improving readability and maintaining consistent UI behavior.

## Changes Made
- Conditionally applied the bookmark background image only for dark mode
- Added proper light mode background handling
- Preserved the existing dark theme appearance
- Improved text visibility and overall theme consistency

## Issue Fixed
Closes #8135

## Testing
- Verified Bookmarked Events page in light mode
- Verified dark mode background remains unchanged
- Checked UI contrast and theme switching behavior