### PR TITLE
chore(events): clean unused variables in EventDetails

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -253,7 +253,7 @@ ${window.location.href}
       toast.success("Event link copied to clipboard!");
       setLinkCopied(true);
       setTimeout(() => setLinkCopied(false), 2000);
-    } catch (_err) {
+    } catch {
       toast.error("Failed to copy link. Please copy the URL from your browser's address bar.");
     }
   };
@@ -331,7 +331,7 @@ const showClosingSoon =
                 {event.type}
               </p>
               <div className="mt-4 flex items-center gap-3">
-                <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight break-words" title={event.title}>{event.title}</h1>
+                <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight wrap-break-word" title={event.title}>{event.title}</h1>
                 <button
                   onClick={handleCopy}
                   className={`p-2 rounded-full transition-colors ${linkCopied
@@ -450,7 +450,7 @@ const showClosingSoon =
                                   }
                                 }
                                 exportToCSV(allRegistrants, `${event.title}_registrants`);
-                              } catch (_error) {
+                              } catch  {
                                 toast.error("Failed to fetch registrants");
                               } finally {
                                 setExportingRegistrants(false);
@@ -488,7 +488,7 @@ const showClosingSoon =
                                   }
                                 }
                                 exportToJSON(allRegistrants, `${event.title}_registrants`);
-                              } catch (_error) {
+                              } catch {
                                 toast.error("Failed to fetch registrants");
                               } finally {
                                 setExportingRegistrants(false);


### PR DESCRIPTION
Solves #10088 

// Before
```
catch (_err) {
    toast.error(...);
}
```

// After
```
catch {
    toast.error(...);
}
```