### PR TITLE
feat: add registrationGuard utility to prevent duplicate event regist…

### DIFF
--- a/src/utils/registrationGuard.js
+++ b/src/utils/registrationGuard.js
@@ -1,0 +1,84 @@
+/**
+ * registrationGuard.js
+ * Prevents duplicate event registrations by tracking and validating
+ * registration attempts on the client side.
+ */
+
+const REGISTRY_KEY = "eventra_registrations";
+
+const getRegistry = () => {
+  try {
+    return JSON.parse(localStorage.getItem(REGISTRY_KEY) || "{}");
+  } catch {
+    return {};
+  }
+};
+
+const saveRegistry = (registry) => {
+  try {
+    localStorage.setItem(REGISTRY_KEY, JSON.stringify(registry));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const isAlreadyRegistered = (userId, eventId) => {
+  if (!userId || !eventId) return false;
+  const registry = getRegistry();
+  const key = `${userId}_${eventId}`;
+  return Boolean(registry[key]);
+};
+
+export const recordRegistration = (userId, eventId, metadata = {}) => {
+  if (!userId || !eventId) return false;
+  const registry = getRegistry();
+  const key = `${userId}_${eventId}`;
+  if (registry[key]) return false;
+  registry[key] = {
+    userId,
+    eventId,
+    registeredAt: new Date().toISOString(),
+    ...metadata,
+  };
+  return saveRegistry(registry);
+};
+
+export const cancelRegistration = (userId, eventId) => {
+  if (!userId || !eventId) return false;
+  const registry = getRegistry();
+  const key = `${userId}_${eventId}`;
+  if (!registry[key]) return false;
+  delete registry[key];
+  return saveRegistry(registry);
+};
+
+export const getUserRegistrations = (userId) => {
+  if (!userId) return [];
+  const registry = getRegistry();
+  return Object.values(registry).filter((r) => r.userId === userId);
+};
+
+export const getEventRegistrationCount = (eventId) => {
+  if (!eventId) return 0;
+  const registry = getRegistry();
+  return Object.values(registry).filter((r) => r.eventId === eventId).length;
+};
+
+export const validateRegistration = (userId, eventId, maxAttendees = null) => {
+  if (!userId) return { valid: false, message: "User not authenticated" };
+  if (!eventId) return { valid: false, message: "Invalid event" };
+
+  if (isAlreadyRegistered(userId, eventId)) {
+    return { valid: false, message: "You are already registered for this event" };
+  }
+
+  if (maxAttendees !== null) {
+    const count = getEventRegistrationCount(eventId);
+    if (count >= maxAttendees) {
+      return { valid: false, message: "This event is fully booked" };
+    }
+  }
+
+  return { valid: true, message: "" };
+};


### PR DESCRIPTION
## Which issue does this PR close?
Closes #8501

## Rationale for this change
Users could register multiple times for the same event causing duplicate 
records, inaccurate participant counts, and potential system abuse.

## What changes are included in this PR?
- Added src/utils/registrationGuard.js:
  - isAlreadyRegistered: checks if user is already registered for event
  - recordRegistration: saves registration with timestamp, blocks duplicates
  - cancelRegistration: removes registration record on cancellation
  - getUserRegistrations: returns all registrations for a user
  - getEventRegistrationCount: returns total registrations for an event
  - validateRegistration: full validation — checks auth, duplicates, 
    and capacity before allowing registration
- Uses userId + eventId composite key to uniquely identify registrations
- Persists to localStorage for cross-session duplicate prevention

## Are these changes tested?
Utility functions verified manually in browser console.

## Are there any user-facing changes?
No direct UI change — registration forms can call validateRegistration 
before submission to block duplicates.