### PR TITLE
fix(dndUtils): add SSR guard before localStorage access

### DIFF
--- a/src/utils/dndUtils.js
+++ b/src/utils/dndUtils.js
@@ -1,4 +1,8 @@
 export const isDndActive = () => {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return false;
+  }
+
   try {
     const prefs = JSON.parse(localStorage.getItem('eventra_notification_prefs') || '{}');
     if (!prefs.dndEnabled) return false;


### PR DESCRIPTION
## Summary
Fixes SSR crash in `src/utils/dndUtils.js` by adding a `typeof window === "undefined"` guard before accessing `localStorage` in `isDndActive()`.

## Changes
- Added SSR guard at the top of `isDndActive()` to return `false` when `localStorage` is unavailable.
- Guard pattern: `if (typeof window === "undefined" || !window.localStorage) { return false; }`

## Impact
- **Fixes:** `ReferenceError: localStorage is not defined` during SSR
- **Severity:** High — SSR pages importing this utility were crashing
- **Root cause:** Missing `typeof window` check before browser-only API

Closes #9305.