### PR TITLE
fix(hooks): add SSR guard before window.addEventListener in useSessionTimeout.js

### DIFF
--- a/src/hooks/useSessionTimeout.js
+++ b/src/hooks/useSessionTimeout.js
@@ -1,7 +1,7 @@
-
 import { useEffect } from 'react';
 export function useSessionTimeout(logoutFn, timeoutMs = 900000) {
   useEffect(() => {
+    if (typeof window === "undefined") return;
     let timer;
     const resetTimer = () => { clearTimeout(timer); timer = setTimeout(logoutFn, timeoutMs); };
     window.addEventListener('mousemove', resetTimer);


### PR DESCRIPTION
## Summary
Adds `if (typeof window === "undefined") return;` at the start of the `useEffect` in `useSessionTimeout`. The hook was accessing `window.addEventListener` without verifying that `window` exists, causing a `ReferenceError` in SSR environments.

## Changes
- `src/hooks/useSessionTimeout.js`: added SSR guard as the first line of the `useEffect` callback

## Impact
- **Severity**: High — crashes any page using this hook during SSR
- **Files**: `src/hooks/useSessionTimeout.js`

Closes #9699.