### PR TITLE
[Bug] : Desynchronization vulnerability in leaveWaitlist error fallback

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -60,7 +60,10 @@ export const getGlobalWaitlist = () => {
   try {
     const raw = localStorage.getItem(GLOBAL_WAITLIST_KEY);
     return raw ? safeJsonParse(raw, []) : [];
-  } catch {
+  } catch (err) {
+    if (err.response && err.response.status >= 400 && err.response.status < 500) {
+      throw err;
+    }
     return [];
   }
 };


### PR DESCRIPTION
In `src/utils/waitlistUtils.js`, the `leaveWaitlist` function attempts to notify the server via `apiUtils.post`. If the server throws an error (e.g., an HTTP 403 because the event has already started and the waitlist is locked), the `catch` block blindly swallows the error and falls through to the offline `localStorage` path. This forces the local state to "removed", telling the user they successfully left the waitlist, even though the server explicitly denied it.

Fixes #8405