### PR TITLE
fix(utils): add SSR guard to localStorage in storageUtils.js

### DIFF
--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -1,4 +1,5 @@
 export const saveToStorage = (key, value) => {
+  if (typeof window === "undefined") return;
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
@@ -7,6 +8,7 @@ export const saveToStorage = (key, value) => {
 };
 
 export const loadFromStorage = (key, fallbackValue) => {
+  if (typeof window === "undefined") return fallbackValue;
   try {
     const stored = localStorage.getItem(key);
 


### PR DESCRIPTION
## Summary

`saveToStorage` and `loadFromStorage` in `src/utils/storageUtils.js` accessed `localStorage` directly without any `typeof window !== "undefined"` guard. In SSR environments (Next.js server components, Node.js test runners, edge runtimes), `localStorage` is undefined and throws `ReferenceError: localStorage is not defined`.

## Changes

- Added `if (typeof window === "undefined") return;` as the first line of `saveToStorage`
- Added `if (typeof window === "undefined") return fallbackValue;` as the first line of `loadFromStorage`

## Impact

The app no longer crashes when `storageUtils.js` is called during server-side rendering. Next.js builds and server-side test execution work correctly.

Closes #9248.