### PR TITLE
fix(useLocalStorage): add SSR guard to removeValue to prevent crash

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -82,13 +82,17 @@ const useLocalStorage = (key, initialValue) => {
   );
 
   const removeValue = useCallback(() => {
+    if (typeof window === "undefined") return;
     try {
       window.localStorage.removeItem(key);
       setStoredValue(initialValueRef.current);
 
       // 🔥 FIX: Mark as internal before dispatching
       isInternalWrite.current = true;
-      window.dispatchEvent(new CustomEvent("local-storage", { detail: { key } }));
+      queueMicrotask(() => {
+        if (typeof window === "undefined") return;
+        window.dispatchEvent(new CustomEvent("local-storage", { detail: { key } }));
+      });
     } catch (error) {
       logger.warn(`useLocalStorage: error removing key "${key}":`, error);
     }


### PR DESCRIPTION
## Summary
Add SSR guard to the `removeValue` function in `useLocalStorage.js`. The sibling `setValue` function correctly uses `queueMicrotask` with an SSR guard, but `removeValue` directly accessed `window.localStorage` and `window.dispatchEvent` without protection — causing SSR crashes.

## Changes
- Added `typeof window === "undefined"` guard at the top of `removeValue`
- Wrapped `window.dispatchEvent` in `queueMicrotask` with SSR guard (matching the `setValue` pattern)

## Impact
- Fixes SSR crash when `removeValue` is called in server-side rendering environments
- Consistent behavior across `setValue`, `readValue`, and `removeValue`

Closes #9629.