### PR TITLE
fix: auto-resolve source conflicts with -X theirs strategy

### DIFF
--- a/.github/workflows/auto-sync-upstream.yml
+++ b/.github/workflows/auto-sync-upstream.yml
@@ -67,12 +67,6 @@ jobs:
           token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Setup Node
-        if: steps.metadata.outputs.isDraft != 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Sync branch with upstream master
         if: steps.metadata.outputs.isDraft != 'true'
         env:
@@ -84,37 +78,6 @@ jobs:
           git remote add upstream "https://github.com/${{ github.repository }}.git" || true
           git fetch upstream master
 
-          if git merge upstream/master --no-edit -m "chore: merge upstream master to sync branch"; then
-            echo "PR #$PR_NUM: clean merge, pushing..."
-            git push origin "HEAD:${{ steps.metadata.outputs.headRef }}"
-            exit 0
-          fi
-
-          CONFLICT_FILES=$(git diff --name-only --diff-filter=U)
-          echo "Conflicted files: $CONFLICT_FILES"
-
-          ONLY_MINIFIED=true
-          for file in $CONFLICT_FILES; do
-            if ! echo "$file" | grep -Eq "^dist/assets/.*\.(css|js)$"; then
-              ONLY_MINIFIED=false
-              break
-            fi
-          done
-
-          if [ "$ONLY_MINIFIED" = "true" ] && [ -n "$CONFLICT_FILES" ]; then
-            echo "PR #$PR_NUM: conflicts only in minified bundles, auto-resolving..."
-            for file in $CONFLICT_FILES; do
-              git checkout --ours -- "$file"
-              git add "$file"
-            done
-            npm ci
-            npm run build
-            git add dist/
-            git commit -m "chore: resolve minified bundle conflicts and rebuild"
-            git push origin "HEAD:${{ steps.metadata.outputs.headRef }}"
-            echo "PR #$PR_NUM: auto-resolved and pushed"
-          else
-            echo "::warning::PR #$PR_NUM: source conflicts detected, manual resolution needed"
-            echo "Conflicted files: $CONFLICT_FILES"
-            git merge --abort
-          fi
+          git merge upstream/master --no-edit -X theirs -m "chore: merge upstream master to sync branch"
+          git push origin "HEAD:${{ steps.metadata.outputs.headRef }}"
+          echo "PR #$PR_NUM: synced with upstream master"


### PR DESCRIPTION
## Summary

Replaces the current conflict-detection logic with a simpler \git merge -X theirs\ strategy that auto-resolves ALL conflicts (both source and minified) in favor of upstream/master.

## Problem

When a PR branch has source conflicts with master, the workflow aborts (\git merge --abort\) and leaves the PR out of sync. The PR author must manually resolve conflicts before the branch can be synced.

## Solution

Use \git merge -X theirs\ which automatically resolves all conflicts by accepting the upstream/master version. This ensures:

- Every open PR branch always receives the sync commit (\chore: merge upstream master to sync branch\)
- Source code conflicts are resolved in favor of upstream/master
- The PR branch never goes stale — always based on latest master
- PR authors can re-apply their conflicting changes after reviewing the merge commit

## Removed

- Setup Node step (no longer needed since we don't rebuild dist/)
- Minified bundle conflict resolution (superseded by -X theirs)
- Warning message and abort path

Fixes #8138

