### PR TITLE
feat: implement waitlist system for fully booked events (closes #8460)

### DIFF
--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { joinWaitlist, leaveWaitlist, getWaitlistStatus, getWaitlistCount } from '../../services/waitlistService';
+
+const WaitlistButton = ({ eventId, isFullyBooked, waitlistEnabled, token, isAuthenticated }) => {
+  const [onWaitlist, setOnWaitlist] = useState(false);
+  const [position, setPosition] = useState(null);
+  const [waitlistCount, setWaitlistCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isFullyBooked || !waitlistEnabled) return;
+
+    getWaitlistCount(eventId).then(data => setWaitlistCount(data.count));
+
+    if (isAuthenticated && token) {
+      getWaitlistStatus(eventId, token).then(data => {
+        setOnWaitlist(data.onWaitlist);
+        setPosition(data.position);
+      });
+    }
+  }, [eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token]);
+
+  if (!isFullyBooked || !waitlistEnabled) return null;
+
+  const handleClick = async () => {
+    if (!isAuthenticated) {
+      alert('Please log in to join the waitlist.');
+      return;
+    }
+    setLoading(true);
+    try {
+      if (onWaitlist) {
+        await leaveWaitlist(eventId, token);
+        setOnWaitlist(false);
+        setPosition(null);
+        setWaitlistCount(prev => prev - 1);
+      } else {
+        const data = await joinWaitlist(eventId, token);
+        setOnWaitlist(true);
+        setPosition(data.position);
+        setWaitlistCount(prev => prev + 1);
+      }
+    } catch (err) {
+      alert(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-sm text-gray-500">
+        Event is full · {waitlistCount} {waitlistCount === 1 ? 'person' : 'people'} on waitlist
+      </span>
+
+      {onWaitlist && position && (
+        <span className="text-sm font-medium text-blue-600">
+          You are #{position} on the waitlist
+        </span>
+      )}
+
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className={`px-4 py-2 rounded-md font-medium text-white transition-colors ${
+          onWaitlist
+            ? 'bg-gray-500 hover:bg-gray-600'
+            : 'bg-yellow-500 hover:bg-yellow-600'
+        } disabled:opacity-50`}
+      >
+        {loading ? 'Please wait...' : onWaitlist ? 'Leave Waitlist' : 'Join Waitlist'}
+      </button>
+    </div>
+  );
+};
+
+export default WaitlistButton;

--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { joinWaitlist, leaveWaitlist, getWaitlistStatus, getWaitlistCount } from '../../services/waitlistService';
 
-// Custom hook - extracts all state & async logic
-const useWaitlist = (eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token) => {
+// Custom hook - args grouped into single options object (fixes Excess Function Arguments)
+const useWaitlist = ({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token }) => {
   const [onWaitlist, setOnWaitlist] = useState(false);
   const [position, setPosition] = useState(null);
   const [waitlistCount, setWaitlistCount] = useState(0);
@@ -49,7 +49,6 @@ const useWaitlist = (eventId, isFullyBooked, waitlistEnabled, isAuthenticated, t
   return { onWaitlist, position, waitlistCount, loading, handleClick };
 };
 
-// Sub-component: count & position info
 const WaitlistInfo = ({ waitlistCount, position, onWaitlist }) => (
   <div>
     <span className="text-sm text-gray-500">
@@ -63,7 +62,6 @@ const WaitlistInfo = ({ waitlistCount, position, onWaitlist }) => (
   </div>
 );
 
-// Sub-component: the button
 const WaitlistToggleButton = ({ onWaitlist, loading, onClick }) => (
   <button
     onClick={onClick}
@@ -76,10 +74,9 @@ const WaitlistToggleButton = ({ onWaitlist, loading, onClick }) => (
   </button>
 );
 
-// Main component - thin orchestrator
 const WaitlistButton = ({ eventId, isFullyBooked, waitlistEnabled, token, isAuthenticated }) => {
   const { onWaitlist, position, waitlistCount, loading, handleClick } =
-    useWaitlist(eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token);
+    useWaitlist({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token });
 
   if (!isFullyBooked || !waitlistEnabled) return null;
 

--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { joinWaitlist, leaveWaitlist, getWaitlistStatus, getWaitlistCount } from '../../services/waitlistService';
 
-const WaitlistButton = ({ eventId, isFullyBooked, waitlistEnabled, token, isAuthenticated }) => {
+// Custom hook - extracts all state & async logic
+const useWaitlist = (eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token) => {
   const [onWaitlist, setOnWaitlist] = useState(false);
   const [position, setPosition] = useState(null);
   const [waitlistCount, setWaitlistCount] = useState(0);
@@ -19,8 +20,6 @@ const WaitlistButton = ({ eventId, isFullyBooked, waitlistEnabled, token, isAuth
       });
     }
   }, [eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token]);
-
-  if (!isFullyBooked || !waitlistEnabled) return null;
 
   const handleClick = async () => {
     if (!isAuthenticated) {
@@ -47,29 +46,47 @@ const WaitlistButton = ({ eventId, isFullyBooked, waitlistEnabled, token, isAuth
     }
   };
 
+  return { onWaitlist, position, waitlistCount, loading, handleClick };
+};
+
+// Sub-component: count & position info
+const WaitlistInfo = ({ waitlistCount, position, onWaitlist }) => (
+  <div>
+    <span className="text-sm text-gray-500">
+      Event is full · {waitlistCount} {waitlistCount === 1 ? 'person' : 'people'} on waitlist
+    </span>
+    {onWaitlist && position && (
+      <span className="block text-sm font-medium text-blue-600">
+        You are #{position} on the waitlist
+      </span>
+    )}
+  </div>
+);
+
+// Sub-component: the button
+const WaitlistToggleButton = ({ onWaitlist, loading, onClick }) => (
+  <button
+    onClick={onClick}
+    disabled={loading}
+    className={`px-4 py-2 rounded-md font-medium text-white transition-colors ${
+      onWaitlist ? 'bg-gray-500 hover:bg-gray-600' : 'bg-yellow-500 hover:bg-yellow-600'
+    } disabled:opacity-50`}
+  >
+    {loading ? 'Please wait...' : onWaitlist ? 'Leave Waitlist' : 'Join Waitlist'}
+  </button>
+);
+
+// Main component - thin orchestrator
+const WaitlistButton = ({ eventId, isFullyBooked, waitlistEnabled, token, isAuthenticated }) => {
+  const { onWaitlist, position, waitlistCount, loading, handleClick } =
+    useWaitlist(eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token);
+
+  if (!isFullyBooked || !waitlistEnabled) return null;
+
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-sm text-gray-500">
-        Event is full · {waitlistCount} {waitlistCount === 1 ? 'person' : 'people'} on waitlist
-      </span>
-
-      {onWaitlist && position && (
-        <span className="text-sm font-medium text-blue-600">
-          You are #{position} on the waitlist
-        </span>
-      )}
-
-      <button
-        onClick={handleClick}
-        disabled={loading}
-        className={`px-4 py-2 rounded-md font-medium text-white transition-colors ${
-          onWaitlist
-            ? 'bg-gray-500 hover:bg-gray-600'
-            : 'bg-yellow-500 hover:bg-yellow-600'
-        } disabled:opacity-50`}
-      >
-        {loading ? 'Please wait...' : onWaitlist ? 'Leave Waitlist' : 'Join Waitlist'}
-      </button>
+      <WaitlistInfo waitlistCount={waitlistCount} position={position} onWaitlist={onWaitlist} />
+      <WaitlistToggleButton onWaitlist={onWaitlist} loading={loading} onClick={handleClick} />
     </div>
   );
 };

--- a/src/services/waitlistService.js
+++ b/src/services/waitlistService.js
@@ -1,0 +1,40 @@
+const API_URL = process.env.REACT_APP_API_URL;
+
+export const joinWaitlist = async (eventId, token) => {
+  const response = await fetch(`${API_URL}/waitlist/join/${eventId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) throw new Error('Failed to join waitlist');
+  return response.json();
+};
+
+export const leaveWaitlist = async (eventId, token) => {
+  const response = await fetch(`${API_URL}/waitlist/leave/${eventId}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) throw new Error('Failed to leave waitlist');
+  return response.json();
+};
+
+export const getWaitlistStatus = async (eventId, token) => {
+  const response = await fetch(`${API_URL}/waitlist/status/${eventId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) return { onWaitlist: false, position: null };
+  return response.json();
+};
+
+export const getWaitlistCount = async (eventId) => {
+  const response = await fetch(`${API_URL}/waitlist/count/${eventId}`);
+  if (!response.ok) return { count: 0 };
+  return response.json();
+};


### PR DESCRIPTION
## Description

Implements a waitlist system for fully booked events as requested in #8460.

Currently, when an event reaches capacity, users simply lose the ability to register with no alternative. This PR adds a waitlist mechanism that captures interest from users when an event is full, giving organizers visibility into demand and enabling future capacity management.

**Changes made:**
- `src/services/waitlistService.js` - API service layer for join, leave, status, and count endpoints
- `src/components/common/WaitlistButton.js` - new reusable component that shows join/leave button with queue position display
- `src/pages/Events/EventCard.js` - register button now conditionally renders based on capacity state

**Logic:**
- When `registeredCount >= capacity` AND `waitlistEnabled === true` → "Join Waitlist" button (amber)
- When `registeredCount >= capacity` AND `waitlistEnabled === false` → "Fully Booked" (disabled, red)
- Otherwise → normal "Register Now" button (unchanged behavior)

Fixes #8460

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports

## Pre-existing Issues (not introduced by this PR)

The following lint errors and test failures exist in the `master` branch 
prior to this PR and are unrelated to the waitlist feature:

**Lint errors (pre-existing):**
- `src/components/SearchFilter.js` — duplicate `matchesLocation` identifier
- `src/components/common/EventCreation/EventLocationSection.jsx` — unexpected token
- `src/components/common/VirtualizedEventGrid.jsx` — missing display name
- `src/components/user/EventsTab.js` — duplicate `SEARCH_ROUTES`

**Test failures (pre-existing):**
- `tests/readTimeUtils.test.mjs` — imports `src/utils/readTimeUtils.js` which does not exist in the repo

**This PR introduces zero new lint errors and zero new test failures.**
