### PR TITLE
fix: getCountdown.js — Invalid Date propagation when eventDate is malformed

### DIFF
--- a/src/utils/getCountdown.js
+++ b/src/utils/getCountdown.js
@@ -2,6 +2,13 @@ export function getCountdown(eventDate) {
   const now = new Date().getTime();
   const target = new Date(eventDate).getTime();
 
+  if (isNaN(target)) {
+    return {
+      status: "UNKNOWN",
+      text: "TBA",
+    };
+  }
+
   const diff = target - now;
 
   if (diff <= 0) {


### PR DESCRIPTION
Resolves #9771