### PR TITLE
Fix/authcontext js

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -41,10 +41,10 @@ const extractSession = (data, fallbackEmail) => {
   // Extract user details from raw API response payload structure
   const rawUser = data?.user ?? data?.data ?? data ?? null;
   const rawRoles = rawUser?.roles ?? (rawUser?.role ? [rawUser.role] : []);
-  
+
   // Normalize roles to ensure consistent uppercase format and organization names
   const resolvedRoles = normalizeRoles(rawRoles);
-  
+
   // Build user permissions by combining token-based and role-based permissions
   const tokenPermissions = Array.isArray(rawUser?.permissions)
     ? rawUser.permissions.map((p) => String(p))
@@ -88,10 +88,10 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
   const [authRequest, setAuthRequest] = useState({ loading: false, error: null });
   const [requiresReauth, setRequiresReauth] = useState(false);
-  
+
   // Ref to track mounting status and prevent setting state on unmounted components
   const isMountedRef = useRef(true);
-  
+
   // Ref to track whether session expired toast has already been displayed to prevent spamming
   const expiryToastShownRef = useRef(false);
 
@@ -121,7 +121,7 @@ export const AuthProvider = ({ children }) => {
       secure: true,
       sameSite: "Strict",
     });
-    
+
     // Clear user metadata from secure/local storage manager
     syncSecureStorage.removeItem("user");
     return true;
@@ -171,9 +171,9 @@ export const AuthProvider = ({ children }) => {
     } catch (e) {
       console.warn("[AuthContext] Failed to read from secure storage during expiry check", e);
     }
-    
+
     clearSession();
-    
+
     if (!hadPreviousSession || expiryToastShownRef.current) return;
     expiryToastShownRef.current = true;
     toast.info(
@@ -183,12 +183,7 @@ export const AuthProvider = ({ children }) => {
         autoClose: 5000,
       }
     );
-    
-    toast.info("Session expired. Please log in again.", {
-      toastId: "session-expired",
-      autoClose: 4000,
-    });
-    
+
     setTimeout(() => {
       window.location.replace("/login");
     }, 1500);
@@ -204,7 +199,7 @@ export const AuthProvider = ({ children }) => {
         const res = await apiUtils.get("/api/auth/me");
         let activeToken = "cookie-managed";
         if (!isMountedRef.current) return;
-        
+
         if (res.ok && res.data) {
           const { sessionUser } = extractSession(res.data, null);
           if (!isMountedRef.current) return;
@@ -215,7 +210,7 @@ export const AuthProvider = ({ children }) => {
         }
       } catch (err) {
         if (!isMountedRef.current) return;
-        
+
         // If server returns unauthorized or forbidden, clear cached state
         if (err?.status === 401 || err?.status === 403) {
           clearSession();
@@ -242,7 +237,7 @@ export const AuthProvider = ({ children }) => {
         if (isMountedRef.current) setLoading(false);
       }
     };
-    
+
     validate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -272,10 +267,10 @@ export const AuthProvider = ({ children }) => {
   useEffect(() => {
     if (!token || token === "cookie-managed") return;
     expiryToastShownRef.current = false;
-    
+
     const expSeconds = user?.exp;
     let timerId;
-    
+
     if (typeof expSeconds === "number") {
       const msUntilExpiry = expSeconds * 1000 - Date.now() + 1000;
       timerId = setTimeout(() => {
@@ -286,7 +281,7 @@ export const AuthProvider = ({ children }) => {
         if (!isTokenValid(token)) clearExpiredSession();
       }, 60000);
     }
-    
+
     return () => {
       if (typeof expSeconds === "number") {
         clearTimeout(timerId);
@@ -308,7 +303,7 @@ export const AuthProvider = ({ children }) => {
     setToken(sessionToken);
     setUser(sessionUser);
     setAuthToken(sessionToken);
-    
+
     try {
       if (sessionToken && sessionToken !== "cookie-managed") {
         setCookie("token", sessionToken, {


### PR DESCRIPTION
## Description

Removed the second toast.info call (the shorter "Session expired. Please log in again." variant). The surviving toast is the better one — fuller message, autoClose: 5000 gives the user enough time to read it before the setTimeout redirect fires at 1500ms. No other changes.

Fixes #9593 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
