### PR TITLE
fix: use onEndRef in useCountdown to prevent onEnd firing in infinite loop on every re-render after countdown ends

### DIFF
--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -58,18 +58,23 @@ const RESOURCES = [
 // ============ UTILITY HOOKS ============
 const useCountdown = (endDate, onEnd) => {
   const [timeLeft, setTimeLeft] = useState(() => calculateTimeLeft(endDate));
-  
+  const onEndRef = useRef(onEnd);
+
+  useEffect(() => {
+    onEndRef.current = onEnd;
+  }, [onEnd]);
+
   useEffect(() => {
     if (timeLeft.ended) {
-      onEnd?.();
+      onEndRef.current?.();
       return;
     }
     const timer = setInterval(() => {
       setTimeLeft(calculateTimeLeft(endDate));
     }, 1000);
     return () => clearInterval(timer);
-  }, [timeLeft.ended, endDate, onEnd]);
-  
+  }, [timeLeft.ended, endDate]);
+
   return timeLeft;
 };
 


### PR DESCRIPTION
### Related Issue
Closes #9808

### Description of Changes
- I added `onEndRef = useRef(onEnd)` inside `useCountdown`.
- Synced `onEndRef.current` with the latest `onEnd` via a separate `useEffect`.
- Replaced `onEnd?.()` with `onEndRef.current?.()` in the countdown effect.
- Removed `onEnd` from the countdown effect's dependency array.
- `onEnd` now fires exactly once when `timeLeft.ended` becomes true, regardless of re-renders.