### PR TITLE
fix: set aria-live=off on CountdownTimer to prevent screen reader announcing every second

### DIFF
--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -127,7 +127,7 @@ const CountdownTimer = memo(({ timeLeft }) => {
   const units = Object.entries(timeLeft).filter(([key]) => key !== 'ended');
   
   return (
-    <div className="grid grid-cols-4 gap-2 sm:gap-3 text-center" role="timer" aria-live="polite">
+    <div className="grid grid-cols-4 gap-2 sm:gap-3 text-center" role="timer" aria-live="off" aria-label="Countdown timer">
       {units.map(([unit, value]) => (
         <motion.div
           key={unit}


### PR DESCRIPTION
### Related Issue
Closes #9814 

### Description of Changes
- I changed `aria-live="polite"` to `aria-live="off"` on the `CountdownTimer` grid div in `GSSoCContribution.js`.
- I added `aria-label="Countdown timer"` to preserve discoverability for assistive technology.
- `role="timer"` already communicates the element's purpose — `aria-live="polite"` was causing screen readers to announce the new time every second, making the page unusable for AT users.