### PR TITLE
fix: remove unused useRef import from RemindersPage

### DIFF
--- a/src/Pages/Events/RemindersPage.js
+++ b/src/Pages/Events/RemindersPage.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState ,useRef  } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Bell, CalendarDays, Clock, MapPin, Trash2 } from "lucide-react";
 import { Link } from "react-router-dom";
 import useDocumentTitle from "../../hooks/useDocumentTitle";


### PR DESCRIPTION
### Related Issue
Closes #9586 

### Description of Changes
-I removed `useRef` from the React import in `RemindersPage.js`.
- `useRef` was imported but never used anywhere in the file, causing ESLint `no-unused-vars` warnings.