### PR TITLE
[Bug] : Notification Leakage across accounts due to static localStora…

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -8,7 +8,16 @@ import { getNotificationMessage } from "../utils/notificationPreferences";
 
 const POLLING_INTERVAL_MS = 60_000;
 const MAX_SEEN_IDS = 500;
-const STORAGE_KEY = "eventra_notification_inbox";
+const getStorageKey = () => {
+  try {
+    const userStr = window.localStorage.getItem('user');
+    if (userStr) {
+      const user = JSON.parse(userStr);
+      if (user && user.id) return 'eventra_notification_inbox_' + user.id;
+    }
+  } catch (e) {}
+  return 'eventra_notification_inbox_guest';
+};
 
 const normalize = (n = {}) => ({
   ...n,
@@ -17,12 +26,12 @@ const normalize = (n = {}) => ({
 });
 
 const persist = (items) => {
-  try { window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items)); } catch {}
+  try { window.localStorage.setItem(getStorageKey(), JSON.stringify(items)); } catch {}
 };
 
 const loadPersisted = () => {
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(getStorageKey());
     if (!raw) return null;
     const parsed = safeJsonParse(raw, []);
     return Array.isArray(parsed) ? parsed.map(normalize) : null;


### PR DESCRIPTION
In the newly added `src/hooks/useNotificationPoller.js`, the caching layer writes to a static `localStorage` key (`const STORAGE_KEY = "eventra_notification_inbox"`). If multiple users log into the application on the same browser (or a public shared computer), the notifications of the previous user are loaded from cache and leaked to the new user before the backend poller overwrites them.

Fixes #8403