### PR TITLE
Remove unsupported Vite rollup cache option

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -129,7 +129,6 @@ export default defineConfig(({ mode }) => {
       },
       manifest: true,
       rollupOptions: {
-        cache: true,
         onwarn(warning, warn) {
           if (warning.code === "MODULE_LEVEL_DIRECTIVE") return;
           warn(warning);


### PR DESCRIPTION
## Summary
- remove the unsupported `build.rollupOptions.cache` setting
- keep the existing Vite cache directory configuration in place

## Validation
- `VITE_API_URL=http://localhost:8080 npm run build`
- confirmed the previous invalid `cache` option warning no longer appears

Closes #10127