### PR TITLE
fix(storageUtils): add SSR guards to prevent crash when localStorage is unavailable

### DIFF
--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -1,4 +1,5 @@
 export const saveToStorage = (key, value) => {
+  if (typeof window === "undefined") return;
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
@@ -7,6 +8,7 @@ export const saveToStorage = (key, value) => {
 };
 
 export const loadFromStorage = (key, fallbackValue) => {
+  if (typeof window === "undefined") return fallbackValue;
   try {
     const stored = localStorage.getItem(key);
 


### PR DESCRIPTION
## Summary

Add `typeof window === "undefined"` guards to `saveToStorage()` and `loadFromStorage()` in `src/utils/storageUtils.js`. Both functions directly access `localStorage` without checking if they are running in a browser environment.

## Changes

- `saveToStorage()`: return `undefined` early when `typeof window === "undefined"`
- `loadFromStorage()`: return `fallbackValue` early when `typeof window === "undefined"`

## Impact

- High severity: application crashes during SSR when storage utilities are imported or called
- Fix is purely protective; zero behavioral change in browser environments

Closes #9517.