### PR TITLE
fix(sentiment): add cant to NEGATION_WORDS, strip apostrophes for contractions, and fix negation window resetting after first keyword match

### DIFF
--- a/src/utils/sentiment.js
+++ b/src/utils/sentiment.js
@@ -18,7 +18,7 @@ const NEGATIVE_KEYWORDS = new Set([
 ]);
 
 const NEGATION_WORDS = new Set([
-  "not", "no", "never", "dont", "cannot", "doesnt", "didnt",
+  "not", "no", "never", "dont", "cant", "cannot", "doesnt", "didnt",
   "isnt", "wasnt", "arent", "neither", "none", "without", "lack", "lacks",
   "havent", "hadnt", "hasnt", "wont", "wouldnt", "couldnt", "shouldnt"
 ]);
@@ -28,8 +28,10 @@ export const analyzeSentiment = (text) => {
     return 0; // Neutral default
   }
 
-  const normalized = text.toLowerCase();
-  
+  // Strip apostrophes before tokenizing so contractions like "don't" → "dont",
+  // "doesn't" → "doesnt", "can't" → "cant" match NEGATION_WORDS correctly
+  const normalized = text.toLowerCase().replace(/'/g, "");
+
   // Simple word tokenization matching alphabetic sequences
   const words = normalized.match(/[a-z]+/g) || [];
   
@@ -54,8 +56,10 @@ export const analyzeSentiment = (text) => {
     if (value !== 0) {
       if (negateNext && negateWindow > 0) {
         score -= value; // Invert the sentiment score change
-        negateNext = false;
-        negateWindow = 0;
+        negateWindow -= 1; // consume one window slot
+        if (negateWindow <= 0) {
+          negateNext = false;
+        }
       } else {
         score += value;
       }


### PR DESCRIPTION
### Related Issues
Closes #10106

### Summary of Changes
Three negation-correctness bugs fixed together in `src/utils/sentiment.js`.

### Fix 1 — Add `"cant"` to `NEGATION_WORDS`
`"can't"` → strip apostrophe → `"cant"`, but only `"cannot"` existed in the
set. `"can't love this"` incorrectly scored +1.5.

### Fix 2 — Strip apostrophes before tokenizing 
`[a-z]+` splits `"don't"` into `["don","t"]` — neither token matched
`NEGATION_WORDS`. Added `.replace(/'/g, "")` before tokenizing so all
contractions collapse to their existing set entries.

### Fix 3 — Decrement window by 1 per keyword, not reset to 0 
After the first keyword negation, `negateNext=false; negateWindow=0` killed
all remaining window slots. Changed to `negateWindow -= 1` so all keywords
within the stated "next 3 words" window are correctly inverted.

### Test Matrix
| Phrase | Before | After | Expected |
|---|---|---|---|
| `"can't love it"` | +1.5 ❌ | −1.5 ✓ | Negative |
| `"don't love it"` | +1.5 ❌ | −1.5 ✓ | Negative |
| `"doesn't work great"` | +1.5 ❌ | −1.5 ✓ | Negative |
| `"not great excellent"` | 0 ❌ | −3.0 ✓ | Very Negative |
| `"not great"` | −1.5 ✓ | −1.5 ✓ | Negative |
| `"love this"` | +1.5 ✓ | +1.5 ✓ | Positive |