### PR TITLE
fix: change safeJsonParse fallback from {} to [] and add Array.isArray guard to prevent elements.map crash on corrupt localStorage

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -174,9 +174,8 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
     const savedLayout = localStorage.getItem(`eventra_floorplan_${eventId}`);
     let initialElements = [];
     if (savedLayout) {
-      try {
-        initialElements = safeJsonParse(savedLayout, {});
-      } catch (e) {
+      initialElements = safeJsonParse(savedLayout, []);
+      if (!Array.isArray(initialElements)) {
         toast.error("Invalid floor plan format");
         initialElements = PRESETS.banquet;
       }


### PR DESCRIPTION
### Related Issue
Closes #9874 

### Description of Changes
- I changed `safeJsonParse(savedLayout, {})` to `safeJsonParse(savedLayout, [])` in `FloorPlanDesigner.js`.
- I added `Array.isArray(initialElements)` validation after parsing — falls back to `PRESETS.banquet` and shows error toast if the stored value is not an array.
- It removed the unreachable `try/catch` block since `safeJsonParse` is designed to never throw.