### PR TITLE
feat: add persistent active state for recommendation filter chips(#8920)

### DIFF
--- a/src/Pages/Home/components/RecommendationBanner.jsx
+++ b/src/Pages/Home/components/RecommendationBanner.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 const RecommendationBanner = () => {
+  const [activeFilter, setActiveFilter] = useState("AI/ML");
   return (
     <section
       className="relative overflow-hidden px-4 md:px-8 py-16 text-slate-900 dark:text-white border-t border-slate-200/60 dark:border-slate-800/60 transition-colors duration-300"
@@ -59,12 +61,19 @@ const RecommendationBanner = () => {
                 'Hackathons',
                 'Beginner Friendly',
               ].map((tag, index) => (
-                <span
-                  key={index}
-                  className="px-3 py-1.5 rounded-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 text-sm text-slate-700 dark:text-slate-300 shadow-sm hover:border-brand-violet/50 transition-colors duration-200"
-                >
-                  {tag}
-                </span>
+                <button
+    key={index}
+    type="button"
+    onClick={() => setActiveFilter(tag)}
+    className={`px-3 py-1.5 rounded-full text-sm shadow-sm transition-all duration-300 border ${
+      activeFilter === tag
+        ? "bg-brand-violet text-white border-brand-violet shadow-[0_0_15px_rgba(139,92,246,0.35)] scale-105"
+        : "bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:border-brand-violet/50"
+    }`}
+  >
+    {tag}
+  </button>
+
               ))}
             </div>
 


### PR DESCRIPTION
## Description

This PR adds a persistent active state for the recommendation filter chips in the Recommendation Banner.

Previously, the filter chips only displayed a hover effect, making it difficult for users to identify the currently selected filter. This update introduces a visually distinct active state that remains highlighted after selection.

### Changes Made

* Added React state management to track the selected filter chip.
* Converted filter chips from static `<span>` elements to interactive `<button>` elements.
* Added persistent active styling for the selected chip.
* Added stronger border, subtle glow effect, and smooth transition animations.
* Ensured only one filter chip remains active at a time.

Fixes #8920

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have run local unit tests using `npm test` and verified they pass
* [ ] I have run `npm run lint` and resolved any new errors or warnings
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
