### PR TITLE
fix: replace undefined isAdmin() and boolean isOrganizer() with correct role checks

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -353,7 +353,7 @@ const EventDetails = () => {
                 Share Event
               </button>
 
-              {(isAdmin() || isOrganizer()) && event.status !== "cancelled" && (
+              {isOrganizer && event.status !== "cancelled" && (
                 <button
                   onClick={() => setShowCancelModal(true)}
                   className="inline-flex items-center justify-center rounded-full border border-red-500 px-6 py-3 text-sm font-semibold text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition"


### PR DESCRIPTION
## Description

In `src/Pages/Events/EventDetails.js` at line 356, two errors existed:

1. `isAdmin()` is called as a function but is never imported or defined
   anywhere in the file — throws `ReferenceError: isAdmin is not defined`
   and crashes the entire component.

2. `isOrganizer` is defined as a boolean on line 47 but was called as
   `isOrganizer()` — throws `TypeError: isOrganizer is not a function`.

Fixed by replacing both incorrect function calls with the existing
`isOrganizer` boolean, which already covers the ADMIN check:

`const isOrganizer = user?.roles?.includes(ROLES.ORGANIZER) || user?.roles?.includes(ROLES.ADMIN);`

Fixes #8490

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
{(isAdmin() || isOrganizer()) && event.status !== "cancelled" && (
```
After:
```js
{isOrganizer && event.status !== "cancelled" && (
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings