### PR TITLE
fix: remove dead buildLocationIndex function from recommendationEngine

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -52,12 +52,6 @@ const createLocationMatcher = (preferredLocation) => {
     eventLocation && parts.some((part) => eventLocation.includes(part));
 };
 
-const buildLocationIndex = (preferredLocation) => {
-  const parts = getLocationParts(preferredLocation);
-  if (parts.length === 0) return null;
-  return { parts, test: (loc) => parts.some((part) => loc.includes(part)) };
-};
-
 const getPopularityScore = (event) => {
   const attendees = Number(event?.attendees) || 0;
   const capacity = Number(event?.maxAttendees) || 0;


### PR DESCRIPTION
## Summary
Removes the unused buildLocationIndex function from recommendationEngine.js.

## Problem
buildLocationIndex was defined as a module-level function but never called
anywhere in the file. createLocationMatcher is the active implementation
used by calculateRecommendationScore and getTrendingEventsForArea.
The dead function increased bundle size and misled contributors.

## Fix
I deleted buildLocationIndex. No call sites exist so no other changes needed.

## Changes
- src/utils/recommendationEngine.js — removed buildLocationIndex

Closes #8902