### PR TITLE
Fixed the KP issue

### DIFF
--- a/docs/auth-rate-limiting.md
+++ b/docs/auth-rate-limiting.md
@@ -23,3 +23,123 @@ Eventra implements client-side protections for authentication flows to reduce ra
 ## Limitations
 
 Client-side rate limiting is an additional usability and security layer and does not replace backend authentication protections.
+
+---
+
+## Session KV Failure Mode Configuration
+
+### Overview
+
+This project uses Upstash KV (distributed session storage) to track user session state, inactivity timeouts, and risk scores across distributed deployments. The `SESSION_KV_FAILURE_MODE` environment variable controls how the authentication middleware responds when KV is unavailable.
+
+### Environment Variable: `SESSION_KV_FAILURE_MODE`
+
+**Type:** `string`  
+**Valid Values:** `fail_open` (default), `fail_closed`  
+**Location:** Set in `.env` or deployment platform environment variables
+
+### Failure Mode Behaviors
+
+#### `fail_open` (Default)
+
+**When KV is unavailable:**
+- JWT signature and expiration are still validated locally
+- If JWT is valid, the request is allowed through
+- `req.sessionRiskChecked` is set to `false` to indicate session state was not verified
+- Structured warning is logged with userId and reason
+
+**Pros:**
+- ✅ Prevents KV outages from authenticating all users
+- ✅ Maintains service availability during infrastructure issues
+- ✅ Better user experience during degraded scenarios
+
+**Cons:**
+- ⚠️ Session inactivity timeouts (2-hour limit) are not enforced during KV outage
+- ⚠️ Invalidated sessions may not be detected until KV recovers
+- **Mitigation:** JWT expiration (default 1 hour) provides a built-in safety window
+
+**When to use:**
+- Production environments where availability is critical
+- High-traffic systems where KV outages are a known risk
+- When JWT expiration (1 hour default) is acceptable as a session safety net
+
+#### `fail_closed` (Strict Mode)
+
+**When KV is unavailable:**
+- All authenticated requests return HTTP 401 with code `REQUIRES_REAUTH`
+- Users are logged out until KV recovers
+- Behavior identical to previous implementation
+
+**Pros:**
+- ✅ Maximum security: all session state checks always enforced
+- ✅ No stale session risk during outages
+- ✅ Predictable deterministic behavior
+
+**Cons:**
+- ❌ Makes KV a single point of failure for authentication
+- ❌ Service-wide logout during any KV issue
+- ❌ Poor user experience during infrastructure degradation
+
+**When to use:**
+- Development/testing environments
+- Compliance scenarios requiring strict session validation
+- Very low-traffic systems where KV reliability is guaranteed
+- Environments where security overrides availability
+
+### Configuration Examples
+
+#### Production (Recommended)
+
+```bash
+# .env.production
+SESSION_KV_FAILURE_MODE=fail_open
+KV_REST_API_URL=https://your-kv-url.upstash.io
+KV_REST_API_TOKEN=your-secure-token
+```
+
+#### Development
+
+```bash
+# .env.development
+SESSION_KV_FAILURE_MODE=fail_open
+# KV credentials optional in dev
+```
+
+#### High-Security Deployment
+
+```bash
+# .env.production.secure
+SESSION_KV_FAILURE_MODE=fail_closed
+KV_REST_API_URL=https://your-kv-url.upstash.io
+KV_REST_API_TOKEN=your-secure-token
+```
+
+### KV Health Cache
+
+To prevent a thundering herd of KV requests during outages, the middleware caches KV health status for **30 seconds**. This means:
+
+- If KV becomes unavailable, only the first request triggers a health check
+- Subsequent requests within 30 seconds use the cached "unavailable" state
+- After 30 seconds, a new health check is attempted
+- This dramatically reduces load on KV and log volume during outages
+
+### Monitoring and Alerts
+
+When `fail_open` mode is active and KV is unavailable, structured warning logs are emitted with:
+
+```json
+{
+  "level": "warn",
+  "message": "KV unavailable, allowing JWT-valid request (fail_open mode)",
+  "reason": "kv_unavailable",
+  "userId": "user-id-here",
+  "mode": "fail_open",
+  "jwtValid": true,
+  "kvStatus": 500
+}
+```
+
+**Recommended alerts:**
+- Alert if `kv_unavailable` warnings exceed 10 per minute (indicates degraded state)
+- Page on-call if `fail_closed` mode logs `requires_reauth` (indicates outage in strict mode)
+- Monitor KV latency; if health checks start timing out, consider increasing cache TTL

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -8,13 +8,56 @@ import {
   isInMemoryRateLimitStorageAllowed,
 } from "../api/_lib/rate-limit-config.js";
 import { getJwtSecret, createJwtConfigErrorResponse } from "../api/_lib/jwtSecret.js";
+import { SESSION_KV_FAILURE_MODE } from "../src/config/env.js";
 
 const validationLimiter = createConcurrencyLimiter(5);
 
-const getSessionRiskState = async (sessionId) => {
+// KV health cache to prevent thundering herd during outages
+// Structure: { isHealthy: boolean, lastCheckTime: number }
+let kvHealthCache = { isHealthy: true, lastCheckTime: 0 };
+const KV_HEALTH_CACHE_TTL = 30 * 1000; // 30 seconds
+
+/**
+ * Checks if KV storage is currently healthy by attempting a lightweight health check.
+ * Results are cached for 30 seconds to prevent excessive KV ping attempts during outages.
+ * @returns {Promise<boolean>} true if KV is healthy, false if unavailable or failed
+ */
+const isKvHealthy = async () => {
+  const now = Date.now();
+  
+  // Return cached result if still valid
+  if (now - kvHealthCache.lastCheckTime < KV_HEALTH_CACHE_TTL) {
+    return kvHealthCache.isHealthy;
+  }
+
+  const kvUrl = process.env.KV_REST_API_URL;
+  const kvToken = process.env.KV_REST_API_TOKEN;
+
+  if (!kvUrl || !kvToken) {
+    return false;
+  }
+
+  try {
+    const res = await fetch(`${kvUrl}/ping`, {
+      headers: { Authorization: `Bearer ${kvToken}` },
+      timeout: 5000, // 5 second timeout for health check
+    });
+    
+    const isHealthy = res.ok;
+    kvHealthCache = { isHealthy, lastCheckTime: now };
+    return isHealthy;
+  } catch (e) {
+    // Network error, timeout, or fetch error - mark as unhealthy
+    kvHealthCache = { isHealthy: false, lastCheckTime: now };
+    return false;
+  }
+};
+
+const getSessionRiskState = async (sessionId, userId) => {
   const kvUrl = process.env.KV_REST_API_URL;
   const kvToken = process.env.KV_REST_API_TOKEN;
   const isProduction = process.env.NODE_ENV === "production";
+  const failureMode = SESSION_KV_FAILURE_MODE || "fail_open";
 
   // Check if distributed storage is configured
   const isDistributedConfigured = isDistributedRateLimitStorageConfigured();
@@ -44,53 +87,82 @@ const getSessionRiskState = async (sessionId) => {
     }
   }
 
-  // Distributed storage is configured - use KV
+  // Distributed storage is configured - use KV with failure mode handling
+  /**
+   * KV Failure Mode Logic:
+   * - fail_open (default): If KV is unavailable, trust the valid JWT and allow the request.
+   *   This prevents a KV outage from breaking authentication for all users.
+   *   Risk: Stale session state (e.g., inactivity timeout not enforced). Mitigated by JWT expiry.
+   * - fail_closed: If KV is unavailable, require re-authentication (original strict behavior).
+   *   Risk: All users logged out during KV outage. Use only if session state accuracy is critical.
+   */
+  
   try {
     const res = await fetch(`${kvUrl}/get/session:${sessionId}`, {
-      headers: { Authorization: `Bearer ${kvToken}` }
+      headers: { Authorization: `Bearer ${kvToken}` },
+      timeout: 10000, // 10 second timeout for session data fetch
     });
+
     if (!res.ok) {
-      // Production: Fail closed on KV request failure
-      if (isProduction) {
+      // KV request failed with bad status code
+      if (failureMode === "fail_closed") {
         console.error(
-          `[SECURITY] Session state unavailable: KV request failed with status ${res.status}. Requiring re-authentication.`
+          `[SECURITY] Session state unavailable: KV request failed with status ${res.status}. Requiring re-authentication (fail_closed mode).`
         );
         return "requires_reauth";
+      } else {
+        // fail_open: Log warning but allow request through
+        console.warn(
+          JSON.stringify({
+            level: "warn",
+            message: "KV unavailable, allowing JWT-valid request (fail_open mode)",
+            reason: "kv_unavailable",
+            userId,
+            mode: "fail_open",
+            jwtValid: true,
+            kvStatus: res.status,
+          })
+        );
+        return "active_unverified"; // Mark as unverified but allow through
       }
-      // Development: Assume active on KV failure
-      console.warn(
-        `[DEV] KV request failed with status ${res.status}. Assuming active session.`
-      );
-      return "active";
     }
+
     const data = await res.json();
     if (!data || !data.result) return "invalidated";
 
     let sessionData = data.result;
     if (typeof sessionData === 'string') {
-       sessionData = JSON.parse(sessionData);
+      sessionData = JSON.parse(sessionData);
     }
 
     // Check inactivity (2 hours)
     if (Date.now() - sessionData.lastActive > 2 * 60 * 60 * 1000 && sessionData.status === "active") {
-       return "requires_reauth";
+      return "requires_reauth";
     }
     return sessionData.status || "active";
-  } catch(e) {
-    // Production: Fail closed on network errors or invalid responses
-    if (isProduction) {
+  } catch (e) {
+    // Network error, timeout, or JSON parse error
+    if (failureMode === "fail_closed") {
       console.error(
-        "[SECURITY] Session state unavailable: KV communication error.",
+        "[SECURITY] Session state unavailable: KV communication error. Requiring re-authentication (fail_closed mode).",
         e.message
       );
       return "requires_reauth";
+    } else {
+      // fail_open: Log warning but allow request through
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          message: "KV communication error, allowing JWT-valid request (fail_open mode)",
+          reason: "kv_unavailable",
+          userId,
+          mode: "fail_open",
+          jwtValid: true,
+          error: e.message,
+        })
+      );
+      return "active_unverified"; // Mark as unverified but allow through
     }
-    // Development: Assume active on errors
-    console.warn(
-      "[DEV] KV communication error. Assuming active session.",
-      e.message
-    );
-    return "active";
   }
 };
 
@@ -165,11 +237,16 @@ async function authorizeSession(request, url) {
     }
 
     if (payload.sessionId) {
-      const status = await getSessionRiskState(payload.sessionId);
+      const status = await getSessionRiskState(payload.sessionId, payload.userId);
       if (status === "invalidated") {
          return new Response(JSON.stringify({ error: "Session invalidated" }), { status: 401, headers: { "Content-Type": "application/json" }});
       } else if (status === "requires_reauth") {
          return new Response(JSON.stringify({ error: "Re-authentication required", code: "REQUIRES_REAUTH" }), { status: 401, headers: { "Content-Type": "application/json" }});
+      }
+      // status === "active" or "active_unverified" - both allow request through
+      // "active_unverified" indicates KV was unavailable but JWT was valid
+      if (status === "active_unverified") {
+        request.sessionRiskChecked = false;
       }
     }
   }

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -22,6 +22,11 @@ const optionalEnvVars = {
     keys: ["VITE_SENTRY_DSN", "REACT_APP_SENTRY_DSN"],
     fallback: "",
   },
+  SESSION_KV_FAILURE_MODE: {
+    keys: ["SESSION_KV_FAILURE_MODE"],
+    fallback: "fail_open",
+    validValues: ["fail_open", "fail_closed"],
+  },
 };
 
 const getFirstDefinedEnvValue = (keys = []) => {
@@ -40,11 +45,18 @@ const isDevelopment = currentMode === "development";
 
 const DEV_API_FALLBACK = "http://localhost:8080";
 
-const getEnvVar = (keys, fallback = "", { required = false, label } = {}) => {
+const getEnvVar = (keys, fallback = "", { required = false, label, validValues = [] } = {}) => {
   const keyList = Array.isArray(keys) ? keys : [keys];
   const value = getFirstDefinedEnvValue(keyList);
 
   if (value) {
+    // Validate against allowed values if provided
+    if (validValues.length > 0 && !validValues.includes(value)) {
+      console.error(
+        `[ENV ERROR] Invalid value for ${label || keyList.join(" or ")}: "${value}". Allowed values: ${validValues.join(", ")}`
+      );
+      return fallback;
+    }
     return value;
   }
 
@@ -95,6 +107,15 @@ export const ENV = {
 export const SENTRY_DSN = getEnvVar(
   optionalEnvVars.SENTRY_DSN.keys,
   optionalEnvVars.SENTRY_DSN.fallback
+);
+
+export const SESSION_KV_FAILURE_MODE = getEnvVar(
+  optionalEnvVars.SESSION_KV_FAILURE_MODE.keys,
+  optionalEnvVars.SESSION_KV_FAILURE_MODE.fallback,
+  {
+    label: "SESSION_KV_FAILURE_MODE",
+    validValues: optionalEnvVars.SESSION_KV_FAILURE_MODE.validValues,
+  }
 );
 
 export const isSentryEnabled = Boolean(SENTRY_DSN && currentMode === "production");


### PR DESCRIPTION

## Session KV Failure Mode Configuration

### Overview

This project uses Upstash KV (distributed session storage) to track user session state, inactivity timeouts, and risk scores across distributed deployments. The `SESSION_KV_FAILURE_MODE` environment variable controls how the authentication middleware responds when KV is unavailable.

### Environment Variable: `SESSION_KV_FAILURE_MODE`

**Type:** `string`  
**Valid Values:** `fail_open` (default), `fail_closed`  
**Location:** Set in `.env` or deployment platform environment variables

### Failure Mode Behaviors

#### `fail_open` (Default)

**When KV is unavailable:**
- JWT signature and expiration are still validated locally
- If JWT is valid, the request is allowed through
- `req.sessionRiskChecked` is set to `false` to indicate session state was not verified
- Structured warning is logged with userId and reason

**Pros:**
- ✅ Prevents KV outages from authenticating all users
- ✅ Maintains service availability during infrastructure issues
- ✅ Better user experience during degraded scenarios

**Cons:**
- ⚠️ Session inactivity timeouts (2-hour limit) are not enforced during KV outage
- ⚠️ Invalidated sessions may not be detected until KV recovers
- **Mitigation:** JWT expiration (default 1 hour) provides a built-in safety window

**When to use:**
- Production environments where availability is critical
- High-traffic systems where KV outages are a known risk
- When JWT expiration (1 hour default) is acceptable as a session safety net

#### `fail_closed` (Strict Mode)

**When KV is unavailable:**
- All authenticated requests return HTTP 401 with code `REQUIRES_REAUTH`
- Users are logged out until KV recovers
- Behavior identical to previous implementation

**Pros:**
- ✅ Maximum security: all session state checks always enforced
- ✅ No stale session risk during outages
- ✅ Predictable deterministic behavior

**Cons:**
- ❌ Makes KV a single point of failure for authentication
- ❌ Service-wide logout during any KV issue
- ❌ Poor user experience during infrastructure degradation

**When to use:**
- Development/testing environments
- Compliance scenarios requiring strict session validation
- Very low-traffic systems where KV reliability is guaranteed
- Environments where security overrides availability

### Configuration Examples

#### Production (Recommended)

```bash
# .env.production
SESSION_KV_FAILURE_MODE=fail_open
KV_REST_API_URL=https://your-kv-url.upstash.io
KV_REST_API_TOKEN=your-secure-token
```

#### Development

```bash
# .env.development
SESSION_KV_FAILURE_MODE=fail_open
# KV credentials optional in dev
```

#### High-Security Deployment

```bash
# .env.production.secure
SESSION_KV_FAILURE_MODE=fail_closed
KV_REST_API_URL=https://your-kv-url.upstash.io
KV_REST_API_TOKEN=your-secure-token
```

### KV Health Cache

To prevent a thundering herd of KV requests during outages, the middleware caches KV health status for **30 seconds**. This means:

- If KV becomes unavailable, only the first request triggers a health check
- Subsequent requests within 30 seconds use the cached "unavailable" state
- After 30 seconds, a new health check is attempted
- This dramatically reduces load on KV and log volume during outages

### Monitoring and Alerts

When `fail_open` mode is active and KV is unavailable, structured warning logs are emitted with:

```json
{
  "level": "warn",
  "message": "KV unavailable, allowing JWT-valid request (fail_open mode)",
  "reason": "kv_unavailable",
  "userId": "user-id-here",
  "mode": "fail_open",
  "jwtValid": true,
  "kvStatus": 500
}
```

**Recommended alerts:**
- Alert if `kv_unavailable` warnings exceed 10 per minute (indicates degraded state)
- Page on-call if `fail_closed` mode logs `requires_reauth` (indicates outage in strict mode)
- Monitor KV latency; if health checks start timing out, consider increasing cache TTL