### PR TITLE
fix(utils): guard submittedAt against invalid Date in exportFeedbackAsCSV

### DIFF
--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -289,7 +289,7 @@ export const exportFeedbackAsCSV = (eventId) => {
       `"${(f.comment || '').replace(/"/g, '""')}"`,
       (f.tags || []).join(';'),
       f.recommend !== undefined ? (f.recommend ? 'Yes' : 'No') : '',
-      new Date(f.submittedAt).toLocaleString(),
+      f.submittedAt ? new Date(f.submittedAt).toLocaleString() : '',
     ]);
 
     const csv = [headers, ...rows].map((row) => row.join(',')).join('\n');


### PR DESCRIPTION
## Summary

Guard `submittedAt` against `null`/`undefined` in `exportFeedbackAsCSV` in `src/utils/feedbackUtils.js`.

## Changes

Changed `new Date(f.submittedAt).toLocaleString()` to `f.submittedAt ? new Date(f.submittedAt).toLocaleString() : ''`.

When `submittedAt` is `null` or `undefined`, `new Date(undefined)` returns `Invalid Date`, and calling `.toLocaleString()` on it produces the string `"Invalid Date"` — leaking an internal error representation into exported CSV data.

## Impact

- **Severity:** Medium — corrupts exported CSV data instead of crashing.
- **Fix:** 1-line change, zero behavior change for entries with valid `submittedAt`.

Closes #9947.