### PR TITLE
fix : lazy require react-toastify to prevent SSR crash in toast.js

### DIFF
--- a/src/utils/storageUtils.js
+++ b/src/utils/storageUtils.js
@@ -1,4 +1,5 @@
 export const saveToStorage = (key, value) => {
+  if (typeof window === "undefined") return;
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch (error) {
@@ -7,6 +8,7 @@ export const saveToStorage = (key, value) => {
 };
 
 export const loadFromStorage = (key, fallbackValue) => {
+  if (typeof window === "undefined") return fallbackValue;
   try {
     const stored = localStorage.getItem(key);
 

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,8 +1,21 @@
-import { toast } from "react-toastify";
-
 const AUTH_TOAST_ID = "auth-feedback";
 
+// Lazy import to avoid SSR crash — react-toastify relies on window internals
+let _toast = null;
+const getToast = () => {
+  if (!_toast) {
+    // eslint-disable-next-line global-require
+    const mod = require("react-toastify");
+    _toast = mod.toast;
+  }
+  return _toast;
+};
+
+const isSSR = typeof window === "undefined";
+
 export function showAuthToast(message, onAfterClose) {
+  if (isSSR) return;
+  const toast = getToast();
   toast.dismiss(AUTH_TOAST_ID);
   toast.success(message, {
     toastId: AUTH_TOAST_ID,
@@ -12,6 +25,8 @@ export function showAuthToast(message, onAfterClose) {
 }
 
 export function showErrorToast(message, onAfterClose) {
+  if (isSSR) return;
+  const toast = getToast();
   toast.dismiss("error-feedback");
   toast.error(message, {
     toastId: "error-feedback",
@@ -21,6 +36,8 @@ export function showErrorToast(message, onAfterClose) {
 }
 
 export function showInfoToast(message, onAfterClose) {
+  if (isSSR) return;
+  const toast = getToast();
   toast.dismiss("info-feedback");
   toast.info(message, {
     toastId: "info-feedback",
@@ -30,25 +47,31 @@ export function showInfoToast(message, onAfterClose) {
 }
 
 export function showSuccessToast(message, options = {}) {
+  if (isSSR) return;
   const { autoClose = 2500, toastId, onClose } = options;
+  const toast = getToast();
   if (toastId) toast.dismiss(toastId);
   toast.success(message, { toastId, autoClose, onClose });
 }
 
 export function showWarningToast(message, options = {}) {
+  if (isSSR) return;
   const { autoClose = 3000, toastId, onClose } = options;
+  const toast = getToast();
   if (toastId) toast.dismiss(toastId);
   toast.warning(message, { toastId, autoClose, onClose });
 }
 
 export function dismissToastsByGroup(groupId) {
-  // Clear category toast elements
+  if (isSSR) return;
   if (typeof window !== "undefined" && window.__EVENTRA_TOASTS__) {
     const list = window.__EVENTRA_TOASTS__[groupId] || [];
-    list.forEach(_id => {
+    list.forEach((_id) => {
       try {
         // trigger clear callbacks
-      } catch {}
+      } catch {
+        /* noop */
+      }
     });
     window.__EVENTRA_TOASTS__[groupId] = [];
   }


### PR DESCRIPTION
## Summary

Replace the static `import { toast } from "react-toastify"` in `src/utils/toast.js` with a lazy `require()` pattern. The static import crashes Next.js SSR because `react-toastify` relies on `window` internals not available server-side.

## Changes

- Add `isSSR` guard at module level using `typeof window === "undefined"`
- Replace static import with lazy `require("react-toastify")` accessed via `getToast()` getter
- All exported functions guard with `if (isSSR) return;` before using `toast`

## Impact

- Fixes SSR crash in Next.js when any toast utility is imported during server-side rendering
- No breaking changes in browser — toast notifications work normally

Closes #9856.