### PR TITLE
fix: decrement negation window by 1 per keyword instead of resetting to 0 so all keywords within the 3-word window are negated not just the first

### DIFF
--- a/src/utils/sentiment.js
+++ b/src/utils/sentiment.js
@@ -51,20 +51,22 @@ export const analyzeSentiment = (text) => {
       value = -1.5;
     }
     
-    if (value !== 0) {
-      if (negateNext && negateWindow > 0) {
-        score -= value; // Invert the sentiment score change
-        negateNext = false;
-        negateWindow = 0;
-      } else {
-        score += value;
-      }
-    } else if (negateNext) {
-      negateWindow -= 1;
+  if (value !== 0) {
+    if (negateNext && negateWindow > 0) {
+      score -= value; // Invert the sentiment score change
+      negateWindow -= 1; // consume one window slot, same as a neutral word
       if (negateWindow <= 0) {
         negateNext = false;
       }
+    } else {
+      score += value;
     }
+  } else if (negateNext) {
+    negateWindow -= 1;
+    if (negateWindow <= 0) {
+      negateNext = false;
+    }
+  }
   });
 
   // Clamp the score between -5 and +5


### PR DESCRIPTION
### Related Issue
Closes #10103 

### Description of Changes
- In `analyzeSentiment` in `sentiment.js`, replaced `negateNext = false; negateWindow = 0` (full reset) with `negateWindow -= 1; if (negateWindow <= 0) negateNext = false` (incremental decrement) in the negation branch.
- Negated keywords now consume one window slot — identical to neutral words — so all sentiment keywords within the 3-word negation window are correctly inverted.
- Single-keyword negations ("not great") behave identically; compound negations ("not great excellent") now correctly score negative.