### PR TITLE
i18n: localize hardcoded strings in BackToTop and InstallAppButton

### DIFF
--- a/src/components/common/BackToTop.jsx
+++ b/src/components/common/BackToTop.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { ChevronUp } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 const SCROLL_THRESHOLD = 400; // px — button appears after scrolling this far
 
@@ -13,6 +14,7 @@ const BackToTop = ({
   const [progress, setProgress] = useState(0);
   const [isChatbotOpen, setIsChatbotOpen] = useState(false);
   const [hasChatbot, setHasChatbot] = useState(false);
+  const { t } = useTranslation();
 
   const prefersReducedMotion =
     typeof window !== "undefined"
@@ -82,8 +84,8 @@ const BackToTop = ({
     <button
       onClick={scrollToTop}
       onKeyDown={handleKeyDown}
-      aria-label={`Back to top (${Math.round(progress)}% scrolled)`}
-      title="Back to top"
+      aria-label={t("common.backToTopProgress", { progress: Math.round(progress), defaultValue: `Back to top (${Math.round(progress)}% scrolled)` })}
+      title={t("common.backToTop", "Back to top")}
       tabIndex={visible ? 0 : -1}
       className={[
         positionClass,

--- a/src/components/common/InstallAppButton.jsx
+++ b/src/components/common/InstallAppButton.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
 import { Download } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 export default function InstallAppButton() {
   const [deferredPrompt, setDeferredPrompt] = useState(null);
   const [isInstallable, setIsInstallable] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const handler = (e) => {
@@ -34,10 +36,10 @@ export default function InstallAppButton() {
     <button
       onClick={handleInstall}
       className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-white text-xs font-semibold hover:opacity-90 transition-opacity"
-      aria-label="Install app"
+      aria-label={t("common.installApp", "Install app")}
     >
       <Download size={14} />
-      Install
+      {t("common.install", "Install")}
     </button>
   );
 }


### PR DESCRIPTION
Resolves #9498 by replacing hardcoded strings with useTranslation calls in BackToTop.jsx and InstallAppButton.jsx.