### PR TITLE
fix : SSR crash in useRoutePrefetch due to unguarded window access

### DIFF
--- a/src/hooks/useRoutePrefetch.js
+++ b/src/hooks/useRoutePrefetch.js
@@ -30,6 +30,9 @@ export const useRoutePrefetch = (config = {}) => {
   const location = useLocation();
 
   const prefetch = useCallback((importFn, key) => {
+    // Guard: window is only available in browser environments.
+    if (typeof window === "undefined") return;
+
     // Wrap in requestIdleCallback to not block the main thread
     if ("requestIdleCallback" in window) {
       window.requestIdleCallback(() => prefetchRoute(importFn, key));


### PR DESCRIPTION
## Summary

The `prefetch` callback in `src/hooks/useRoutePrefetch.js` accessed `window` directly to check for `requestIdleCallback` support, causing a `ReferenceError` in SSR environments where `window` is `undefined`.

## Changes

- Added an SSR guard `if (typeof window === "undefined") return;` at the top of the `prefetch` callback.
- The hook now safely no-ops on the server side.

## Impact

- Fixes SSR rendering crashes for any page using `useRoutePrefetch`.
- No behaviour change in browser environments.

Closes #9294.