### PR TITLE
fix(src/hooks/useBookmarks.js): add SSR guards to readStorage and writeStorage

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -31,6 +31,7 @@ export const MAX_BOOKMARKS = 200;
 const cache = new Map(); // Map<storageKey, BookmarkEntry[]>
 
 const readStorage = (key) => {
+  if (typeof localStorage === 'undefined') return [];
   try {
     const stored = localStorage.getItem(key);
     if (!stored) return [];
@@ -42,6 +43,7 @@ const readStorage = (key) => {
 };
 
 const writeStorage = (key, value) => {
+  if (typeof localStorage === 'undefined') return;
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch {


### PR DESCRIPTION
## Summary
Adds `typeof localStorage === "undefined"` guards to the readStorage and writeStorage functions in useBookmarks.js. Without these guards, the hook crashes immediately in SSR/Node.js environments when any component calls useBookmarks.

## Changes
- Added `if (typeof localStorage === "undefined") return []` to readStorage
- Added `if (typeof localStorage === "undefined") return` to writeStorage

## Impact
Medium — Any Next.js page or component using useBookmarks crashes during server-side rendering or static generation, breaking SEO and initial page load.

Closes #9664.