### PR TITLE
fix(#8859): add concurrency limiter for validation pipeline in middleware

### DIFF
--- a/api/_lib/concurrency.js
+++ b/api/_lib/concurrency.js
@@ -1,0 +1,39 @@
+export function createConcurrencyLimiter(concurrency) {
+  if (concurrency < 1) {
+    throw new Error("Concurrency must be at least 1");
+  }
+  const queue = [];
+  let activeCount = 0;
+
+  function next() {
+    activeCount--;
+    if (queue.length > 0) {
+      const entry = queue.shift();
+      entry();
+    }
+  }
+
+  async function run(fn) {
+    if (activeCount >= concurrency) {
+      await new Promise((resolve) => {
+        queue.push(resolve);
+      });
+    }
+    activeCount++;
+    try {
+      return await fn();
+    } finally {
+      next();
+    }
+  }
+
+  return { run };
+}
+
+export async function runAll(limit, fns) {
+  if (!Array.isArray(fns) || fns.length === 0) {
+    return [];
+  }
+  const limiter = createConcurrencyLimiter(limit);
+  return Promise.all(fns.map((fn) => limiter.run(fn)));
+}

--- a/middleware.js
+++ b/middleware.js
@@ -22,6 +22,10 @@
 const API_RATE_LIMIT = 60;
 const API_RATE_WINDOW_S = 60;
 
+// Concurrency limiter for validation pipeline
+import { createConcurrencyLimiter } from "./api/_lib/concurrency.js";
+const validationLimiter = createConcurrencyLimiter(5);
+
 // ---------------------------------------------------------------------------
 // CSP Backend Origin Configuration
 // Reads backend origins from environment variables and validates them
@@ -295,6 +299,10 @@ const createGeoBlockedResponse = () =>
   );
 
 export default async function middleware(request) {
+  return validationLimiter.run(() => handleRequest(request));
+}
+
+async function handleRequest(request) {
   const country = request.geo?.country;
   
   if (isCountryBlocked(country)) {


### PR DESCRIPTION
## Description
Adds a concurrency limiter to bound parallel async validation operations in the middleware, preventing event loop starvation under high traffic.

## Changes
- Created \pi/_lib/concurrency.js\ with \createConcurrencyLimiter()\ and \unAll()\ utilities
- Integrated the limiter into the middleware request pipeline to limit concurrent processing to 5
- Prevents unbounded \Promise.all()\ scenarios from overwhelming the event loop

## Related Issue
Closes #8859