### PR TITLE
fix: add early exit for non-navigation keys before querySelectorAll in useArrowKeyNavigation

### DIFF
--- a/src/hooks/useArrowKeyNavigation.js
+++ b/src/hooks/useArrowKeyNavigation.js
@@ -30,6 +30,9 @@ export default function useArrowKeyNavigation({
 
   const onKeyDown = useCallback(
     (e) => {
+      const navigationKeys = ["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"];
+      if (!navigationKeys.includes(e.key)) return;
+
       const container = containerRef.current;
       if (!container) return;
 


### PR DESCRIPTION
### Related Issue
Closes #9338 

### Description of Changes
- I added an early return at the top of `onKeyDown` in `useArrowKeyNavigation.js` that exits immediately if the pressed key is not one of the six handled navigation keys (ArrowRight, ArrowDown, ArrowLeft, ArrowUp, Home, End).
- `querySelectorAll` now only runs when a navigation key is pressed, eliminating unnecessary DOM queries on regular typing, Tab, Enter, Escape, and other key events.