### PR TITLE
style: add hover scale effect to Open Source badge in footer

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -346,10 +346,10 @@ return (
               </Link>
  
               {/* Open-source badge */}
-              <span className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 border border-indigo-100 dark:border-indigo-800 align-middle">
-                <FaCode size={9} aria-hidden="true" />
-                Open Source
-              </span>
+              <span className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-indigo-50 dark:bg-indigo-950 text-indigo-600 dark:text-indigo-400 border border-indigo-100 dark:border-indigo-800 align-middle transition-all duration-200 hover:bg-indigo-100 dark:hover:bg-indigo-900 hover:scale-110 cursor-default">
+  <FaCode size={9} aria-hidden="true" />
+  Open Source
+</span>
  
               <p className="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed max-w-xs">
                 {t("footer.tagline")}


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
The "Open Source" badge in the footer was static with no hover feedback.

## What changes are included in this PR?
- Added hover:scale-110 and a slightly darker background on hover to 
  the Open Source badge for subtle interactivity

## Are these changes tested?
Manually tested — badge scales and darkens slightly on hover.

## Are there any user-facing changes?
Yes — minor visual polish, hover effect on Open Source badge.