### PR TITLE
fix(offline-queue): resolve IndexedDB async schema upgrade DOMExcepti…

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -126,79 +126,25 @@ const openDB = () => {
       }
 
       // ── Schema upgrade path (oldVersion >= 1) ──────────────────────────────
-      // Step 1: Rescue whatever is currently in the store BEFORE touching it.
-      //         We also merge with the localStorage mirror to maximise recovery.
-      let rescuedItems = [];
-      const lsMirror = _rescueFromLocalStorage();
-
+      // Step 1: Synchronously delete and recreate store during upgrade transaction
       if (db.objectStoreNames.contains(STORE_NAME)) {
-        // Read all existing records synchronously inside the upgrade transaction
-        const oldStore = transaction.objectStore(STORE_NAME);
-        const getAllReq = oldStore.getAll();
-
-        getAllReq.onsuccess = () => {
-          const dbItems = getAllReq.result || [];
-
-          // Merge DB items with localStorage mirror — deduplicate by item id
-          const seen = new Set();
-          rescuedItems = [...dbItems, ...lsMirror].filter((item) => {
-            if (!item || !item.id || seen.has(item.id)) return false;
-            seen.add(item.id);
-            return true;
-          });
-
-          // Step 2: Delete old store so we can recreate with updated schema
-          db.deleteObjectStore(STORE_NAME);
-
-          // Step 3: Create new store with updated schema
-          db.createObjectStore(STORE_NAME, { keyPath: "id" });
-
-          // Step 4: Re-insert rescued items into the new store
-          // We must use the same upgrade transaction — it stays open until
-          // the upgrade completes, so we can reuse it here.
-          const newStore = transaction.objectStore(STORE_NAME);
-          rescuedItems.forEach((item) => {
-            newStore.put(item);
-          });
-
-          // Step 5: Update localStorage mirror to reflect rescued items
-          try {
-            if (rescuedItems.length > 0) {
-              localStorage.setItem(QUEUE_KEY, JSON.stringify(rescuedItems));
-            } else {
-              localStorage.removeItem(QUEUE_KEY);
-            }
-          } catch {
-            // localStorage might be full — non-fatal
-          }
-
-          // Step 6: Notify UI
-          _dispatchUpgradeEvent(rescuedItems.length);
-        };
-
-        getAllReq.onerror = () => {
-          // Couldn't read old store — fall back to localStorage mirror only
-          db.deleteObjectStore(STORE_NAME);
-          const newStore = db.createObjectStore(STORE_NAME, { keyPath: "id" });
-
-          lsMirror.forEach((item) => {
-            newStore.put(item);
-          });
-
-          try {
-            if (lsMirror.length > 0) {
-              localStorage.setItem(QUEUE_KEY, JSON.stringify(lsMirror));
-            }
-          } catch {
-            // non-fatal
-          }
-
-          _dispatchUpgradeEvent(lsMirror.length);
-        };
-      } else {
-        // Store didn't exist yet — just create it
-        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+        db.deleteObjectStore(STORE_NAME);
       }
+      db.createObjectStore(STORE_NAME, { keyPath: "id" });
+
+      // Step 2: Rescue queued actions synchronously from the localStorage mirror
+      const rescuedItems = _rescueFromLocalStorage();
+
+      // Step 3: Put rescued items back into the newly created store synchronously
+      if (rescuedItems.length > 0) {
+        const store = transaction.objectStore(STORE_NAME);
+        rescuedItems.forEach((item) => {
+          store.put(item);
+        });
+      }
+
+      // Step 4: Dispatch upgrade event
+      _dispatchUpgradeEvent(rescuedItems.length);
     };
 
     request.onsuccess = (e) => resolve(e.target.result);


### PR DESCRIPTION
## Description

This PR resolves a fatal `DOMException` / `InvalidStateError` crash occurring during IndexedDB version upgrades in the offline event queue (`src/utils/offlineQueue.js`).
## Fixes #8683 
### Motivation & Context
In the previous implementation of the `onupgradeneeded` lifecycle handler, the schema structural modifications (`deleteObjectStore` and `createObjectStore`) were placed inside the asynchronous `onsuccess` callback of an IndexedDB `.getAll()` query request. 

According to the IndexedDB specification, structural schema alterations are strictly forbidden outside the main synchronous execution thread of the `onupgradeneeded` handler (the active `versionchange` transaction state). Doing so throws a fatal `InvalidStateError` / `DOMException` and crashes the application when updating the database version.

### Key Changes
1. **Synchronous Schema Modifications**: Rewrote `onupgradeneeded` to execute `deleteObjectStore` and `createObjectStore` completely synchronously inside the main lifecycle block.
2. **Synchronous LocalStorage Recovery**: Bypassed asynchronous IndexedDB database reads during upgrades by utilizing the synchronous `localStorage` backup mirror (`_rescueFromLocalStorage()`) to recover queued items.
3. **Queue Restoration**: Repopulated the newly updated store synchronously within the active `versionchange` transaction block, ensuring queue persistence without crashing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual