### PR TITLE
fix: resolve 401 cascade by correcting double-prefixed refresh route

### DIFF
--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -191,11 +191,11 @@ export function setupResponseInterceptor(api, { isDev, timeoutMs, getOnUnauthori
 
       const onUnauthorized = getOnUnauthorized();
       if (status === 401) {
-        if (!config._retry && !config.url?.includes("/api/auth/refresh")) {
+        if (!config._retry && !config.url?.includes("/auth/refresh")) {
           config._retry = true;
           try {
             if (isDev) logger.info(`[API] Attempting OAuth token refresh...`);
-            await api.post("/api/auth/refresh");
+            await api.post("/auth/refresh");
             return api(config);
           } catch (refreshError) {
             logger.error("OAuth token refresh failed. Locking user out.", refreshError);


### PR DESCRIPTION
## 📌 Related Issue Fixes
Closes #8789

## 📝 Description
This PR fixes the malformed token refresh route in the Axios interceptor that was causing a 401 Unauthorized cascade.

### 🔹 What has been changed?
* **`src/config/api/interceptors.js`**: Removed the redundant `/api` prefix from the refresh token POST request and the retry conditional check. The route is now correctly targeted as `/auth/refresh`.

### 🔹 Why are these changes needed?
The Axios instance is already configured with an `/api` base URL. Hardcoding `/api/auth/refresh` in the interceptor resulted in a double prefix (`/api/api/auth/refresh`), which the backend rejected. Correcting this string ensures the refresh token logic executes cleanly, preventing users from being locked out of protected streams.

## 🛠️ Type of Change
* [x] Bug fix (non-breaking change which fixes an issue)

## 📋 Checklist
* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings