### PR TITLE
fix(#8866): reject oversized cookies before JWT decode in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -243,8 +243,13 @@ const TICKET_ROLES = new Set([
   "EVENT_MANAGER",
 ]);
 
+const MAX_COOKIE_SIZE = 4096; // 4KB
+
 const parseTokenFromCookie = (request) => {
   const cookieHeader = request.headers.get("cookie") || "";
+  if (cookieHeader.length > MAX_COOKIE_SIZE) {
+    return null;
+  }
   const tokenMatch = cookieHeader.match(/(?:^|;\s*)token\s*=\s*([^;]*)/);
   return tokenMatch ? tokenMatch[1] : null;
 };


### PR DESCRIPTION
## Description
Adds a maximum cookie size check (4KB) in the middleware before attempting JWT decode, preventing memory pressure in the edge runtime from oversized cookies.

## Changes
- Added \MAX_COOKIE_SIZE\ (4096 bytes) constant in middleware
- \parseTokenFromCookie()\ now rejects cookie headers larger than 4KB before attempting base64url decode
- Prevents memory exhaustion attacks via oversized JWT tokens in cookies

## Related Issue
Closes #8866