### PR TITLE
fix(utils): add AudioContext safety net in notificationPreferences.js

### DIFF
--- a/src/utils/notificationPreferences.js
+++ b/src/utils/notificationPreferences.js
@@ -148,6 +148,9 @@ export const playNotificationSound = (soundKey) => {
     gain.connect(audioContext.destination);
     oscillator.start();
     oscillator.stop(audioContext.currentTime + 0.3);
+    // Safety net: always close the AudioContext, even if onended never fires
+    // (e.g., tab closed, navigation, scheduling miss)
+    setTimeout(() => { audioContext.close(); }, 500);
     oscillator.onended = () => audioContext.close();
   } catch {
     // Audio playback can be blocked until the user interacts with the page.


### PR DESCRIPTION
## Summary

`src/utils/notificationPreferences.js` — `playNotificationSound()` creates an `AudioContext` but only closes it via `oscillator.onended`. If the callback never fires (tab closed, navigation), the AudioContext leaks.

## Changes

- Add `setTimeout(() => { audioContext.close(); }, 500)` safety net immediately after `oscillator.stop()`.

## Impact

- **Severity:** Medium — memory leak in long-lived sessions with notification sounds.

Closes #9368.