### PR TITLE
Fix navbar create event route

### DIFF
--- a/src/components/navbar/AuthButtons.jsx
+++ b/src/components/navbar/AuthButtons.jsx
@@ -93,7 +93,7 @@ const AuthButtons = ({ isLoggedIn = false }) => {
                     {t("nav.myProfile") || "My Profile"}
                   </Link>
                   <Link
-                    to="/events/create"
+                    to="/create-event"
                     role="menuitem"
                     onClick={closeMenu}
                     className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-text-light hover:bg-bg hover:text-text transition-colors"
@@ -156,7 +156,7 @@ const AuthButtons = ({ isLoggedIn = false }) => {
       {/* Context-Aware Primary CTA */}
       {isLoggedIn ? (
         <Link
-          to="/events/create"
+          to="/create-event"
           className="px-4 py-2 rounded-lg text-sm font-semibold bg-primary text-white hover:bg-primary-hover transition-all duration-200 whitespace-nowrap shadow-sm hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 flex items-center gap-1.5"
         >
           <PlusCircle className="w-4 h-4" />

--- a/src/components/navbar/ProfileMenu.jsx
+++ b/src/components/navbar/ProfileMenu.jsx
@@ -13,7 +13,7 @@ import {
 
 const menuItems = [
   { labelKey: "nav.dashboard", path: "/dashboard", icon: LayoutDashboard },
-  { labelKey: "nav.createEvent", path: "/events/create", icon: PlusCircle },
+  { labelKey: "nav.createEvent", path: "/create-event", icon: PlusCircle },
   { labelKey: "nav.viewProfile", path: "/dashboard/profile", icon: User },
   { labelKey: "nav.about", path: "/about", icon: Info },
   { labelKey: "nav.faqFull", path: "/faq", icon: HelpCircle },


### PR DESCRIPTION
## Summary
- Point navbar create-event actions at the registered `/create-event` route.
- Update both the account menu entry and the primary logged-in CTA.
- Align `ProfileMenu` with the same registered route.

Closes #10014

## Validation
- Reviewed the navbar route references after the change.
