### PR TITLE
fix(useCSVExport): add document guard to prevent SSR crash in exportToCSV

### DIFF
--- a/src/hooks/useCSVExport.js
+++ b/src/hooks/useCSVExport.js
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 
 export const useCSVExport = () => {
   const exportToCSV = useCallback((data, filename = 'export.csv') => {
+    if (typeof document === 'undefined') return;
     if (!data || !data.length) return;
     
     const headers = Object.keys(data[0]);


### PR DESCRIPTION
## Summary

Add a typeof document === 'undefined' guard at the top of the exportToCSV callback in src/hooks/useCSVExport.js. While exportToCSV is typically called from user events (not during SSR), this adds defensive programming to prevent crashes if the code path is ever reached in a server context.

## Changes

- Add if (typeof document === 'undefined') return; as the first line of exportToCSV

## Impact

Prevents potential SSR/hydration crashes. Adds defensive programming safety.

Closes #9207.