### PR TITLE
fix(hooks): add SSR guards to useState initializer and load in useNotifications.js

### DIFF
--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -8,6 +8,7 @@ let flushTimeout = null;
 
 export function useNotifications() {
   const [notifications, setNotifications] = useState(() => {
+    if (typeof window === "undefined") return [];
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
       return raw ? JSON.parse(raw) : [];
@@ -17,6 +18,7 @@ export function useNotifications() {
   });
 
   const load = useCallback(() => {
+    if (typeof window === "undefined") return;
     try {
       const raw = window.localStorage.getItem(STORAGE_KEY);
       setNotifications(raw ? JSON.parse(raw) : []);


### PR DESCRIPTION
## Summary

Add SSR guards to `src/hooks/useNotifications.js` to prevent server-side rendering crashes when `window` is undefined.

## Changes

- `useState` initializer: Added `if (typeof window === "undefined") return [];` as first line. Without this guard, `window.localStorage.getItem(STORAGE_KEY)` throws `ReferenceError: window is not defined` during SSR.
- `load()` callback: Added `if (typeof window === "undefined") return;` guard for consistency and safety.

## Impact

- **Severity:** High — SSR crashes on any page that mounts `useNotifications`.
- **Fix:** 2-line addition, zero behavior change for client-side usage.

Closes #9943.