### PR TITLE
fix: Resolve Global Collaboration Network popup flickering , Hover edge and Edge Overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26556,21 +26556,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",

--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import useReducedMotion from "../../hooks/useReducedMotion";
 import {
@@ -217,6 +217,7 @@ export default function CollaborationNetworkMap() {
   const [zoom, setZoom] = useState(1);
   const [showConnections, setShowConnections] = useState(true);
   const [particlesEnabled, setParticlesEnabled] = useState(false);
+  const hoverTimeoutRef = useRef(null);
 
   // Memoized computations
   const hubCoordinates = useMemo(() => {
@@ -268,7 +269,10 @@ export default function CollaborationNetworkMap() {
       if (e.key === "-" || e.key === "_") setZoom((z) => Math.max(z - 0.2, 0.5));
     };
     window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
+    };
   }, []);
 
   const getCoordinates = useCallback(
@@ -280,10 +284,28 @@ export default function CollaborationNetworkMap() {
     if (!hub) return {};
     const xPercent = (hub.x / 1000) * 100;
     const yPercent = (hub.y / 500) * 100;
+    
+    // Prevent horizontal overflow
+    let xTransform = "-50%";
+    if (hub.x > 750) {
+      xTransform = "-90%";
+    } else if (hub.x < 250) {
+      xTransform = "-10%";
+    }
+
+    // Prevent vertical overflow for nodes near the top
+    let yTransform = "-100%";
+    let yOffset = -4;
+    if (hub.y < 250) {
+      yTransform = "0%";
+      yOffset = 4;
+    }
+
     return { 
       left: `${xPercent}%`, 
-      top: `${yPercent - 4}%`, 
-      transform: "translate(-50%, -100%)" 
+      top: `${yPercent + yOffset}%`, 
+      x: xTransform,
+      y: yTransform
     };
   }, []);
 
@@ -302,10 +324,21 @@ export default function CollaborationNetworkMap() {
 
   const handleHubHover = useCallback(
     (hub) => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current);
+      }
       if (!pinnedHub) setActiveHub(hub);
     },
     [pinnedHub]
   );
+
+  const handleHubMouseLeave = useCallback(() => {
+    if (!pinnedHub) {
+      hoverTimeoutRef.current = setTimeout(() => {
+        setActiveHub(null);
+      }, 150);
+    }
+  }, [pinnedHub]);
 
   return (
     <section className="bg-white dark:bg-slate-950 py-16 text-slate-900 dark:text-slate-100 transition-colors duration-300">
@@ -504,7 +537,7 @@ export default function CollaborationNetworkMap() {
                       key={hub.id}
                       className="cursor-pointer select-none outline-none"
                       onMouseEnter={() => handleHubHover(hub)}
-                      onMouseLeave={() => !pinnedHub && setActiveHub(null)}
+                      onMouseLeave={handleHubMouseLeave}
                       onClick={() => handleHubClick(hub)}
                       role="button"
                     >
@@ -562,12 +595,14 @@ export default function CollaborationNetworkMap() {
             <AnimatePresence>
               {(activeHub || pinnedHub) && (
                 <motion.div
-                  initial={{ opacity: 0, y: -4, scale: 0.95 }}
-                  animate={{ opacity: 1, y: 0, scale: 1 }}
-                  exit={{ opacity: 0, y: -4, scale: 0.95 }}
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
                   transition={{ duration: 0.15 }}
                   className="absolute w-72 z-30 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 p-4 shadow-xl rounded-2xl"
                   style={getPopupStyle(activeHub || pinnedHub)}
+                  onMouseEnter={() => handleHubHover(activeHub || pinnedHub)}
+                  onMouseLeave={handleHubMouseLeave}
                 >
                   {pinnedHub && (
                     <button


### PR DESCRIPTION
### PR Description
**Resolves:** #8632 

**Overview**
This PR addresses the usability issues with the node details popup on the Global Collaboration Network map. Previously, the **popup would continuously flicker** when trying to interact with it, and **popups near the edges of the map (like Tokyo or Sydney) were getting cut off.** 

**Changes Made**
* **Hover State Management:** Introduced a 150ms delay upon leaving a node and added dedicated hover handlers (`onMouseEnter` / `onMouseLeave`) to the popup component itself. This allows users to smoothly transition their cursor from the node to the popup to click "View Details" without it prematurely disappearing.
* **Smart Edge Detection:** Updated the positioning logic so that popups are now context-aware. If a node is too close to the right/left edges, the popup intelligently translates horizontally to stay fully within the visible frame. If a node is too close to the top edge, the popup will now drop below the node rather than above it. 
* **Framer Motion Transform Fix:** Resolved a conflict where Framer Motion's vertical float animation was overriding the CSS `transform` styles. The translation properties (`x` and `y`) are now passed directly to the style engine to ensure the edge detection offsets apply correctly. 

**Testing Instructions**
1. Navigate to the Networking page and scroll down to the Global Collaboration Network section.
2. Hover over any central node (like Bengaluru) and move the cursor onto the popup. Verify that it remains open and does not flicker.
3. Hover over edge nodes like Tokyo, Sydney, or London and verify the popups shift appropriately to stay fully visible inside the frame.

**Live Demo Video and Screenshots**

https://github.com/user-attachments/assets/94711f8a-8298-40f3-96a8-e96d0f6f30de

<img width="1723" height="970" alt="Screenshot 2026-06-15 at 1 06 07 AM" src="https://github.com/user-attachments/assets/cc326cdc-726b-45cd-9d4e-4cb2d2748936" />
<img width="1652" height="839" alt="Screenshot 2026-06-15 at 1 06 21 AM" src="https://github.com/user-attachments/assets/aff59e14-1416-40bb-b74e-adf9b516dfe8" />

Fixes #8632 

