### PR TITLE
Add dashboard quests route

### DIFF
--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -38,6 +38,14 @@ export default function AppRoutes() {
             </ProtectedRoute>
           }
         />
+        <Route
+          path="/dashboard/quests"
+          element={
+            <ProtectedRoute>
+              <UserAchievements />
+            </ProtectedRoute>
+          }
+        />
 
         <Route path="*" element={<NotFoundPage />} />
       </Routes>


### PR DESCRIPTION
## Summary
- Add `/dashboard/quests` as a protected route.
- Reuse the existing `UserAchievements` page, which already renders the Quest Center section.
- Keep the dashboard sidebar link target unchanged.

Closes #10013

## Validation
- Reviewed the new route entry beside `/dashboard/achievements`.
