### PR TITLE
fix(sse): remove insecure localhost fallback in production multiplexer

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -1,19 +1,7 @@
 import { logger } from "./logger.js";
+import { resolveBackendUrl } from "../config/backendConfig/envResolver.js";
 
-const getEnvVar = (name) => {
-  if (typeof process !== "undefined" && process.env) {
-    return process.env[name];
-  }
-  return undefined;
-};
-
-const getBaseUrl = () => {
-  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_API_URL) {
-    return import.meta.env.VITE_API_URL;
-  }
-  return getEnvVar("VITE_API_URL") || getEnvVar("REACT_APP_API_URL") || getEnvVar("API_URL") || "http://localhost:8080";
-};
-const BASE_URL = getBaseUrl();
+const BASE_URL = resolveBackendUrl() || "";
 
 const MULTIPLEX_CHANNEL_NAME = "eventra_sse_multiplexer";
 const LOCK_NAME = "eventra_sse_leader_lock";


### PR DESCRIPTION
## Description
Resolves a high-impact configuration vulnerability (Issue #2) where the Server-Sent Events (SSE) multiplexer silently defaulted to `http://localhost:8080` in production environments when explicit API URL environment variables were missing. 
Closes #9107
## Changes Made
- **Refactored `getBaseUrl()`:** Removed the redundant and insecure URL resolution logic in `src/utils/sseMultiplexer.js`.
- **Centralized Env Resolution:** Imported and integrated the existing `resolveBackendUrl()` utility from `src/config/backendConfig/envResolver.js` to ensure the SSE client strictly adheres to the application's global environment configuration.
- **Fail-Safe Implementation:** The SSE multiplexer will now gracefully handle missing configurations or halt connection attempts in production, rather than leaking requests to the end-user's local network.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security patch (Prevents insecure local network pings)
- [ ] New feature (non-breaking change which adds functionality)

## Testing & Verification
- [x] Verified that `BASE_URL` successfully pulls from `VITE_API_URL` during the build process.
- [x] Verified that the multiplexer logic relies on the environment detector's strict `isDevelopment()` checks rather than blind fallbacks.

## Related Issues
Closes #2 (Hardcoded Localhost Fallbacks)
