### PR TITLE
fix(api/_lib/rate-limit-storage.js): async cleanup hook registered with process.on exit prevents Redis from closing cleanly

### DIFF
--- a/api/_lib/rate-limit-storage.js
+++ b/api/_lib/rate-limit-storage.js
@@ -44,12 +44,12 @@ function registerCleanupHook() {
   };
   if (typeof process !== "undefined" && typeof process.on === "function") {
     process.on("beforeExit", cleanup);
-    process.on("SIGINT", () => {
-      cleanup();
+    process.on("SIGINT", async () => {
+      await cleanup();
       process.exit(0);
     });
-    process.on("SIGTERM", () => {
-      cleanup();
+    process.on("SIGTERM", async () => {
+      await cleanup();
       process.exit(0);
     });
   }


### PR DESCRIPTION
Resolves #9663