### PR TITLE
fix: pass totalEvents, eventsPerPage and onPageSizeChange to PaginationControls (#9872)

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -418,7 +418,10 @@ const EventsPage = () => {
               <PaginationControls
                 currentPage={listing.currentPage}
                 totalPages={listing.totalPages}
+                totalEvents={listing.totalElements}
+                eventsPerPage={listing.eventsPerPage}
                 onPageChange={listing.setSafePage}
+                onPageSizeChange={listing.setEventsPerPage}
               />
             </div>
           )}

--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -32,6 +32,22 @@ import {
 } from "../../utils/advancedFilterUtils";
 const FILTER_STORAGE_KEY = "eventra:event-filters:v1";
 
+const EventsPagination = ({ listing }) => {
+  if (listing.isLoading || listing.totalPages <= 1) return null;
+  return (
+    <div className="mt-8 flex justify-center">
+      <PaginationControls
+        currentPage={listing.currentPage}
+        totalPages={listing.totalPages}
+        totalEvents={listing.totalElements}
+        eventsPerPage={listing.eventsPerPage}
+        onPageChange={listing.setSafePage}
+        onPageSizeChange={listing.setEventsPerPage}
+      />
+    </div>
+  );
+};
+
 const ExploreEventsSkeleton = () => (
   <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" aria-label="Loading events">
     {Array.from({ length: 6 }, (_, index) => (
@@ -414,16 +430,7 @@ const EventsPage = () => {
           )}
 
           {!listing.isLoading && listing.totalPages > 1 && (
-            <div className="mt-8 flex justify-center">
-              <PaginationControls
-                currentPage={listing.currentPage}
-                totalPages={listing.totalPages}
-                totalEvents={listing.totalElements}
-                eventsPerPage={listing.eventsPerPage}
-                onPageChange={listing.setSafePage}
-                onPageSizeChange={listing.setEventsPerPage}
-              />
-            </div>
+            <EventsPagination listing={listing} />
           )}
         </ErrorBoundary>
 


### PR DESCRIPTION
# Pass totalEvents, eventsPerPage and onPageSizeChange to PaginationControls

## Description

Fixes #9872

`PaginationControls` has an early-return guard that fires when `totalEvents`
resolves to `0`:

```js
const safeTotalEvents = Number(totalEvents) || 0;
if (safeTotalEvents === 0) return null;
```
EventsPage was only passing currentPage, totalPages, and onPageChange, leaving totalEvents undefined. The guard always triggered and the entire pagination bar never rendered on the /events page.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have run npm run lint and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports