### PR TITLE
fix: remove duplicate EventDuration render in EventCard date section (#9822)

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -329,7 +329,7 @@ const durationText = getEventDuration(event);
               {new Date(event.date).toLocaleDateString("en-US", {
                 weekday: "short", day: "numeric", month: "short", year: "numeric",
               })}
-              <EventDuration duration={durationText} /><EventDuration duration={durationText} />
+              <EventDuration duration={durationText} />
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Description

Fixes #9822

The `<EventDuration>` component was rendered twice consecutively on the same
line inside the event date `<span>` in `EventCard.js`, causing the duration
text to appear duplicated on every event card on the `/events` page.

**Root cause:** A paste or merge error left two identical
`<EventDuration duration={durationText} />` calls side by side with no
whitespace between them.

**Change:** Removed the second (redundant) instance. No logic was changed —
the rendered output is now correct with the duration appearing exactly once.

```diff
- <EventDuration duration={durationText} /><EventDuration duration={durationText} />
+ <EventDuration duration={durationText} />
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have run npm run lint and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports

