### PR TITLE
fix(shareUtils): add SSR guard for document in copyToClipboard fallback

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -175,6 +175,10 @@ export const generateEventSharingData = (event, baseUrl = null) => {
  * @returns {Promise<boolean>} Success status
  */
 export const copyToClipboard = async (text) => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return false;
+  }
+
   try {
     if (navigator.clipboard) {
       await navigator.clipboard.writeText(text);
@@ -192,7 +196,6 @@ export const copyToClipboard = async (text) => {
       return successful;
     }
   } catch (err) {
-     
     console.error("Failed to copy text: ", err);
     return false;
   }


### PR DESCRIPTION
## Summary
Fixes SSR crash in `src/utils/shareUtils.js` by adding an SSR guard before the `document.execCommand` fallback in `copyToClipboard()`.

## Changes
- Added early return guard at the top of `copyToClipboard()`: `if (typeof window === "undefined" || typeof document === "undefined") { return false; }`.
- This prevents the crash when the fallback branch is reached during SSR and `document.body.appendChild()` would otherwise be called.

## Impact
- **Fixes:** `TypeError: Cannot read property body of undefined` during SSR.
- **Severity:** High — SSR renders of pages with copy-to-clipboard functionality crashed.
- **Root cause:** The `navigator.clipboard` check was present but the fallback `execCommand` path had no `document` guard.

Closes #9307.