### PR TITLE
[Bug] : signatureValidator.js allows replay attacks via future timest…

### DIFF
--- a/src/utils/signatureValidator.js
+++ b/src/utils/signatureValidator.js
@@ -22,7 +22,7 @@ export function validateSignature(
 
   const age = now - Number(timestamp);
 
-  if (age > MAX_REQUEST_AGE_MS) {
+  if (Math.abs(age) > MAX_REQUEST_AGE_MS) {
     return {
       valid: false,
       error: "Expired request",


### PR DESCRIPTION
In `src/utils/signatureValidator.js`, the logic to prevent replay attacks calculates the request age using `const age = now - Number(timestamp);` and rejects it if `age > MAX_REQUEST_AGE_MS`. However, if an attacker provides a timestamp far into the future, `age` becomes a large negative number. Since negative numbers are not greater than `MAX_REQUEST_AGE_MS`, the check passes.

Fixes #8404