### PR TITLE
feat: add reusable copy-to-clipboard button with tooltip feedback to EventDetails page 

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -30,6 +30,7 @@ import { downloadICSFile, generateGoogleCalendarLink, generateOutlookLink } from
 import useRecentlyViewed from "../../hooks/useRecentlyViewed";
 import { apiUtils, API_ENDPOINTS } from "../../config/api";
 import mockEvents from "./eventsMockData.json";
+import CopyButton from '../../components/ui/CopyButton';
 
 const isRequestCanceled = (error, signal) =>
   signal?.aborted ||
@@ -577,6 +578,9 @@ const EventDetails = () => {
               <div className="rounded-3xl bg-slate-50 p-5 dark:bg-gray-800 space-y-4">
                 <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">Share & Add to Calendar</h3>
                 <SocialShareButtons event={event} layout="grid" />
+                <div className="mt-4">
+                  <CopyButton textToCopy={window.location.href} />
+                </div>
 
                 <div className="flex flex-col gap-2">
                   <button onClick={() => { downloadICSFile(event); toast.success("Calendar invite downloaded!"); }} className="w-full inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2.5 text-sm font-semibold text-gray-800 dark:text-gray-100 shadow-sm hover:bg-green-50 dark:hover:bg-green-900/20 hover:border-green-300 dark:hover:border-green-700 transition-all duration-200" aria-label="Download .ics calendar invite">

--- a/src/components/ui/CopyButton.jsx
+++ b/src/components/ui/CopyButton.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+
+const CopyButton = ({ textToCopy }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      // Uses native browser clipboard API
+      await navigator.clipboard.writeText(textToCopy);
+      setCopied(true);
+      
+      // Reset the tooltip/state after 2 seconds
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  return (
+    <div className="relative inline-block text-left">
+      <button
+        onClick={handleCopy}
+        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors duration-200 shadow-sm focus:outline-none"
+        title="Copy event link"
+      >
+        {/* Simple inline SVG share/copy icon if no icon library is handy */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="w-4 h-4"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935-2.186 2.25 2.25 0 00-3.935 2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z"
+          />
+        </svg>
+        <span>Copy Link</span>
+      </button>
+
+      {/* Smooth confirmation Tooltip overlay */}
+      {copied && (
+        <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-black bg-opacity-80 rounded shadow-md pointer-events-none transition-opacity duration-200 animate-fade-in">
+          Copied!
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CopyButton;


### PR DESCRIPTION
## Description

This PR implements a standalone, reusable `CopyButton` component and integrates it into the `EventDetails.js` page. 

**Motivation and Context:**
Previously, users had to manually copy the URL from the browser's address bar to share an event or hackathon link. This enhancement adds a clean, one-click "Copy Link" shortcut button directly in the "Share & Add to Calendar" card container. It utilizes the native browser Clipboard API and features a smooth, temporary tooltip ("Copied!") overlay to give clear interactive feedback to the user, enhancing the overall mobile and desktop sharing experience.

Fixes #8168 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots / Video (if applicable)
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/e3d970ac-1604-4fca-8e28-0e851295a3be" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports