### PR TITLE
fix: prevent events link and logo overlap

### DIFF
--- a/src/components/navbar/DesktopNavbar.jsx
+++ b/src/components/navbar/DesktopNavbar.jsx
@@ -2,8 +2,10 @@ import NavbarLinks from "./NavbarLinks";
 
 const DesktopNavbar = () => {
   return (
-    <div className="hidden lg:flex items-center justify-center flex-1 min-w-0 overflow-x-auto navbar-links-scroll px-3 xl:px-6">
-      <NavbarLinks />
+    <div className="hidden lg:flex items-center flex-1 min-w-0 overflow-x-auto navbar-links-scroll">
+      <div className="mx-auto px-4">
+        <NavbarLinks />
+      </div>
     </div>
   );
 };

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -110,10 +110,8 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
             </div>
           </Link>
 
-          {/* Desktop Links - Wrapping instead of absolute positioning */}
-          <div className="hidden lg:flex items-center justify-center flex-1 overflow-x-auto">
-            <DesktopNavbar />
-          </div>
+          {/* Desktop Links - safe centered to prevent overlapping */}
+          <DesktopNavbar />
 
           {/* Right Controls Container */}
           <div className="relative z-10 flex items-center gap-2 sm:gap-2.5 shrink-0">


### PR DESCRIPTION
## Description

This PR fixes a responsive navbar layout issue where the EVENTS navigation link became partially hidden and overlapped with the logo on narrower desktop screen widths.

#### Changes made
-Removed the redundant wrapper around DesktopNavbar in Navbar.jsx.
-Removed justify-center from the outer flex container in DesktopNavbar.jsx.
-Wrapped NavbarLinks with a container using mx-auto to implement a safer centering approach.

Fixes #8476

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
