### PR TITLE
style: add subtle indigo border tint to footer on hover

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -324,7 +324,7 @@ const Newsletter = () => {
 const Footer = () => {
   const { t } = useTranslation();
 return (
-    <footer className="relative z-50 bg-white dark:bg-gray-950 border-t border-gray-100 dark:border-gray-800 transition-colors duration-300">
+    <footer className="relative z-50 bg-white dark:bg-gray-950 border-t border-gray-100 dark:border-gray-800 transition-colors duration-300 hover:border-indigo-100 dark:hover:border-indigo-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
  
         {/* ── Main grid ── */}


### PR DESCRIPTION
## Which issue does this PR close?
N/A — small UI polish, no related issue.

## Rationale for this change
The footer's top border was static, with no subtle indication tying it 
visually to the indigo accent color used throughout the rest of the footer.

## What changes are included in this PR?
- Added a subtle indigo tint to the footer's top border on hover

## Are these changes tested?
Manually tested — border color shifts to a light indigo tint on hover.

## Are there any user-facing changes?
Yes — minor visual polish, subtle border tint on footer hover.