### PR TITLE
fix: hide starter prompts after first interaction in Eventra Assist

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -105,6 +105,7 @@ export default function Chatbot() {
   const replyTimerRef = useRef(null);
   const prevLangRef = useRef(i18n.language);
   const quickPrompts = useMemo(() => getQuickPrompts(t), [t]);
+  const hasInteracted = messages.length > 1;
 
   const clearReplyTimer = useCallback(() => {
     if (replyTimerRef.current) {
@@ -507,18 +508,20 @@ export default function Chatbot() {
             "
             >
               {/* Quick prompts */}
-              <div className="mb-3.5 flex flex-wrap gap-1.5">
-                {quickPrompts.map((prompt) => (
-                  <button
-                    key={prompt}
-                    type="button"
-                    onClick={() => sendMessage(prompt)}
-                    className="rounded-full border border-slate-200/60 dark:border-slate-800/50 bg-slate-50/50 dark:bg-slate-950/40 px-3 py-1.5 text-xs font-bold text-slate-600 dark:text-slate-300 hover:bg-linear-to-r hover:from-indigo-600 hover:to-pink-600 hover:text-white hover:border-transparent transition-all duration-300 transform hover:scale-[1.03] focus:ring-2 focus:ring-indigo-500 focus:outline-none"
-                  >
-                    {prompt}
-                  </button>
-                ))}
-              </div>
+              {!hasInteracted && (
+                <div className="mb-3.5 flex flex-wrap gap-1.5">
+                  {quickPrompts.map((prompt) => (
+                    <button
+                      key={prompt}
+                      type="button"
+                      onClick={() => sendMessage(prompt)}
+                      className="rounded-full border border-slate-200/60 dark:border-slate-800/50 bg-slate-50/50 dark:bg-slate-950/40 px-3 py-1.5 text-xs font-bold text-slate-600 dark:text-slate-300 hover:bg-linear-to-r hover:from-indigo-600 hover:to-pink-600 hover:text-white hover:border-transparent transition-all duration-300 transform hover:scale-[1.03] focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                    >
+                      {prompt}
+                    </button>
+                  ))}
+                </div>
+              )}
 
               {/* Contextual action links */}
               {latestActions.length > 0 && (


### PR DESCRIPTION
## Description

Starter prompts in the **Eventra Assist** chatbot remained visible even after 
a user interacted and received a response. This reduced the available 
conversation area, making responses harder to read — especially on mobile devices.

This fix hides the starter prompts once the user has sent their first message, 
freeing up space for the actual conversation.

**Changes made in `src/components/Chatbot.jsx`:**
- Added a `hasInteracted` boolean derived from `messages.length > 1`
- Wrapped the starter prompts render block with `{!hasInteracted && (...)}` condition

Fixes #8571

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
