### PR TITLE
fix(ContactUs): add SSR guard to window.location.href in SEOHead url prop

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -432,7 +432,7 @@ const ContactUs = () => {
       <SEOHead
         title={t("contactUs.pageTitle")}
         description={t("contactUs.pageDescription")}
-        url={window.location.href}
+        url={typeof window !== "undefined" ? window.location.href : ""}
       />
       <ContactUsInner />
     </>


### PR DESCRIPTION
## Summary
Replace the direct `window.location.href` access in the `SEOHead` url prop with a conditional check that returns an empty string during SSR. This prevents the Contact Us page from crashing during server-side rendering.

## Changes
- `url={window.location.href}` → `url={typeof window !== "undefined" ? window.location.href : ""}`

## Impact
- Prevents SSR crash on the Contact Us page
- SEOHead gracefully falls back to an empty string during SSR

Closes #9633.