### PR TITLE
fix(OfflineBanner): add SSR guard for navigator.onLine in useState initializer

### DIFF
--- a/src/components/common/OfflineBanner.jsx
+++ b/src/components/common/OfflineBanner.jsx
@@ -15,7 +15,9 @@ import { motion, AnimatePresence } from "framer-motion";
  * - Decorative icons are aria-hidden.
  */
 const OfflineBanner = () => {
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const [isOnline, setIsOnline] = useState(() =>
+    typeof navigator !== "undefined" ? navigator.onLine : true
+  );
   const [showRestoredMsg, setShowRestoredMsg] = useState(false);
   const [liveMessage, setLiveMessage] = useState("");
 const [offlineSince, setOfflineSince] = useState(null);


### PR DESCRIPTION
## Summary

Add SSR guard to `OfflineBanner.jsx` so `navigator.onLine` is only accessed in browser environments.

## Changes

- `src/components/common/OfflineBanner.jsx`: Changed `useState(navigator.onLine)` to `useState(() => typeof navigator !== "undefined" ? navigator.onLine : true)` — a lazy initializer that safely handles SSR.

## Impact

This prevents `ReferenceError: navigator is not defined` during server-side rendering when `OfflineBanner` is rendered during SSR/Next.js build.

Closes #9715.
