### PR TITLE
fix: improve error messages when backend returns 500

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -94,7 +94,14 @@ const EventDetails = () => {
       if (fallback) {
         setEvent({ ...fallback, status: getEventStatus(fallback) });
       } else {
-        setFetchError("Event not found.");
+        const status = error?.status || error?.response?.status;
+        if (status >= 500) {
+          setFetchError("Something went wrong on our end. Please try again later.");
+        } else if (status === 404) {
+          setFetchError("Event not found.");
+        } else {
+          setFetchError("Could not load event details. Please try again.");
+        }
       }
     } finally {
       const shouldFinishLoading = isLatestRequest();

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -113,6 +113,7 @@ const Login = () => {
         );
       }
     } catch (err) {
+      const errStatus = err?.status || err?.response?.status;
       toast.error(getPublicErrorMessage(err, AUTH_ERRORS.loginFailed));
       const retryAfterHeader =
         err?.response?.headers?.["retry-after"] ||
@@ -126,7 +127,7 @@ const Login = () => {
         toast.error(
           `Too many requests. Please wait ${Math.ceil(serverDelayMs / 1000)} seconds before trying again.`
         );
-      } else {
+      } else if (!errStatus || errStatus < 500) {
         recordAttempt();
         toast.error(err.message || "Login failed. Please check your credentials.");
       }

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -3,7 +3,7 @@ import { getCSRFToken, requiresCSRF } from "../../utils/csrfToken.js";
 import { logger } from "../../utils/logger.js";
 import { ApiError, RateLimitError, CSRFError } from "./errors.js";
 
-const RETRYABLE_STATUS_CODES = [502, 503, 504];
+const RETRYABLE_STATUS_CODES = [500, 502, 503, 504];
 const RETRYABLE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);
 const MAX_RETRIES = 1;
 const RETRY_DELAY_MS = 1_000;

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -309,6 +309,10 @@ export const AuthProvider = ({ children }) => {
   );
 
   const getAuthErrorMessage = (error, fallbackMessage) => {
+    const status = error?.status || error?.response?.status;
+    if (status >= 500) {
+      return "Something went wrong on our end. Please try again shortly.";
+    }
     return (
       error?.response?.data?.message ||
       error?.response?.data?.error ||
@@ -329,10 +333,6 @@ export const AuthProvider = ({ children }) => {
 
         const data = res.data;
 
-        if (res.status !== 200) {
-          throw new Error(data?.message || data?.error || "Invalid credentials");
-        }
-
         const { sessionUser } = extractSession(data, usernameOrEmail);
 
         const persisted = await persistSession("cookie-managed", sessionUser);
@@ -344,6 +344,14 @@ export const AuthProvider = ({ children }) => {
         if (!isMountedRef.current) return false;
         // Fix (Issue #8646):
         document.cookie = "token=; Max-Age=0; path=/; Secure; SameSite=Strict";
+
+        const status = error?.status || error?.response?.status;
+        // Re-throw server errors so Login.js catch can show the correct message
+        if (status >= 500) {
+          setAuthRequest({ loading: false, error: null });
+          throw error;
+        }
+
         setAuthRequest({
           loading: false,
           error: getAuthErrorMessage(error, "Login failed. Please try again."),


### PR DESCRIPTION
## Description

When the backend returns HTTP 500 errors, the frontend displayed misleading error messages. This PR fixes the error messaging to accurately describe server issues and added 500 to the retryable status codes.

## Changes

### `src/context/AuthContext.js`
- `getAuthErrorMessage`: return server error message for status >= 500 instead of falling through to generic message
- `login()` catch: re-throw server errors (500+) so the Login component can show the correct message via `getPublicErrorMessage` (which maps 500 to `t("error.serverError")`); clear authRequest.error to avoid duplicate inline error display
- Removed dead code that threw `"Invalid credentials"` for non-200 responses (this path was unreachable because axios interceptors handle non-2xx before the success handler)

### `src/components/auth/Login.js`
- Skip the duplicate toast and failure recording for server errors (status >= 500) — the primary `getPublicErrorMessage` toast already shows the correct "server error" message

### `src/Pages/Events/EventDetails.js`
- When loading event details fails, check the HTTP status code:
  - 500+ -> "Something went wrong on our end. Please try again later." (was: "Event not found.")
  - 404 -> "Event not found."
  - Other -> "Could not load event details. Please try again." (was: "Event not found.")

### `src/config/api/interceptors.js`
- Added `500` to `RETRYABLE_STATUS_CODES` so transient internal server errors are automatically retried once before failing (was: only 502/503/504 were retried)

Closes #9032
