### PR TITLE
fix(hooks): chain setTimeout slices so long-lived tokens are auto-logged-out at expiry

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -34,34 +34,45 @@ export function useTokenExpiry({ token, user, onExpired }) {
     }
 
     let timeoutId;
-    if (typeof expSeconds === "number") {
+    // 🔥 CodeScene refactor: extracted to reduce the cyclomatic complexity
+    // of the useTokenExpiry effect (was 18, threshold = 9).
+    const armExpiryTimer = (expSecs) => {
       const MAX_TIMEOUT_MS = 2147483647; // 32-bit signed max (24.8 days)
       // 🔥 FIX: chain timers when the expiry is far in the future. Previously
       // the code clamped delayMs to MAX_TIMEOUT_MS and then forgot to re-arm,
       // so a 1-year token would fire the timer after 24.8 days, see the token
       // was still valid, do nothing, and the user would never be auto-logged-out.
-      const armExpiryTimer = (remainingMs) => {
+      const stillOnToken = () =>
+        token === "cookie-managed" ? Date.now() < expSecs * 1000 : isTokenValid(token);
+      const scheduleSlice = (remainingMs) => {
         const clamped = Math.min(remainingMs, MAX_TIMEOUT_MS);
         timeoutId = setTimeout(() => {
           timeoutId = null;
-          const stillOnToken = token === "cookie-managed" ? Date.now() < expSeconds * 1000 : isTokenValid(token);
           if (!isMountedRef.current) return;
-          if (stillOnToken) {
+          if (stillOnToken()) {
             // Re-arm for the next slice. If remainingMs was <= MAX_TIMEOUT_MS this
             // is a no-op; otherwise we chain another slice until expiry.
-            armExpiryTimer(Math.max(0, expSeconds * 1000 - Date.now() - 1000));
+            scheduleSlice(Math.max(0, expSecs * 1000 - Date.now() - 1000));
           } else {
             clearExpiredSession();
           }
         }, clamped);
       };
-      const initialDelay = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);
-      if (initialDelay > 0) armExpiryTimer(initialDelay);
-    } else if (token !== "cookie-managed") {
+      const initialDelay = Math.max(expSecs * 1000 - Date.now() + 1000, 0);
+      if (initialDelay > 0) scheduleSlice(initialDelay);
+    };
+
+    const armPollingInterval = () => {
       timeoutId = setInterval(() => {
         if (!isTokenValid(token)) clearExpiredSession();
       }, 60_000);
       if (!isTokenValid(token)) clearExpiredSession();
+    };
+
+    if (typeof expSeconds === "number") {
+      armExpiryTimer(expSeconds);
+    } else if (token !== "cookie-managed") {
+      armPollingInterval();
     }
 
     return () => {

--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -35,13 +35,28 @@ export function useTokenExpiry({ token, user, onExpired }) {
 
     let timeoutId;
     if (typeof expSeconds === "number") {
-      let delayMs = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);
-      if (delayMs > 2147483647) delayMs = 2147483647;
-      timeoutId = setTimeout(() => {
-        if (token === "cookie-managed" ? Date.now() >= expSeconds * 1000 : !isTokenValid(token)) {
-          clearExpiredSession();
-        }
-      }, delayMs);
+      const MAX_TIMEOUT_MS = 2147483647; // 32-bit signed max (24.8 days)
+      // 🔥 FIX: chain timers when the expiry is far in the future. Previously
+      // the code clamped delayMs to MAX_TIMEOUT_MS and then forgot to re-arm,
+      // so a 1-year token would fire the timer after 24.8 days, see the token
+      // was still valid, do nothing, and the user would never be auto-logged-out.
+      const armExpiryTimer = (remainingMs) => {
+        const clamped = Math.min(remainingMs, MAX_TIMEOUT_MS);
+        timeoutId = setTimeout(() => {
+          timeoutId = null;
+          const stillOnToken = token === "cookie-managed" ? Date.now() < expSeconds * 1000 : isTokenValid(token);
+          if (!isMountedRef.current) return;
+          if (stillOnToken) {
+            // Re-arm for the next slice. If remainingMs was <= MAX_TIMEOUT_MS this
+            // is a no-op; otherwise we chain another slice until expiry.
+            armExpiryTimer(Math.max(0, expSeconds * 1000 - Date.now() - 1000));
+          } else {
+            clearExpiredSession();
+          }
+        }, clamped);
+      };
+      const initialDelay = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);
+      if (initialDelay > 0) armExpiryTimer(initialDelay);
     } else if (token !== "cookie-managed") {
       timeoutId = setInterval(() => {
         if (!isTokenValid(token)) clearExpiredSession();


### PR DESCRIPTION
Closes #8660.

Summary of What Has Been Done:
useTokenExpiry.js clamped delayMs to 2147483647 (32-bit max, 24.8 days). For a 1-year token the timer fired after 24.8 days, the token was still valid, and no new setTimeout was scheduled — the user was never auto-logged-out again.

Changes Made:
- Replaced the one-shot clamp with a recursive armExpiryTimer(remainingMs) that chains a new 24.8-day slice each time the previous slice fires and the token is still valid.
- When the token finally expires the loop exits and clearExpiredSession is called.

Impact it Made:
- Closes the security/UX gap for long-lived tokens (1y refresh tokens, etc.).