### PR TITLE
fix : validate eventDate in getCountdown to prevent NaN propagation

### DIFF
--- a/src/utils/getCountdown.js
+++ b/src/utils/getCountdown.js
@@ -1,8 +1,12 @@
 export function getCountdown(eventDate) {
   const now = new Date().getTime();
-  const target = new Date(eventDate).getTime();
+  const target = new Date(eventDate);
 
-  const diff = target - now;
+  if (isNaN(target.getTime())) {
+    return { status: "UNKNOWN", text: "Invalid date" };
+  }
+
+  const diff = target.getTime() - now;
 
   if (diff <= 0) {
     return {


### PR DESCRIPTION
## Summary

Adds `isNaN(target.getTime())` validation in `src/utils/getCountdown.js` to return a graceful `{status: "UNKNOWN", text: "Invalid date"}` fallback when `eventDate` is `undefined`, `null`, or an invalid date string.

## Changes

- Added `isNaN(target.getTime())` check after constructing `new Date(eventDate)`
- Returns `{status: "UNKNOWN", text: "Invalid date"}` for invalid dates
- Prevents `NaN` propagation to days/hours/minutes values

## Impact

- Medium: Prevents NaN-countdown UI by returning a clear fallback. Client-side behavior otherwise unchanged.

Closes #9771