### PR TITLE
fix(calendarExporter): add SSR guard to prevent crash in downloadICSFile and downloadBulkICSFile

### DIFF
--- a/src/utils/calendarExporter.js
+++ b/src/utils/calendarExporter.js
@@ -38,6 +38,8 @@ const escapeICSText = (text = "") => {
  * @param {CalendarEvent} event - The event object to export.
  */
 export const downloadICSFile = (event) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
   const { title, description, date, endDate, location, id } = event;
   
   const formattedStart = formatToICSDate(date);
@@ -191,6 +193,7 @@ export const generateYahooCalendarLink = (event) => {
  * @param {string} [filename="registered-events"] - Custom filename for the downloaded file.
  */
 export const downloadBulkICSFile = (events, filename = "registered-events") => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   if (!Array.isArray(events) || events.length === 0) return;
 
   const createdDate = formatToICSDate(new Date());


### PR DESCRIPTION
Summary: Add SSR guards to downloadICSFile and downloadBulkICSFile in src/utils/calendarExporter.js to prevent ReferenceError during server-side rendering.

Changes: Added typeof window/document guards at the top of both functions.

Impact: Fixes SSR crash in Next.js/Vercel deployments. No client-side behavioral change.

Closes #9396