### PR TITLE
fix(security): enforce strict CSRF validation by default in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,9 +91,19 @@ REACT_APP_CSP_REPORT_URI=
 REACT_APP_SENTRY_DSN=
 
 # Optional: CSRF token enforcement mode
-# Values: "warning" (default) - logs missing tokens but allows requests
-#         "strict" - blocks requests when CSRF token is missing
+# Values: "strict" - blocks requests when CSRF token is missing (recommended for production)
+#         "warning" - logs missing tokens but allows requests (default for development)
 #         "disabled" - disables CSRF protection entirely (not recommended)
+#
+# Default behavior (when not explicitly set):
+#   - Production: defaults to "strict" for enhanced security
+#   - Development/Test: defaults to "warning" for easier debugging
+#
+# Recommendation: Use "strict" mode in production deployments to ensure
+# CSRF tokens are properly validated. Backend CSRF validation remains the
+# primary security boundary, but frontend enforcement provides defense in depth.
+#
+# Invalid values will log a warning and fall back to the environment-specific default.
 VITE_CSRF_ENFORCEMENT_MODE=warning
 
 # ============================================

--- a/src/__tests__/csrfProtection.test.js
+++ b/src/__tests__/csrfProtection.test.js
@@ -245,4 +245,92 @@ describe("CSRF Protection", () => {
       });
     });
   });
+
+  describe("getCSRFEnforcementMode", () => {
+    it("should default to strict in production when no configuration is set", async () => {
+      const originalProcessEnv = global.process?.env;
+
+      delete global.process?.env?.VITE_CSRF_ENFORCEMENT_MODE;
+      global.process = { env: { NODE_ENV: "production" } };
+
+      const { getCSRFEnforcementMode } = await import("../utils/csrfToken.js");
+      const mode = getCSRFEnforcementMode();
+
+      expect(mode).toBe("strict");
+
+      if (originalProcessEnv) global.process.env = originalProcessEnv;
+    });
+
+    it("should default to warning in development when no configuration is set", async () => {
+      const originalProcessEnv = global.process?.env;
+
+      delete global.process?.env?.VITE_CSRF_ENFORCEMENT_MODE;
+      global.process = { env: { NODE_ENV: "development" } };
+
+      const { getCSRFEnforcementMode } = await import("../utils/csrfToken.js");
+      const mode = getCSRFEnforcementMode();
+
+      expect(mode).toBe("warning");
+
+      if (originalProcessEnv) global.process.env = originalProcessEnv;
+    });
+
+    it("should use explicit strict configuration when set", async () => {
+      const originalProcessEnv = global.process?.env;
+
+      global.process = { env: { NODE_ENV: "development", VITE_CSRF_ENFORCEMENT_MODE: "strict" } };
+
+      const { getCSRFEnforcementMode } = await import("../utils/csrfToken.js");
+      const mode = getCSRFEnforcementMode();
+
+      expect(mode).toBe("strict");
+
+      if (originalProcessEnv) global.process.env = originalProcessEnv;
+    });
+
+    it("should use explicit warning configuration when set", async () => {
+      const originalProcessEnv = global.process?.env;
+
+      global.process = { env: { NODE_ENV: "production", VITE_CSRF_ENFORCEMENT_MODE: "warning" } };
+
+      const { getCSRFEnforcementMode } = await import("../utils/csrfToken.js");
+      const mode = getCSRFEnforcementMode();
+
+      expect(mode).toBe("warning");
+
+      if (originalProcessEnv) global.process.env = originalProcessEnv;
+    });
+
+    it("should use explicit disabled configuration when set", async () => {
+      const originalProcessEnv = global.process?.env;
+
+      global.process = { env: { NODE_ENV: "production", VITE_CSRF_ENFORCEMENT_MODE: "disabled" } };
+
+      const { getCSRFEnforcementMode } = await import("../utils/csrfToken.js");
+      const mode = getCSRFEnforcementMode();
+
+      expect(mode).toBe("disabled");
+
+      if (originalProcessEnv) global.process.env = originalProcessEnv;
+    });
+
+    it("should log warning and fall back to default for invalid configuration value", async () => {
+      const originalProcessEnv = global.process?.env;
+      const originalConsoleWarn = console.warn;
+
+      global.process = { env: { NODE_ENV: "production", VITE_CSRF_ENFORCEMENT_MODE: "invalid" } };
+      console.warn = vi.fn();
+
+      const { getCSRFEnforcementMode } = await import("../utils/csrfToken.js");
+      const mode = getCSRFEnforcementMode();
+
+      expect(mode).toBe("strict");
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid VITE_CSRF_ENFORCEMENT_MODE value: "invalid"')
+      );
+
+      console.warn = originalConsoleWarn;
+      if (originalProcessEnv) global.process.env = originalProcessEnv;
+    });
+  });
 });

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -1,5 +1,5 @@
 import { syncServerTimeFromHeader } from "../../utils/timeSync.js";
-import { getCSRFToken, requiresCSRF } from "../../utils/csrfToken.js";
+import { getCSRFToken, requiresCSRF, getCSRFEnforcementMode } from "../../utils/csrfToken.js";
 import { logger } from "../../utils/logger.js";
 import { ApiError, RateLimitError, CSRFError } from "./errors.js";
 
@@ -113,16 +113,6 @@ const normalizeApiErrorWithTimeout = (error, timeoutMs) => {
     error.response?.data?.message || error.message || `Request failed with status ${status}`,
     { status, data: error.response?.data || null },
   );
-};
-
-const getCSRFEnforcementMode = () => {
-  if (typeof import.meta.env !== "undefined" && import.meta.env.VITE_CSRF_ENFORCEMENT_MODE) {
-    return import.meta.env.VITE_CSRF_ENFORCEMENT_MODE;
-  }
-  if (typeof process !== "undefined" && process.env?.VITE_CSRF_ENFORCEMENT_MODE) {
-    return process.env.VITE_CSRF_ENFORCEMENT_MODE;
-  }
-  return "warning";
 };
 
 export function setupRequestInterceptor(api, { isDev, buildApiUrl, getAuthToken, getOnUnauthorized }) {

--- a/src/utils/csrfToken.js
+++ b/src/utils/csrfToken.js
@@ -11,14 +11,32 @@ const CSRF_HEADER_NAME = "X-CSRF-Token";
 
 const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-const getCSRFEnforcementMode = () => {
+export const getCSRFEnforcementMode = () => {
+  const validModes = ["strict", "warning", "disabled"];
+  
+  const isProduction =
+    (typeof process !== "undefined" && process.env?.NODE_ENV === "production") ||
+    (typeof import.meta.env !== "undefined" && import.meta.env?.MODE === "production");
+  
+  const defaultMode = isProduction ? "strict" : "warning";
+  
+  let configuredMode;
   if (typeof import.meta.env !== "undefined" && import.meta.env.VITE_CSRF_ENFORCEMENT_MODE) {
-    return import.meta.env.VITE_CSRF_ENFORCEMENT_MODE;
+    configuredMode = import.meta.env.VITE_CSRF_ENFORCEMENT_MODE;
+  } else if (typeof process !== "undefined" && process.env?.VITE_CSRF_ENFORCEMENT_MODE) {
+    configuredMode = process.env.VITE_CSRF_ENFORCEMENT_MODE;
   }
-  if (typeof process !== "undefined" && process.env?.VITE_CSRF_ENFORCEMENT_MODE) {
-    return process.env.VITE_CSRF_ENFORCEMENT_MODE;
+  
+  if (configuredMode && !validModes.includes(configuredMode)) {
+    console.warn(
+      `[CSRF] Invalid VITE_CSRF_ENFORCEMENT_MODE value: "${configuredMode}". ` +
+      `Valid values are: ${validModes.join(", ")}. ` +
+      `Falling back to environment default: "${defaultMode}".`
+    );
+    return defaultMode;
   }
-  return "warning";
+  
+  return configuredMode || defaultMode;
 };
 
 /**


### PR DESCRIPTION
## Description

This PR fixes a security configuration issue where CSRF enforcement defaulted to `warning` mode when `VITE_CSRF_ENFORCEMENT_MODE` was not explicitly configured.

The implementation now uses environment-aware defaults:

* Production environments default to `strict`
* Development and test environments default to `warning`

The change also introduces validation for invalid configuration values and ensures the application falls back to a secure environment-specific default rather than silently accepting unsupported values.

Additional updates include documentation improvements and comprehensive test coverage to verify enforcement behavior across different environments and configuration scenarios.

Fixes #9379 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have run local unit tests using `npm test` and verified they pass
* [x] I have run `npm run lint` and resolved any new errors or warnings
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports

## Summary of Changes

* Updated CSRF enforcement logic to use environment-aware defaults.
* Production deployments now default to `strict` mode when no configuration is provided.
* Development and test environments continue to default to `warning` mode for easier debugging.
* Added validation for unsupported `VITE_CSRF_ENFORCEMENT_MODE` values.
* Added warning logs when invalid configuration values are detected.
* Updated `.env.example` documentation to clearly explain default behavior and security recommendations.
* Centralized CSRF enforcement mode usage across request interceptors.
* Added unit tests covering:

  * Production default behavior
  * Development default behavior
  * Explicit strict mode
  * Explicit warning mode
  * Explicit disabled mode
  * Invalid configuration fallback behavior

## Security Impact

This change improves defense-in-depth by ensuring production deployments enforce CSRF protection by default even when configuration is omitted. Invalid configuration values can no longer silently weaken CSRF enforcement, reducing the risk of accidental misconfiguration.
