### PR TITLE
fix: replace useEffect with useLayoutEffect to sync valueRef synchronously and prevent stale closure comparisons

### DIFF
--- a/src/hooks/useStableFilters.js
+++ b/src/hooks/useStableFilters.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * A custom React hook that acts as a drop-in replacement for `useState`, designed to skip
@@ -81,7 +81,7 @@ export function useStableFilters(initialValue) {
 
   // Keep the ref in sync so the stable setter always compares against the
   // latest committed value, not a stale closure capture.
-  useEffect(() => {
+  useLayoutEffect(() => {
     valueRef.current = value;
   }, [value]);
 


### PR DESCRIPTION
### Related Issue
Closes #9336 

### Description of Changes
- I replaced `useEffect` with `useLayoutEffect` for syncing `valueRef.current` in `useStableFilters.js`.
- `useLayoutEffect` runs synchronously after React commits the render, before paint, ensuring `valueRef.current` is always up to date when `setStableValue` is called.
- It prevents stale comparisons that caused the hook to incorrectly trigger re-renders it was designed to suppress.