### PR TITLE
fix: migrate bg-gradient-* to bg-linear-* for Tailwind v4 compatibility

### DIFF
--- a/src/Pages/About/AboutCTA.js
+++ b/src/Pages/About/AboutCTA.js
@@ -32,7 +32,7 @@ const bubbles = [
 const AboutCTA = () => {
   return (
     <motion.section
-      className="relative overflow-hidden rounded-3xl mx-4 md:mx-8 my-16 border border-slate-800 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950"
+      className="relative overflow-hidden rounded-3xl mx-4 md:mx-8 my-16 border border-slate-800 bg-linear-to-br from-slate-950 via-slate-900 to-indigo-950"
       initial={{ opacity: 0, y: 40 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-100px" }}
@@ -94,7 +94,7 @@ const AboutCTA = () => {
           viewport={{ once: true }}
         >
           Build, Collaborate & Grow
-          <span className="block bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
+          <span className="block bg-linear-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
             Together with Eventra
           </span>
         </motion.h2>
@@ -146,7 +146,7 @@ const AboutCTA = () => {
         >
           <Link
             to="/signup"
-            className="group inline-flex items-center justify-center gap-2 px-8 py-4 rounded-xl font-semibold text-white bg-gradient-to-r from-blue-600 to-indigo-600 shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 hover:scale-105 transition-all duration-300"
+            className="group inline-flex items-center justify-center gap-2 px-8 py-4 rounded-xl font-semibold text-white bg-linear-to-r from-blue-600 to-indigo-600 shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 hover:scale-105 transition-all duration-300"
           >
             <Users size={20} />
             Get Started Free

--- a/src/Pages/About/MissionVision.js
+++ b/src/Pages/About/MissionVision.js
@@ -111,7 +111,7 @@ export default function MissionVision() {
           <motion.div
             variants={cardVariants}
             whileHover={{ y: -6 }}
-            className="group bg-gradient-to-br from-indigo-950/60 via-slate-900 to-slate-900 border border-indigo-900/40 rounded-3xl p-10"
+            className="group bg-linear-to-br from-indigo-950/60 via-slate-900 to-slate-900 border border-indigo-900/40 rounded-3xl p-10"
           >
             <motion.div
               variants={iconVariants}

--- a/src/Pages/About/ModernAbout.js
+++ b/src/Pages/About/ModernAbout.js
@@ -143,7 +143,7 @@ export default function ModernAbout() {
               className="text-5xl md:text-7xl font-bold text-white mb-8 leading-tight"
             >
               Building Better Events
-              <span className="block bg-gradient-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
+              <span className="block bg-linear-to-r from-blue-400 via-indigo-400 to-purple-400 bg-clip-text text-transparent">
                 Together
               </span>
             </motion.h1>

--- a/src/Pages/Calendar/MyCalendar.jsx
+++ b/src/Pages/Calendar/MyCalendar.jsx
@@ -201,7 +201,7 @@ const MyCalendar = () => {
               <CalendarIcon className="w-4 h-4" />
               Scheduling Studio
             </div>
-            <h1 className="text-3xl sm:text-4xl font-black tracking-tight mt-1.5 bg-clip-text text-transparent bg-gradient-to-r from-slate-950 to-indigo-700 dark:from-slate-100 dark:to-indigo-400">
+            <h1 className="text-3xl sm:text-4xl font-black tracking-tight mt-1.5 bg-clip-text text-transparent bg-linear-to-r from-slate-950 to-indigo-700 dark:from-slate-100 dark:to-indigo-400">
               Registrations Calendar
             </h1>
             <p className="text-slate-500 dark:text-slate-400 mt-2 text-xs sm:text-sm max-w-2xl leading-relaxed">
@@ -242,7 +242,7 @@ const MyCalendar = () => {
             {myEvents.length > 0 && (
               <button
                 onClick={() => downloadBulkICSFile(myEvents)}
-                className="p-2.5 px-4 rounded-2xl text-xs font-black uppercase tracking-wider transition-all flex items-center gap-2 cursor-pointer bg-gradient-to-r from-indigo-600 to-indigo-700 hover:from-indigo-500 hover:to-indigo-600 text-white shadow-md hover:shadow-lg"
+                className="p-2.5 px-4 rounded-2xl text-xs font-black uppercase tracking-wider transition-all flex items-center gap-2 cursor-pointer bg-linear-to-r from-indigo-600 to-indigo-700 hover:from-indigo-500 hover:to-indigo-600 text-white shadow-md hover:shadow-lg"
                 aria-label="Export all events as ICS"
               >
                 <Download className="w-3.5 h-3.5" />
@@ -276,12 +276,12 @@ const MyCalendar = () => {
                       onClick={() => setActiveCategory(cat.id)}
                       className={`relative p-2.5 px-4 rounded-xl text-xs font-black tracking-wide border cursor-pointer transition-all ${
                         isActive
-                          ? "bg-gradient-to-r from-indigo-500/10 to-indigo-600/15 border-indigo-500 text-indigo-600 dark:text-indigo-400 shadow-md"
+                          ? "bg-linear-to-r from-indigo-500/10 to-indigo-600/15 border-indigo-500 text-indigo-600 dark:text-indigo-400 shadow-md"
                           : "bg-white/50 dark:bg-slate-900/30 border-slate-200/50 dark:border-slate-800/40 text-slate-500 hover:text-slate-800 dark:hover:text-slate-200"
                       }`}
                     >
                       <span className="relative z-10 flex items-center gap-2">
-                        <span className={`w-2 h-2 rounded-full bg-gradient-to-r ${cat.color}`} />
+                        <span className={`w-2 h-2 rounded-full bg-linear-to-r ${cat.color}`} />
                         {cat.label}
                       </span>
                     </motion.button>
@@ -384,7 +384,7 @@ const MyCalendar = () => {
                                       <span
                                         key={`${item.eventId}-${i}`}
                                         className={`w-1.5 h-1.5 rounded-full ${
-                                          selected ? "bg-white" : `bg-gradient-to-r ${theme.color}`
+                                          selected ? "bg-white" : `bg-linear-to-r ${theme.color}`
                                         }`}
                                       />
                                     );
@@ -482,7 +482,7 @@ const MyCalendar = () => {
                     <>
                       {/* Vertical line */}
                       <div className="absolute left-3.5 sm:left-5 top-2 bottom-2 w-0.5 bg-slate-200 dark:bg-slate-800/80 rounded-full" />
-                      <div className="absolute left-3.5 sm:left-5 top-2 h-1/2 w-0.5 bg-gradient-to-b from-indigo-500 to-pink-500 rounded-full shadow-[0_0_8px_rgba(99,102,241,0.5)]" />
+                      <div className="absolute left-3.5 sm:left-5 top-2 h-1/2 w-0.5 bg-linear-to-b from-indigo-500 to-pink-500 rounded-full shadow-[0_0_8px_rgba(99,102,241,0.5)]" />
 
                       <div className="space-y-8">
                         {timelineEvents.map((item, index) => {
@@ -502,7 +502,7 @@ const MyCalendar = () => {
                               className="absolute -left-[30px] sm:-left-[37px] top-1.5 w-5 h-5 rounded-full bg-white dark:bg-slate-950 border-4 flex items-center justify-center z-10"
                               style={{ borderColor: getCategoryBorderColor(theme) }}
                             >
-                              <span className={`w-1.5 h-1.5 rounded-full bg-gradient-to-r ${theme.color} animate-ping`} />
+                              <span className={`w-1.5 h-1.5 rounded-full bg-linear-to-r ${theme.color} animate-ping`} />
                             </div>
 
                             {/* Date label */}
@@ -526,7 +526,7 @@ const MyCalendar = () => {
                               <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
                                 <div className="space-y-1.5">
                                   <div className="flex items-center gap-2.5">
-                                    <span className={`px-2.5 py-0.5 rounded-lg text-[9px] font-black uppercase bg-gradient-to-r ${theme.color} text-white`}>
+                                    <span className={`px-2.5 py-0.5 rounded-lg text-[9px] font-black uppercase bg-linear-to-r ${theme.color} text-white`}>
                                       {item.event.category || "General"}
                                     </span>
                                     <span className="text-[11px] font-semibold text-slate-400">

--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -213,7 +213,7 @@ const ContactUsInner = () => {
   };
 
   return (
-    <div className="pastel-grid-bg min-h-screen bg-white bg-gradient-to-r from-slate-900 to-black hover:from-black hover:to-slate-800 shadow-xl shadow-black/20 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 relative overflow-hidden">
+    <div className="pastel-grid-bg min-h-screen bg-white bg-linear-to-r from-slate-900 to-black hover:from-black hover:to-slate-800 shadow-xl shadow-black/20 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 relative overflow-hidden">
       <div className="max-w-4xl w-full mx-auto">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -228,7 +228,7 @@ const ContactUsInner = () => {
         >
           <div className="md:flex gap-0">
             <div
-              className="md:w-3/5 lg:w-2/5 bg-gradient-to-r from-slate-950 via-slate-900 to-indigo-950 text-white p-12 flex flex-col justify-between rounded-3xl shadow-xl backdrop-blur-lg"
+              className="md:w-3/5 lg:w-2/5 bg-linear-to-r from-slate-950 via-slate-900 to-indigo-950 text-white p-12 flex flex-col justify-between rounded-3xl shadow-xl backdrop-blur-lg"
               data-aos="fade-right"
               data-aos-duration="1000"
               data-aos-anchor=".ContactUs"
@@ -389,7 +389,7 @@ const ContactUsInner = () => {
                     whileTap={{ scale: 0.98 }}
                     type="submit"
                     disabled={isSubmitting}
-                    className="w-full overflow-hidden rounded-xl border border-slate-300/25 bg-gradient-to-r from-slate-800 via-slate-900 to-indigo-900 px-4 py-3.5 text-sm font-semibold text-white shadow-lg shadow-slate-900/35 transition-all duration-300 hover:from-slate-700 hover:via-slate-800 hover:to-indigo-800 hover:shadow-slate-900/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-80 dark:border-slate-600/40 dark:focus-visible:ring-offset-gray-900"
+                    className="w-full overflow-hidden rounded-xl border border-slate-300/25 bg-linear-to-r from-slate-800 via-slate-900 to-indigo-900 px-4 py-3.5 text-sm font-semibold text-white shadow-lg shadow-slate-900/35 transition-all duration-300 hover:from-slate-700 hover:via-slate-800 hover:to-indigo-800 hover:shadow-slate-900/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-80 dark:border-slate-600/40 dark:focus-visible:ring-offset-gray-900"
                   >
                     {isSubmitting ? (
                       <svg

--- a/src/Pages/Events/BookmarkedEvents.js
+++ b/src/Pages/Events/BookmarkedEvents.js
@@ -58,7 +58,7 @@ const BookmarkedEvents = () => {
 
           <Link
             to="/events"
-            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-600 via-indigo-700 to-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-lg transition-all duration-300 hover:from-indigo-500 hover:via-indigo-600 hover:to-slate-800 hover:shadow-xl"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-indigo-600 via-indigo-700 to-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-lg transition-all duration-300 hover:from-indigo-500 hover:via-indigo-600 hover:to-slate-800 hover:shadow-xl"
           >
             <CalendarDays size={18} />
             Explore Events

--- a/src/Pages/Events/EventAnalyticsDashboard.jsx
+++ b/src/Pages/Events/EventAnalyticsDashboard.jsx
@@ -52,7 +52,7 @@ const StatCard = ({ title, value, change, icon: Icon, colorClass, index }) => (
     transition={{ delay: index * 0.1 }}
     className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-white/10 rounded-3xl p-6 shadow-sm hover:shadow-md transition-shadow relative overflow-hidden"
   >
-    <div className={`absolute top-0 right-0 w-24 h-24 bg-gradient-to-br ${colorClass} opacity-10 rounded-bl-[100px] pointer-events-none`} />
+    <div className={`absolute top-0 right-0 w-24 h-24 bg-linear-to-br ${colorClass} opacity-10 rounded-bl-[100px] pointer-events-none`} />
     <div className="flex items-start justify-between">
       <div>
         <p className="text-sm font-semibold text-slate-500 dark:text-slate-400 mb-1">{title}</p>
@@ -62,7 +62,7 @@ const StatCard = ({ title, value, change, icon: Icon, colorClass, index }) => (
           {change} from last week
         </p>
       </div>
-      <div className={`p-3 rounded-2xl bg-gradient-to-br ${colorClass} text-white shadow-lg`}>
+      <div className={`p-3 rounded-2xl bg-linear-to-br ${colorClass} text-white shadow-lg`}>
         <Icon size={24} />
       </div>
     </div>

--- a/src/Pages/Events/EventCTA.js
+++ b/src/Pages/Events/EventCTA.js
@@ -6,7 +6,7 @@ const EventCTA = () => {
 
   return (
     <section 
-      className="relative py-16 px-8 m-8 rounded-3xl bg-gradient-to-r from-slate-950 via-slate-900 to-indigo-950 text-white shadow-xl overflow-hidden"
+      className="relative py-16 px-8 m-8 rounded-3xl bg-linear-to-r from-slate-950 via-slate-900 to-indigo-950 text-white shadow-xl overflow-hidden"
       // AOS Implementation
       data-aos="zoom-in-up"
       data-aos-duration="1000"

--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -156,7 +156,7 @@ export default function EventHero({
         className="absolute inset-0 bg-[url('/assets/eventbg.png')] bg-cover bg-center bg-no-repeat"
         aria-hidden="true"
       />
-      <div className="absolute inset-0 bg-gradient-to-b from-blue-50/80 via-indigo-50/40 to-white dark:from-slate-950/90 dark:via-slate-900/70 dark:to-slate-950/95" />
+      <div className="absolute inset-0 bg-linear-to-b from-blue-50/80 via-indigo-50/40 to-white dark:from-slate-950/90 dark:via-slate-900/70 dark:to-slate-950/95" />
 
       <div className="relative z-10 flex flex-col items-center justify-center px-4 py-16 sm:py-20 md:py-24">
         <h1
@@ -164,7 +164,7 @@ export default function EventHero({
           style={{ fontFamily: '"Big Shoulders Display", sans-serif' }}
         >
           Discover{" "}
-          <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+          <span className="bg-linear-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
             Events
           </span>
         </h1>

--- a/src/Pages/Events/LiveInteractionHub.jsx
+++ b/src/Pages/Events/LiveInteractionHub.jsx
@@ -15,7 +15,7 @@ const LiveInteractionHub = () => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-indigo-900 via-purple-900 to-black p-6">
+    <div className="min-h-screen bg-linear-to-br from-indigo-900 via-purple-900 to-black p-6">
       <div className="mx-auto max-w-4xl bg-white/10 backdrop-blur-xl rounded-3xl shadow-xl border border-white/20">
         <Tab.Group selectedIndex={selectedIndex} onChange={setSelectedIndex}>
           <Tab.List className="flex p-2 space-x-2">

--- a/src/Pages/Events/RemindersPage.js
+++ b/src/Pages/Events/RemindersPage.js
@@ -59,7 +59,7 @@ const RemindersPage = () => {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-indigo-50 via-white to-white pt-12 pb-16 text-slate-900 dark:from-slate-950 dark:via-slate-950 dark:to-gray-950 dark:text-gray-100" style={{
+    <div className="min-h-screen bg-linear-to-b from-indigo-50 via-white to-white pt-12 pb-16 text-slate-900 dark:from-slate-950 dark:via-slate-950 dark:to-gray-950 dark:text-gray-100" style={{
     backgroundImage: "url('/assets/bookmarkbg.png')",
     backgroundSize: "cover",
     backgroundPosition: "center",
@@ -84,7 +84,7 @@ const RemindersPage = () => {
 
           <Link
             to="/bookmarks"
-            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-600 via-indigo-700 to-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-lg transition-all duration-300 hover:from-indigo-500 hover:via-indigo-600 hover:to-slate-800 hover:shadow-xl"
+            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-linear-to-r from-indigo-600 via-indigo-700 to-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-lg transition-all duration-300 hover:from-indigo-500 hover:via-indigo-600 hover:to-slate-800 hover:shadow-xl"
           >
             <CalendarDays size={18} />
             View Bookmarks

--- a/src/Pages/Events/VirtualVenueWalkthrough.jsx
+++ b/src/Pages/Events/VirtualVenueWalkthrough.jsx
@@ -194,7 +194,7 @@ const VirtualVenueWalkthrough = () => {
         <div>
           <div className="flex items-center gap-2">
             <span className="h-2.5 w-2.5 rounded-full bg-emerald-500 animate-pulse" />
-            <h1 className="text-3xl font-extrabold tracking-tight bg-gradient-to-r from-indigo-400 via-purple-400 to-pink-500 bg-clip-text text-transparent">
+            <h1 className="text-3xl font-extrabold tracking-tight bg-linear-to-r from-indigo-400 via-purple-400 to-pink-500 bg-clip-text text-transparent">
               Eventra 3D Virtual Venue
             </h1>
           </div>
@@ -262,7 +262,7 @@ const VirtualVenueWalkthrough = () => {
                   <button
                     key={room.id}
                     onClick={() => setSelectedRoom(room)}
-                    className="absolute bg-gradient-to-tr text-white p-3 rounded-2xl flex flex-col justify-between border select-none transition-all duration-300 transform active:scale-95 cursor-pointer outline-none group/item"
+                    className="absolute bg-linear-to-tr text-white p-3 rounded-2xl flex flex-col justify-between border select-none transition-all duration-300 transform active:scale-95 cursor-pointer outline-none group/item"
                     style={{
                       left: room.coordinates.x,
                       top: room.coordinates.y,
@@ -348,7 +348,7 @@ const VirtualVenueWalkthrough = () => {
             <div className="text-[10px] font-bold tracking-widest text-indigo-400 uppercase">Currently Exploring</div>
             <div className="space-y-2">
               <h2 className="text-2xl font-extrabold flex items-center gap-2">
-                <span className="w-1.5 h-6 bg-gradient-to-b from-indigo-500 to-purple-500 rounded-full" />
+                <span className="w-1.5 h-6 bg-linear-to-b from-indigo-500 to-purple-500 rounded-full" />
                 {selectedRoom.label}
               </h2>
               <p className="text-xs text-gray-400 leading-relaxed bg-white/5 border border-white/5 p-3 rounded-xl">
@@ -386,7 +386,7 @@ const VirtualVenueWalkthrough = () => {
                     <button
                       key={booth.id}
                       onClick={() => handleOpenBooth(booth)}
-                      className="p-3.5 bg-gradient-to-r from-slate-900 to-indigo-950/30 hover:to-indigo-950/60 border border-white/5 hover:border-indigo-500/30 rounded-xl transition-all duration-300 text-left flex items-center justify-between group cursor-pointer"
+                      className="p-3.5 bg-linear-to-r from-slate-900 to-indigo-950/30 hover:to-indigo-950/60 border border-white/5 hover:border-indigo-500/30 rounded-xl transition-all duration-300 text-left flex items-center justify-between group cursor-pointer"
                     >
                       <div className="flex items-center gap-3">
                         {/* Mock logo shape */}

--- a/src/Pages/FAQ/FaqCTA.jsx
+++ b/src/Pages/FAQ/FaqCTA.jsx
@@ -78,7 +78,7 @@ export default function FAQCTA() {
       <div className="absolute inset-0 overflow-hidden rounded-3xl">
         <div className="absolute top-0 left-1/4 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl animate-pulse" />
         <div className="absolute bottom-0 right-1/4 w-96 h-96 bg-teal-500/10 rounded-full blur-3xl animate-pulse" />
-        <div className="absolute inset-0 bg-gradient-to-tr from-[#0C0C1F] via-[#1A1F36] to-[#0B1E2E] rounded-3xl" />
+        <div className="absolute inset-0 bg-linear-to-tr from-[#0C0C1F] via-[#1A1F36] to-[#0B1E2E] rounded-3xl" />
       </div>
 
       {/* Decorative border */}
@@ -93,7 +93,7 @@ export default function FAQCTA() {
           transition={{ duration: 0.6 }}
         >
           <div className="relative inline-flex items-center gap-2 bg-white/5 backdrop-blur-md rounded-full px-6 py-2 border border-white/20 shadow-lg shadow-purple-500/10">
-            <div className="absolute inset-0 rounded-full bg-gradient-to-r from-purple-500/20 via-transparent to-teal-500/20 opacity-50" />
+            <div className="absolute inset-0 rounded-full bg-linear-to-r from-purple-500/20 via-transparent to-teal-500/20 opacity-50" />
             <HelpCircle className="relative w-5 h-5 text-white/90" aria-hidden="true" />
             <span className="relative text-white/90 text-sm tracking-wider font-medium">
               {t("faq.ctaBadge")}
@@ -109,7 +109,7 @@ export default function FAQCTA() {
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.8, ease: "easeOut" }}
         >
-          <span className="bg-gradient-to-r from-white via-purple-200 to-teal-200 bg-clip-text text-transparent">
+          <span className="bg-linear-to-r from-white via-purple-200 to-teal-200 bg-clip-text text-transparent">
             {t("faq.ctaHeading")}
           </span>
         </motion.h2>
@@ -146,7 +146,7 @@ export default function FAQCTA() {
             >
               {/* Animated gradient background on hover */}
               <div
-                className={`absolute inset-0 bg-gradient-to-br ${card.hoverGradient} opacity-0 group-hover:opacity-100 transition-opacity duration-500`}
+                className={`absolute inset-0 bg-linear-to-br ${card.hoverGradient} opacity-0 group-hover:opacity-100 transition-opacity duration-500`}
               />
 
               {/* Glowing border effect */}
@@ -155,7 +155,7 @@ export default function FAQCTA() {
               {/* Icon container with glow */}
               <div className="relative">
                 <div
-                  className={`absolute inset-0 bg-gradient-to-br ${card.accentColor} rounded-full blur-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500`}
+                  className={`absolute inset-0 bg-linear-to-br ${card.accentColor} rounded-full blur-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500`}
                 />
                 <div className="relative p-4 bg-white/5 rounded-2xl border border-white/10 group-hover:border-white/20 transition-all duration-300">
                   {card.icon}

--- a/src/Pages/Feedback/SurveyEngine.jsx
+++ b/src/Pages/Feedback/SurveyEngine.jsx
@@ -223,7 +223,7 @@ const SurveyEngine = () => {
         {/* HEADER BAR */}
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
           <div>
-            <h1 className="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-indigo-500 to-sky-400 bg-clip-text text-transparent">
+            <h1 className="text-4xl font-extrabold tracking-tight bg-linear-to-r from-indigo-500 to-sky-400 bg-clip-text text-transparent">
               Dynamic Survey Constructor
             </h1>
             <p className="mt-1 text-slate-500 dark:text-slate-400">

--- a/src/Pages/FeedbackSystemDemo.jsx
+++ b/src/Pages/FeedbackSystemDemo.jsx
@@ -125,7 +125,7 @@ const FeedbackSystemDemo = () => {
   const tagStats = getTagStats(demoEvent.id);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 p-8">
+    <div className="min-h-screen bg-linear-to-br from-slate-900 to-slate-800 p-8">
       <div className="max-w-6xl mx-auto">
         {/* Header */}
         <motion.div
@@ -356,7 +356,7 @@ const FeedbackSystemDemo = () => {
                     .map(([tag, count]) => (
                       <div
                         key={tag}
-                        className="px-4 py-2 bg-gradient-to-r from-indigo-500 to-purple-500 text-white rounded-full text-sm font-medium shadow-md"
+                        className="px-4 py-2 bg-linear-to-r from-indigo-500 to-purple-500 text-white rounded-full text-sm font-medium shadow-md"
                       >
                         {tag} ×{count}
                       </div>

--- a/src/Pages/Hackathons/HackathonCTA.js
+++ b/src/Pages/Hackathons/HackathonCTA.js
@@ -19,7 +19,7 @@ const HackathonCTA = () => {
     <>
       <section
         className="relative mx-6 sm:mx-8 my-10 py-16 sm:py-20 px-6 sm:px-12 rounded-3xl overflow-hidden
-          bg-gradient-to-br from-indigo-50/50 via-white to-blue-50/50 dark:from-slate-950 dark:via-indigo-950/80 dark:to-slate-950
+          bg-linear-to-br from-indigo-50/50 via-white to-blue-50/50 dark:from-slate-950 dark:via-indigo-950/80 dark:to-slate-950
           border border-indigo-100 dark:border-white/10
           shadow-[0_8px_30px_rgba(99,102,241,0.08)] dark:shadow-[0_0_80px_rgba(99,102,241,0.15)]
           text-center transition-colors duration-300"
@@ -69,7 +69,7 @@ const HackathonCTA = () => {
             transition={{ duration: prefersReducedMotion ? 0 : 0.6, delay: 0.1 }}
           >
             Join Our{" "}
-            <span className="bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 dark:from-blue-400 dark:via-indigo-400 dark:to-violet-400 bg-clip-text text-transparent">
+            <span className="bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 dark:from-blue-400 dark:via-indigo-400 dark:to-violet-400 bg-clip-text text-transparent">
               Hackathon Community
             </span>
           </motion.h2>
@@ -88,7 +88,7 @@ const HackathonCTA = () => {
           <div className="flex flex-col sm:flex-row justify-center gap-4">
             <motion.a
               href="/hackathons"
-              className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 text-white font-semibold px-8 py-3.5 rounded-xl shadow-lg dark:shadow-[0_0_24px_rgba(99,102,241,0.4)] hover:shadow-xl dark:hover:shadow-[0_0_36px_rgba(99,102,241,0.6)] transition-all duration-300 border border-indigo-500/30"
+              className="inline-flex items-center justify-center gap-2 bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 text-white font-semibold px-8 py-3.5 rounded-xl shadow-lg dark:shadow-[0_0_24px_rgba(99,102,241,0.4)] hover:shadow-xl dark:hover:shadow-[0_0_36px_rgba(99,102,241,0.6)] transition-all duration-300 border border-indigo-500/30"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
@@ -133,7 +133,7 @@ const HackathonCTA = () => {
                 <X className="w-4 h-4 text-slate-500 dark:text-slate-300" />
               </button>
 
-              <div className="w-14 h-14 rounded-full bg-gradient-to-br from-blue-600 to-violet-600 flex items-center justify-center mx-auto mb-5 shadow-[0_8px_16px_rgba(99,102,241,0.25)] dark:shadow-[0_0_24px_rgba(99,102,241,0.4)]">
+              <div className="w-14 h-14 rounded-full bg-linear-to-br from-blue-600 to-violet-600 flex items-center justify-center mx-auto mb-5 shadow-[0_8px_16px_rgba(99,102,241,0.25)] dark:shadow-[0_0_24px_rgba(99,102,241,0.4)]">
                 <UserPlus className="w-6 h-6 text-white" />
               </div>
 
@@ -144,7 +144,7 @@ const HackathonCTA = () => {
               </p>
 
               <button
-                className="mt-6 px-6 py-2.5 rounded-xl bg-gradient-to-r from-blue-600 to-violet-600 text-white font-semibold text-sm shadow-md hover:shadow-lg dark:shadow-none dark:hover:shadow-[0_0_20px_rgba(99,102,241,0.4)] transition-all"
+                className="mt-6 px-6 py-2.5 rounded-xl bg-linear-to-r from-blue-600 to-violet-600 text-white font-semibold text-sm shadow-md hover:shadow-lg dark:shadow-none dark:hover:shadow-[0_0_20px_rgba(99,102,241,0.4)] transition-all"
                 onClick={() => setShowModal(false)}
               >
                 Got it

--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -184,7 +184,7 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
       }`}
       {...props}
     >
-      <div className={`h-[3px] w-full bg-gradient-to-r ${style.topBar}`} />
+      <div className={`h-[3px] w-full bg-linear-to-r ${style.topBar}`} />
 
       <div className="flex flex-1 flex-col gap-4 p-5">
         <div className="flex items-start justify-between gap-2">
@@ -311,7 +311,7 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
               <button
                 type="button"
                 onClick={() => navigate(`/register/${normalizedHackathon.id}`)}
-                className="rounded-xl bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
+                className="rounded-xl bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
               >
                 Register
               </button>
@@ -327,7 +327,7 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
             <>
               <button
                 type="button"
-                className="rounded-xl bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
+                className="rounded-xl bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
                 aria-label={
                   status === "live"
                     ? `Join ${normalizedHackathon.title}`

--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -43,7 +43,7 @@ export default function HackathonHero({
   const { user } = useAuth();
 
   return (
-    <div className="relative overflow-hidden bg-gradient-to-b from-slate-50 via-indigo-50/40 to-slate-50 dark:from-slate-950 dark:via-indigo-950/60 dark:to-slate-950 text-slate-900 dark:text-white py-16 sm:py-20 md:py-24 border-b border-slate-200 dark:border-indigo-900/40 transition-colors duration-300">
+    <div className="relative overflow-hidden bg-linear-to-b from-slate-50 via-indigo-50/40 to-slate-50 dark:from-slate-950 dark:via-indigo-950/60 dark:to-slate-950 text-slate-900 dark:text-white py-16 sm:py-20 md:py-24 border-b border-slate-200 dark:border-indigo-900/40 transition-colors duration-300">
 
       {/* ── Animated mesh background blobs ── */}
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
@@ -99,7 +99,7 @@ export default function HackathonHero({
             Discover{" "}
           </span>
           <span
-            className="bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 dark:from-blue-400 dark:via-indigo-400 dark:to-violet-400 bg-clip-text text-transparent"
+            className="bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 dark:from-blue-400 dark:via-indigo-400 dark:to-violet-400 bg-clip-text text-transparent"
             style={{ filter: "drop-shadow(0 0 24px rgba(99,102,241,0.3))" }}
           >
             Hackathons
@@ -181,11 +181,11 @@ export default function HackathonHero({
           <motion.button
             whileHover={{ scale: 1.04 }}
             whileTap={{ scale: 0.97 }}
-            className="relative overflow-hidden px-7 py-3.5 rounded-xl font-semibold text-white shadow-lg dark:shadow-[0_0_24px_rgba(99,102,241,0.4)] bg-gradient-to-r from-blue-600 via-indigo-600 to-violet-600 transition-all duration-200 flex items-center gap-2 border border-indigo-500/30"
+            className="relative overflow-hidden px-7 py-3.5 rounded-xl font-semibold text-white shadow-lg dark:shadow-[0_0_24px_rgba(99,102,241,0.4)] bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 transition-all duration-200 flex items-center gap-2 border border-indigo-500/30"
             onClick={scrollToCards}
           >
             {/* Shine effect */}
-            <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full hover:translate-x-full transition-transform duration-700" />
+            <span className="absolute inset-0 bg-linear-to-r from-transparent via-white/20 to-transparent -translate-x-full hover:translate-x-full transition-transform duration-700" />
             <Sparkles className="w-5 h-5" />
             Explore Hackathons
           </motion.button>
@@ -225,10 +225,10 @@ export default function HackathonHero({
               className="relative overflow-hidden rounded-2xl border border-slate-200 dark:border-white/10 bg-white/80 dark:bg-white/5 p-6 flex flex-col items-center text-center backdrop-blur-md shadow-sm hover:shadow-md dark:shadow-[0_4px_24px_rgba(0,0,0,0.3)] transition-all duration-300 group"
             >
               {/* Gradient top border line */}
-              <div className={`absolute top-0 left-0 right-0 h-[3px] bg-gradient-to-r ${stat.color} opacity-80 group-hover:opacity-100 transition-opacity`} />
+              <div className={`absolute top-0 left-0 right-0 h-[3px] bg-linear-to-r ${stat.color} opacity-80 group-hover:opacity-100 transition-opacity`} />
 
               {/* Icon */}
-              <div className={`mb-4 flex items-center justify-center h-12 w-12 rounded-xl bg-gradient-to-br ${stat.color} shadow-sm dark:shadow-[0_0_20px_rgba(99,102,241,0.2)]`}>
+              <div className={`mb-4 flex items-center justify-center h-12 w-12 rounded-xl bg-linear-to-br ${stat.color} shadow-sm dark:shadow-[0_0_20px_rgba(99,102,241,0.2)]`}>
                 <stat.icon className="h-6 w-6 text-white" />
               </div>
 

--- a/src/Pages/Hackathons/HackathonLifecycle.jsx
+++ b/src/Pages/Hackathons/HackathonLifecycle.jsx
@@ -198,7 +198,7 @@ const HackathonLifecycle = () => {
               <Shield className="w-4 h-4" />
               Eventra Organizer Hub
             </div>
-            <h1 className="text-4xl md:text-5xl font-black tracking-tight mt-2 bg-clip-text text-transparent bg-gradient-to-r from-text to-primary">
+            <h1 className="text-4xl md:text-5xl font-black tracking-tight mt-2 bg-clip-text text-transparent bg-linear-to-r from-text to-primary">
               Hackathon Lifecycle
             </h1>
             <p className="text-text-light mt-2 max-w-xl text-base">
@@ -285,7 +285,7 @@ const HackathonLifecycle = () => {
                   )}
                 </div>
 
-                <div className={`inline-flex p-2.5 rounded-xl bg-gradient-to-br ${phase.color} text-white mb-4`}>
+                <div className={`inline-flex p-2.5 rounded-xl bg-linear-to-br ${phase.color} text-white mb-4`}>
                   <PhaseIcon className="w-5 h-5" />
                 </div>
 
@@ -322,7 +322,7 @@ const HackathonLifecycle = () => {
               {/* DESCRIPTION BOARD */}
               <div className="bg-card-bg border border-border rounded-3xl p-6 md:p-8 shadow-sm">
                 <div className="flex items-center gap-3">
-                  <div className={`p-3 rounded-xl bg-gradient-to-br ${selectedPhase.color} text-white`}>
+                  <div className={`p-3 rounded-xl bg-linear-to-br ${selectedPhase.color} text-white`}>
                     <selectedPhase.icon className="w-6 h-6" />
                   </div>
                   <div>
@@ -470,7 +470,7 @@ const HackathonLifecycle = () => {
               </div>
 
               {/* ACTION CALLOUT CARD */}
-              <div className="bg-gradient-to-br from-primary/30 to-secondary/20 rounded-3xl p-6 text-white border border-primary/20 shadow-lg relative overflow-hidden">
+              <div className="bg-linear-to-br from-primary/30 to-secondary/20 rounded-3xl p-6 text-white border border-primary/20 shadow-lg relative overflow-hidden">
                 <div className="absolute top-0 right-0 transform translate-x-8 -translate-y-8 opacity-10">
                   <Award className="w-48 h-48" />
                 </div>

--- a/src/Pages/HelpCenter.js
+++ b/src/Pages/HelpCenter.js
@@ -252,7 +252,7 @@ const HelpCenter = () => {
               className="group bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 flex flex-col items-center text-center transition-transform transform hover:scale-105 hover:shadow-2xl"
             >
               <div
-                className={`w-16 h-16 mb-4 flex items-center justify-center text-white rounded-full bg-gradient-to-br ${item.color} shadow-lg group-hover:rotate-12 transition-transform`}
+                className={`w-16 h-16 mb-4 flex items-center justify-center text-white rounded-full bg-linear-to-br ${item.color} shadow-lg group-hover:rotate-12 transition-transform`}
               >
                 {item.icon}
               </div>
@@ -344,7 +344,7 @@ const HelpCenter = () => {
                 className="block h-full bg-white dark:bg-gray-800 rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 overflow-hidden border border-gray-100 dark:border-gray-700"
               >
                 {/* Gradient Header */}
-                <div className={`h-3 bg-gradient-to-r ${guide.gradient}`}></div>
+                <div className={`h-3 bg-linear-to-r ${guide.gradient}`}></div>
 
                 {/* Card Content */}
                 <div className="p-6">
@@ -357,7 +357,7 @@ const HelpCenter = () => {
 
                   {/* Icon Container */}
                   <div
-                    className={`relative z-10 w-16 h-16 mb-4 rounded-xl bg-gradient-to-br ${guide.gradient} flex items-center justify-center text-white shadow-lg group-hover:scale-110 group-hover:rotate-3 transition-all duration-300`}
+                    className={`relative z-10 w-16 h-16 mb-4 rounded-xl bg-linear-to-br ${guide.gradient} flex items-center justify-center text-white shadow-lg group-hover:scale-110 group-hover:rotate-3 transition-all duration-300`}
                   >
                     {guide.icon}
                   </div>
@@ -376,7 +376,7 @@ const HelpCenter = () => {
                   <div className="flex items-center justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
                     <div className="flex items-center space-x-4">
                       <span
-                        className={`text-xs font-semibold px-3 py-1 rounded-full bg-gradient-to-r ${guide.gradient} text-white`}
+                        className={`text-xs font-semibold px-3 py-1 rounded-full bg-linear-to-r ${guide.gradient} text-white`}
                       >
                         {guide.difficulty}
                       </span>
@@ -405,7 +405,7 @@ const HelpCenter = () => {
 
                 {/* Hover Glow Effect */}
                 <div
-                  className={`absolute inset-0 opacity-0 group-hover:opacity-20 bg-gradient-to-br ${guide.gradient} transition-opacity duration-300 pointer-events-none`}
+                  className={`absolute inset-0 opacity-0 group-hover:opacity-20 bg-linear-to-br ${guide.gradient} transition-opacity duration-300 pointer-events-none`}
                 ></div>
               </Link>
             </motion.div>
@@ -483,12 +483,12 @@ const HelpCenter = () => {
               className="group relative bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 dark:border-gray-700"
             >
               <div
-                className={`absolute top-0 left-0 w-full h-1 rounded-t-2xl bg-gradient-to-r ${guideline.color}`}
+                className={`absolute top-0 left-0 w-full h-1 rounded-t-2xl bg-linear-to-r ${guideline.color}`}
               ></div>
 
               <div className="flex items-start space-x-4">
                 <div
-                  className={`flex-shrink-0 w-12 h-12 rounded-xl bg-gradient-to-br ${guideline.color} flex items-center justify-center text-white shadow-lg group-hover:scale-110 transition-transform duration-300`}
+                  className={`flex-shrink-0 w-12 h-12 rounded-xl bg-linear-to-br ${guideline.color} flex items-center justify-center text-white shadow-lg group-hover:scale-110 transition-transform duration-300`}
                 >
                   {guideline.icon}
                 </div>
@@ -526,7 +526,7 @@ const HelpCenter = () => {
       {/* FAQ Section */}
       <section className="py-20">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h2 className="text-3xl font-bold bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 text-center mb-4 text-gray-900 dark:text-white">
+          <h2 className="text-3xl font-bold bg-linear-to-br from-slate-950 via-slate-900 to-indigo-950 text-center mb-4 text-gray-900 dark:text-white">
             {t("helpCenter.faqHeading")}
           </h2>
           <p className="text-center text-gray-600 dark:text-gray-300 mb-12 max-w-2xl mx-auto">

--- a/src/Pages/Home/components/HomeCTA.jsx
+++ b/src/Pages/Home/components/HomeCTA.jsx
@@ -38,7 +38,7 @@ export default function CTASection() {
             className="text-4xl sm:text-5xl lg:text-6xl font-black text-slate-900 dark:text-white mb-6 tracking-tight leading-[1.1] drop-shadow-sm"
           >
             <span className="inline-block text-black dark:text-white">Ignite Ideas, </span>
-            <span className="inline-block bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 dark:from-indigo-400 dark:via-purple-400 dark:to-pink-400">
+            <span className="inline-block bg-clip-text text-transparent bg-linear-to-r from-indigo-600 via-purple-600 to-pink-600 dark:from-indigo-400 dark:via-purple-400 dark:to-pink-400">
               Connect Innovators
             </span>
           </motion.h2>

--- a/src/Pages/Home/components/RecommendationBanner.jsx
+++ b/src/Pages/Home/components/RecommendationBanner.jsx
@@ -8,7 +8,7 @@ const RecommendationBanner = () => {
       }}
     >
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute top-0 left-0 right-0 h-28 bg-gradient-to-b from-white/80 dark:from-slate-950/40 to-transparent" />
+        <div className="absolute top-0 left-0 right-0 h-28 bg-linear-to-b from-white/80 dark:from-slate-950/40 to-transparent" />
         <div className="absolute top-10 left-8 h-40 w-40 rounded-full bg-white/35 dark:bg-slate-800/10 blur-3xl" />
         <div className="absolute top-24 right-8 h-52 w-52 rounded-full bg-sky-100/35 dark:bg-brand-violet/5 blur-3xl" />
       </div>

--- a/src/Pages/Home/components/Testimonials.js
+++ b/src/Pages/Home/components/Testimonials.js
@@ -231,7 +231,7 @@ const ModernTestimonialTrain = () => {
 
   return (
     <section 
-      className="relative py-20 px-4 bg-gradient-to-b from-indigo-50 via-indigo-100 to-white dark:from-gray-900 dark:via-indigo-900/20 dark:to-black text-gray-900 dark:text-gray-100 overflow-hidden"
+      className="relative py-20 px-4 bg-linear-to-b from-indigo-50 via-indigo-100 to-white dark:from-gray-900 dark:via-indigo-900/20 dark:to-black text-gray-900 dark:text-gray-100 overflow-hidden"
       aria-label="Community Testimonials"
     >
       {/* 🎨 Floating decorative stars */}
@@ -251,7 +251,7 @@ const ModernTestimonialTrain = () => {
       {/* 📰 Header Section */}
       <div className="max-w-7xl mx-auto text-center mb-10">
         <motion.h2 
-          className="text-3xl md:text-4xl font-extrabold bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-purple-600 dark:from-indigo-400 dark:to-purple-400"
+          className="text-3xl md:text-4xl font-extrabold bg-clip-text text-transparent bg-linear-to-r from-indigo-600 to-purple-600 dark:from-indigo-400 dark:to-purple-400"
           initial={{ opacity: 0, y: -20 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
@@ -435,7 +435,7 @@ const ModernTestimonialTrain = () => {
         viewport={{ once: true }}
         transition={{ delay: 0.2 }}
       >
-        <div className="inline-flex items-center gap-3 px-6 py-3 rounded-2xl bg-gradient-to-r from-indigo-500/10 to-purple-500/10 border border-indigo-200/50 dark:border-indigo-800/50">
+        <div className="inline-flex items-center gap-3 px-6 py-3 rounded-2xl bg-linear-to-r from-indigo-500/10 to-purple-500/10 border border-indigo-200/50 dark:border-indigo-800/50">
           <span className="text-sm text-gray-700 dark:text-gray-300">
             Have a story to share?
           </span>

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -238,7 +238,7 @@ const WhatsHappening = () => {
       </div>
 
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute top-0 left-0 right-0 h-28 bg-gradient-to-b from-white/80 dark:from-slate-950/40 to-transparent" />
+        <div className="absolute top-0 left-0 right-0 h-28 bg-linear-to-b from-white/80 dark:from-slate-950/40 to-transparent" />
         <div className="absolute top-10 left-8 h-40 w-40 rounded-full bg-white/35 dark:bg-slate-800/10 blur-3xl" />
         <div className="absolute top-24 right-8 h-52 w-52 rounded-full bg-sky-100/35 dark:bg-brand-violet/5 blur-3xl" />
       </div>

--- a/src/Pages/Leaderboard/ContributorGuide.js
+++ b/src/Pages/Leaderboard/ContributorGuide.js
@@ -147,7 +147,7 @@ const ContributorGuide = () => {
   const duration = prefersReducedMotion ? 0 : 0.5;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-zinc-50 via-white to-blue-50/30 dark:from-zinc-950 dark:via-zinc-900 dark:to-blue-950/20 pt-24 pb-16 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-linear-to-br from-zinc-50 via-white to-blue-50/30 dark:from-zinc-950 dark:via-zinc-900 dark:to-blue-950/20 pt-24 pb-16 px-4 sm:px-6 lg:px-8">
       <div className="max-w-6xl mx-auto space-y-16">
         
         {/* HERO SECTION */}
@@ -163,7 +163,7 @@ const ContributorGuide = () => {
           </div>
           <h1 className="text-4xl md:text-6xl font-bold tracking-tight text-zinc-900 dark:text-white">
             Welcome to{" "}
-            <span className="bg-gradient-to-r from-blue-600 via-violet-600 to-indigo-600 bg-clip-text text-transparent">
+            <span className="bg-linear-to-r from-blue-600 via-violet-600 to-indigo-600 bg-clip-text text-transparent">
               Eventra
             </span>
           </h1>
@@ -179,7 +179,7 @@ const ContributorGuide = () => {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration }}
-          className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-violet-600 via-indigo-600 to-blue-600 p-[1px]"
+          className="relative overflow-hidden rounded-3xl bg-linear-to-br from-violet-600 via-indigo-600 to-blue-600 p-[1px]"
         >
           <div className="relative bg-zinc-950 rounded-3xl p-6 md:p-10 overflow-hidden">
             {/* Decorative glow */}
@@ -248,7 +248,7 @@ const ContributorGuide = () => {
                     ].map((badge, i) => (
                       <div
                         key={i}
-                        className={`p-4 rounded-xl bg-gradient-to-br ${badge.gradient} border text-center hover:scale-105 transition-transform`}
+                        className={`p-4 rounded-xl bg-linear-to-br ${badge.gradient} border text-center hover:scale-105 transition-transform`}
                       >
                         <div className="text-2xl mb-1">{badge.emoji}</div>
                         <div className="text-sm font-bold text-white">{badge.title}</div>
@@ -284,7 +284,7 @@ const ContributorGuide = () => {
                   transition={{ duration, delay: index * 0.05 }}
                   className="group relative bg-white dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-6 hover:border-zinc-300 dark:hover:border-zinc-700 hover:shadow-xl hover:shadow-zinc-200/50 dark:hover:shadow-zinc-950/50 transition-all"
                 >
-                  <div className={`inline-flex p-3 rounded-xl bg-gradient-to-br ${type.gradient} mb-4 shadow-lg`}>
+                  <div className={`inline-flex p-3 rounded-xl bg-linear-to-br ${type.gradient} mb-4 shadow-lg`}>
                     <Icon className="text-white" size={22} />
                   </div>
                   <h3 className="text-lg font-bold text-zinc-900 dark:text-white mb-2">
@@ -365,7 +365,7 @@ const ContributorGuide = () => {
 
           <div className="relative">
             {/* Vertical connecting line */}
-            <div className="absolute left-6 md:left-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-sky-500/50 via-violet-500/50 to-rose-500/50 -translate-x-1/2 hidden sm:block"></div>
+            <div className="absolute left-6 md:left-1/2 top-0 bottom-0 w-px bg-linear-to-b from-sky-500/50 via-violet-500/50 to-rose-500/50 -translate-x-1/2 hidden sm:block"></div>
 
             <div className="space-y-8">
               {WORKFLOW_STEPS.map((item, idx) => {
@@ -382,7 +382,7 @@ const ContributorGuide = () => {
                   >
                     {/* Timeline dot */}
                     <div className="relative z-10 shrink-0">
-                      <div className={`w-12 h-12 rounded-full bg-gradient-to-br ${item.color} flex items-center justify-center shadow-lg ring-4 ring-white dark:ring-zinc-950`}>
+                      <div className={`w-12 h-12 rounded-full bg-linear-to-br ${item.color} flex items-center justify-center shadow-lg ring-4 ring-white dark:ring-zinc-950`}>
                         <span className="text-white font-bold text-lg">{item.step}</span>
                       </div>
                     </div>
@@ -390,7 +390,7 @@ const ContributorGuide = () => {
                     {/* Content card */}
                     <div className="flex-1 bg-white dark:bg-zinc-900/50 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 hover:border-zinc-300 dark:hover:border-zinc-700 transition-all">
                       <div className="flex items-center gap-3 mb-2">
-                        <div className={`p-2 rounded-lg bg-gradient-to-br ${item.color}`}>
+                        <div className={`p-2 rounded-lg bg-linear-to-br ${item.color}`}>
                           <Icon className="text-white" size={16} />
                         </div>
                         <h3 className="text-lg font-bold text-zinc-900 dark:text-white">
@@ -539,7 +539,7 @@ Closes #<issue_number>`}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration }}
-          className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-zinc-900 via-zinc-900 to-indigo-950 p-10 md:p-14 text-center"
+          className="relative overflow-hidden rounded-3xl bg-linear-to-br from-zinc-900 via-zinc-900 to-indigo-950 p-10 md:p-14 text-center"
         >
           {/* Decorative elements */}
           <div className="absolute top-0 left-1/4 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl"></div>

--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -144,7 +144,7 @@ const CountdownTimer = memo(({ timeLeft }) => {
           key={unit}
           initial={{ scale: 0.8, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
-          className="bg-gradient-to-br from-indigo-500 to-purple-600 rounded-xl p-2 sm:p-3 text-white shadow-lg"
+          className="bg-linear-to-br from-indigo-500 to-purple-600 rounded-xl p-2 sm:p-3 text-white shadow-lg"
         >
           <div className="text-lg sm:text-2xl font-bold tabular-nums">{String(value).padStart(2, '0')}</div>
           <div className="text-[10px] sm:text-xs opacity-90 capitalize">{unit}</div>
@@ -499,7 +499,7 @@ const timeLeft = useCountdown(
   if (isLoading) {
     return (
       <div className="w-[95%] mx-auto my-10 min-h-screen pb-12">
-        <div className="p-8 rounded-3xl bg-gradient-to-br from-indigo-600 to-purple-600 mb-8">
+        <div className="p-8 rounded-3xl bg-linear-to-br from-indigo-600 to-purple-600 mb-8">
           <Skeleton className="h-8 w-64 mb-4" />
           <Skeleton className="h-4 w-96 mb-6" />
           <div className="grid grid-cols-4 gap-3">
@@ -544,7 +544,7 @@ const timeLeft = useCountdown(
         {/* 🎯 HERO SECTION */}
         <motion.section
           variants={itemVariants}
-          className="p-6 sm:p-8 rounded-3xl shadow-lg bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500 text-white mb-6 sm:mb-8 relative overflow-hidden"
+          className="p-6 sm:p-8 rounded-3xl shadow-lg bg-linear-to-br from-indigo-600 via-purple-600 to-pink-500 text-white mb-6 sm:mb-8 relative overflow-hidden"
           aria-labelledby="hero-heading"
         >
           {/* Decorative background */}
@@ -779,7 +779,7 @@ const timeLeft = useCountdown(
         {/* Getting Started & Best Practices */}
         <motion.section className="grid md:grid-cols-2 gap-4 sm:gap-6 mb-6 sm:mb-8" variants={itemVariants}>
           {/* Getting Started */}
-          <article className="p-4 sm:p-6 rounded-2xl bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-gray-700 dark:to-gray-800 border dark:border-gray-700">
+          <article className="p-4 sm:p-6 rounded-2xl bg-linear-to-br from-blue-50 to-indigo-50 dark:from-gray-700 dark:to-gray-800 border dark:border-gray-700">
             <div className="flex items-center gap-3 mb-4">
               <div className="w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-xl flex items-center justify-center">
                 <Users className="w-5 h-5 text-blue-600 dark:text-blue-400" aria-hidden="true" />
@@ -845,7 +845,7 @@ const timeLeft = useCountdown(
             whileHover={{ scale: 1.03 }}
             whileTap={{ scale: 0.98 }}
             onClick={() => window.open("https://github.com/SandeepVashishtha/Eventra", "_blank", "noopener,noreferrer")}
-            className="px-6 sm:px-8 py-3 rounded-full font-semibold text-white bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-2 dark:focus:ring-offset-black"
+            className="px-6 sm:px-8 py-3 rounded-full font-semibold text-white bg-linear-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 shadow-lg hover:shadow-xl transition-all flex items-center justify-center gap-2 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-2 dark:focus:ring-offset-black"
           >
             <GitBranch className="w-4 h-4" aria-hidden="true" />
             Start Contributing
@@ -867,7 +867,7 @@ const timeLeft = useCountdown(
         <motion.section
           ref={statsRef}
           variants={itemVariants}
-          className="p-4 sm:p-6 rounded-2xl bg-gradient-to-r from-indigo-50 to-purple-50 dark:from-gray-800 dark:to-gray-700 border dark:border-gray-600"
+          className="p-4 sm:p-6 rounded-2xl bg-linear-to-r from-indigo-50 to-purple-50 dark:from-gray-800 dark:to-gray-700 border dark:border-gray-600"
           aria-labelledby="stats-heading"
         >
           <h3 id="stats-heading" className="sr-only">Community Statistics</h3>

--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -458,7 +458,7 @@ export default function LeaderBoard() {
         badgeClass: "bg-yellow-400 text-yellow-950 shadow-[0_2px_10px_rgba(234,179,8,0.3)]",
         size: "h-22 w-22",
         pointsClass: "text-amber-500",
-        medalClass: "bg-gradient-to-r from-yellow-400 to-amber-500 text-amber-950",
+        medalClass: "bg-linear-to-r from-yellow-400 to-amber-500 text-amber-950",
       },
       isFirst: true,
     },

--- a/src/Pages/Leaderboard/components/LeaderboardHero.jsx
+++ b/src/Pages/Leaderboard/components/LeaderboardHero.jsx
@@ -10,7 +10,7 @@ export default function LeaderboardHero({ stats, currentContributors }) {
 
       <h1 id="leaderboard-heading" className="mt-5 text-4xl sm:text-6xl font-extrabold tracking-tight text-slate-950">
         Community{" "}
-        <span className="bg-gradient-to-r from-slate-700 via-slate-500 to-slate-300 bg-clip-text text-transparent">
+        <span className="bg-linear-to-r from-slate-700 via-slate-500 to-slate-300 bg-clip-text text-transparent">
           Leaderboard
         </span>
       </h1>

--- a/src/Pages/Leaderboard/components/PodiumCard.jsx
+++ b/src/Pages/Leaderboard/components/PodiumCard.jsx
@@ -14,7 +14,7 @@ const PodiumCard = memo(({ contributor, position, orderClass, styling, isFirst =
       aria-label={`${position} place: ${contributor?.username || "Unknown"}`}
     >
       <div className="relative mb-4">
-        <span className={`absolute -inset-1 rounded-full bg-gradient-to-r ${styling.ringClass} blur-sm opacity-80`} aria-hidden="true" />
+        <span className={`absolute -inset-1 rounded-full bg-linear-to-r ${styling.ringClass} blur-sm opacity-80`} aria-hidden="true" />
         <img
           src={contributor.avatar}
           alt={`${contributor.username}'s avatar`}
@@ -37,7 +37,7 @@ const PodiumCard = memo(({ contributor, position, orderClass, styling, isFirst =
         href={contributor.profile}
         target="_blank"
         rel="noopener noreferrer"
-        className={`text-base font-black ${isFirst ? "bg-gradient-to-r from-slate-950 via-indigo-950 to-pink-950 dark:from-white dark:via-indigo-200 dark:to-pink-100 bg-clip-text text-transparent" : "text-slate-900 dark:text-white"} hover:text-indigo-500 transition-colors truncate max-w-[200px] text-center`}
+        className={`text-base font-black ${isFirst ? "bg-linear-to-r from-slate-950 via-indigo-950 to-pink-950 dark:from-white dark:via-indigo-200 dark:to-pink-100 bg-clip-text text-transparent" : "text-slate-900 dark:text-white"} hover:text-indigo-500 transition-colors truncate max-w-[200px] text-center`}
         aria-label={`View ${contributor.username}'s GitHub profile`}
       >
         {contributor.username}

--- a/src/Pages/NotFoundPage.jsx
+++ b/src/Pages/NotFoundPage.jsx
@@ -57,7 +57,7 @@ const NotFoundPage = () => {
       {/* Full-viewport centred section that matches Eventra's indigo/violet palette */}
       <section
         className="relative flex min-h-[85vh] flex-col items-center justify-center overflow-hidden
-                   bg-gradient-to-br from-indigo-950 via-violet-900 to-indigo-800
+                   bg-linear-to-br from-indigo-950 via-violet-900 to-indigo-800
                    px-4 py-20 text-center"
         aria-labelledby="not-found-heading"
       >
@@ -84,7 +84,7 @@ const NotFoundPage = () => {
             <motion.h1
               id="not-found-heading"
               variants={itemVariants}
-              className="bg-gradient-to-b from-white to-indigo-200 bg-clip-text
+              className="bg-linear-to-b from-white to-indigo-200 bg-clip-text
                          text-[8rem] font-black leading-none tracking-tight
                          text-transparent sm:text-[10rem]"
             >

--- a/src/Pages/Privacy.js
+++ b/src/Pages/Privacy.js
@@ -145,7 +145,7 @@ export const Privacy = () => {
               variants={item}
               className="bg-card-bg/80 backdrop-blur-lg rounded-2xl border border-border shadow-md overflow-hidden group hover:border-primary transition-colors duration-300"
             >
-              <div className="absolute inset-0 bg-gradient-to-r from-primary/10 via-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none"></div>
+              <div className="absolute inset-0 bg-linear-to-r from-primary/10 via-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none"></div>
 
               <div className="relative z-10">
                 <button

--- a/src/Pages/Projects/ProjectCTA.js
+++ b/src/Pages/Projects/ProjectCTA.js
@@ -11,7 +11,7 @@ const ProjectCTA = () => {
   
   return (
     <section 
-      className="relative py-16 px-8 m-8 rounded-3xl bg-gradient-to-tr from-sky-100 via-white to-blue-100 dark:from-[#111827] dark:via-[#0f172a] dark:to-black text-black dark:text-white shadow-xl overflow-hidden border border-gray-200 dark:border-gray-800"
+      className="relative py-16 px-8 m-8 rounded-3xl bg-linear-to-tr from-sky-100 via-white to-blue-100 dark:from-[#111827] dark:via-[#0f172a] dark:to-black text-black dark:text-white shadow-xl overflow-hidden border border-gray-200 dark:border-gray-800"
       // AOS Implementation
       data-aos="zoom-in-up"
       data-aos-duration="1000"

--- a/src/Pages/Projects/ProjectHero.js
+++ b/src/Pages/Projects/ProjectHero.js
@@ -30,7 +30,7 @@ export default function ProjectHero({
     <div
       className={`
         relative overflow-hidden
-        bg-gradient-to-b from-blue-50 via-indigo-50/30 to-white 
+        bg-linear-to-b from-blue-50 via-indigo-50/30 to-white 
         dark:from-slate-950 dark:via-slate-900 dark:to-black
         ${darkTheme.textPrimary}
         pt-16 sm:pt-18 lg:pt-20
@@ -118,7 +118,7 @@ export default function ProjectHero({
               style={{ fontFamily: '"Anton", sans-serif' }}
             >
               Discover{" "}
-              <span className="bg-gradient-to-r from-sky-500 via-indigo-500 to-pink-500 bg-clip-text text-transparent">
+              <span className="bg-linear-to-r from-sky-500 via-indigo-500 to-pink-500 bg-clip-text text-transparent">
                 Amazing
               </span>
               <br className="hidden sm:block" />
@@ -246,7 +246,7 @@ export default function ProjectHero({
                   data-aos="zoom-in"
                   data-aos-delay={700 + idx * 120}
                   className={`
-                    bg-gradient-to-br ${stat.color}
+                    bg-linear-to-br ${stat.color}
                     shadow hover:shadow-lg rounded-2xl
                     border border-transparent dark:border-slate-700
                     flex flex-col items-center justify-center

--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -333,7 +333,7 @@ const InnerGallery = () => {
   const hasActiveFilters = searchQuery || filterCategory !== "all" || sortBy !== "recent";
 
   return (
-    <div className="flex flex-col min-h-screen bg-gradient-to-br from-zinc-50 via-white to-blue-50/30 dark:from-zinc-950 dark:via-zinc-900 dark:to-blue-950/20">
+    <div className="flex flex-col min-h-screen bg-linear-to-br from-zinc-50 via-white to-blue-50/30 dark:from-zinc-950 dark:via-zinc-900 dark:to-blue-950/20">
       {/* HERO */}
       <ProjectHero scrollToCard={scrollToCard} />
 

--- a/src/Pages/Terms.js
+++ b/src/Pages/Terms.js
@@ -320,7 +320,7 @@ export const Terms = () => {
       {/* ── Scroll progress bar ── */}
       <div className="fixed top-0 left-0 right-0 z-50 h-0.5 bg-transparent">
         <div
-          className="h-full bg-gradient-to-r from-primary to-secondary transition-all duration-100"
+          className="h-full bg-linear-to-r from-primary to-secondary transition-all duration-100"
           style={{ width: `${scrollProgress}%` }}
         />
       </div>
@@ -361,7 +361,7 @@ export const Terms = () => {
           <h1 className="text-5xl sm:text-6xl font-extrabold tracking-tight
             text-text mb-4 leading-none">
             Terms of{" "}
-            <span className="bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
+            <span className="bg-linear-to-r from-primary to-secondary bg-clip-text text-transparent">
               Service
             </span>
           </h1>
@@ -389,7 +389,7 @@ export const Terms = () => {
         {/* ── Intro Card ── */}
         <div
           className="relative rounded-2xl overflow-hidden mb-10 p-6 sm:p-8
-            bg-gradient-to-br from-primary to-secondary
+            bg-linear-to-br from-primary to-secondary
             shadow-xl shadow-glow-md"
           style={{
             opacity: animateIn ? 1 : 0,

--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -201,7 +201,7 @@ export default function UserAchievements() {
               <Trophy className="w-4.5 h-4.5 animate-pulse" />
               {t("userAchievements.progressionStudio")}
             </div>
-            <h1 className="text-3xl sm:text-4xl font-black tracking-tight mt-1.5 bg-clip-text text-transparent bg-gradient-to-r from-text to-primary">
+            <h1 className="text-3xl sm:text-4xl font-black tracking-tight mt-1.5 bg-clip-text text-transparent bg-linear-to-r from-text to-primary">
               {t("userAchievements.heading")}
             </h1>
             <p className="text-text-light mt-2 text-xs sm:text-sm max-w-2xl leading-relaxed">
@@ -211,7 +211,7 @@ export default function UserAchievements() {
           <div className="shrink-0">
             <button
               onClick={() => setIsBadgeModalOpen(true)}
-              className="flex items-center gap-2 px-5 py-3 rounded-2xl bg-gradient-to-r from-primary via-primary/80 to-secondary hover:opacity-90 text-white font-extrabold text-xs uppercase tracking-wider transition-all shadow-premium-md hover:shadow-glow-sm active:scale-[0.98] cursor-pointer"
+              className="flex items-center gap-2 px-5 py-3 rounded-2xl bg-linear-to-r from-primary via-primary/80 to-secondary hover:opacity-90 text-white font-extrabold text-xs uppercase tracking-wider transition-all shadow-premium-md hover:shadow-glow-sm active:scale-[0.98] cursor-pointer"
             >
               <Sparkles className="w-4 h-4 text-amber-300 animate-spin-slow" />
               <span>{t("userAchievements.attendeeBadgeCenter")}</span>
@@ -385,7 +385,7 @@ export default function UserAchievements() {
           <motion.div
             initial={{ opacity: 0, y: 15 }}
             animate={{ opacity: 1, y: 0 }}
-            className="bg-gradient-to-br from-primary/20 via-primary/10 to-card-bg/60 border border-primary/20 backdrop-blur-xl rounded-3xl p-6 shadow-premium-lg space-y-4"
+            className="bg-linear-to-br from-primary/20 via-primary/10 to-card-bg/60 border border-primary/20 backdrop-blur-xl rounded-3xl p-6 shadow-premium-lg space-y-4"
           >
             <div className="flex items-center gap-2">
               <Sparkles className="w-5 h-5 text-yellow-450 animate-bounce" />
@@ -511,7 +511,7 @@ export default function UserAchievements() {
                             <motion.div
                               initial={{ width: 0 }}
                               animate={{ width: `${Math.min(100, (badge.currentProgress / badge.targetProgress) * 100)}%` }}
-                              className={`h-full rounded-full bg-gradient-to-r ${badge.earned ? 'from-emerald-500 to-teal-500' : 'from-primary/60 to-primary'}`}
+                              className={`h-full rounded-full bg-linear-to-r ${badge.earned ? 'from-emerald-500 to-teal-500' : 'from-primary/60 to-primary'}`}
                             />
                           </div>
                         </div>
@@ -540,7 +540,7 @@ export default function UserAchievements() {
                             <div className="flex flex-wrap gap-2 pt-0.5">
                               <button
                                 onClick={() => setActiveShareBadge(badge)}
-                                className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-extrabold rounded-xl bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-white transition-all cursor-pointer shadow-premium-sm hover:shadow-glow-sm hover:scale-[1.03]"
+                                className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-extrabold rounded-xl bg-linear-to-r from-primary to-secondary hover:opacity-90 text-white transition-all cursor-pointer shadow-premium-sm hover:shadow-glow-sm hover:scale-[1.03]"
                               >
                                 <Share2 className="w-3.5 h-3.5" />
                                 <span>{t("userAchievements.badgesSectionShareCertificate")}</span>
@@ -679,7 +679,7 @@ export default function UserAchievements() {
 
                     <button
                       onClick={() => handleDownloadSVG(activeShareBadge)}
-                      className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-gradient-to-r from-primary to-secondary hover:opacity-90 text-xs font-black uppercase tracking-wider text-white transition cursor-pointer shadow-premium-md hover:shadow-glow-sm"
+                      className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-linear-to-r from-primary to-secondary hover:opacity-90 text-xs font-black uppercase tracking-wider text-white transition cursor-pointer shadow-premium-md hover:shadow-glow-sm"
                     >
                       <Award size={13} className="text-yellow-350" />
                       <span>{t("userAchievements.modalDownloadCertificate")}</span>
@@ -732,7 +732,7 @@ export default function UserAchievements() {
                       
                       {/* Attached Card Mockup */}
                       <div className="border border-slate-850 rounded-2xl overflow-hidden bg-slate-950/70">
-                        <div className="p-5 bg-gradient-to-br from-indigo-950/50 to-slate-950 text-center border-b border-slate-850">
+                        <div className="p-5 bg-linear-to-br from-indigo-950/50 to-slate-950 text-center border-b border-slate-850">
                           <span className="inline-block p-3 rounded-2xl bg-indigo-900/30 border border-indigo-500/25 text-3xl mx-auto shadow-none">
                             {activeShareBadge.icon}
                           </span>
@@ -764,7 +764,7 @@ export default function UserAchievements() {
                       
                       {/* Attached Article Mockup */}
                       <div className="border border-slate-200 dark:border-slate-800 rounded-xl overflow-hidden bg-bg/80">
-                        <div className="p-5 bg-gradient-to-br from-indigo-50 to-white dark:from-indigo-950/20 dark:to-slate-950 text-center border-b border-slate-200 dark:border-slate-800">
+                        <div className="p-5 bg-linear-to-br from-indigo-50 to-white dark:from-indigo-950/20 dark:to-slate-950 text-center border-b border-slate-200 dark:border-slate-800">
                           <span className="inline-block p-3 rounded-2xl bg-indigo-100 dark:bg-indigo-900/30 border border-indigo-300/30 dark:border-indigo-500/25 text-3xl mx-auto shadow-none">
                             {activeShareBadge.icon}
                           </span>

--- a/src/components/CollaborationMap.jsx
+++ b/src/components/CollaborationMap.jsx
@@ -75,7 +75,7 @@ export default function CollaborationMap() {
           <span className="inline-block text-xs uppercase tracking-[0.25em] text-indigo-400 font-bold bg-indigo-500/10 px-3.5 py-1.5 rounded-full border border-indigo-500/20">
             Global Network
           </span>
-          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-gray-500 dark:bg-gradient-to-r from-white via-slate-100 to-indigo-200 bg-clip-text">
+          <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-gray-500 dark:bg-linear-to-r from-white via-slate-100 to-indigo-200 bg-clip-text">
             Collaboration Hubs
           </h2>
           <p className="max-w-xl mx-auto text-sm sm:text-base text-slate-400">

--- a/src/components/CommunityEvent.js
+++ b/src/components/CommunityEvent.js
@@ -122,8 +122,8 @@ const CommunityEvent = () => {
     <div
       className={`
         relative overflow-hidden
-        /* 🔥 FIX: Changed bg-linear-to-b to bg-gradient-to-b for correct Tailwind execution */
-        bg-gradient-to-b from-blue-50 via-indigo-50/30 to-white 
+        /* Tailwind v4: bg-linear-to-b */
+        bg-linear-to-b from-blue-50 via-indigo-50/30 to-white 
         dark:from-slate-950 dark:via-slate-900 dark:to-black
         ${darkTheme.textPrimary}
         min-h-[80vh]

--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -241,7 +241,7 @@ const ContributorsInner = () => {
   if (loading) {
     return (
       <ErrorBoundary level="feature">
-        <section className="pastel-grid-bg pt-20 md:pt-24 py-20 bg-gradient-to-br from-indigo-50 to-white dark:from-gray-900 dark:to-black">
+        <section className="pastel-grid-bg pt-20 md:pt-24 py-20 bg-linear-to-br from-indigo-50 to-white dark:from-gray-900 dark:to-black">
         <div className="max-w-7xl mx-auto px-6">
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-12 mt-16">
             {[...Array(8)].map((_, i) => (
@@ -257,7 +257,7 @@ const ContributorsInner = () => {
   if (error)
     return (
       <ErrorBoundary level="feature">
-        <section className="pastel-grid-bg pt-20 md:pt-24 py-20 bg-gradient-to-br from-indigo-50 to-white dark:from-gray-900 dark:to-black">
+        <section className="pastel-grid-bg pt-20 md:pt-24 py-20 bg-linear-to-br from-indigo-50 to-white dark:from-gray-900 dark:to-black">
         <div className="max-w-3xl mx-auto px-6 text-center">
           <h2 className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-4">
             Contributors are unavailable
@@ -277,7 +277,7 @@ const ContributorsInner = () => {
   return (
     // UPDATED: Section background
       <ErrorBoundary level="feature">
-        <section className="pastel-grid-bg pt-20 md:pt-24 py-20 bg-gradient-to-br from-indigo-50 to-white dark:from-gray-900 dark:to-black">
+        <section className="pastel-grid-bg pt-20 md:pt-24 py-20 bg-linear-to-br from-indigo-50 to-white dark:from-gray-900 dark:to-black">
         <div className="max-w-7xl mx-auto px-6">
           {/* Added The Search Bar */}
           <div className="flex justify-center mb-8">

--- a/src/components/EventTimeline.tsx
+++ b/src/components/EventTimeline.tsx
@@ -206,7 +206,7 @@ export const EventTimeline: React.FC = () => {
                 Interactive Schedule
               </span>
             </div>
-            <h2 className="text-3xl font-extrabold tracking-tight dark:text-white sm:text-4xl bg-gradient-to-r from-white via-slate-100 to-indigo-300 bg-clip-text text-slate-950">
+            <h2 className="text-3xl font-extrabold tracking-tight dark:text-white sm:text-4xl bg-linear-to-r from-white via-slate-100 to-indigo-300 bg-clip-text text-slate-950">
               My Timeline Planner
             </h2>
             <p className="mt-2 text-sm text-slate-400 max-w-xl">

--- a/src/components/Layout/DesktopNavGroup.jsx
+++ b/src/components/Layout/DesktopNavGroup.jsx
@@ -78,7 +78,7 @@ const DesktopNavGroup = ({ item, isActive, isOpen, onToggle, setOpenDropdown }) 
             />
             <motion.span
               layoutId="activeBoxGlow"
-              className="absolute -bottom-0.5 left-3 right-3 h-[2px] bg-gradient-to-r from-indigo-500/0 via-indigo-500 to-indigo-500/0 dark:via-indigo-400 blur-[1.5px] -z-0"
+              className="absolute -bottom-0.5 left-3 right-3 h-[2px] bg-linear-to-r from-indigo-500/0 via-indigo-500 to-indigo-500/0 dark:via-indigo-400 blur-[1.5px] -z-0"
               transition={{ type: "spring", stiffness: 380, damping: 30 }}
             />
           </>

--- a/src/components/Layout/ThemeToggleButton.jsx
+++ b/src/components/Layout/ThemeToggleButton.jsx
@@ -22,7 +22,7 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
           onClick={() => {
              setIsCustomizerOpen(true);
             }}       
-   className="flex items-center justify-center gap-1 px-2 py-2 w-full rounded-xl bg-gradient-to-r from-indigo-500 to-pink-500 text-white font-semibold border-none shadow-md hover:shadow-lg transition-all cursor-pointer"
+   className="flex items-center justify-center gap-1 px-2 py-2 w-full rounded-xl bg-linear-to-r from-indigo-500 to-pink-500 text-white font-semibold border-none shadow-md hover:shadow-lg transition-all cursor-pointer"
         >
           <Palette className="w-5 h-5" />
           <span>THEME Customizer</span>
@@ -56,7 +56,7 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
   whileTap={{ scale: 0.92 }}
   onClick={() => setIsCustomizerOpen(true)}
   title="Open Theme Customizer"
-        className="flex items-center justify-center w-9 h-9 rounded-full transition-all duration-300 focus:outline-none bg-gradient-to-r from-indigo-500/10 to-pink-500/10 hover:from-indigo-500/20 hover:to-pink-500/20 border border-indigo-200/50 dark:border-indigo-800/40 hover:shadow-[0_0_12px_rgba(236,72,153,0.3)] text-indigo-550 dark:text-indigo-400 cursor-pointer"
+        className="flex items-center justify-center w-9 h-9 rounded-full transition-all duration-300 focus:outline-none bg-linear-to-r from-indigo-500/10 to-pink-500/10 hover:from-indigo-500/20 hover:to-pink-500/20 border border-indigo-200/50 dark:border-indigo-800/40 hover:shadow-[0_0_12px_rgba(236,72,153,0.3)] text-indigo-550 dark:text-indigo-400 cursor-pointer"
       >
         <Palette className="w-4 h-4 animate-pulse text-indigo-500 dark:text-indigo-400" />
       </motion.button>

--- a/src/components/Layout/UserProfileDropdown.jsx
+++ b/src/components/Layout/UserProfileDropdown.jsx
@@ -71,7 +71,7 @@ const UserProfileDropdown = ({
                   }}
                 />
               ) : (
-                <div className="w-12 h-12 rounded-full bg-gradient-to-r from-indigo-800 to-indigo-950 flex items-center justify-center">
+                <div className="w-12 h-12 rounded-full bg-linear-to-r from-indigo-800 to-indigo-950 flex items-center justify-center">
                   <UserIcon className="w-6 h-6 text-white" />
                 </div>
               )}

--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -55,7 +55,7 @@ const NotFoundPage = () => {
     <main
       ref={ref}
       // UPDATED: Added a light mode background and made the dark theme conditional
-      className="relative min-h-screen flex flex-col justify-center items-center overflow-hidden bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-indigo-900 dark:via-blue-900 dark:to-black p-6"
+      className="relative min-h-screen flex flex-col justify-center items-center overflow-hidden bg-linear-to-br from-gray-50 via-white to-gray-100 dark:from-indigo-900 dark:via-blue-900 dark:to-black p-6"
     >
       {/* Floating bubbles along edges */}
       {bubblePositions.map((pos, i) => (

--- a/src/components/admin/SurveyAnalytics.jsx
+++ b/src/components/admin/SurveyAnalytics.jsx
@@ -317,7 +317,7 @@ const SurveyAnalytics = ({ questions = [], surveyTitle = "Survey" }) => {
                               </span>
                               <div className="flex-1 h-2.5 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
                                 <div
-                                  className="h-full rounded-full bg-gradient-to-r from-indigo-500 to-sky-400 transition-all duration-500"
+                                  className="h-full rounded-full bg-linear-to-r from-indigo-500 to-sky-400 transition-all duration-500"
                                   style={{ width: `${percent}%` }}
                                 />
                               </div>
@@ -401,7 +401,7 @@ const SurveyAnalytics = ({ questions = [], surveyTitle = "Survey" }) => {
                             key={comment.id}
                             className="p-3 bg-slate-50 dark:bg-slate-950/40 border border-slate-100 dark:border-slate-800/40 rounded-2xl space-y-1.5 flex items-start gap-2.5 hover:bg-slate-100/50 dark:hover:bg-slate-900/30 transition"
                           >
-                            <div className="w-7 h-7 rounded-full bg-gradient-to-tr from-indigo-500 to-sky-400 text-white flex items-center justify-center text-[10px] font-black shrink-0 mt-0.5 shadow-sm">
+                            <div className="w-7 h-7 rounded-full bg-linear-to-tr from-indigo-500 to-sky-400 text-white flex items-center justify-center text-[10px] font-black shrink-0 mt-0.5 shadow-sm">
                               {comment.author.charAt(0)}
                             </div>
                             <div className="flex-1 space-y-0.5">

--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -66,7 +66,7 @@ export default function LoginForm() {
     <div className="login-form-container">
       <form onSubmit={handleSubmit} className="auth-form">
 
-        <h1 className="text-4xl font-extrabold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent text-center">
+        <h1 className="text-4xl font-extrabold bg-linear-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent text-center">
           Welcome Back
         </h1>
 
@@ -173,7 +173,7 @@ export default function LoginForm() {
             rounded-2xl
             font-semibold
             text-white
-            bg-gradient-to-r
+            bg-linear-to-r
             from-indigo-600
             via-purple-600
             to-pink-600

--- a/src/components/auth/PasswordStrengthIndicator.js
+++ b/src/components/auth/PasswordStrengthIndicator.js
@@ -40,11 +40,11 @@ const PasswordStrengthIndicator = ({ password }) => {
   const getBarColorClass = (currentScore) => {
     switch (currentScore) {
       case 1:
-        return 'bg-gradient-to-r from-red-500 to-rose-500 shadow-sm shadow-red-500/20';
+        return 'bg-linear-to-r from-red-500 to-rose-500 shadow-sm shadow-red-500/20';
       case 2:
-        return 'bg-gradient-to-r from-amber-400 to-amber-500 shadow-sm shadow-amber-500/20';
+        return 'bg-linear-to-r from-amber-400 to-amber-500 shadow-sm shadow-amber-500/20';
       case 3:
-        return 'bg-gradient-to-r from-emerald-500 to-green-500 shadow-sm shadow-green-500/20';
+        return 'bg-linear-to-r from-emerald-500 to-green-500 shadow-sm shadow-green-500/20';
       default:
         return 'bg-slate-200 dark:bg-slate-700';
     }

--- a/src/components/auth/Signup.js
+++ b/src/components/auth/Signup.js
@@ -267,14 +267,14 @@ const Signup = () => {
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: prefersReducedMotion ? 0 : 0.5 }}
-      className="min-h-screen bg-gradient-to-br from-gray-50 via-blue-50/30 to-indigo-50/30 px-4 py-8 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 sm:px-6 lg:px-8"
+      className="min-h-screen bg-linear-to-br from-gray-50 via-blue-50/30 to-indigo-50/30 px-4 py-8 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 sm:px-6 lg:px-8"
     >
       <div className="mx-auto grid max-w-5xl items-center gap-8 md:grid-cols-2">
         <motion.section
           initial={{ x: prefersReducedMotion ? 0 : -20, opacity: 0 }}
           animate={{ x: 0, opacity: 1 }}
           transition={{ duration: prefersReducedMotion ? 0 : 0.5 }}
-          className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-blue-600 via-indigo-600 to-purple-700 p-8 text-white shadow-2xl"
+          className="relative overflow-hidden rounded-3xl bg-linear-to-br from-blue-600 via-indigo-600 to-purple-700 p-8 text-white shadow-2xl"
         >
           <div className="absolute inset-0 opacity-10">
             <div className="absolute left-10 top-10 h-32 w-32 rounded-full bg-white blur-3xl" />

--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -312,12 +312,12 @@ const SignupForm = () => {
     <div className="w-full">
       <div className="text-center space-y-4 mb-8">
         <motion.div
-          className="mx-auto w-16 h-16 rounded-2xl bg-gradient-to-r from-indigo-600 to-purple-600 flex items-center justify-center shadow-lg"
+          className="mx-auto w-16 h-16 rounded-2xl bg-linear-to-r from-indigo-600 to-purple-600 flex items-center justify-center shadow-lg"
         >
           <Zap className="w-8 h-8 text-white" />
         </motion.div>
 
-        <h1 className="text-4xl font-extrabold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+        <h1 className="text-4xl font-extrabold bg-linear-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
           Create Your Account
         </h1>
 
@@ -541,7 +541,7 @@ const SignupForm = () => {
           w-full py-4
           rounded-2xl
           font-semibold
-          bg-gradient-to-r
+          bg-linear-to-r
           from-indigo-600
           via-purple-600
           to-pink-600

--- a/src/components/auth/Unauthorized.js
+++ b/src/components/auth/Unauthorized.js
@@ -30,7 +30,7 @@ const Unauthorized = () => {
   };
 
   return (
-    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 via-red-100 to-red-200 dark:from-red-900/40 dark:via-gray-900 dark:to-black overflow-hidden px-4">
+    <div className="relative min-h-screen flex items-center justify-center bg-linear-to-br from-red-50 via-red-100 to-red-200 dark:from-red-900/40 dark:via-gray-900 dark:to-black overflow-hidden px-4">
       {/* Floating decorative bubbles */}
       {bubblePositions.map((pos, i) => (
         <motion.div

--- a/src/components/common/AdvancedFilterPanel.jsx
+++ b/src/components/common/AdvancedFilterPanel.jsx
@@ -145,7 +145,7 @@ overflow-hidden
         w-full
         px-8 py-6
         flex items-center justify-between
-        bg-gradient-to-r
+        bg-linear-to-r
         from-indigo-50
         to-white
         dark:from-gray-800

--- a/src/components/common/CommandPalette.jsx
+++ b/src/components/common/CommandPalette.jsx
@@ -294,7 +294,7 @@ export default function CommandPalette({
                           className={`
                             group flex items-center justify-between px-3 py-2.5 rounded-xl cursor-pointer transition-all duration-150 select-none
                             ${active
-                              ? "bg-gradient-to-r from-indigo-600 to-pink-600 text-white shadow-lg shadow-indigo-500/20 translate-x-1"
+                              ? "bg-linear-to-r from-indigo-600 to-pink-600 text-white shadow-lg shadow-indigo-500/20 translate-x-1"
                               : "hover:bg-slate-100 dark:hover:bg-slate-800/40 text-slate-700 dark:text-slate-300"
                             }
                           `}

--- a/src/components/common/CountdownTimer.jsx
+++ b/src/components/common/CountdownTimer.jsx
@@ -127,7 +127,7 @@ const CountdownTimer = ({ date, time, timezone }) => {
 
   return (
     <div
-      className="rounded-2xl bg-gradient-to-br from-indigo-50 to-white dark:from-indigo-950/40 dark:to-gray-800 border border-indigo-200 dark:border-indigo-700 p-5"
+      className="rounded-2xl bg-linear-to-br from-indigo-50 to-white dark:from-indigo-950/40 dark:to-gray-800 border border-indigo-200 dark:border-indigo-700 p-5"
       aria-label={`Event countdown timer: ${timeLeft.days} days, ${timeLeft.hours} hours, ${timeLeft.minutes} minutes, ${timeLeft.seconds} seconds remaining`}
     >
       {/* sr-only live region: announced every 60 seconds to avoid screen reader spam */}

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -103,8 +103,8 @@ const EmptyState = ({
       {/* Background decoration */}
       {!compact && (
         <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          <div className="absolute -top-10 -right-10 w-40 h-40 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/10 dark:to-indigo-900/10 rounded-full blur-3xl" />
-          <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-gradient-to-tr from-purple-50 to-pink-50 dark:from-purple-900/10 dark:to-pink-900/10 rounded-full blur-3xl" />
+          <div className="absolute -top-10 -right-10 w-40 h-40 bg-linear-to-br from-blue-50 to-indigo-50 dark:from-blue-900/10 dark:to-indigo-900/10 rounded-full blur-3xl" />
+          <div className="absolute -bottom-10 -left-10 w-40 h-40 bg-linear-to-tr from-purple-50 to-pink-50 dark:from-purple-900/10 dark:to-pink-900/10 rounded-full blur-3xl" />
         </div>
       )}
 
@@ -135,7 +135,7 @@ const EmptyState = ({
             {resolvedActionPath && !handleAction ? (
               <Link
                 to={resolvedActionPath}
-                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500/30"
                 aria-label={displayActionLabel}
               >
                 {displayActionLabel}
@@ -144,7 +144,7 @@ const EmptyState = ({
               <button
                 type="button"
                 onClick={handleAction}
-                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500/30"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold text-white bg-linear-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 transition-all shadow-md hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500/30"
                 aria-label={displayActionLabel}
               >
                 {displayActionLabel}

--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -1,4 +1,4 @@
-ï»¿import { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
 import { toast } from "react-toastify";
@@ -47,7 +47,7 @@ const EventCreation = () => {
     error: submitError,
     success: submitSuccess,
   } = useFormSubmit(async (eventData) => {
-    // Auth is handled by the HttpOnly session cookie Î“Ã‡Ã¶ apiUtils sends it
+    // Auth is handled by the HttpOnly session cookie GÇö apiUtils sends it
     // automatically via withCredentials. Never read tokens from sessionStorage;
     // setToken was removed as part of the HttpOnly cookie migration.
 
@@ -625,7 +625,7 @@ const EventCreation = () => {
 
               {/* Date and Time Fields */}
               {formData.isMultiDay ? (
-                // â‰¡Æ’Ã¶â•£ Multi-day Event
+                // =ƒö¦ Multi-day Event
                 <motion.div
                   className="grid grid-cols-1 sm:grid-cols-4 gap-4"
                   initial={{ opacity: 0, x: -20 }}
@@ -715,7 +715,7 @@ const EventCreation = () => {
                   </div>
                 </motion.div>
               ) : (
-                // â‰¡Æ’Ã¶â•• Single-day Event
+                // =ƒö+ Single-day Event
                 <motion.div
                   className="grid grid-cols-1 sm:grid-cols-3 gap-4"
                   initial={{ opacity: 0, x: -20 }}
@@ -972,7 +972,7 @@ const EventCreation = () => {
                         onClick={() => removeTag(tag)}
                         className="ml-1 text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-200 font-bold"
                       >
-                        â”œÃ¹
+                        +ù
                       </button>
                     </span>
                   ))}

--- a/src/components/common/EventCreation/components/TemplatePicker.jsx
+++ b/src/components/common/EventCreation/components/TemplatePicker.jsx
@@ -41,7 +41,7 @@ export default function TemplatePicker({
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}
-            <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-gradient-to-r from-indigo-50 to-white dark:from-gray-800 dark:to-gray-900">
+            <div className="px-8 py-6 border-b border-gray-200 dark:border-gray-700 bg-linear-to-r from-indigo-50 to-white dark:from-gray-800 dark:to-gray-900">
               <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
                 Event Templates
               </h2>

--- a/src/components/common/EventMaterials.jsx
+++ b/src/components/common/EventMaterials.jsx
@@ -263,8 +263,8 @@ const EventMaterials = ({ materials }) => {
                       <motion.div
                         className={`h-full rounded-full ${
                           transfer.type === "p2p" 
-                            ? "bg-gradient-to-r from-emerald-500 to-teal-500" 
-                            : "bg-gradient-to-r from-indigo-500 to-purple-500"
+                            ? "bg-linear-to-r from-emerald-500 to-teal-500" 
+                            : "bg-linear-to-r from-indigo-500 to-purple-500"
                         }`}
                         initial={{ width: 0 }}
                         animate={{ width: `${transfer.progress}%` }}

--- a/src/components/common/KeyboardShortcutsModal.jsx
+++ b/src/components/common/KeyboardShortcutsModal.jsx
@@ -189,7 +189,7 @@ const ShortcutRow = ({ action, keys, isPressed }) => (
             className={`
               px-2.5 py-1.5 rounded-lg border text-xs font-black uppercase tracking-tight shadow-sm transition-all duration-150
               ${active
-                ? "bg-gradient-to-r from-indigo-500 to-pink-500 text-white border-transparent scale-95 shadow-[0_0_12px_rgba(99,102,241,0.4)]"
+                ? "bg-linear-to-r from-indigo-500 to-pink-500 text-white border-transparent scale-95 shadow-[0_0_12px_rgba(99,102,241,0.4)]"
                 : "bg-slate-50 dark:bg-slate-800 border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300"
               }
             `}
@@ -319,7 +319,7 @@ const KeyboardShortcutsModal = ({ isOpen, onClose }) => {
             <div className="flex items-center justify-between mb-6 flex-shrink-0">
               <div className="flex items-center gap-3">
                 <div className="relative">
-                  <span className="absolute -inset-0.5 rounded-full bg-gradient-to-r from-indigo-500 to-pink-500 blur opacity-70 animate-pulse" />
+                  <span className="absolute -inset-0.5 rounded-full bg-linear-to-r from-indigo-500 to-pink-500 blur opacity-70 animate-pulse" />
                   <div className="relative flex h-10 w-10 items-center justify-center rounded-xl bg-slate-900 text-indigo-400 border border-white/10">
                     <Keyboard className="h-5 w-5" />
                   </div>
@@ -362,7 +362,7 @@ const KeyboardShortcutsModal = ({ isOpen, onClose }) => {
                       className={`
                         px-3.5 py-2.5 rounded-xl text-xs font-black uppercase tracking-tight transition-all duration-150 select-none
                         ${active
-                          ? "bg-gradient-to-r from-indigo-500 to-pink-500 text-white shadow-[0_0_15px_rgba(99,102,241,0.5)] border-transparent"
+                          ? "bg-linear-to-r from-indigo-500 to-pink-500 text-white shadow-[0_0_15px_rgba(99,102,241,0.5)] border-transparent"
                           : "bg-white dark:bg-slate-800 border-b-4 border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 border-l border-r border-t border-slate-200/30 dark:border-slate-700/10"
                         }
                       `}

--- a/src/components/common/PriceRangeSlider.jsx
+++ b/src/components/common/PriceRangeSlider.jsx
@@ -57,7 +57,7 @@ const PriceRangeSlider = ({
 
         {/* Active range track */}
         <div
-          className="absolute h-2 bg-gradient-to-r from-indigo-500 to-purple-600 rounded-full top-2"
+          className="absolute h-2 bg-linear-to-r from-indigo-500 to-purple-600 rounded-full top-2"
           style={{
             left: `${minPercent}%`,
             right: `${100 - maxPercent}%`,

--- a/src/components/common/ProgressStepper.jsx
+++ b/src/components/common/ProgressStepper.jsx
@@ -17,7 +17,7 @@ const ProgressStepper = ({ steps, currentStep }) => {
         
         {/* Progress Fill */}
         <motion.div
-          className="absolute top-1/2 left-0 h-1 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-full -translate-y-1/2"
+          className="absolute top-1/2 left-0 h-1 bg-linear-to-r from-blue-600 to-indigo-600 rounded-full -translate-y-1/2"
           initial={{ width: "0%" }}
           animate={{ width: `${(currentStep / (steps.length - 1)) * 100}%` }}
           transition={{ duration: 0.3, ease: "easeOut" }}

--- a/src/components/common/ProjectSubmission.js
+++ b/src/components/common/ProjectSubmission.js
@@ -122,7 +122,7 @@ const ProjectSubmission = ({ onClose, onSubmit }) => {
         </p>
         <button
           onClick={onClose}
-          className="bg-gradient-to-r from-indigo-500 to-indigo-600 hover:from-indigo-600 hover:to-indigo-700 text-white font-medium py-2.5 px-6 rounded-lg shadow-md transition-transform duration-200 hover:-translate-y-0.5"
+          className="bg-linear-to-r from-indigo-500 to-indigo-600 hover:from-indigo-600 hover:to-indigo-700 text-white font-medium py-2.5 px-6 rounded-lg shadow-md transition-transform duration-200 hover:-translate-y-0.5"
          aria-label="button">
           Close
         </button>

--- a/src/components/common/ScrollProgressBar.jsx
+++ b/src/components/common/ScrollProgressBar.jsx
@@ -70,7 +70,7 @@ const ScrollProgressBar = () => {
     <div className="fixed top-0 left-0 w-full h-1 z-[9999] bg-transparent pointer-events-none">
       <div
         ref={progressBarRef}
-        className="h-full bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 transition-all duration-75 ease-out shadow-md"
+        className="h-full bg-linear-to-r from-indigo-500 via-purple-500 to-pink-500 transition-all duration-75 ease-out shadow-md"
         style={{ width: "0%" }}
       />
     </div>

--- a/src/components/common/SkeletonLoaders.jsx
+++ b/src/components/common/SkeletonLoaders.jsx
@@ -1,5 +1,5 @@
 const shimmer =
-  "animate-pulse bg-gradient-to-r from-gray-200 via-gray-100 to-gray-200 dark:from-gray-700 dark:via-gray-600 dark:to-gray-700 bg-[length:200%_100%]";
+  "animate-pulse bg-linear-to-r from-gray-200 via-gray-100 to-gray-200 dark:from-gray-700 dark:via-gray-600 dark:to-gray-700 bg-[length:200%_100%]";
 
 export const SkeletonBlock = ({ className = "", ...props }) => (
   <div className={`${shimmer} rounded ${className}`} {...props} />
@@ -7,7 +7,7 @@ export const SkeletonBlock = ({ className = "", ...props }) => (
 
 export const SkeletonEventCard = () => (
   <div aria-hidden="true" className="group relative bg-white dark:bg-gray-900 rounded-3xl shadow-xl flex flex-col overflow-hidden border border-gray-100 dark:border-gray-800">
-    <div className="flex items-center px-5 py-4 gap-4 bg-gradient-to-r from-white/80 to-indigo-50/60 dark:from-gray-900/80 dark:to-indigo-950/60 border-b border-gray-100 dark:border-gray-800">
+    <div className="flex items-center px-5 py-4 gap-4 bg-linear-to-r from-white/80 to-indigo-50/60 dark:from-gray-900/80 dark:to-indigo-950/60 border-b border-gray-100 dark:border-gray-800">
       <SkeletonBlock className="w-10 h-10 rounded-xl" />
       <SkeletonBlock className="h-6 flex-1" />
       <SkeletonBlock className="h-6 w-16 rounded-full" />
@@ -114,7 +114,7 @@ export const GitHubStatCardSkeleton = () => (
 );
 
 export const LeaderboardStatCardSkeleton = () => (
-  <div aria-hidden="true" className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-gradient-to-br from-indigo-50 to-gray-50 dark:from-gray-800 dark:to-gray-900">
+  <div aria-hidden="true" className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-linear-to-br from-indigo-50 to-gray-50 dark:from-gray-800 dark:to-gray-900">
     <div className="flex items-center">
       <SkeletonBlock className="h-12 w-12 rounded-xl mr-4" />
       <div className="flex-1">
@@ -140,7 +140,7 @@ export const SkeletonLeaderboard = ({ rows = 10 }) => (
           ))}
         </tr>
       </thead>
-      <tbody className="bg-gradient-to-b from-indigo-50 to-white dark:from-gray-900 dark:to-black divide-y divide-gray-400 dark:divide-gray-500">
+      <tbody className="bg-linear-to-b from-indigo-50 to-white dark:from-gray-900 dark:to-black divide-y divide-gray-400 dark:divide-gray-500">
         {[...Array(rows)].map((_, i) => (
           <tr key={i} className="animate-pulse">
             <td className="px-6 py-4 whitespace-nowrap">

--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -143,10 +143,10 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/75 backdrop-blur-md">
       <div
         ref={modalRef}
-        className="w-full max-w-2xl rounded-2xl bg-gradient-to-b from-gray-900 to-slate-950 text-white shadow-2xl overflow-hidden flex flex-col max-h-[90vh]"
+        className="w-full max-w-2xl rounded-2xl bg-linear-to-b from-gray-900 to-slate-950 text-white shadow-2xl overflow-hidden flex flex-col max-h-[90vh]"
       >
         {/* Header */}
-        <div className="relative h-32 bg-gradient-to-r from-indigo-900/60 to-purple-900/60 p-6 flex items-end">
+        <div className="relative h-32 bg-linear-to-r from-indigo-900/60 to-purple-900/60 p-6 flex items-end">
           <button
             onClick={onClose}
             className="absolute top-4 right-4 p-2 hover:bg-white/10 rounded-full"

--- a/src/components/feedback/FeedbackSummary.jsx
+++ b/src/components/feedback/FeedbackSummary.jsx
@@ -47,7 +47,7 @@ const FeedbackSummary = ({ eventId, compact = false }) => {
 
   // Full view (for event details page)
   return (
-    <div className="bg-gradient-to-br from-indigo-50 to-blue-50 dark:from-indigo-900/20 dark:to-blue-900/20 rounded-2xl border border-indigo-200 dark:border-indigo-800 p-6 space-y-6">
+    <div className="bg-linear-to-br from-indigo-50 to-blue-50 dark:from-indigo-900/20 dark:to-blue-900/20 rounded-2xl border border-indigo-200 dark:border-indigo-800 p-6 space-y-6">
       {/* Rating Section */}
       <div className="border-b border-indigo-200 dark:border-indigo-800 pb-6">
         <div className="flex items-start justify-between mb-4">
@@ -98,7 +98,7 @@ const FeedbackSummary = ({ eventId, compact = false }) => {
                     </span>
                     <div className="flex-1 h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
                       <div
-                        className="h-full bg-gradient-to-r from-yellow-400 to-yellow-500 rounded-full transition-all"
+                        className="h-full bg-linear-to-r from-yellow-400 to-yellow-500 rounded-full transition-all"
                         style={{ width: `${percentage}%` }}
                       />
                     </div>

--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -322,10 +322,10 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0, gssocE
               transition={{ duration: 0.8, ease: 'easeOut' }}
               className={`h-full rounded-full ${
                 isClaimed
-                  ? 'bg-gradient-to-r from-emerald-400 to-teal-500'
+                  ? 'bg-linear-to-r from-emerald-400 to-teal-500'
                   : isComplete
-                    ? 'bg-gradient-to-r from-amber-400 to-orange-500 shadow-[0_0_8px_rgba(245,158,11,0.4)]'
-                    : 'bg-gradient-to-r from-indigo-500 to-violet-500'
+                    ? 'bg-linear-to-r from-amber-400 to-orange-500 shadow-[0_0_8px_rgba(245,158,11,0.4)]'
+                    : 'bg-linear-to-r from-indigo-500 to-violet-500'
               }`}
             />
           </div>
@@ -339,7 +339,7 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0, gssocE
             whileHover={{ scale: 1.04 }}
             whileTap={{ scale: 0.96 }}
             onClick={() => claimXP(quest.id, quest.rewardXP, isWeekly)}
-            className="mt-4 w-full py-2.5 rounded-xl bg-gradient-to-r from-amber-500 to-orange-500 text-white text-xs font-black uppercase tracking-wider shadow-md hover:shadow-lg transition-shadow flex items-center justify-center gap-2"
+            className="mt-4 w-full py-2.5 rounded-xl bg-linear-to-r from-amber-500 to-orange-500 text-white text-xs font-black uppercase tracking-wider shadow-md hover:shadow-lg transition-shadow flex items-center justify-center gap-2"
           >
             <Gift className="w-3.5 h-3.5" />
             Claim {quest.rewardXP} XP
@@ -353,7 +353,7 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0, gssocE
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="absolute inset-0 bg-gradient-to-br from-emerald-400/20 to-teal-400/10 rounded-2xl pointer-events-none"
+              className="absolute inset-0 bg-linear-to-br from-emerald-400/20 to-teal-400/10 rounded-2xl pointer-events-none"
             />
           )}
         </AnimatePresence>
@@ -445,7 +445,7 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0, gssocE
           <motion.div
             initial={{ width: 0 }}
             animate={{ width: totalAvailableXP > 0 ? `${(claimedXP / totalAvailableXP) * 100}%` : '0%' }}
-            className="h-full rounded-full bg-gradient-to-r from-violet-500 to-fuchsia-500"
+            className="h-full rounded-full bg-linear-to-r from-violet-500 to-fuchsia-500"
           />
         </div>
       </div>

--- a/src/components/hackathons/InteractiveWhiteboard.jsx
+++ b/src/components/hackathons/InteractiveWhiteboard.jsx
@@ -438,7 +438,7 @@ const InteractiveWhiteboard = () => {
             </div>
 
             {/* Note Textarea Container */}
-            <div className="flex-1 p-2 bg-gradient-to-b from-[#0e101a] to-[#0a0c12]">
+            <div className="flex-1 p-2 bg-linear-to-b from-[#0e101a] to-[#0a0c12]">
               <textarea
                 className="w-full h-full min-h-[80px] bg-transparent border-none outline-none resize-none text-xs text-gray-200 select-text cursor-text leading-relaxed p-1 font-medium"
                 value={sticky.text}

--- a/src/components/ui/ImageWithFallback.tsx
+++ b/src/components/ui/ImageWithFallback.tsx
@@ -30,7 +30,7 @@ if (error || !src) {
     if (fallbackType === 'avatar') {
       return (
         <div
-          className={`flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white font-semibold select-none ${className}`}
+          className={`flex items-center justify-center bg-linear-to-br from-indigo-500 to-purple-600 text-white font-semibold select-none ${className}`}
           title={alt || name}
         >
           {getInitials(name)}

--- a/src/components/user/DashboardEmptyState.jsx
+++ b/src/components/user/DashboardEmptyState.jsx
@@ -22,15 +22,15 @@ const DashboardEmptyState = () => {
     >
       {/* ── Decorative background blobs ── */}
       <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-        <div className="absolute -top-16 -right-16 h-56 w-56 rounded-full bg-gradient-to-br from-indigo-100 to-purple-100 opacity-60 blur-3xl dark:from-indigo-900/20 dark:to-purple-900/20" />
-        <div className="absolute -bottom-16 -left-16 h-56 w-56 rounded-full bg-gradient-to-tr from-blue-100 to-cyan-100 opacity-60 blur-3xl dark:from-blue-900/20 dark:to-cyan-900/20" />
-        <div className="absolute left-1/2 top-0 h-px w-3/4 -translate-x-1/2 bg-gradient-to-r from-transparent via-indigo-300/40 to-transparent dark:via-indigo-500/20" />
+        <div className="absolute -top-16 -right-16 h-56 w-56 rounded-full bg-linear-to-br from-indigo-100 to-purple-100 opacity-60 blur-3xl dark:from-indigo-900/20 dark:to-purple-900/20" />
+        <div className="absolute -bottom-16 -left-16 h-56 w-56 rounded-full bg-linear-to-tr from-blue-100 to-cyan-100 opacity-60 blur-3xl dark:from-blue-900/20 dark:to-cyan-900/20" />
+        <div className="absolute left-1/2 top-0 h-px w-3/4 -translate-x-1/2 bg-linear-to-r from-transparent via-indigo-300/40 to-transparent dark:via-indigo-500/20" />
       </div>
 
       <div className="relative z-10 flex flex-col items-center px-8 py-14 text-center sm:px-14">
         {/* ── Illustration ── */}
         <div className="mb-8 flex items-center justify-center">
-          <div className="relative flex h-28 w-28 items-center justify-center rounded-3xl bg-gradient-to-br from-indigo-50 to-purple-50 shadow-inner dark:from-indigo-900/30 dark:to-purple-900/30">
+          <div className="relative flex h-28 w-28 items-center justify-center rounded-3xl bg-linear-to-br from-indigo-50 to-purple-50 shadow-inner dark:from-indigo-900/30 dark:to-purple-900/30">
             {/* Orbiting calendar icon */}
             <Calendar
               size={52}
@@ -82,7 +82,7 @@ const DashboardEmptyState = () => {
           <button
             type="button"
             onClick={() => navigate("/events")}
-            className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-600 to-purple-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-indigo-500/25 transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-xl hover:shadow-indigo-500/30 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 active:scale-[0.98]"
+            className="inline-flex items-center gap-2 rounded-2xl bg-linear-to-r from-indigo-600 to-purple-600 px-6 py-3 text-sm font-bold text-white shadow-lg shadow-indigo-500/25 transition-all hover:from-indigo-700 hover:to-purple-700 hover:shadow-xl hover:shadow-indigo-500/30 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 active:scale-[0.98]"
             aria-label="Browse all events"
           >
             <Search size={16} />

--- a/src/components/user/EventBadgeGenerator.jsx
+++ b/src/components/user/EventBadgeGenerator.jsx
@@ -200,7 +200,7 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
               {/* Progress bar */}
               <div className="w-full h-1.5 bg-slate-800 rounded-full overflow-hidden">
                 <motion.div 
-                  className="h-full bg-gradient-to-r from-indigo-500 to-purple-500" 
+                  className="h-full bg-linear-to-r from-indigo-500 to-purple-500" 
                   animate={{ width: `${(completedCount / 3) * 100}%` }}
                 />
               </div>
@@ -320,7 +320,7 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
           {/* Badge element to snapshot */}
           <div 
             ref={badgeRef}
-            className={`w-[260px] h-[400px] bg-gradient-to-b ${currentTemplate.bgGradient} border-2 ${currentTemplate.borderClass} rounded-3xl relative overflow-hidden flex flex-col justify-between items-center p-5 select-none`}
+            className={`w-[260px] h-[400px] bg-linear-to-b ${currentTemplate.bgGradient} border-2 ${currentTemplate.borderClass} rounded-3xl relative overflow-hidden flex flex-col justify-between items-center p-5 select-none`}
             style={{ fontFamily: "Inter, sans-serif" }}
           >
             {/* Template Ambient Glow Overlay */}
@@ -339,7 +339,7 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
             <div className="flex flex-col items-center space-y-3 z-10 mt-3">
               <div className="relative">
                 {/* Aura border */}
-                <span className={`absolute -inset-1 rounded-full bg-gradient-to-r ${currentTemplate.ringClass} blur-xs opacity-80 animate-pulse`} />
+                <span className={`absolute -inset-1 rounded-full bg-linear-to-r ${currentTemplate.ringClass} blur-xs opacity-80 animate-pulse`} />
                 <div className="relative w-16 h-16 rounded-full overflow-hidden border-2 border-slate-800 bg-slate-900 flex items-center justify-center">
                   {avatar ? (
                     <img src={avatar} alt="Avatar" className="w-full h-full object-cover" loading="lazy" />

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -611,7 +611,7 @@ const normalizedSearch = debouncedTerm.trim().toLowerCase();
               {filteredRegisteredEvents.length > 0 && (
                 <section className="space-y-4">
                   <div className="ud-tab-header">
-                    <h3 className="ud-page-title bg-gradient-to-r from-indigo-600 to-pink-600 bg-clip-text text-transparent font-extrabold">
+                    <h3 className="ud-page-title bg-linear-to-r from-indigo-600 to-pink-600 bg-clip-text text-transparent font-extrabold">
                       <Ticket size={18} /> Registered Events
                     </h3>
                     <span className="text-sm text-slate-500 dark:text-slate-400 font-medium">


### PR DESCRIPTION
## Description

Tailwind CSS v4 changed the gradient utility prefix from `bg-gradient-*` to `bg-linear-*`. This PR migrates all 100+ files from the old v3 syntax to the correct v4 syntax.

## Changes

- Replaced all `bg-gradient-to-*` with `bg-linear-to-*` across 71 source files
- Fixed incorrect comment in `src/components/CommunityEvent.js` that was actively reverting v4 syntax back to v3

Closes #9055
