### PR TITLE
fix(#8858): guard against unhandled promise rejection in lock critical section

### DIFF
--- a/api/events/register.js
+++ b/api/events/register.js
@@ -75,13 +75,16 @@ export default async function registerForEvent(req, res, deps = {}) {
   if (!rsvpLocks.has(eventId)) {
     rsvpLocks.set(eventId, Promise.resolve());
   }
-  
+
   const release = await new Promise(resolve => {
     const previous = rsvpLocks.get(eventId);
     let releaseFn;
-    const next = previous.then(() => new Promise(r => { releaseFn = r; }));
+    const next = Promise.resolve(previous).then(
+      () => new Promise(r => { releaseFn = r; }),
+      () => { releaseFn = () => {}; }
+    );
     rsvpLocks.set(eventId, next);
-    previous.then(() => resolve(releaseFn));
+    Promise.resolve(previous).then(() => resolve(releaseFn), () => resolve(() => {}));
   });
 
   try {


### PR DESCRIPTION
## Description
Prevents unhandled Promise rejections in the RSVP lock mechanism by ensuring \egisterAttendee()\ rejection never leaves the lock in a dangling state. Added rejection handlers to the lock promise chain for safe recovery.

## Changes
- Added rejection handlers to \Promise.resolve(previous).then()\ chains in lock acquisition
- Ensures \elease()\ is always defined even if the previous lock promise rejects
- Prevents permanent blocking of event registration due to unhandled rejections

## Related Issue
Closes #8858