### PR TITLE
fix : validate eventDate in getCountdown to prevent NaN propagation

### DIFF
--- a/src/utils/getCountdown.js
+++ b/src/utils/getCountdown.js
@@ -1,6 +1,14 @@
 export function getCountdown(eventDate) {
+  if (!eventDate) {
+    return { status: "UPCOMING", text: "Date TBD" };
+  }
+
   const now = new Date().getTime();
   const target = new Date(eventDate).getTime();
+
+  if (isNaN(target)) {
+    return { status: "UPCOMING", text: "Date TBD" };
+  }
 
   const diff = target - now;
 


### PR DESCRIPTION
## Summary

Add null/undefined and `isNaN` validation for the `eventDate` parameter in `src/utils/getCountdown.js` to prevent `NaN` values from appearing in countdown text when the event date is invalid or missing.

## Changes

- Return `{ status: "UPCOMING", text: "Date TBD" }` for falsy `eventDate`
- Return `{ status: "UPCOMING", text: "Date TBD" }` when `new Date(eventDate).getTime()` is `NaN`

## Impact

- Event cards with missing or malformed dates no longer display "Starts in: NaN Days NaN Hours"
- Improves user experience when event data is incomplete

Closes #9854.