### PR TITLE
Use default branch for license link

### DIFF
--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -56,6 +56,7 @@ export default function GitHubStats() {
     pullRequests: 0,
     releases: 0,
     license: "N/A",
+    defaultBranch: "master",
     watchers: 0,
     languages: {},
   });
@@ -122,6 +123,7 @@ export default function GitHubStats() {
           pullRequests: prCount,
           releases: "—",
           license: repoData.license?.spdx_id || "N/A",
+          defaultBranch: repoData.default_branch || "master",
           watchers: repoData.subscribers_count || 0,
           languages: {},
         };
@@ -186,7 +188,7 @@ export default function GitHubStats() {
       label: "License",
       value: stats.license,
       icon: <Scale className="text-gray-600 dark:text-gray-400" size={40} />,
-      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/blob/main/LICENSE`,
+      link: `https://github.com/${GITHUB_USER}/${GITHUB_REPO}/blob/${stats.defaultBranch || "master"}/LICENSE`,
     },
     {
       label: "Last Update",


### PR DESCRIPTION
## Summary
- store the repository default branch from GitHub metadata
- build the License card URL from that branch instead of hardcoding `main`
- keep `master` as the fallback branch for this repository

## Validation
- `VITE_API_URL=http://localhost:8080 npm run build`

Closes #10131