### PR TITLE
fix: respect fallback=null in Gate component to prevent hard redirects

### DIFF
--- a/src/components/auth/Gate.jsx
+++ b/src/components/auth/Gate.jsx
@@ -37,7 +37,7 @@ const Gate = ({
     return <Navigate to={redirectTo} replace state={{ from: location, sessionExpired }} />;
   }
 
-  const needsRedirect = !fallback || typeof fallback === "undefined";
+  const needsRedirect = typeof fallback === "undefined";
   const deny = (reason) => {
     if (!needsRedirect) return fallback;
     if (!isAuthenticated()) return <Navigate to={redirectTo} replace state={{ from: location, sessionExpired }} />;


### PR DESCRIPTION
### Describe the bug
In the newly rewritten `src/components/auth/Gate.jsx`, the logic evaluated `const needsRedirect = !fallback || typeof fallback === "undefined"`. When passing `fallback={null}` to intentionally hide a button without permissions, `!null` evaluates to `true`, forcing an unexpected redirect to `/unauthorized`.

### Proposed changes
- Updated the logic to specifically check for `typeof fallback === "undefined"`.
- This allows developers to use `<Gate fallback={null}>` for silent conditional rendering without triggering page navigation.

Fixes #8103