### PR TITLE
fix: resolve userName mapping bug in joinWaitlist (#8253)

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -164,7 +164,11 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
     if (response.ok) {
       const newEntry = {
         userId,
-        userName: registrationForm.eventTitle || "the event",
+        userName:
+          user.fullName ||
+          `${user.firstName || ""} ${user.lastName || ""}`.trim() ||
+          user.username ||
+          "Anonymous",
         userEmail: user.email,
         phone: registrationForm.phone || "",
         eventId: id,


### PR DESCRIPTION
## 🚀 Description
This Pull Request resolves a bug in the `joinWaitlist` function in `waitlistUtils.js`.

### Details
1. **Fix userName mapping**: In the online waitlist join path, the successful response handler incorrectly mapped `userName` to `registrationForm.eventTitle` (the event's title) instead of the actual user's name (e.g. `user.fullName`, `user.firstName`, `user.lastName` or `user.username`). This caused organizers to see event titles as attendee names in the waitlist view.
2. **Offline fallback syntax errors**: Confirmed that the syntax error in the offline fallback block (duplicate arguments passed to `addLocalNotification` without commas or separators) is fully resolved in the upstream master branch.

Fixes #8253