### PR TITLE
Replace invalid text wrapping utility

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -333,7 +333,7 @@ const lastUpdated = getLastUpdated(event.updatedAt);
                 {event.type}
               </p>
               <div className="mt-4 flex items-center gap-3">
-                <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight wrap-break-word" title={event.title}>{event.title}</h1>
+                <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight break-words" title={event.title}>{event.title}</h1>
                 <button
                   onClick={handleCopy}
                   className={`p-2 rounded-full transition-colors ${linkCopied

--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -244,7 +244,7 @@ export default function GitHubStats() {
                     <div className="p-2 sm:p-3 md:p-4 bg-gray-50 dark:bg-gray-700 rounded-full shadow-inner [&>svg]:w-7 [&>svg]:h-7 sm:[&>svg]:w-9 sm:[&>svg]:h-9 md:[&>svg]:w-10 md:[&>svg]:h-10">
                       {icon}
                     </div>
-                    <p className="text-base sm:text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100 text-center wrap-break-word px-1">
+                    <p className="text-base sm:text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100 text-center break-words px-1">
                       {value}
                     </p>
                     <p className="text-xs sm:text-sm font-medium text-gray-500 dark:text-gray-400 text-center px-1">

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -404,7 +404,7 @@ const WhatsHappening = () => {
                               </span>
                             </div>
 
-                            <h3 title={event.title} className="text-lg sm:text-xl font-semibold text-slate-900 dark:text-white mb-2 leading-snug group-hover:text-brand-violet dark:group-hover:text-brand-violet transition-colors line-clamp-2 wrap-break-word min-w-0">
+                            <h3 title={event.title} className="text-lg sm:text-xl font-semibold text-slate-900 dark:text-white mb-2 leading-snug group-hover:text-brand-violet dark:group-hover:text-brand-violet transition-colors line-clamp-2 break-words min-w-0">
                               {event.title}
                             </h3>
                             

--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -245,7 +245,7 @@ const EventCreation = () => {
 
                 <div className="p-8 space-y-8">
                   <div className="space-y-4">
-                    <h2 className="text-3xl font-bold text-gray-900 dark:text-white wrap-break-word">
+                    <h2 className="text-3xl font-bold text-gray-900 dark:text-white break-words">
                       {formData.title}
                     </h2>
                     <div className="flex flex-wrap gap-2">

--- a/src/components/events/LiveQABoard.jsx
+++ b/src/components/events/LiveQABoard.jsx
@@ -84,7 +84,7 @@ function QuestionCard({ q, isModerator, onUpvote, onFlag, onDelete }) {
             <AlertTriangle className="h-3 w-3" /> Flagged for moderation
           </span>
         )}
-        <p className="text-sm text-slate-200 wrap-break-word leading-relaxed font-sans">{q.text}</p>
+        <p className="text-sm text-slate-200 break-words leading-relaxed font-sans">{q.text}</p>
         <span className="text-[10px] text-slate-500 font-medium">{formatTime(q.createdAt)}</span>
       </div>
 


### PR DESCRIPTION
## Summary
- replace invalid `wrap-break-word` class usage with Tailwind's `break-words` utility
- cover event details, home stats, home event cards, event creation, and live Q&A text

## Validation
- `rg -n wrap-break-word src`
- `VITE_API_URL=http://localhost:8080 npm run build`

Closes #10129