### PR TITLE
cleanup: remove dead code from Leaderboard components

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -92,11 +92,7 @@ export default function LeaderBoard() {
   const { t } = useTranslation();
   useDocumentTitle(t("leaderboard.pageTitle"));
 
-  const CATEGORY_FILTERS = useMemo(() => [
-    { id: "overall", label: t("leaderboard.filters.overall"), icon: "🏆", description: t("leaderboard.filters.overallDesc") },
-    { id: "monthly", label: t("leaderboard.filters.monthly"), icon: "⭐", description: t("leaderboard.filters.monthlyDesc") },
-    { id: "mentors", label: t("leaderboard.filters.mentors"), icon: "🎓", description: t("leaderboard.filters.mentorsDesc") },
-  ], [t]);
+
 
   const [contributors, setContributors] = useState([]);
   const [streaks, setStreaks] = useState({});
@@ -160,14 +156,7 @@ export default function LeaderBoard() {
 
   const top3 = useMemo(() => sortedContributors.slice(0, 3), [sortedContributors]);
 
-  const sortOptions = useMemo(
-    () => [
-      { label: t("leaderboard.sortOptions.points"), value: "points" },
-      { label: t("leaderboard.sortOptions.prs"), value: "prs" },
-      { label: t("leaderboard.sortOptions.username"), value: "username" },
-    ],
-    [t]
-  );
+
 
   useEffect(() => {
     const timer = setTimeout(() => {


### PR DESCRIPTION
Resolves #9505 by removing unused \CATEGORY_FILTERS\ and \sortOptions\ variables from \Leaderboard.jsx\ that were causing dead code warnings.