### PR TITLE
style: add hover scale and shadow effect to newsletter subscribe button

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -227,10 +227,10 @@ const Newsletter = () => {
         </div>
  
         <button
-          type="submit"
-          disabled={isSubmitting}
-          className="shrink-0 px-4 py-2 rounded-lg  bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60 text-white text-sm font-medium transition-colors"
-        >
+  type="submit"
+  disabled={isSubmitting}
+  className="shrink-0 px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60 text-white text-sm font-medium transition-all duration-200 hover:scale-105 hover:shadow-md hover:shadow-indigo-500/30"
+>
           {isSubmitting ? t("footer.newsletter.subscribing") : t("footer.newsletter.subscribe")}
         </button>
       </form>


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
The newsletter Subscribe button in the footer had a flat hover state with 
only a color change, making it feel less interactive compared to other 
buttons across the app.

## What changes are included in this PR?
- Added hover:scale-105 and hover:shadow-md with indigo glow to the 
  newsletter Subscribe button in Footer.js
- Changed transition-colors to transition-all for smooth scale + shadow animation

## Are these changes tested?
Manually tested — button now scales slightly and shows a subtle shadow glow 
on hover, consistent with other interactive buttons in the app.

## Are there any user-facing changes?
Yes — minor visual polish on the footer newsletter subscribe button hover state.