### PR TITLE
fix(utils): add SSR guards to lenisUtils.js

### DIFF
--- a/src/utils/lenisUtils.js
+++ b/src/utils/lenisUtils.js
@@ -9,6 +9,7 @@
  * @param {Object} options - Scroll options
  */
 export const scrollToElement = (selector, options = {}) => {
+  if (typeof window === 'undefined') return;
   const element = document.querySelector(selector);
   if (element && window.lenis) {
     window.lenis.scrollTo(element, {
@@ -25,6 +26,7 @@ export const scrollToElement = (selector, options = {}) => {
  * @param {Object} options - Scroll options
  */
 export const scrollToTop = (options = {}) => {
+  if (typeof window === 'undefined') return;
   if (window.lenis) {
     window.lenis.scrollTo(0, {
       duration: 1.2,
@@ -43,6 +45,7 @@ export const scrollToTop = (options = {}) => {
  * Stop Lenis scrolling (useful for modals)
  */
 export const stopScroll = () => {
+  if (typeof window === 'undefined') return;
   if (window.lenis) {
     window.lenis.stop();
   }
@@ -52,6 +55,7 @@ export const stopScroll = () => {
  * Start Lenis scrolling
  */
 export const startScroll = () => {
+  if (typeof window === 'undefined') return;
   if (window.lenis) {
     window.lenis.start();
   }
@@ -62,5 +66,6 @@ export const startScroll = () => {
  * @returns {number} Current scroll position
  */
 export const getScrollPosition = () => {
+  if (typeof window === 'undefined') return 0;
   return window.lenis ? window.lenis.scroll : window.scrollY;
 };


### PR DESCRIPTION
## Summary

Every exported function in `src/utils/lenisUtils.js` accesses `window` or `document` without SSR guards, causing crashes in SSR environments.

## Changes

- Add `if (typeof window === 'undefined') return;` guard to `scrollToElement`, `scrollToTop`, `stopScroll`, `startScroll`.
- Add `if (typeof window === 'undefined') return 0;` guard to `getScrollPosition`.

## Impact

- **Severity:** High — SSR crash on pages that import lenisUtils during server render.

Closes #9365.