### PR TITLE
fix: add Sentry ingest domain to CSP connect-src

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,7 +24,7 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=(), payment=(), usb=(), bluetooth=()"
     Cross-Origin-Opener-Policy = "same-origin-allow-popups"
     Cross-Origin-Resource-Policy = "same-site"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com; frame-src 'self' https://accounts.google.com"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://o4511372299075584.ingest.de.sentry.io; frame-src 'self' https://accounts.google.com"
 
 [[headers]]
   for = "/"


### PR DESCRIPTION
Fixes #9985

## Problem
The CSP `connect-src` directive in `netlify.toml` did not include Sentry's
ingest domain, so the browser blocked outgoing error-tracking requests in
production. Client-side errors were silently never reported.

## Fix
Added `https://o4511372299075584.ingest.de.sentry.io` to `connect-src` in
`netlify.toml`.

## Testing
Verified the updated CSP header locally by checking `netlify.toml` matches
the working Sentry-inclusive CSP already present in `vercel.json`.