### PR TITLE
feat: implement structured feature request fields for Feedback page (…

### DIFF
--- a/src/Pages/Feedback/FeedbackPage.js
+++ b/src/Pages/Feedback/FeedbackPage.js
@@ -310,6 +310,11 @@ const FeedbackPage = () => {
     feedbackType: "",
     message: "",
     rating: 0,
+    // Feature request structured fields
+    featureTitle: "",
+    featureProblem: "",
+    featureAlternatives: "",
+    featurePriority: "",
   });
 
   const [errors, setErrors] = useState({});
@@ -337,6 +342,15 @@ const FeedbackPage = () => {
     { value: "event", label: t("feedback.feedbackTypes.event"), icon: Calendar },
     { value: "other", label: t("feedback.feedbackTypes.other"), icon: MoreHorizontal },
   ];
+
+  const featurePriorityOptions = [
+    { value: "low", label: t("feedback.featureRequest.priorityLow"), icon: MoreHorizontal },
+    { value: "medium", label: t("feedback.featureRequest.priorityMedium"), icon: BarChart },
+    { value: "high", label: t("feedback.featureRequest.priorityHigh"), icon: Star },
+    { value: "critical", label: t("feedback.featureRequest.priorityCritical"), icon: CheckCircle },
+  ];
+
+  const isFeatureRequest = formData.feedbackType === "feature";
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -375,6 +389,25 @@ const FeedbackPage = () => {
     // Rating validation
     if (!formData.rating || formData.rating === 0) {
       newErrors.rating = t("validation.feedbackRatingRequired");
+    }
+
+    // Feature request structured fields validation
+    if (formData.feedbackType === "feature") {
+      if (!formData.featureTitle || !formData.featureTitle.trim()) {
+        newErrors.featureTitle = t("validation.featureTitleRequired");
+      } else if (formData.featureTitle.trim().length < 5) {
+        newErrors.featureTitle = t("validation.featureTitleMinLength");
+      }
+
+      if (!formData.featureProblem || !formData.featureProblem.trim()) {
+        newErrors.featureProblem = t("validation.featureProblemRequired");
+      } else if (formData.featureProblem.trim().length < 20) {
+        newErrors.featureProblem = t("validation.featureProblemMinLength");
+      }
+
+      if (!formData.featurePriority || formData.featurePriority === "") {
+        newErrors.featurePriority = t("validation.featurePriorityRequired");
+      }
     }
 
     setErrors(newErrors);
@@ -446,6 +479,10 @@ const FeedbackPage = () => {
         feedbackType: "",
         message: "",
         rating: 0,
+        featureTitle: "",
+        featureProblem: "",
+        featureAlternatives: "",
+        featurePriority: "",
       });
       setSentimentScore(0);
       setErrors({});
@@ -590,6 +627,122 @@ const FeedbackPage = () => {
                   error={errors.feedbackType}
                   required={true}
                 />
+
+                {/* STRUCTURED FEATURE REQUEST FIELDS */}
+                <AnimatePresence>
+                  {isFeatureRequest && (
+                    <motion.div
+                      key="feature-request-fields"
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      transition={{ duration: prefersReducedMotion ? 0 : 0.3 }}
+                      className="overflow-hidden"
+                    >
+                      <div className="mt-4 rounded-2xl border border-indigo-100 dark:border-indigo-800 bg-indigo-50/40 dark:bg-indigo-950/20 p-5 space-y-4">
+                        <div className="flex items-center gap-2 mb-1">
+                          <Plus className="w-4 h-4 text-indigo-500" />
+                          <p className="text-sm font-semibold text-indigo-700 dark:text-indigo-300">
+                            {t("feedback.featureRequest.sectionTitle")}
+                          </p>
+                        </div>
+
+                        {/* Feature Title */}
+                        <FloatingInput
+                          id="featureTitle"
+                          label={t("feedback.featureRequest.titleLabel")}
+                          value={formData.featureTitle}
+                          onChange={handleChange}
+                          error={errors.featureTitle}
+                          icon={Plus}
+                          required={true}
+                        />
+
+                        {/* Problem it solves */}
+                        <div className="relative mt-2">
+                          <div className="relative">
+                            <MessageSquare className="absolute left-4 top-4 text-gray-400 dark:text-gray-500 w-5 h-5 z-10" />
+                            <textarea
+                              id="featureProblem"
+                              name="featureProblem"
+                              rows="3"
+                              maxLength={500}
+                              value={formData.featureProblem}
+                              onChange={handleChange}
+                              className={`w-full px-4 pl-14 pt-6 pb-2 border-2 rounded-xl focus:ring-4 focus:outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 transition-all duration-300 resize-none ${
+                                errors.featureProblem
+                                  ? "border-red-500 focus:border-red-500 focus:ring-red-100 dark:focus:ring-red-900/30"
+                                  : "border-gray-300 dark:border-gray-600 focus:border-indigo-500 focus:ring-indigo-100 dark:focus:ring-indigo-900/30"
+                              }`}
+                            />
+                            <label
+                              htmlFor="featureProblem"
+                              className={`absolute left-14 pointer-events-none transition-all duration-200 ease-out ${
+                                formData.featureProblem
+                                  ? "top-2 text-xs font-medium"
+                                  : "top-4 text-sm"
+                              } ${
+                                errors.featureProblem
+                                  ? "text-red-500"
+                                  : formData.featureProblem
+                                  ? "text-black dark:text-white"
+                                  : "text-gray-500 dark:text-gray-400"
+                              }`}
+                            >
+                              {t("feedback.featureRequest.problemLabel")}{" "}
+                              <span className="text-red-500">*</span>
+                            </label>
+                          </div>
+                          {errors.featureProblem && (
+                            <p className="text-red-500 text-xs mt-2 ml-1">
+                              {errors.featureProblem}
+                            </p>
+                          )}
+                        </div>
+
+                        {/* Alternatives considered (optional) */}
+                        <div className="relative mt-2">
+                          <div className="relative">
+                            <MoreHorizontal className="absolute left-4 top-4 text-gray-400 dark:text-gray-500 w-5 h-5 z-10" />
+                            <textarea
+                              id="featureAlternatives"
+                              name="featureAlternatives"
+                              rows="2"
+                              maxLength={300}
+                              value={formData.featureAlternatives}
+                              onChange={handleChange}
+                              className="w-full px-4 pl-14 pt-6 pb-2 border-2 rounded-xl focus:ring-4 focus:outline-none bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 transition-all duration-300 resize-none border-gray-300 dark:border-gray-600 focus:border-indigo-500 focus:ring-indigo-100 dark:focus:ring-indigo-900/30"
+                            />
+                            <label
+                              htmlFor="featureAlternatives"
+                              className={`absolute left-14 pointer-events-none transition-all duration-200 ease-out ${
+                                formData.featureAlternatives
+                                  ? "top-2 text-xs font-medium text-black dark:text-white"
+                                  : "top-4 text-sm text-gray-500 dark:text-gray-400"
+                              }`}
+                            >
+                              {t("feedback.featureRequest.alternativesLabel")}
+                              <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
+                                ({t("feedback.featureRequest.optionalBadge")})
+                              </span>
+                            </label>
+                          </div>
+                        </div>
+
+                        {/* Priority */}
+                        <CustomFloatingSelect
+                          id="featurePriority"
+                          label={t("feedback.featureRequest.priorityLabel")}
+                          value={formData.featurePriority}
+                          onChange={handleSelectChange}
+                          options={featurePriorityOptions}
+                          error={errors.featurePriority}
+                          required={true}
+                        />
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
 
                 {/* MESSAGE */}
                 <div className="relative mt-6">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -92,7 +92,12 @@
     "feedbackTypeRequired": "Please select a feedback type",
     "feedbackMessageRequired": "Message is required",
     "feedbackMessageMinLength": "Message must be at least 20 characters",
-    "feedbackRatingRequired": "Please provide a rating"
+    "feedbackRatingRequired": "Please provide a rating",
+    "featureTitleRequired": "Feature title is required",
+    "featureTitleMinLength": "Feature title must be at least 5 characters",
+    "featureProblemRequired": "Please describe the problem this feature would solve",
+    "featureProblemMinLength": "Problem description must be at least 20 characters",
+    "featurePriorityRequired": "Please select a priority level"
   },
   "error": {
     "generic": "An unexpected error occurred. Please try again.",
@@ -784,6 +789,18 @@
     "charCountDisplay": "{{current}} / {{max}}",
     "toastValidationError": "Please fill in all required fields correctly",
     "toastSuccess": "Thank you for your feedback! We appreciate your input.",
-    "toastError": "There was an error submitting your feedback. Please try again."
+    "toastError": "There was an error submitting your feedback. Please try again.",
+    "featureRequest": {
+      "sectionTitle": "Feature Request Details",
+      "titleLabel": "Feature Title",
+      "problemLabel": "Problem it solves",
+      "alternativesLabel": "Alternatives considered",
+      "optionalBadge": "optional",
+      "priorityLabel": "Priority",
+      "priorityLow": "Low",
+      "priorityMedium": "Medium",
+      "priorityHigh": "High",
+      "priorityCritical": "Critical"
+    }
   }
 }

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -92,7 +92,12 @@
     "feedbackTypeRequired": "Please select a feedback type",
     "feedbackMessageRequired": "Message is required",
     "feedbackMessageMinLength": "Message must be at least 20 characters",
-    "feedbackRatingRequired": "Please provide a rating"
+    "feedbackRatingRequired": "Please provide a rating",
+    "featureTitleRequired": "Feature title is required",
+    "featureTitleMinLength": "Feature title must be at least 5 characters",
+    "featureProblemRequired": "Please describe the problem this feature would solve",
+    "featureProblemMinLength": "Problem description must be at least 20 characters",
+    "featurePriorityRequired": "Please select a priority level"
   },
   "error": {
     "generic": "An unexpected error occurred. Please try again.",
@@ -674,6 +679,18 @@
     "charCountDisplay": "{{current}} / {{max}}",
     "toastValidationError": "Please fill in all required fields correctly",
     "toastSuccess": "Thank you for your feedback! We appreciate your input.",
-    "toastError": "There was an error submitting your feedback. Please try again."
+    "toastError": "There was an error submitting your feedback. Please try again.",
+    "featureRequest": {
+      "sectionTitle": "Feature Request Details",
+      "titleLabel": "Feature Title",
+      "problemLabel": "Problem it solves",
+      "alternativesLabel": "Alternatives considered",
+      "optionalBadge": "optional",
+      "priorityLabel": "Priority",
+      "priorityLow": "Low",
+      "priorityMedium": "Medium",
+      "priorityHigh": "High",
+      "priorityCritical": "Critical"
+    }
   }
 }

--- a/src/i18n/locales/te.json
+++ b/src/i18n/locales/te.json
@@ -92,7 +92,12 @@
     "feedbackTypeRequired": "Please select a feedback type",
     "feedbackMessageRequired": "Message is required",
     "feedbackMessageMinLength": "Message must be at least 20 characters",
-    "feedbackRatingRequired": "Please provide a rating"
+    "feedbackRatingRequired": "Please provide a rating",
+    "featureTitleRequired": "Feature title is required",
+    "featureTitleMinLength": "Feature title must be at least 5 characters",
+    "featureProblemRequired": "Please describe the problem this feature would solve",
+    "featureProblemMinLength": "Problem description must be at least 20 characters",
+    "featurePriorityRequired": "Please select a priority level"
   },
   "error": {
     "generic": "An unexpected error occurred. Please try again.",
@@ -674,6 +679,18 @@
     "charCountDisplay": "{{current}} / {{max}}",
     "toastValidationError": "Please fill in all required fields correctly",
     "toastSuccess": "Thank you for your feedback! We appreciate your input.",
-    "toastError": "There was an error submitting your feedback. Please try again."
+    "toastError": "There was an error submitting your feedback. Please try again.",
+    "featureRequest": {
+      "sectionTitle": "Feature Request Details",
+      "titleLabel": "Feature Title",
+      "problemLabel": "Problem it solves",
+      "alternativesLabel": "Alternatives considered",
+      "optionalBadge": "optional",
+      "priorityLabel": "Priority",
+      "priorityLow": "Low",
+      "priorityMedium": "Medium",
+      "priorityHigh": "High",
+      "priorityCritical": "Critical"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #9363

When a user selects **Feature Request** as the feedback type on the `/feedback` page, a structured section now slides in with additional required fields — matching the GitHub issue template format.

## Changes

- **FeedbackPage.js** — Added conditional feature request fields that animate in/out using `AnimatePresence` when `feedbackType === "feature"`:
  - Feature Title (required, min 5 chars)
  - Problem it solves (required textarea, min 20 chars)
  - Alternatives considered (optional textarea)
  - Priority selector — Low / Medium / High / Critical (required)
- **Validation** — All required feature fields are validated on submit with appropriate error messages
- **i18n** — Added translation keys to `en.json`, `hi.json`, and `te.json`

## How to Test

1. Go to `/feedback`
2. Select **Feature Request** from the Feedback Type dropdown
3. Verify the structured fields animate in
4. Try submitting without filling them — validation errors should appear
5. Fill all fields and submit — should succeed normally
