### PR TITLE
[Bug] : "Unsaved changes" false positive blocks navigation after succ…

### DIFF
--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -307,6 +307,7 @@ export const useEventForm = () => {
       throw new Error(errorMessage);
     }
 
+    resetForm();
     return result;
   });
 


### PR DESCRIPTION
In `src/hooks/useEventForm.js`, a `beforeunload` event listener blocks navigation if `hasUnsavedChanges` is true. However, when the user successfully submits the form and creates the event, the hook fails to call `resetForm()`. Because the `formData` state still contains the user's input, `hasUnsavedChanges` remains true. When the user attempts to navigate away to view their new event, the browser throws an annoying "You have unsaved changes" prompt.

Fixes #8406