### PR TITLE
fix: add null checks for CountUp targets on Events page (#8569)

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -27,6 +27,30 @@ const TRENDING_SEARCHES = [
   "Web Development",
 ];
 
+const StatCounter = ({ stat, shouldAnimate }) => {
+  const prefix = stat.prefix || "";
+  const suffix = stat.suffix || "";
+
+  if (!shouldAnimate) {
+    return (
+      <>
+        {prefix}0{suffix}
+      </>
+    );
+  }
+
+  return (
+    <CountUp
+      start={0}
+      end={stat.value}
+      duration={2.5}
+      prefix={prefix}
+      suffix={suffix}
+      startOnMount
+    />
+  );
+};
+
 export default function EventHero({
   searchQuery,
   handleSearch,
@@ -38,12 +62,17 @@ export default function EventHero({
 
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [searchHistory, setSearchHistory] = useState([]);
+  const [hasMounted, setHasMounted] = useState(false);
   const searchContainerRef = useRef(null);
   const dropdownRef = useRef(null);
   const statsRef = useRef(null);
 
   // Trigger stats animation only when visible
   const isStatsInView = useInView(statsRef, { once: true, margin: "-100px" });
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   useEffect(() => {
     setSearchHistory(getStoredSearchHistory());
@@ -312,16 +341,7 @@ export default function EventHero({
                   <stat.icon className={`h-5 w-5 sm:h-6 sm:w-6 ${darkTheme.textSecondary}`} />
                 </div>
                 <p className={`text-xl sm:text-2xl md:text-3xl font-bold tracking-tight ${darkTheme.textPrimary}`}>
-                  <CountUp
-                    key={isStatsInView ? "start" : "reset"}
-                    start={0}
-                    end={stat.value}
-                    duration={2.5}
-                    prefix={stat.prefix}
-                    suffix={stat.suffix}
-                    enableScrollSpy
-                    scrollSpyDelay={200}
-                  />
+                  <StatCounter stat={stat} shouldAnimate={hasMounted && isStatsInView} />
                 </p>
                 <p className={`mt-1 text-xs sm:text-sm font-medium ${darkTheme.textSecondary}`}>
                   {stat.label}


### PR DESCRIPTION
## Description
The /events page was throwing 4x `[CountUp] target is null or undefined null` 
console errors because CountUp was initializing before the DOM elements were 
mounted, or refs were null at the time of initialization.

Fixed by adding null guards before each CountUp initialization so they only 
run when the target elements are confirmed to exist in the DOM.

Fixes #8569

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)
**Before:** 4x `[CountUp] target is null or undefined null` in console, counters show 0
**After:** No console errors, all 4 stat counters animate correctly

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports