### PR TITLE
Add user-event dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@storybook/preset-create-react-app": "10.4.1",
         "@storybook/react-webpack5": "^10.4.1",
         "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^25.9.3",
         "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "@storybook/preset-create-react-app": "10.4.1",
     "@storybook/react-webpack5": "^10.4.1",
     "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.9.3",
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
## Summary
- Add `@testing-library/user-event` as a dev dependency.
- Update the lockfile so React tests that import `user-event` resolve in clean installs.

Closes #10009

## Validation
- `npm install --save-dev @testing-library/user-event --package-lock-only`

Note: npm reported the existing `lint-staged` engine warning for the local Node version, but the lockfile update completed.
