### PR TITLE
fix(userProfileAnalyzer): add SSR guard before localStorage access

### DIFF
--- a/src/utils/userProfileAnalyzer.js
+++ b/src/utils/userProfileAnalyzer.js
@@ -1,13 +1,17 @@
 import { safeJsonParse } from "../utils/safeJsonParse";
 export const getUserProfile = () => {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return {
+      interests: [],
+      techStack: [],
+      eventTypes: [],
+      level: "Beginner",
+    };
+  }
+
   let saved = {};
   try {
-    saved =
-      safeJsonParse(
-        localStorage.getItem(
-          "eventra_user_profile"
-        )
-      ) || {};
+    saved = safeJsonParse(localStorage.getItem("eventra_user_profile"), {}) || {};
   } catch {
     saved = {};
   }


### PR DESCRIPTION
## Summary
Fixes SSR crash in `src/utils/userProfileAnalyzer.js` by adding a browser environment check before accessing `localStorage` in `getUserProfile()`.

## Changes
- Added early return in `getUserProfile()` when `typeof window === "undefined"` or `!window.localStorage`, returning default profile values `{ interests: [], techStack: [], eventTypes: [], level: "Beginner" }`.

## Impact
- **Fixes:** `ReferenceError: localStorage is not defined` during SSR.
- **Severity:** High — server renders of any user profile page crashed.
- **Root cause:** Missing `typeof window === "undefined"` check before `localStorage.getItem()`.

Closes #9308.