### PR TITLE
fix(hooks/useMultiSessionRecovery.js): add readMultiSessions to useEffect deps

### DIFF
--- a/src/hooks/useMultiSessionRecovery.js
+++ b/src/hooks/useMultiSessionRecovery.js
@@ -31,7 +31,7 @@ export const useMultiSessionRecovery = ({
     setLocalSessions((current) =>
       normalizeMultiSessions([...current, ...readMultiSessions(storage, storageKey), ...initialSessions]),
     );
-  }, [initialSessions, storage, storageKey]);
+  }, [initialSessions, storage, storageKey, readMultiSessions]);
 
   const persist = useCallback(
     (nextSessions) => {


### PR DESCRIPTION
## Summary
The `useEffect` calls `readMultiSessions(storage, storageKey)` but `readMultiSessions` is absent from the dependency array, causing ESLint exhaustive-deps warnings and stale closure risk.

## Changes
Added `readMultiSessions` to the dependency array:
```js
}, [initialSessions, storage, storageKey, readMultiSessions]);
```

## Impact
If `readMultiSessions` changes (module update, hot reload), the effect wont re-run, causing stale data. Medium severity.

Closes #8954