### PR TITLE
Fix event details route param

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -225,7 +225,7 @@ function App() {
                           }
                         />
                         <Route
-                          path="/events/:id"
+                          path="/events/:eventId"
                           element={
                             <Suspense fallback={<EventDetailSkeleton />}>
                               <EventDetails />


### PR DESCRIPTION
## Summary
- Aligns the top-level event details route parameter with `EventDetails`.
- Fixes direct `/events/:eventId` page loads resolving `eventId` as `undefined`.

## Root cause
`App.jsx` declared `/events/:id`, while `EventDetails` reads `eventId` from `useParams()`.

## Validation
- Inspected the diff to confirm the change is limited to the route declaration.

Closes #9996
