### PR TITLE
fix(hooks): add SSR guard to clearBookmarks in useBookmarks.js

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -180,6 +180,7 @@ const useBookmarks = (userId = "guest") => {
    * Removes all bookmarks for the current user from both state and localStorage.
    */
   const clearBookmarks = useCallback(() => {
+    if (typeof window === "undefined") return;
     setBookmarks([]);
     cache.set(storageKeyRef.current, []);
     try {


### PR DESCRIPTION
## Summary

Add SSR guard to `clearBookmarks` callback in `src/hooks/useBookmarks.js`.

## Changes

Added `if (typeof window === "undefined") return;` as the first line of `clearBookmarks` to prevent `ReferenceError: window is not defined` during SSR.

Without this guard, calling `clearBookmarks` during SSR crashes the server process.

## Impact

- **Severity:** High — SSR crash when `clearBookmarks` is called during server-side rendering.
- **Fix:** 1-line addition, zero behavior change for client-side usage.

Closes #9946.