### PR TITLE
fix(hooks): add SSR guard before window.addEventListener in useAutoSaveDraft.js

### DIFF
--- a/src/hooks/useAutoSaveDraft.js
+++ b/src/hooks/useAutoSaveDraft.js
@@ -37,6 +37,7 @@ export const useAutoSaveDraft = (formData, onSave, intervalMs = 30000, enabled =
 
   // Save on page unload
   useEffect(() => {
+    if (typeof window === "undefined") return;
     if (!enabled) return;
     const handleUnload = () => saveDraft(formDataRef.current);
     window.addEventListener("beforeunload", handleUnload);


### PR DESCRIPTION
## Summary
Adds `if (typeof window === "undefined") return;` at the start of the `useEffect` in `useAutoSaveDraft` that registers the `beforeunload` listener. The hook was directly accessing `window.addEventListener` without verifying that `window` exists, causing a `ReferenceError` in SSR environments.

## Changes
- `src/hooks/useAutoSaveDraft.js`: added SSR guard as the first line of the `beforeunload` useEffect

## Impact
- **Severity**: High — crashes any form using auto-save during SSR
- **Files**: `src/hooks/useAutoSaveDraft.js`

Closes #9700.