### PR TITLE
devops: improve Docker configuration (#9430 #9435)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,4 +35,6 @@ create_upstream_prs.py
 dummy_fix_*.txt
 test_cleanup.cjs
 *.log
+api
+middleware
 *.tsbuildinfo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - .:/app
       # Exclude host node_modules to avoid OS-specific native module conflicts
       - node_modules_cache:/app/node_modules
-    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    command: sh -c "npm ci && npm run dev -- --host 0.0.0.0"
     environment:
       - NODE_ENV=development
 


### PR DESCRIPTION
Adds api/ and middleware/ to .dockerignore and switches docker-compose to npm ci for deterministic installs. Closes #9430 Closes #9435