### PR TITLE
fix: replace console.warn with logger.warn in cspReporting.js

### DIFF
--- a/src/Pages/Auth/Login.jsx
+++ b/src/Pages/Auth/Login.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import LoginComponent from "../../components/auth/Login";
 
 const Login = () => {

--- a/src/Pages/Auth/Signup.jsx
+++ b/src/Pages/Auth/Signup.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import SignupComponent from "../../components/auth/Signup";
 
 const Signup = () => {

--- a/src/Pages/Dashboard/Dashboard.jsx
+++ b/src/Pages/Dashboard/Dashboard.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import DashboardComponent from "../../components/Dashboard";
 
 const Dashboard = () => {

--- a/src/Pages/User/Profile.jsx
+++ b/src/Pages/User/Profile.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import UserProfileComponent from "../../components/user/UserProfile";
 
 const Profile = () => {

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 
 const ScrollToTop = () => {
   const [isVisible, setIsVisible] = useState(false);

--- a/src/components/common/EventCardSkeleton.jsx
+++ b/src/components/common/EventCardSkeleton.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 const EventCardSkeleton = () => {
   return (
     <div className="animate-pulse bg-white dark:bg-gray-900 rounded-3xl shadow-xl overflow-hidden border border-gray-200 dark:border-gray-800">

--- a/src/utils/cspReporting.js
+++ b/src/utils/cspReporting.js
@@ -20,6 +20,8 @@
  * silently breaking the UI.
  */
 
+import { logger } from "./logger";
+
 const runtimeEnv =
   typeof import.meta !== "undefined" && import.meta.env
     ? import.meta.env
@@ -39,16 +41,16 @@ const reportUri = runtimeEnv.VITE_CSP_REPORT_URI || runtimeEnv.REACT_APP_CSP_REP
  */
 function buildReport(event) {
   return {
-    'csp-report': {
-      'document-uri': event.documentURI,
-      'violated-directive': event.violatedDirective,
-      'effective-directive': event.effectiveDirective,
-      'original-policy': event.originalPolicy,
-      'blocked-uri': event.blockedURI,
-      'source-file': event.sourceFile,
-      'line-number': event.lineNumber,
-      'column-number': event.columnNumber,
-      'status-code': event.statusCode,
+    "csp-report": {
+      "document-uri": event.documentURI,
+      "violated-directive": event.violatedDirective,
+      "effective-directive": event.effectiveDirective,
+      "original-policy": event.originalPolicy,
+      "blocked-uri": event.blockedURI,
+      "source-file": event.sourceFile,
+      "line-number": event.lineNumber,
+      "column-number": event.columnNumber,
+      "status-code": event.statusCode,
     },
   };
 }
@@ -63,7 +65,7 @@ function sendReport(report) {
   if (!reportUri) return;
 
   const blob = new Blob([JSON.stringify(report)], {
-    type: 'application/csp-report',
+    type: "application/csp-report",
   });
 
   try {
@@ -71,9 +73,9 @@ function sendReport(report) {
   } catch {
     // Beacon API unavailable — fall back to a best-effort fetch.
     fetch(reportUri, {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify(report),
-      headers: { 'Content-Type': 'application/csp-report' },
+      headers: { "Content-Type": "application/csp-report" },
       keepalive: true,
     }).catch(() => {
       // Swallow — reporting is best-effort and must never crash the app.
@@ -99,7 +101,7 @@ let _cspHandler = null;
  * DOM is ready. Calling it again while already active is a no-op.
  */
 export function initCspReporting() {
-  if (typeof document === 'undefined') return;
+  if (typeof document === "undefined") return;
   // Guard against double registration
   if (_cspHandler) return;
 
@@ -109,10 +111,10 @@ export function initCspReporting() {
     if (isDev) {
       // Surfaced as a warning so it is visible in DevTools without
       // being confused with an application error.
-      console.warn(
-        '[CSP Violation]',
+      logger.warn(
+        "[CSP Violation]",
         `Directive: ${event.effectiveDirective}`,
-        `Blocked: ${event.blockedURI || '(inline)'}`,
+        `Blocked: ${event.blockedURI || "(inline)"}`,
         `Source: ${event.sourceFile}:${event.lineNumber}`,
         report
       );
@@ -121,7 +123,7 @@ export function initCspReporting() {
     sendReport(report);
   };
 
-  document.addEventListener('securitypolicyviolation', _cspHandler);
+  document.addEventListener("securitypolicyviolation", _cspHandler);
 }
 
 /**
@@ -133,9 +135,9 @@ export function initCspReporting() {
  * silently did nothing and caused a memory leak on every test teardown.
  */
 export function teardownCspReporting() {
-  if (typeof document === 'undefined') return;
+  if (typeof document === "undefined") return;
   if (!_cspHandler) return;
 
-  document.removeEventListener('securitypolicyviolation', _cspHandler);
+  document.removeEventListener("securitypolicyviolation", _cspHandler);
   _cspHandler = null;
 }


### PR DESCRIPTION
**Fixes:** #9088

Replaces console.warn with logger.warn and adds the required logger import.

**gssoc26**