### PR TITLE
fix: merge server waitlist data instead of overwriting entire global waitlist

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -83,7 +83,8 @@ export const syncWaitlistFromServer = async (eventId) => {
     const response = await apiUtils.get(`${API_ENDPOINTS.EVENTS.ALL}/${eventId}/waitlist`);
     if (response.ok && response.data) {
       const serverData = Array.isArray(response.data) ? response.data : response.data.entries || [];
-      saveGlobalWaitlist(serverData);
+      const existing = getGlobalWaitlist().filter(r => r.eventId !== eventId);
+      saveGlobalWaitlist([...existing, ...serverData]);
       return serverData;
     }
   } catch {


### PR DESCRIPTION
## Description

In `src/utils/waitlistUtils.js` at line 86, `saveGlobalWaitlist(serverData)`
replaced the ENTIRE `eventra_global_waitlists` localStorage key with waitlist
data from just the one eventId that was synced.

Syncing event A's waitlist silently deleted all cached waitlist entries
for events B, C, D from localStorage.

Fixed by reading the existing global waitlist first, filtering out only
the entries for the synced eventId, then merging with the new server data:

```js
const existing = getGlobalWaitlist().filter(r => r.eventId !== eventId);
saveGlobalWaitlist([...existing, ...serverData]);
```

Closes #8494

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video

Before:
```js
saveGlobalWaitlist(serverData);
```
After:
```js
const existing = getGlobalWaitlist().filter(r => r.eventId !== eventId);
saveGlobalWaitlist([...existing, ...serverData]);
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings