### PR TITLE
fix(utils): sweep stale entries and add hard cap to globalErrorHandler dedup map

### DIFF
--- a/src/utils/globalErrorHandler.js
+++ b/src/utils/globalErrorHandler.js
@@ -6,6 +6,26 @@ const recentErrors = new Map();
 const DEDUP_WINDOW_MS = 3000;
 const MAX_RECENT_ERRORS = 200; // 🔥 FIX: hard cap to prevent unbounded growth
 
+// 🔥 CodeScene refactor: extracted to keep isDuplicate below the
+// "Bumpy Road Ahead" threshold (no nested conditional logic).
+const sweepStaleEntries = (now) => {
+  for (const [key, ts] of recentErrors) {
+    if (now - ts > DEDUP_WINDOW_MS) recentErrors.delete(key);
+  }
+};
+
+// 🔥 CodeScene refactor: extracted to keep isDuplicate below the
+// "Bumpy Road Ahead" threshold (no nested conditional logic).
+const evictOldestEntries = () => {
+  const overflow = recentErrors.size - MAX_RECENT_ERRORS;
+  let dropped = 0;
+  for (const key of recentErrors.keys()) {
+    if (dropped >= overflow) break;
+    recentErrors.delete(key);
+    dropped++;
+  }
+};
+
 function isDuplicate(fingerprint) {
   const now = Date.now();
   const lastSeen = recentErrors.get(fingerprint);
@@ -18,21 +38,10 @@ function isDuplicate(fingerprint) {
   // small map) rather than only when the map exceeds MAX_RECENT_ERRORS.
   // Previously stale entries were never reaped if errors stopped arriving
   // or arrived slowly with different fingerprints.
-  for (const [key, ts] of recentErrors) {
-    if (now - ts > DEDUP_WINDOW_MS) recentErrors.delete(key);
-  }
+  sweepStaleEntries(now);
 
-  // Housekeep stale entries so the map doesn't grow without bound
-  if (recentErrors.size > MAX_RECENT_ERRORS) {
-    // Drop the oldest entries first (Map iteration is insertion-order).
-    const overflow = recentErrors.size - MAX_RECENT_ERRORS;
-    let dropped = 0;
-    for (const key of recentErrors.keys()) {
-      if (dropped >= overflow) break;
-      recentErrors.delete(key);
-      dropped++;
-    }
-  }
+  // Enforce the hard cap by dropping the oldest entries (insertion-order).
+  if (recentErrors.size > MAX_RECENT_ERRORS) evictOldestEntries();
   return false;
 }
 
@@ -45,27 +54,29 @@ function buildFingerprint(error) {
   return `${msg}::${firstFrame}`;
 }
 
+// 🔥 CodeScene refactor: extracted to deduplicate the onerror / onunhandledrejection
+// handler bodies. Both previously repeated the same fingerprint / isDuplicate / log /
+// logError sequence with only the log label differing.
+const handleReport = (error, message, logLabel, extra) => {
+  const fp = buildFingerprint(error || message);
+  if (isDuplicate(fp)) return;
+  console.error(logLabel, error || message);
+  if (error) {
+    logError(error, null, extra);
+  }
+};
+
 export const initializeGlobalErrorHandling = () => {
   if (typeof window === "undefined") return;
 
   window.onerror = (message, source, lineno, colno, error) => {
-    const fp = buildFingerprint(error || message);
-    if (isDuplicate(fp)) return;
-
-    console.error("[GlobalError]", error || message);
-    if (error) {
-      logError(error, null, { source, lineno, colno });
-    }
+    handleReport(error, message, "[GlobalError]", { source, lineno, colno });
   };
 
   window.onunhandledrejection = (event) => {
     const reason = event.reason;
     const wrapped = reason instanceof Error ? reason : new Error(String(reason));
-    const fp = buildFingerprint(wrapped);
-    if (isDuplicate(fp)) return;
-
-    console.error("[UnhandledPromiseRejection]", reason);
-    logError(wrapped, null, {
+    handleReport(wrapped, reason, "[UnhandledPromiseRejection]", {
       type: "unhandled_promise_rejection",
     });
   };

--- a/src/utils/globalErrorHandler.js
+++ b/src/utils/globalErrorHandler.js
@@ -4,6 +4,7 @@ import { logError } from "./errorLogger.js";
 // that happen in rapid succession (e.g. a render loop).
 const recentErrors = new Map();
 const DEDUP_WINDOW_MS = 3000;
+const MAX_RECENT_ERRORS = 200; // 🔥 FIX: hard cap to prevent unbounded growth
 
 function isDuplicate(fingerprint) {
   const now = Date.now();
@@ -13,10 +14,23 @@ function isDuplicate(fingerprint) {
   }
   recentErrors.set(fingerprint, now);
 
+  // 🔥 FIX: sweep stale entries on EVERY call (cheap O(K) scan over the
+  // small map) rather than only when the map exceeds MAX_RECENT_ERRORS.
+  // Previously stale entries were never reaped if errors stopped arriving
+  // or arrived slowly with different fingerprints.
+  for (const [key, ts] of recentErrors) {
+    if (now - ts > DEDUP_WINDOW_MS) recentErrors.delete(key);
+  }
+
   // Housekeep stale entries so the map doesn't grow without bound
-  if (recentErrors.size > 50) {
-    for (const [key, ts] of recentErrors) {
-      if (now - ts > DEDUP_WINDOW_MS) recentErrors.delete(key);
+  if (recentErrors.size > MAX_RECENT_ERRORS) {
+    // Drop the oldest entries first (Map iteration is insertion-order).
+    const overflow = recentErrors.size - MAX_RECENT_ERRORS;
+    let dropped = 0;
+    for (const key of recentErrors.keys()) {
+      if (dropped >= overflow) break;
+      recentErrors.delete(key);
+      dropped++;
     }
   }
   return false;


### PR DESCRIPTION
Closes #8664.

Summary of What Has Been Done:
Stale entries were only reaped when the map exceeded 50 entries. If errors stopped arriving, the cap was never re-evaluated. The 50-entry cap was also too low.

Changes Made:
- Sweep stale entries on every call.
- Raise the hard cap to 200.
- When the cap is exceeded, drop the oldest entries first (Map iteration is insertion-order).

Impact it Made:
- Prevents a slow memory leak in the error-dedup path.