### PR TITLE
[Feature] : Configurable Web Push "Do Not Disturb" (DND) Hours

### DIFF
--- a/src/utils/dndUtils.js
+++ b/src/utils/dndUtils.js
@@ -1,0 +1,16 @@
+export const isDndActive = () => {
+  try {
+    const prefs = JSON.parse(localStorage.getItem('eventra_notification_prefs') || '{}');
+    if (!prefs.dndEnabled) return false;
+    const now = new Date();
+    const currentHour = now.getHours();
+    const start = prefs.dndStart || 22;
+    const end = prefs.dndEnd || 8;
+    if (start > end) {
+      return currentHour >= start || currentHour < end;
+    }
+    return currentHour >= start && currentHour < end;
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
With the introduction of `usePushSubscription.js`, users are receiving desktop/mobile notifications. However, if an event organizer makes an update at 3 AM in the attendee's local timezone, their phone buzzes and wakes them up, leading to frustration and users revoking push permissions entirely.

Fixes #8410
