### PR TITLE
Fix non functional theme palette button

### DIFF
--- a/src/components/Layout/ThemeToggleButton.jsx
+++ b/src/components/Layout/ThemeToggleButton.jsx
@@ -19,8 +19,10 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
         </motion.button>
         <motion.button
           whileTap={{ scale: 0.95 }}
-          onClick={() => setIsCustomizerOpen && setIsCustomizerOpen(true)}
-          className="flex items-center justify-center gap-3 px-4 py-3 w-full rounded-xl bg-gradient-to-r from-indigo-500 to-pink-500 text-white font-semibold border-none shadow-md hover:shadow-lg transition-all cursor-pointer"
+          onClick={() => {
+             setIsCustomizerOpen(true);
+            }}       
+   className="flex items-center justify-center gap-3 px-4 py-3 w-full rounded-xl bg-gradient-to-r from-indigo-500 to-pink-500 text-white font-semibold border-none shadow-md hover:shadow-lg transition-all cursor-pointer"
         >
           <Palette className="w-5 h-5" />
           <span>THEME Customizer</span>
@@ -49,11 +51,11 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
         </motion.span>
       </motion.button>
 
-      <motion.button
-        whileHover={{ scale: 1.08 }}
-        whileTap={{ scale: 0.92 }}
-        onClick={() => setIsCustomizerOpen && setIsCustomizerOpen(true)}
-        title="Open Theme Customizer"
+     <motion.button
+  whileHover={{ scale: 1.08 }}
+  whileTap={{ scale: 0.92 }}
+  onClick={() => setIsCustomizerOpen(true)}
+  title="Open Theme Customizer"
         className="flex items-center justify-center w-9 h-9 rounded-full transition-all duration-300 focus:outline-none bg-gradient-to-r from-indigo-500/10 to-pink-500/10 hover:from-indigo-500/20 hover:to-pink-500/20 border border-indigo-200/50 dark:border-indigo-800/40 hover:shadow-[0_0_12px_rgba(236,72,153,0.3)] text-indigo-550 dark:text-indigo-400 cursor-pointer"
       >
         <Palette className="w-4 h-4 animate-pulse text-indigo-500 dark:text-indigo-400" />


### PR DESCRIPTION
## Description

Fixed the non-functional theme palette button in the navigation bar.

Previously, clicking the palette/theme customization button did not trigger any visible action because the click handler was conditionally checking for the setter function.

Updated the click handler to directly open the Theme Customizer when the palette button is clicked.

Fixes # 8211

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

Not added (unable to capture due to existing unrelated local build issues).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports