### PR TITLE
fix(hooks): add SSR guard to executeSyncWithLocalLock in useOfflineSync

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -404,8 +404,17 @@ const useOfflineSync = () => {
       const LOCK_KEY = "eventra_offline_sync_local_lock";
       const LOCK_TIMEOUT_MS = 30_000;
 
+      // 🔥 FIX: SSR guard. Previously the localStorage access below
+      // threw ReferenceError in any Node.js-like environment. On SSR
+      // there is no cross-tab concern, so we just return without
+      // acquiring a lock — the Web Locks API path (if available) still
+      // runs via handleOnline. Falls through to a no-op otherwise.
+      if (typeof window === "undefined" || !window.localStorage) {
+        return;
+      }
+
       const now = Date.now();
-      const lockVal = localStorage.getItem(LOCK_KEY);
+      const lockVal = window.localStorage.getItem(LOCK_KEY);
 
       if (lockVal) {
         try {
@@ -419,9 +428,9 @@ const useOfflineSync = () => {
 
       const currentTabId = Math.random().toString(36).slice(2, 9);
       const lockData = JSON.stringify({ timestamp: now, tabId: currentTabId });
-      
+
       try {
-        localStorage.setItem(LOCK_KEY, lockData);
+        window.localStorage.setItem(LOCK_KEY, lockData);
       } catch {
         // If localStorage fails (private mode etc.), run sync directly to avoid blocking
         await executeSync();
@@ -431,7 +440,7 @@ const useOfflineSync = () => {
       const heartbeatInterval = setInterval(() => {
         if (syncLockAborted.current) { clearInterval(heartbeatInterval); return; }
         try {
-          localStorage.setItem(LOCK_KEY, JSON.stringify({ timestamp: Date.now(), tabId: currentTabId }));
+          window.localStorage.setItem(LOCK_KEY, JSON.stringify({ timestamp: Date.now(), tabId: currentTabId }));
         } catch {}
       }, 10_000);
       heartbeatIntervalRef.current = heartbeatInterval;
@@ -441,11 +450,11 @@ const useOfflineSync = () => {
       } finally {
         clearInterval(heartbeatInterval);
         try {
-          const checkVal = localStorage.getItem(LOCK_KEY);
+          const checkVal = window.localStorage.getItem(LOCK_KEY);
           if (checkVal) {
             const parsed = safeJsonParse(checkVal, {});
             if (parsed && parsed.tabId === currentTabId) {
-              localStorage.removeItem(LOCK_KEY);
+              window.localStorage.removeItem(LOCK_KEY);
             }
           }
         } catch {}


### PR DESCRIPTION
Closes #8937.

Summary of What Has Been Done:
executeSyncWithLocalLock called localStorage directly in 4 places with no typeof window guard.

Changes Made:
- Added an early return at the top of the function: when window or localStorage is unavailable there is no cross-tab concern, so we just return without acquiring a lock. The Web Locks API path in handleOnline still runs.
- Updated the bare 'localStorage.*' references inside the function to use 'window.localStorage.*' for consistency with the rest of the file.

Impact it Made:
- Removes the SSR crash. Hook now mounts cleanly in any environment.