### PR TITLE
Enable credentials and manage auth cookie token

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -34,7 +34,7 @@ const API = axios.create({
   baseURL: API_BASE_URL || undefined,
   timeout: REQUEST_TIMEOUT_MS,
   headers: { "Content-Type": "application/json" },
-  withCredentials: false,
+  withCredentials: true,
 });
 
 let onUnauthorized = null;

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -116,6 +116,7 @@ export const AuthProvider = ({ children }) => {
     
     // Invalidate token cookie
     document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; Secure; SameSite=Strict";
+    document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Strict";
     
     // Clear user metadata from secure/local storage manager
     syncSecureStorage.removeItem("user");
@@ -196,13 +197,25 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     const validate = async () => {
       try {
+        const cookieToken = document.cookie
+          .split("; ")
+          .find((row) => row.startsWith("token="))
+          ?.split("=")[1];
+        
+        let activeToken = "cookie-managed";
+        if (cookieToken && cookieToken !== "cookie-managed") {
+          activeToken = cookieToken;
+          setToken(cookieToken);
+          setAuthToken(cookieToken);
+        }
+
         const res = await userService.getProfile();
         if (!isMountedRef.current) return;
         
         if (res.ok && res.data) {
           const { sessionUser } = extractSession(res.data, null);
           if (!isMountedRef.current) return;
-          setToken("cookie-managed");
+          setToken(activeToken);
           setUser(sessionUser);
         } else {
           clearSession();
@@ -219,7 +232,11 @@ export const AuthProvider = ({ children }) => {
             const cachedUser = await syncSecureStorage.getItemAsync("user");
             if (cachedUser) {
               setUser(JSON.parse(cachedUser));
-              setToken("cookie-managed");
+              const cookieToken = document.cookie
+                .split("; ")
+                .find((row) => row.startsWith("token="))
+                ?.split("=")[1];
+              setToken(cookieToken || "cookie-managed");
             } else {
               clearSession();
             }
@@ -300,6 +317,15 @@ export const AuthProvider = ({ children }) => {
     setAuthToken(sessionToken);
     
     try {
+      if (sessionToken && sessionToken !== "cookie-managed") {
+        const secureFlag = window.location.protocol === "https:" ? "Secure;" : "";
+        document.cookie = `token=${sessionToken}; path=/; ${secureFlag} SameSite=Strict`;
+      }
+    } catch (err) {
+      console.warn("[AuthContext] Failed to write cookie:", err);
+    }
+
+    try {
       // Security Contract: Strip authorization keys from display profile object stored in localStorage
       const { roles: _roles, permissions: _permissions, scopes: _scopes, ...displayProfile } = sessionUser;
       await syncSecureStorage.setItem("user", JSON.stringify(displayProfile));
@@ -343,7 +369,8 @@ export const AuthProvider = ({ children }) => {
 
         const { sessionUser } = extractSession(data, usernameOrEmail);
 
-        const persisted = await persistSession("cookie-managed", sessionUser);
+        const tokenValue = data?.token || data?.data?.token || "cookie-managed";
+        const persisted = await persistSession(tokenValue, sessionUser);
         if (!persisted) return false;
 
         setAuthRequest({ loading: false, error: null });
@@ -352,6 +379,7 @@ export const AuthProvider = ({ children }) => {
         if (!isMountedRef.current) return false;
         // Fix (Issue #8646):
         document.cookie = "token=; Max-Age=0; path=/; Secure; SameSite=Strict";
+        document.cookie = "token=; Max-Age=0; path=/; SameSite=Strict";
 
         const status = error?.status || error?.response?.status;
         // Re-throw server errors so Login.js catch can show the correct message


### PR DESCRIPTION
Enable axios withCredentials and add comprehensive cookie-based token handling in AuthContext. Read existing token cookie on startup and use it to set the in-memory token/axios auth header, persist response token values returned from login, and write the session token back to a cookie (only when a real token is present). Add defensive try/catch around cookie writes, adjust cookie-clear operations for non-HTTPS contexts, and ensure a fallback "cookie-managed" token is used when appropriate. Changes touch src/config/api.js and src/context/AuthContext.js to support cookie-based authentication flows.
