### PR TITLE
fix(utils): add SSR guards to feedbackUtils.js saveFeedback/deleteFeedback/clearAllFeedback

### DIFF
--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -1,4 +1,4 @@
- 
+
 /**
  * Feedback Utilities
  * Handles localStorage-based feedback management for events
@@ -52,6 +52,7 @@ export const getEventFeedback = (eventId) => {
  * @returns {boolean} Success status
  */
 export const saveFeedback = (eventId, feedback) => {
+  if (typeof window === "undefined") return false;
   try {
     const allFeedback = safeJsonParse(localStorage.getItem(FEEDBACK_STORAGE_KEY), {});
     const rawList = allFeedback[eventId] || [];
@@ -252,6 +253,7 @@ export const getTagStats = (eventId) => {
  * @returns {boolean} Success status
  */
 export const deleteFeedback = (eventId, userId = null) => {
+  if (typeof window === "undefined") return false;
   try {
     const allFeedback = safeJsonParse(localStorage.getItem(FEEDBACK_STORAGE_KEY), {});
     const eventFeedback = allFeedback[eventId] || [];
@@ -304,6 +306,7 @@ export const exportFeedbackAsCSV = (eventId) => {
  * Clear all feedback (for testing)
  */
 export const clearAllFeedback = () => {
+  if (typeof window === "undefined") return false;
   try {
     localStorage.removeItem(FEEDBACK_STORAGE_KEY);
     return true;


### PR DESCRIPTION
## Summary
Add SSR guards to the three write-path functions in `src/utils/feedbackUtils.js` that access `localStorage` without checking for the browser environment. `getEventFeedback()` already has a guard — the write paths were missed.

## Changes
- `saveFeedback(eventId, feedback)`: Added `if (typeof window === "undefined") return false;`
- `deleteFeedback(eventId, userId)`: Added `if (typeof window === "undefined") return false;`
- `clearAllFeedback()`: Added `if (typeof window === "undefined") return false;`

## Impact
**Medium / Crash** — SSR hydration pages that render feedback widgets will crash with `ReferenceError: localStorage is not defined` when these functions are called.

Closes #9968.