### PR TITLE
fix(App): add SSR guard to useState initializer that accesses window.innerWidth

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,7 +82,7 @@ function App() {
   });
   const [showKeyboardModal, setShowKeyboardModal] = useState(false);
   const [showChatbot, setShowChatbot] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(window.innerWidth >= 1024);
+  const [isDesktop, setIsDesktop] = useState(() => { if (typeof window === "undefined") return false; return window.innerWidth >= 1024; });
 
   useLenis();
   useRoutePrefetch(); // Predictive route pre-loading


### PR DESCRIPTION
## Summary
Replace the direct `window.innerWidth` access in the `isDesktop` `useState` initializer with a lazy initializer function that guards against SSR. The existing `setIsDesktop` call inside `useEffect` already has a guard, but the initial render-time access would crash in SSR.

## Changes
- `useState(window.innerWidth >= 1024)` → `useState(() => { if (typeof window === "undefined") return false; return window.innerWidth >= 1024; })`

## Impact
- Prevents SSR crash on all pages that render the App component
- Returns a sensible default (`false`) during SSR

Closes #9631.