### PR TITLE
fix(hooks): add SSR guard to removeValue in useLocalStorage.js

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -82,6 +82,7 @@ const useLocalStorage = (key, initialValue) => {
   );
 
   const removeValue = useCallback(() => {
+    if (typeof window === "undefined") return;
     try {
       window.localStorage.removeItem(key);
       setStoredValue(initialValueRef.current);


### PR DESCRIPTION
## Summary

Add SSR guard to `removeValue` callback in `src/hooks/useLocalStorage.js`.

## Changes

Added `if (typeof window === "undefined") return;` as the first line of `removeValue` to prevent `ReferenceError: window is not defined` during SSR.

Without this guard, calling `removeValue` during SSR (e.g., from a component that unconditionally calls cleanup on unmount) crashes the server process.

## Impact

- **Severity:** High — SSR crash when `removeValue` is called during server-side rendering.
- **Fix:** 1-line addition, zero behavior change for client-side usage.

Closes #9944.