### PR TITLE
Fix event details share modal

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -664,7 +664,11 @@ const showClosingSoon =
         </div>
 
         {showShareModal && (
-          <ShareModal event={event} onClose={() => setShowShareModal(false)} />
+          <ShareModal
+            isOpen={showShareModal}
+            event={event}
+            onClose={() => setShowShareModal(false)}
+          />
         )}
       </div>
     </>


### PR DESCRIPTION
## Summary
- Passes the existing share modal open state into `ShareModal`.
- Restores the event details share dialog for the share button and keyboard shortcut.

## Root cause
`EventDetails` conditionally mounted `ShareModal`, but did not provide the required `isOpen` prop, so the modal rendered nothing.

## Validation
- Inspected the diff to confirm the change is limited to the share modal render call.

Closes #9999
