### PR TITLE
fix: sanitize eventType and eventDate in generateCertificatePDF to match all other field sanitization

### DIFF
--- a/src/components/CertificateDownload.jsx
+++ b/src/components/CertificateDownload.jsx
@@ -48,8 +48,8 @@ export const generateCertificatePDF = ({ participantName, eventName, eventDate, 
 
   doc.setFontSize(12);
   doc.setTextColor(...t.text);
-  doc.text(`Event Type: ${eventType || "Event"}`, 148, 150, { align: "center", maxWidth: 240 });
-  doc.text(`Date: ${eventDate || ""}`, 148, 162, { align: "center", maxWidth: 240 });
+  doc.text(`Event Type: ${sanitizeText(eventType || "Event", 40)}`, 148, 150, { align: "center", maxWidth: 240 });
+  doc.text(`Date: ${sanitizeText(eventDate || "", 30)}`, 148, 162, { align: "center", maxWidth: 240 });
 
   if (organizerName) {
     doc.text(`Organized by: ${sanitizeText(organizerName, 40)}`, 148, 174, { align: "center", maxWidth: 240 });


### PR DESCRIPTION
### Related Issue
Closes #9416 

### Description of Changes
- I wrapped `eventType` and `eventDate` in `sanitizeText()` inside `generateCertificatePDF` in `CertificateDownload.jsx`.
- It brings these two fields in line with the existing sanitization applied to `participantName`, `eventName`, and `organizerName`.
- It prevents malformed or oversized content from being injected into generated PDF certificates.