### PR TITLE
fix: replace deprecated motion() with motion.create() (regression fix)

### DIFF
--- a/src/Pages/FAQ/FaqCTA.jsx
+++ b/src/Pages/FAQ/FaqCTA.jsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 // ✅ OPTIMIZATION: Module-level definition prevents re-creation on every render
-const MotionLink = motion(Link);
+const MotionLink = motion.create(Link);
 
 // ✅ MAINTAINABILITY: Extracted repeated classes
 const CARD_BASE_CLASSES =

--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -26,7 +26,7 @@ import projectsData from "../../Projects/mockProjectsData.json";
 const CountUp = CountUpLib.default || CountUpLib;
 
 // ─── MOTION LINK SUB-COMPONENT ──────────────────────────────────────────────
-const MotionLink = motion(Link);
+const MotionLink = motion.create(Link);
 
 // ─── STATIC SEARCH INDEX CONFIGURATION ───────────────────────────────────────
 const createSearchItem = (item, type, searchType) => ({


### PR DESCRIPTION
Fixes #9284

## Problem
The deprecated `motion(Link)` API was reintroduced in two files after being previously fixed in #7851:
- `Hero.js` (line 29)
- `FaqCTA.jsx` (line 7)

This appears to be a regression from commit 8e33591.

## Fix
- Replaced `motion(Link)` with `motion.create(Link)` in both files

## Testing
- No deprecation warnings in console
- Home and FAQ pages load correctly