### PR TITLE
fix: remove invalid aria-modal from role=menu and remove unimplemented aria-orientation in ProfileMenu

### DIFF
--- a/src/components/navbar/ProfileMenu.jsx
+++ b/src/components/navbar/ProfileMenu.jsx
@@ -104,8 +104,6 @@ const ProfileMenu = ({ user, logout }) => {
       {isOpen && (
         <div
           role="menu"
-          aria-modal="true"
-          aria-orientation="vertical"
           aria-label="Profile menu"
           className="absolute right-0 mt-3 w-56 origin-top-right rounded-xl border border-border bg-navbar shadow-lg p-2 z-50 animate-in fade-in zoom-in-95 duration-100"
         >


### PR DESCRIPTION
## Summary
Two invalid ARIA attributes removed from the ProfileMenu dropdown
that caused incorrect screen reader behaviour and misleading keyboard
navigation signals.

## Bug 1— aria-modal on role=menu
aria-modal is only valid on dialog and alertdialog roles. On role=menu
it caused screen readers to hide all other page content while the
dropdown was open — making the rest of the app inaccessible to AT
users. I removed aria-modal="true" from the menu div. The existing
Tab focus trap in handleKeyDown is the correct mechanism.

## Bug 2 — aria-orientation without arrow keys
aria-orientation="vertical" signals that up/down arrow keys navigate
menu items per ARIA APG. No arrow key handling exists in handleKeyDown.
I removed the attribute to avoid misleading AT users. Can be re-added
when arrow key navigation is implemented.

## Changes
- src/components/navbar/ProfileMenu.jsx

Closes #8595 