### PR TITLE
fix: add missing favicon link tag in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Eventra" />
 
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="manifest" href="/manifest.json" />
+
     <!-- Preconnect for faster external resource loading -->
     <link rel="preconnect" href="https://api.github.com" />
     <link rel="dns-prefetch" href="https://api.github.com" />


### PR DESCRIPTION
## Description

The favicon was not rendering on the production site despite favicon.png being present in the public/ folder. The root cause was that index.html had no <link rel="icon"> tag, so browsers had no reference to the favicon asset.
Added the missing favicon and manifest link tags in index.html to fix the production rendering issue.

Fixes #8682

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

Before:

<img width="619" height="158" alt="image" src="https://github.com/user-attachments/assets/8d9b6040-4bc5-47f6-b078-b4aec0df0168" />


After:

<img width="429" height="70" alt="image" src="https://github.com/user-attachments/assets/cbd9b7e8-a774-4f88-854b-14a5c5e41e0e" />

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have run `npm run lint` and resolved any new errors or warnings


Note: Lint errors present are pre-existing in the codebase and unrelated to this fix.