### PR TITLE
fix : add SSR guards to localStorage access in offlineQueue.js

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -66,9 +66,10 @@ const DB_VERSION = 2;
 // Internal: rescue items from localStorage mirror before schema wipe
 // ---------------------------------------------------------------------------
 const _rescueFromLocalStorage = () => {
+  if (typeof localStorage === "undefined") return [];
   try {
-          const raw = localStorage.getItem(QUEUE_KEY);
-          return safeJsonParse(raw, []);
+    const raw = localStorage.getItem(QUEUE_KEY);
+    return safeJsonParse(raw, []);
   } catch {
     return [];
   }
@@ -175,6 +176,7 @@ const openDB = () => {
  * Read the current offline queue from localStorage (Synchronous fallback).
  */
 export const getQueue = () => {
+  if (typeof localStorage === "undefined") return [];
   try {
     const raw = localStorage.getItem(QUEUE_KEY);
     return safeJsonParse(raw, []);
@@ -381,14 +383,16 @@ queue.push(actionItem);
  */
 export const setQueue = async (newQueue) => {
   // 1. Sync mirror updates immediately
-  try {
-    if (newQueue.length === 0) {
-      localStorage.removeItem(QUEUE_KEY);
-    } else {
-      localStorage.setItem(QUEUE_KEY, JSON.stringify(newQueue));
+  if (typeof localStorage !== "undefined") {
+    try {
+      if (newQueue.length === 0) {
+        localStorage.removeItem(QUEUE_KEY);
+      } else {
+        localStorage.setItem(QUEUE_KEY, JSON.stringify(newQueue));
+      }
+    } catch (error) {
+      logger.error("Error setting localStorage backup:", error);
     }
-  } catch (error) {
-    logger.error("Error setting localStorage backup:", error);
   }
 
   // 2. Sync IndexedDB in background
@@ -424,10 +428,12 @@ export const setQueue = async (newQueue) => {
  */
 export const clearQueue = async () => {
   // 1. Sync mirror
-  try {
-    localStorage.removeItem(QUEUE_KEY);
-  } catch (error) {
-    logger.error("Error clearing localStorage backup:", error);
+  if (typeof localStorage !== "undefined") {
+    try {
+      localStorage.removeItem(QUEUE_KEY);
+    } catch (error) {
+      logger.error("Error clearing localStorage backup:", error);
+    }
   }
 
   // 2. Sync IndexedDB


### PR DESCRIPTION
## Summary

Adds `typeof localStorage !== 'undefined'` guards to localStorage access in `src/utils/offlineQueue.js` to prevent crashes in SSR environments. Affected functions: `_rescueFromLocalStorage`, `getQueue`, `setQueue`, and `clearQueue`.

## Changes

- Added early-return guard in `_rescueFromLocalStorage()` for SSR environments
- Added early-return guard in `getQueue()` for SSR environments
- Wrapped localStorage operations in `setQueue()` with SSR guard
- Wrapped localStorage operation in `clearQueue()` with SSR guard

## Impact

- High: Prevents SSR crashes in Next.js/Remix environments. Client-side behavior unchanged.

Closes #9777