### PR TITLE
fix : getRelativeTime returns null for numeric Unix timestamps instead of processing them

### DIFF
--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -1,7 +1,10 @@
 const RELATIVE_TIME_FALLBACK = "—";
 
 export function getRelativeTime(dateInput) {
-  if (typeof dateInput === "number") return null;
+  // Handle numeric Unix timestamps (milliseconds since epoch)
+  if (typeof dateInput === "number") {
+    dateInput = new Date(dateInput).toISOString();
+  }
   if (dateInput === null || dateInput === undefined) {
     return RELATIVE_TIME_FALLBACK;
   }


### PR DESCRIPTION
## Summary

`getRelativeTime()` in `src/utils/relativeTime.js` unconditionally returned `null` for any numeric input (Unix timestamps in milliseconds). Valid timestamps passed via `Date.now()` or similar were silently dropped, breaking callers.

## Changes

- Replaced the early `return null` for numeric inputs with a conversion: `dateInput = new Date(dateInput).toISOString()`.
- The rest of the function handles the converted ISO string normally.

## Impact

- Fixes silent data loss for components that pass numeric timestamps to relative time utilities.
- No behaviour change for string or Date inputs.

Closes #9293.