### PR TITLE
fix(hooks): abort in-flight fetch on unmount in useAnalytics

### DIFF
--- a/src/hooks/useAnalytics.js
+++ b/src/hooks/useAnalytics.js
@@ -8,22 +8,38 @@ const useAnalytics = () => {
 
   useEffect(() => {
     if (!token) { setLoading(false); return; }
+
+    // 🔥 FIX: Abort in-flight requests when the component unmounts or the
+    // token changes. Previously the fetch could resolve after unmount and
+    // call setAnalytics / setLoading, triggering React's "state update on an
+    // unmounted component" warning and leaking a dangling promise.
+    const controller = new AbortController();
+    let aborted = false;
+
     const fetchAnalytics = async () => {
       try {
         const res = await fetch(
           `${process.env.REACT_APP_API_URL}/analytics/summary`,
-          { headers: { Authorization: `Bearer ${token}` } }
+          { headers: { Authorization: `Bearer ${token}` }, signal: controller.signal }
         );
         if (!res.ok) throw new Error("API unavailable");
         const data = await res.json();
+        if (aborted) return;
         setAnalytics(data);
-      } catch {
+      } catch (err) {
+        // Ignore AbortError — the request was cancelled on unmount, not a real failure
+        if (err?.name === "AbortError" || aborted) return;
         // falls back to mock data silently
       } finally {
-        setLoading(false);
+        if (!aborted) setLoading(false);
       }
     };
     fetchAnalytics();
+
+    return () => {
+      aborted = true;
+      controller.abort();
+    };
   }, [token]);
 
   return { analytics, loading };


### PR DESCRIPTION
Closes #8435.

Summary of What Has Been Done:
useAnalytics.js fired a fetch in useEffect but never created an AbortController. If the component unmounted before the request resolved, setAnalytics and setLoading were still called, causing React state-update-on-unmounted-component warnings and a dangling promise.

Changes Made:
- Created an AbortController, passed its signal to fetch, and aborted it in the cleanup return.
- Added an `aborted` flag to guard the setAnalytics / setLoading calls and ignore AbortError from the rejected fetch.

Impact it Made:
- Eliminates React warnings on dashboards that mount/unmount quickly.
- Closes the memory leak from a dangling fetch promise.