### PR TITLE
fix: add missing helpCenter i18n keys to en.json

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -427,26 +427,147 @@
     "toastCopyFailed": "Failed to copy story."
   },
   "helpCenter": {
-    "pageTitle": "Eventra | Help Center",
-    "heroHeading": "Need Help with Hackathons, Projects, or Contributions?",
-    "heroSubtitle": "Find step-by-step guides, FAQs, and tips to make the most of your Eventra experience",
-    "categoriesHeading": "Browse by Category",
-    "communityHeading": "Connect with the Community",
-    "communitySubtitle": "Join discussions, meet contributors, and stay updated with the latest news",
-    "communityVisitLink": "Click to visit and connect with our community",
-    "tutorialsHeading": "Step-by-Step Tutorials",
-    "tutorialsSubtitle": "Master every aspect of the platform with our detailed tutorials",
-    "difficultyBeginner": "Beginner",
-    "difficultyIntermediate": "Intermediate",
-    "guidelinesHeading": "Platform Guidelines",
-    "guidelinesSubtitle": "Follow these best practices to get the most out of Eventra",
-    "guidelinesLearnMore": "Learn more",
-    "faqHeading": "Frequently Asked Questions",
-    "faqSubtitle": "Everything you need to know about using Eventra and participating in events",
-    "ctaHeading": "Need Help or Have Feedback?",
-    "ctaSubtitle": "Reach out to our support team and we will get back to you within 24 hours",
-    "ctaContactUs": "Contact Us",
-    "ctaGiveFeedback": "Give Feedback"
+  "pageTitle": "Eventra | Help Center",
+  "heroHeading": "Need Help with Hackathons, Projects, or Contributions?",
+  "heroSubtitle": "Find step-by-step guides, FAQs, and tips to make the most of your Eventra experience",
+  "categoriesHeading": "Browse by Category",
+  "communityHeading": "Connect with the Community",
+  "communitySubtitle": "Join discussions, meet contributors, and stay updated with the latest news",
+  "communityVisitLink": "Click to visit and connect with our community",
+  "tutorialsHeading": "Step-by-Step Tutorials",
+  "tutorialsSubtitle": "Master every aspect of the platform with our detailed tutorials",
+  "difficultyBeginner": "Beginner",
+  "difficultyIntermediate": "Intermediate",
+  "guidelinesHeading": "Platform Guidelines",
+  "guidelinesSubtitle": "Follow these best practices to get the most out of Eventra",
+  "guidelinesLearnMore": "Learn more",
+  "faqHeading": "Frequently Asked Questions",
+  "faqSubtitle": "Everything you need to know about using Eventra and participating in events",
+  "ctaHeading": "Need Help or Have Feedback?",
+  "ctaSubtitle": "Reach out to our support team and we will get back to you within 24 hours",
+  "ctaContactUs": "Contact Us",
+  "ctaGiveFeedback": "Give Feedback",
+  "categories": {
+    "hostingHackathons": {
+      "title": "Hosting Hackathons",
+      "description": "Learn how to create and manage hackathons on Eventra."
+    },
+    "projectSubmission": {
+      "title": "Project Submission",
+      "description": "Everything you need to know about submitting your projects."
+    },
+    "exploreProjects": {
+      "title": "Explore Projects",
+      "description": "Discover and browse projects from the community."
+    },
+    "contributing": {
+      "title": "Contributing",
+      "description": "How to contribute to open source projects on Eventra."
+    },
+    "leaderboard": {
+      "title": "Leaderboard",
+      "description": "Understand how the leaderboard rankings work."
+    },
+    "tipsBestPractices": {
+      "title": "Tips & Best Practices",
+      "description": "Get the most out of Eventra with these tips."
+    },
+    "events": {
+      "title": "Events",
+      "description": "Find and join events happening in the community."
+    },
+    "seeOnGitHub": {
+      "title": "See on GitHub",
+      "description": "Access the source code and contribute on GitHub."
+    },
+    "apiDocs": {
+      "title": "API Documentation",
+      "description": "Integrate with Eventra using our REST API."
+    },
+    "contributors": {
+      "title": "Contributors",
+      "description": "Meet the people who build and maintain Eventra."
+    },
+    "communityEvents": {
+      "title": "Community Events",
+      "description": "Discover events organized by the Eventra community."
+    },
+    "contactUs": {
+      "title": "Contact Us",
+      "description": "Get in touch with the Eventra team for support."
+    }
+  },
+  "faqs": {
+    "1": {
+      "category": "Events",
+      "question": "How do I register for an event or hackathon?",
+      "answer": "Navigate to the Events or Hackathons page, find the one you want, and click the Register button. Fill in the required details and submit your registration."
+    },
+    "2": {
+      "category": "Projects",
+      "question": "How do I submit a project?",
+      "answer": "Go to the Projects section, click Submit Project, and fill in the required details including your project title, description, and repository link."
+    },
+    "3": {
+      "category": "Hackathons",
+      "question": "How do I join a hackathon?",
+      "answer": "Browse the Hackathons page and click Join on any open hackathon. You can participate solo or as part of a team."
+    },
+    "4": {
+      "category": "Community",
+      "question": "How is the leaderboard score calculated?",
+      "answer": "Scores are based on your contributions, event participation, merged pull requests, and project submissions on the platform."
+    },
+    "5": {
+      "category": "Contributions",
+      "question": "How do I contribute to Eventra as an open source project?",
+      "answer": "Check the Contributors Guide page for detailed instructions on setting up the project locally, picking issues, and submitting pull requests."
+    }
+  },
+  "tutorials": {
+    "hostingHackathon": {
+      "title": "Hosting a Hackathon",
+      "description": "A step-by-step guide to creating and publishing your own hackathon on Eventra."
+    },
+    "submittingProject": {
+      "title": "Submitting a Project",
+      "description": "Learn how to showcase your work by submitting a project to the Eventra platform."
+    },
+    "creatingEvent": {
+      "title": "Creating an Event",
+      "description": "Set up and publish community events with all the details participants need."
+    },
+    "contributingGsoc": {
+      "title": "Contributing via GSSoC",
+      "description": "Get started with open source contributions through GirlScript Summer of Code on Eventra."
+    }
+  },
+  "guidelines": {
+    "checkHackathonRules": {
+      "title": "Check Hackathon Rules",
+      "description": "Always read the rules and eligibility criteria before joining a hackathon to ensure you qualify."
+    },
+    "documentYourWork": {
+      "title": "Document Your Work",
+      "description": "Write clear README files and project descriptions so others can understand and use your work."
+    },
+    "followContributionGuidelines": {
+      "title": "Follow Contribution Guidelines",
+      "description": "Read the contributor guide before submitting pull requests to ensure your code meets project standards."
+    },
+    "respectDeadlines": {
+      "title": "Respect Deadlines",
+      "description": "Submit your projects and registrations before the deadline — late entries may not be accepted."
+    },
+    "avoidDuplicates": {
+      "title": "Avoid Duplicates",
+      "description": "Search existing projects and issues before creating new ones to avoid duplicate submissions."
+    },
+    "getSupport": {
+      "title": "Get Support",
+      "description": "If you're stuck, reach out via the Contact page or community channels — we're happy to help."
+    }
+  }
   },
   "contactUs": {
     "pageTitle": "Contact Us",


### PR DESCRIPTION
## Description

[Please include a summary of the changes and the related issue. Please also include relevant motivation and context.](fix: add missing helpCenter translation keys to en.json)

Fixes #9224 

## Description
The Help Center page (`/helpcenter`) was rendering raw i18n translation
keys as visible text instead of actual human-readable content across the
entire page. Every category card, FAQ item, tutorial card, and guideline
block was broken — displaying strings like
`helpCenter.categories.hostingHackathons.title` instead of actual text.

Root cause: the `helpCenter` section in `src/locales/en.json` was missing
four complete sub-sections that `HelpCenter.js` depends on via
`useTranslation()`:
- `helpCenter.categories` (12 entries)
- `helpCenter.faqs` (5 entries)  
- `helpCenter.tutorials` (4 entries)
- `helpCenter.guidelines` (6 entries)

Fix: added all 27 missing translation key groups to `src/locales/en.json`.
No component or logic files were modified.

Fixes # (add the issue number you opened here)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports