### PR TITLE
fix: replace catch param reassignment (error = directError) with let finalError to preserve original 401 status when fallback throws a TypeError

### DIFF
--- a/src/utils/githubApiClient.js
+++ b/src/utils/githubApiClient.js
@@ -55,6 +55,8 @@ export const fetchGitHubJson = async (path, queryParams = {}, options = {}) => {
 
     return data;
   } catch (error) {
+    let finalError = error;
+
     if (error?.status === 401 || error?.status === 403) {
       try {
         const { data } = await fetchWithTimeout(directUrl, {
@@ -66,30 +68,27 @@ export const fetchGitHubJson = async (path, queryParams = {}, options = {}) => {
         });
         return data;
       } catch (directError) {
-        error = directError;
+        finalError = directError;
       }
     }
 
     let message = "Failed to fetch data from GitHub";
-    //let severity = "warn";
 
-    if (error instanceof FetchError) {
-      if (error.status === 403) {
+    if (finalError instanceof FetchError) {
+      if (finalError.status === 403) {
         message = "GitHub API rate limit exceeded. Please try again later.";
-      } else if (error.status === 404) {
+      } else if (finalError.status === 404) {
         message = "GitHub repository or resource not found.";
-      } else if (error.status >= 500) {
+      } else if (finalError.status >= 500) {
         message = "GitHub's servers are currently experiencing issues.";
       }
     }
 
-    // Log the error for diagnostics while providing a clean message to the UI
-    logError(error, { componentStack: "githubApiClient" }, { path, queryParams, friendlyMessage: message });
+    logError(finalError, { componentStack: "githubApiClient" }, { path, queryParams, friendlyMessage: message });
 
-    // Re-throw a clean error for the UI components to catch
     const wrappedError = new Error(message);
-    wrappedError.status = error.status;
-    wrappedError.originalError = error;
+    wrappedError.status = finalError.status ?? error.status;
+    wrappedError.originalError = finalError;
     throw wrappedError;
   }
 };


### PR DESCRIPTION
### Related Issue
Closes #9990 

### Description of Changes
- I introduced `let finalError = error` in `fetchGitHubJson`'s catch block in `githubApiClient.js`.
- I replaced `error = directError` with `finalError = directError` to avoid reassigning the catch parameter (`no-ex-assign` violation).
- I updated all subsequent references from `error` to `finalError` for consistent error handling.
- I used `finalError.status ?? error.status` for `wrappedError.status` so the original proxy HTTP status is preserved when the fallback throws a statusless network error.