### PR TITLE
feat : add bookmarked events filter

### DIFF
--- a/src/Pages/Events/EventFiltersToolbar.js
+++ b/src/Pages/Events/EventFiltersToolbar.js
@@ -39,7 +39,6 @@ const EventFiltersToolbar = ({
   onSearchChange,
   onResetFilters,
   visibleEvents = [],
-currentFilterConfig,
 onApplyPreset,
 // totalElements = 0,
 }) => {
@@ -49,7 +48,6 @@ onApplyPreset,
   const { clearPresetError: _clearPresetError } = useEventFilterPresets();
 
   useFilterSuggestions({
-<<<<<<< HEAD
   currentFilters: {
     searchQuery,
     filterType,
@@ -61,19 +59,8 @@ onApplyPreset,
   visibleEvents,
   presets: [],
 });
-=======
-    currentFilters: {
-  searchQuery,
-  filterType,
-  categoryFilter,
-  sortType,
-  viewMode,
-  advancedFilters,
-},
-    visibleEvents,
-    presets: [],
-  });
->>>>>>> 4bae66c7 ( feat(events) : add registration progress indicator to event details)
+    
+
 
   useEffect(() => {
     setLocalQuery(searchQuery || "");
@@ -210,6 +197,7 @@ onApplyPreset,
             { key: "live", label: "Live Now" },
             { key: "upcoming", label: "Upcoming" },
             { key: "past", label: "Past Events" },
+            { key: "bookmarked", label: "⭐Bookmarked" },
           ].map((tab) => {
             const isActive = filterType === tab.key;
 

--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -12,7 +12,7 @@ import {
   normalizeAdvancedFilters,
 } from "../../utils/advancedFilterUtils";
 import { getRouteSearchResults } from "../../utils/searchUtils.mjs";
-
+import { getBookmarkedEvents } from "../../utils/bookmarkUtils";
 
 const DEFAULT_EVENTS_PER_PAGE = 12;
 
@@ -226,13 +226,25 @@ const useEventListing = () => {
       : [...events];
 
     // 2. Status timing filter
-    filtered = filtered.filter((event) => {
-      const status = getEventStatus(event);
-      if (filterType === "live" && status !== "live") return false;
-      if (filterType === "upcoming" && status !== "upcoming") return false;
-      if (filterType === "past" && status !== "past" && status !== "ended") return false;
-      return true;
-    });
+filtered = filtered.filter((event) => {
+  const status = getEventStatus(event);
+
+  if (filterType === "live" && status !== "live") return false;
+
+  if (filterType === "upcoming" && status !== "upcoming") return false;
+
+  if (filterType === "past" && status !== "past" && status !== "ended") return false;
+
+  if (filterType === "bookmarked") {
+    const bookmarks = getBookmarkedEvents();
+
+    return bookmarks.some(
+      (bookmark) => String(bookmark.id) === String(event.id)
+    );
+  }
+
+  return true;
+});
 
     // 3. Category filter
     const target = categoryFilter && categoryFilter !== "all"


### PR DESCRIPTION
## 📌 Summary

This PR introduces a new **Bookmarked Events** filter in the Events page, allowing users to quickly view only the events they have bookmarked.

The feature improves navigation and provides a faster way to revisit saved events without manually searching through the complete event list.

---

## ✨ What's Added

- ⭐ Added a **Bookmarked** filter option to the Events filter toolbar.
- 🔖 Displays only bookmarked events when the filter is selected.
- 💾 Uses the existing bookmark storage (`bookmarkUtils`) without changing the bookmark system.
- 🔄 Integrates seamlessly with the current filtering workflow.
- 🎨 Maintains the existing UI and user experience.

---

## 🧪 Testing

- ✅ Verified bookmarked events are displayed correctly.
- ✅ Verified non-bookmarked events are hidden.
- ✅ Tested bookmark add/remove behavior.
- ✅ Confirmed existing filters continue to work normally.
- ✅ No breaking changes introduced.

---

## 📷 Screenshots

<!-- Add screenshots or screen recordings here if available -->

---

Closes #9890