### PR TITLE
fix: reset peersCount to 1 before each ping cycle so disconnected peers are no longer counted

### DIFF
--- a/src/components/common/CollaborativeWhiteboard.jsx
+++ b/src/components/common/CollaborativeWhiteboard.jsx
@@ -191,6 +191,7 @@ export default function CollaborativeWhiteboard() {
     // Ping peers count check
     const interval = setInterval(() => {
       if (bcRef.current) {
+        setPeersCount(1); // reset to self before each ping cycle
         bcRef.current.postMessage({ type: "WHITEBOARD_PING", from: peerId.current });
       }
     }, 3000);


### PR DESCRIPTION
### Related Issue
Closes #9936 

### Description of Changes
- I added `setPeersCount(1)` immediately before `postMessage({ type: "WHITEBOARD_PING" })` inside the 3-second interval in `CollaborativeWhiteboard.jsx`.
- `peersCount` now resets to 1 (self) at the start of each ping cycle and increments back up for each PONG received.
- Peers that disconnect stop sending PONGs, so their absence is correctly reflected in the count on the next cycle.