### PR TITLE
fix: guard channel.onclose against already-terminal states to prevent double updateState('failed') when onerror triggers cleanup which fires onclose

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -647,7 +647,7 @@ this.channel.onmessage = async (e) => {
     };
 
     this.channel.onclose = () => {
-      if (this.currentState !== "completed") {
+      if (this.currentState !== "completed" && this.currentState !== "failed") {
         this.updateState("failed");
       }
       this.cleanup();


### PR DESCRIPTION
### Related Issue
Closes #10051 

### Description of Changes
- I added `&& this.currentState !== "failed"` to the `channel.onclose` guard condition in `setupDataChannel` in `p2pFileTransfer.js`.
- It prevents `updateState("failed")` from firing a second time when `channel.onerror` → `cleanup()` → `channel.close()` → `channel.onclose` fires in sequence.
- It eliminates duplicate `onStateChange` calls and any double side-effects (toasts, fallback triggers, analytics events) caused by the error → close cascade.