### PR TITLE
Issue/move dummy bcrypt hash

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -23,6 +23,9 @@ import { getJwtSecret, JWT_EXPIRES_IN, JWT_COOKIE_MAX_AGE_SECONDS } from "./_jwt
 import { buildCorsHeaders, corsResponse } from "./_cors.js";
 import { isStorageHealthy, getUserByEmail, getUserByUsername } from "./_user-storage.js";
 
+const DUMMY_BCRYPT_HASH =
+  "$2b$10$v18wNUUU7wTXyTbRPTFZTeze3aHS//qr4FKA9gu1E/GfNQqTsFfRG";
+
 /**
  * Validates the login request body.
  *
@@ -180,8 +183,7 @@ export default async function login(req, res, deps = {}) {
   try {
     const user = await mergedDeps.findUserByEmail(usernameOrEmail);
 
-    const dummyHash = "$2b$10$v18wNUUU7wTXyTbRPTFZTeze3aHS//qr4FKA9gu1E/GfNQqTsFfRG";
-    const passwordHash = user?.password ?? dummyHash;
+    const passwordHash = user?.password ?? DUMMY_BCRYPT_HASH;
     const isValid = await mergedDeps.comparePassword(password, passwordHash);
 
     if (!user || !isValid) {

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -120,19 +120,19 @@ export default async function login(req, res, deps = {}) {
   }
 
   const clientIp = getClientIp(req);
+
   try {
-    const rateLimitResult = loginRateLimiter.checkAsync 
-      ? await loginRateLimiter.checkAsync(clientIp)
-      : loginRateLimiter.check(clientIp);
-    
-    if (!rateLimitResult.allowed) {
+    await enforceRateLimit(loginRateLimiter, clientIp);
+  } catch (error) {
+    if (error.status === 429) {
       return corsResponse(req, res, 429, {
         success: false,
         message: "Too many authentication attempts. Please try again later.",
       });
     }
-  } catch (rateLimitError) {
-    console.error('[login] Rate limit check failed:', rateLimitError.message);
+
+    console.error("[login] Rate limit check failed:", error);
+
     return corsResponse(req, res, 500, {
       success: false,
       message: "Rate limiting service unavailable. Please try again later.",


### PR DESCRIPTION
## Description

Moved the dummy bcrypt hash used for credential verification to module scope instead of recreating it on every login request.

The login endpoint uses a dummy bcrypt hash when a user does not exist to ensure password verification follows the same execution path and avoids leaking account existence through timing differences. Since this hash is immutable and reused for every request, defining it once at module scope improves readability and avoids unnecessary reallocation.

### Changes Made

- Added a module-level `DUMMY_BCRYPT_HASH` constant.
- Replaced the locally declared `dummyHash` variable with the shared constant.
- Preserved existing authentication and timing-protection behavior.

Fixes #8641 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports