### PR TITLE
fix: correct undefined export in ProjectsPage causing ReferenceError …

### DIFF
--- a/src/Pages/Projects/ProjectsPage.js
+++ b/src/Pages/Projects/ProjectsPage.js
@@ -530,4 +530,4 @@ const InnerGallery = () => {
   );
 };
 
-export default Project
+export default ProjectGallery;


### PR DESCRIPTION
Fixes #9986

## Problem
`ProjectsPage.js` exported a bare `Project` identifier that was never
declared anywhere in the file — the actual component defined and meant
to be exported is `ProjectGallery`. This caused a `ReferenceError:
Project is not defined` at runtime, crashing the Projects route and
triggering the app's ErrorBoundary fallback ("Something went wrong").
It also broke route prefetching for the same reason.

## Fix
Changed `export default Project` to `export default ProjectGallery;`

## Testing
Verified the export now correctly references the defined component.