### PR TITLE
fix: use centralized API URL in waitlist service

### DIFF
--- a/src/services/waitlistService.js
+++ b/src/services/waitlistService.js
@@ -1,4 +1,6 @@
-const API_URL = process.env.REACT_APP_API_URL;
+import { ENV } from '../config/env';
+
+const API_URL = ENV.API_URL;
 
 export const joinWaitlist = async (eventId, token) => {
   const response = await fetch(`${API_URL}/waitlist/join/${eventId}`, {


### PR DESCRIPTION
## Description

This PR fixes the waitlist service to use the project's centralized environment configuration instead of directly accessing the Create React App-specific environment variable.

Previously, `src/services/waitlistService.js` used `process.env.REACT_APP_API_URL`, which is not the standard environment variable source for this Vite-based project. This could result in an undefined API base URL and cause all waitlist API requests to fail.

### Changes Made

- Replaced the direct use of `process.env.REACT_APP_API_URL`.
- Updated the waitlist service to use the centralized `ENV.API_URL` configuration from `src/config/env.js`.
- Kept all existing API endpoints, request methods, and response handling unchanged.
- Aligned the waitlist service with the project's standard environment variable resolution pattern.

Fixes #10110 

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Screenshots / Video (if applicable)

N/A (Configuration fix)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports