### PR TITLE
fix: use server-synced time for bookmark savedAt timestamps

### DIFF
--- a/src/hooks/useBookmarks.js
+++ b/src/hooks/useBookmarks.js
@@ -5,6 +5,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { safeJsonParse } from "../utils/safeJsonParse";
 import { getOrMigrateKey } from "../utils/storageKeyManager";
+import { getServerNow } from "../utils/timeSync.js";
 
 // Simple synchronous hash to avoid exposing raw userId (email) in localStorage keys.
 const hashUserId = (userId) => {
@@ -70,7 +71,7 @@ const toBookmarkEntry = (event) => ({
   type: event?.type ?? event?.category ?? "",
   image: event?.image ?? event?.imageUrl ?? "",
   status: event?.status ?? "",
-  savedAt: Date.now(),
+  savedAt: getServerNow(),
 });
 
 /**

--- a/src/hooks/useBookmarks.test.js
+++ b/src/hooks/useBookmarks.test.js
@@ -1,12 +1,14 @@
 import { renderHook, act } from "@testing-library/react";
 import useBookmarks from "./useBookmarks";
 import { safeJsonParse } from "../utils/safeJsonParse";
+import { getServerNow, setServerClockOffsetMs } from "../utils/timeSync";
 
 const makeEvent = (id, title = `Event ${id}`) => ({ id, title, date: "2025-10-01" });
 
 describe("useBookmarks", () => {
   beforeEach(() => {
     localStorage.clear();
+    setServerClockOffsetMs(0);
   });
 
   // ─── Initial state ──────────────────────────────────────────────────────────
@@ -62,7 +64,7 @@ describe("useBookmarks", () => {
   });
 
   it("toggleBookmark stamps a savedAt timestamp on newly added bookmarks", () => {
-    const before = Date.now();
+    const before = getServerNow();
     const { result } = renderHook(() => useBookmarks("user-5"));
 
     act(() => {
@@ -71,7 +73,22 @@ describe("useBookmarks", () => {
 
     const { savedAt } = result.current.bookmarks[0];
     expect(savedAt).toBeGreaterThanOrEqual(before);
-    expect(savedAt).toBeLessThanOrEqual(Date.now());
+    expect(savedAt).toBeLessThanOrEqual(getServerNow());
+  });
+
+  it("toggleBookmark uses server-synced clock offset for savedAt", () => {
+    setServerClockOffsetMs(15_000);
+    const before = getServerNow();
+    const { result } = renderHook(() => useBookmarks("user-5b"));
+
+    act(() => {
+      result.current.toggleBookmark(makeEvent(31));
+    });
+
+    const { savedAt } = result.current.bookmarks[0];
+    expect(savedAt).toBeGreaterThanOrEqual(before);
+    expect(savedAt).toBeLessThanOrEqual(getServerNow());
+    expect(savedAt).toBeGreaterThanOrEqual(Date.now() + 14_000);
   });
 
   it("toggleBookmark does not mutate other bookmarks when removing one", () => {


### PR DESCRIPTION
## Summary
Replaces client `Date.now()` with `getServerNow()` from `timeSync.js` when creating bookmark entries in `useBookmarks`.

This keeps `savedAt` consistent with server-synced time used elsewhere in the app, so bookmark cap-eviction (which drops the oldest entry by `savedAt`) works correctly even when the client clock is skewed.

Closes #7201
