### PR TITLE
fix(utils): handle Web Locks API tab backgrounding in SSE multiplexer

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -99,9 +99,29 @@ class SseMultiplexer {
           this.queryGlobalSubscribers();
           this.reconcileConnections();
 
-          // Keep the lock active until tab unloads/unmounts
+          // Detect when the tab is backgrounded so the lock is released cleanly
+          // before the browser auto-releases it (which would leave releaseLockPromise hanging).
+          const onVisibilityChange = () => {
+            if (document.visibilityState === "hidden") {
+              this.stopHeartbeatChecks();
+              this.isLeader = false;
+              document.removeEventListener("visibilitychange", onVisibilityChange);
+              if (this.releaseLockPromise) {
+                this.releaseLockPromise();
+                this.releaseLockPromise = null;
+              }
+              // Revert to localStorage-based election so another tab can claim leadership
+              this.setupLocalStorageElection();
+            }
+          };
+          document.addEventListener("visibilitychange", onVisibilityChange);
+
+          // Keep the lock active until tab unloads/unmounts or is backgrounded
           await new Promise((resolve) => {
-            this.releaseLockPromise = resolve;
+            this.releaseLockPromise = () => {
+              document.removeEventListener("visibilitychange", onVisibilityChange);
+              resolve();
+            };
           });
         })
         .catch((err) => {


### PR DESCRIPTION
## Summary

The `SSEClient` in `src/utils/sseMultiplexer.js` used the Web Locks API for leader election. When a browser tab was backgrounded or suspended, the browser automatically released the Web Lock — but the internal `releaseLockPromise` was never called, causing the promise to hang indefinitely and leaving the tab in an inconsistent `isLeader = false` state.

## Changes

- Added a `visibilitychange` listener inside the Web Locks request callback to detect when the tab moves to background
- When `document.visibilityState === "hidden"`, the fix calls `stopHeartbeatChecks()`, sets `isLeader = false`, resolves `releaseLockPromise`, and transitions to localStorage-based election so another tab can claim leadership
- Updated `releaseLockPromise` to also remove the `visibilitychange` listener on resolve, preventing memory leaks

## Impact

Multi-tab SSE scenarios are now stable: backgrounded tabs properly release leadership, preventing heartbeat failures, duplicate SSE connections, and inconsistent subscriber state.

Closes #9247.