### PR TITLE
enhancement: add high-contrast accessible custom scrollbar styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import './styles/scrollbar.css';
 @import "tailwindcss";
 @import url("https://fonts.googleapis.com/css2?family=Oxanium:wght@800&family=Inter:wght@300;400;500;600;700;800;900&display=swap");
 

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -1,0 +1,17 @@
+/* High Contrast scrollbar styling for accessibility */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb {
+  background: #6366f1;
+  border: 2px solid #f1f1f1;
+  border-radius: 5px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #4f46e5;
+}


### PR DESCRIPTION
## 🎯 Summary
Added a dedicated scrollbar.css file styling webkit-scrollbars with high-contrast indicator borders and imported it in index.css.

## 🔧 Changes
- modified/created `src/styles/scrollbar.css`
- modified/created `src/index.css`

## ✅ Testing
Visually verified on Chrome and Edge scroll tracks.

## 🔗 Closes
Closes #8843 