### PR TITLE
fix: cap token expiry timeout delay

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -3,6 +3,20 @@ import { toast } from "react-toastify";
 import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils";
 import { syncSecureStorage } from "../utils/secureStorage";
 
+export const MAX_TOKEN_EXPIRY_TIMEOUT_MS = 2_147_483_647;
+const TOKEN_EXPIRY_BUFFER_MS = 1_000;
+
+export function getTokenExpiryDelayMs(expSeconds, nowMs = Date.now()) {
+  return Math.max(expSeconds * 1000 - nowMs + TOKEN_EXPIRY_BUFFER_MS, 0);
+}
+
+export function getSafeTokenExpiryDelayMs(expSeconds, nowMs = Date.now()) {
+  return Math.min(
+    getTokenExpiryDelayMs(expSeconds, nowMs),
+    MAX_TOKEN_EXPIRY_TIMEOUT_MS
+  );
+}
+
 export function useTokenExpiry({ token, user, onExpired }) {
   const expiryToastShownRef = useRef(false);
 
@@ -34,22 +48,36 @@ export function useTokenExpiry({ token, user, onExpired }) {
     }
 
     let timeoutId;
+    let cancelled = false;
+
     if (typeof expSeconds === "number") {
-      let delayMs = Math.max(expSeconds * 1000 - Date.now() + 1000, 0);
-      if (delayMs > 2147483647) delayMs = 2147483647;
-      timeoutId = setTimeout(() => {
-        if (token === "cookie-managed" ? Date.now() >= expSeconds * 1000 : !isTokenValid(token)) {
-          clearExpiredSession();
-        }
-      }, delayMs);
+      const scheduleExpiryCheck = () => {
+        const delayMs = getSafeTokenExpiryDelayMs(expSeconds);
+
+        timeoutId = setTimeout(() => {
+          if (cancelled) return;
+
+          if (token === "cookie-managed" ? Date.now() >= expSeconds * 1000 : !isTokenValid(token)) {
+            clearExpiredSession();
+            return;
+          }
+
+          scheduleExpiryCheck();
+        }, delayMs);
+      };
+
+      scheduleExpiryCheck();
     } else if (token !== "cookie-managed") {
       timeoutId = setInterval(() => {
-        if (!isTokenValid(token)) clearExpiredSession();
+        if (!isTokenValid(token)) {
+          clearExpiredSession();
+        }
       }, 60_000);
       if (!isTokenValid(token)) clearExpiredSession();
     }
 
     return () => {
+      cancelled = true;
       if (timeoutId) {
         if (typeof expSeconds === "number") clearTimeout(timeoutId);
         else clearInterval(timeoutId);

--- a/tests/useTokenExpiryTimeout.test.mjs
+++ b/tests/useTokenExpiryTimeout.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import {
+  getSafeTokenExpiryDelayMs,
+  getTokenExpiryDelayMs,
+  MAX_TOKEN_EXPIRY_TIMEOUT_MS,
+} from "../src/hooks/useTokenExpiry.js";
+
+const nowMs = 1_700_000_000_000;
+
+{
+  const expSeconds = Math.floor((nowMs + 60_000) / 1000);
+  assert.equal(
+    getTokenExpiryDelayMs(expSeconds, nowMs),
+    61_000,
+    "adds the one-second expiry buffer to normal delays"
+  );
+  assert.equal(
+    getSafeTokenExpiryDelayMs(expSeconds, nowMs),
+    61_000,
+    "keeps normal delays unchanged"
+  );
+}
+
+{
+  const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+  const expSeconds = Math.floor((nowMs + thirtyDaysMs) / 1000);
+
+  assert.ok(
+    getTokenExpiryDelayMs(expSeconds, nowMs) > MAX_TOKEN_EXPIRY_TIMEOUT_MS,
+    "30-day remember-me tokens exceed the browser timeout limit"
+  );
+  assert.equal(
+    getSafeTokenExpiryDelayMs(expSeconds, nowMs),
+    MAX_TOKEN_EXPIRY_TIMEOUT_MS,
+    "long-lived tokens are capped to avoid 32-bit setTimeout overflow"
+  );
+}
+
+{
+  const alreadyExpiredSeconds = Math.floor((nowMs - 5_000) / 1000);
+  assert.equal(
+    getSafeTokenExpiryDelayMs(alreadyExpiredSeconds, nowMs),
+    0,
+    "expired tokens still schedule an immediate validation"
+  );
+}
+
+console.log("useTokenExpiry timeout tests passed");


### PR DESCRIPTION
## Summary
- Add safe token-expiry delay helpers capped at the browser `setTimeout` limit
- Re-check long-lived tokens after each capped timeout instead of letting 30-day tokens overflow
- Add regression coverage for normal, expired, and long-lived remember-me token delays

## Tests
- `node --loader ./tests/loaders/jsExtension.mjs tests/useTokenExpiryTimeout.test.mjs`
- `.\node_modules\.bin\eslint src\hooks\useTokenExpiry.js tests\useTokenExpiryTimeout.test.mjs`

Closes #8407