### PR TITLE
fix(utils): guard process.env access in logger.js to prevent SSR crash

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,9 +1,25 @@
 /**
  * Determines if the current environment is for development.
+ * Safe in both browser (Vite via import.meta.env) and Node-like environments
+ * (e.g. SSR, tests) where neither is available. Without the typeof guard,
+ * `process` is undefined in the browser and the module crashes on load.
  */
-const isDevelopment = typeof import.meta.env !== "undefined" 
-  ? import.meta.env.DEV 
-  : process.env.NODE_ENV !== "production";
+const isDevelopment = (() => {
+  if (typeof import.meta !== "undefined" && import.meta.env) {
+    if (import.meta.env.DEV === true) return true;
+    if (import.meta.env.PROD === true) return false;
+  }
+  if (
+    typeof process !== "undefined" &&
+    process &&
+    process.env &&
+    process.env.NODE_ENV
+  ) {
+    return process.env.NODE_ENV !== "production";
+  }
+  // In any other environment (SSR, edge runtime) default to true so logs surface.
+  return true;
+})();
 
 /**
  * Formats a log message with the specified level.


### PR DESCRIPTION
Closes #8432.

Summary of What Has Been Done:
isDevelopment referenced process.env at module load when import.meta.env was undefined. Browsers (the project primary runtime) have no global process, so the module crashed with ReferenceError on cold load and broke every module that imports logger.

Changes Made:
- Replaced the bare process.env access in the top-level ternary with a typed-guarded IIFE.
- The IIFE handles three environments: Vite (import.meta.env.DEV/PROD), Node-like (typeof process guard), and SSR/edge/unknown (default true so dev logs surface).

Impact it Made:
- Logger.js now loads cleanly in any environment.
- No more module-level crash that previously broke the entire app on first import.