### PR TITLE
feat: add .env.production.example with production-optimized defaults (#9623)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,52 @@
+# ============================================
+# Eventra Production Environment Variables
+# ============================================
+# Copy this file to .env.production and fill in your values.
+# Required variables MUST be set before building for production.
+# WARNING: Never commit .env.production or expose secrets.
+
+# ── Backend API ──────────────────────────────
+# At least one of these is required. Resolution order: BACKEND_URL > VITE_API_URL > REACT_APP_API_URL
+# BACKEND_URL=https://your-api.example.com
+# VITE_API_URL=https://your-api.example.com
+# REACT_APP_API_URL=https://your-api.example.com
+
+# ── Public Metadata ──────────────────────────
+REACT_APP_GITHUB_REPO=SandeepVashishtha/Eventra
+REACT_APP_PUBLIC_URL=https://eventra.sandeepvashishtha.tech
+
+# ── Authentication (Server-side) ─────────────
+# REQUIRED: JWT signing secret (min 64 chars). Generate with: openssl rand -base64 48
+# JWT_SECRET=
+
+# REQUIRED IN PRODUCTION: Persistent auth storage
+# DATABASE_URL=postgresql://user:password@host:5432/database
+
+# ── OAuth & External Services ────────────────
+# REACT_APP_GOOGLE_CLIENT_ID=your_client_id
+# GITHUB_TOKEN=your_github_token
+
+# ── Rate Limiting (Server-side) ──────────────
+# REQUIRED IN PRODUCTION: Distributed rate limiting storage
+# Vercel KV (preferred):
+# KV_REST_API_URL=https://your-kv-url
+# KV_REST_API_TOKEN=your-kv-token
+# Alternative: Redis:
+# RATE_LIMIT_REDIS_URL=rediss://user:password@host:port
+
+# ── Security ─────────────────────────────────
+# VITE_CSRF_ENFORCEMENT_MODE=strict
+# BLOCKED_COUNTRIES=CU,IR,KP,SY,RU
+# ALLOWED_ORIGINS=https://your-domain.com,https://www.your-domain.com
+
+# ── Monitoring ───────────────────────────────
+# REACT_APP_SENTRY_DSN=https://key@o123.ingest.sentry.io/123
+# REACT_APP_CSP_REPORT_URI=https://your-csp-endpoint.report-uri.com/a/d/g
+
+# ── Push Notifications ───────────────────────
+# REACT_APP_VAPID_PUBLIC_KEY=your_vapid_public_key
+
+# ── Build Configuration ──────────────────────
+# NODE_ENV=production
+# GENERATE_SOURCEMAP=false
+# VITE_CACHE_DIR=node_modules/.vite


### PR DESCRIPTION
Adds a production-focused env template with clear required/optional sections. Closes #9623