### PR TITLE
fix(waitlistUtils): add SSR guards to addLocalNotification to prevent localStorage and window crashes

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -33,6 +33,11 @@ const parseEventId = (eventId) => {
 
 // Helper to add local notifications using localStorage
 export const addLocalNotification = async (title, message) => {
+  // SSR guard: localStorage and window are not available in Node.js/SSR environments
+  if (typeof window === "undefined" || typeof localStorage === "undefined") {
+    return;
+  }
+
   try {
     const canonicalKey = "eventra_notification_inbox";
     const raw = localStorage.getItem(canonicalKey);


### PR DESCRIPTION
## Summary
Add SSR guards to `addLocalNotification` in `src/utils/waitlistUtils.js` to prevent crashes when called during server-side rendering (Node.js/SSR environments).

## Changes
- Added `typeof window === "undefined" || typeof localStorage === "undefined"` guard at the start of `addLocalNotification`
- Returns early on the server side, preventing access to undefined `localStorage` and `window` globals

## Impact
- **Severity**: High — causes SSR crashes in Next.js/Gatsby environments
- **Scope**: Any page that calls `addLocalNotification` during server-side rendering

Closes #9898.