### PR TITLE
perf: convert mock data import to dynamic import in useCalendarEvents (#9447)

### DIFF
--- a/src/Pages/Calendar/useCalendarEvents.js
+++ b/src/Pages/Calendar/useCalendarEvents.js
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import mockEvents from "../Events/eventsMockData.json";
 
 import { eventService } from "../../services/eventService";
 import { getEventStatus } from "../../utils/eventUtils";
@@ -27,7 +26,9 @@ const useCalendarEvents = () => {
       if (process.env.NODE_ENV === "development") {
         console.warn("Failed to fetch events. Falling back to mock data.", error);
         setLoadError(error?.message || "Failed to load events.");
-        setEvents(normalizeEvents(mockEvents));
+        import("../Events/eventsMockData.json").then(({ default: mockEvents }) => {
+          setEvents(normalizeEvents(mockEvents));
+        });
       } else {
         setEvents([]);
         setLoadError(error?.message || "Failed to load events. Please try again.");


### PR DESCRIPTION
Converts static import of eventsMockData.json (10KB) to dynamic import so it's only loaded in dev when API fails. Closes #9447