### PR TITLE
feat: add keyboard event handlers to custom clickable divs

### DIFF
--- a/src/Pages/Archive/EventArchivePage.jsx
+++ b/src/Pages/Archive/EventArchivePage.jsx
@@ -96,7 +96,7 @@ function ArchiveCard({ event, onClick }) {
 function EventDetailModal({ event, onClose }) {
   if (!event) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onClose} role="presentation" onKeyDown={(e) => e.key === 'Escape' && onClose()}>
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}

--- a/src/Pages/Events/EventCalendarView.jsx
+++ b/src/Pages/Events/EventCalendarView.jsx
@@ -23,7 +23,7 @@ const EventPopover = ({ event, onClose }) => {
   if (!event) return null;
 
   return (
-    <div className="fixed inset-0 z-1000 flex items-center justify-center p-4 bg-slate-900/40 backdrop-blur-sm" onClick={onClose}>
+    <div className="fixed inset-0 z-1000 flex items-center justify-center p-4 bg-slate-900/40 backdrop-blur-sm" onClick={onClose} role="presentation" onKeyDown={(e) => e.key === 'Escape' && onClose()}>
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -424,7 +424,7 @@ const showClosingSoon =
                     </button>
                     {showExportDropdown && (
                       <>
-                        <div className="fixed inset-0 z-10" onClick={() => setShowExportDropdown(false)} />
+                        <div className="fixed inset-0 z-10" onClick={() => setShowExportDropdown(false)} role="presentation" onKeyDown={(e) => e.key === 'Escape' && setShowExportDropdown(false)} />
                         <div className="absolute right-0 mt-2 w-40 rounded-2xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-lg py-1.5 z-20 animate-fadeIn text-left">
                           <button
                             onClick={async () => {

--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -533,7 +533,7 @@ export default function UserAchievements() {
 
                         {/* Share section */}
                         {badge.earned && (
-                          <div className="pt-4 border-t border-dashed border-border space-y-2.5" onClick={(e) => e.stopPropagation()}>
+                          <div className="pt-4 border-t border-dashed border-border space-y-2.5" onClick={(e) => e.stopPropagation()} role="presentation" onKeyDown={(e) => e.stopPropagation()}>
                             <span className="block text-[9px] font-black uppercase tracking-widest text-text-light leading-none">
                               {t("userAchievements.badgesSectionShare")}
                             </span>

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -71,7 +71,7 @@ function ConfirmModal({ open, title, message, onConfirm, onCancel }) {
   if (!open) return null;
 
   return (
-    <div className="ad-modal-overlay" onClick={onCancel} onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }} tabIndex={0}>
+    <div className="ad-modal-overlay" onClick={onCancel} role="presentation" onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}>
       <motion.div
         className="ad-modal" tabIndex={0}
         initial={{ opacity: 0, scale: 0.95 }}
@@ -522,7 +522,7 @@ const AdminDashboard = () => {
                       </button>
                       {showExportDropdown && (
                         <>
-                          <div className="fixed inset-0 z-10" onClick={() => setShowExportDropdown(false)} />
+                          <div className="fixed inset-0 z-10" onClick={() => setShowExportDropdown(false)} role="presentation" onKeyDown={(e) => e.key === 'Escape' && setShowExportDropdown(false)} />
                           <div className="absolute right-0 mt-1.5 w-36 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-lg py-1 z-20 animate-fadeIn">
                             <button onClick={() => { exportToCSV(users, "users_list"); setShowExportDropdown(false); }} className="w-full text-left px-3 py-2 text-xs font-semibold text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-850 transition">Export as CSV</button>
                             <button onClick={() => { exportToJSON(users, "users_list"); setShowExportDropdown(false); }} className="w-full text-left px-3 py-2 text-xs font-semibold text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-850 transition">Export as JSON</button>
@@ -759,7 +759,7 @@ const AdminDashboard = () => {
 
       {/* Waitlist Management Modal */}
       {selectedWaitlistEvent && (
-        <div className="ad-modal-overlay" onClick={() => setSelectedWaitlistEvent(null)}>
+        <div className="ad-modal-overlay" onClick={() => setSelectedWaitlistEvent(null)} role="presentation" onKeyDown={(e) => e.key === 'Escape' && setSelectedWaitlistEvent(null)}>
           <motion.div
             className="ad-modal" style={{ maxWidth: "600px", width: "90%" }}
             initial={{ opacity: 0, scale: 0.95 }}

--- a/src/components/hackathons/TeamWorkspace.jsx
+++ b/src/components/hackathons/TeamWorkspace.jsx
@@ -611,7 +611,7 @@ const TeamWorkspace = () => {
       {isChatOpen && (
         <div className="fixed inset-0 z-50 flex justify-end bg-black/70 backdrop-blur-sm transition-all duration-350 animate-fade-in">
           {/* Backdrop closer */}
-          <div className="absolute inset-0 cursor-default" onClick={() => setIsChatOpen(false)} />
+          <div className="absolute inset-0 cursor-default" onClick={() => setIsChatOpen(false)} role="presentation" onKeyDown={(e) => e.key === 'Escape' && setIsChatOpen(false)} />
 
           {/* Drawer Panel Container */}
           <div className="relative w-full max-w-md h-full bg-[#07080e] border-l border-slate-800 shadow-2xl flex flex-col z-10 animate-slide-in">

--- a/src/components/notifications/NotificationItem.jsx
+++ b/src/components/notifications/NotificationItem.jsx
@@ -132,7 +132,7 @@ const NotificationItem = ({
 
   const inner = (
     <div className="flex w-full items-start gap-2">
-      <div className="flex min-w-0 flex-1 gap-3" onClick={handleClick} role="presentation">
+      <div className="flex min-w-0 flex-1 gap-3" onClick={handleClick} role="presentation" onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleClick(e)} tabIndex={0}>
         {content}
       </div>
       {actions}

--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -687,7 +687,7 @@ const ConfirmModal = ({ open, onCancel, onConfirm, loading }) => {
   if (!open) return null;
   return ReactDOM.createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/50" onClick={onCancel} />
+      <div className="absolute inset-0 bg-black/50" onClick={onCancel} role="presentation" onKeyDown={(e) => e.key === 'Escape' && onCancel()} />
       <div className="relative w-full max-w-md mx-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl p-6 z-10">
         <h4 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Save changes?</h4>
         <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -836,7 +836,7 @@ const applyPreset = (preset) => {
               className="backdrop"
               onClick={() => setCancelTarget(null)}
             >
-              <div onClick={(e) => e.stopPropagation()}>
+              <div onClick={(e) => e.stopPropagation()} role="presentation" onKeyDown={(e) => e.stopPropagation()}>
                 <h3>Cancel?</h3>
                 <button onClick={handleCancelConfirm}>
                   Yes


### PR DESCRIPTION
Resolves #9504 by adding role='presentation' and onKeyDown handlers to divs acting as modals/backdrops.