### PR TITLE
fix: treat empty hackathons array as valid data, not error

### DIFF
--- a/src/services/hackathonService.js
+++ b/src/services/hackathonService.js
@@ -4,10 +4,10 @@ export const fetchHackathons = async () => {
   const response = await apiUtils.get(API_ENDPOINTS.HACKATHONS.LIST);
   const data = response.data;
 
-  if (Array.isArray(data) && data.length > 0) {
-    return data;
+  if (!Array.isArray(data)) {
+    throw new Error("Hackathons API returned no data");
   }
-  throw new Error("Hackathons API returned no data");
+  return data;
 };
 
 export const hostHackathon = async (hackathonData, config) => {


### PR DESCRIPTION
## Summary
Fixes a bug where an empty array from the hackathons API was treated as an error, showing Failed to load hackathons instead of the normal No Hackathons Found empty state.

## Root Cause
hackathonService.js line 7-10 required data.length > 0, throwing Hackathons API returned no data for empty arrays. The UI already has a proper empty state - this bug bypassed it.

## Fix
Accept any valid array (including empty) and let the UI's existing empty state handle the no hackathons case.

Closes https://github.com/SandeepVashishtha/Eventra/issues/9219