### PR TITLE
fix: await sendChunks in channel.onopen to prevent silent error swallowing and floating Promise memory leak during DataChannel backpressure

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -557,12 +557,18 @@ export class P2PFileTransferCoordinator {
 
     this.channel.onopen = async () => {
       this.updateState("transferring", 0, "15.4 MB/s");
-      
+
       // If we already have the file cached, we act as the sender!
       if (!this.isInitiator) {
         const fileChunks = await getCachedFile(this.fileId);
         if (fileChunks) {
-          this.sendChunks(fileChunks);
+          try {
+            await this.sendChunks(fileChunks);
+          } catch (err) {
+            logger.error("sendChunks failed during P2P transfer:", err);
+            this.updateState("failed");
+            this.cleanup();
+          }
         }
       }
     };


### PR DESCRIPTION
### Related Issue
Closes #10041 


### Description of Changes
- I added `await` before `this.sendChunks(fileChunks)` in the `channel.onopen` handler in `p2pFileTransfer.js`.
- I wrapped the call in a `try/catch` so any exception from `sendChunks` (including DataChannel errors during backpressure) triggers `updateState("failed")` and `cleanup()` instead of becoming a silent unhandled rejection.
- It prevents the floating `onbufferedamountlow` Promise from hanging indefinitely when the channel closes during congestion.