### PR TITLE
fix(hooks/useDocumentTitle.js): add document SSR guard in useEffect

### DIFF
--- a/src/hooks/useDocumentTitle.js
+++ b/src/hooks/useDocumentTitle.js
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 
 const useDocumentTitle = (title) => {
     useEffect(() => {
+        if (typeof document === "undefined") return;
         const previousTitle = document.title
         document.title = title
 


### PR DESCRIPTION
## Summary
`document.title` is accessed inside useEffect without checking if `document` is defined, causing a ReferenceError in SSR environments.

## Changes
Added document guard at the top of the effect:
```js
useEffect(() => {
  if (typeof document === "undefined") return;
  const previousTitle = document.title;
  document.title = title;
```

## Impact
SSR renders crash with "document is not defined". High-severity bug.

Closes #8956