### PR TITLE
fix: prevent clock precision quantization issues in rateLimiter refill

### DIFF
--- a/src/utils/rateLimiter.js
+++ b/src/utils/rateLimiter.js
@@ -54,6 +54,7 @@ export function createRateLimiter({
   function refill() {
     const now = Date.now();
     const elapsed = Math.max(0, (now - lastRefill) / 1000);
+    if (elapsed === 0) return;
     tokens = Math.min(maxTokens, tokens + elapsed * refillRate);
     lastRefill = now;
   }


### PR DESCRIPTION
## 🎯 Summary
Added guard clause in rateLimiter refill to skip updating state when elapsed duration is exactly zero.

## 🔧 Changes
- modified/created `src/utils/rateLimiter.js`

## ✅ Testing
Verified by running concurrent mock request bursts.

## 🔗 Closes
Closes #8816 