### PR TITLE
fix: add radix 10 to parseInt(eventId) to prevent ambiguous base parsing of event IDs

### DIFF
--- a/src/Pages/Events/FloorPlanDesignerPage.js
+++ b/src/Pages/Events/FloorPlanDesignerPage.js
@@ -14,7 +14,7 @@ const FloorPlanDesignerPage = () => {
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
 
   // Load the corresponding event info from mock data
-  const event = eventsMockData.find((e) => e.id === parseInt(eventId)) || {
+  const event = eventsMockData.find((e) => e.id === parseInt(eventId, 10)) || {
     id: eventId,
     title: "Community Meetup & Workshop",
     date: "2026-06-15",


### PR DESCRIPTION
### Related Issue
Closes #9688 

### Description of Changes
- I added explicit radix `10` to `parseInt(eventId)` in `FloorPlanDesignerPage.js`.
- It prevents incorrect base detection for event IDs starting with `"0x"` (hex) or `"0"` (legacy octal), ensuring the correct event is always loaded from mock data.
- It resolves ESLint `radix` rule warning.