### PR TITLE
fix: prevent search results dropdown from overlapping page sections (#8921)

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -209,7 +209,7 @@ export default function EventHero({
                     exit={{ opacity: 0, y: 8, scale: 0.98 }}
                     transition={{ duration: prefersReducedMotion ? 0 : 0.18, ease: "easeOut" }}
                     className={`
-                      absolute left-0 right-0 top-full z-50 mt-3 overflow-hidden rounded-3xl
+                      absolute left-0 right-0 top-full z-50 mt-3 overflow-y-auto max-h-96 rounded-3xl
                       border border-slate-200 dark:border-slate-700/60 ${darkTheme.card}
                       text-left shadow-2xl backdrop-blur-xl ring-1 ring-black/5 dark:ring-white/10
                     `}


### PR DESCRIPTION
###Description

This PR fixes the search results dropdown overflow issue reported in #8921.

Previously, when displaying longer search results, the dropdown could extend beyond its intended area and overlap subsequent page sections, affecting content visibility and user experience.

###Changes Made
Added a maximum height constraint to the search results dropdown.
Enabled vertical scrolling for overflow content within the dropdown.
Prevented the dropdown from overlapping adjacent sections such as "What's Happening Now".
Preserved existing search functionality, animations, and styling.

Fixes #8921

###Type of change

Bug fix (non-breaking change which fixes an issue)

New feature (non-breaking change which adds functionality)

Breaking change (fix or feature that would cause existing functionality to not work as expected)

This change requires a documentation update

Screenshots / Video (if applicable)

N/A

Checklist

My code follows the style guidelines of this project

I have performed a self-review of my code

I have made corresponding changes to the documentation

My changes generate no new warnings
