### PR TITLE
refactor(auth): replace direct rate limit checks with enforceRateLimit

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -120,19 +120,19 @@ export default async function login(req, res, deps = {}) {
   }
 
   const clientIp = getClientIp(req);
+
   try {
-    const rateLimitResult = loginRateLimiter.checkAsync 
-      ? await loginRateLimiter.checkAsync(clientIp)
-      : loginRateLimiter.check(clientIp);
-    
-    if (!rateLimitResult.allowed) {
+    await enforceRateLimit(loginRateLimiter, clientIp);
+  } catch (error) {
+    if (error.status === 429) {
       return corsResponse(req, res, 429, {
         success: false,
         message: "Too many authentication attempts. Please try again later.",
       });
     }
-  } catch (rateLimitError) {
-    console.error('[login] Rate limit check failed:', rateLimitError.message);
+
+    console.error("[login] Rate limit check failed:", error);
+
     return corsResponse(req, res, 500, {
       success: false,
       message: "Rate limiting service unavailable. Please try again later.",


### PR DESCRIPTION
## Description

Refactored the login endpoint to use the shared `enforceRateLimit()` helper instead of performing manual rate-limit checks through `loginRateLimiter.check()` / `checkAsync()`.

This aligns the authentication endpoint with the centralized rate-limiting pattern used elsewhere in the codebase, reduces duplicate logic, and ensures rate-limit enforcement behavior remains consistent across endpoints.

### Changes Made

- Replaced manual rate-limit checking logic with `enforceRateLimit()`
- Added proper handling for rate-limit exceptions (`429`)
- Preserved existing user-facing error responses
- Retained fallback handling for unexpected rate-limiter failures (`500`)
- Removed endpoint-specific rate-limit enforcement logic

Fixes #8640 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports