### PR TITLE
Respect timezone in event creation payload

### DIFF
--- a/src/utils/eventCreationUtils.js
+++ b/src/utils/eventCreationUtils.js
@@ -1,4 +1,4 @@
-import { parseTimeString } from "./timezoneUtils";
+import { parseTimeString, resolveEventInstant } from "./timezoneUtils";
 
 export const parseTimeToMinutes = (timeStr) => {
   if (!timeStr) return 0;
@@ -57,16 +57,27 @@ export const buildEventPayload = (formData) => {
     );
   }
 
-  const eventStartDate = new Date(
-    `${formData.isMultiDay ? formData.startDate : formData.date}T${formData.startTime}`
+  const eventStartDate = resolveEventInstant(
+    formData.isMultiDay ? formData.startDate : formData.date,
+    formData.startTime,
+    formData.timezone,
   );
-  const eventEndDate = new Date(
-    `${formData.isMultiDay ? formData.endDate : formData.date}T${formData.endTime}`
+  const eventEndDate = resolveEventInstant(
+    formData.isMultiDay ? formData.endDate : formData.date,
+    formData.endTime,
+    formData.timezone,
   );
 
   if (isNaN(eventStartDate.getTime()) || isNaN(eventEndDate.getTime())) {
     throw new Error("Invalid date or time format");
   }
+
+  const registrationStart = formData.registrationStart
+    ? resolveEventInstant(formData.registrationStart, "12:00 AM", formData.timezone)
+    : null;
+  const registrationEnd = formData.registrationEnd
+    ? resolveEventInstant(formData.registrationEnd, "11:59 PM", formData.timezone)
+    : null;
 
   return {
     title: formData.title.trim(),
@@ -86,12 +97,8 @@ export const buildEventPayload = (formData) => {
     capacity: formData.capacity ? Number(formData.capacity) : null,
     isPublic: formData.isPublic,
     requiresApproval: formData.requiresApproval,
-    registrationStart: formData.registrationStart
-      ? new Date(formData.registrationStart).toISOString()
-      : null,
-    registrationEnd: formData.registrationEnd
-      ? new Date(formData.registrationEnd).toISOString()
-      : null,
+    registrationStart: registrationStart ? registrationStart.toISOString() : null,
+    registrationEnd: registrationEnd ? registrationEnd.toISOString() : null,
     category: formData.category,
     tags: formData.tags.filter((tag) => tag.trim()),
     ticketTiers: formData.ticketTiers


### PR DESCRIPTION
## Summary
- use the existing timezone-aware instant resolver for event start and end timestamps
- apply the selected event timezone to registration window timestamps as well
- keep null registration dates as null in the payload

## Validation
- `VITE_API_URL=http://localhost:8080 npm run build`

Closes #10130