### PR TITLE
fix: align DesktopNavbar breakpoint from xl to lg to close nav dead zone

### DIFF
--- a/src/components/navbar/DesktopNavbar.jsx
+++ b/src/components/navbar/DesktopNavbar.jsx
@@ -2,7 +2,7 @@ import NavbarLinks from "./NavbarLinks";
 
 const DesktopNavbar = () => {
   return (
-    <div className="hidden xl:flex items-center justify-center flex-1 min-w-0 px-1 xl:px-2">
+    <div className="hidden lg:flex items-center justify-center flex-1 min-w-0 px-1 lg:px-2">
       <NavbarLinks />
     </div>
   );


### PR DESCRIPTION
# fix: align DesktopNavbar breakpoint from xl to lg to close nav dead zone (#9082)

## Description

Fixes #9082

Resolves a breakpoint mismatch in the navbar that left users on screens between
**1024px and 1279px** with no navigation — neither desktop links nor the mobile
hamburger button was visible.

**Root cause:** `DesktopNavbar.jsx` used `xl:flex` (1280px) to show nav links,
but `Navbar.jsx` was already hiding the hamburger with `lg:hidden` (1024px) and
showing the desktop wrapper with `lg:flex` (1024px). This created a 256px dead
zone where the outer container rendered but contained nothing, and the mobile
menu was also gone.

**Fix:** Changed `DesktopNavbar.jsx`'s wrapper class from `hidden xl:flex` to
`hidden lg:flex` and updated the responsive padding from `xl:px-2` to `lg:px-2`.
All three navbar files now agree on the `lg` breakpoint for the mobile-to-desktop
layout switch.

### Breakpoint behaviour before and after

| Viewport | Before | After |
|---|---|---|
| < 1024px | ✅ Mobile hamburger visible | ✅ Mobile hamburger visible |
| 1024px – 1279px | 🔴 No navigation | ✅ Desktop links visible |
| ≥ 1280px | ✅ Desktop links visible | ✅ Desktop links visible |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
