### PR TITLE
fix: remove daily dayOffset from device fingerprint salt

### DIFF
--- a/src/utils/deviceFingerprint.js
+++ b/src/utils/deviceFingerprint.js
@@ -77,7 +77,8 @@ export const getDeviceFingerprint = () => {
     // Per-origin salt: different for each deployment and never a static literal
     // in the bundle. Combining the origin with a domain-specific namespace
     // avoids salt collisions if two deployments share the same hostname root.
-    const dayOffset = Math.floor(Date.now() / 86400000);
+    // Remove daily time-based salt offset to maintain fingerprint stability across days
+    const dayOffset = 0;
 const salt = dayOffset + `eventra:fingerprint:${window.location.origin}`;
 
     _memoizedFingerprint = CryptoJS.SHA256(fingerprintRaw + salt).toString();
@@ -114,7 +115,8 @@ export const getFastFingerprint = () => {
   try {
     const screenInfo = `${window.screen?.width || 0}x${window.screen?.height || 0}x${window.screen?.colorDepth || 0}`;
     const navInfo = `${window.navigator?.userAgent || ""}_${window.navigator?.language || ""}_${window.navigator?.hardwareConcurrency || 0}`;
-    const dayOffset = Math.floor(Date.now() / 86400000);
+    // Remove daily time-based salt offset to maintain fingerprint stability across days
+    const dayOffset = 0;
 const salt = dayOffset + `eventra:fast-fingerprint:${window.location.origin}`;
     _memoizedFastFingerprint = CryptoJS.SHA256(`${screenInfo}_${navInfo}_${salt}`).toString();
     return _memoizedFastFingerprint;


### PR DESCRIPTION

## 🎯 Summary
Removed the day-based time salt offset to keep fingerprints stable and consistent across page reloads on different days.

## 🔧 Changes
- modified/created `src/utils/deviceFingerprint.js`

## ✅ Testing
Verified same fingerprint is generated before and after day boundary simulation.

## 🔗 Closes
Closes #8821 