### PR TITLE
fix: resolve tooltip clipping and positioning  in collaboration map

### DIFF
--- a/src/components/CollaborationMap.jsx
+++ b/src/components/CollaborationMap.jsx
@@ -19,30 +19,19 @@ const CONNECTIONS = [
   { from: "blr", to: "syd" },
 ];
 
+const getTooltipTransform = (city) => {
+    if (!city) return "translate(-50%, -90%)";
+
+    if (city.x < 350) return "translate(-10%, 10%)";
+    if (city.y < 180) return "translate(-50%, 10%)";
+    if (city.x > 800) return "translate(-100%, -120%)";
+
+    return "translate(-50%, -90%)";
+  };  
+
 export default function CollaborationMap() {
   const [hoveredCity, setHoveredCity] = useState(null);
   const mapRef = useRef(null);
-
-  const getTooltipTransform = () => {
-    if (!hoveredCity) return "translate(-50%, -120%)";
-    // Left edge
-    if (hoveredCity.x < 350) {
-      return "translate(-10%, 10%)";
-    } 
-      
-    // Top edge
-    if (hoveredCity.y < 180) {
-      return "translate(-50%, 10%)";
-    }
-
-    // Right edge
-    if (hoveredCity.x > 800) {
-      return "translate(-100%, -120%)";
-    }
-
-    return "translate(-50%, -90%)";
-  };
-
 
   // 🔥 FIX: Added click-outside listener to support mobile touch dismissals
   useEffect(() => {
@@ -220,7 +209,7 @@ export default function CollaborationMap() {
                 style={{
                   left: `${(hoveredCity.x / 1000) * 100}%`,
                   top: `${(hoveredCity.y / 500) * 100}%`,
-                  transform: getTooltipTransform(),
+                  transform: getTooltipTransform(hoveredCity),
                   minWidth: "210px",
                   borderRadius: "14px",
                   boxShadow: "0 8px 32px rgba(0,0,0,0.18)",

--- a/src/components/CollaborationMap.jsx
+++ b/src/components/CollaborationMap.jsx
@@ -23,6 +23,27 @@ export default function CollaborationMap() {
   const [hoveredCity, setHoveredCity] = useState(null);
   const mapRef = useRef(null);
 
+  const getTooltipTransform = () => {
+    if (!hoveredCity) return "translate(-50%, -120%)";
+    // Left edge
+    if (hoveredCity.x < 350) {
+      return "translate(-10%, 10%)";
+    } 
+      
+    // Top edge
+    if (hoveredCity.y < 180) {
+      return "translate(-50%, 10%)";
+    }
+
+    // Right edge
+    if (hoveredCity.x > 800) {
+      return "translate(-100%, -120%)";
+    }
+
+    return "translate(-50%, -90%)";
+  };
+
+
   // 🔥 FIX: Added click-outside listener to support mobile touch dismissals
   useEffect(() => {
     const handleOutsideClick = (e) => {
@@ -74,7 +95,7 @@ export default function CollaborationMap() {
         </div>
 
         {/* Glassmorphic Map Container */}
-        <div ref={mapRef} className="relative bg-slate-900/40 backdrop-blur-xl border border-white/10 dark:border-slate-800/50 shadow-2xl rounded-3xl p-6 md:p-8 overflow-hidden">
+        <div ref={mapRef} className="relative bg-slate-900/40 backdrop-blur-xl border border-white/10 dark:border-slate-800/50 shadow-2xl rounded-3xl p-6 md:p-8 overflow-visible">
           
           {/* Legend/Status */}
           <div className="absolute top-6 left-6 z-10 hidden sm:flex items-center gap-4 bg-slate-950/60 backdrop-blur border border-white/5 rounded-2xl px-4 py-2.5 text-xs text-slate-300">
@@ -199,7 +220,7 @@ export default function CollaborationMap() {
                 style={{
                   left: `${(hoveredCity.x / 1000) * 100}%`,
                   top: `${(hoveredCity.y / 500) * 100}%`,
-                  transform: "translate(-50%, -120%)",
+                  transform: getTooltipTransform(),
                   minWidth: "210px",
                   borderRadius: "14px",
                   boxShadow: "0 8px 32px rgba(0,0,0,0.18)",


### PR DESCRIPTION
## Description
This PR resolves the tooltip clipping issue in the Collaboration Hub section.

Previously, hub information cards were partially hidden or rendred outisde the visible map area when hovering over nodes located near the edges of the map. This affected the readability and usability of the collaboration network visualization.

### Changes Made
- Changed the map container overflow from hidden to visible to prevent tooltip clipping.
- Added dynamic tooltip positioning logic based on node location.
- Improved tooltip placement for nodes near the:
  - Left edge
  - Top edge
  - Right edge
- Adjusted the default tooltip offset for better visual alignment.

Added dynamic tooltip positioning based on node location to prevent clipping near map boundaries.
Fixes #8711 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots 
<img width="598" height="446" alt="image" src="https://github.com/user-attachments/assets/e112179d-61ea-4ab7-93ac-c48af784fa2f" />
<img width="589" height="316" alt="image" src="https://github.com/user-attachments/assets/f7b564d9-48df-433e-88cf-20d2aee93178" />

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports

program: gssoc