### PR TITLE
fix(utils): add window.localStorage guard in getOrMigrateKey to prevent SSR crash

### DIFF
--- a/src/utils/storageKeyManager.js
+++ b/src/utils/storageKeyManager.js
@@ -57,7 +57,7 @@ export const getOpaqueKey = (namespace, userId) => {
  */
 export const getOrMigrateKey = (namespace, userId, legacyKey) => {
   const newKey = getOpaqueKey(namespace, userId);
-  if (typeof window !== "undefined" && legacyKey && legacyKey !== newKey) {
+  if (typeof window !== "undefined" && window.localStorage && legacyKey && legacyKey !== newKey) {
     try {
       const oldData = localStorage.getItem(legacyKey);
       if (oldData !== null && localStorage.getItem(newKey) === null) {


### PR DESCRIPTION
## Summary
Add `&& window.localStorage` check inside the `typeof window !== "undefined"` guard in `getOrMigrateKey()` in `src/utils/storageKeyManager.js`. Currently, the condition only checks `typeof window !== "undefined"` but then calls `localStorage.getItem()` directly without verifying `window.localStorage` exists. In environments like Firefox private browsing or iframe contexts where `window` exists but `localStorage` throws, this causes a `TypeError`.

## Changes
- Changed `if (typeof window !== "undefined" && legacyKey ...)` to `if (typeof window !== "undefined" && window.localStorage && legacyKey ...)`

## Impact
- `TypeError` crash in Firefox private browsing, iframe contexts, or Safari with strict storage settings
- Prevents legacy key migration from completing, leading to data loss for returning users
- Inconsistent with `getSalt()` which properly guards with `window.localStorage`

Closes #9912.