### PR TITLE
Fix Node ESM utility imports

### DIFF
--- a/src/services/sessionRecoveryService.js
+++ b/src/services/sessionRecoveryService.js
@@ -1,6 +1,6 @@
-import { API_ENDPOINTS, apiUtils } from "../config/api";
-import { sanitizeSessionState } from "../utils/sessionSanitization";
-import { safeJsonParse } from "../utils/safeJsonParse";
+import { API_ENDPOINTS, apiUtils } from "../config/api.js";
+import { sanitizeSessionState } from "../utils/sessionSanitization.js";
+import { safeJsonParse } from "../utils/safeJsonParse.js";
 
 export const CLOUD_RECOVERY_PENDING_KEY = "eventra:cloud-session-recovery:pending:v1";
 export const CLOUD_RECOVERY_CACHE_KEY = "eventra:cloud-session-recovery:cache:v1";

--- a/src/utils/eventCreationUtils.js
+++ b/src/utils/eventCreationUtils.js
@@ -1,4 +1,4 @@
-import { parseTimeString } from "./timezoneUtils";
+import { parseTimeString } from "./timezoneUtils.js";
 
 export const parseTimeToMinutes = (timeStr) => {
   if (!timeStr) return 0;

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -31,7 +31,7 @@ const mapStatusKey = (status = "") => {
   return explicitStatusMap[normalized] ?? null;
 };
 
-import { getServerTime } from "./timeSync";
+import { getServerTime } from "./timeSync.js";
 
 const parseEventDate = (dateValue) => {
   if (!dateValue) return null;

--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -1,4 +1,4 @@
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 
 const DEFAULT_TIMEOUT = 10000;
 

--- a/src/utils/githubApiClient.js
+++ b/src/utils/githubApiClient.js
@@ -1,5 +1,5 @@
-import { fetchWithTimeout, FetchError } from "./fetchWithTimeout";
-import { logError } from "./errorLogger";
+import { fetchWithTimeout, FetchError } from "./fetchWithTimeout.js";
+import { logError } from "./errorLogger.js";
 
 const GITHUB_HOST = "github.com";
 

--- a/src/utils/offlineEventCache.js
+++ b/src/utils/offlineEventCache.js
@@ -1,4 +1,4 @@
-import { safeJsonParse } from "./safeJsonParse";
+import { safeJsonParse } from "./safeJsonParse.js";
 
 const EVENTS_CACHE_KEY = "eventra_cached_events";
 const EVENT_DETAILS_CACHE_KEY = "eventra_cached_event_details";


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions to local utility imports exercised by native Node ESM tests
- keep Vite-compatible import paths while allowing `.mjs` tests to load the same modules directly

## Validation
- `node --import ./tests/setup.js --test tests/eventCreationUtils.test.mjs tests/eventUtils.test.mjs tests/fetchWithTimeout.test.mjs tests/githubApiClient.test.mjs tests/multiSessionRecovery.test.mjs tests/offlineEventCache.test.mjs`

Closes #10128