### PR TITLE
fix(utils): add cancel() to createAsyncValidator and validate maxRetries in withRetry

### DIFF
--- a/src/utils/asyncValidators.js
+++ b/src/utils/asyncValidators.js
@@ -17,11 +17,18 @@ import { apiUtils } from "../config/api.js";
 export const createAsyncValidator = (asyncValidatorFn, debounceMs = 300) => {
   let timeoutId;
 
-  return async function asyncValidator(value, ...args) {
-    return new Promise((resolve) => {
+  const cancel = () => {
+    if (timeoutId) {
       clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
 
+  const asyncValidator = async function asyncValidator(value, ...args) {
+    return new Promise((resolve) => {
+      cancel();
       timeoutId = setTimeout(async () => {
+        timeoutId = null;
         try {
           const result = await asyncValidatorFn(value, ...args);
           resolve(result);
@@ -31,6 +38,13 @@ export const createAsyncValidator = (asyncValidatorFn, debounceMs = 300) => {
       }, debounceMs);
     });
   };
+
+  // 🔥 FIX: expose .cancel() so consumers can clear pending timeouts on
+  // unmount. Without this, a field that is removed from the form leaves a
+  // pending timeout that resolves into a stale validator call.
+  asyncValidator.cancel = cancel;
+
+  return asyncValidator;
 };
 
 /**
@@ -43,8 +57,17 @@ export const createAsyncValidator = (asyncValidatorFn, debounceMs = 300) => {
  * @returns {Function} Retry-enabled async validator
  */
 export const withRetry = (validatorFn, maxRetries = 3, initialDelay = 1000) => {
+  // 🔥 FIX: refuse to run with maxRetries <= 0. Previously a 0-retry call
+  // would skip the for-loop body, leave `lastError` undefined, and
+  // `throw lastError` would throw `undefined` (a silent failure).
+  if (!Number.isFinite(maxRetries) || maxRetries < 1) {
+    throw new TypeError(
+      `withRetry requires maxRetries >= 1 (got ${maxRetries})`
+    );
+  }
+
   return async function retryValidator(value, ...args) {
-    let lastError;
+    let lastError = new Error("withRetry: no attempts executed");
 
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       try {


### PR DESCRIPTION
Closes #8667.

Summary of What Has Been Done:
createAsyncValidator had no cleanup hook, so pending timeouts fired into stale validator calls. withRetry threw undefined when called with maxRetries=0.

Changes Made:
- Exposed .cancel() on the returned validator so callers can clear pending timeouts on unmount.
- Validated maxRetries >= 1 in withRetry and throw a proper TypeError when called with 0.

Impact it Made:
- Prevents stale validator resolutions after unmount.
- Stops the silent throw undefined from a zero-retry call.