### PR TITLE
fix: SSR crash in calendarExport.js — missing window/document guards

### DIFF
--- a/src/utils/calendarExport.js
+++ b/src/utils/calendarExport.js
@@ -1,6 +1,7 @@
 import { createEvent } from "ics";
 
 export const downloadICS = (event) => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   const startDate = new Date(event.date);
 
   const eventConfig = {


### PR DESCRIPTION
Resolves #9768