### PR TITLE
perf: add React.memo to Home page sub-components (#9444 #9445 #9446)

### DIFF
--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -1,6 +1,6 @@
 import { GitBranch, ChevronLeft, ChevronRight } from "lucide-react";
 import { FaMedal, FaCodeBranch, FaUserFriends, FaBuilding, FaMapMarkerAlt, FaGithub, FaExternalLinkAlt } from "react-icons/fa";
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, memo } from "react";
 import useReducedMotion from "../../../hooks/useReducedMotion.js";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
@@ -516,4 +516,4 @@ const Contributors = () => {
   );
 };
 
-export default Contributors;
+export default memo(Contributors);

--- a/src/Pages/Home/components/Testimonials.js
+++ b/src/Pages/Home/components/Testimonials.js
@@ -1,5 +1,5 @@
 import { Quote, Star, Play, Pause, ChevronLeft, ChevronRight, Share2, CheckCircle, ExternalLink } from "lucide-react";
-import { useRef, useEffect, useState, useMemo, useCallback } from "react";
+import { useRef, useEffect, useState, useMemo, useCallback, memo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 
 // 🎯 Enhanced testimonials data with more metadata
@@ -456,4 +456,4 @@ const ModernTestimonialTrain = () => {
   );
 };
 
-export default ModernTestimonialTrain;
+export default memo(ModernTestimonialTrain);

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, memo } from "react";
 import { Link } from "react-router-dom";
 import { useInView } from "react-intersection-observer";
 import { HomeCardSkeleton } from "../../../components/common/SkeletonLoaders";
@@ -510,4 +510,4 @@ const WhatsHappening = () => {
   );
 };
 
-export default WhatsHappening;
+export default memo(WhatsHappening);


### PR DESCRIPTION
Adds React.memo to WhatsHappening, ModernTestimonialTrain, and Contributors. Prevents unnecessary re-renders of animation-heavy components. Closes #9444 Closes #9445 Closes #9446