### PR TITLE
fix(hooks/useInstallPrompt.js): add window SSR guard in useEffect

### DIFF
--- a/src/hooks/useInstallPrompt.js
+++ b/src/hooks/useInstallPrompt.js
@@ -5,6 +5,7 @@ export function useInstallPrompt() {
   const [isInstallable, setIsInstallable] = useState(false);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const handler = (e) => {
       e.preventDefault();
       setDeferredPrompt(e);


### PR DESCRIPTION
## Summary
`window.addEventListener()` and `window.removeEventListener()` are called without checking if `window` is defined, crashing in SSR environments.

## Changes
Added window guard inside the useEffect:
```js
useEffect(() => {
  if (typeof window === "undefined") return;
  window.addEventListener("beforeinstallprompt", handler);
  return () => window.removeEventListener("beforeinstallprompt", handler);
}, []);
```

## Impact
SSR renders crash with "window is not defined". High-severity bug.

Closes #8957