### PR TITLE
fix: resolve unused isPinned variable warning in CollaborationNetworkMap (#8256)

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -496,7 +496,6 @@ export default function CollaborationNetworkMap() {
                 {/* Interactive SVG City Nodes mapping */}
                 {filteredHubs.map((hub) => {
                   const isActive = activeHub?.id === hub.id || pinnedHub?.id === hub.id;
-                  const isPinned = pinnedHub?.id === hub.id;
                   const config = ACTIVITY_LEVELS[hub.activity];
                   const hubSize = getHubSize(hub.devs);
 


### PR DESCRIPTION
## 🚀 Description
This Pull Request resolves an ESLint unused variable warning in `CollaborationNetworkMap.jsx`.

### Details
1. **Remove unused variable**: Removed the `isPinned` variable declaration on line 499 as it is assigned a value but never read or used anywhere else in the file.
2. **ESLint Compliance**: Verified that the modified file passes the ESLint checker successfully with no warnings or errors.

Fixes #8256