### PR TITLE
fix: safely read response headers in interceptor to prevent TypeError

### DIFF
--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -47,7 +47,7 @@ export const createRequestInterceptor = (isDev) => (config) => {
 
 export const createResponseInterceptor = (API) => {
   const fulfill = (response) => {
-    const headerValue = response.headers.get("x-server-time") || response.headers.get("date");
+    const headerValue = response.headers?.["x-server-time"] || response.headers?.["date"] || (typeof response.headers?.get === 'function' ? (response.headers.get("x-server-time") || response.headers.get("date")) : null);
     if (headerValue) syncServerTimeFromHeader(headerValue);
     return response;
   };
@@ -179,7 +179,7 @@ export function setupRequestInterceptor(api, { isDev, buildApiUrl, getAuthToken,
 export function setupResponseInterceptor(api, { isDev, timeoutMs, getOnUnauthorized }) {
   api.interceptors.response.use(
     (response) => {
-      const headerValue = response.headers.get("x-server-time") || response.headers.get("date");
+      const headerValue = response.headers?.["x-server-time"] || response.headers?.["date"] || (typeof response.headers?.get === 'function' ? (response.headers.get("x-server-time") || response.headers.get("date")) : null);
       if (headerValue) {
         syncServerTimeFromHeader(headerValue);
       }


### PR DESCRIPTION
### Describe the bug
In `src/config/api/interceptors.js`, the successful response interceptor attempted to sync server time using `response.headers.get("x-server-time")`. However, since the API client uses Axios, `response.headers` is a plain JavaScript object, not a native Fetch API `Headers` instance. This caused a `TypeError` that crashed every single successful API response globally.

### Proposed changes
- Replaced `.get()` method calls with safe optional chaining and bracket notation.
- Added a fallback to ensure compatibility with both Axios and native Fetch paradigms if the interceptor is ever reused.

Fixes #8102