### PR TITLE
feat(#8884): add health check endpoint with service dependency probes

### DIFF
--- a/api/_lib/health.js
+++ b/api/_lib/health.js
@@ -1,0 +1,78 @@
+import { isStorageHealthy } from "../auth/_user-storage.js";
+
+const START_TIME = Date.now();
+const START_TIME_ISO = new Date(START_TIME).toISOString();
+
+function getMemoryUsage() {
+  try {
+    const usage = process.memoryUsage();
+    return {
+      rssBytes: usage.rss,
+      rssMB: Math.round(usage.rss / 1024 / 1024 * 100) / 100,
+      heapTotalBytes: usage.heapTotal,
+      heapTotalMB: Math.round(usage.heapTotal / 1024 / 1024 * 100) / 100,
+      heapUsedBytes: usage.heapUsed,
+      heapUsedMB: Math.round(usage.heapUsed / 1024 / 1024 * 100) / 100,
+      heapUsagePercent: usage.heapTotal > 0
+        ? Math.round((usage.heapUsed / usage.heapTotal) * 10000) / 100
+        : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getUptime() {
+  const seconds = Math.floor((Date.now() - START_TIME) / 1000);
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  return { seconds, formatted: `${days}d ${hours}h ${minutes}m ${seconds % 60}s` };
+}
+
+function getSystemInfo() {
+  return {
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    pid: process.pid,
+    cwd: process.cwd(),
+    env: process.env.NODE_ENV || "development",
+  };
+}
+
+async function checkDatabase() {
+  try {
+    const result = await isStorageHealthy();
+    return { status: result ? "healthy" : "degraded", message: result ? "Database reachable" : "Database unreachable" };
+  } catch (error) {
+    return { status: "unhealthy", message: error.message };
+  }
+}
+
+async function checkRateLimiter() {
+  try {
+    const { rateLimiterStorageHealth } = await import("./rate-limit-storage.js");
+    const healthy = typeof rateLimiterStorageHealth === "function"
+      ? await rateLimiterStorageHealth().catch(() => false)
+      : true;
+    return { status: healthy ? "healthy" : "degraded", message: "Rate limiter functional" };
+  } catch {
+    return { status: "healthy", message: "Rate limiter (in-memory) functional" };
+  }
+}
+
+export async function getHealthReport() {
+  const [db, rateLimiter] = await Promise.all([checkDatabase(), checkRateLimiter()]);
+  const allHealthy = db.status === "healthy" && rateLimiter.status === "healthy";
+  return {
+    status: allHealthy ? "healthy" : "degraded",
+    version: process.env.VERCEL_GIT_COMMIT_SHA || process.env.COMMIT_REF || "unknown",
+    uptime: getUptime(),
+    startTime: START_TIME_ISO,
+    timestamp: new Date().toISOString(),
+    memory: getMemoryUsage(),
+    system: getSystemInfo(),
+    checks: { database: db, rateLimiter },
+  };
+}

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,24 @@
+import { getHealthReport } from "../_lib/health.js";
+import { buildCorsHeaders } from "../auth/_cors.js";
+
+export default async function healthHandler(req, res) {
+  if (req.method === "OPTIONS") {
+    return res.status(200).set(buildCorsHeaders(req)).end();
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const report = await getHealthReport();
+    const httpStatus = report.status === "healthy" ? 200 : 503;
+    return res.status(httpStatus).json(report);
+  } catch (error) {
+    return res.status(503).json({
+      status: "unhealthy",
+      timestamp: new Date().toISOString(),
+      error: error.message,
+    });
+  }
+}

--- a/middleware.js
+++ b/middleware.js
@@ -346,7 +346,8 @@ async function handleRequest(request) {
       "/api/events",
       "/api/hackathons",
       "/api/projects",
-      "/api/validate"
+      "/api/validate",
+      "/api/health"
     ];
 
     const isPublicPath = PUBLIC_PATHS.some(path => url.pathname.startsWith(path) && (request.method === "GET" || url.pathname.includes("/auth/") || url.pathname.includes("/validate/")));


### PR DESCRIPTION
## Description
Adds a \GET /api/health\ endpoint that reports service health including database connectivity, rate limiter status, memory usage, and system info.

## Changes
- Created \pi/health.js\ - HTTP handler for GET /api/health
- Created \pi/_lib/health.js\ - Health check module with probes for database and rate limiter
- Added \/api/health\ to PUBLIC_PATHS in middleware.js (bypasses auth)
- Returns 200 when all services healthy, 503 when degraded
- Reports: uptime (formatted), memory usage (human-readable MB), system info (Node version, platform), and per-check status

**Lines changed: 105 (104 additions, 1 deletion)**

Closes #8884