### PR TITLE
fix: validate endDate with formatToICSDate in generateOutlookLink to prevent RangeError crash on invalid date strings

### DIFF
--- a/src/utils/calendarExporter.js
+++ b/src/utils/calendarExporter.js
@@ -136,9 +136,15 @@ export const generateOutlookLink = (event) => {
   const { title, description, date, endDate, location } = event;
   const startDate = new Date(date);
   if (isNaN(startDate.getTime())) return null;
-  
+
   const start = startDate.toISOString();
-  const end = endDate ? new Date(endDate).toISOString() : new Date(startDate.getTime() + 2 * 60 * 60 * 1000).toISOString();
+  const fallbackEnd = new Date(startDate.getTime() + 2 * 60 * 60 * 1000).toISOString();
+  // Use formatToICSDate for safe validation — matches the pattern used by
+  // generateGoogleCalendarLink and generateYahooCalendarLink. Falls back to
+  // the 2-hour default if endDate is absent or an invalid date string.
+  const end = endDate
+    ? (formatToICSDate(endDate) ? new Date(endDate).toISOString() : fallbackEnd)
+    : fallbackEnd;
 
   const baseUrl = "https://outlook.live.com/calendar/0/deeplink/compose";
   const params = new URLSearchParams({


### PR DESCRIPTION
## Summary
Fixes generateOutlookLink in calendarExporter.js crashing with RangeError
when endDate is an invalid date string, by aligning it with the safe
formatToICSDate validation pattern used by all other link generators.

## Problem
generateOutlookLink called new Date(endDate).toISOString() directly
without validation. Invalid date strings produce Invalid Date objects
whose .toISOString() throws RangeError. generateGoogleCalendarLink
and generateYahooCalendarLink both use formatToICSDate which safely
returns null for invalid dates — generateOutlookLink was inconsistent.

## Fix
I used formatToICSDate(endDate) to validate the end date before calling
.toISOString(). Falls back to the 2-hour default duration when
formatToICSDate returns null for missing or invalid endDate values.
generateOutlookLink now matches the defensive pattern of its siblings.

## Changes
- src/utils/calendarExporter.js — validated endDate via formatToICSDate
  in generateOutlookLink with 2-hour fallback for invalid values

Closes #8910