### PR TITLE
fix: add onversionchange and onclose handlers to dbInstance to prevent stale IndexedDB singleton causing InvalidStateError on all cache operations

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -40,6 +40,21 @@ const getDB = () => {
     };
     request.onsuccess = (e) => {
       dbInstance = e.target.result;
+
+      // Reset the singleton if another tab upgrades the DB version.
+      // Failing to close here blocks the other tab's upgrade indefinitely.
+      dbInstance.onversionchange = () => {
+        dbInstance.close();
+        dbInstance = null;
+        logger.warn("[P2P Cache] IndexedDB version change detected. Connection closed — will reopen on next access.");
+      };
+
+      // Reset the singleton if the connection is closed for any other reason.
+      dbInstance.onclose = () => {
+        dbInstance = null;
+        logger.warn("[P2P Cache] IndexedDB connection closed unexpectedly. Will reopen on next access.");
+      };
+
       resolve(dbInstance);
     };
     request.onerror = (e) => {


### PR DESCRIPTION
### Related Issue
Closes #10043 

### Description of Changes
- I registered `dbInstance.onversionchange` in `getDB()`'s `onsuccess` handler in `p2pFileTransfer.js`.
- On version change: calls `dbInstance.close()` and resets `dbInstance = null` so the other tab's upgrade can proceed and the next `getDB()` call opens a fresh connection.
- Registered `dbInstance.onclose` to reset `dbInstance = null` if the connection closes unexpectedly for any other reason.
- Both handlers log a warning via `logger.warn` for diagnostics.