### PR TITLE
fix: add focus trap and Escape handling to EventCancellationModal and EventFeedbackModal

### DIFF
--- a/src/components/events/EventCancellationModal.jsx
+++ b/src/components/events/EventCancellationModal.jsx
@@ -7,12 +7,13 @@
 // Delegates the actual API call to useEventCancellation().
 // ---------------------------------------------------------------------------
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import useEventCancellation, {
   REFUND_POLICIES,
   REFUND_POLICY_LABELS,
 } from "../../hooks/useEventCancellation";
+import FocusTrap from "../common/FocusTrap";
 
 /**
  * EventCancellationModal
@@ -26,6 +27,19 @@ const EventCancellationModal = ({ event, onClose, onSuccess }) => {
   const [reason, setReason] = useState("");
   const [refundPolicy, setRefundPolicy] = useState(REFUND_POLICIES.FULL);
   const [refundPercent, setRefundPercent] = useState(50);
+
+  // The parent unmounts this component entirely on close (rather than toggling
+  // an `isOpen` prop), so useFocusTrap's built-in restore-on-deactivate effect
+  // never runs. Restore focus manually via unmount cleanup instead.
+  const previouslyFocusedRef = useRef(null);
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement;
+    return () => {
+      if (previouslyFocusedRef.current?.focus) {
+        previouslyFocusedRef.current.focus();
+      }
+    };
+  }, []);
 
   const { cancel, isCancelling, cancellationError } = useEventCancellation(
     event?.id,
@@ -41,13 +55,14 @@ const EventCancellationModal = ({ event, onClose, onSuccess }) => {
 
   return (
     // Backdrop
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="cancel-event-title"
-    >
-      <div className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-gray-900 shadow-2xl p-6">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <FocusTrap isActive onEscape={isCancelling ? undefined : onClose}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cancel-event-title"
+          className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-gray-900 shadow-2xl p-6"
+        >
 
         {/* Close button */}
         <button
@@ -187,7 +202,8 @@ const EventCancellationModal = ({ event, onClose, onSuccess }) => {
             )}
           </button>
         </div>
-      </div>
+        </div>
+      </FocusTrap>
     </div>
   );
 };

--- a/src/components/events/EventCancellationModal.jsx
+++ b/src/components/events/EventCancellationModal.jsx
@@ -15,6 +15,9 @@ import useEventCancellation, {
 } from "../../hooks/useEventCancellation";
 import FocusTrap from "../common/FocusTrap";
 
+// Restores focus to a previously-focused element, if it's still focusable.
+const restoreFocusTo = (el) => el?.focus?.();
+
 /**
  * EventCancellationModal
  *
@@ -34,11 +37,7 @@ const EventCancellationModal = ({ event, onClose, onSuccess }) => {
   const previouslyFocusedRef = useRef(null);
   useEffect(() => {
     previouslyFocusedRef.current = document.activeElement;
-    return () => {
-      if (previouslyFocusedRef.current?.focus) {
-        previouslyFocusedRef.current.focus();
-      }
-    };
+    return () => restoreFocusTo(previouslyFocusedRef.current);
   }, []);
 
   const { cancel, isCancelling, cancellationError } = useEventCancellation(

--- a/src/components/feedback/EventFeedbackModal.jsx
+++ b/src/components/feedback/EventFeedbackModal.jsx
@@ -4,6 +4,7 @@ import { X, CheckCircle, ThumbsUp, ThumbsDown } from 'lucide-react';
 import StarRating from './StarRating';
 import { saveFeedback, getUserFeedback } from '../../utils/feedbackUtils';
 import { toast } from 'react-toastify';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 /**
  * EventFeedbackModal Component
@@ -16,6 +17,7 @@ const EventFeedbackModal = ({ isOpen, onClose, event }) => {
   const [selectedTags, setSelectedTags] = useState([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
+  const { containerRef } = useFocusTrap(isOpen, onClose);
 
   const FEEDBACK_TAGS = [
     'Well Organized',
@@ -104,15 +106,19 @@ const EventFeedbackModal = ({ isOpen, onClose, event }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
       <motion.div
+        ref={containerRef}
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.95 }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-feedback-title"
         className="w-full max-w-lg rounded-2xl bg-white dark:bg-gray-900 shadow-2xl border border-gray-200 dark:border-gray-800"
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-800 p-6">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            <h2 id="event-feedback-title" className="text-2xl font-bold text-gray-900 dark:text-white">
               Share Your Feedback
             </h2>
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{event.title}</p>


### PR DESCRIPTION
## Summary

Fixes #10108.

`EventCancellationModal` and `EventFeedbackModal` rendered as dialogs but neither trapped keyboard focus nor closed on Escape, unlike `Modal.jsx`/`OfflineConflictModal.jsx`, which already implement this correctly elsewhere in the codebase.

- **`EventCancellationModal.jsx`**: wraps the dialog panel in the existing `FocusTrap` component; Escape now closes the dialog (gated on `isCancelling`, consistent with the other exit affordances — the ✕ button and "Keep Event" — which are already disabled during an in-flight cancel/refund request). Since the parent (`EventDetails.js`) unmounts this component entirely on close rather than toggling an `isOpen` prop, `useFocusTrap`'s own restore-on-deactivate effect never gets a chance to run — added a small manual restore-focus-on-unmount effect to cover that case.
- **`EventFeedbackModal.jsx`**: switched from wrapping in `<FocusTrap>` (which only mounted while `isOpen` was true, so its restore-focus effect never fired across the toggle) to calling `useFocusTrap` directly in the component body, mirroring `OfflineConflictModal.jsx`'s pattern. Also added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` (plus the `id` on the header it points to), which were missing entirely.

No new dependencies — both fixes reuse the `FocusTrap`/`useFocusTrap` infrastructure already proven elsewhere in the repo.

## Test plan

- [ ] Open the "Cancel Event" flow (organizer/admin) — confirm Tab stays contained inside the dialog, Escape closes it (except mid-cancel), and focus returns to the "Cancel Event" trigger button after closing.
- [ ] Open the event feedback modal — confirm Tab containment, Escape-to-close, and focus return to the trigger button.
- [ ] `npm run lint` / `npm run test` pass.