### PR TITLE
Fix: Handle OAuth token refresh non-200 responses

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -64,6 +64,7 @@ export const API_ENDPOINTS = {
     SIGNUP: buildApiUrl("/auth/signup"),
     LOGOUT: buildApiUrl("/auth/logout"),
     RESET_PASSWORD: buildApiUrl("/auth/reset-password"),
+    REFRESH: buildApiUrl("/auth/refresh"),
   },
   EVENTS: {
     CREATE: buildApiUrl("/events/create"),

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -190,8 +190,24 @@ export function setupResponseInterceptor(api, { isDev, timeoutMs, getOnUnauthori
       const status = error?.response?.status;
 
       const onUnauthorized = getOnUnauthorized();
-      if (status === 401 && onUnauthorized) {
-        onUnauthorized();
+      if (status === 401) {
+        if (!config._retry && !config.url?.includes("/api/auth/refresh")) {
+          config._retry = true;
+          try {
+            if (isDev) logger.info(`[API] Attempting OAuth token refresh...`);
+            await api.post("/api/auth/refresh");
+            return api(config);
+          } catch (refreshError) {
+            logger.error("OAuth token refresh failed. Locking user out.", refreshError);
+            if (onUnauthorized) {
+              onUnauthorized();
+            }
+            throw normalizeApiErrorWithTimeout(refreshError, timeoutMs);
+          }
+        }
+        if (onUnauthorized) {
+          onUnauthorized();
+        }
       }
 
       const retryCount = config._retryCount || 0;


### PR DESCRIPTION
### Description
This PR fixes Issue #8430 by adding robust error handling for the token refresh logic. It intercepts 401 Unauthorized responses, attempts a token refresh at pi/auth/refresh, and if it fails (non-200 response), it securely locks the user out with proper error reporting.

### Related Issue
Fixes #8430

### Checklist
- [x] Tested locally
- [x] Follows GSSoC 2026 guidelines