### PR TITLE
fix(hooks): hoist successCount/droppedCount/failedQueue above try block in useOfflineSync

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -290,14 +290,19 @@ const useOfflineSync = () => {
 
       isSyncing.current = true;
 
+      // 🔥 FIX: Hoist counters and the failure list ABOVE the try so the
+      // `finally` block can read them. Previously they were declared inside
+      // the try (block-scoped) and the dispatch in finally threw
+      // ReferenceError on every successful sync, leaving the OfflineManager
+      // spinner stuck permanently.
+      let successCount = 0;
+      let droppedCount = 0;
+      let failedQueue = [];
+
       try {
         toast.info(`Syncing ${sessionValidatedQueue.length} cached offline action(s)...`, {
           autoClose: 2000,
         });
-
-        const failedQueue = [];
-        let successCount = 0;
-        let droppedCount = 0;
 
         for (const item of sessionValidatedQueue) {
           // Halt the zombie loop immediately if the session changed or component unmounted.


### PR DESCRIPTION
Closes #8434.

Summary of What Has Been Done:
successCount, droppedCount, and failedQueue were declared with let/const INSIDE the try block of executeSync. The matching finally block references them in the eventra-offline-queue-processed dispatch. Block-scoped declarations are not visible in finally, so every completed sync threw ReferenceError and the event was never emitted.

Changes Made:
- Hoisted let successCount = 0, let droppedCount = 0, let failedQueue = [] above the try block.
- Removed the inner duplicate declarations that were causing shadowed redeclaration errors.

Impact it Made:
- OfflineManager spinner no longer stays stuck after a successful sync.
- The eventra-offline-queue-processed event is now emitted reliably so UI components can reset their state.