### PR TITLE
fix: add noValidate to Newsletter form in Footer to suppress browser native validation

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -218,7 +218,8 @@ const Newsletter = () => {
 
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col  gap-3 max-w-lg"
+        noValidate
+        className="flex flex-col gap-3 max-w-lg"
       >
         <div className="relative flex-grow">
           <FaEnvelope className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />


### PR DESCRIPTION
## Summary
Fixes the Newsletter form in Footer.js where the missing noValidate
attribute allowed the browser to show its own native validation tooltip
alongside the custom styled error UI.

## Problem
The form had a type="email" input and custom validation in handleSubmit
but no noValidate. The browser fired its native validation before
handleSubmit ran, causing two conflicting error UIs to appear.

## Fix
I added noValidate to the form element so the browser skips native
validation entirely and defers to the handleSubmit custom validator.

## Changes
- src/components/Layout/Footer.js — added noValidate to Newsletter form

Closes #8585 