### PR TITLE
fix(security): restrict ErrorButton to development builds

### DIFF
--- a/docs/ERROR_BOUNDARY_GUIDE.md
+++ b/docs/ERROR_BOUNDARY_GUIDE.md
@@ -201,6 +201,8 @@ clearErrorLog();
 
 ### Testing Error Boundary
 
+The application includes a development-only ErrorButton component (visible in development mode) that allows you to test error boundary behavior by intentionally triggering an error. This button is automatically excluded from production builds.
+
 ```javascript
 // Temporarily add error in component
 useEffect(() => {
@@ -212,6 +214,8 @@ function ErrorTest() {
   throw new Error("Deliberate error for testing");
 }
 ```
+
+**Note**: The ErrorButton component is wrapped with `import.meta.env.DEV` check and will not be rendered in production builds.
 
 ### Viewing Error Logs
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -301,7 +301,7 @@ function App() {
                 </ErrorBoundary>
                 )}
 
-                <ErrorButton />
+                {import.meta.env.DEV && <ErrorButton />}
               </div>
             </SessionRecoveryProvider>
           </MyEventsProvider>

--- a/tests/errorButtonProductionSafety.test.mjs
+++ b/tests/errorButtonProductionSafety.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const appPath = "src/App.jsx";
+const appSource = readFileSync(appPath, "utf8");
+
+// Test 1: ErrorButton must be wrapped in development-only check
+assert.match(
+  appSource,
+  /import\.meta\.env\.DEV\s*&&\s*<ErrorButton\s*\/>/,
+  `${appPath} must wrap ErrorButton with import.meta.env.DEV check to prevent production exposure`
+);
+
+// Test 2: ErrorButton component must still exist for development testing
+assert.match(
+  appSource,
+  /function ErrorButton\(\)/,
+  `${appPath} must retain ErrorButton component definition for development testing`
+);
+
+// Test 3: ErrorButton must not be rendered unconditionally
+assert.doesNotMatch(
+  appSource,
+  /^\s*<ErrorButton\s*\/>\s*$/m,
+  `${appPath} must not render ErrorButton unconditionally (must be dev-only)`
+);
+
+// Test 4: Verify the error-throwing behavior is preserved
+assert.match(
+  appSource,
+  /throw new Error\(['"]This is your first error!['"]\)/,
+  `${appPath} must preserve ErrorButton error-throwing behavior for development testing`
+);
+
+console.log("error button production safety tests passed ✓");


### PR DESCRIPTION
## Description

This PR fixes a production security issue where the development-only `ErrorButton` component ("Break the world") could be rendered in the application UI and intentionally trigger runtime errors.

### Changes Made

* Wrapped `ErrorButton` rendering with `import.meta.env.DEV`
* Ensured the component is only available during development
* Added automated tests to verify production safety
* Updated Error Boundary documentation with development-only usage guidance

### Motivation

Debug and testing utilities should never be exposed to production users. This change preserves the existing Error Boundary testing workflow for contributors while preventing accidental or intentional application crashes in production.

Fixes #8656 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A – Development-only functionality was restricted from production builds.

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have run local unit tests using `npm test` and verified they pass
* [x] I have run `npm run lint` and resolved any new errors or warnings
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
