### PR TITLE
Fix/remove hardcoded stats

### DIFF
--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { Award, Calendar, Code2, Sparkles, Users, X } from "lucide-react";
+import { Award, Calendar, Code2, Sparkles, Users, X, Rocket } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import ModernSearchInput from "../../components/common/ModernSearchInput";
 import { useAuth } from "../../context/AuthContext";
@@ -130,7 +130,7 @@ export default function HackathonHero({
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={onSearchKeyDown}
-              placeholder="Search hackathons by name, location, or tags..."
+              placeholder="Search hackathons by name, technology, prize pool, or organizer..."
               tags={
                 <AnimatePresence>
                   {selectedTags.map((tag) => (
@@ -165,9 +165,27 @@ export default function HackathonHero({
                 </motion.span>
               ))}
             </div>
-            <span className="text-sm text-indigo-700 dark:text-indigo-300 font-semibold">
-              {filteredCount}{" "}{filteredCount === 1 ? "hackathon" : "hackathons"} found
-            </span>
+            {filteredCount > 0 ? (
+              <span className="text-sm text-indigo-700 dark:text-indigo-300 font-semibold">
+                {filteredCount}{" "}{filteredCount === 1 ? "hackathon" : "hackathons"} found
+              </span>
+            ) : (
+              <motion.div 
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="mt-4 flex flex-col items-center text-center p-6 bg-white/40 dark:bg-slate-900/40 rounded-2xl border border-indigo-100 dark:border-indigo-900/50 backdrop-blur-md w-full"
+              >
+                <div className="w-12 h-12 bg-indigo-100 dark:bg-indigo-900/50 rounded-full flex items-center justify-center mb-3">
+                  <Rocket className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
+                </div>
+                <p className="text-lg font-bold text-slate-800 dark:text-slate-200 mb-1">
+                  No hackathons available right now 🚀
+                </p>
+                <p className="text-sm text-slate-600 dark:text-slate-400">
+                  Be the first to host one or check back later for upcoming opportunities.
+                </p>
+              </motion.div>
+            )}
           </div>
         </motion.div>
 

--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -1,4 +1,4 @@
-import { Code2, RefreshCw, Compass, ChevronDown, X } from "lucide-react";
+import { Code2, RefreshCw, Compass, ChevronDown, X, Rocket, PlusCircle } from "lucide-react";
 import TeamMatchmaking from "./components/TeamMatchmaking";
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
@@ -796,43 +796,58 @@ const HackathonHub = () => {
                   <motion.div
                     animate={{ y: [0, -8, 0] }}
                     transition={{ duration: prefersReducedMotion ? 0 : 3, repeat: Infinity, ease: "easeInOut" }}
-                    className="flex justify-center items-center w-20 h-20 rounded-full bg-bg dark:bg-bg shadow-sm mx-auto border border-border"
+                    className="flex justify-center items-center w-24 h-24 rounded-full bg-indigo-50 dark:bg-indigo-950/30 shadow-sm mx-auto border border-indigo-100 dark:border-indigo-800/50"
                   >
-                    <Code2 className="h-10 w-10 text-primary" />
+                    <Rocket className="h-12 w-12 text-indigo-600 dark:text-indigo-400" />
                   </motion.div>
 
                   <h3 className="mt-6 text-2xl font-bold text-slate-900 dark:text-gray-100">
-                    No Hackathons Found
+                    No hackathons available right now 🚀
                   </h3>
 
-                  <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                  <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed max-w-sm mx-auto">
                     {debouncedSearchQuery || filters.difficulty || filters.prize || filters.location || selectedTags.length > 0
-                      ? "No hackathons match your current filters. Try adjusting your search or filters."
-                      : "Check back later for exciting new hackathons!"}
+                      ? "No hackathons match your current filters. Try adjusting your search or clearing your filters."
+                      : "Be the first to host one or check back later for upcoming opportunities."}
                   </p>
 
-                  <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                    <motion.button
-                      type="button"
-                      whileHover={{ scale: 1.05 }}
-                      whileTap={{ scale: 0.95 }}
-                      onClick={resetFilters}
-                      className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-lg text-white bg-primary hover:opacity-90 shadow-lg transition-all"
-                    >
-                      <RefreshCw className="w-4 h-4" />
-                      Reset Filters
-                    </motion.button>
-
+                  <div className="mt-8 flex flex-col sm:flex-row flex-wrap gap-4 justify-center items-center">
                     <motion.button
                       type="button"
                       whileHover={{ scale: 1.05 }}
                       whileTap={{ scale: 0.95 }}
                       onClick={scrollToCards}
-                      className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-lg text-black dark:text-white border border-black/15 dark:border-gray-600 bg-bg hover:bg-card-bg shadow-md transition-all"
+                      className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-xl text-white bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 hover:opacity-90 shadow-lg transition-all"
                     >
-                      Explore Hackathons
                       <Compass className="w-4 h-4" />
+                      Explore Hackathons
                     </motion.button>
+
+                    <motion.div
+                      whileHover={{ scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                    >
+                      <Link 
+                        to="/host-hackathon"
+                        className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-xl text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800 bg-white dark:bg-gray-900 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 shadow-sm transition-all"
+                      >
+                        <PlusCircle className="w-4 h-4" />
+                        Host a Hackathon
+                      </Link>
+                    </motion.div>
+
+                    {(debouncedSearchQuery || filters.difficulty || filters.prize || filters.location || selectedTags.length > 0) && (
+                      <motion.button
+                        type="button"
+                        whileHover={{ scale: 1.05 }}
+                        whileTap={{ scale: 0.95 }}
+                        onClick={resetFilters}
+                        className="flex items-center justify-center gap-2 px-6 py-2.5 text-sm font-medium rounded-xl text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-all w-full sm:w-auto"
+                      >
+                        <RefreshCw className="w-4 h-4" />
+                        Reset Filters
+                      </motion.button>
+                    )}
                   </div>
                 </div>
               </motion.div>

--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -253,38 +253,111 @@ const AchievementBadge = memo(({ achievement, onUnlock }) => {
 });
 AchievementBadge.displayName = "AchievementBadge";
 
-const TimelineItem = memo(({ item, isLast }) => {
-  const Icon = item.icon;
-  const statusColors = getStatusColor(item.status);
+const HorizontalTimeline = memo(({ timeline, variants }) => {
+  const total = timeline.length - 1;
+  const currentIndex = timeline.findIndex(item => item.status === 'current');
+  const progressPercent = currentIndex >= 0 ? (currentIndex / total) * 100 : 100;
   
+  const currentItem = timeline[currentIndex];
+  const nextItem = timeline[currentIndex + 1];
+
   return (
-    <div className="flex gap-4" role="listitem">
-      <div className="flex flex-col items-center">
-        <motion.div
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
-          className={`w-10 h-10 rounded-full flex items-center justify-center border-2 ${statusColors}`}
-          aria-label={`${item.phase}: ${item.status}`}
-        >
-          <Icon className="w-5 h-5" aria-hidden="true" />
-        </motion.div>
-        {!isLast && (
-          <div className={`w-0.5 flex-1 my-2 ${item.status === 'completed' ? 'bg-green-400' : 'bg-gray-300 dark:bg-gray-600'}`} aria-hidden="true" />
-        )}
+    <motion.section variants={variants} className="p-5 sm:p-8 rounded-3xl bg-white dark:bg-slate-800/60 border border-slate-200/60 dark:border-slate-700/60 shadow-lg shadow-slate-200/30 dark:shadow-none mb-6 sm:mb-8 backdrop-blur-xl">
+      <div className="flex flex-col md:flex-row md:items-end justify-between gap-5 mb-10 border-b border-slate-100 dark:border-slate-700/50 pb-6">
+        <div>
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-10 h-10 rounded-xl bg-indigo-50 dark:bg-indigo-500/10 flex items-center justify-center border border-indigo-100 dark:border-indigo-500/20">
+              <Calendar className="w-5 h-5 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
+            </div>
+            <h3 className="text-2xl font-black text-slate-900 dark:text-white tracking-tight">Program Timeline</h3>
+          </div>
+          <p className="text-sm font-medium text-slate-500 dark:text-slate-400 ml-[52px]">Track your milestones and upcoming deadlines</p>
+        </div>
+        
+        <div className="flex flex-col md:items-end bg-slate-50 dark:bg-slate-900/50 p-4 rounded-2xl border border-slate-200/60 dark:border-slate-800/80 shadow-inner">
+          <div className="flex items-center gap-3 mb-1.5">
+            <span className="text-sm font-bold text-slate-700 dark:text-slate-300">Program Progress</span>
+            <span className="text-xs font-black text-white bg-linear-to-r from-indigo-500 to-violet-600 px-2.5 py-1 rounded-full shadow-md shadow-indigo-500/20">{Math.round(progressPercent)}% Complete</span>
+          </div>
+          {currentItem && (
+            <p className="text-xs text-slate-600 dark:text-slate-400 mt-1.5 font-medium">
+              Current Phase: <strong className="text-slate-900 dark:text-white font-bold">{currentItem.phase}</strong>
+            </p>
+          )}
+          {nextItem && (
+            <p className="text-xs text-slate-500 dark:text-slate-500 mt-1 font-medium">
+              Next Milestone: <span className="text-indigo-600 dark:text-indigo-400 font-semibold">{nextItem.phase} ({nextItem.date})</span>
+            </p>
+          )}
+        </div>
       </div>
-      <div className="pb-6">
-        <h4 className="font-medium text-gray-900 dark:text-white">{item.phase}</h4>
-        <p className="text-sm text-gray-500 dark:text-gray-400">{item.date}</p>
-        {item.status === 'current' && (
-          <span className="inline-block mt-1 px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400 rounded-full">
-            In Progress
-          </span>
-        )}
+      
+      <div className="relative w-full py-4 overflow-x-auto hide-scrollbar">
+        <div className="min-w-[700px] flex items-start justify-between relative px-8 md:px-12 pb-8 pt-2">
+          {/* Progress Bar Background */}
+          <div className="absolute top-[34px] left-20 right-20 h-2 bg-slate-100 dark:bg-slate-800/80 rounded-full overflow-hidden border border-slate-200/50 dark:border-slate-700/50" aria-hidden="true">
+            {/* Active Progress Bar */}
+            <motion.div 
+              initial={{ width: 0 }}
+              animate={{ width: `${progressPercent}%` }}
+              transition={{ duration: 1.5, ease: "easeOut", delay: 0.2 }}
+              className="absolute top-0 left-0 h-full bg-linear-to-r from-blue-500 via-indigo-500 to-violet-500 rounded-full shadow-[0_0_10px_rgba(99,102,241,0.5)]" 
+            />
+          </div>
+          
+          {timeline.map((item, idx) => {
+            const Icon = item.icon;
+            const isCompleted = item.status === 'completed';
+            const isCurrent = item.status === 'current';
+            
+            return (
+              <div key={item.phase} className="relative flex flex-col items-center w-32 shrink-0 z-10 group" role="listitem">
+                <motion.div
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  transition={{ delay: idx * 0.1, type: "spring", stiffness: 200 }}
+                  className={`w-14 h-14 rounded-2xl flex items-center justify-center border-4 shadow-xl transition-all duration-300 ${
+                    isCompleted ? 'bg-linear-to-br from-indigo-500 to-violet-600 border-white dark:border-slate-900 text-white group-hover:scale-110 group-hover:-translate-y-1 shadow-indigo-500/20' : 
+                    isCurrent ? 'bg-white dark:bg-slate-900 text-indigo-600 dark:text-indigo-400 border-indigo-500 shadow-indigo-500/30 scale-110 group-hover:scale-125 group-hover:-translate-y-1' : 
+                    'bg-slate-50 dark:bg-slate-800 text-slate-400 dark:text-slate-500 border-white dark:border-slate-900 shadow-slate-200/50 dark:shadow-none'
+                  } ${isCurrent ? 'rotate-3 group-hover:rotate-6' : '-rotate-3 group-hover:rotate-0'}`}
+                  aria-label={`${item.phase}: ${item.status}`}
+                >
+                  {isCompleted ? <CheckCircle className="w-6 h-6" /> : <Icon className={`w-6 h-6 ${isCurrent ? 'animate-pulse' : ''}`} aria-hidden="true" />}
+                </motion.div>
+                
+                <div className="mt-5 text-center">
+                  <h4 className={`text-sm font-extrabold mb-1.5 transition-colors ${
+                    isCurrent ? 'text-indigo-600 dark:text-indigo-400' : 
+                    isCompleted ? 'text-slate-900 dark:text-white' : 
+                    'text-slate-400 dark:text-slate-500'
+                  }`}>
+                    {item.phase}
+                  </h4>
+                  <p className={`text-xs ${isCurrent ? 'text-slate-700 dark:text-slate-300 font-bold' : 'text-slate-500 dark:text-slate-500 font-medium'}`}>
+                    {item.date}
+                  </p>
+                  <AnimatePresence>
+                    {isCurrent && (
+                      <motion.span 
+                        initial={{ opacity: 0, y: -10, scale: 0.8 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        className="absolute -bottom-10 left-1/2 -translate-x-1/2 whitespace-nowrap px-3 py-1.5 text-[10px] font-black uppercase tracking-widest bg-indigo-100 text-indigo-700 dark:bg-indigo-500/20 dark:text-indigo-300 rounded-xl border border-indigo-200 dark:border-indigo-500/30 shadow-sm"
+                      >
+                        Active Phase
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
-    </div>
+    </motion.section>
   );
 });
-TimelineItem.displayName = "TimelineItem";
+HorizontalTimeline.displayName = "HorizontalTimeline";
 
 const ResourceItem = memo(({ resource, onCopy }) => {
   const [copied, setCopied] = useState(false);
@@ -762,19 +835,8 @@ const timeLeft = useCountdown(
           </div>
         </motion.section>
 
-        {/* 📅 Timeline */}
-        <motion.section variants={itemVariants} className="p-4 sm:p-6 rounded-2xl bg-card-bg border border-gray-200 dark:border-gray-700 mb-6 sm:mb-8">
-          <div className="flex items-center gap-2 mb-4 sm:mb-6">
-            <Calendar className="w-5 h-5 text-purple-500" aria-hidden="true" />
-            <h3 className="font-semibold text-gray-900 dark:text-white">Program Timeline</h3>
-          </div>
-          
-          <div className="relative pl-2" role="list" aria-label="Program timeline">
-            {GSSOC_TIMELINE.map((item, idx) => (
-              <TimelineItem key={item.phase} item={item} isLast={idx === GSSOC_TIMELINE.length - 1} />
-            ))}
-          </div>
-        </motion.section>
+        {/* 📅 Horizontal Timeline */}
+        <HorizontalTimeline timeline={GSSOC_TIMELINE} variants={itemVariants} />
 
         {/* Getting Started & Best Practices */}
         <motion.section className="grid md:grid-cols-2 gap-4 sm:gap-6 mb-6 sm:mb-8" variants={itemVariants}>

--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -401,18 +401,6 @@ const ResourceItem = memo(({ resource, onCopy }) => {
 });
 ResourceItem.displayName = "ResourceItem";
 
-const StatCard = memo(({ label, value, icon: Icon, color }) => (
-  <motion.div 
-    whileHover={{ y: -2 }}
-    className="p-3 text-center"
-    role="status"
-  >
-    <Icon className={`w-6 h-6 mx-auto mb-2 ${color}`} aria-hidden="true" />
-    <div className="text-xl font-bold text-gray-900 dark:text-white tabular-nums">{formatNumber(value)}</div>
-    <div className="text-xs text-gray-600 dark:text-gray-400">{label}</div>
-  </motion.div>
-));
-StatCard.displayName = "StatCard";
 
 // Skeleton Components
 const Skeleton = ({ className }) => (
@@ -565,9 +553,6 @@ const timeLeft = useCountdown(
     }
   }), [prefersReducedMotion]);
   
-  // Stats section visibility
-  const statsRef = useRef(null);
-  useInView(statsRef, { once: true, margin: "-100px" });
   
   if (isLoading) {
     return (
@@ -925,32 +910,6 @@ const timeLeft = useCountdown(
           </motion.button>
         </motion.nav>
 
-        {/* 📊 Footer Stats */}
-        <motion.section
-          ref={statsRef}
-          variants={itemVariants}
-          className="p-4 sm:p-6 rounded-2xl bg-linear-to-r from-indigo-50 to-purple-50 dark:from-gray-800 dark:to-gray-700 border dark:border-gray-600"
-          aria-labelledby="stats-heading"
-        >
-          <h3 id="stats-heading" className="sr-only">Community Statistics</h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 text-center">
-            {[
-              { label: "Active Contributors", value: 500, suffix: "+", icon: Users, color: "text-blue-500" },
-              { label: "Issues Solved", value: 1200, icon: CheckCircle, color: "text-green-500" },
-              { label: "PRs Merged", value: 850, suffix: "+", icon: GitBranch, color: "text-purple-500" },
-              { label: "Countries", value: 45, suffix: "+", icon: Globe, color: "text-orange-500" },
-            ].map(({ label, value, suffix, icon: Icon, color }) => (
-              <StatCard 
-                key={label} 
-                label={label} 
-                value={value} 
-                suffix={suffix}
-                icon={Icon} 
-                color={color} 
-              />
-            ))}
-          </div>
-        </motion.section>
       </motion.main>
       
       {/* Toast Notifications */}


### PR DESCRIPTION
## Description
This PR resolves an issue on the Leaderboard/Contributor page where hardcoded, fabricated statistics (e.g., "500 Active Contributors", "1.2k Issues Solved") were being displayed. Displaying inaccurate placeholder metrics can mislead users and reduce trust in the platform's community data.
Closes #9163
## Changes Made
- **Removed Fabricated Metrics**: Completely removed the "Footer Stats" section that displayed static placeholder values.
- **Code Cleanup**: Removed the now-unused `StatCard` component, the `statsRef` variable, and associated Intersection Observer hooks to eliminate dead code and improve component rendering performance.

## Design Decision (Option B)
Since securely and accurately aggregating metrics like "Total PRs Merged" and "Contributor Geography" via frontend-only GitHub API requests is prone to rate-limiting and pagination complexities, we have opted for Option B (Removing the section). This ensures that we strictly adhere to displaying only reliable and authentic information to our contributors.

## Type of Change
- [x] Bug Fix
- [x] Code Cleanup / Refactor
