### PR TITLE
fix : add SSR guard before localStorage access in getEventFeedback

### DIFF
--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -31,6 +31,7 @@ export const submitEventFeedback = async ({ eventId, rating, comment, tags = [] 
  * @returns {Array} Array of feedback objects
  */
 export const getEventFeedback = (eventId) => {
+  if (typeof window === "undefined") return [];
   try {
     const allFeedback = safeJsonParse(localStorage.getItem(FEEDBACK_STORAGE_KEY), {});
     const rawFeedback = allFeedback[eventId] || [];


### PR DESCRIPTION
## Summary

Add `typeof window === "undefined"` SSR guard in `src/utils/feedbackUtils.js` inside the `getEventFeedback` function to prevent server-side rendering crashes.

## Changes

- Return `[]` early from `getEventFeedback` when `window` is not defined

## Impact

- Fixes SSR crash in Next.js when `getEventFeedback` is called during server-side rendering
- No breaking changes in browser environments

Closes #9853.