### PR TITLE
fix(calendarExportIcs): add SSR guards to prevent crash during server-side rendering

### DIFF
--- a/src/utils/calendarExportIcs.js
+++ b/src/utils/calendarExportIcs.js
@@ -1,5 +1,6 @@
 
 export function exportToIcs(event) {
+  if (typeof document === "undefined" || typeof URL === "undefined") return;
   const icsContent = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:${event.title}\nDTSTART:${event.date}\nEND:VEVENT\nEND:VCALENDAR`;
   const blob = new Blob([icsContent], { type: 'text/calendar' });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary

Add SSR guards to `calendarExportIcs.js` which directly accesses `document.createElement` and `URL.createObjectURL` without checking if these browser APIs are available.

## Changes

- `src/utils/calendarExportIcs.js`: Added `if (typeof document === "undefined" || typeof URL === "undefined") return;` at the start of `exportToIcs`.

## Impact

This prevents `ReferenceError: document is not defined` during SSR if `exportToIcs` is accidentally called in a server context.

Closes #9716.
