### PR TITLE
style: add scale animation to footer Eventra logo on hover

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -338,11 +338,11 @@ return (
                 className="inline-flex items-center gap-2 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
               >
                 <span
-                  className="text-xl font-extrabold tracking-tight text-gray-900 dark:text-white group-hover:!text-indigo-600 dark:group-hover:text-indigo-400 transition-colors"
-                  style={{ fontFamily: "Anton, sans-serif", letterSpacing: "-0.01em" }}
-                >
-                  Eventra
-                </span>
+  className="text-xl font-extrabold tracking-tight text-gray-900 dark:text-white group-hover:!text-indigo-600 dark:group-hover:text-indigo-400 transition-all duration-300 group-hover:scale-105 inline-block"
+  style={{ fontFamily: "Anton, sans-serif", letterSpacing: "-0.01em" }}
+>
+  Eventra
+</span>
               </Link>
  
               {/* Open-source badge */}


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
The Eventra logo/wordmark in the footer only changed color on hover with 
no other interactive feedback.

## What changes are included in this PR?
- Added group-hover:scale-105 with inline-block display to the Eventra 
  logo text in the footer for a subtle pop effect on hover

## Are these changes tested?
Manually tested — logo scales slightly on hover alongside the existing 
color transition.

## Are there any user-facing changes?
Yes — minor visual polish, scale animation on footer logo hover.