### PR TITLE
fix: replace console.warn and console.error with logger utility in activityTracker

### DIFF
--- a/src/utils/activityTracker.js
+++ b/src/utils/activityTracker.js
@@ -1,4 +1,5 @@
 import { safeJsonParse } from "./safeJsonParse.js";
+import { logger } from "./logger.js";
 // 🔥 FIX: In-memory queue and lock to prevent localStorage race conditions
 let isUpdating = false;
 let interestQueue = [];
@@ -38,7 +39,7 @@ const processInterestQueue = () => {
         existing = safeJsonParse(raw, {}) || {};
       }
     } catch (parseError) {
-      console.warn("Failed to parse user profile JSON, resetting it:", parseError);
+      logger.warn("Failed to parse user profile JSON, resetting it:", parseError);
     }
 
     let interests = existing.interests || [];
@@ -65,7 +66,7 @@ const processInterestQueue = () => {
       );
     }
   } catch (error) {
-    console.error("Failed to update user interests:", error);
+    logger.error("Failed to update user interests:", error);
     interestQueue = []; // Clear the queue on persistent error to avoid infinite recursion
   } finally {
     isUpdating = false;
@@ -91,6 +92,6 @@ export const clearActivityHistory = () => {
       localStorage.removeItem("eventra_user_profile");
     }
   } catch (error) {
-    console.error("Failed to clear activity history:", error);
+    logger.error("Failed to clear activity history:", error);
   }
 };


### PR DESCRIPTION
## Summary
Replaces console.warn and console.error with the project's logger
utility in activityTracker.js for consistent logging across all utils.

## Problem
Three logging calls used console directly while every other file in
the codebase uses logger from utils/logger. console calls ignore
log-level config, always fire in tests, and produce inconsistent
output format.

## Fix
I imported logger and replaced all three console calls with logger.warn
and logger.error respectively. No behavioural change.

## Changes
- src/utils/activityTracker.js

Closes #8984 