### PR TITLE
fix(utils): guard localStorage in dndUtils.isDndActive to prevent SSR crash

### DIFF
--- a/src/utils/dndUtils.js
+++ b/src/utils/dndUtils.js
@@ -1,6 +1,7 @@
 export const isDndActive = () => {
+  if (typeof window === "undefined" || !window.localStorage) return false;
   try {
-    const prefs = JSON.parse(localStorage.getItem('eventra_notification_prefs') || '{}');
+    const prefs = JSON.parse(window.localStorage.getItem('eventra_notification_prefs') || '{}');
     if (!prefs.dndEnabled) return false;
     const now = new Date();
     const currentHour = now.getHours();


### PR DESCRIPTION
Closes #8662.

Summary of What Has Been Done:
isDndActive accessed localStorage.getItem at the top of the function without a typeof window guard, so it threw ReferenceError in Node-like environments (SSR, tests).

Changes Made:
- Added a typeof window === undefined || !window.localStorage early-return that defaults to false (DND off is the safe default).

Impact it Made:
- Removes the SSR crash. Safe default of false (DND off).