### PR TITLE
refactor: centralize JWT_SECRET validation logic

### DIFF
--- a/api/_lib/jwtSecret.js
+++ b/api/_lib/jwtSecret.js
@@ -1,0 +1,87 @@
+/**
+ * JWT Secret Validation Utility
+ * 
+ * Provides a single source of truth for JWT_SECRET retrieval and validation.
+ * Enforces fail-closed security behavior - missing or invalid JWT_SECRET
+ * will throw an error or return an error response.
+ */
+
+/**
+ * Retrieves and validates the JWT_SECRET from environment variables.
+ * 
+ * @returns {string} The validated JWT_SECRET
+ * @throws {Error} If JWT_SECRET is missing, empty, or whitespace-only
+ * 
+ * @example
+ * try {
+ *   const secret = getJwtSecret();
+ *   // Use secret for JWT operations
+ * } catch (error) {
+ *   // Handle missing JWT_SECRET
+ * }
+ */
+export function getJwtSecret() {
+  const secret = process.env.JWT_SECRET;
+
+  if (!secret || !secret.trim()) {
+    throw new Error("JWT_SECRET is not configured");
+  }
+
+  return secret;
+}
+
+/**
+ * Creates a standardized HTTP 500 Response for JWT configuration errors.
+ * 
+ * @returns {Response} A Response object with status 500 and error message
+ * 
+ * @example
+ * try {
+ *   const secret = getJwtSecret();
+ * } catch (error) {
+ *   return createJwtConfigErrorResponse();
+ * }
+ */
+export function createJwtConfigErrorResponse() {
+  return new Response(
+    JSON.stringify({
+      error: "Server authentication misconfiguration"
+    }),
+    {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    }
+  );
+}
+
+/**
+ * Validates JWT_SECRET and throws an error with guidance if invalid.
+ * This is useful for server startup validation (e.g., in sse-mock-server.js).
+ * 
+ * @returns {string} The validated JWT_SECRET
+ * @throws {Error} If JWT_SECRET is missing, empty, or whitespace-only
+ * 
+ * @example
+ * try {
+ *   const secret = validateJwtSecretOrExit();
+ *   // Server can start safely with secret
+ * } catch (error) {
+ *   console.error(error.message);
+ *   process.exit(1);
+ * }
+ */
+export function validateJwtSecretOrExit() {
+  const secret = process.env.JWT_SECRET;
+
+  if (!secret || !secret.trim()) {
+    const error = new Error(
+      "FATAL: JWT_SECRET environment variable is required and must not be empty or whitespace-only.\n" +
+      "Generate a secure secret using: openssl rand -base64 32"
+    );
+    throw error;
+  }
+
+  return secret;
+}

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -7,6 +7,7 @@ import {
   isDistributedRateLimitStorageConfigured,
   isInMemoryRateLimitStorageAllowed,
 } from "../api/_lib/rate-limit-config.js";
+import { getJwtSecret, createJwtConfigErrorResponse } from "../api/_lib/jwtSecret.js";
 
 const validationLimiter = createConcurrencyLimiter(5);
 
@@ -148,12 +149,11 @@ async function authorizeSession(request, url) {
       );
     }
 
-    const jwtSecret = process.env.JWT_SECRET;
-    if (!jwtSecret || !jwtSecret.trim()) {
-      return new Response(
-        JSON.stringify({ error: "Server authentication misconfiguration" }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
-      );
+    let jwtSecret;
+    try {
+      jwtSecret = getJwtSecret();
+    } catch (error) {
+      return createJwtConfigErrorResponse();
     }
 
     const payload = await verifyJwt(token, jwtSecret);

--- a/middleware/jwt.js
+++ b/middleware/jwt.js
@@ -1,3 +1,5 @@
+import { getJwtSecret, createJwtConfigErrorResponse } from "../api/_lib/jwtSecret.js";
+
 const base64urlDecode = (str) => {
   let base64 = str.replace(/-/g, "+").replace(/_/g, "/");
   while (base64.length % 4) base64 += "=";
@@ -86,13 +88,12 @@ const forbiddenResponse = (url) =>
   );
 
 export async function verifyTicketAccess(request) {
-  const jwtSecret = process.env.JWT_SECRET;
-  if (!jwtSecret || !jwtSecret.trim()) {
+  let jwtSecret;
+  try {
+    jwtSecret = getJwtSecret();
+  } catch (error) {
     console.error("[middleware] JWT_SECRET is not configured. Rejecting ticket route request.");
-    return new Response(
-      JSON.stringify({ error: "Server authentication misconfiguration" }),
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
+    return createJwtConfigErrorResponse();
   }
 
   const token = parseTokenFromCookie(request);

--- a/sse-mock-server.js
+++ b/sse-mock-server.js
@@ -9,6 +9,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import jwt from "jsonwebtoken";
+import { validateJwtSecretOrExit } from "./api/_lib/jwtSecret.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -128,11 +129,11 @@ const MOCK_EVENTS = [
   { id: "event-3", title: "Web Dev Workshop" }
 ];
 
-const JWT_SECRET = process.env.JWT_SECRET;
-
-if (!JWT_SECRET || !JWT_SECRET.trim()) {
-  console.error("FATAL: JWT_SECRET environment variable is required and must not be empty or whitespace-only.");
-  console.error("Generate a secure secret using: openssl rand -base64 32");
+let JWT_SECRET;
+try {
+  JWT_SECRET = validateJwtSecretOrExit();
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
 

--- a/tests/jwtSecret.test.mjs
+++ b/tests/jwtSecret.test.mjs
@@ -1,0 +1,156 @@
+/**
+ * Tests for JWT Secret Validation Utility
+ * 
+ * These tests verify that the jwtSecret utility enforces fail-closed security:
+ * - getJwtSecret() throws when JWT_SECRET is missing
+ * - getJwtSecret() throws when JWT_SECRET is empty
+ * - getJwtSecret() throws when JWT_SECRET is whitespace-only
+ * - getJwtSecret() returns the secret when valid
+ * - createJwtConfigErrorResponse() returns correct error response
+ * - validateJwtSecretOrExit() throws with guidance when invalid
+ * - validateJwtSecretOrExit() returns secret when valid
+ */
+
+import { strict as assert } from "node:assert";
+import { describe, it, before, after } from "node:test";
+import { getJwtSecret, createJwtConfigErrorResponse, validateJwtSecretOrExit } from "../api/_lib/jwtSecret.js";
+
+describe("JWT Secret Utility", () => {
+  const originalJwtSecret = process.env.JWT_SECRET;
+
+  after(() => {
+    // Restore original JWT_SECRET after all tests
+    if (originalJwtSecret !== undefined) {
+      process.env.JWT_SECRET = originalJwtSecret;
+    } else {
+      delete process.env.JWT_SECRET;
+    }
+  });
+
+  describe("getJwtSecret()", () => {
+    it("throws error when JWT_SECRET is missing", () => {
+      delete process.env.JWT_SECRET;
+      
+      assert.throws(
+        () => getJwtSecret(),
+        { message: "JWT_SECRET is not configured" }
+      );
+    });
+
+    it("throws error when JWT_SECRET is empty string", () => {
+      process.env.JWT_SECRET = "";
+      
+      assert.throws(
+        () => getJwtSecret(),
+        { message: "JWT_SECRET is not configured" }
+      );
+    });
+
+    it("throws error when JWT_SECRET is whitespace-only", () => {
+      process.env.JWT_SECRET = "   ";
+      
+      assert.throws(
+        () => getJwtSecret(),
+        { message: "JWT_SECRET is not configured" }
+      );
+    });
+
+    it("throws error when JWT_SECRET is tabs-only", () => {
+      process.env.JWT_SECRET = "\t\t";
+      
+      assert.throws(
+        () => getJwtSecret(),
+        { message: "JWT_SECRET is not configured" }
+      );
+    });
+
+    it("throws error when JWT_SECRET is mixed whitespace", () => {
+      process.env.JWT_SECRET = " \t \n ";
+      
+      assert.throws(
+        () => getJwtSecret(),
+        { message: "JWT_SECRET is not configured" }
+      );
+    });
+
+    it("returns the secret when JWT_SECRET is valid", () => {
+      process.env.JWT_SECRET = "valid-secret-key";
+      
+      const secret = getJwtSecret();
+      assert.strictEqual(secret, "valid-secret-key");
+    });
+
+    it("returns the secret when JWT_SECRET has leading/trailing whitespace", () => {
+      process.env.JWT_SECRET = "  valid-secret-key  ";
+      
+      const secret = getJwtSecret();
+      assert.strictEqual(secret, "  valid-secret-key  ");
+    });
+  });
+
+  describe("createJwtConfigErrorResponse()", () => {
+    it("returns a Response with status 500", () => {
+      const response = createJwtConfigErrorResponse();
+      
+      assert.strictEqual(response.status, 500);
+    });
+
+    it("returns a Response with correct error message", async () => {
+      const response = createJwtConfigErrorResponse();
+      const body = await response.json();
+      
+      assert.strictEqual(body.error, "Server authentication misconfiguration");
+    });
+
+    it("returns a Response with Content-Type application/json", () => {
+      const response = createJwtConfigErrorResponse();
+      
+      assert.strictEqual(response.headers.get("Content-Type"), "application/json");
+    });
+  });
+
+  describe("validateJwtSecretOrExit()", () => {
+    it("throws error when JWT_SECRET is missing", () => {
+      delete process.env.JWT_SECRET;
+      
+      assert.throws(
+        () => validateJwtSecretOrExit(),
+        /FATAL: JWT_SECRET environment variable is required/
+      );
+    });
+
+    it("throws error with guidance when JWT_SECRET is missing", () => {
+      delete process.env.JWT_SECRET;
+      
+      assert.throws(
+        () => validateJwtSecretOrExit(),
+        /Generate a secure secret using: openssl rand -base64 32/
+      );
+    });
+
+    it("throws error when JWT_SECRET is empty string", () => {
+      process.env.JWT_SECRET = "";
+      
+      assert.throws(
+        () => validateJwtSecretOrExit(),
+        /FATAL: JWT_SECRET environment variable is required/
+      );
+    });
+
+    it("throws error when JWT_SECRET is whitespace-only", () => {
+      process.env.JWT_SECRET = "   ";
+      
+      assert.throws(
+        () => validateJwtSecretOrExit(),
+        /FATAL: JWT_SECRET environment variable is required/
+      );
+    });
+
+    it("returns the secret when JWT_SECRET is valid", () => {
+      process.env.JWT_SECRET = "valid-secret-key";
+      
+      const secret = validateJwtSecretOrExit();
+      assert.strictEqual(secret, "valid-secret-key");
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR refactors JWT secret validation by introducing a centralized utility and removing duplicated validation logic across middleware components.

### Changes Made

* Added a shared JWT secret utility:

  * `getJwtSecret()`
  * `createJwtConfigErrorResponse()`
  * `validateJwtSecretOrExit()`
* Replaced duplicated `JWT_SECRET` validation logic in:

  * `middleware/index.js`
  * `middleware/jwt.js`
  * `sse-mock-server.js`
* Standardized JWT configuration error handling across the codebase.
* Added comprehensive test coverage for JWT secret validation scenarios.
* Preserved existing fail-closed security behavior.

### Motivation

Previously, JWT secret validation logic was duplicated across multiple files, increasing maintenance overhead and creating a risk of future configuration-handling inconsistencies.

This refactor introduces a single source of truth for JWT secret retrieval and validation, improving maintainability while preserving existing security guarantees.

Fixes #9383 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

N/A

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have run local unit tests using `npm test` and verified they pass
* [x] I have run `npm run lint` and resolved any new errors or warnings
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
