### PR TITLE
perf: improve event page component performance (#9432 #9433 #9437)

### DIFF
--- a/src/Pages/Events/EventFiltersToolbar.js
+++ b/src/Pages/Events/EventFiltersToolbar.js
@@ -1,4 +1,4 @@
-import { Grid, List, Calendar, Search, X, RotateCcw, Sparkles, Filter, Save, Pencil, Trash2, Upload, RefreshCcw, Download } from "lucide-react";
+import { Grid, List, Search, X, RotateCcw, Sparkles, Filter } from "lucide-react";
 import { useState, useEffect, useRef, memo, useCallback } from "react";
 import StyledDropdown from "../../components/StyledDropdown";
 import AdvancedFilterPanel from "../../components/common/AdvancedFilterPanel";
@@ -396,5 +396,5 @@ const EventFiltersToolbar = ({
   );
 };
 
-export default EventFiltersToolbar;
+export default memo(EventFiltersToolbar);
 

--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion, useInView } from "framer-motion";
 import useReducedMotion from "../../hooks/useReducedMotion.js";
 import { Award, Calendar, Clock, Code2, Sparkles, TrendingUp, Trash2, Users } from "lucide-react";
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, memo } from "react";
 import { useNavigate } from "react-router-dom";
 import ModernSearchInput from "../../components/common/ModernSearchInput";
 import CountUpLib from "react-countup";
@@ -36,8 +36,10 @@ const StatCounter = ({ stat, shouldAnimate }) => {
       <>
         {prefix}0{suffix}
       </>
-    );
-  }
+  );
+}
+
+export default memo(EventHero);
 
   return (
     <CountUp
@@ -51,7 +53,7 @@ const StatCounter = ({ stat, shouldAnimate }) => {
   );
 };
 
-export default function EventHero({
+function EventHero({
   searchQuery,
   handleSearch,
   filteredEvents,


### PR DESCRIPTION
Adds React.memo to EventHero and EventFiltersToolbar + removes 7 unused icon imports from EventFiltersToolbar. Closes #9432 Closes #9433 Closes #9437