### PR TITLE
Fix useFocusTrap for SSR

### DIFF
--- a/src/hooks/useFocusTrap.js
+++ b/src/hooks/useFocusTrap.js
@@ -107,8 +107,10 @@ export function useFocusTrap(isActive, onEscape) {
   }, [isActive]);
 
   useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
   }, [handleKeyDown]);
 
   // Restore focus when the trap deactivates (dialog/drawer closes).


### PR DESCRIPTION
## What was broken
The `useFocusTrap` hook was causing a crash in server environments due to `document.addEventListener` being called without an SSR guard.
## What changed
Added a check to ensure `document` exists before calling `document.addEventListener`.
## How to test
Test the fix by running the application in a server environment and verifying that the `useFocusTrap` hook no longer causes a crash.

---
_Opened by autonomous agent. Human review required before merge._