### PR TITLE
fix: sanitize applicationText in handleApplySubmit to prevent XSS from raw user proposal input

### DIFF
--- a/src/components/CollaborationHub.js
+++ b/src/components/CollaborationHub.js
@@ -171,7 +171,11 @@ const CollaborationHub = () => {
       return;
     }
 
-    // Sanitize user proposal pitch text
+    const sanitizedProposal = sanitizeInputText(applicationText);
+    if (!sanitizedProposal.trim()) {
+      toast.error('Proposal message contains invalid content.');
+      return;
+    }
     toast.success('Your partnership proposal has been submitted successfully!');
     setApplicationText('');
     setProposalFile(null);


### PR DESCRIPTION
### Related Issue
Closes #9414 

### Description of Changes
- I added `sanitizeInputText(applicationText)` call in `handleApplySubmit` in `CollaborationHub.jsx`.
- I added a guard to reject submissions where the sanitized result is empty.
- It aligns `handleApplySubmit` with the existing sanitization pattern already in `handleRequestSubmit`.