### PR TITLE
style: add subtle color transition to footer copyright text on hover

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -403,10 +403,10 @@ return (
  
         {/* ── Bottom bar ── */}
         <div className="py-5 border-t border-gray-100 dark:border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-3">
-          <p className="text-xs text-gray-400 dark:text-gray-500">
-            © {new Date().getFullYear()} Eventra.{" "}
-            <span>{t("footer.rights")}</span>
-          </p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 transition-colors duration-200 hover:text-gray-600 dark:hover:text-gray-300">
+  © {new Date().getFullYear()} Eventra.{" "}
+  <span>{t("footer.rights")}</span>
+</p>
  
           <div className="flex flex-wrap items-center justify-center sm:justify-end gap-x-3 gap-y-2 text-xs text-gray-400 dark:text-gray-500">
             <Link


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
The footer copyright text had no hover feedback, appearing slightly 
disconnected from the rest of the interactive footer elements.

## What changes are included in this PR?
- Added a subtle color transition on hover to the copyright text in 
  the footer bottom bar

## Are these changes tested?
Manually tested — text color darkens smoothly on hover.

## Are there any user-facing changes?
Yes — minor visual polish, hover color transition on footer copyright text.