### PR TITLE
fix: preserve login rate limit counters after successful auth

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -297,7 +297,10 @@ async function handleRequest(request) {
     responseHeaders.set("Access-Control-Allow-Credentials", "true");
     responseHeaders.set("Vary", "Origin");
     return new Response(
-      JSON.stringify({ error: "Too many requests. Please try again later." }),
+      JSON.stringify({
+        success: false,
+        error: "Too many requests. Please try again later.",
+      }),
       {
         status: 429,
         headers: responseHeaders,

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -15,9 +15,7 @@ import '../../styles/auth.css';
 import { emailPattern } from '../../validation';
 import {
   canAttempt,
-  clearAttempts,
   incrementFailures,
-  resetFailures,
   getBackoffDelay,
 } from "../../utils/authRateLimiter";
 
@@ -93,9 +91,6 @@ const Login = () => {
       }
       const ok = await login(sanitizedUsernameOrEmail, formData.password);
       if (ok) {
-        clearAttempts("login");
-        resetFailures("login");
-
         showAuthToast(
           "Login successful! Redirecting to dashboard...",
           () => navigate("/dashboard", { replace: true })


### PR DESCRIPTION
## Summary
- Stops clearing client-side login rate limit counters after a successful login, so brute-force protection stays effective across login/logout cycles
- Standardizes middleware 429 responses to include `success: false` alongside the error message

Closes #7228
