### PR TITLE
fix(serviceWorkerRegistration): add typeof navigator guard to prevent SSR crash when registering service worker

### DIFF
--- a/src/utils/serviceWorkerRegistration.js
+++ b/src/utils/serviceWorkerRegistration.js
@@ -1,7 +1,7 @@
 import { logger } from "./logger";
 
 export const registerServiceWorker = () => {
-  if ('serviceWorker' in navigator) {
+  if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
         .register('/service-worker.js')
@@ -16,7 +16,7 @@ export const registerServiceWorker = () => {
 };
 
 export const unregisterServiceWorker = () => {
-  if ('serviceWorker' in navigator) {
+  if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
     navigator.serviceWorker.ready
       .then((registration) => {
         registration.unregister();


### PR DESCRIPTION
## Summary
Add `typeof navigator !== "undefined"` guard to both `registerServiceWorker` and `unregisterServiceWorker` in `src/utils/serviceWorkerRegistration.js` to prevent crashes during server-side rendering.

## Changes
- `registerServiceWorker`: `if (typeof navigator !== "undefined" && "serviceWorker" in navigator)`
- `unregisterServiceWorker`: `if (typeof navigator !== "undefined" && "serviceWorker" in navigator)`

## Impact
- **Severity**: Medium — prevents SSR crashes when this module is imported in Node.js environments
- **Scope**: Service worker registration feature

Closes #9902.