### PR TITLE
fix: remove dead SyntaxError check in storageManager.get — safeJsonParse absorbs parse errors so the check was never reachable

### DIFF
--- a/src/utils/storage/storageManager.js
+++ b/src/utils/storage/storageManager.js
@@ -50,14 +50,10 @@ export const storageManager = {
 
       return parsed.value;
     } catch (error) {
-      // 4. Detailed logging instead of silent deletion
-      logger.error(`[Storage] Corruption error for key "${key}":`, error);
-      
-      // Only remove if it's a parse error (definitely corrupted)
-      if (error instanceof SyntaxError) {
-        logger.warn(`[Storage] Removing corrupted key: ${key}`);
-        localStorage.removeItem(key);
-      }
+      // safeJsonParse never re-throws SyntaxError — only localStorage access
+      // errors (SecurityError, QuotaExceededError) reach here. Log and return
+      // null; do not attempt removeItem since the access error would repeat.
+      logger.error(`[Storage] Access error for key "${key}":`, error);
       return null;
     }
   },


### PR DESCRIPTION
## Summary
Removes unreachable dead code from storageManager.get catch block.

## Problem
The catch checked instanceof SyntaxError before removing a corrupted
key. safeJsonParse never re-throws — it always returns the fallback.
Only localStorage access errors reach the catch and they are never
SyntaxError. The removeItem was therefore dead code.

## Fix
I removed the instanceof check. Updated the comment to correctly
describe which errors actually reach the catch block.

## Changes
- src/utils/storage/storageManager.js — removed dead SyntaxError
  conditional from get catch block

Closes #8982 