### PR TITLE
fix(hooks/useOfflineStatus.js): add navigator/window SSR guards

### DIFF
--- a/src/hooks/useOfflineStatus.js
+++ b/src/hooks/useOfflineStatus.js
@@ -5,9 +5,12 @@ import { useState, useEffect } from 'react';
  * @returns {boolean} isOffline
  */
 export const useOfflineStatus = () => {
-  const [isOffline, setIsOffline] = useState(!navigator.onLine);
+  const [isOffline, setIsOffline] = useState(
+    typeof navigator !== "undefined" ? !navigator.onLine : false
+  );
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const handleOnline = () => setIsOffline(false);
     const handleOffline = () => setIsOffline(true);
 


### PR DESCRIPTION
## Summary
`useState(!navigator.onLine)` uses `navigator` which is undefined in SSR, causing the entire hook to fail. Also `window.addEventListener` is called without a window guard.

## Changes
Added navigator and window guards:
```js
const [isOffline, setIsOffline] = useState(
  typeof navigator !== "undefined" ? !navigator.onLine : false
);

useEffect(() => {
  if (typeof window === "undefined") return;
  ...
}, []);
```

## Impact
Hook crashes the server during SSR with "navigator is not defined". High-severity bug.

Closes #8953