### PR TITLE
fix: wrap shouldShowError in Boolean() to return boolean instead of string from short-circuit evaluation

### DIFF
--- a/src/hooks/useValidationState.js
+++ b/src/hooks/useValidationState.js
@@ -135,7 +135,7 @@ export const useValidationState = (
    * Check if field should show error message
    */
   const shouldShowError = useMemo(() => {
-    return touched && validationState === "error" && error;
+    return Boolean(touched && validationState === "error" && error);
   }, [touched, validationState, error]);
 
   /**


### PR DESCRIPTION
### Related Issue
Closes #9334 

### Description of Changes
- I wrapped the `shouldShowError` expression in `Boolean()` in `useValidationState.js`.
- It ensures the hook always returns a strict `boolean` as documented, not a string from `&&` short-circuit evaluation.
- It prevents TypeScript type errors and broken strict equality checks in consumer components.