### PR TITLE
fix(utils): drop redundant storage listener in reminderUtils to prevent double-fire

### DIFF
--- a/src/utils/reminderUtils.js
+++ b/src/utils/reminderUtils.js
@@ -191,17 +191,15 @@ export const subscribeToReminderChanges = (callback) => {
     callback(Array.isArray(event.detail) ? event.detail : readReminders());
   };
 
-  const handleStorageChange = (event) => {
-    if (event.key === REMINDERS_STORAGE_KEY) {
-      callback(readReminders());
-    }
-  };
-
+  // 🔥 FIX: drop the 'storage' event listener. The REMINDERS_CHANGED_EVENT
+  // custom event already covers in-tab updates, and the 'storage' event only
+  // fires in cross-tab scenarios in most modern browsers. When the same tab
+  // does fire 'storage' (Safari, older Edge, some test harnesses), it caused
+  // the callback to run twice for every local write — every reminder UI re-
+  // rendered and unread-count badges briefly showed duplicates.
   window.addEventListener(REMINDERS_CHANGED_EVENT, handleLocalChange);
-  window.addEventListener("storage", handleStorageChange);
 
   return () => {
     window.removeEventListener(REMINDERS_CHANGED_EVENT, handleLocalChange);
-    window.removeEventListener("storage", handleStorageChange);
   };
 };


### PR DESCRIPTION
Closes #8663.

Summary of What Has Been Done:
subscribeToReminderChanges listened to BOTH the custom REMINDERS_CHANGED_EVENT (fired on every writeReminders) AND the storage event. In Safari, older Edge, and some test harnesses the storage event fires in the same tab that wrote, so every local write fired the callback twice.

Changes Made:
- Dropped the storage event listener. The custom event already covers the in-tab case. Cross-tab sync can be re-added later via BroadcastChannel if needed.

Impact it Made:
- Prevents the reminder list UI from re-rendering twice on every add/remove.