### PR TITLE
fix: remove duplicate isCryptoAvailable declaration

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -465,19 +465,7 @@ export const decryptWithKey = async (key, stored) => {
   return new TextDecoder().decode(decrypted);
 };
 
-const isCryptoAvailable = () => {
-  try {
-    return (
-      typeof window !== 'undefined' &&
-      typeof crypto !== 'undefined' &&
-      typeof crypto.subtle !== 'undefined' &&
-      typeof crypto.getRandomValues === 'function' &&
-      window.isSecureContext !== false
-    );
-  } catch {
-    return false;
-  }
-};
+
 
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove duplicate `isCryptoAvailable` declaration in `src/utils/secureStorage.js`

## Test plan
- [x] Verify app builds without duplicate declaration errors
- [x] Confirm secure storage encryption still works in a secure context