### PR TITLE
fix : add SSR guard to downloadICS

### DIFF
--- a/src/utils/calendarExport.js
+++ b/src/utils/calendarExport.js
@@ -1,6 +1,8 @@
 import { createEvent } from "ics";
 
 export const downloadICS = (event) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
   const startDate = new Date(event.date);
 
   const eventConfig = {


### PR DESCRIPTION
## Summary

Adds an SSR guard (`typeof window/document !== "undefined"`) check at the top of `downloadICS` in `src/utils/calendarExport.js` to prevent crashes in server-side rendering environments.

## Changes

- Added `if (typeof window === "undefined" || typeof document === "undefined") return;` guard at the start of `downloadICS`

## Impact

- High: Prevents SSR crashes in Next.js/Remix environments. Client-side behavior unchanged.

Closes #9768