### PR TITLE
fix: replace duplicate role=main with role=region in GSSoCContribution to fix ARIA landmark violation

### DIFF
--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -388,12 +388,13 @@ const GSSoCContribution = () => {
         )}
       </AnimatePresence>
       
-      <motion.main
+      <motion.section
         variants={containerVariants}
         initial="hidden"
         animate="visible"
         className="w-[95%] mx-auto my-10 min-h-screen pb-12"
-        role="main"
+        role="region"
+        aria-label="GSSoC Contribution Hub"
       >
         {/* 🎯 PROFESSIONAL HERO SECTION */}
         <motion.section
@@ -508,7 +509,7 @@ const GSSoCContribution = () => {
             ))}
           </div>
         </motion.section>
-      </motion.main>
+      </motion.section>
       
       <ToastContainer toasts={toasts} onClose={removeToast} />
     </>


### PR DESCRIPTION
### Related Issue
Closes #9812

### Description of Changes
- I replaced `<motion.main role="main">` with `<motion.section role="region" aria-label="GSSoC Contribution Hub">` in `GSSoCContribution.js`.
- `GSSoCContribution` renders inside Leaderboard's `role="main"` div — it is a sub-region, not a page-level main landmark.
- It resolves the duplicate `role="main"` WCAG 2.1 critical accessibility violation.