### PR TITLE
fix(#8860): add cleanup hook to close Redis connections on process exit

### DIFF
--- a/api/auth/_user-storage.js
+++ b/api/auth/_user-storage.js
@@ -432,6 +432,21 @@ class RedisStorageBackend extends StorageBackend {
 // ---------------------------------------------------------------------------
 
 let storageBackend = null;
+let cleanupRegistered = false;
+
+function registerCleanupHook() {
+  if (cleanupRegistered) return;
+  cleanupRegistered = true;
+  const cleanup = async () => {
+    if (storageBackend) {
+      await storageBackend.close().catch(() => {});
+      storageBackend = null;
+    }
+  };
+  process.on("exit", cleanup);
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+}
 
 /**
  * Get the appropriate storage backend based on environment.
@@ -442,6 +457,8 @@ export async function getStorageBackend() {
   if (storageBackend) {
     return storageBackend;
   }
+
+  registerCleanupHook();
 
   // Development/Testing: Use in-memory Maps
   if (isInMemoryStorageAllowed()) {


### PR DESCRIPTION
## Description
Adds a cleanup hook (process.on exit/SIGINT/SIGTERM) that calls \storageBackend.close()\ to properly disconnect Redis connections on serverless function completion.

## Changes
- Added \egisterCleanupHook()\ function that registers handlers for process exit, SIGINT, and SIGTERM
- Modified \getStorageBackend()\ to call \egisterCleanupHook()\ before initializing storage
- Ensures \edis.quit()\ is called on the ioredis client to prevent dangling connections

## Related Issue
Closes #8860