### PR TITLE
fix(offlineQueue): add typeof window guard to openDB to prevent SSR crash

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -98,7 +98,7 @@ const _dispatchUpgradeEvent = (rescuedCount) => {
 // ---------------------------------------------------------------------------
 const openDB = () => {
   return new Promise((resolve, reject) => {
-    if (!window.indexedDB) {
+    if (typeof window === "undefined" || !window.indexedDB) {
       reject(new Error("IndexedDB is not supported in this environment"));
       return;
     }


### PR DESCRIPTION
## Summary

The `openDB()` function in `src/utils/offlineQueue.js` checks `!window.indexedDB` but does not first guard against `window` itself being `undefined`. In SSR environments, `window` is undefined, so accessing `window.indexedDB` throws `ReferenceError` before the check can run.

## Changes

Change `if (!window.indexedDB)` to `if (typeof window === "undefined" || !window.indexedDB)`.

## Impact

- Application crashes during SSR when `openDB()` is called
- Zero behavioral change in browser environments

Closes #9513.