### PR TITLE
fix: clamp scroll progress between 0 and 100 to prevent bar overflow or disappearance during iOS rubber-band scrolling

### DIFF
--- a/src/components/common/ScrollProgressBar.jsx
+++ b/src/components/common/ScrollProgressBar.jsx
@@ -25,8 +25,8 @@ const ScrollProgressBar = () => {
         return;
       }
 
-      const progress = (scrollTop / scrollableHeight) * 100;
-      
+      const progress = Math.min(100, Math.max(0, (scrollTop / scrollableHeight) * 100));
+
       // Directly manipulate the DOM for zero-render performance
       progressBarRef.current.style.width = `${progress}%`;
       ticking = false;


### PR DESCRIPTION
### Related Issue
Closes #9959 

### Description of Changes
- I wrapped the `progress` calculation in `Math.min(100, Math.max(0, ...))` in `ScrollProgressBar.jsx`.
- It prevents the progress bar from receiving a negative width (disappears) or a width exceeding 100% (overflows container) during elastic/momentum scrolling on iOS Safari and similar browsers.