### PR TITLE
chore: reduce ESLint max-warnings from 250 to 50 (#9456)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test:unit": "node --test tests/eventPaginationUtils.test.mjs tests/routeSearchUtils.test.mjs tests/userNameUtils.test.mjs tests/relativeTime.test.mjs tests/safeJsonParse.test.mjs tests/registerUtils.test.mjs tests/bookmarkUtils.test.mjs tests/auth.test.mjs tests/eventDraftUtils.test.mjs tests/exportCsv.test.mjs tests/hackathonFilterUtils.test.mjs tests/offlineQueue.test.mjs tests/colorTokens.test.mjs tests/themeConsistency.test.mjs tests/sseMultiplexer.test.mjs tests/cspReporting.test.mjs tests/Verifyauth.test.mjs tests/secureStorage.test.mjs tests/conflictDetection.test.mjs tests/eventRecommendationsResponsive.test.mjs tests/spatialSeatSelectorAccessibility.test.mjs tests/navbar.keyboard.test.mjs tests/shareModalUtils.test.mjs tests/distributedRateLimiter.test.mjs tests/serviceWorkerLeaderboard.test.mjs tests/eventReminder.test.mjs tests/p2pFileTransfer.test.mjs tests/useContrastChecker.test.mjs",
     "test:e2e": "playwright test",
     "check": "npm run lint && npm run test",
-    "lint": "eslint src --max-warnings=250",
+    "lint": "eslint src --max-warnings=50",
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,css}\"",
     "prepare": "node scripts/setup-git-config.js",


### PR DESCRIPTION
Reduces the warning threshold so code quality issues surface earlier. Closes #9456