### PR TITLE
style: add underline animation to footer nav links on hover

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -387,7 +387,7 @@ return (
                   <li key={link.nameKey || link.href}>
                     <Link
                       to={link.href}
-                      className="group inline-flex items-center gap-2 text-xs sm:text-sm text-gray-500  dark:text-gray-400 hover:!text-indigo-600 dark:hover:text-indigo-400 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+                      className="group relative inline-flex items-center gap-2 text-xs sm:text-sm text-gray-500 dark:text-gray-400 hover:!text-indigo-600 dark:hover:text-indigo-400 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded after:absolute after:left-6 after:-bottom-0.5 after:h-px after:w-0 after:bg-indigo-500 after:transition-all after:duration-300 group-hover:after:w-[calc(100%-1.5rem)]"
                     >
                       <span className="text-gray-400 dark:text-gray-500 group-hover:!text-indigo-500 dark:group-hover:text-indigo-400 transition-colors duration-200 shrink-0">
                         {link.icon}


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
Footer navigation links only changed color on hover with no other visual feedback.

## What changes are included in this PR?
- Added animated underline that expands from left to right on hover for 
  footer nav links using CSS pseudo-element (after:)

## Are these changes tested?
Manually tested — underline animates smoothly on hover for all footer links.

## Are there any user-facing changes?
Yes — minor visual polish, animated underline on footer link hover.