### PR TITLE
fix: replace all console.error calls with logger utility across all validators in asyncValidators

### DIFF
--- a/src/utils/asyncValidators.js
+++ b/src/utils/asyncValidators.js
@@ -5,6 +5,7 @@
  */
 
 import { apiUtils } from "../config/api.js";
+import { logger } from "./logger.js";
 
 /**
  * Generic async validator factory
@@ -82,7 +83,7 @@ export const validateUsernameAvailable = async (username) => {
 
     return response.data.available === true || "Username already taken";
   } catch (error) {
-    console.error("Username validation error:", error);
+    logger.error("Username validation error:", error);
     throw error;
   }
 };
@@ -106,7 +107,7 @@ export const validateEmailAvailable = async (email) => {
 
     return response.data.available === true || "Email already registered";
   } catch (error) {
-    console.error("Email validation error:", error);
+    logger.error("Email validation error:", error);
     throw error;
   }
 };
@@ -130,7 +131,7 @@ export const validateEmailDomainExists = async (email) => {
 
     return response.data.valid === true || "Email domain does not exist";
   } catch (error) {
-    console.error("Email domain validation error:", error);
+    logger.error("Email domain validation error:", error);
     throw error;
   }
 };
@@ -162,7 +163,7 @@ export const validatePasswordStrength = async (password) => {
     const allMet = Object.values(requirements).every(Boolean);
     return allMet || "Password does not meet strength requirements";
   } catch (error) {
-    console.error("Password strength validation error:", error);
+    logger.error("Password strength validation error:", error);
     throw error;
   }
 };
@@ -186,7 +187,7 @@ export const validatePhoneNumber = async (phone) => {
 
     return response.data.valid === true || "Invalid phone number";
   } catch (error) {
-    console.error("Phone validation error:", error);
+    logger.error("Phone validation error:", error);
     throw error;
   }
 };
@@ -210,7 +211,7 @@ export const validateInvitationCode = async (code) => {
 
     return response.data.valid === true || "Invitation code is invalid or already used";
   } catch (error) {
-    console.error("Invitation code validation error:", error);
+    logger.error("Invitation code validation error:", error);
     throw error;
   }
 };
@@ -235,7 +236,7 @@ export const validatePromoCode = async (code, context = {}) => {
 
     return response.data.valid === true || response.data.message || "Invalid promo code";
   } catch (error) {
-    console.error("Promo code validation error:", error);
+    logger.error("Promo code validation error:", error);
     throw error;
   }
 };
@@ -283,7 +284,7 @@ export const createCustomAsyncValidator = (endpoint, options = {}) => {
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       return response.data[successField] === true || errorMessage;
     } catch (error) {
-      console.error("Custom validation error:", error);
+      logger.error("Custom validation error:", error);
       throw error;
     }
   };


### PR DESCRIPTION
## Summary
Replaces eight console.error calls with the project's logger utility
in asyncValidators.js for consistent logging across all validators.

## Problem
All eight validator functions used console.error directly while every
other file in the codebase uses logger from utils/logger. console.error
calls ignore log-level config, always fire in tests producing noisy
output, and are inconsistent with the project logging standard.

## Fix
I imported logger and replaced all eight console.error calls with
logger.error. No behavioural change.

## Changes
- src/utils/asyncValidators.js

Closes #8986 