### PR TITLE
feat: implement cross-tab session logout synchronizer

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -8,6 +8,7 @@ import { useTokenExpiry } from "../hooks/useTokenExpiry.js";
 import { isTokenValid } from "../utils/tokenUtils.js";
 import { toast } from "react-toastify";
 import { ROLES, ROLE_PERMISSIONS } from "../config/roles.js";
+import { getSessionChannel, closeSessionChannel, SESSION_TERMINATED } from "../utils/sessionBroadcast.js";
 
 // Create context for Authentication
 const AuthContext = createContext();
@@ -117,6 +118,32 @@ export const AuthProvider = ({ children }) => {
     // Clear user metadata from secure/local storage manager
     syncSecureStorage.removeItem("user");
     return true;
+  }, []);
+
+  // Ref so the broadcast handler can call clearSession without stale closure
+  const clearSessionRef = useRef(null);
+  useEffect(() => {
+    clearSessionRef.current = clearSession;
+  }, [clearSession]);
+
+  // Cross-tab session logout synchronizer
+  useEffect(() => {
+    const channel = getSessionChannel();
+    if (!channel) return;
+
+    const handleMessage = (event) => {
+      if (event.data?.type === SESSION_TERMINATED) {
+        clearSessionRef.current?.();
+        window.location.replace("/login");
+      }
+    };
+
+    channel.addEventListener("message", handleMessage);
+
+    return () => {
+      channel.removeEventListener("message", handleMessage);
+      closeSessionChannel();
+    };
   }, []);
 
   // Hook to handle periodic token validation and auto-logout on expiration

--- a/src/utils/sessionBroadcast.js
+++ b/src/utils/sessionBroadcast.js
@@ -1,0 +1,27 @@
+// src/utils/sessionBroadcast.js
+
+export const SESSION_CHANNEL_NAME = "eventra_session";
+export const SESSION_TERMINATED = "SESSION_TERMINATED";
+
+let _channel = null;
+
+export const getSessionChannel = () => {
+  if (!_channel && typeof window !== "undefined" && "BroadcastChannel" in window) {
+    _channel = new BroadcastChannel(SESSION_CHANNEL_NAME);
+  }
+  return _channel;
+};
+
+export const broadcastSessionTerminated = () => {
+  const ch = getSessionChannel();
+  if (ch) {
+    ch.postMessage({ type: SESSION_TERMINATED });
+  }
+};
+
+export const closeSessionChannel = () => {
+  if (_channel) {
+    _channel.close();
+    _channel = null;
+  }
+};

--- a/src/utils/sessionSnapshot.js
+++ b/src/utils/sessionSnapshot.js
@@ -1,3 +1,5 @@
+import { broadcastSessionTerminated } from './sessionBroadcast';
+
 const SESSION_ID_KEY = "session_id";
 const SESSION_USER_KEY = "session_user_id";
 
@@ -76,6 +78,7 @@ export const clearSessionSnapshot = () => {
   try {
     storage.removeItem(SESSION_ID_KEY);
     storage.removeItem(SESSION_USER_KEY);
+    broadcastSessionTerminated();
   } catch {
     // Storage may be unavailable in private browsing contexts.
   }


### PR DESCRIPTION
Closes #8408

## What changed
- Added `src/utils/sessionBroadcast.js` — thin wrapper around the `BroadcastChannel` API
- `clearSessionSnapshot()` now broadcasts a `SESSION_TERMINATED` event after clearing storage
- `AuthContext` listens on the same channel and immediately calls `clearSession()` + redirects to `/login` when the event is received in any other tab

## Why
Logging out in one tab left other open tabs fully active with sensitive data visible until manual refresh — a security risk on shared computers.