### PR TITLE
fix: useTokenExpiry setTimeout callback accesses window.location without SSR guard

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -21,7 +21,11 @@ export function useTokenExpiry({ token, user, onExpired }) {
       toastId: "session-expired",
       autoClose: 4000,
     });
-    setTimeout(() => window.location.replace("/login"), 1500);
+    setTimeout(() => {
+      if (typeof window !== 'undefined') {
+        window.location.replace("/login");
+      }
+    }, 1500);
   }, [onExpired]);
 
   useEffect(() => {


### PR DESCRIPTION
Resolves #9630