### PR TITLE
fix: implement sliding-window negation handling in sentiment analyzer and add unit tests

### DIFF
--- a/src/utils/sentiment.js
+++ b/src/utils/sentiment.js
@@ -17,6 +17,12 @@ const NEGATIVE_KEYWORDS = new Set([
   "crashed", "slowly", "laggy", "painful", "horrible", "defect", "failure"
 ]);
 
+const NEGATION_WORDS = new Set([
+  "not", "no", "never", "dont", "cannot", "doesnt", "didnt",
+  "isnt", "wasnt", "arent", "neither", "none", "without", "lack", "lacks",
+  "havent", "hadnt", "hasnt", "wont", "wouldnt", "couldnt", "shouldnt"
+]);
+
 export const analyzeSentiment = (text) => {
   if (!text || typeof text !== "string") {
     return 0; // Neutral default
@@ -28,12 +34,36 @@ export const analyzeSentiment = (text) => {
   const words = normalized.match(/[a-z]+/g) || [];
   
   let score = 0;
+  let negateNext = false;
+  let negateWindow = 0;
   
   words.forEach(word => {
+    if (NEGATION_WORDS.has(word)) {
+      negateNext = true;
+      negateWindow = 3; // Negation applies to any of the next 3 words
+      return;
+    }
+    
+    let value = 0;
     if (POSITIVE_KEYWORDS.has(word)) {
-      score += 1.5;
+      value = 1.5;
     } else if (NEGATIVE_KEYWORDS.has(word)) {
-      score -= 1.5;
+      value = -1.5;
+    }
+    
+    if (value !== 0) {
+      if (negateNext && negateWindow > 0) {
+        score -= value; // Invert the sentiment score change
+        negateNext = false;
+        negateWindow = 0;
+      } else {
+        score += value;
+      }
+    } else if (negateNext) {
+      negateWindow -= 1;
+      if (negateWindow <= 0) {
+        negateNext = false;
+      }
     }
   });
 

--- a/tests/sentiment.test.mjs
+++ b/tests/sentiment.test.mjs
@@ -39,4 +39,14 @@ assert.strictEqual(mutedDisplay.label, "Muted / Negative", "score -1.5 to -0.2 s
 const frustratedDisplay = getSentimentDisplay(-2.0);
 assert.strictEqual(frustratedDisplay.label, "Frustrated / Highly Negative", "score <-1.5 should be frustrated");
 
+// Test negation handling
+const negationNegative = analyzeSentiment("not helpful at all");
+assert.ok(negationNegative < 0, "negated positive word ('not helpful') should result in negative score");
+
+const negationPositive = analyzeSentiment("no failure noticed");
+assert.ok(negationPositive > 0, "negated negative word ('no failure') should result in positive score");
+
+const negationWindowTest = analyzeSentiment("not very perfect");
+assert.ok(negationWindowTest < 0, "negated positive word with intermediate word ('not very perfect') should result in negative score");
+
 console.log("sentiment tests passed ✓");


### PR DESCRIPTION
Closes #8791 

## 🚀 Description
  This PR resolves false positives/negatives in the sentiment analyzer by implementing sliding-window negation handling. Now phrases like "not helpful" or "no failure" correctly invert their sentiment scores.

  Fixes #GSSOC-SENTIMENT-NEGATION

  ## 🛠️ Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  
  ## ✅ Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] Unit tests pass successfully
  ```
* **Uniqueness Check Results:**
  * **Open Issues Checked:** None Found
  * **Closed Issues Checked:** None Found
  * **Open PRs Checked:** None Found
  * **Merged PRs Checked:** None Found
  * **Discussions Checked:** None Found
  * **Roadmap Checked:** None Found
  * **Uniqueness Verdict:** **UNIQUE**
* **Verification Plan:**
  * Run: `node --test tests/sentiment.test.mjs` (Verified: All tests pass)