### PR TITLE
fix: SSR crash in csrfToken.js — document access without guards

### DIFF
--- a/src/utils/csrfToken.js
+++ b/src/utils/csrfToken.js
@@ -47,6 +47,7 @@ export const getCSRFEnforcementMode = () => {
  * @returns {string|null}
  */
 export function getCSRFTokenFromMeta() {
+  if (typeof document === "undefined") return null;
   const meta = document.querySelector(`meta[name="${CSRF_META_NAME}"]`);
   return meta ? meta.getAttribute("content") : null;
 }
@@ -57,6 +58,7 @@ export function getCSRFTokenFromMeta() {
  * @returns {string|null}
  */
 export function getCSRFTokenFromCookie(name = CSRF_COOKIE_NAME) {
+  if (typeof document === "undefined") return null;
   const cookies = document.cookie.split(";").map((c) => c.trim());
   for (const cookie of cookies) {
     if (cookie.startsWith(`${name}=`)) {


### PR DESCRIPTION
Resolves #9769