### PR TITLE
fix(registerUtils): add SSR guards to prevent crash when localStorage is unavailable

### DIFF
--- a/src/utils/registerUtils.js
+++ b/src/utils/registerUtils.js
@@ -5,6 +5,7 @@ const STORAGE_KEY = "eventRegistrations";
 const normalizeEmail = (email) => (email || "").trim().toLowerCase();
 
 const readRegistrations = () => {
+  if (typeof window === "undefined") return {};
   try {
     const data = localStorage.getItem(STORAGE_KEY);
     const parsed = safeJsonParse(data, {});
@@ -22,6 +23,7 @@ const readRegistrations = () => {
 };
 
 const writeRegistrations = (registrations) => {
+  if (typeof window === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(registrations));
   } catch {


### PR DESCRIPTION
## Summary

Add `typeof window === "undefined"` guards to `readRegistrations()` and `writeRegistrations()` in `src/utils/registerUtils.js`. Both functions directly access `localStorage` without checking if they are running in a browser environment.

## Changes

- `readRegistrations()`: return `{}` early when `typeof window === "undefined"`
- `writeRegistrations()`: return `undefined` early when `typeof window === "undefined"`

## Impact

- Application crashes during SSR when these functions are called
- Fix is purely protective; zero behavioral change in browser environments

Closes #9512.