### PR TITLE
Removed Horizontal Scrollbar 

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -551,6 +551,14 @@ html {
 /* Lenis smooth scrolling styles */
 html.lenis {
   height: auto;
+  overflow-x: hidden !important; /* Forces horizontal cutoff on html */
+}
+
+/* Overrides the dynamic inline body overflow: auto rules */
+body[style] {
+  overflow-x: hidden !important;
+  position: relative !important;
+  max-width: 100vw !important;
 }
 
 .lenis.lenis-smooth {


### PR DESCRIPTION
## Description

This PR resolves a persistent global horizontal scrollbar layout bug caused by a conflict between the Lenis smooth-scrolling library's calculations and native browser viewports.

### Changes:
* **Lenis Style Overrides:** Added `overflow-x: hidden !important` to the `html.lenis` class block to restrict horizontal boundaries during virtual scroll injection.
* **Inline Attribute Override:** Implemented a `body[style]` selector utilizing `!important` flags to explicitly override the runtime-injected `style="overflow: auto;"` property on the document body, preventing layout calculations from spilling outside `100vw`.

Fixes #9011 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots / Video (if applicable)

<img width="1896" height="146" alt="image" src="https://github.com/user-attachments/assets/f3653d90-707f-42a6-8205-3d07369b6012" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
