### PR TITLE
refactor: migrate SEOHead to react-helmet-async

### DIFF
--- a/src/components/SEOHead.jsx
+++ b/src/components/SEOHead.jsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
+import { Helmet } from "react-helmet-async";
 
 /**
- * SEOHead - Sets document title and meta tags dynamically.
+ * SEOHead - Sets document title and meta tags dynamically using react-helmet-async.
  *
  * @param {Object} props
  * @param {string} props.title - Page title
@@ -17,59 +17,25 @@ export default function SEOHead({
   url,
   type = "website",
 }) {
-  useEffect(() => {
-    // Set document title
-    document.title = title ? `${title} | Eventra` : "Eventra - Event Management";
+  const fullTitle = title ? `${title} | Eventra` : "Eventra - Event Management";
 
-    // Helper to set, create, or remove a meta tag
-    const setMeta = (attr, key, content) => {
-      let el = document.querySelector(`meta[${attr}="${key}"]`);
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      {description && <meta name="description" content={description} />}
       
-      // 🔥 FIX: If the new page doesn't have this content, destroy the old tag
-      // to prevent stale data from leaking across SPA routes.
-      if (!content) {
-        if (el) el.remove();
-        return;
-      }
+      {title && <meta property="og:title" content={title} />}
+      {description && <meta property="og:description" content={description} />}
+      {type && <meta property="og:type" content={type} />}
+      {image && <meta property="og:image" content={image} />}
+      {url && <meta property="og:url" content={url} />}
       
-      if (!el) {
-        el = document.createElement("meta");
-        el.setAttribute(attr, key);
-        document.head.appendChild(el);
-      }
-      el.setAttribute("content", content);
-    };
-
-    // Standard meta
-    setMeta("name", "description", description);
-
-    // Open Graph
-    setMeta("property", "og:title", title);
-    setMeta("property", "og:description", description);
-    setMeta("property", "og:type", type);
-    setMeta("property", "og:image", image); // 🔥 FIX: Removed 'if (image)' so cleanup runs if it's missing
-    setMeta("property", "og:url", url);
-
-    // Twitter Card
-    setMeta("name", "twitter:card", image ? "summary_large_image" : "summary");
-    setMeta("name", "twitter:title", title);
-    setMeta("name", "twitter:description", description);
-    setMeta("name", "twitter:image", image);
-
-    // Canonical URL
-    let link = document.querySelector('link[rel="canonical"]');
-    if (url) {
-      if (!link) {
-        link = document.createElement("link");
-        link.setAttribute("rel", "canonical");
-        document.head.appendChild(link);
-      }
-      link.setAttribute("href", url);
-    } else {
-      // 🔥 FIX: Destroy the old canonical link if the new page doesn't have one
-      if (link) link.remove();
-    }
-  }, [title, description, image, url, type]);
-
-  return null; // This component only manages side effects
+      <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+      {title && <meta name="twitter:title" content={title} />}
+      {description && <meta name="twitter:description" content={description} />}
+      {image && <meta name="twitter:image" content={image} />}
+      
+      {url && <link rel="canonical" href={url} />}
+    </Helmet>
+  );
 }


### PR DESCRIPTION
Resolves #9495 by refactoring \SEOHead.jsx\ to use \<Helmet>\ from \eact-helmet-async\ instead of raw DOM manipulation.