### PR TITLE
fix(#9142): raise search dropdown z-index to prevent overlap

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -200,7 +200,7 @@ export default function EventHero({
                   exit={{ opacity: 0, y: 8, scale: 0.98 }}
                   transition={{ duration: prefersReducedMotion ? 0 : 0.18, ease: "easeOut" }}
                   className={`
-                    absolute left-0 right-0 top-full z-30 mt-3 overflow-hidden rounded-3xl
+                    absolute left-0 right-0 top-full z-50 mt-3 overflow-hidden rounded-3xl
                     border border-slate-200 dark:border-slate-700/60 ${darkTheme.card}
                     text-left shadow-2xl backdrop-blur-xl ring-1 ring-black/5 dark:ring-white/10
                   `}


### PR DESCRIPTION
Fixes the search results dropdown overlapping the hero section by raising its z-index from \z-30\ to \z-50\ to match its parent wrapper.

Closes #9142