### PR TITLE
fix : remove unused dayOffset from salt strings in deviceFingerprint

### DIFF
--- a/src/utils/deviceFingerprint.js
+++ b/src/utils/deviceFingerprint.js
@@ -77,9 +77,7 @@ export const getDeviceFingerprint = () => {
     // Per-origin salt: different for each deployment and never a static literal
     // in the bundle. Combining the origin with a domain-specific namespace
     // avoids salt collisions if two deployments share the same hostname root.
-    // Remove daily time-based salt offset to maintain fingerprint stability across days
-    const dayOffset = 0;
-const salt = dayOffset + `eventra:fingerprint:${window.location.origin}`;
+    const salt = `eventra:fingerprint:${window.location.origin}`;
 
     _memoizedFingerprint = CryptoJS.SHA256(fingerprintRaw + salt).toString();
     return _memoizedFingerprint;
@@ -115,9 +113,7 @@ export const getFastFingerprint = () => {
   try {
     const screenInfo = `${window.screen?.width || 0}x${window.screen?.height || 0}x${window.screen?.colorDepth || 0}`;
     const navInfo = `${window.navigator?.userAgent || ""}_${window.navigator?.language || ""}_${window.navigator?.hardwareConcurrency || 0}`;
-    // Remove daily time-based salt offset to maintain fingerprint stability across days
-    const dayOffset = 0;
-const salt = dayOffset + `eventra:fast-fingerprint:${window.location.origin}`;
+    const salt = `eventra:fast-fingerprint:${window.location.origin}`;
     _memoizedFastFingerprint = CryptoJS.SHA256(`${screenInfo}_${navInfo}_${salt}`).toString();
     return _memoizedFastFingerprint;
   } catch {


### PR DESCRIPTION
## Summary

Removes the unused `dayOffset` variable (always `0`) from salt string construction in `src/utils/deviceFingerprint.js`. Previously, `dayOffset + string` coerced `0` to `"0"`, producing corrupted salts like `"0eventra:fingerprint:..."`.

## Changes

- Removed `const dayOffset = 0;` and `const salt = dayOffset + \`...\`;` pattern in `getDeviceFingerprint()` and `getFastFingerprint()`
- Replaced with `const salt = \`...\`;` using template literals directly

## Impact

- Low-Medium: Security hardening — ensures salt strings are not corrupted by numeric coercion.

Closes #9770