### PR TITLE
fix : return absolute date instead of null for future dates beyond 30 days

### DIFF
--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -46,7 +46,12 @@ export function getRelativeTime(dateInput) {
   if (diffDay < 30)
     return `In ${Math.floor(diffDay / 7)} week${Math.floor(diffDay / 7) !== 1 ? "s" : ""}`;
 
-  return null;
+  return new Date(dateInput).toLocaleDateString("en-US", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
 }
 
 export function getSmartDateLabel(dateInput, timeInput = "") {


### PR DESCRIPTION
## Summary

Fix `getRelativeTime` in `src/utils/relativeTime.js` to never return `null`. Currently, dates more than 30 days in the future fall through all conditions and return `null`, causing blank UI text. Replace with an absolute date string fallback.

## Changes

- Replace `return null;` with a `toLocaleDateString` absolute date fallback for dates > 30 days out
- Consistent with the pattern already used in `getSmartDateLabel`

## Impact

- Future event dates more than 30 days away now display an absolute date instead of blank text
- Fixes a silent UI bug

Closes #9855.