### PR TITLE
fix: spread currentPointsRef.current into newStroke.points to prevent shared reference causing duplicate points on every pencil mouse move

### DIFF
--- a/src/components/common/CollaborativeWhiteboard.jsx
+++ b/src/components/common/CollaborativeWhiteboard.jsx
@@ -327,7 +327,7 @@ export default function CollaborativeWhiteboard() {
         tool,
         color,
         lineWidth,
-        points: currentPointsRef.current,
+        points: [...currentPointsRef.current],  // ← copy, not the same reference
       };
 
       bcRef.current.postMessage({


### PR DESCRIPTION
### Related Issue
Closes #9934 

### Description of Changes
- I changed `points: currentPointsRef.current` to `points: [...currentPointsRef.current]` in `startDrawing` inside `InteractiveWhiteboard.jsx`.
- It breaks the shared array reference between `currentPointsRef.current` and the React state stored in `remoteActiveStrokes`.
- `currentPointsRef.current.push()` in `draw` no longer mutates the state array, so the `setRemoteActiveStrokes` updater adds each point exactly once.