### PR TITLE
fix(activityTracker): preserve pending interests on storage write failure

### DIFF
--- a/src/utils/activityTracker.js
+++ b/src/utils/activityTracker.js
@@ -68,7 +68,8 @@ const processInterestQueue = async () => {
     }
   } catch (error) {
     logger.error("Failed to update user interests:", error);
-    interestQueue = []; // Clear the queue on persistent error to avoid infinite recursion
+    // Do not clear interestQueue — the isUpdating lock already prevents infinite recursion.
+    // Preserving the queue allows pending interests to be retried on the next call.
   } finally {
     isUpdating = false;
     if (interestQueue.length > 0) {


### PR DESCRIPTION
## Summary

Fix a race condition in `activityTracker.js` where the catch block in `processInterestQueue` cleared the entire `interestQueue` on storage write failure, causing silent data loss of interests queued concurrently.

## Changes

- `src/utils/activityTracker.js`: Removed `interestQueue = [];` from the catch block. The `isUpdating` lock already prevents infinite recursion, so clearing the queue was unnecessary and caused data loss.

## Impact

If a user rapidly adds interests and the first storage write fails, their subsequent interests were silently dropped. With this fix, all pending interests are preserved and retried on the next call.

Closes #9719.
