### PR TITLE
fix: add Vary: Origin header to CORS responses (#9448)

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -200,6 +200,7 @@ async function handleRequest(request) {
     addSecurityHeaders(responseHeaders);
     responseHeaders.set("Access-Control-Allow-Origin", url.origin);
     responseHeaders.set("Access-Control-Allow-Credentials", "true");
+    responseHeaders.set("Vary", "Origin");
     return new Response(
       JSON.stringify({ error: "Too many requests. Please try again later." }),
       {

--- a/middleware/jwt.js
+++ b/middleware/jwt.js
@@ -81,6 +81,7 @@ const forbiddenResponse = (url) =>
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": url.origin,
         "Access-Control-Allow-Credentials": "true",
+        "Vary": "Origin",
       },
     },
   );


### PR DESCRIPTION
Adds Vary: Origin to CORS responses in middleware to prevent caching proxies from serving incorrect CORS headers to different origins. Closes #9448