### PR TITLE
fix(#8862): prevent rsvpLocks Map memory leak with reference counting

### DIFF
--- a/api/events/register.js
+++ b/api/events/register.js
@@ -19,6 +19,7 @@ import { checkCapacity } from "../_lib/capacityValidator.js";
 
 // Concurrency lock for RSVP
 const rsvpLocks = new Map();
+const rsvpLockCounters = new Map();
 
 /**
  * Registration handler.
@@ -72,6 +73,9 @@ export default async function registerForEvent(req, res, deps = {}) {
     return;
   }
   
+  const counter = rsvpLockCounters.get(eventId) || 0;
+  rsvpLockCounters.set(eventId, counter + 1);
+
   if (!rsvpLocks.has(eventId)) {
     rsvpLocks.set(eventId, Promise.resolve());
   }
@@ -149,5 +153,12 @@ export default async function registerForEvent(req, res, deps = {}) {
     res.status(500).json({ error: "Internal server error" });
   } finally {
     release();
+    const remaining = rsvpLockCounters.get(eventId) - 1;
+    if (remaining <= 0) {
+      rsvpLocks.delete(eventId);
+      rsvpLockCounters.delete(eventId);
+    } else {
+      rsvpLockCounters.set(eventId, remaining);
+    }
   }
 }


### PR DESCRIPTION
## Description
The \svpLocks\ Map stores Promise resolvers per eventId but never deletes entries after resolution, causing unbounded memory growth. Added reference counting to safely clean up entries when no callers remain.

## Changes
- Added \svpLockCounters\ Map to track active callers per eventId
- Decrement counter after lock release in finally block
- Delete Map entries only when the counter reaches zero
- Prevents unbounded memory leak from ever-growing \svpLocks\ Map

## Related Issue
Closes #8862