### PR TITLE
fix: ContactUs.js crashes SSR with window.location.href in SEOHead prop

### DIFF
--- a/src/Pages/Contact/ContactUs.js
+++ b/src/Pages/Contact/ContactUs.js
@@ -432,7 +432,7 @@ const ContactUs = () => {
       <SEOHead
         title={t("contactUs.pageTitle")}
         description={t("contactUs.pageDescription")}
-        url={window.location.href}
+        url={typeof window !== 'undefined' ? window.location.href : ''}
       />
       <ContactUsInner />
     </>


### PR DESCRIPTION
Resolves #9633