### PR TITLE
test: ensure proper resource cleanup in sseMultiplexer subscribing test

### DIFF
--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -106,42 +106,46 @@ const testStatusSyncOnSubscribe = async () => {
 
   let receivedStatusMsg = null;
   const statusTestChannel = new globalThis.BroadcastChannel("eventra_sse_multiplexer");
-  statusTestChannel.onmessage = (e) => {
-    if (e.data && e.data.type === "SSE_STATUS" && e.data.path === "/stream/status_sync") {
-      receivedStatusMsg = e.data;
-    }
-  };
+  try {
+    statusTestChannel.onmessage = (e) => {
+      if (e.data && e.data.type === "SSE_STATUS" && e.data.path === "/stream/status_sync") {
+        receivedStatusMsg = e.data;
+      }
+    };
 
-  // Simulate follower tab subscribing to "/stream/status_sync"
-  sseMultiplexer.handleBroadcastMessage({
-    type: "SUBSCRIBE",
-    tabId: "tab_b",
-    path: "/stream/status_sync",
-  });
+    // Simulate follower tab subscribing to "/stream/status_sync"
+    sseMultiplexer.handleBroadcastMessage({
+      type: "SUBSCRIBE",
+      tabId: "tab_b",
+      path: "/stream/status_sync",
+    });
 
-  // Wait for the async connection open simulated by MockEventSource (5ms)
-  await new Promise((resolve) => setTimeout(resolve, 15));
+    // Wait for the async connection open simulated by MockEventSource (5ms)
+    await new Promise((resolve) => setTimeout(resolve, 15));
 
-  assert.ok(receivedStatusMsg !== null, "Follower should receive current connection status on SUBSCRIBE");
-  assert.equal(receivedStatusMsg.status, "connected");
-  assert.equal(receivedStatusMsg.tabId, sseMultiplexer.tabId, "Broadcast message should contain leader's tabId");
+    assert.ok(receivedStatusMsg !== null, "Follower should receive current connection status on SUBSCRIBE");
+    assert.equal(receivedStatusMsg.status, "connected");
+    assert.equal(receivedStatusMsg.tabId, sseMultiplexer.tabId, "Broadcast message should contain leader's tabId");
 
-  // Verify same for SUBSCRIBERS_RESPONSE
-  receivedStatusMsg = null;
-  sseMultiplexer.handleBroadcastMessage({
-    type: "SUBSCRIBERS_RESPONSE",
-    tabId: "tab_b",
-    paths: ["/stream/status_sync"],
-  });
+    // Verify same for SUBSCRIBERS_RESPONSE
+    receivedStatusMsg = null;
+    sseMultiplexer.handleBroadcastMessage({
+      type: "SUBSCRIBERS_RESPONSE",
+      tabId: "tab_b",
+      paths: ["/stream/status_sync"],
+    });
 
-  // Wait for any status update to complete
-  await new Promise((resolve) => setTimeout(resolve, 15));
+    // Wait for any status update to complete
+    await new Promise((resolve) => setTimeout(resolve, 15));
 
-  assert.ok(receivedStatusMsg !== null, "Follower responding with active path should receive current connection status");
-  assert.equal(receivedStatusMsg.status, "connected");
-  assert.equal(receivedStatusMsg.tabId, sseMultiplexer.tabId, "Broadcast message should contain leader's tabId");
-
-  statusTestChannel.close();
+    assert.ok(receivedStatusMsg !== null, "Follower responding with active path should receive current connection status");
+    assert.equal(receivedStatusMsg.status, "connected");
+    assert.equal(receivedStatusMsg.tabId, sseMultiplexer.tabId, "Broadcast message should contain leader's tabId");
+  } finally {
+    statusTestChannel.close();
+    sseMultiplexer.channel?.close();
+    channels.clear();
+  }
 };
 
 const runTests = async () => {


### PR DESCRIPTION
```markdown
# test: ensure proper resource cleanup in sseMultiplexer subscribing test

## Description

This PR optimizes the `testStatusSyncOnSubscribe` unit test by wrapping its assertion logic in a `try...finally` block. 

Previously, if any assertions within the test failed, execution stopped immediately without executing the cleanup statements at the end of the test. This left mock broadcast channels open, resulting in resource/memory leaks and polluting the global test channel registry. Wrapping it in `try...finally` guarantees that all channels are closed and registries are cleared regardless of whether the test passes or fails.

Fixes #8539 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

N/A (Test suite optimization)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
```