### PR TITLE
fix(utils/abuseLogger.js): add SSR guard for localStorage

### DIFF
--- a/src/utils/abuseLogger.js
+++ b/src/utils/abuseLogger.js
@@ -1,4 +1,5 @@
 export const logAbuseAttempt = (type, details = {}) => {
+  if (typeof localStorage === "undefined") return;
   try {
     let existing;
     try {


### PR DESCRIPTION
## Summary
Accesses `localStorage` in `logAbuseAttempt()` without checking if it is defined, causing a ReferenceError in SSR environments (Next.js, Remix, Jest without jsdom).

## Changes
Added SSR guard at the top of `logAbuseAttempt()`:
```js
if (typeof localStorage === "undefined") return;
```

## Impact
Without this fix, any server-side render or unit test that calls `logAbuseAttempt()` crashes immediately with "localStorage is not defined". This is a high-severity bug.

Closes #8948