### PR TITLE
feat: add AuthGuard component to block unauthenticated access to prot…

### DIFF
--- a/src/components/routes/AuthGuard.jsx
+++ b/src/components/routes/AuthGuard.jsx
@@ -1,0 +1,40 @@
+/**
+ * AuthGuard.jsx
+ * Redirects unauthenticated users away from protected routes.
+ * Saves the attempted URL so users are redirected back after login.
+ */
+
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+
+const PROTECTED_PATHS = [
+  "/dashboard",
+  "/settings",
+  "/profile",
+  "/create-event",
+  "/bookmarks",
+  "/reminders",
+];
+
+export const isProtectedPath = (pathname) => {
+  return PROTECTED_PATHS.some((path) => pathname.startsWith(path));
+};
+
+const AuthGuard = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated()) {
+    return (
+      <Navigate
+        to="/login"
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  return children;
+};
+
+export default AuthGuard;


### PR DESCRIPTION
## Which issue does this PR close?
Closes #8500

## Rationale for this change
Protected dashboard routes were accessible via direct URL navigation 
without authentication checks.

## What changes are included in this PR?
- Added src/components/routes/AuthGuard.jsx:
  - Checks isAuthenticated() before rendering protected content
  - Redirects unauthenticated users to /login
  - Saves attempted URL in location state for post-login redirect
  - PROTECTED_PATHS list covers dashboard, settings, profile, 
    create-event, bookmarks, reminders
  - isProtectedPath helper exported for use in routers

## Are these changes tested?
Manually tested — logged out users redirected to login on protected routes.

## Are there any user-facing changes?
Yes — unauthenticated users are redirected to login instead of seeing 
protected content.