### PR TITLE
fix(auth): prevent user account enumeration via bcrypt status code discrepancy

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -111,7 +111,11 @@ export default async function login(req, res, deps = {}) {
 
     // 4. Verify credentials. Always run the comparison shape regardless of
     //    whether the user exists to avoid leaking timing/enumeration signals.
-    const passwordHash = user?.password ?? "";
+    //    A valid dummy bcrypt hash is used for non-existent users to prevent
+    //    bcrypt from throwing errors on invalid/empty hashes, which would
+    //    leak the user's non-existence via an HTTP 500 response.
+    const dummyHash = "$2b$10$v18wNUUU7wTXyTbRPTFZTeze3aHS//qr4FKA9gu1E/GfNQqTsFfRG";
+    const passwordHash = user?.password ?? dummyHash;
     const isValid = await comparePassword(password, passwordHash);
 
     if (!user || !isValid) {

--- a/tests/loginEndpoint.test.mjs
+++ b/tests/loginEndpoint.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Tests for api/auth/login.js
+ *
+ * Verifies that the login handler does not throw an error and returns HTTP 401
+ * for both incorrect password and non-existent users, preventing account enumeration.
+ */
+
+import "./helpers/authTestEnv.mjs";
+
+import assert from "node:assert/strict";
+import login from "../api/auth/login.js";
+
+// Mock request and response builders
+function mockReq(body) {
+  return {
+    method: "POST",
+    body,
+    headers: {
+      "x-forwarded-for": "127.0.0.1",
+    },
+  };
+}
+
+function mockRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+    headers: {},
+  };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  res.setHeader = (name, value) => {
+    res.headers[name] = value;
+    return res;
+  };
+  return res;
+}
+
+async function runTests() {
+  // Test case 1: Registered user with wrong password -> 401
+  {
+    const req = mockReq({ usernameOrEmail: "registered@example.com", password: "wrong_password" });
+    const res = mockRes();
+
+    const deps = {
+      findUserByEmail: async () => ({
+        id: "123",
+        email: "registered@example.com",
+        password: "$2b$10$v18wNUUU7wTXyTbRPTFZTeze3aHS//qr4FKA9gu1E/GfNQqTsFfRG",
+      }),
+      comparePassword: async () => false,
+    };
+
+    await login(req, res, deps);
+
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.body, { error: "Invalid credentials" });
+  }
+
+  // Test case 2: Unregistered user -> 401 (no 500 error)
+  {
+    const req = mockReq({ usernameOrEmail: "unregistered@example.com", password: "some_password" });
+    const res = mockRes();
+
+    const deps = {
+      findUserByEmail: async () => null,
+      comparePassword: async (plain, hash) => {
+        // Simulating standard bcrypt behavior where an invalid/empty hash throws an error
+        if (!hash || !hash.startsWith("$2")) {
+          throw new Error("bcrypt: hash must be a valid bcrypt hash string");
+        }
+        return false;
+      },
+    };
+
+    // This should run without throwing any error and return 401
+    await login(req, res, deps);
+
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.body, { error: "Invalid credentials" });
+  }
+
+  console.log("loginEndpoint.test.mjs passed ✓");
+}
+
+runTests().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

This PR resolves the account enumeration vulnerability in the `/api/auth/login` endpoint 

Fixes #8140

Previously, when an unregistered username/email was used to log in, `bcrypt.compare` was invoked with an empty string (`user?.password ?? ""`). In standard bcrypt environments, calling it with an invalid/empty hash throws an exception, leading to an HTTP `500 Internal Server Error`. In contrast, entering a registered user's email with an incorrect password returned HTTP `401 Unauthorized`. This discrepancy allowed attackers to systematically identify registered accounts.

### Changes

- **In [login.js](file:///c:/Users/NIKITA%20SHARAD%20PAWAR/OneDrive/Desktop/MY%20DOCS/PROJECTS%20&%20CODES/Project-1/Eventra/api/auth/login.js)**: Replaced the fallback empty string `""` with a valid pre-computed dummy bcrypt hash (`$2b$10$v18wNUUU7wTXyTbRPTFZTeze3aHS//qr4FKA9gu1E/GfNQqTsFfRG`). This ensures `bcrypt.compare` completes successfully and returns `401 Unauthorized` without throwing an exception or leaking timing information.
- **In [loginEndpoint.test.mjs](file:///c:/Users/NIKITA%20SHARAD%20PAWAR/OneDrive/Desktop/MY%20DOCS/PROJECTS%20&%20CODES/Project-1/Eventra/tests/loginEndpoint.test.mjs)**: Added unit tests verifying correct status codes (401) for incorrect password and non-existent users.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] All unit tests pass successfully