### PR TITLE
fix: add missing worker-src and Sentry directives to Content Security Policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -59,10 +59,10 @@
           "key": "Cross-Origin-Resource-Policy",
           "value": "same-site"
         },
-        {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
-        },
+       {
+  "key": "Content-Security-Policy",
+  "value": "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-attr 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://eventra-backend-springboot-eybhdvaubxcua7ha.centralindia-01.azurewebsites.net https://accounts.google.com https://www.googleapis.com https://api.emailjs.com https://api.github.com https://o4511372299075584.ingest.de.sentry.io; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; worker-src blob:; upgrade-insecure-requests"
+},
         {
           "key": "Vary",
           "value": "Origin"


### PR DESCRIPTION
## Description
Two CSP violations were being logged on every page load due to missing 
directives in the `Content-Security-Policy` header inside `vercel.json`.

**Violation 1 — Missing `worker-src blob:`**
A blob worker was being blocked because `worker-src` was not explicitly 
defined. The browser fell back to `script-src` which does not permit 
blob workers, causing the worker to be killed silently.

**Violation 2 — Sentry ingest URL missing from `connect-src`**
Sentry's error reporting was being blocked because the ingest domain 
`https://o4511372299075584.ingest.de.sentry.io` was not listed in 
`connect-src`, meaning all crash reports were silently dropped.

Fixes #10028 

## Changes
- `vercel.json` — added `worker-src blob:` directive
- `vercel.json` — added Sentry ingest URL to `connect-src`

No component or logic files were modified.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports