### PR TITLE
fix: remove dead HTTP error check from getGlobalWaitlist and increase notification ID entropy in waitlistUtils

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -38,7 +38,7 @@ export const addLocalNotification = async (title, message) => {
     const raw = localStorage.getItem(canonicalKey);
     const notifications = raw ? safeJsonParse(raw, []) : [];
     const newNotification = {
-      id: `local-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+      id: `local-${Date.now()}-${Math.floor(Math.random() * 1e9)}`,
       isRead: false,
       createdAt: new Date().toISOString(),
       timestamp: new Date().toISOString(),
@@ -61,9 +61,9 @@ export const getGlobalWaitlist = () => {
     const raw = localStorage.getItem(GLOBAL_WAITLIST_KEY);
     return raw ? safeJsonParse(raw, []) : [];
   } catch (err) {
-    if (err.response && err.response.status >= 400 && err.response.status < 500) {
-      throw err;
-    }
+    // localStorage throws SecurityError or QuotaExceededError — never HTTP errors.
+    // Log and return empty array so the UI degrades gracefully.
+    logger.error("[WaitlistUtils] Failed to read global waitlist from storage:", err);
     return [];
   }
 };


### PR DESCRIPTION
## Summary
Two fixes in waitlistUtils.js — one removes unreachable dead code from a
catch block and adds proper error logging, the other prevents notification
ID collisions during bulk waitlist promotions.

## Bug 1 — Dead HTTP check in getGlobalWaitlist
I removed the if (err.response && err.response.status) conditional from
the catch block — localStorage never throws HTTP errors. Added
logger.error so real storage errors (SecurityError, QuotaExceededError)
are visible in logs instead of being silently swallowed.

## Bug 2— ID collision risk in addLocalNotification
I increased Math.random() * 1000 to Math.random() * 1e9 so notification
IDs have 1 billion possible suffix values instead of 1000. Prevents
duplicate IDs when multiple notifications are created within the same
millisecond during bulk waitlist promotions.

## Changes
- src/utils/waitlistUtils.js

Closes #8905 