### PR TITLE
fix: prevent NaN values in events pagination count

### DIFF
--- a/src/Pages/Events/PaginationControls.js
+++ b/src/Pages/Events/PaginationControls.js
@@ -116,17 +116,23 @@ const PaginationControls = ({
   onPageChange,
   onPageSizeChange,
 }) => {
-  if (totalEvents === 0) {
-    return null;
-  }
+  const safeTotalEvents = Number(totalEvents) || 0;
+const safeCurrentPage = Number(currentPage) || 1;
+const safeEventsPerPage = Number(eventsPerPage) || EVENTS_PER_PAGE_OPTIONS[0];
 
-  const startEvent = (currentPage - 1) * eventsPerPage + 1;
-  const endEvent = Math.min(currentPage * eventsPerPage, totalEvents);
+if (safeTotalEvents === 0) {
+  return null;
+}
 
+const startEvent = (safeCurrentPage - 1) * safeEventsPerPage + 1;
+const endEvent = Math.min(
+  safeCurrentPage * safeEventsPerPage,
+  safeTotalEvents
+);
   return (
     <div className="mt-10 flex flex-col gap-4 border-t border-gray-200 pt-6 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
       <p className="text-sm text-gray-600 dark:text-gray-400">
-        Showing {startEvent}–{endEvent} of {totalEvents} events
+        Showing {startEvent}–{endEvent} of {safeTotalEvents} events
       </p>
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">


### PR DESCRIPTION
Fixed the events pagination count showing NaN values when event count data is missing or invalid.

The pagination calculation now uses safe fallback values before generating the visible event range, preventing invalid text like:

"Showing NaN–NaN of events"

Changes made:
- Added validation for pagination values
- Added fallback handling for missing total events, current page, and events per page values
- Kept empty event states handled safely

Now the pagination displays proper values such as:

"Showing 1–6 of 16 events"

Fixes #8497

Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Checklist:

- [x] Code changes are limited to the pagination fix
- [x] Verified NaN values are prevented
- [x] No unrelated files were changed