### PR TITLE
style: add underline on hover to footer bottom bar links for better a…

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -410,25 +410,25 @@ return (
  
           <div className="flex flex-wrap items-center justify-center sm:justify-end gap-x-3 gap-y-2 text-xs text-gray-400 dark:text-gray-500">
             <Link
-              to="/privacy"
-              className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
-            >
-              {t("footer.privacy")}
-            </Link>
-            <span className="text-gray-200 dark:text-gray-700" aria-hidden="true">|</span>
-            <Link
-              to="/terms"
-              className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
-            >
-              {t("footer.terms")}
-            </Link>
-            <span className="text-gray-200 dark:text-gray-700" aria-hidden="true">|</span>
-            <Link
-              to="/api-docs"
-              className="hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
-            >
-              {t("footer.links.apiDocs")}
-            </Link>
+  to="/privacy"
+  className="hover:text-indigo-600 dark:hover:text-indigo-400 hover:underline underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+>
+  {t("footer.privacy")}
+</Link>
+<span className="text-gray-200 dark:text-gray-700" aria-hidden="true">|</span>
+<Link
+  to="/terms"
+  className="hover:text-indigo-600 dark:hover:text-indigo-400 hover:underline underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+>
+  {t("footer.terms")}
+</Link>
+<span className="text-gray-200 dark:text-gray-700" aria-hidden="true">|</span>
+<Link
+  to="/api-docs"
+  className="hover:text-indigo-600 dark:hover:text-indigo-400 hover:underline underline-offset-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+>
+  {t("footer.links.apiDocs")}
+</Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
Footer bottom bar links (Privacy, Terms, API Docs) only changed color on 
hover, with no underline to clearly signal they are clickable links.

## What changes are included in this PR?
- Added hover:underline with underline-offset-2 to Privacy, Terms, 
  and API Docs links in the footer bottom bar

## Are these changes tested?
Manually tested — links now show underline on hover for better affordance.

## Are there any user-facing changes?
Yes — minor visual polish, underline on hover for footer bottom links.