### PR TITLE
fix: use useRef to stabilize random duration in ConnectionParticle and prevent animation restarts on re-render

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -190,21 +190,24 @@ const formatTimeInZone = (timezone) => {
 };
 
 // ============ PARTICLE ANIMATION COMPONENT ============
-const ConnectionParticle = ({ path, color, delay }) => (
-  <motion.circle
-    r="2.5"
-    fill={color}
-    initial={{ offsetDistance: "0%", opacity: 0.9 }}
-    animate={{ offsetDistance: "100%", opacity: 0.2 }}
-    transition={{
-      duration: 4 + Math.random() * 3,
-      repeat: Infinity,
-      ease: "linear",
-      delay,
-    }}
-    style={{ offsetPath: `path("${path}")` }}
-  />
-);
+const ConnectionParticle = ({ path, color, delay }) => {
+  const duration = useRef(4 + Math.random() * 3);
+  return (
+    <motion.circle
+      r="2.5"
+      fill={color}
+      initial={{ offsetDistance: "0%", opacity: 0.9 }}
+      animate={{ offsetDistance: "100%", opacity: 0.2 }}
+      transition={{
+        duration: duration.current,
+        repeat: Infinity,
+        ease: "linear",
+        delay,
+      }}
+      style={{ offsetPath: `path("${path}")` }}
+    />
+  );
+};
 
 // ============ MAIN COMPONENT ============
 export default function CollaborationNetworkMap() {


### PR DESCRIPTION
### Related Issue
Closes #9418

### Description of Changes
- I converted `ConnectionParticle` from an arrow function expression to a block-body function to support hooks.
- I added `useRef` to compute the random particle animation duration once on mount.
- `duration.current` is now stable across all re-renders, preventing Framer Motion from restarting the particle animation on every parent re-render.