### PR TITLE
fix(a11y): replace aria-label="button" with descriptive label on remove image button (#9875)

### DIFF
--- a/src/Pages/Projects/SubmitProject.js
+++ b/src/Pages/Projects/SubmitProject.js
@@ -490,8 +490,8 @@ const handleSubmit = async (e) => {
                         onClick={handleRemoveImage}
                         className="absolute top-2 right-2 p-1.5 bg-rose-600 hover:bg-rose-500 text-white rounded-full shadow-md transition-all duration-200 cursor-pointer"
                         title="Remove image"
-                       aria-label="button">
-                        <XMarkIcon className="w-3.5 h-3.5" />
+                        aria-label="Remove uploaded project image">
+                        <XMarkIcon className="w-3.5 h-3.5" aria-hidden="true" />
                       </button>
                     </div>
                   ) : (


### PR DESCRIPTION
## Description

Fixes #9875

The "Remove image" button in `SubmitProject.js` had `aria-label="button"` — a
value identical to the element's implicit role. Screen readers announced this
as "button, button" with no indication of what the button actually does,
violating WCAG 2.1 SC 4.1.2 (Name, Role, Value).

**Changes:**
- Replaced `aria-label="button"` with `aria-label="Remove uploaded project image"` to match the existing `title` attribute and give screen reader users a clear description
- Added `aria-hidden="true"` to `<XMarkIcon>` so assistive technology does not announce the decorative icon alongside the label
- Fixed the indentation inconsistency on the `aria-label` line

```diff
- aria-label="button">
- <XMarkIcon className="w-3.5 h-3.5" />
+ aria-label="Remove uploaded project image">
+ <XMarkIcon className="w-3.5 h-3.5" aria-hidden="true" />
```

Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have run npm run lint and resolved any new errors or warnings
- [ ] I have verified responsiveness and visual alignment on desktop and mobile viewports