### PR TITLE
fix: resolve eslint unused variable warning for feedbackColor #8942

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -246,11 +246,7 @@ const Newsletter = () => {
         {feedback.message ? (
           <p
             id={feedbackId}
-            className={`text-xs font-medium ${
-              feedback.type === "success"
-                ? "text-emerald-600 dark:text-emerald-400"
-                : "text-red-600 dark:text-red-400"
-            }`}
+            className={`text-xs font-medium ${feedbackColor}`}
           >
             {feedback.message}
           </p>


### PR DESCRIPTION
## Description

Integrated the declared but unused `feedbackColor` variable into the newsletter component's feedback message element inside `src/components/Layout/Footer.js`. This resolves the ESLint `no-unused-vars` warning and ensures proper code quality standards are maintained.

Fixes #8942

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports