### PR TITLE
fix : SSR crash in useTokenExpiry due to unguarded window.location.replace

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -7,6 +7,9 @@ export function useTokenExpiry({ token, user, onExpired }) {
   const expiryToastShownRef = useRef(false);
 
   const clearExpiredSession = useCallback(() => {
+    // Guard: window is only available in browser environments.
+    if (typeof window === "undefined") return;
+
     let hadPreviousSession = false;
     try { hadPreviousSession = !!syncSecureStorage.getItem("user"); } catch {}
     console.warn("[useTokenExpiry] Session expired. Clearing state.");


### PR DESCRIPTION
## Summary

`clearExpiredSession` in `src/hooks/useTokenExpiry.js` schedules `window.location.replace` inside `setTimeout`. While the hook is gated by token checks, any code path accessing browser-only globals should be defended with an SSR guard.

## Changes

- Added `if (typeof window === "undefined") return;` at the top of `clearExpiredSession`.
- The function is now resilient to unexpected execution contexts.

## Impact

- Defense-in-depth: prevents latent crashes if the function is ever invoked in a non-browser context.
- No behaviour change in browser environments.

Closes #9296.