### PR TITLE
Fix contributor guide CTA route

### DIFF
--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -501,7 +501,7 @@ const Contributors = () => {
               <FaExternalLinkAlt className="text-sm" />
             </Link>
             <Link
-              to="/ContributorGuide"
+              to="/contributorguide"
               className="inline-flex items-center justify-center gap-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white px-8 py-3 w-full sm:w-auto rounded-full font-semibold shadow-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 hover:scale-105 transition-all duration-300 ease-out"
             >
               <span>Guide</span>


### PR DESCRIPTION
## Summary
- Update the home-page contributor guide CTA from `/ContributorGuide` to `/contributorguide`.
- Match the existing public route registration.
- Avoid routing users to the not-found page on case-sensitive route matching.

Closes #10015

## Validation
- Reviewed the link target against `src/components/routes/PublicRoutes.js`.
