### PR TITLE
fix(utils): cap module-level prefetchMap to prevent memory leak in long sessions

### DIFF
--- a/src/utils/prefetchUtils.js
+++ b/src/utils/prefetchUtils.js
@@ -1,10 +1,11 @@
 /**
  * Route Prefetching Utilities
- * 
+ *
  * Provides functions to pre-load lazy-loaded route components.
  */
 
 const prefetchMap = new Map();
+const MAX_PREFETCH_ENTRIES = 50; // 🔥 FIX: cap the module-level map to prevent memory leak across long sessions
 const MAX_CONCURRENT_PREFETCHES = 4;
 
 async function asyncPool(iterable, iteratorFn, concurrency) {
@@ -39,6 +40,16 @@ export const prefetchRoute = async (importFn, key) => {
   try {
     const promise = importFn();
     prefetchMap.set(key, promise);
+
+    // 🔥 FIX: Bound the prefetchMap to prevent unbounded growth across long
+    // browsing sessions. Drop the oldest entry (insertion-order: first key in
+    // the Map) once we exceed the cap. The module loader has its own cache, so
+    // we don't lose correctness by evicting.
+    if (prefetchMap.size > MAX_PREFETCH_ENTRIES) {
+      const oldestKey = prefetchMap.keys().next().value;
+      if (oldestKey !== key) prefetchMap.delete(oldestKey);
+    }
+
     await promise;
     return promise;
   } catch (error) {


### PR DESCRIPTION
Closes #8439.

Summary of What Has Been Done:
prefetchMap (a module-level Map) was written to on every successful prefetch but entries were only removed on import failure. Over a long browsing session, every distinct key ever prefetched (and the underlying import Promise + module record) remained in the map for the lifetime of the page.

Changes Made:
- Added a bounded cap (MAX_PREFETCH_ENTRIES = 50).
- When exceeded, evict the oldest entry by insertion order.
- The module loader has its own cache, so we do not lose correctness by evicting.

Impact it Made:
- Caps memory growth on long browsing sessions.
- Reduces redundant work when the same route is re-entered after eviction.