### PR TITLE
fix: use announceTimerRef to cancel previous timeout in announce and prevent screen reader announcement flood on rapid key presses

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -22,7 +22,11 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
   const [announcement, setAnnouncement] = useState("");
   const announce = useCallback((message) => {
     setAnnouncement("");
-    setTimeout(() => { setAnnouncement(message); }, 50);
+    if (announceTimerRef.current) clearTimeout(announceTimerRef.current);
+    announceTimerRef.current = setTimeout(() => {
+      setAnnouncement(message);
+      announceTimerRef.current = null;
+    }, 50);
   }, []);
 
   const [zoom, setZoom] = useState(0.8);
@@ -32,6 +36,7 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
 
   const canvasRef = useRef(null);
   const rafRef = useRef(null);
+  const announceTimerRef = useRef(null);
   const zoomRef = useRef(zoom);
   const snapToGridRef = useRef(snapToGrid);
   const selectedIdRef = useRef(selectedId);
@@ -437,6 +442,10 @@ const FloorPlanDesigner = ({ eventId = "default", onDirtyChange }) => {
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
+      }
+      if (announceTimerRef.current !== null) {
+        clearTimeout(announceTimerRef.current);
+        announceTimerRef.current = null;
       }
     };
   }, [handleMouseMove, handleMouseUp]);


### PR DESCRIPTION
### Related Issue
Closes #9880 

### Description of Changes
- I added `announceTimerRef` using `useRef` to track the current pending announce timeout.
- I updated `announce` to call `clearTimeout(announceTimerRef.current)` before scheduling the new timeout — ensures only the last announcement in a rapid sequence fires.
- I added `clearTimeout(announceTimerRef.current)` to the event listener cleanup to prevent timeout firing on unmounted component.