### PR TITLE
fix: clear stale error and isLoading on logout and clear stale user on falsy setToken in useAuthStore

### DIFF
--- a/src/store/useAuthStore.js
+++ b/src/store/useAuthStore.js
@@ -47,7 +47,7 @@ export const useAuthStore = create((set) => ({
   logout: () => {
     // Clear the in-memory token immediately.
     inMemoryTokenStore.clearToken();
-    set({ user: null, isAuthenticated: false });
+    set({ user: null, isAuthenticated: false, error: null, isLoading: false });
     logger.info("User logged out");
   },
 
@@ -65,6 +65,14 @@ export const useAuthStore = create((set) => ({
    */
   setToken: (token) => {
     inMemoryTokenStore.setToken(token);
-    set({ isAuthenticated: !!token });
+    // When token is falsy (null, undefined, "") treat it as a session
+    // invalidation — clear user and error alongside isAuthenticated so
+    // the store is never left in the inconsistent { isAuthenticated: false,
+    // user: <stale> } state.
+    if (!token) {
+      set({ isAuthenticated: false, user: null, error: null });
+    } else {
+      set({ isAuthenticated: true });
+    }
   },
 }));


### PR DESCRIPTION
## Summary
Two state consistency fixes in useAuthStore.js — one ensures logout
leaves the store in a fully clean baseline state, the other prevents
a stale user object persisting when a token is invalidated.

## Bug 1 — logout stale error and isLoading
I added error: null and isLoading: false to the logout set call so
the store is fully reset and the login UI cannot display a stale
error message on the next render.

## Bug 2 — setToken stale user on falsy token
I added a branch in setToken — when token is falsy, user and error
are cleared alongside isAuthenticated: false to eliminate the
{ isAuthenticated: false, user: <stale> } inconsistent state.
When token is truthy, only isAuthenticated is updated as before
since setToken is not responsible for setting user data.

## Changes
- src/store/useAuthStore.js

Closes #8980 