### PR TITLE
fix: replace allSeats prop with allSeatsRef to prevent memo defeat and unnecessary re-renders of all seats

### DIFF
--- a/src/components/events/SpatialSeatSelector.jsx
+++ b/src/components/events/SpatialSeatSelector.jsx
@@ -292,6 +292,11 @@ const SpatialSeatSelector = ({
     return list;
   }, [elements, elementSeatPositions]);
 
+  const allSeatsRef = useRef(allSeats);
+  useEffect(() => {
+    allSeatsRef.current = allSeats;
+  }, [allSeats]);
+
   // Auto-center and zoom to highlighted seat in read-only dashboard view
   useEffect(() => {
     if (readOnly && selectedSeat && elements.length > 0) {
@@ -545,7 +550,7 @@ const SpatialSeatSelector = ({
                     key={`seat-${el.id}-${seat.index}`}
                     el={el}
                     seat={seat}
-                    allSeats={allSeats}
+                    allSeatsRef={allSeatsRef}
                     isSelected={isSeatSelected(el.id, seat.index)}
                     readOnly={readOnly}
                     onSelect={handleSeatClick}
@@ -667,7 +672,7 @@ const SpatialSeatSelector = ({
 
 // ── Optimized Seat Component ────────────────────────────────────────────────
 
-const Seat = ({ el, seat, allSeats, isSelected, readOnly, onSelect, onHover, containerRef }) => {
+const Seat = ({ el, seat, allSeatsRef, isSelected, readOnly, onSelect, onHover, containerRef }) => {
   const isVIP = el.tier && el.tier.toLowerCase().includes("vip");
   const isOccupied = el.assignedAttendees[seat.index];
   const seatLabel = (el.seatLabels && el.seatLabels[seat.index]) || `Seat ${seat.index + 1}`;
@@ -699,7 +704,7 @@ const Seat = ({ el, seat, allSeats, isSelected, readOnly, onSelect, onHover, con
       let bestSeat = null;
       let minScore = Infinity;
 
-      (allSeats || []).forEach((s) => {
+      (allSeatsRef.current || []).forEach((s) => {
         if (s.elementId === el.id && s.index === seat.index) return;
         const dx = s.x - seat.x;
         const dy = s.y - seat.y;


### PR DESCRIPTION
### Related Issue
Closes #9420 

### Description of Changes
- I added `allSeatsRef` (a `useRef`) in `SpatialSeatSelector` that tracks the latest `allSeats` value via a `useEffect`.
- I replaced the `allSeats` prop on `MemoizedSeat` with the stable `allSeatsRef`.
- I updated the `Seat` component to read `allSeatsRef.current` inside `handleKeyDown`.
- `memo(Seat)` now correctly skips re-renders for seats whose props haven't changed, since `allSeatsRef` is a stable ref object.