### PR TITLE
fix: prevent CountUp target null error

### DIFF
--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -7,7 +7,7 @@ import { useReducedMotion } from "../../hooks/useReducedMotion";
 import CountUpLib from "react-countup";
 import ErrorBoundary from "../../components/common/ErrorBoundary";
 
-const CountUp = CountUpLib.default;
+const CountUp = CountUpLib.default || CountUpLib;
 
 // Framer Motion Variants
 const container = {


### PR DESCRIPTION
## Description

This PR fixes the CountUp console error reported in Issue #8179.

### Root Cause

`react-countup` was imported and assigned using:

```javascript
const CountUp = CountUpLib.default;
```

In Vite/CommonJS interop scenarios, `CountUpLib` can already be the component itself, causing `.default` to be `undefined`. This resulted in the CountUp component not rendering correctly and produced the browser console error:

```text
[CountUp] target is null or undefined
```

### Changes Made

* Added a fallback to support both module formats:

  ```javascript
  const CountUp = CountUpLib.default || CountUpLib;
  ```
* Ensured the CountUp component resolves correctly regardless of module export format.
* Eliminated the console error while preserving existing functionality.

Fixes #8179

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have run local unit tests using `npm test` and verified they pass
* [ ] I have run `npm run lint` and resolved any new errors or warnings
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
