### PR TITLE
fix(useBookmarks): add SSR guard before localStorage access in readStorage/writeStorage

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -31,6 +31,7 @@ export const MAX_BOOKMARKS = 200;
 const cache = new Map(); // Map<storageKey, BookmarkEntry[]>
 
 const readStorage = (key) => {
+  if (typeof window === "undefined") return [];
   try {
     const stored = localStorage.getItem(key);
     if (!stored) return [];
@@ -42,6 +43,7 @@ const readStorage = (key) => {
 };
 
 const writeStorage = (key, value) => {
+  if (typeof window === "undefined") return;
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch {


### PR DESCRIPTION
## Summary

Add typeof window === 'undefined' guards to the readStorage and writeStorage helper functions in src/hooks/useBookmarks.js. These functions are called during hook state initialization (useState initializer), which runs during SSR in Next.js/Remix environments. Without the guards, localStorage access causes a ReferenceError that crashes the server.

## Changes

- Add SSR guard to readStorage(key) returning [] when typeof window === 'undefined'
- Add SSR guard to writeStorage(key, value) returning early when typeof window === 'undefined'

## Impact

Fixes server-side rendering crashes. All bookmark functionality becomes unavailable during SSR without this fix.

Closes #9203.