### PR TITLE
fix: remove dead parseProfile function that was defined but never called in useRecommendations

### DIFF
--- a/src/hooks/useRecommendations.js
+++ b/src/hooks/useRecommendations.js
@@ -9,16 +9,6 @@ import { getUserProfile } from "../utils/userProfileAnalyzer";
 const USER_PROFILE_KEY = "eventra_user_profile";
 const PROFILE_UPDATED_EVENT = "userProfileUpdated";
 
-const parseProfile = (raw) => {
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === "object" ? parsed : {};
-  } catch {
-    return {};
-  }
-};
-
 const useRecommendations = (events = []) => {
   const [profileKey, setProfileKey] = useState(() => {
     if (typeof window === "undefined") return null;


### PR DESCRIPTION
### Related Issue
Closes #9340 

### Description of Changes
- I removed the unused `parseProfile` function from `useRecommendations.js`.
- The function was defined with JSON parsing and validation logic but was never called — profile data is sourced exclusively via `getUserProfile()` from the external utility.
- It eliminates misleading dead code and reduces bundle size.