### PR TITLE
feat: add "Registration Closing Soon" indicator for events 

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -39,8 +39,8 @@ import { checkRegistrationConflict } from "../../utils/conflictDetection";
 // Warning badge shown when an event's registration deadline is within the
 // next 48 hours. Re-evaluates every minute so the remaining-time label stays
 // fresh and the badge auto-hides the moment registration closes. Returns null
-// when the event has no upcoming deadline.
-const RegistrationClosingBadge = ({ event }) => {
+// for past events or when the event has no upcoming deadline.
+const RegistrationClosingBadge = ({ event, isPastEvent }) => {
   const [closingInfo, setClosingInfo] = useState(() =>
     getRegistrationClosingInfo(event)
   );
@@ -55,12 +55,12 @@ const RegistrationClosingBadge = ({ event }) => {
     return () => clearInterval(intervalId);
   }, [event]);
 
-  if (!closingInfo.isClosingSoon) return null;
+  if (isPastEvent || !closingInfo.isClosingSoon) return null;
 
   return (
     <div
       role="status"
-      className="inline-flex items-center gap-[5px] py-1 px-[10px] bg-amber-100 dark:bg-amber-900/30 rounded-[6px] border border-amber-300 dark:border-amber-700 shrink-0 text-[12px] font-medium leading-none text-amber-700 dark:text-amber-300"
+      className="mt-3 inline-flex items-center gap-[5px] py-1 px-[10px] bg-amber-100 dark:bg-amber-900/30 rounded-[6px] border border-amber-300 dark:border-amber-700 shrink-0 text-[12px] font-medium leading-none text-amber-700 dark:text-amber-300"
       title={closingInfo.label}
     >
       <AlertTriangle
@@ -332,11 +332,7 @@ const EventCard = ({ event }) => {
         <p className="text-gray-500 dark:text-gray-400 text-sm leading-6 line-clamp-2">
           {event.description}
         </p>
-        {!isPastEvent && (
-          <div className="mt-3 empty:mt-0">
-            <RegistrationClosingBadge event={event} />
-          </div>
-        )}
+        <RegistrationClosingBadge event={event} isPastEvent={isPastEvent} />
       </div>
 
       {/* Info Grid */}

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -73,6 +73,16 @@ const RegistrationClosingBadge = ({ event, isPastEvent }) => {
   );
 };
 
+// Event summary text plus the registration-closing-soon indicator.
+const EventDescription = ({ event, isPastEvent }) => (
+  <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800">
+    <p className="text-gray-500 dark:text-gray-400 text-sm leading-6 line-clamp-2">
+      {event.description}
+    </p>
+    <RegistrationClosingBadge event={event} isPastEvent={isPastEvent} />
+  </div>
+);
+
 const getCapacityStyles = (ratio, isFull) => {
   if (isFull || ratio >= 0.85) {
     return {
@@ -328,12 +338,7 @@ const EventCard = ({ event }) => {
       </div>
 
       {/* Description */}
-      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800">
-        <p className="text-gray-500 dark:text-gray-400 text-sm leading-6 line-clamp-2">
-          {event.description}
-        </p>
-        <RegistrationClosingBadge event={event} isPastEvent={isPastEvent} />
-      </div>
+      <EventDescription event={event} isPastEvent={isPastEvent} />
 
       {/* Info Grid */}
       <div className="px-5 py-4 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-4 text-gray-600 dark:text-gray-400 text-sm bg-gray-50/50 dark:bg-gray-800/30">

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -4,6 +4,7 @@ import { getUserTimezone } from "../../utils/timezoneUtils";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { getSmartDateLabel } from "../../utils/relativeTime";
+import { getRegistrationClosingInfo } from "../../utils/registrationDeadline";
 import {
   Bookmark,
   BookmarkCheck,
@@ -34,6 +35,43 @@ import {
   subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
+
+// Warning badge shown when an event's registration deadline is within the
+// next 48 hours. Re-evaluates every minute so the remaining-time label stays
+// fresh and the badge auto-hides the moment registration closes. Returns null
+// when the event has no upcoming deadline.
+const RegistrationClosingBadge = ({ event }) => {
+  const [closingInfo, setClosingInfo] = useState(() =>
+    getRegistrationClosingInfo(event)
+  );
+
+  useEffect(() => {
+    setClosingInfo(getRegistrationClosingInfo(event));
+
+    const intervalId = setInterval(() => {
+      setClosingInfo(getRegistrationClosingInfo(event));
+    }, 60 * 1000);
+
+    return () => clearInterval(intervalId);
+  }, [event]);
+
+  if (!closingInfo.isClosingSoon) return null;
+
+  return (
+    <div
+      role="status"
+      className="inline-flex items-center gap-[5px] py-1 px-[10px] bg-amber-100 dark:bg-amber-900/30 rounded-[6px] border border-amber-300 dark:border-amber-700 shrink-0 text-[12px] font-medium leading-none text-amber-700 dark:text-amber-300"
+      title={closingInfo.label}
+    >
+      <AlertTriangle
+        size={12}
+        className="text-amber-600 dark:text-amber-400 shrink-0"
+        aria-hidden="true"
+      />
+      <span>{closingInfo.label}</span>
+    </div>
+  );
+};
 
 const getCapacityStyles = (ratio, isFull) => {
   if (isFull || ratio >= 0.85) {
@@ -294,6 +332,11 @@ const EventCard = ({ event }) => {
         <p className="text-gray-500 dark:text-gray-400 text-sm leading-6 line-clamp-2">
           {event.description}
         </p>
+        {!isPastEvent && (
+          <div className="mt-3 empty:mt-0">
+            <RegistrationClosingBadge event={event} />
+          </div>
+        )}
       </div>
 
       {/* Info Grid */}

--- a/src/Pages/Events/EventCard.test.js
+++ b/src/Pages/Events/EventCard.test.js
@@ -189,6 +189,36 @@ describe('EventCard', () => {
     });
   });
 
+  describe('registration closing soon indicator', () => {
+    const HOUR = 60 * 60 * 1000;
+
+    it('shows a warning badge when registration closes within 48 hours', () => {
+      renderCard({ registrationEnd: new Date(Date.now() + 12 * HOUR).toISOString() });
+      expect(screen.getByText(/registration closes in 12 hours/i)).toBeInTheDocument();
+    });
+
+    it('does not show the badge when there is no registration deadline', () => {
+      renderCard();
+      expect(screen.queryByText(/registration closes/i)).not.toBeInTheDocument();
+    });
+
+    it('does not show the badge once registration has closed', () => {
+      renderCard({ registrationEnd: new Date(Date.now() - HOUR).toISOString() });
+      expect(screen.queryByText(/registration closes/i)).not.toBeInTheDocument();
+    });
+
+    it('does not show the badge when the deadline is beyond 48 hours', () => {
+      renderCard({ registrationEnd: new Date(Date.now() + 72 * HOUR).toISOString() });
+      expect(screen.queryByText(/registration closes/i)).not.toBeInTheDocument();
+    });
+
+    it('does not show the badge for past events', () => {
+      getEventStatus.mockReturnValue('past');
+      renderCard({ registrationEnd: new Date(Date.now() + 12 * HOUR).toISOString() });
+      expect(screen.queryByText(/registration closes/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe('copy link button', () => {
     it('renders a copy-link button with the correct aria-label', () => {
       renderCard();

--- a/src/utils/registrationDeadline.js
+++ b/src/utils/registrationDeadline.js
@@ -1,0 +1,75 @@
+// Computes a "Registration Closing Soon" indicator for events whose
+// registration deadline (`registrationEnd`) is approaching.
+//
+// The badge appears only while the deadline is within the next
+// REGISTRATION_CLOSING_WINDOW_HOURS and has not yet passed, so it
+// automatically hides once registration closes.
+
+export const REGISTRATION_CLOSING_WINDOW_HOURS = 48;
+
+const MS_PER_MINUTE = 60 * 1000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+// Resolve the registration deadline from an event, tolerating the few
+// field names the codebase/data uses for it. Returns a valid Date or null.
+const getRegistrationDeadlineDate = (event = {}) => {
+  if (!event || typeof event !== "object") return null;
+
+  const raw =
+    event.registrationEnd ??
+    event.registrationDeadline ??
+    event.registrationClose ??
+    null;
+
+  if (raw === null || raw === undefined || raw === "") return null;
+
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const pluralize = (value, unit) => `${value} ${unit}${value === 1 ? "" : "s"}`;
+
+// Build the human-readable remaining-time label.
+// Examples: "Registration closes in 12 hours", "Registration closes tomorrow".
+const buildClosingLabel = (msRemaining) => {
+  if (msRemaining < MS_PER_HOUR) {
+    const minutes = Math.max(1, Math.round(msRemaining / MS_PER_MINUTE));
+    return `Registration closes in ${pluralize(minutes, "minute")}`;
+  }
+
+  if (msRemaining < MS_PER_DAY) {
+    const hours = Math.round(msRemaining / MS_PER_HOUR);
+    return `Registration closes in ${pluralize(hours, "hour")}`;
+  }
+
+  const days = Math.round(msRemaining / MS_PER_DAY);
+  if (days === 1) return "Registration closes tomorrow";
+  return `Registration closes in ${pluralize(days, "day")}`;
+};
+
+// Returns the closing-soon state for an event. `isClosingSoon` is true only
+// when the deadline is in the future and within the configured window.
+// `now` is injectable for testing.
+export const getRegistrationClosingInfo = (event = {}, now = Date.now()) => {
+  const deadline = getRegistrationDeadlineDate(event);
+
+  if (!deadline) {
+    return { isClosingSoon: false, label: null, deadline: null, msRemaining: null };
+  }
+
+  const msRemaining = deadline.getTime() - now;
+  const windowMs = REGISTRATION_CLOSING_WINDOW_HOURS * MS_PER_HOUR;
+
+  // Already closed, or further out than the window -> no badge.
+  if (msRemaining <= 0 || msRemaining > windowMs) {
+    return { isClosingSoon: false, label: null, deadline, msRemaining };
+  }
+
+  return {
+    isClosingSoon: true,
+    label: buildClosingLabel(msRemaining),
+    deadline,
+    msRemaining,
+  };
+};

--- a/src/utils/registrationDeadline.js
+++ b/src/utils/registrationDeadline.js
@@ -16,13 +16,15 @@ const MS_PER_DAY = 24 * MS_PER_HOUR;
 const getRegistrationDeadlineDate = (event = {}) => {
   if (!event || typeof event !== "object") return null;
 
+  // Falls back to "" (not null) so a single falsy check covers missing,
+  // null, undefined and empty-string deadlines without a complex conditional.
   const raw =
     event.registrationEnd ??
     event.registrationDeadline ??
     event.registrationClose ??
-    null;
+    "";
 
-  if (raw === null || raw === undefined || raw === "") return null;
+  if (!raw) return null;
 
   const date = new Date(raw);
   return Number.isNaN(date.getTime()) ? null : date;

--- a/src/utils/registrationDeadline.test.js
+++ b/src/utils/registrationDeadline.test.js
@@ -1,0 +1,86 @@
+import {
+  getRegistrationClosingInfo,
+  REGISTRATION_CLOSING_WINDOW_HOURS,
+} from "./registrationDeadline";
+
+const NOW = new Date("2026-06-22T12:00:00Z").getTime();
+const HOUR = 60 * 60 * 1000;
+
+const eventClosingIn = (ms) => ({
+  registrationEnd: new Date(NOW + ms).toISOString(),
+});
+
+describe("getRegistrationClosingInfo", () => {
+  describe("when there is no usable deadline", () => {
+    it("returns not-closing when registrationEnd is absent", () => {
+      expect(getRegistrationClosingInfo({}, NOW).isClosingSoon).toBe(false);
+    });
+
+    it("returns not-closing for an invalid date", () => {
+      const info = getRegistrationClosingInfo({ registrationEnd: "not-a-date" }, NOW);
+      expect(info.isClosingSoon).toBe(false);
+      expect(info.label).toBeNull();
+    });
+
+    it("returns not-closing for an empty string", () => {
+      expect(getRegistrationClosingInfo({ registrationEnd: "" }, NOW).isClosingSoon).toBe(false);
+    });
+  });
+
+  describe("window boundaries", () => {
+    it("hides the badge once registration has closed", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(-HOUR), NOW);
+      expect(info.isClosingSoon).toBe(false);
+      expect(info.label).toBeNull();
+    });
+
+    it("hides the badge when the deadline is beyond the 48h window", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(49 * HOUR), NOW);
+      expect(info.isClosingSoon).toBe(false);
+    });
+
+    it("shows the badge when the deadline is just inside the window", () => {
+      const info = getRegistrationClosingInfo(
+        eventClosingIn(REGISTRATION_CLOSING_WINDOW_HOURS * HOUR - HOUR),
+        NOW
+      );
+      expect(info.isClosingSoon).toBe(true);
+    });
+  });
+
+  describe("label formatting", () => {
+    it("renders minutes when under an hour remains", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(30 * 60 * 1000), NOW);
+      expect(info.label).toBe("Registration closes in 30 minutes");
+    });
+
+    it("renders hours when under a day remains", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(12 * HOUR), NOW);
+      expect(info.label).toBe("Registration closes in 12 hours");
+    });
+
+    it("renders 'tomorrow' when roughly a day remains", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(24 * HOUR), NOW);
+      expect(info.label).toBe("Registration closes tomorrow");
+    });
+
+    it("renders days when more than a day remains", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(47 * HOUR), NOW);
+      expect(info.label).toBe("Registration closes in 2 days");
+    });
+
+    it("uses singular units correctly", () => {
+      const info = getRegistrationClosingInfo(eventClosingIn(60 * 1000), NOW);
+      expect(info.label).toBe("Registration closes in 1 minute");
+    });
+  });
+
+  it("reads alternative deadline field names", () => {
+    const info = getRegistrationClosingInfo(
+      { registrationDeadline: new Date(NOW + 12 * HOUR).toISOString() },
+      NOW
+    );
+    expect(info.isClosingSoon).toBe(true);
+    expect(info.label).toBe("Registration closes in 12 hours");
+  });
+});


### PR DESCRIPTION
## Summary
Closes #9343.

Adds a dynamic warning badge on event cards when an event's registration deadline is approaching, so time-sensitive events stand out and users register in time.

## Behavior
- Shows a badge when registration closes within the next **48 hours**
- Displays remaining time: "Registration closes in 12 hours", "Registration closes tomorrow", "Registration closes in 30 minutes", "Registration closes in 2 days"
- **Auto-hides** once registration closes (re-evaluates every 60s)
- Never shown for past events

## Changes
- `src/utils/registrationDeadline.js` — `getRegistrationClosingInfo()` helper (pure, injectable clock); reads the existing `registrationEnd` field (falls back to `registrationDeadline`/`registrationClose`)
- `src/Pages/Events/EventCard.js` — `RegistrationClosingBadge` rendered below the description, reusing the existing amber ⚠ badge styling; ticks every minute to stay fresh
- Unit tests for the helper and the card badge

## Notes
- Uses existing registration-deadline data and frontend date math only — no API/schema changes.
- `role="status"` + `aria-hidden` icon for accessibility.


