### PR TITLE
Fix GitHubStats pull request count sampling

### DIFF
--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -17,17 +17,26 @@ import {
 
 import { safeJsonParse } from "../../../utils/safeJsonParse";
 import { ENV } from "../../../config/env";
-import {
-  fetchRepository,
-  fetchContributors,
-  fetchPullRequests,
-} from "../../../utils/githubApiClient";
+import { fetchGitHubJson } from "../../../utils/githubApiClient";
 
 const repoPath = ENV.GITHUB_REPO;
 const [GITHUB_USER, GITHUB_REPO] = repoPath.split("/");
 
 const LS_KEY = "eventra:repoStats";
 const CACHE_MS = 30 * 60 * 1000; // 30 min
+const PULL_REQUESTS_PAGE_SIZE = 100;
+
+const fetchRepository = (owner, repo) =>
+  fetchGitHubJson(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`);
+
+const fetchContributors = (owner, repo, page, perPage) =>
+  fetchGitHubJson(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contributors`, {
+    page,
+    per_page: perPage,
+  });
+
+const fetchPullRequests = (owner, repo, params) =>
+  fetchGitHubJson(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls`, params);
 
 const readCache = () => {
   try {
@@ -75,7 +84,10 @@ export default function GitHubStats() {
           await Promise.allSettled([
             fetchRepository(GITHUB_USER, GITHUB_REPO),
             fetchContributors(GITHUB_USER, GITHUB_REPO, 1, 1),
-            fetchPullRequests(GITHUB_USER, GITHUB_REPO, { per_page: 1 }),
+            fetchPullRequests(GITHUB_USER, GITHUB_REPO, {
+              state: "all",
+              per_page: PULL_REQUESTS_PAGE_SIZE,
+            }),
           ]);
 
         if (repoResult.status === "rejected") {
@@ -103,7 +115,10 @@ export default function GitHubStats() {
         if (prResult.status === "fulfilled") {
           const pullRequests = prResult.value;
           if (Array.isArray(pullRequests) && pullRequests.length > 0) {
-            prCount = pullRequests.length;
+            prCount =
+              pullRequests.length === PULL_REQUESTS_PAGE_SIZE
+                ? `${PULL_REQUESTS_PAGE_SIZE}+`
+                : pullRequests.length;
           }
         } else if (prResult.status === "rejected") {
           prCount = "—";


### PR DESCRIPTION
## Summary
- fetch up to 100 pull requests instead of a one-item sample
- include all PR states for the summary metric
- display `100+` when the result is capped at the page size

## Validation
- `VITE_API_URL=http://localhost:8080 npm run build`

Closes #10124