### PR TITLE
fix(utils): replace Node.js crypto import with Web Crypto API in signatureValidator

### DIFF
--- a/src/utils/signatureValidator.js
+++ b/src/utils/signatureValidator.js
@@ -1,10 +1,52 @@
-import crypto from "crypto";
+/**
+ * Lightweight HMAC-SHA256 signature validation using the Web Crypto API.
+ *
+ * Compatible with both browsers (window.crypto.subtle) and Node.js ≥ 19
+ * (globalThis.crypto.subtle). No `import crypto from "crypto"` because
+ * the Node.js built-in module is unavailable in the browser and crashes
+ * the bundle on load.
+ */
 
 const usedNonces = new Map();
 
 const MAX_REQUEST_AGE_MS = 5 * 60 * 1000;
 
-export function validateSignature(
+// Resolve a crypto-like object available in the current environment.
+const getCrypto = () => {
+  if (typeof globalThis !== "undefined" && globalThis.crypto?.subtle) {
+    return globalThis.crypto;
+  }
+  if (typeof window !== "undefined" && window.crypto?.subtle) {
+    return window.crypto;
+  }
+  return null;
+};
+
+/**
+ * Compute HMAC-SHA256 using the Web Crypto API.
+ * Returns a hex string identical to what crypto.createHmac('sha256', secret)
+ * would produce, but works in browsers.
+ */
+const hmacSha256Hex = async (secret, data) => {
+  const c = getCrypto();
+  if (!c) {
+    throw new Error("HMAC: Web Crypto API is not available in this environment");
+  }
+  const enc = new TextEncoder();
+  const key = await c.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await c.subtle.sign("HMAC", key, enc.encode(data));
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+export async function validateSignature(
   payload,
   timestamp,
   nonce,
@@ -36,14 +78,10 @@ export function validateSignature(
     };
   }
 
-  const expectedSignature = crypto
-    .createHmac("sha256", secret)
-    .update(
-      JSON.stringify(payload) +
-        timestamp +
-        nonce
-    )
-    .digest("hex");
+  const expectedSignature = await hmacSha256Hex(
+    secret,
+    JSON.stringify(payload) + timestamp + nonce
+  );
 
   if (expectedSignature !== signature) {
     return {
@@ -63,10 +101,7 @@ const cleanupInterval = setInterval(() => {
   const now = Date.now();
 
   for (const [nonce, timestamp] of usedNonces) {
-    if (
-      now - timestamp >
-      MAX_REQUEST_AGE_MS
-    ) {
+    if (now - timestamp > MAX_REQUEST_AGE_MS) {
       usedNonces.delete(nonce);
     }
   }


### PR DESCRIPTION
## Summary
Replace the top-level `import crypto from "crypto"` in `src/utils/signatureValidator.js` with the Web Crypto API. The Node.js built-in `crypto` module is unavailable in browsers and causes the application bundle to crash on load.

## Changes
- Replace `import crypto from "crypto"` with a runtime-compatible `hmacSha256Hex()` helper using `window.crypto.subtle` (available in all modern browsers and Node.js ≥ 19)
- Rewrite `validateSignature()` to be `async` and use `crypto.subtle.importKey()` + `crypto.subtle.sign()` for HMAC-SHA256
- Keep the module-level `usedNonces` Map and `setInterval` cleanup (unchanged)
- Uses the same `getCrypto()` pattern already proven in `src/utils/requestSigner.js`

## Impact
**Critical / Crash** — The browser bundle cannot load while this import is present. Any page importing `signatureValidator.js` crashes with `Uncaught ReferenceError: crypto is not defined`.

Closes #9965.