### PR TITLE
fix: remove duplicate Back-to-Top button causing double button rendering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,6 @@ import Navbar from "./components/navbar/Navbar";
 import SkipToContent from "./components/accessibility/SkipToContent";
 import OfflineBanner from "./components/common/OfflineBanner";
 import OfflineConflictModal from "./components/common/OfflineConflictModal";
-import ScrollToTop from "./components/ScrollToTop";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import NotificationToastContainer from "./components/common/NotificationProvider";
@@ -267,7 +266,7 @@ function App() {
                   </PageTransition>
                 </main>
 
-                <ScrollToTop />
+                
                 {showChatbot && (
                   <ErrorBoundary level="section" label="Chatbot Assist" silent>
                     <Suspense fallback={null}>


### PR DESCRIPTION


## Description
Two Back-to-Top button components were being rendered simultaneously in App.jsx:

ScrollToTop (legacy) — simple button, no chatbot awareness, no accessibility features, fixed bottom-6 right-6 position
BackToTop (current) — advanced component with progress ring, chatbot detection, accessibility, reduced motion support

Both were imported and rendered in App.jsx, causing duplicate buttons on screen. Removed the legacy ScrollToTop import and usage, keeping only the superior BackToTop component.

Fixes #7119 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Screenshots / Video (if applicable)

Before:


https://github.com/user-attachments/assets/9e0e81aa-3bae-4f1c-8d0c-0a4ad223c2e8




## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
