### PR TITLE
[Bug] : 32-bit setTimeout overflow in useTokenExpiry.js instantly log…

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -35,7 +35,8 @@ export function useTokenExpiry({ token, user, onExpired }) {
 
     let timeoutId;
     if (typeof expSeconds === "number") {
-      const delayMs = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);
+      let delayMs = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);
+      if (delayMs > 2147483647) delayMs = 2147483647;
       timeoutId = setTimeout(() => {
         if (token === "cookie-managed" ? Date.now() >= expSeconds * 1000 : !isTokenValid(token)) {
           clearExpiredSession();


### PR DESCRIPTION
In `src/hooks/useTokenExpiry.js`, the hook calculates the delay until the token expires: `const delayMs = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);`. It then passes this to `setTimeout`. However, `setTimeout` in JavaScript uses a 32-bit signed integer. If a user selects "Remember Me" and receives a token expiring in > 24.8 days, `delayMs` exceeds `2,147,483,647`. This causes an integer overflow, making `setTimeout` trigger immediately, instantly logging the user out the moment they log in.

Fixes #8407