### PR TITLE
fix(storageManager): add SSR guards to get() and set() to prevent localStorage crashes

### DIFF
--- a/src/utils/storage/storageManager.js
+++ b/src/utils/storage/storageManager.js
@@ -7,6 +7,9 @@ const DEFAULT_EXPIRY = 1000 * 60 * 60; // 1 hour
 
 export const storageManager = {
   set(key, value, expiry = DEFAULT_EXPIRY) {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
     try {
       const payload = {
         value,
@@ -21,6 +24,9 @@ export const storageManager = {
   },
 
   get(key, validator = null) {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
     try {
       const raw = localStorage.getItem(key);
       if (!raw) return null;


### PR DESCRIPTION
## Summary
Add SSR guards to `storageManager.get()` and `storageManager.set()` in `src/utils/storage/storageManager.js` to prevent crashes when called during server-side rendering.

## Changes
- Added `typeof window === "undefined" || !window.localStorage` guard to `set()` — returns early
- Added `typeof window === "undefined" || !window.localStorage` guard to `get()` — returns `null`

## Impact
- **Severity**: High — causes SSR crashes in Next.js/Gatsby pages using Leaderboard or Contributors components
- **Scope**: `src/Pages/Leaderboard/Leaderboard.jsx` and `src/components/Contributors.js`

Closes #9899.