### PR TITLE
fix: add displayName to Cell component in VirtualizedEventGrid (#8254)

### DIFF
--- a/src/components/common/VirtualizedEventGrid.jsx
+++ b/src/components/common/VirtualizedEventGrid.jsx
@@ -20,6 +20,8 @@ const Cell = memo(({ columnIndex, rowIndex, style, data }) => {
   );
 });
 
+Cell.displayName = "Cell";
+
 const VirtualizedEventGrid = ({ events }) => {
   const rowCount = Math.ceil(events.length / COLUMN_COUNT);
 


### PR DESCRIPTION
## 🚀 Description
This Pull Request resolves a React display-name linting error in `VirtualizedEventGrid.jsx`.

### Details
1. **Added displayName**: Added `Cell.displayName = "Cell";` to the memoized `Cell` component to satisfy ESLint configurations (`react/display-name` rule). This ensures proper debugging and inspection capabilities in react-devtools.

Fixes #8254