### PR TITLE
style: add subtle lift effect to footer social link buttons on hover

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -364,7 +364,7 @@ return (
                   href={s.href}
                   aria-label={s.label}
                   title={s.label}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-indigo-50 dark:hover:bg-indigo-950 hover:text-indigo-600 dark:hover:text-indigo-400 border border-gray-200 dark:border-gray-700 hover:border-indigo-200 dark:hover:border-indigo-800 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-indigo-50 dark:hover:bg-indigo-950 hover:text-indigo-600 dark:hover:text-indigo-400 border border-gray-200 dark:border-gray-700 hover:border-indigo-200 dark:hover:border-indigo-800 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                 >
                   {s.icon}
                   <span>{s.name}</span>


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
Footer social link buttons (GitHub, LinkedIn, Discord) only had color 
changes on hover with no depth feedback.

## What changes are included in this PR?
- Added hover:-translate-y-0.5 and hover:shadow-sm to footer social 
  link buttons for a subtle lift effect on hover

## Are these changes tested?
Manually tested — buttons lift slightly with shadow on hover.

## Are there any user-facing changes?
Yes — minor visual polish, lift effect on footer social buttons hover.