### PR TITLE
fix: don't resolve Promise true for transferring state in connectionSafetyTimeout — let checkInterval detect actual completion or failure

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -385,16 +385,20 @@ export class P2PFileTransferCoordinator {
         }
       }, 2500);
 
-      // Add a secondary connection safety timer of 5 seconds total
+      // Add a secondary connection safety timer of 5 seconds total.
+      // Only resolve for "completed" — if still "transferring", let checkInterval
+      // continue polling until the transfer finishes or fails.
       connectionSafetyTimeout = setTimeout(() => {
         if (this.currentState === "connecting" || this.currentState === "searching") {
           this.cleanup();
           clearAllTimers();
           resolve(false); // WebRTC connection handshakes timed out, fallback to server
-        } else if (this.currentState === "completed" || this.currentState === "transferring") {
+        } else if (this.currentState === "completed") {
           clearAllTimers();
-          resolve(true);
+          resolve(true); // Transfer already confirmed complete
         }
+        // "transferring" → stay alive; checkInterval will resolve on "completed" or "failed"
+        // "failed" → checkInterval already handled it
       }, 5000);
 
       // Attach state listener check to resolve immediately if completed


### PR DESCRIPTION
### Related Issue
Closes #10045 

### Description of Changes
- I removed `"transferring"` from the `connectionSafetyTimeout` resolve-true branch in `startP2PSearch` in `p2pFileTransfer.js`.
- When state is `"transferring"` at 5 seconds, the timeout now exits without resolving, keeping `checkInterval` alive to observe the final `"completed"` or `"failed"` state.
- The Promise only resolves `true` from the safety timeout when state is already `"completed"` (transfer fully confirmed), preventing false-positive success signals for in-progress transfers.