### PR TITLE
fix: truncate survey sanitizer input before regex to prevent ReDoS

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -144,24 +144,28 @@ export const validate = {
   /**
    * Survey sanitizers & XSS guards.
    * Capped to 150 chars for prompts, 80 for options.
+   * Input is truncated before regex evaluation to prevent ReDoS.
    */
   sanitizeSurveyPrompt: (val) => {
     if (typeof val !== "string") return "";
-    let cleaned = val.replace(/<\/?[^>]+(>|$)/g, "");
+    let cleaned = val.length > 300 ? val.substring(0, 300) : val;
+    cleaned = cleaned.replace(/<\/?[^>]+(>|$)/g, "");
     if (cleaned.length > 150) cleaned = cleaned.substring(0, 150);
     return cleaned;
   },
 
   sanitizeSurveyOption: (val) => {
     if (typeof val !== "string") return "";
-    let cleaned = val.replace(/<\/?[^>]+(>|$)/g, "");
+    let cleaned = val.length > 200 ? val.substring(0, 200) : val;
+    cleaned = cleaned.replace(/<\/?[^>]+(>|$)/g, "");
     if (cleaned.length > 80) cleaned = cleaned.substring(0, 80);
     return cleaned;
   },
 
   detectHTML: (val) => {
     if (typeof val !== "string") return false;
-    return /<\/?[^>]+(>|$)/g.test(val);
+    const bounded = val.length > 300 ? val.substring(0, 300) : val;
+    return /<\/?[^>]+(>|$)/g.test(bounded);
   },
 };
 

--- a/src/validation.test.js
+++ b/src/validation.test.js
@@ -268,6 +268,15 @@ describe("Validation Utilities", () => {
         expect(validate.detectHTML("<p>Hello</p>")).toBe(true);
         expect(validate.detectHTML("Hello world")).toBe(false);
       });
+
+      it("truncates oversized input before regex evaluation to avoid ReDoS", () => {
+        const malicious = "<".repeat(50_000);
+        const start = performance.now();
+        expect(validate.sanitizeSurveyPrompt(malicious)).toBe("");
+        expect(validate.sanitizeSurveyOption(malicious)).toBe("");
+        expect(validate.detectHTML(malicious)).toBe(true);
+        expect(performance.now() - start).toBeLessThan(100);
+      });
     });
   });
 


### PR DESCRIPTION
##Summary

Truncates input before the HTML-stripping regex in sanitizeSurveyPrompt, sanitizeSurveyOption, and detectHTML. Includes a ReDoS performance test.

Closes #4146