### PR TITLE
fix(utils): add SSR guards to lenisUtils.js

### DIFF
--- a/src/utils/lenisUtils.js
+++ b/src/utils/lenisUtils.js
@@ -9,6 +9,7 @@
  * @param {Object} options - Scroll options
  */
 export const scrollToElement = (selector, options = {}) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   const element = document.querySelector(selector);
   if (element && window.lenis) {
     window.lenis.scrollTo(element, {
@@ -25,6 +26,7 @@ export const scrollToElement = (selector, options = {}) => {
  * @param {Object} options - Scroll options
  */
 export const scrollToTop = (options = {}) => {
+  if (typeof window === "undefined") return;
   if (window.lenis) {
     window.lenis.scrollTo(0, {
       duration: 1.2,
@@ -43,6 +45,7 @@ export const scrollToTop = (options = {}) => {
  * Stop Lenis scrolling (useful for modals)
  */
 export const stopScroll = () => {
+  if (typeof window === "undefined") return;
   if (window.lenis) {
     window.lenis.stop();
   }
@@ -52,6 +55,7 @@ export const stopScroll = () => {
  * Start Lenis scrolling
  */
 export const startScroll = () => {
+  if (typeof window === "undefined") return;
   if (window.lenis) {
     window.lenis.start();
   }
@@ -62,5 +66,6 @@ export const startScroll = () => {
  * @returns {number} Current scroll position
  */
 export const getScrollPosition = () => {
+  if (typeof window === "undefined") return 0;
   return window.lenis ? window.lenis.scroll : window.scrollY;
 };


### PR DESCRIPTION
## Summary
Adds `typeof window === "undefined"` guards to all exported functions in `src/utils/lenisUtils.js`. Without these guards, the utility crashes with `ReferenceError` in SSR environments where `document` and `window` are undefined.

## Changes
- `scrollToElement`: guard before `document.querySelector` and `window.lenis`
- `scrollToTop`: guard before `window.lenis` and `window.scrollTo`
- `stopScroll`: guard before `window.lenis`
- `startScroll`: guard before `window.lenis`
- `getScrollPosition`: guard before accessing `window.lenis` / `window.scrollY`, returns `0` as safe default

## Impact
- **Severity**: High — SSR crashes on any page using scroll utilities
- **Files**: `src/utils/lenisUtils.js`

Closes #9696.