### PR TITLE
fix(a11y): add aria-label, aria-pressed and aria-hidden to ThemeToggleButton (#9828)

### DIFF
--- a/src/components/Layout/ThemeToggleButton.jsx
+++ b/src/components/Layout/ThemeToggleButton.jsx
@@ -8,12 +8,14 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
         <motion.button
           whileTap={{ scale: 0.95 }}
           onClick={toggleTheme}
+          aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+          aria-pressed={isDarkMode}
           className="flex items-center justify-center gap-1 px-2 py-2 w-full rounded-xl bg-zinc-100 dark:bg-zinc-800/80 text-zinc-900 dark:text-zinc-100 font-semibold border border-zinc-200 dark:border-zinc-700/50 hover:bg-zinc-200 dark:hover:bg-zinc-700/80 transition-all cursor-pointer"
         >
           {isDarkMode ? (
-            <Sun className="w-5 h-5 text-amber-500" />
+            <Sun className="w-5 h-5 text-amber-500" aria-hidden="true" />
           ) : (
-            <Moon className="w-5 h-5 text-indigo-500" />
+            <Moon className="w-5 h-5 text-indigo-500" aria-hidden="true" />
           )}
           <span>{isDarkMode ? "Switch to Light" : "Switch to Dark"}</span>
         </motion.button>
@@ -22,9 +24,10 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
           onClick={() => {
              setIsCustomizerOpen(true);
             }}       
+          aria-label="Open Theme Customizer"
    className="flex items-center justify-center gap-1 px-2 py-2 w-full rounded-xl bg-linear-to-r from-indigo-500 to-pink-500 text-white font-semibold border-none shadow-md hover:shadow-lg transition-all cursor-pointer"
         >
-          <Palette className="w-5 h-5" />
+          <Palette className="w-5 h-5" aria-hidden="true" />
           <span>THEME Customizer</span>
         </motion.button>
       </div>
@@ -56,9 +59,10 @@ const ThemeToggleButton = ({ isDarkMode, toggleTheme, isMobile, setIsCustomizerO
   whileTap={{ scale: 0.92 }}
   onClick={() => setIsCustomizerOpen(true)}
   title="Open Theme Customizer"
+  aria-label="Open Theme Customizer"
         className="flex items-center justify-center w-9 h-9 rounded-full transition-all duration-300 focus:outline-none bg-linear-to-r from-indigo-500/10 to-pink-500/10 hover:from-indigo-500/20 hover:to-pink-500/20 border border-indigo-200/50 dark:border-indigo-800/40 hover:shadow-[0_0_12px_rgba(236,72,153,0.3)] text-indigo-550 dark:text-indigo-400 cursor-pointer"
       >
-        <Palette className="w-4 h-4 animate-pulse text-indigo-500 dark:text-indigo-400" />
+        <Palette className="w-4 h-4 animate-pulse text-indigo-500 dark:text-indigo-400" aria-hidden="true" />
       </motion.button>
     </div>
   );


### PR DESCRIPTION
## Description

Fixes #9828

Three accessibility gaps in `ThemeToggleButton.jsx` (WCAG 2.1 SC 4.1.2 — Name, Role, Value):

**1. Mobile theme toggle — missing `aria-label` and `aria-pressed`**

Screen readers announced this as an unlabelled button with no state information.
Added `aria-label` describing the action and `aria-pressed={isDarkMode}` to
convey whether dark mode is currently active. Also added `aria-hidden="true"` to
the decorative Sun/Moon icons since the visible `<span>` already provides the
label.

**2. Mobile Palette button — missing `aria-label`, icon not hidden**

The visible span text is sufficient for sighted users but the `<Palette>` icon
was read aloud by AT alongside the text, producing "Palette THEME Customizer".
Added `aria-label="Open Theme Customizer"` and `aria-hidden="true"` to the icon.

**3. Desktop Palette button — icon-only with only `title`, no `aria-label`**

`title` is announced on hover by some screen readers but not reliably on
keyboard focus. Added an explicit `aria-label` matching the existing `title`,
and `aria-hidden="true"` on the icon.

The desktop theme toggle already had `aria-label` correctly — not changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports
