### PR TITLE
fix(aiProfileParser): prevent setTimeout memory leak in parseResumePDF by returning a cleanup function

### DIFF
--- a/src/components/user/AiProfileGeneratorModal.jsx
+++ b/src/components/user/AiProfileGeneratorModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import ReactDOM from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -17,6 +17,10 @@ const AiProfileGeneratorModal = ({ isOpen, onClose, onApplyProfile }) => {
   const [error, setError] = useState("");
   const [parsedData, setParsedData] = useState(null);
   const fileInputRef = useRef(null);
+  const resumeCleanupRef = useRef(null);
+
+  // Clean up any pending resume parse on unmount
+  useEffect(() => () => { if (resumeCleanupRef.current) resumeCleanupRef.current(); }, []);
 
   if (!isOpen) return null;
 
@@ -54,7 +58,12 @@ const AiProfileGeneratorModal = ({ isOpen, onClose, onApplyProfile }) => {
         data = await parseGithubProfile(githubUrl);
       } else {
         if (!resumeFile) throw new Error("Please upload a resume PDF.");
-        data = await parseResumePDF(resumeFile);
+        const { promise, cleanup } = parseResumePDF(resumeFile);
+        // Cancel any pending parse from a previous attempt before starting a new one
+        if (resumeCleanupRef.current) resumeCleanupRef.current();
+        resumeCleanupRef.current = cleanup;
+        data = await promise;
+        resumeCleanupRef.current = null;
       }
       
       setParsedData(data);

--- a/src/utils/aiProfileParser.js
+++ b/src/utils/aiProfileParser.js
@@ -86,23 +86,42 @@ export async function parseGithubProfile(githubUrl) {
  * @param {File} file - The uploaded PDF file.
  * @returns {Promise<Object>} - The structured profile data.
  */
-export async function parseResumePDF(file) {
-  return new Promise((resolve, reject) => {
+/**
+ * Deterministically simulates parsing a Resume PDF.
+ * In a full production environment, this would hit an API endpoint that uses pdf-parse and an LLM.
+ * @param {File} file - The uploaded PDF file.
+ * @returns {{ promise: Promise<Object>, cleanup: () => void }} Object with the parse promise and a cleanup function.
+ */
+export function parseResumePDF(file) {
+  let settled = false;
+  let timeoutId = null;
+
+  const cleanup = () => {
+    if (!settled && timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const promise = new Promise((resolve, reject) => {
     if (!file || file.type !== "application/pdf") {
-      return reject(new Error("Please upload a valid PDF resume."));
+      reject(new Error("Please upload a valid PDF resume."));
+      return;
     }
 
     // Simulate network/parsing delay
-    setTimeout(() => {
+    timeoutId = setTimeout(() => {
+      settled = true;
+      timeoutId = null;
       // Create deterministic mock data based on the file name length
       // to give the illusion of processing different files differently.
       const nameLen = file.name.length;
-      
+
       let mockSkills = ["JavaScript", "React", "Node.js", "Git", "HTML5", "CSS3"];
       if (nameLen % 2 === 0) {
         mockSkills = ["Python", "Django", "PostgreSQL", "Docker", "AWS", "Machine Learning"];
       }
-      
+
       let mockBio = "Results-driven software engineer with experience building scalable web applications and RESTful APIs.";
       if (nameLen % 3 === 0) {
         mockBio = "Creative frontend developer passionate about UI/UX design, accessibility, and modern JavaScript frameworks.";
@@ -117,4 +136,6 @@ export async function parseResumePDF(file) {
       });
     }, 2500);
   });
+
+  return { promise, cleanup };
 }


### PR DESCRIPTION
## Summary
Refactor `parseResumePDF` in `src/utils/aiProfileParser.js` to return `{ promise, cleanup }` instead of a plain Promise. The `cleanup()` function clears the setTimeout if the operation is cancelled before the 2500ms delay resolves.

`AiProfileGeneratorModal` is also updated to use the new API: it stores the cleanup in a ref, calls it on unmount via useEffect, and calls it before starting a new parse to cancel any in-flight attempt.

## Changes
- `parseResumePDF` now returns `{ promise, cleanup }` instead of a Promise
- `cleanup()` calls `clearTimeout` if the operation has not yet settled
- `AiProfileGeneratorModal` uses `resumeCleanupRef` to manage cancellation
- A useEffect cleanup runs on unmount to prevent stale state updates

## Impact
- **Severity**: Medium — prevents memory leaks and stale state updates in unmounted components
- **Scope**: AI profile auto-generation (PDF resume upload feature)

Closes #9901.