### PR TITLE
fix(exportCsv): add SSR guard to prevent crash in server environments

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -66,6 +66,9 @@ const sanitizeCSVField = (field) => {
  * @param {string} [filename]       - Desired download filename (will be sanitized)
  */
 export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv") => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
   if (!attendees || attendees.length === 0) {
     return;
   }
@@ -127,6 +130,9 @@ export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv"
  * @param {string} surveyTitle       - Raw title of the survey (will be sanitized)
  */
 export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
   if (!questions || questions.length === 0 || !responses || responses.length === 0) {
     return;
   }
@@ -176,6 +182,9 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
  * @param {string} [filename]        - Desired download filename (will be sanitized)
  */
 export const exportEventsToCSV = (events, filename = "eventra-events.csv") => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
   if (!events || events.length === 0) {
     return;
   }


### PR DESCRIPTION
## Summary

Add SSR guards to `exportAttendeesToCSV`, `exportSurveyToCSV`, and `exportEventsToCSV` in `src/utils/exportCsv.js`. These functions call `window.URL.createObjectURL()` and `document.createElement()` without checking for server-side environments, causing Next.js SSR crashes.

## Changes

- Added `if (typeof window === "undefined" || typeof document === "undefined") { return; }` at the top of `exportAttendeesToCSV`, `exportSurveyToCSV`, and `exportEventsToCSV`

## Impact

- Fixes SSR crash in any Next.js page that imports these utilities
- No functional change in browser environments

Closes #9466