### PR TITLE
Fix: Resolve memory leak in image upload (#8429)

### DIFF
--- a/src/components/common/EventCreation/EventMediaSection.jsx
+++ b/src/components/common/EventCreation/EventMediaSection.jsx
@@ -91,20 +91,18 @@ const EventMediaSection = ({
     }
 
     setIsUploading(true);
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      setFormData((prev) => ({
+    const objectUrl = URL.createObjectURL(file);
+    setFormData((prev) => {
+      if (prev.bannerPreview && prev.bannerPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(prev.bannerPreview);
+      }
+      return {
         ...prev,
         banner: file,
-        bannerPreview: reader.result,
-      }));
-      setIsUploading(false);
-    };
-    reader.onerror = () => {
-      logger.error("Failed to read file");
-      setIsUploading(false);
-    };
-    reader.readAsDataURL(file);
+        bannerPreview: objectUrl,
+      };
+    });
+    setIsUploading(false);
   };
 
   return (
@@ -121,7 +119,14 @@ const EventMediaSection = ({
               <img src={formData.bannerPreview} alt="Preview" className="w-full h-full object-cover" />
               <button
                 type="button"
-                onClick={() => setFormData(prev => ({ ...prev, banner: null, bannerPreview: null }))}
+                onClick={() => {
+                  setFormData(prev => {
+                    if (prev.bannerPreview && prev.bannerPreview.startsWith("blob:")) {
+                      URL.revokeObjectURL(prev.bannerPreview);
+                    }
+                    return { ...prev, banner: null, bannerPreview: null };
+                  });
+                }}
                 className="absolute top-2 right-2 p-1.5 bg-red-500 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
               >
                 <X className="w-4 h-4" />

--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -696,12 +696,14 @@ export const useEventForm = () => {
       return;
     }
 
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      setFormData((prev) => ({ ...prev, banner: file, bannerPreview: event.target.result }));
-      setErrors((prev) => ({ ...prev, banner: "" }));
-    };
-    reader.readAsDataURL(file);
+    const objectUrl = URL.createObjectURL(file);
+    setFormData((prev) => {
+      if (prev.bannerPreview && prev.bannerPreview.startsWith("blob:")) {
+        URL.revokeObjectURL(prev.bannerPreview);
+      }
+      return { ...prev, banner: file, bannerPreview: objectUrl };
+    });
+    setErrors((prev) => ({ ...prev, banner: "" }));
   }, []);
 
   // Browser guard for unsaved changes
@@ -715,6 +717,16 @@ export const useEventForm = () => {
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [hasUnsavedChanges]);
+
+  // Cleanup ObjectURLs on unmount
+  useEffect(() => {
+    return () => {
+      const preview = formDataRef.current?.bannerPreview;
+      if (preview && preview.startsWith("blob:")) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, []);
 
   /**
    * isFormValid — true when the errors object is empty AND all required


### PR DESCRIPTION
## Description
Solving Issue #8429: Memory leak during image upload.
Replaced FileReader.readAsDataURL(file) with URL.createObjectURL(file) in the image upload flow. eadAsDataURL was creating huge base64 string copies of images in memory, leading to memory bloat/leaks especially for large images or multiple uploads. The new implementation correctly uses memory-efficient object URLs and properly revokes them (URL.revokeObjectURL) when they are replaced or when the component unmounts.

## Related Issue
Fixes #8429

## Checklist
- [x] I have tested this code
- [x] I have read the contributing guidelines