### PR TITLE
Add jest-dom dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@storybook/addon-onboarding": "^10.4.1",
         "@storybook/preset-create-react-app": "10.4.1",
         "@storybook/react-webpack5": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "16.3.2",
         "@types/node": "^25.9.3",
         "@vitejs/plugin-react": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@storybook/addon-onboarding": "^10.4.1",
     "@storybook/preset-create-react-app": "10.4.1",
     "@storybook/react-webpack5": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "16.3.2",
     "@types/node": "^25.9.3",
     "@vitejs/plugin-react": "^6.0.2",


### PR DESCRIPTION
## Summary
- Add `@testing-library/jest-dom` as a dev dependency.
- Update the lockfile so `src/setupTests.js` can import the matcher package in clean installs.

Closes #10008

## Validation
- `npm install --save-dev @testing-library/jest-dom --package-lock-only`

Note: npm reported the existing `lint-staged` engine warning for the local Node version, but the lockfile update completed.
