### PR TITLE
feat: add mock data fallback for trending events API failure

### DIFF
--- a/src/components/TrendingEvents/TrendingEvents.jsx
+++ b/src/components/TrendingEvents/TrendingEvents.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { eventService } from "../../services/eventService";
 import EventCard from "../../Pages/Events/EventCard";
 import { Calendar, TrendingUp, Users, Bookmark, Eye } from "lucide-react";
+import mockEvents from "../../Pages/Events/eventsMockData.json";
 
 const toNumber = (value) => {
   const n = typeof value === "number" ? value : Number(value);
@@ -71,8 +72,9 @@ const TrendingEvents = ({ title = "Trending Events", limit = 6, fetchSize = 24 }
         setEvents(normalized);
       } catch {
         if (!active) return;
-        setError("Failed to load trending events.");
-        setEvents([]);
+        // Backend unavailable — surface local mock data so the section stays useful.
+        const fallback = Array.isArray(mockEvents) ? mockEvents : [];
+        setEvents(fallback.slice(0, fetchSize));
       } finally {
         if (!active) return;
         setIsLoading(false);


### PR DESCRIPTION
## 📌 Related Issue Fixes
Relates to #8790

## 📝 Description
This PR implements a frontend fallback mechanism for the trending events feed. When the `GET /api/events` endpoint fails or is unavailable, the UI will gracefully degrade by loading static mock data instead of breaking the layout or rendering an empty state.

### 🔹 What has been changed?
* Imported `eventsMockData.json` into `src/components/TrendingEvents/TrendingEvents.jsx`.
* Modified the `catch` block in the API fetch routine to inject the local mock data payload when the server throws an error.

### 🔹 Why are these changes needed?
Currently, backend failures (like the 500 Internal Server Error reported in #8790) completely break the trending events UI. While the root API issue requires a backend fix, this fallback ensures visitors still see a populated, visually intact interface rather than a broken component during server downtime or API outages.

⚠️ **Note to Maintainers:** This is a UI stopgap. It should be merged alongside the actual backend endpoint fix to ensure the application remains stable during edge cases.

## 🛠️ Type of Change
* [x] Bug fix (non-breaking change which fixes an issue)
* [x] UI/UX Improvement (Graceful degradation)

## 📋 Checklist
* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings