### PR TITLE
fix: add target=_blank and rel=noopener noreferrer to sponsor social links to prevent page navigation and window.opener exploit

### DIFF
--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -177,16 +177,16 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
 
                 <div className="flex gap-3 text-gray-400">
                   {booth.sponsorWebsite && (
-                    <a href={booth.sponsorWebsite}><Globe size={16} /></a>
+                    <a href={booth.sponsorWebsite} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} website`}><Globe size={16} /></a>
                   )}
                   {booth.sponsorLinkedin && (
-                    <a href={booth.sponsorLinkedin}><Linkedin size={16} /></a>
+                    <a href={booth.sponsorLinkedin} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} LinkedIn`}><Linkedin size={16} /></a>
                   )}
                   {booth.sponsorTwitter && (
-                    <a href={booth.sponsorTwitter}><Twitter size={16} /></a>
+                    <a href={booth.sponsorTwitter} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} Twitter`}><Twitter size={16} /></a>
                   )}
                   {booth.sponsorGithub && (
-                    <a href={booth.sponsorGithub}><Github size={16} /></a>
+                    <a href={booth.sponsorGithub} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} GitHub`}><Github size={16} /></a>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
### Related Issue
Closes #9877 

### Description of Changes
- I added `target="_blank"` and `rel="noopener noreferrer"` to all four sponsor social links in `VirtualBoothModal.jsx`.
- I added descriptive `aria-label` attributes to each icon-only link for screen reader accessibility.
- It prevents the user from being navigated away from the event page when clicking social links inside the modal.
- Closes the reverse tabnapping `window.opener` security vulnerability.