### PR TITLE
fix(utils): stop using event title as cache key in recommendationEngine

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -19,7 +19,12 @@ const normalizeList = (value) => {
 
 const unique = (items) => Array.from(new Set(items.filter(Boolean)));
 
-const getEventId = (event) => String(event?.id ?? event?.eventId ?? event?.title ?? "");
+const getEventId = (event) => {
+  if (!event) return null;
+  const id = event.id ?? event.eventId;
+  if (id === undefined || id === null || id === "") return null;
+  return String(id);
+};
 
 const unwrapEvent = (entry) => entry?.event || entry?.eventSummary || entry || {};
 
@@ -66,8 +71,14 @@ const _cacheOrder = [];
 const MAX_CACHE_SIZE = 100;
 
 const _getCachedTags = (event) => {
+  // 🔥 FIX: Skip the cache entirely when the event has no real id.
+  // Previously getEventId fell back to the event title, so two events with
+  // the same title would collide on the same cache key and the last write
+  // would win — silently corrupting similarity scores. Returning the tags
+  // directly is correct here; the cache only exists to amortise work for
+  // events we expect to be re-encountered, and id-less events are not.
   const id = getEventId(event);
-  if (!id) return [];
+  if (!id) return getEventTags(event);
   if (_tagCache.has(id)) {
     const tags = _tagCache.get(id);
     const idx = _cacheOrder.indexOf(id);


### PR DESCRIPTION
Closes #8437.

Summary of What Has Been Done:
getEventId fell back to event.title when no id/eventId was present. Two events sharing a title would collide on the same _getCachedTags cache key and the last write would win, silently corrupting similarity scores.

Changes Made:
- Return null from getEventId when no real id is present (was: return title).
- Have _getCachedTags skip the cache and return the live tags directly when there is no stable id (correct because id-less events are not stable cache candidates).

Impact it Made:
- Prevents silent data corruption in the recommendation cache.
- Similarity scores now reflect the actual event being compared.