### PR TITLE
fix(hooks): add SSR guard to removeValue in useSessionStorage.js

### DIFF
--- a/src/hooks/useSessionStorage.js
+++ b/src/hooks/useSessionStorage.js
@@ -56,6 +56,7 @@ const useSessionStorage = (key, initialValue) => {
   );
 
   const removeValue = useCallback(() => {
+    if (typeof window === "undefined") return;
     try {
       window.sessionStorage.removeItem(key);
       setStoredValue(initialValueRef.current);


### PR DESCRIPTION
## Summary

Add SSR guard to `removeValue` callback in `src/hooks/useSessionStorage.js`.

## Changes

Added `if (typeof window === "undefined") return;` as the first line of `removeValue` to prevent `ReferenceError: window is not defined` during SSR.

Without this guard, calling `removeValue` during SSR crashes the server process.

## Impact

- **Severity:** High — SSR crash when `removeValue` is called during server-side rendering.
- **Fix:** 1-line addition, zero behavior change for client-side usage.

Closes #9945.