### PR TITLE
fix: correct leaderboard href case in Footer from /leaderBoard to /leaderboard (#9826)

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -43,7 +43,7 @@ const footerColumns = [
       { nameKey: "footer.links.communityEvents", href: "/community-event", icon: <FaUsers size={12} /> },
       { nameKey: "footer.links.contributors", href: "/contributors", icon: <FaCode size={12} /> },
       { nameKey: "footer.links.contributorsGuide", href: "/contributorguide", icon: <FaBook size={12} /> },
-      { nameKey: "footer.links.leaderboard", href: "/leaderBoard", icon: <FaTrophy size={12} /> },
+      { nameKey: "footer.links.leaderboard", href: "/leaderboard", icon: <FaTrophy size={12} /> },
     ],
   },
   {


### PR DESCRIPTION
## Description

Fixes #9826

The Leaderboard link in the Footer's Community section used `/leaderBoard`
(capital B) while the registered route in `PublicRoutes.js` is `/leaderboard`
(all lowercase). React Router matches routes case-sensitively, so every click
from the footer landed on a 404. The navbar and all other links in the codebase
already use the correct lowercase path.

```diff
- { nameKey: "footer.links.leaderboard", href: "/leaderBoard", ... }
+ { nameKey: "footer.links.leaderboard", href: "/leaderboard", ... }
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have run npm run lint and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports