### PR TITLE
feat: add ranking badges for trending events

### DIFF
--- a/src/components/TrendingEvents/TrendingEvents.jsx
+++ b/src/components/TrendingEvents/TrendingEvents.jsx
@@ -1,3 +1,4 @@
+import { getTrendingBadge } from "../../utils/trendingRankUtils";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { eventService } from "../../services/eventService";
@@ -270,17 +271,9 @@ const TrendingEvents = ({
                 key={event.id ?? event.title}
                 className="rounded-3xl overflow-hidden"
               >
-                <div className="px-5 pt-4">
-                  <span className="inline-flex items-center rounded-full bg-yellow-100 px-3 py-1 text-xs font-semibold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
-                  {index === 0
-                  ? "🏆 #1 Trending"
-                  : index === 1
-                  ? "🥈 #2 Trending"
-                  : index === 2
-                  ? "🥉 #3 Trending"
-                  : `#${index + 1} Trending`}
-                  </span>
-                  </div>
+                <span className="inline-flex items-center rounded-full bg-yellow-100 px-3 py-1 text-xs font-semibold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+  {getTrendingBadge(index)}
+</span>
                 <EventCard
                   event={{
                     ...event,

--- a/src/components/TrendingEvents/TrendingEvents.jsx
+++ b/src/components/TrendingEvents/TrendingEvents.jsx
@@ -256,17 +256,31 @@ const TrendingEvents = ({
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {trending.map(
-            ({
-              event,
-              registrations,
-              pageViews,
-              bookmarks,
-              engagement,
-            }) => (
+            (
+              {
+                event,
+                registrations,
+                pageViews,
+                bookmarks,
+                engagement,
+              },
+              index
+            ) => (
               <div
                 key={event.id ?? event.title}
                 className="rounded-3xl overflow-hidden"
               >
+                <div className="px-5 pt-4">
+                  <span className="inline-flex items-center rounded-full bg-yellow-100 px-3 py-1 text-xs font-semibold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                  {index === 0
+                  ? "🏆 #1 Trending"
+                  : index === 1
+                  ? "🥈 #2 Trending"
+                  : index === 2
+                  ? "🥉 #3 Trending"
+                  : `#${index + 1} Trending`}
+                  </span>
+                  </div>
                 <EventCard
                   event={{
                     ...event,

--- a/src/utils/trendingRankUtils.js
+++ b/src/utils/trendingRankUtils.js
@@ -1,0 +1,9 @@
+export const getTrendingBadge = (index) => {
+  const badges = {
+    0: "🏆 #1 Trending",
+    1: "🥈 #2 Trending",
+    2: "🥉 #3 Trending",
+  };
+
+  return badges[index] || `#${index + 1} Trending`;
+};


### PR DESCRIPTION
## Description

Added dynamic ranking badges to the Trending Events section to clearly indicate each event's relative popularity.

### Changes Made

* Displayed ranking badges based on the existing trending order.
* Added special badges for the top three events:

  * 🏆 #1 Trending
  * 🥈 #2 Trending
  * 🥉 #3 Trending
* Displayed numeric ranking (`#4`, `#5`, etc.) for remaining trending events.
* Reused the existing trending calculation logic without modifying the ranking algorithm.

### Benefits

* Improves visibility of the most popular events.
* Makes the Trending Events section more engaging.
* Helps users quickly identify top-ranked events.
* Lightweight frontend enhancement with minimal impact on existing code.

Fixes #9346

---

## Type of change

* [x] New feature (non-breaking change which adds functionality)

---

## Screenshots / Video (if applicable)

(Add before and after screenshots.)

---

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] My changes generate no new warnings.
* [x] I have verified responsiveness and visual alignment on desktop and mobile viewports.
* [ ] I have run local unit tests using `npm test` and verified they pass.
* [ ] I have run `npm run lint` and resolved any new errors or warnings.
* [ ] I have made corresponding changes to the documentation.
