### PR TITLE
fix(hooks): add SSR guards to window.localStorage access in useNotificationPoller.js

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -14,6 +14,9 @@ const getStorageKey = () => {
   if (typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.VITE_TEST_MODE === "true")) {
     return "eventra_notification_inbox";
   }
+  if (typeof window === "undefined" || !window.localStorage) {
+    return 'eventra_notification_inbox_guest';
+  }
   try {
     const userStr = window.localStorage.getItem('user');
     if (userStr) {
@@ -31,10 +34,12 @@ const normalize = (n = {}) => ({
 });
 
 const persist = (items) => {
+  if (typeof window === "undefined" || !window.localStorage) return;
   try { window.localStorage.setItem(getStorageKey(), JSON.stringify(items)); } catch {}
 };
 
 const loadPersisted = () => {
+  if (typeof window === "undefined" || !window.localStorage) return null;
   try {
     const raw = window.localStorage.getItem(getStorageKey());
     if (!raw) return null;
@@ -226,6 +231,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
 
   // Same-tab sync listener
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const handleUpdate = () => {
       const persisted = loadPersisted();
       if (persisted) {


### PR DESCRIPTION
## Summary
Add `typeof window === "undefined"` guards before all direct `window.localStorage` access in `useNotificationPoller.js`. Currently, `getStorageKey()`, `persist()`, `loadPersisted()`, and the same-tab sync listener `useEffect` all access `window.localStorage` without guards, causing SSR crashes in Next.js/Vite SSR builds.

## Changes
- `getStorageKey()`: added `if (typeof window === "undefined" || !window.localStorage)` guard before `window.localStorage.getItem(...)`
- `persist(items)`: added SSR guard before `window.localStorage.setItem(...)`
- `loadPersisted()`: added SSR guard before `window.localStorage.getItem(...)`
- Same-tab sync listener `useEffect`: added `if (typeof window === "undefined") return` before adding event listeners

## Impact
- SSR crash: `ReferenceError: window is not defined` in Next.js/Vite SSR environments
- Blocks adoption of the notification poller in SSR frameworks
- Affects users who rely on server-side rendering for SEO and performance

Closes #9908.