### PR TITLE
fix: set correct MIME type headers for CSS and JS assets in /assets f…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -79,6 +79,32 @@
       ]
     },
     {
+  "source": "/assets/(.*)\\.css",
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "text/css"
+    },
+    {
+      "key": "Cache-Control",
+      "value": "public, max-age=31536000, immutable"
+    }
+  ]
+},
+{
+  "source": "/assets/(.*)\\.js",
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/javascript"
+    },
+    {
+      "key": "Cache-Control",
+      "value": "public, max-age=31536000, immutable"
+    }
+  ]
+},
+    {
       "source": "/assets/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Description

Multiple CSS and JS assets in the `/assets/` folder were being served with incorrect `Content-Type: application/json` header instead of the correct `text/css` and `application/javascript` types respectively.
This caused the browser to throw the following console error on page load:

"Refused to apply style from '<URL>' because its MIME type ('application/json') is not a supported stylesheet MIME type, and strict MIME checking is enabled."

The issue affected 6+ asset files including vendor-ui, index, LazyImage, StatusBadge, react-big-calendar, and Login bundles — meaning styles for these components were completely blocked from loading on every page.

The root cause was the absence of explicit Content-Type headers for `.css` and `.js` files in `vercel.json`. The existing `X-Content-Type-Options: nosniff` header enforces strict MIME checking, so without correct Content-Type declarations, the browser rejected all mistyped assets.

Fix: Added two specific header rules in `vercel.json` for `/assets/(.*).css` and `/assets/(.*).js` before the generic `/assets/(.*)` cache rule, ensuring correct MIME types are served for all static assets.

Fixes #9806 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test` and verified they pass
- [ ] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports