### PR TITLE
feat: add formRetryQueue utility to preserve user input on network fa…

### DIFF
--- a/src/utils/formRetryQueue.js
+++ b/src/utils/formRetryQueue.js
@@ -1,0 +1,50 @@
+/**
+ * formRetryQueue.js
+ * Saves form data to localStorage when submission fails due to network issues.
+ * Allows users to retry without losing their input.
+ */
+
+const QUEUE_KEY = "eventra_form_retry_queue";
+
+export const saveFormData = (formId, data) => {
+  try {
+    const queue = getQueue();
+    queue[formId] = { data, savedAt: new Date().toISOString() };
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const getFormData = (formId) => {
+  try {
+    const queue = getQueue();
+    return queue[formId] || null;
+  } catch {
+    return null;
+  }
+};
+
+export const clearFormData = (formId) => {
+  try {
+    const queue = getQueue();
+    delete queue[formId];
+    localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const getQueue = () => {
+  try {
+    return JSON.parse(localStorage.getItem(QUEUE_KEY) || "{}");
+  } catch {
+    return {};
+  }
+};
+
+export const hasSavedData = (formId) => {
+  return Boolean(getFormData(formId));
+};


### PR DESCRIPTION
## Which issue does this PR close?
Closes #8510

## Rationale for this change
User-entered form data was lost on network interruptions with no way to recover it.

## What changes are included in this PR?
- Added src/utils/formRetryQueue.js with localStorage-based form data persistence
- saveFormData: saves form data with timestamp on submission failure
- getFormData: retrieves saved data for a specific form
- clearFormData: clears saved data after successful submission
- hasSavedData: checks if saved data exists for a form
- Forms can use this utility to restore user input after network failure

## Are these changes tested?
Utility functions verified manually in browser console.

## Are there any user-facing changes?
No direct UI change — utility layer that forms can integrate with.