### PR TITLE
fix: resolve syntax error in waitlistUtils

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -229,9 +229,6 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
   await addLocalNotification(
     "Waitlist Joined (Offline)",
     `You have been added to the offline waitlist for ${registrationForm.eventTitle || "the event"}. It will sync when you are back online.`
-    "Waitlist Joined",
-    `You have successfully joined the waitlist for ${registrationForm.eventTitle || "the event"
-    }.`
   );
 
   return newEntry;


### PR DESCRIPTION
## Description

This PR fixes a syntax error in `src/utils/waitlistUtils.js` that prevented the development server from compiling successfully.

Fixes #8413 

### Root Cause

Two notification argument sets were accidentally merged into a single `addLocalNotification()` call in the offline waitlist flow, resulting in invalid JavaScript syntax and a build-time parse error.

### Changes Made

* Removed the unintended merged notification arguments.
* Restored the correct `addLocalNotification()` call structure.
* Verified that the application compiles and the development server starts successfully.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have run local unit tests using `npm test` and verified they pass
* [ ] I have run `npm run lint` and resolved any new errors or warnings
* [x] I have verified that the development server starts successfully after the fix
