### PR TITLE
fix: wrap upcomingEvents in useMemo to prevent redundant formatEventsData and formatHackathonsData calls on every render

### DIFF
--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -161,10 +161,11 @@ const WhatsHappening = () => {
       }));
   };
 
-  const upcomingEvents = [
+  const upcomingEvents = useMemo(() => [
     ...formatEventsData(eventsData),
     ...formatHackathonsData(hackathonsData),
-  ].sort((a, b) => new Date(a.rawDate) - new Date(b.rawDate));
+  ].sort((a, b) => new Date(a.rawDate) - new Date(b.rawDate)),
+  [eventsData]);
 
   const [cardsPerView, setCardsPerView] = useState(1);
 


### PR DESCRIPTION
### Related Issue
Closes #9760

### Description of Changes
- I wrapped the `upcomingEvents` computation in `useMemo` with `[eventsData]` as the dependency in `WhatsHappening.js`.
- `hackathonsData` is a static JSON import and does not need to be in the dependency array.
- `formatEventsData` and `formatHackathonsData` now only re-run when `eventsData` actually changes, eliminating redundant computation on every auto-play tick, hover, and carousel state update.