### PR TITLE
fix(calendarLinks): use correct event property names for date fields

### DIFF
--- a/src/utils/calendarLinks.js
+++ b/src/utils/calendarLinks.js
@@ -13,7 +13,7 @@ export const formatICSDate = (dateString) => {
 export const getGoogleCalendarUrl = (event) => {
   const baseUrl = "https://calendar.google.com/calendar/render?action=TEMPLATE";
   const text = `&text=${encodeURIComponent(event.title || '')}`;
-  const dates = `&dates=${formatICSDate(event.startDateTime)}/${formatICSDate(event.endDateTime)}`;
+  const dates = `&dates=${formatICSDate(event.date)}/${formatICSDate(event.endDate)}`;
   const details = `&details=${encodeURIComponent(event.description || '')}`;
   const location = `&location=${encodeURIComponent(event.location || '')}`;
   
@@ -33,8 +33,8 @@ export const generateRawICSContent = (event) => {
     'BEGIN:VEVENT',
     `UID:${event.id || Date.now()}@eventra.com`,
     `DTSTAMP:${formatICSDate(new Date().toISOString())}`,
-    `DTSTART:${formatICSDate(event.startDateTime)}`,
-    `DTEND:${formatICSDate(event.endDateTime)}`,
+    `DTSTART:${formatICSDate(event.date)}`,
+    `DTEND:${formatICSDate(event.endDate)}`,
     `SUMMARY:${(event.title || '').replace(/,/g, '\\,')}`,
     `DESCRIPTION:${(event.description || '').replace(/,/g, '\\,')}`,
     `LOCATION:${(event.location || '').replace(/,/g, '\\,')}`,


### PR DESCRIPTION
Summary: Fix incorrect property names in src/utils/calendarLinks.js. The event object uses event.date and event.endDate, not event.startDateTime and event.endDateTime.

Changes: Replaced event.startDateTime with event.date and event.endDateTime with event.endDate in both getGoogleCalendarUrl and generateRawICSContent functions.

Impact: Fixes broken ICS exports where date fields were undefined. Improves reliability of Google Calendar URL generation.

Closes #9397