### PR TITLE
fix: use callbackRef in useKeyboardShortcut to eliminate stale closure and always listen to correct key

### DIFF
--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -89,17 +89,23 @@ const calculateTimeLeft = (endDate) => {
   };
 };
 
-const useKeyboardShortcut = (key, callback, deps = []) => {
+const useKeyboardShortcut = (key, callback) => {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
   useEffect(() => {
     const handler = (e) => {
       if (e.key === key && !e.target.matches("input, textarea")) {
         e.preventDefault();
-        callback();
+        callbackRef.current();
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [key]);
 };
 
 const useToast = () => {
@@ -339,7 +345,7 @@ const GSSoCContribution = () => {
   useKeyboardShortcut("/", () => {
     searchInputRef.current?.focus();
     addToast("🔍 Search focused. Start typing...", "info", 1500);
-  }, [addToast]);
+  });
   
   const containerVariants = useMemo(() => ({
     hidden: { opacity: 0 },


### PR DESCRIPTION
### Related Issue
Closes #9810 

### Description of Changes
- I replaced the external `deps` parameter in `useKeyboardShortcut` with a `useRef`-based callback pattern.
- `callbackRef` is synced to the latest `callback` via a separate `useEffect`.
- `key` is now the sole dependency of the listener effect — the listener is correctly recreated only when the key changes.
- Removed the `deps` argument from the `useKeyboardShortcut` call site.