### PR TITLE
fix: remove hardcoded Sentry DSN and deduplicate initialization (#9354 #9353)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import * as Sentry from "@sentry/react";
-
 import "./index.css";
 import "./i18n/i18n";
 import App from "./App";
@@ -14,11 +12,6 @@ import { initCspReporting } from "./utils/cspReporting";
 import * as serviceWorkerRegistration from "./serviceWorkerRegistration";
 import { RealTimeProvider } from "./context/RealTimeContext";
 import { HelmetProvider } from "react-helmet-async";
-
-// Initialize Sentry
-Sentry.init({
-  dsn: "https://0f5776d794dcf89120ca6b00a5923f93@o4511372299075584.ingest.de.sentry.io/4511556614946896",
-});
 
 // Initialize Global Runtime Monitoring
 initializeGlobalErrorHandling();


### PR DESCRIPTION
Removes the hardcoded Sentry.init({ dsn: ... }) from src/index.jsx. Sentry is already initialized in src/utils/errorLogger.js using an environment-based DSN from env.js. This fixes both the leaked DSN (Closes #9354) and the double initialization (Closes #9353).