### PR TITLE
Fix leaderboard stat key mismatch

### DIFF
--- a/src/utils/leaderboardUtils.js
+++ b/src/utils/leaderboardUtils.js
@@ -130,6 +130,8 @@ export function computeLeaderboardStats(contributors) {
     totalContributors: contributors.length,
     totalPRs,
     totalPoints,
+    flooredTotalPRs: Math.floor(totalPRs),
+    flooredTotalPoints: Math.floor(totalPoints),
   };
 }
 


### PR DESCRIPTION
## Summary
- return the `flooredTotalPRs` and `flooredTotalPoints` keys consumed by leaderboard UI components
- keep the existing `totalPRs` and `totalPoints` fields for compatibility

## Validation
- `node --import ./tests/setup.js --test tests/leaderboardUtils.test.mjs`

Closes #10122