### PR TITLE
fix: fixed sseMultiplexer-js

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -117,6 +117,8 @@ class SseMultiplexer {
   }
 
   setupLocalStorageElection() {
+    if (this.localStorageInterval) clearInterval(this.localStorageInterval);
+
     const HEARTBEAT_INTERVAL = 3000;
     const HEARTBEAT_TIMEOUT = 7000;
 
@@ -482,7 +484,7 @@ class SseMultiplexer {
       let payload = evt.data;
       try {
         payload = JSON.parse(evt.data);
-      } catch {}
+      } catch { }
 
       // Dispatch locally
       this.dispatchLocalMessage(path, payload, evt.type);


### PR DESCRIPTION
## Description

One line added at line 120 — if (this.localStorageInterval) clearInterval(this.localStorageInterval); — before the new interval is assigned on line 150.
Worth noting the symmetry this creates in the file: teardown() already had if (this.localStorageInterval) clearInterval(this.localStorageInterval) (original line 613), so the guard pattern was already established for cleanup — it just wasn't applied defensively on re-entry. The fix brings setupLocalStorageElection() in line with the same idiom already used in becomeLocalStorageLeader() for this.heartbeatInterval (lines 236–238), where a clear-before-set guard was already present.
Fixes #9511 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots / Video (if applicable)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports
