### PR TITLE
fix: apply aria-controls conditionally when dropdown is open and use functional updater for toggle in UserProfileDropdown

### DIFF
--- a/src/components/Layout/UserProfileDropdown.jsx
+++ b/src/components/Layout/UserProfileDropdown.jsx
@@ -19,12 +19,12 @@ const UserProfileDropdown = ({
 }) => (
   <div className="relative profile-container">
     <button
-      onClick={() => setShowProfileDropdown(!showProfileDropdown)}
+      onClick={() => setShowProfileDropdown((prev) => !prev)}
       type="button"
       aria-label="Open user menu"
       aria-expanded={showProfileDropdown}
       aria-haspopup="menu"
-      aria-controls="user-profile-menu"
+      aria-controls={showProfileDropdown ? "user-profile-menu" : undefined}
       className="flex items-center gap-2 text-sm font-medium text-black/90 dark:text-white/90 hover:text-black dark:hover:text-white transition-colors"
     >
       {user?.profilePicture ? (


### PR DESCRIPTION
## Summary
Two fixes in UserProfileDropdown.jsx — one invalid ARIA attribute and
one stale closure toggle.

## Bug 1 — Invalid aria-controls
aria-controls="user-profile-menu" was always set on the toggle button
even when AnimatePresence had removed the referenced element from the DOM.
I changed to aria-controls={showProfileDropdown ? "user-profile-menu" : undefined}
so the attribute only exists when the element does.

## Bug 2 — Stale closure toggle
I replaced !showProfileDropdown with the functional updater (prev) => !prev
to guarantee the toggle always reads the latest state.

## Changes
- src/components/Layout/UserProfileDropdown.jsx
  — aria-controls conditionally applied based on showProfileDropdown
  — toggle uses functional updater

Closes #8589