### PR TITLE
fix: remove unused buildLocationIndex helper

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -52,12 +52,6 @@ const createLocationMatcher = (preferredLocation) => {
     eventLocation && parts.some((part) => eventLocation.includes(part));
 };
 
-const buildLocationIndex = (preferredLocation) => {
-  const parts = getLocationParts(preferredLocation);
-  if (parts.length === 0) return null;
-  return { parts, test: (loc) => parts.some((part) => loc.includes(part)) };
-};
-
 const getPopularityScore = (event) => {
   const attendees = Number(event?.attendees) || 0;
   const capacity = Number(event?.maxAttendees) || 0;


### PR DESCRIPTION
## Description

Removes the unused module-level `buildLocationIndex` helper from `src/utils/recommendationEngine.js`.

The active recommendation flow already uses `createLocationMatcher` in the relevant code paths, so this removes dead code without changing behavior.

Closes #8902

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

N/A — utility dead-code cleanup only.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings in the touched file
- [x] Targeted lint passed: `npx eslint src/utils/recommendationEngine.js --max-warnings=250`
- [x] Targeted unit test passed: `node --test tests/recommendationEngine.test.mjs`
- [x] `git diff --check -- src/utils/recommendationEngine.js` passed
- [ ] Full `npm test`, `npm run lint`, and `npm run build` were not marked as passing because the cloned baseline failed before this focused change; targeted checks for the touched file passed.
