### PR TITLE
[Feature] : Cross-Tab Session Logout Synchronizer

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -8,7 +8,7 @@ import { useTokenExpiry } from "../hooks/useTokenExpiry.js";
 import { isTokenValid } from "../utils/tokenUtils.js";
 import { toast } from "react-toastify";
 import { ROLES, ROLE_PERMISSIONS } from "../config/roles.js";
-import { getSessionChannel, closeSessionChannel, SESSION_TERMINATED } from "../utils/sessionBroadcast.js";
+import { getSessionChannel, closeSessionChannel, SESSION_TERMINATED, broadcastSessionTerminated } from "../utils/sessionBroadcast.js";
 
 // Create context for Authentication
 const AuthContext = createContext();
@@ -360,6 +360,7 @@ export const AuthProvider = ({ children }) => {
       console.warn("[AuthContext] Backend logout request failed (best-effort error):", error);
     }
     clearSession();
+    broadcastSessionTerminated();
     setAuthRequest({ loading: false, error: null });
   }, [clearSession]);
 


### PR DESCRIPTION
We recently added `src/utils/sessionSnapshot.js` to track unique browser sessions. However, if a user opens the app in three different tabs and clicks "Log Out" on one of them, the other two tabs remain fully functional and display sensitive data until they are manually refreshed.

Fixes #8407