### PR TITLE
fix: replace test_secret string check with VITE_TEST_MODE env var (#9450)

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -10,7 +10,7 @@ import { getNotificationMessage } from "../utils/notificationPreferences";
 const POLLING_INTERVAL_MS = 60_000;
 const MAX_SEEN_IDS = 500;
 const getStorageKey = () => {
-  if (typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.JWT_SECRET === "test_secret")) {
+  if (typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.VITE_TEST_MODE === "true")) {
     return "eventra_notification_inbox";
   }
   try {

--- a/src/utils/storageKeyManager.js
+++ b/src/utils/storageKeyManager.js
@@ -35,7 +35,7 @@ export const getOpaqueKey = (namespace, userId) => {
   }
 
   const isTest = typeof process !== "undefined" &&
-    (process.env.NODE_ENV === "test" || process.env.JWT_SECRET === "test_secret") &&
+    (process.env.NODE_ENV === "test" || process.env.VITE_TEST_MODE === "true") &&
     process.env.TEST_OPACITY !== "true";
 
   if (isTest) {


### PR DESCRIPTION
Replaces hardcoded JWT_SECRET === 'test_secret' comparison with VITE_TEST_MODE env var check. Closes #9450