### PR TITLE
devops: reduce chunkSizeWarningLimit from 1500KB to 500KB (#9357)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -113,7 +113,7 @@ const env = loadEnv(mode, process.cwd(), "");
       // Use esbuild for CSS minification instead of the default lightningcss,
       // which cannot parse the custom Tailwind `short` screen media query.
       cssMinify: "esbuild",
-      chunkSizeWarningLimit: 1500,
+      chunkSizeWarningLimit: 500,
       rollupOptions: {
         output: {
           // manualChunks must be a function in Vite 8 / Rolldown


### PR DESCRIPTION
Reduces chunkSizeWarningLimit from 1500KB to 500KB (Vite default). The 3x threshold masked oversized chunks. Now the build will warn on chunks exceeding 500KB, encouraging better code splitting. Closes #9357