### PR TITLE
fix(notifications): route waitlist notifications through the canonical inbox

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -84,7 +84,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
         if (!isMounted.current || tokenRef.current !== t) return;
         const data = res.data;
         applyList(Array.isArray(data) ? data : data?.content || [], { deliverNew: true });
-      } catch (err) {
+      } catch {
         if (isMounted.current && tokenRef.current === t) {
           const persisted = loadPersisted();
           const fallback = persisted?.length ? persisted : seedNotifications.map(normalize);
@@ -206,6 +206,80 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
 
   const markAsReadRef = useRef(markAsRead);
   useEffect(() => { markAsReadRef.current = markAsRead; }, [markAsRead]);
+
+  // Same-tab sync listener
+  useEffect(() => {
+    const handleUpdate = () => {
+      const persisted = loadPersisted();
+      if (persisted) {
+        setNotifications(persisted);
+        setUnreadCount(persisted.filter((n) => !n.isRead).length);
+        persisted.forEach((n) => {
+          if (n.id) seenIds.current.add(n.id);
+        });
+      }
+    };
+    window.addEventListener("eventra-notifications-updated", handleUpdate);
+    return () => window.removeEventListener("eventra-notifications-updated", handleUpdate);
+  }, []);
+
+  // Legacy IndexedDB eventra_notifications migration
+  useEffect(() => {
+    const migrateLegacy = async () => {
+      try {
+        const { get: idbGet, del: idbDel } = await import("idb-keyval");
+        const raw = await idbGet("eventra_notifications");
+        if (raw) {
+          const legacy = safeJsonParse(raw, []);
+          if (Array.isArray(legacy) && legacy.length > 0) {
+            const currentPersisted = loadPersisted() || [];
+            const merged = [...currentPersisted];
+
+            legacy.forEach((ln) => {
+              if (!ln) return;
+              const id = ln.id ? String(ln.id) : `legacy-${Date.now()}-${Math.random()}`;
+              const isRead = ln.isRead ?? ln.read ?? false;
+              const title = ln.title ?? "";
+              const message = ln.message ?? "";
+              const category = ln.category ?? "system";
+              const timestamp = ln.createdAt || ln.timestamp || new Date().toISOString();
+
+              const exists = merged.some(
+                (cn) =>
+                  String(cn.id) === id ||
+                  (cn.title === title && cn.message === message)
+              );
+
+              if (!exists) {
+                merged.push({
+                  id,
+                  isRead,
+                  title,
+                  message,
+                  category,
+                  timestamp,
+                });
+              }
+            });
+
+            // Sort newest first
+            merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+            persist(merged);
+            setNotifications(merged);
+            setUnreadCount(merged.filter((n) => !n.isRead).length);
+            merged.forEach((n) => {
+              if (n.id) seenIds.current.add(n.id);
+            });
+          }
+          await idbDel("eventra_notifications");
+        }
+      } catch {
+        // fail silently in environments without IndexedDB support
+      }
+    };
+
+    migrateLegacy();
+  }, []);
 
   return {
     notifications, unreadCount, loading,

--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -1,10 +1,10 @@
-import { get as idbGet, set as idbSet } from "idb-keyval";
+
 import { safeJsonParse } from "./safeJsonParse.js";
 import { apiUtils, API_ENDPOINTS } from "../config/api";
 import { logger } from "./logger.js";
 
 const GLOBAL_WAITLIST_KEY = "eventra_global_waitlists";
-const NOTIFICATIONS_STORAGE_KEY = "eventra_notifications";
+
 
 /**
  * Coerce an eventId value to a safe integer.
@@ -30,20 +30,23 @@ const parseEventId = (eventId) => {
   return id;
 };
 
-// Helper to add local notifications using IndexedDB
+// Helper to add local notifications using localStorage
 export const addLocalNotification = async (title, message) => {
   try {
-    const raw = await idbGet(NOTIFICATIONS_STORAGE_KEY);
+    const canonicalKey = "eventra_notification_inbox";
+    const raw = localStorage.getItem(canonicalKey);
     const notifications = raw ? safeJsonParse(raw, []) : [];
     const newNotification = {
-      id: Date.now() + Math.floor(Math.random() * 1000),
-      read: false,
+      id: `local-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+      isRead: false,
       createdAt: new Date().toISOString(),
+      timestamp: new Date().toISOString(),
       title,
       message,
+      category: "registrations",
     };
     notifications.unshift(newNotification);
-    await idbSet(NOTIFICATIONS_STORAGE_KEY, JSON.stringify(notifications));
+    localStorage.setItem(canonicalKey, JSON.stringify(notifications));
     // Trigger cross-component real-time sync
     window.dispatchEvent(new CustomEvent("eventra-notifications-updated"));
   } catch (error) {

--- a/tests/helpers/mockIdbKeyval.js
+++ b/tests/helpers/mockIdbKeyval.js
@@ -42,7 +42,13 @@ export const set = (key, val) => {
   return makeSyncThenable(undefined);
 };
 
+export const del = (key) => {
+  globalThis.localStorage.removeItem(key);
+  return makeSyncThenable(undefined);
+};
+
 export default {
   get,
-  set
+  set,
+  del
 };

--- a/tests/loaders/jsExtension.mjs
+++ b/tests/loaders/jsExtension.mjs
@@ -10,7 +10,12 @@ import path from "node:path";
 import fs from "node:fs";
 
 export async function resolve(specifier, context, nextResolve) {
-  if (context.parentURL && (context.parentURL.includes("useOfflineSync.test.mjs") || context.parentURL.includes("useOfflineSync.js"))) {
+  if (context.parentURL && (
+    context.parentURL.includes("useOfflineSync.test.mjs") ||
+    context.parentURL.includes("useOfflineSync.js") ||
+    context.parentURL.includes("notificationSync.test.mjs") ||
+    context.parentURL.includes("useNotificationPoller.js")
+  )) {
     if (specifier.endsWith("AuthContext") || specifier.includes("AuthContext")) {
       return {
         url: pathToFileURL(path.resolve("tests/helpers/mockAuthContext.js")).href,

--- a/tests/notificationSync.test.mjs
+++ b/tests/notificationSync.test.mjs
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+// ── Minimal JSDOM Environment Setup ──────────────────────────────────────────
+const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>", {
+  url: "http://localhost",
+});
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+Object.defineProperty(globalThis, "navigator", {
+  value: dom.window.navigator,
+  writable: true,
+  configurable: true,
+});
+globalThis.localStorage = dom.window.localStorage;
+globalThis.CustomEvent = dom.window.CustomEvent;
+globalThis.Event = dom.window.Event;
+
+// ── Custom React Mock Loop for hookResult rendering ─────────────────────────
+let renderingEnabled = false;
+let isRunningRender = false;
+let _stateSlots = [];
+let _stateIndex = 0;
+let _effects = [];
+let _effectStates = [];
+let _effectIndex = 0;
+let _cleanups = [];
+let hookResult = null;
+
+function resetReact() {
+  renderingEnabled = false;
+  isRunningRender = false;
+  for (const cleanup of _cleanups) {
+    if (typeof cleanup === "function") {
+      try {
+        cleanup();
+      } catch (e) {}
+    }
+  }
+  _stateSlots = [];
+  _stateIndex = 0;
+  _effects = [];
+  _effectStates = [];
+  _effectIndex = 0;
+  _cleanups = [];
+  hookResult = null;
+}
+
+globalThis.React = {
+  useState: (initial) => {
+    const idx = _stateIndex++;
+    if (_stateSlots[idx] === undefined) {
+      _stateSlots[idx] = typeof initial === "function" ? initial() : initial;
+    }
+    const setState = (valOrFn) => {
+      const prev = _stateSlots[idx];
+      const next = typeof valOrFn === "function" ? valOrFn(prev) : valOrFn;
+      if (prev !== next) {
+        _stateSlots[idx] = next;
+        if (renderingEnabled && !isRunningRender) {
+          renderHook();
+        }
+      }
+    };
+    return [_stateSlots[idx], setState];
+  },
+  useEffect: (fn, deps) => {
+    const idx = _effectIndex++;
+    const prevDeps = _effectStates[idx];
+    let shouldRun = false;
+
+    if (!prevDeps || !deps) {
+      shouldRun = true;
+    } else {
+      for (let i = 0; i < deps.length; i++) {
+        if (deps[i] !== prevDeps[i]) {
+          shouldRun = true;
+          break;
+        }
+      }
+    }
+
+    if (shouldRun) {
+      if (_cleanups[idx]) {
+        try {
+          _cleanups[idx]();
+        } catch (e) {}
+        _cleanups[idx] = null;
+      }
+      _effectStates[idx] = deps ? [...deps] : [];
+      _effects.push({ fn, idx });
+    }
+  },
+  useCallback: (fn) => fn,
+  useRef: (initial) => {
+    const idx = _stateIndex++;
+    if (_stateSlots[idx] === undefined) {
+      _stateSlots[idx] = { current: initial };
+    }
+    return _stateSlots[idx];
+  },
+};
+
+globalThis.mockAuth = () => ({
+  token: "mock-token",
+  user: { id: "user-1", email: "user-1@example.com" },
+  isAuthenticated: () => true,
+  loading: false,
+});
+
+// ── Imports under test ───────────────────────────────────────────────────────
+const { useNotificationPoller } = await import("../src/hooks/useNotificationPoller.js");
+const { joinWaitlist, promoteNextUser } = await import("../src/utils/waitlistUtils.js");
+const { apiUtils } = await import("../src/config/api.js");
+
+function renderHook() {
+  if (isRunningRender) return;
+  isRunningRender = true;
+  try {
+    _stateIndex = 0;
+    _effectIndex = 0;
+    _effects = [];
+
+    const deliverNew = () => {};
+    const hasCompletedInitialFetchRef = { current: true };
+
+    hookResult = useNotificationPoller(deliverNew, hasCompletedInitialFetchRef);
+
+    // Run the collected effects
+    const currentEffects = [..._effects];
+    _effects = [];
+    for (const { fn, idx } of currentEffects) {
+      const cleanup = fn();
+      if (typeof cleanup === "function") {
+        _cleanups[idx] = cleanup;
+      }
+    }
+  } finally {
+    isRunningRender = false;
+  }
+}
+
+// ── Test Helpers ─────────────────────────────────────────────────────────────
+const resetAll = () => {
+  localStorage.clear();
+  resetReact();
+};
+
+const runAll = async () => {
+  console.log("Running Notification Synchronization tests...");
+
+  // 1 & 2 & 3. Waitlist promotion, inbox write, and unread increment
+  {
+    resetAll();
+    const eventId = 1;
+    const user = { id: "user-1", email: "user1@example.com", fullName: "User One" };
+
+    // Join waitlist
+    await joinWaitlist(eventId, user, {});
+
+    // Render hook to initialize state
+    renderingEnabled = true;
+    renderHook();
+
+    assert.equal(hookResult.notifications.length, 0, "Initially 0 notifications");
+    assert.equal(hookResult.unreadCount, 0, "Initially unread count is 0");
+
+    // Promote user (triggers addLocalNotification)
+    await promoteNextUser(eventId, { id: eventId, title: "Special Masterclass" });
+
+    // Verify localStorage has the new notification
+    const inboxRaw = localStorage.getItem("eventra_notification_inbox");
+    assert.ok(inboxRaw, "Notification should be in local storage");
+    const inbox = JSON.parse(inboxRaw);
+    assert.equal(inbox.length, 2);
+    assert.equal(inbox[0].title, "Waitlist Promotion");
+    assert.match(inbox[0].message, /Special Masterclass/);
+
+    // Verify hook state synchronized automatically via the window event listener
+    assert.equal(hookResult.notifications.length, 2, "Notifications length should be 2");
+    assert.equal(hookResult.notifications[0].title, "Waitlist Promotion");
+    assert.equal(hookResult.unreadCount, 2, "Unread count should be 2");
+
+    console.log("✓ Test 1-3: Waitlist promotion, inbox write, and unread increment passed!");
+  }
+
+  // 4. Mark as read works
+  {
+    resetAll();
+    const eventId = 2;
+    const user = { id: "user-2", email: "user2@example.com", fullName: "User Two" };
+
+    await joinWaitlist(eventId, user, {});
+    await promoteNextUser(eventId, { id: eventId, title: "React Meetup" });
+
+    renderingEnabled = true;
+    renderHook();
+    window.dispatchEvent(new CustomEvent("eventra-notifications-updated"));
+
+    assert.equal(hookResult.unreadCount, 2);
+    const notificationId = hookResult.notifications[0].id;
+
+    // Mock API put call for marking read
+    let apiPutCalled = false;
+    apiUtils.put = async (url, data) => {
+      apiPutCalled = true;
+      return { ok: true, status: 200 };
+    };
+
+    await hookResult.markAsRead(notificationId);
+
+    assert.ok(apiPutCalled, "apiUtils.put should have been called");
+    assert.equal(hookResult.unreadCount, 1, "Unread count should become 1");
+    assert.equal(hookResult.notifications[0].isRead, true, "Notification should be marked read");
+
+    // Verify localStorage persistence
+    const inbox = JSON.parse(localStorage.getItem("eventra_notification_inbox"));
+    assert.equal(inbox[0].isRead, true, "Persisted notification should be marked read");
+
+    console.log("✓ Test 4: Mark as read works passed!");
+  }
+
+  // 5 & 6. Legacy IndexedDB migration and deduplication works
+  {
+    resetAll();
+
+    // Seed legacy IndexedDB notifications (stored in localStorage under eventra_notifications by mockIdbKeyval)
+    const legacyNotifications = [
+      { id: "legacy-1", title: "Legacy Promotion", message: "You were promoted!", isRead: false, timestamp: new Date().toISOString() },
+      { id: "legacy-2", title: "Legacy Reminder", message: "Event tomorrow", isRead: true, timestamp: new Date().toISOString() },
+    ];
+    localStorage.setItem("eventra_notifications", JSON.stringify(legacyNotifications));
+
+    // Seed current canonical store with an overlapping notification to test deduplication
+    const currentInbox = [
+      { id: "legacy-1", title: "Legacy Promotion", message: "You were promoted!", isRead: false, timestamp: new Date().toISOString() },
+      { id: "new-notif", title: "New Announcement", message: "Welcome", isRead: false, timestamp: new Date().toISOString() },
+    ];
+    localStorage.setItem("eventra_notification_inbox", JSON.stringify(currentInbox));
+
+    renderingEnabled = true;
+    renderHook();
+
+    // Allow async migration effect to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify legacy store deleted
+    assert.equal(localStorage.getItem("eventra_notifications"), null, "Legacy notifications key should be deleted");
+
+    // Verify merged and deduplicated results
+    const mergedInbox = JSON.parse(localStorage.getItem("eventra_notification_inbox"));
+    assert.equal(mergedInbox.length, 3, "Merged inbox size should be 3 (deduplicated 'legacy-1')");
+
+    // Check presence of all expected items
+    const ids = mergedInbox.map(n => n.id);
+    assert.ok(ids.includes("legacy-1"));
+    assert.ok(ids.includes("legacy-2"));
+    assert.ok(ids.includes("new-notif"));
+
+    // Verify hook state contains all items
+    assert.equal(hookResult.notifications.length, 3);
+    assert.equal(hookResult.unreadCount, 2); // 'legacy-1' (unread) and 'new-notif' (unread), 'legacy-2' (read)
+
+    console.log("✓ Test 5-6: Migration and deduplication passed!");
+  }
+
+  // 7. Deletion works
+  {
+    resetAll();
+
+    const inbox = [
+      { id: "del-1", title: "To Delete", message: "Delete me", isRead: false, timestamp: new Date().toISOString() },
+    ];
+    localStorage.setItem("eventra_notification_inbox", JSON.stringify(inbox));
+
+    renderingEnabled = true;
+    renderHook();
+    window.dispatchEvent(new CustomEvent("eventra-notifications-updated"));
+
+    assert.equal(hookResult.notifications.length, 1);
+
+    // Mock API delete call
+    let apiDeleteCalled = false;
+    apiUtils.delete = async (url) => {
+      apiDeleteCalled = true;
+      return { ok: true, status: 200 };
+    };
+
+    await hookResult.deleteNotification("del-1");
+
+    assert.ok(apiDeleteCalled, "apiUtils.delete should have been called");
+    assert.equal(hookResult.notifications.length, 0, "Notifications should be empty after deletion");
+    assert.equal(hookResult.unreadCount, 0, "Unread count should be 0");
+
+    // Verify localStorage persistence
+    const saved = JSON.parse(localStorage.getItem("eventra_notification_inbox"));
+    assert.equal(saved.length, 0, "Persisted store should be empty");
+
+    console.log("✓ Test 7: Deletion works passed!");
+  }
+
+  console.log("\nAll Notification Synchronization tests passed successfully! ✓");
+};
+
+runAll().catch((err) => {
+  console.error("Test execution failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

This PR fixes the notification inconsistency reported in #8173.

While tracing the waitlist promotion flow, I found that waitlist notifications were being persisted into a separate legacy IndexedDB key (`eventra_notifications`) while the Notification Center only reads from the canonical inbox (`eventra_notification_inbox`).

Because of this split, valid waitlist notifications existed in storage but never appeared in the UI. Unread counts also stayed incorrect, and same-tab updates never propagated.

To fix this, I moved waitlist-originated notifications into the same store already used by the Notification Center and added migration logic for legacy entries.

### What changed

* Refactored `waitlistUtils.js` so `addLocalNotification()` now writes directly to the canonical inbox in `localStorage`
* Removed the old IndexedDB notification write path
* Added same-tab notification sync through `eventra-notifications-updated`
* Updated `useNotificationPoller` to listen for live notification changes and refresh state immediately
* Added one-time migration logic for older `eventra_notifications` entries
* Added deduplication during migration to avoid repeated notification entries
* Removed legacy entries after successful migration
* Added regression coverage for:

  * waitlist promotion notifications
  * unread count updates
  * mark-as-read persistence
  * legacy migration
  * deduplication
  * deletion flow

### Root cause

The waitlist subsystem and the Notification Center evolved on separate storage contracts. One wrote into IndexedDB while the other only consumed `localStorage`, so notification state became fragmented.

### Why this matters

This makes notification behavior consistent across:

* Waitlist promotions
* Registration updates
* Notification Bell
* Notification Center
* Unread counters

It also removes duplicate notification persistence paths and simplifies future maintenance.

## Testing

Verified locally:

* Waitlist promotions now appear instantly in Notification Center
* Unread counts update correctly
* Same-tab notification updates work without refresh
* Legacy IndexedDB notifications migrate correctly
* Duplicate notifications are prevented
* Notification deletion still works as expected

Commands run:

```bash
npm run lint
npm run test
npm run build
```

Closes #8173
