### PR TITLE
refactor: migrate toast notifications from react-toastify to react-hot-toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-intersection-observer": "^10.0.3",
     "react-qr-code": "^2.0.21",
     "react-router-dom": "^7.15.1",
-    "react-toastify": "^11.1.0",
     "recharts": "^3.8.1",
     "vite": "8.0.14",
     "zustand": "^5.0.14"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,7 @@ import { Routes, Route, useLocation } from "react-router-dom";
 import "./App.css";
 import "./styles/reduced-motion.css";
 import "./styles/print.css";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 // Critical path - loaded eagerly (needed before first paint)
 import Navbar from "./components/navbar/Navbar";
@@ -118,7 +118,7 @@ function App() {
       });
     };
     const handleOffline = () => {
-      toast.warning("You are currently offline. Running in secure local offline caching mode.", {
+      toast("You are currently offline. Running in secure local offline caching mode.", {
         position: "bottom-right",
         autoClose: 5000,
       });

--- a/src/Pages/CertificateVerification/CertificateVerifier.jsx
+++ b/src/Pages/CertificateVerification/CertificateVerifier.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Input } from '../../components/common/Input';
 import { exportToCSV } from '../../utils/exportUtils';
 import { verifyCertificate } from '../../utils/certificateUtils';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 import { LinkedInShareButton } from '../../components/common/LinkedInShareButton';
 
 // Glassmorphic container style

--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -2,7 +2,7 @@ import { Star, MessageSquare } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 import { User, Mail, FileText, AlertCircle } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import SEOHead from "../../components/SEOHead";
 
 import useReducedMotion from "../../hooks/useReducedMotion.js";

--- a/src/Pages/Events/EventAnalyticsDashboard.js
+++ b/src/Pages/Events/EventAnalyticsDashboard.js
@@ -8,7 +8,7 @@ import {
   TrendingUp, Users, DollarSign, Download, Calendar, 
   Map as MapIcon, ArrowUpRight, ArrowDownRight, Filter
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { jsPDF } from "jspdf";
 import html2canvas from "html2canvas";
 
@@ -59,7 +59,7 @@ const EventAnalyticsDashboard = ({ eventId, eventData }) => {
     const dashboard = document.getElementById("analytics-dashboard");
     if (!dashboard) return;
 
-    toast.info("Generating report...");
+    toast("Generating report...");
     try {
       const canvas = await html2canvas(dashboard, { scale: 2 });
       const imgData = canvas.toDataURL("image/png");

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -18,7 +18,7 @@ import {
   Share2,
   AlertTriangle,
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { addEventToGoogleCalendar } from "../../utils/calendarUtils";
 import LazyImage from "../../components/common/LazyImage";
 import ShareModal from "../../components/common/ShareModal";
@@ -114,7 +114,7 @@ const EventCard = ({ event }) => {
 
     if (isBookmarked) {
       removeBookmarkedEvent(event.id);
-      toast.info("Removed from bookmarked events.", {
+      toast("Removed from bookmarked events.", {
         toastId: `bookmark-${event.id}`,
         autoClose: 1800,
         className: "custom-toast",

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -2,7 +2,7 @@ import "./EventDetails.print.css";
 import { useEffect, useState, useCallback, useRef } from "react";
 import { Helmet } from "react-helmet-async";
 import { sanitizeMarkdown } from "../../utils/sanitizeHtml";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { Link, useParams } from "react-router-dom";
 import { Calendar, MapPin, Clock, Tag, Share2, CalendarPlus, Link2 } from "lucide-react";
 import { getEventStatus, isEventRegistrationClosed } from "../../utils/eventUtils";

--- a/src/Pages/Events/EventDetailsPage.js
+++ b/src/Pages/Events/EventDetailsPage.js
@@ -6,7 +6,7 @@ import { sanitizeHtml } from "../../utils/sanitizeHtml";
 import CountdownTimer from "../../components/common/CountdownTimer";
 import { Calendar, MapPin, Clock, Users, Tag, ArrowLeft, WifiOff } from "lucide-react";
 import { Share2, Twitter, Facebook, Linkedin, MessageCircle, Copy, Check } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { getEventStatus } from "../../utils/eventUtils";
 import { logError } from "../../utils/errorLogger";
 // Note: eventsMockData.json is NOT statically imported here.

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -28,7 +28,7 @@ import { useSessionRecovery } from "../../context/SessionRecoveryContext";
 import CalendarView from "../../components/CalendarView";
 
 import { validate } from "../../validation";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import {
   getCacheAgeLabel,
   getCachedEventDetail,
@@ -201,7 +201,7 @@ const EventRegistration = () => {
             },
           });
 
-          toast.warning(`Showing ${getCacheAgeLabel(cached.cachedAt)} event details.`);
+          toast(`Showing ${getCacheAgeLabel(cached.cachedAt)} event details.`);
           return;
         }
 
@@ -331,7 +331,7 @@ const EventRegistration = () => {
           setRegistered(true);
           addRegistration(event, formData);
           clearSession();
-          toast.warning("Network error. Registration queued and will sync when you are online.", {
+          toast("Network error. Registration queued and will sync when you are online.", {
             autoClose: 4000,
           });
         } else {
@@ -347,7 +347,7 @@ const EventRegistration = () => {
         toast.success(isEventFull ? "Successfully joined waitlist!" : "Registration successful!");
         addRegistration(event, formData);
         clearSession();
-        toast.info(failureMessage);
+        toast(failureMessage);
         return;
       }
 
@@ -388,7 +388,7 @@ const EventRegistration = () => {
 
     const isFull = await checkEventCapacity(eventId, event);
     if (isFull) {
-      toast.info("This event is full. You will be added to the waitlist.");
+      toast("This event is full. You will be added to the waitlist.");
     }
 
     if (await checkAndHandleConflicts()) return;
@@ -399,7 +399,7 @@ const EventRegistration = () => {
   // Handle conflict modal actions
   const handleConflictCancel = useCallback(() => {
     setShowConflictModal(false);
-    toast.info("Registration cancelled due to scheduling conflict.");
+    toast("Registration cancelled due to scheduling conflict.");
   }, []);
 
   const handleConflictProceed = useCallback(() => {
@@ -409,7 +409,7 @@ const EventRegistration = () => {
   const handleSelectAlternative = useCallback((alternativeEvent) => {
     setShowConflictModal(false);
     navigate(`/events/${alternativeEvent.id}/register`);
-    toast.info(`Redirecting to ${alternativeEvent.title}`);
+    toast(`Redirecting to ${alternativeEvent.title}`);
   }, [navigate]);
 
   const isEventFull = useMemo(() => event ? event.attendees >= event.maxAttendees : false, [event]);

--- a/src/Pages/Events/VirtualVenueWalkthrough.jsx
+++ b/src/Pages/Events/VirtualVenueWalkthrough.jsx
@@ -5,7 +5,7 @@ import {
 } from "lucide-react";
 import useReducedMotion from "../../hooks/useReducedMotion";
 import VirtualBoothModal from "../../components/events/VirtualBoothModal";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 // Default premium developer sponsor booths (fallback if none loaded from designer)
 const DEFAULT_SPONSORS = [
@@ -413,7 +413,7 @@ const VirtualVenueWalkthrough = () => {
               </div>
             </div>
             <button
-              onClick={() => toast.info("Full screen expansion would display optimized layout HUD.")}
+              onClick={() => toast("Full screen expansion would display optimized layout HUD.")}
               className="p-2 bg-indigo-500/10 hover:bg-indigo-500/20 border border-indigo-500/20 hover:border-indigo-500/40 rounded-lg text-indigo-400 transition-colors cursor-pointer"
               title="Full Screen View"
             >

--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -2,7 +2,7 @@ import { BarChart, Calendar, Check, CheckCircle, ChevronDown, Mail, MessageSquar
 import React, { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import useReducedMotion from "../../hooks/useReducedMotion.js";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 import { analyzeSentiment, getSentimentDisplay } from "../../utils/sentiment.js";
 

--- a/src/Pages/Feedback/SurveyEngine.jsx
+++ b/src/Pages/Feedback/SurveyEngine.jsx
@@ -1,7 +1,7 @@
 import { Plus, Trash2, PlusCircle, Save, ArrowUp, ArrowDown } from "lucide-react";
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 import SurveyAnalytics from "../../components/admin/SurveyAnalytics";
 import { validate } from "../../validation";
@@ -101,7 +101,7 @@ const SurveyEngine = () => {
     setDraftDetected(false);
     setCachedDraft(null);
     setIsInitialized(true);
-    toast.info("Survey template draft discarded");
+    toast("Survey template draft discarded");
   };
 
   // Question type configuration
@@ -121,14 +121,14 @@ const SurveyEngine = () => {
       options: type === "choice" ? ["Option 1", "Option 2"] : [],
     };
     setQuestions([...questions, newQuestion]);
-    toast.info(`Added a new ${type} question!`);
+    toast(`Added a new ${type} question!`);
   };
 
   // Update question properties
   const updateQuestionText = (id, text) => {
     // Show validation notifications if HTML is detected
     if (validate.detectHTML(text)) {
-      toast.warning("HTML elements detected. They will be automatically sanitized to prevent XSS.");
+      toast("HTML elements detected. They will be automatically sanitized to prevent XSS.");
     }
     const sanitized = validate.sanitizeSurveyPrompt(text);
     setQuestions(
@@ -169,7 +169,7 @@ const SurveyEngine = () => {
 
   const updateOptionText = (questionId, optionIndex, text) => {
     if (validate.detectHTML(text)) {
-      toast.warning("HTML elements detected. They will be automatically sanitized to prevent XSS.");
+      toast("HTML elements detected. They will be automatically sanitized to prevent XSS.");
     }
     const sanitized = validate.sanitizeSurveyOption(text);
     setQuestions(

--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -1,7 +1,7 @@
 import { ArrowRightIcon, ChartBarIcon, UserGroupIcon, StarIcon, ClipboardDocumentListIcon, BuildingOffice2Icon, EnvelopeIcon, MapPinIcon, TrophyIcon, LinkIcon, CalendarDaysIcon, DocumentTextIcon, ComputerDesktopIcon } from "@heroicons/react/24/outline";
 import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 
 import useReducedMotion from "../../hooks/useReducedMotion.js";

--- a/src/Pages/Networking/MatchmakingHub.jsx
+++ b/src/Pages/Networking/MatchmakingHub.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { fetchRecommendedConnections, suggestMeetingSlots } from "../../utils/aiMatchmaking";
 import { Calendar, MessageSquare, Zap, Star } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 const MatchmakingHub = () => {
   const [connections, setConnections] = useState([]);

--- a/src/Pages/Projects/SubmitProject.js
+++ b/src/Pages/Projects/SubmitProject.js
@@ -2,7 +2,7 @@ import { ArrowRightIcon, LightBulbIcon, FolderOpenIcon, CodeBracketIcon, CheckCi
   UserGroupIcon, EnvelopeIcon, LinkIcon, RectangleGroupIcon, CpuChipIcon, BookmarkIcon, UsersIcon, ClockIcon, UserPlusIcon, PhotoIcon, ArchiveBoxIcon, DocumentTextIcon, PencilSquareIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
 import { API_ENDPOINTS, apiUtils } from "../../config/api";

--- a/src/Pages/RegistrationPage.test.js
+++ b/src/Pages/RegistrationPage.test.js
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 
 import RegistrationPage from './RegistrationPage';
 import { apiUtils } from '../config/api';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 
 jest.mock('../config/api', () => ({
   API_ENDPOINTS: {

--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -4,7 +4,7 @@ import useDocumentTitle from '../hooks/useDocumentTitle';
 import QuestCenter from '../components/gamification/QuestCenter';
 import EventBadgeGenerator from '../components/user/EventBadgeGenerator';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 import {
   Award,
   Zap,

--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import {
   Bot,
   Minus,

--- a/src/components/CollaborationHub.js
+++ b/src/components/CollaborationHub.js
@@ -2,7 +2,7 @@ import StatusBadge from "./common/StatusBadge";
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useReducedMotion } from '../hooks/useReducedMotion';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 import './components.css';
 import CharacterCounter from "../../components/common/CharacterCounter";
 import { sanitizeInputText } from "../utils/inputSanitization";

--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { ArrowRight, Pencil, CheckCircle, AlertCircle, Calendar, Users, MapPin, Ticket as TicketIcon } from "lucide-react";
 
 import { useEventForm } from "../hooks/useEventForm";

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { motion, AnimatePresence } from "framer-motion";
 import { createPortal } from "react-dom";
 

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -32,7 +32,7 @@ import "./AdminDashboard.css";
 import AnalyticsDashboard from "./AnalyticsDashboard";
 import TicketScanner from "./TicketScanner";
 import SectionErrorBoundary from "../common/SectionErrorBoundary";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 import { ROLES, PERMISSIONS } from "../../config/roles";
 import {
@@ -463,7 +463,7 @@ const AdminDashboard = () => {
                               <td>
                                 <div className="ad-action-btns">
                                   {hasPermission(PERMISSIONS.EDIT_USER) && (
-                                    <button className="ad-icon-action" title="Edit" onClick={() => toast.info('Edit coming soon')}><Edit2 size={14} /></button>
+                                    <button className="ad-icon-action" title="Edit" onClick={() => toast('Edit coming soon')}><Edit2 size={14} /></button>
                                   )}
                                   {hasPermission(PERMISSIONS.DELETE_USER) && (
                                     <button className="ad-icon-action ad-icon-danger" title="Delete" onClick={() => confirmDelete('user', u.id)}><Trash2 size={14} /></button>
@@ -541,7 +541,7 @@ const AdminDashboard = () => {
                               <td>
                                 <div className="ad-action-btns">
                                   {hasPermission(PERMISSIONS.EDIT_EVENT) && (
-                                    <button className="ad-icon-action" title="Edit" onClick={() => toast.info('Edit coming soon')}><Edit2 size={14} /></button>
+                                    <button className="ad-icon-action" title="Edit" onClick={() => toast('Edit coming soon')}><Edit2 size={14} /></button>
                                   )}
                                   {hasPermission(PERMISSIONS.DELETE_EVENT) && (
                                     <button className="ad-icon-action ad-icon-danger" title="Delete" onClick={() => confirmDelete('event', ev.id)}><Trash2 size={14} /></button>

--- a/src/components/admin/AnalyticsDashboard.jsx
+++ b/src/components/admin/AnalyticsDashboard.jsx
@@ -11,7 +11,7 @@ import {
   PieChart,
   Pie,
 } from "recharts";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { useAnalyticsStream, SSE_STATUS } from "../../context/RealTimeContext";
 import BudgetPlanner from "./BudgetPlanner";
 import { safeJsonParse } from "../../utils/safeJsonParse";
@@ -179,11 +179,11 @@ const [activeTab, setActiveTab] = useState('analytics');
 
     // 5. Fire Feedback Notifications Interceptors
     if (cleanCheckinData.status === "Flagged") {
-      toast.warning(`⚠️ Security Alert: Flagged entry attempt from ${cleanCheckinData.name}`);
+      toast(`⚠️ Security Alert: Flagged entry attempt from ${cleanCheckinData.name}`);
     } else if (String(cleanCheckinData.id).includes("manual")) {
       toast.success(`🚀 Simulator: Successfully injected real-time check-in record for ${cleanCheckinData.name}!`);
     } else {
-      toast.info(`🔔 Check-in Verified: ${cleanCheckinData.name} matched to ${cleanCheckinData.event}`);
+      toast(`🔔 Check-in Verified: ${cleanCheckinData.name} matched to ${cleanCheckinData.event}`);
     }
   }, []);
 
@@ -255,9 +255,9 @@ const [activeTab, setActiveTab] = useState('analytics');
       });
 
       if (randomStatus === "Flagged") {
-        toast.warning(`⚠️ Security Alert: Flagged entry attempt from ${randomName}`);
+        toast(`⚠️ Security Alert: Flagged entry attempt from ${randomName}`);
       } else {
-        toast.info(`🔔 Check-in Verified: ${randomName} matched to ${randomEvent}`);
+        toast(`🔔 Check-in Verified: ${randomName} matched to ${randomEvent}`);
       }
     }, 12000); // Trigger every 12 seconds emulating active hackathon flow
 

--- a/src/components/admin/SurveyAnalytics.jsx
+++ b/src/components/admin/SurveyAnalytics.jsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Cell,
 } from "recharts";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { useSurveySimulator } from "./useSurveySimulator";
 
 // Pre-defined high-quality feedback pool for open text responses

--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -16,7 +16,7 @@ import {
   Wifi,
   WifiOff,
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { pushToQueue } from "../../utils/offlineQueue";
 import { validateTicket, recordCheckIn, fetchCheckInHistory, fetchScannerEvents } from "../../services/ticketService";
 import "./TicketScanner.css";
@@ -226,7 +226,7 @@ export default function TicketScanner() {
         data: ticketData,
         message: "Check-in queued offline — will sync when connection resumes.",
       });
-      toast.info(`Offline check-in queued for ${userName}.`);
+      toast(`Offline check-in queued for ${userName}.`);
       await pushToQueue({
         actionType: "TICKET_CHECK_IN",
         ticketId,
@@ -253,7 +253,7 @@ export default function TicketScanner() {
           data: ticketData,
           message: "This ticket has already been checked in!",
         });
-        toast.warning(`Duplicate Attempt: ${userName} is already checked in.`);
+        toast(`Duplicate Attempt: ${userName} is already checked in.`);
         addToHistory({
           id: `dup-${Date.now()}`,
           ticketId,

--- a/src/components/admin/useSurveySimulator.js
+++ b/src/components/admin/useSurveySimulator.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 export function useSurveySimulator(questions, feedbackPool) {
   const [totalSubmissions, setTotalSubmissions] = useState(142);

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -3,7 +3,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { useAuth } from '../../context/AuthContext';
 import useDocumentTitle from "../../hooks/useDocumentTitle";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { showAuthToast } from "../../utils/toast";
 import { getPublicErrorMessage, AUTH_ERRORS } from "../../utils/errorMessages";
 import useReducedMotion from "../../hooks/useReducedMotion";

--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useAuth } from "../../context/AuthContext";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { showAuthToast } from "../../utils/toast";
 import { ValidationMessage } from "../forms";
 import { LogIn, Mail, Lock, Eye, EyeOff } from "lucide-react";

--- a/src/components/common/CollaborativeWhiteboard.jsx
+++ b/src/components/common/CollaborativeWhiteboard.jsx
@@ -11,7 +11,7 @@ import {
   Users, 
   Sparkles
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 // DB Configuration for Whiteboard State Cache
 const DB_NAME = "eventra_whiteboard_db";
@@ -255,7 +255,7 @@ export default function CollaborativeWhiteboard() {
         case "WHITEBOARD_CLEAR":
           setLocalStrokes([]);
           saveHistory([]);
-          toast.info("Whiteboard cleared by another peer.");
+          toast("Whiteboard cleared by another peer.");
           break;
 
         default:

--- a/src/components/common/CopyLinkButton.jsx
+++ b/src/components/common/CopyLinkButton.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link2, Check } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 const CopyLinkButton = () => {
   const [copied, setCopied] = useState(false);

--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { Download, Calendar, Globe, Link2, Plus } from "lucide-react";
 import { logger } from "../../../utils/logger";
 import useReducedMotion from "../../../hooks/useReducedMotion";
@@ -315,7 +315,7 @@ const EventCreation = () => {
   const handleDiscardDraft = () => {
     localStorage.removeItem(DRAFT_KEY);
     setShowRestoreModal(false);
-    toast.info("Saved draft discarded.");
+    toast("Saved draft discarded.");
   };
 
   useEffect(() => {

--- a/src/components/common/NotificationProvider.js
+++ b/src/components/common/NotificationProvider.js
@@ -1,24 +1,17 @@
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
+import { Toaster } from "react-hot-toast";
 
 const NotificationToastContainer = () => {
   return (
-    <ToastContainer
+    <Toaster
       position="bottom-right"
-      autoClose={3000}
-      hideProgressBar={false}
-      newestOnTop
-      closeOnClick
-      closeButton
-      rtl={false}
-      pauseOnFocusLoss
-      draggable
-      pauseOnHover
-      theme="colored"
-      limit={3}
-      style={{ 
+      reverseOrder={false}
+      gutter={8}
+      containerStyle={{
         zIndex: 10050,
-        marginBottom: '1rem'
+        marginBottom: "1rem",
+      }}
+      toastOptions={{
+        duration: 3000,
       }}
     />
   );

--- a/src/components/common/OfflineManager.jsx
+++ b/src/components/common/OfflineManager.jsx
@@ -5,7 +5,7 @@ import {
   AlertTriangle, History, X, ChevronRight, Clock
 } from "lucide-react";
 import { getQueueIndexedDB, setQueue, clearQueue } from "../../utils/offlineQueue";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 const OfflineManager = ({ isOpen, onClose }) => {
   const [pendingActions, setPendingActions] = useState([]);

--- a/src/components/common/QRTicket/QRTicketModal.jsx
+++ b/src/components/common/QRTicket/QRTicketModal.jsx
@@ -31,7 +31,7 @@
 import { useRef, useEffect } from "react";
 import QRTicket from "./QRTicket";
 import { useTicketDownload } from "./useTicketDownload";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 export default function QRTicketModal({ isOpen, onClose, ticket }) {
   const ticketRef = useRef(null);

--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Share2, Copy, Mail, Check } from 'lucide-react';
 import { generateSharingUrl, copyToClipboard } from '../../../utils/shareUtils';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 import './ShareMenu.css';
 
 /**

--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -10,7 +10,7 @@ import {
   Twitter,
   X,
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { isValidShareUrl } from "../../utils/shareUtils";
 
 const ModalCloseButton = memo(({ onClick }) => (

--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Layout, Save, RotateCcw, Plus, Minus, Move, AlertTriangle } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import ConfirmationModal from "../../common/ConfirmationModal";
 import ElementPalette from "./FloorPlan/ElementPalette";
 import PropertiesPanel from "./FloorPlan/PropertiesPanel";

--- a/src/components/feedback/EventFeedbackForm.jsx
+++ b/src/components/feedback/EventFeedbackForm.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { Loader2 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 const EventFeedbackForm = ({ eventId, eventTitle = "this event" }) => {
   const [rating, setRating] = useState(0);

--- a/src/components/feedback/EventFeedbackModal.jsx
+++ b/src/components/feedback/EventFeedbackModal.jsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { X, CheckCircle, ThumbsUp, ThumbsDown } from 'lucide-react';
 import StarRating from './StarRating';
 import { saveFeedback, getUserFeedback } from '../../utils/feedbackUtils';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 
 /**
  * EventFeedbackModal Component
@@ -49,7 +49,7 @@ const EventFeedbackModal = ({ isOpen, onClose, event }) => {
 
   const handleSubmit = async () => {
     if (rating === 0) {
-      toast.warning('Please select a rating');
+      toast('Please select a rating');
       return;
     }
 

--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 import {
   Zap, CheckCircle, Gift, Target,
   Flame, Star, Trophy, Sparkles, Timer,

--- a/src/components/hackathons/InteractiveWhiteboard.jsx
+++ b/src/components/hackathons/InteractiveWhiteboard.jsx
@@ -3,7 +3,7 @@ import {
   Square, Circle, PenTool, RotateCcw, Trash2, Plus, Move,
   Check, Palette, HelpCircle, X
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 const COLORS = [
   { name: "Indigo", value: "#6366f1" },
@@ -167,7 +167,7 @@ const InteractiveWhiteboard = () => {
 
   const handleDeleteSticky = (id) => {
     setStickies(stickies.filter(s => s.id !== id));
-    toast.info("Sticky note removed.");
+    toast("Sticky note removed.");
   };
 
   // History controls
@@ -182,7 +182,7 @@ const InteractiveWhiteboard = () => {
   const handleClear = () => {
     setElements([]);
     setStickies([]);
-    toast.info("Canvas cleared successfully.");
+    toast("Canvas cleared successfully.");
   };
 
   const getCanvasCoords = (e) => {

--- a/src/components/hackathons/TeamWorkspace.jsx
+++ b/src/components/hackathons/TeamWorkspace.jsx
@@ -12,7 +12,7 @@ import {
   RefreshCw,
   AlertTriangle,
 } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import InteractiveWhiteboard from "./InteractiveWhiteboard";
 
 const INITIAL_TASKS = [
@@ -177,7 +177,7 @@ const TeamWorkspace = () => {
               time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
             },
           ]);
-          toast.info(`New message from ${incoming.sender}!`);
+          toast(`New message from ${incoming.sender}!`);
           msgIndex++;
         }
       }, 5000);
@@ -218,7 +218,7 @@ const TeamWorkspace = () => {
 
   const handleDeleteTask = (id) => {
     setTasks(tasks.filter((t) => t.id !== id));
-    toast.info("Task removed from checklist.");
+    toast("Task removed from checklist.");
   };
 
   // Pins / Announcements handlers
@@ -240,7 +240,7 @@ const TeamWorkspace = () => {
 
   const handleDeletePin = (id) => {
     setPins(pins.filter((p) => p.id !== id));
-    toast.info("Announcement unpinned.");
+    toast("Announcement unpinned.");
   };
 
   // Chat message sending

--- a/src/components/reminders/ReminderChecker.js
+++ b/src/components/reminders/ReminderChecker.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { popDueReminders } from "../../utils/reminderUtils";
 
 const CHECK_INTERVAL_MS = 30 * 1000;
@@ -59,7 +59,7 @@ const ReminderChecker = () => {
         }
 
         // Trigger notification
-        toast.info(`${reminder.event.title} starts ${reminder.timingLabel}.`, {
+        toast(`${reminder.event.title} starts ${reminder.timingLabel}.`, {
           toastId: `reminder-due-${reminder.id}`,
           autoClose: 6000,
           className: "custom-toast",

--- a/src/components/reminders/ReminderControls.js
+++ b/src/components/reminders/ReminderControls.js
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Bell, BellOff, Check } from "lucide-react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import {
   REMINDER_TIMINGS,
   addReminder,
@@ -51,7 +51,7 @@ const ReminderControls = ({ event, canSetReminder, compact = false }) => {
   const handleReminderToggle = async (timing) => {
     try {
       if (eventHasPassed) {
-        toast.warning("Reminders are not available for past events.", {
+        toast("Reminders are not available for past events.", {
           toastId: `reminder-past-${event.id}`,
           className: "custom-toast",
         });
@@ -59,7 +59,7 @@ const ReminderControls = ({ event, canSetReminder, compact = false }) => {
       }
 
       if (!canSetReminder) {
-        toast.info("Bookmark or register for this event before setting a reminder.", {
+        toast("Bookmark or register for this event before setting a reminder.", {
           toastId: `reminder-locked-${event.id}`,
           className: "custom-toast",
         });
@@ -68,7 +68,7 @@ const ReminderControls = ({ event, canSetReminder, compact = false }) => {
 
       if (activeTimingSet.has(timing)) {
         removeReminder(event.id, timing);
-        toast.info("Reminder removed.", {
+        toast("Reminder removed.", {
           toastId: `reminder-remove-${event.id}-${timing}`,
           autoClose: 1800,
           className: "custom-toast",
@@ -86,7 +86,7 @@ const ReminderControls = ({ event, canSetReminder, compact = false }) => {
           invalid: "We could not read this event date.",
         };
 
-        toast.warning(messages[result.reason] || "Unable to set reminder.", {
+        toast(messages[result.reason] || "Unable to set reminder.", {
           toastId: `reminder-failed-${event.id}-${timing}`,
           className: "custom-toast",
         });
@@ -95,7 +95,7 @@ const ReminderControls = ({ event, canSetReminder, compact = false }) => {
 
       const permission = await requestBrowserNotificationPermission().catch(() => "denied");
       if (permission === "denied") {
-        toast.info("Reminder saved. Browser notifications are blocked in your settings.", {
+        toast("Reminder saved. Browser notifications are blocked in your settings.", {
           toastId: `reminder-browser-denied-${event.id}`,
           autoClose: 2600,
           className: "custom-toast",

--- a/src/components/user/EventBadgeGenerator.jsx
+++ b/src/components/user/EventBadgeGenerator.jsx
@@ -15,7 +15,7 @@ import {
 import html2canvas from "html2canvas";
 import { jsPDF } from "jspdf";
 import QRCode from "react-qr-code";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 
 // Predefined premium templates
 const BADGE_TEMPLATES = {

--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -3,7 +3,7 @@ import { X, Download, ShieldCheck, Calendar, MapPin, Clock, User, Mail, Award, L
 import html2canvas from "html2canvas";
 import { jsPDF } from "jspdf";
 import QRCode from "react-qr-code";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import "./EventTicket.css";
 import { useMyEvents } from "../../context/MyEventsContext";
 import SpatialSeatSelector from "../events/SpatialSeatSelector";
@@ -85,7 +85,7 @@ const EventTicket = ({ event, user, onClose }) => {
   const handleDownload = async (format = "png") => {
     if (!ticketRef.current) return;
     setDownloading(true);
-    toast.info(`Generating your high-resolution ticket ${format.toUpperCase()}...`);
+    toast(`Generating your high-resolution ticket ${format.toUpperCase()}...`);
 
     try {
       // Force temporary state to front-side without rotation to capture cleanly

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -10,7 +10,7 @@ import {
 import { API_ENDPOINTS, apiUtils, setOnUnauthorizedHandler } from "../config/api";
 import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils";
 import { syncSecureStorage } from "../utils/secureStorage";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { ROLES, ROLE_PERMISSIONS } from "../config/roles";
 
 const AuthContext = createContext();
@@ -71,7 +71,7 @@ export const AuthProvider = ({ children }) => {
     }
 
     expiryToastShownRef.current = true;
-    toast.info("Session expired. Please log in again.", {
+    toast("Session expired. Please log in again.", {
       toastId: "session-expired",
       autoClose: 5000,
     });

--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { toast } from "react-toastify";
+import { toast } from "react-hot-toast";
 import { API_ENDPOINTS, apiUtils } from "../config/api";
 import { useFormSubmit } from "./useFormSubmit";
 import {

--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { toast } from 'react-toastify';
+import { toast } from 'react-hot-toast';
 import { useAuth } from '../context/AuthContext';
 import { API_ENDPOINTS } from '../config/api';
 import { logger } from "../utils/logger";
@@ -165,7 +165,7 @@ const useOfflineSync = () => {
       // The queue was saved under a previous session; firing it now could
       // attach those actions to whichever user happens to be logged in.
       if (!token || !isTokenValid(token)) {
-        toast.warning(
+        toast(
           "Offline actions are pending but your session has expired. Please log in again to sync them.",
           { autoClose: 6000 }
         );
@@ -196,7 +196,7 @@ const useOfflineSync = () => {
           'This prevents cross-user action replay.'
         );
         await clearQueue();
-        toast.warning(
+        toast(
           "Offline actions from a previous session have been cleared for security.",
           { autoClose: 5000 }
         );
@@ -211,7 +211,7 @@ const useOfflineSync = () => {
       isSyncing.current = true;
 
       try {
-        toast.info(`Syncing ${validatedQueue.length} cached offline action(s)...`, {
+        toast(`Syncing ${validatedQueue.length} cached offline action(s)...`, {
           autoClose: 2000,
         });
 
@@ -284,7 +284,7 @@ const useOfflineSync = () => {
           await setQueue(failedQueue);
           // Only show toast if we didn't abort completely
           if (!conflictController.signal.aborted) {
-            toast.warning(
+            toast(
               `Synced ${successCount} registration(s). ${failedQueue.length} remaining in local draft queue.`,
             );
           }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,12 +1,11 @@
-import '@testing-library/jest-dom';
-import { TextDecoder, TextEncoder } from "util";
+import "@testing-library/jest-dom";
+import { vi, TextDecoder, TextEncoder } from "util";
 
 if (typeof global.TextEncoder === "undefined") {
   global.TextEncoder = TextEncoder;
 }
-
 if (typeof global.TextDecoder === "undefined") {
   global.TextDecoder = TextDecoder;
 }
-
 global.IS_REACT_ACT_ENVIRONMENT = true;
+global.jest = vi;

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,13 +1,33 @@
-import { toast } from "react-toastify";
+import toast from "react-hot-toast";
 
 const AUTH_TOAST_ID = "auth-feedback";
 
-/** Auth flows: dismiss stale toasts, show one toast, navigate after it closes. */
 export function showAuthToast(message, onAfterClose) {
   toast.dismiss(AUTH_TOAST_ID);
-  toast.success(message, {
-    toastId: AUTH_TOAST_ID,
-    autoClose: 2500,
-    onClose: onAfterClose,
-  });
+  toast.success(message, { id: AUTH_TOAST_ID, duration: 2500 });
+  if (typeof onAfterClose === "function") setTimeout(onAfterClose, 2600);
+}
+
+export function showErrorToast(message, onAfterClose) {
+  toast.dismiss("error-feedback");
+  toast.error(message, { id: "error-feedback", duration: 3500 });
+  if (typeof onAfterClose === "function") setTimeout(onAfterClose, 3600);
+}
+
+export function showInfoToast(message, onAfterClose) {
+  toast.dismiss("info-feedback");
+  toast(message, { id: "info-feedback", duration: 2500 });
+  if (typeof onAfterClose === "function") setTimeout(onAfterClose, 2600);
+}
+
+export function showSuccessToast(message, options = {}) {
+  const toastId = options.toastId;
+  if (toastId) toast.dismiss(toastId);
+  toast.success(message, { id: toastId, duration: options.autoClose ?? 2500 });
+}
+
+export function showWarningToast(message, options = {}) {
+  const toastId = options.toastId;
+  if (toastId) toast.dismiss(toastId);
+  toast(message, { id: toastId, duration: options.autoClose ?? 3000, icon: '⚠️' });
 }


### PR DESCRIPTION
## Description
Migrates all toast notifications from react-toastify to react-hot-toast.

- Removed react-toastify from package.json
- Replaced all react-toastify imports with react-hot-toast
- Replaced ToastContainer with Toaster
- Converted toast.info() and toast.warning() to toast()
- Updated toast.js utility for react-hot-toast API
- Fixed test mocks

Fixes #4781