### PR TITLE
fix(csrfToken): add SSR guard to prevent crash in getCSRFTokenFromMeta and getCSRFTokenFromCookie

### DIFF
--- a/src/utils/csrfToken.js
+++ b/src/utils/csrfToken.js
@@ -15,6 +15,7 @@ const CSRF_HEADER_NAME = "X-CSRF-Token";
  * @returns {string|null}
  */
 export function getCSRFTokenFromMeta() {
+  if (typeof document === "undefined") return null;
   const meta = document.querySelector(`meta[name="${CSRF_META_NAME}"]`);
   return meta ? meta.getAttribute("content") : null;
 }
@@ -25,6 +26,7 @@ export function getCSRFTokenFromMeta() {
  * @returns {string|null}
  */
 export function getCSRFTokenFromCookie(name = CSRF_COOKIE_NAME) {
+  if (typeof document === "undefined") return null;
   const cookies = document.cookie.split(";").map((c) => c.trim());
   for (const cookie of cookies) {
     if (cookie.startsWith(`${name}=`)) {


### PR DESCRIPTION
## Summary

Add SSR guards to `getCSRFTokenFromMeta` and `getCSRFTokenFromCookie` in `src/utils/csrfToken.js` to prevent `ReferenceError` during server-side rendering.

## Changes

- Added `if (typeof document === "undefined") return null;` guard at the top of `getCSRFTokenFromMeta()`.
- Added `if (typeof document === "undefined") return null;` guard at the top of `getCSRFTokenFromCookie()`.

## Impact

- Fixes SSR crash in Next.js/Vercel deployments where `document` is not available on the server.
- No impact on client-side CSRF token handling — both functions return `null` gracefully when `document` is absent, and callers already handle `null`.

Closes #9398