### PR TITLE
fix(#9148): show skeleton placeholders during leaderboard loading and em-dash on error

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -515,7 +515,7 @@ export default function LeaderBoard() {
             </span>
           </div>
 
-          <LeaderboardStatsCards stats={stats} loading={loading} />
+          <LeaderboardStatsCards stats={stats} loading={loading} error={!!error} />
 
           <LeaderboardTable
             loading={loading}

--- a/src/Pages/Leaderboard/components/LeaderboardHero.jsx
+++ b/src/Pages/Leaderboard/components/LeaderboardHero.jsx
@@ -1,6 +1,10 @@
 import { Trophy } from "lucide-react";
 
-export default function LeaderboardHero({ stats, currentContributors }) {
+const BadgeSkeleton = () => (
+  <span className="inline-block w-28 h-7 rounded-full bg-slate-200 dark:bg-slate-700 animate-pulse" />
+);
+
+export default function LeaderboardHero({ stats, currentContributors, loading }) {
   return (
     <header className="mb-10 rounded-[32px] border border-slate-200/70 bg-white/85 px-6 py-8 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur-xl sm:px-8">
       <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-1.5 text-[11px] font-bold uppercase tracking-[0.22em] text-slate-600">
@@ -20,9 +24,19 @@ export default function LeaderboardHero({ stats, currentContributors }) {
       </p>
 
       <div className="mt-6 flex flex-wrap items-center justify-center gap-3 text-xs font-semibold text-slate-500">
-        <span className="rounded-full border border-slate-200 bg-white px-3 py-1.5">{stats.totalContributors} contributors</span>
-        <span className="rounded-full border border-slate-200 bg-white px-3 py-1.5">{stats.flooredTotalPRs} merged PRs</span>
-        <span className="rounded-full border border-slate-200 bg-white px-3 py-1.5">{currentContributors.length} shown on this page</span>
+        {loading ? (
+          <>
+            <BadgeSkeleton />
+            <BadgeSkeleton />
+            <BadgeSkeleton />
+          </>
+        ) : (
+          <>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1.5">{stats.totalContributors} contributors</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1.5">{stats.flooredTotalPRs} merged PRs</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1.5">{currentContributors.length} shown on this page</span>
+          </>
+        )}
       </div>
     </header>
   );

--- a/src/Pages/Leaderboard/components/LeaderboardStatsCards.jsx
+++ b/src/Pages/Leaderboard/components/LeaderboardStatsCards.jsx
@@ -29,7 +29,7 @@ const cards = [
   },
 ];
 
-export default function LeaderboardStatsCards({ stats, loading }) {
+export default function LeaderboardStatsCards({ stats, loading, error }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
       {cards.map((card, idx) => (
@@ -50,6 +50,8 @@ export default function LeaderboardStatsCards({ stats, loading }) {
             <p className="mt-1 text-3xl font-extrabold text-slate-950">
               {loading ? (
                 <span className="inline-block w-12 h-8 bg-slate-200 dark:bg-slate-800 rounded animate-pulse" />
+              ) : error ? (
+                <span className="text-2xl font-bold text-slate-400">&mdash;</span>
               ) : (
                 <AnimatedCounter value={stats[card.key]} />
               )}


### PR DESCRIPTION
## Changes
- LeaderboardHero now accepts `loading` prop and shows skeleton badges instead of "0 contributors" during load
- LeaderboardStatsCards now accepts `error` prop and shows em-dash instead of misleading 0 values on failure
- Both components gracefully fall back when data is unavailable

Closes #9148
