### PR TITLE
fix: add tabId to SSE_MESSAGE broadcast so leader self-filter correctly drops its own rebroadcast and prevents double dispatch to local callbacks

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -31,7 +31,7 @@ const MESSAGE_REQUIRED_FIELDS = {
   UNSUBSCRIBE_ALL: ["tabId", "paths"],
   QUERY_SUBSCRIBERS: ["tabId"],
   SUBSCRIBERS_RESPONSE: ["tabId", "paths"],
-  SSE_MESSAGE: ["path", "data"],
+  SSE_MESSAGE: ["path", "data", "tabId"],
   SSE_STATUS: ["path", "status", "tabId"],
   RECONNECT_REQUEST: ["path"],
   PING: ["tabId"],
@@ -495,6 +495,7 @@ class SseMultiplexer {
         path,
         data: payload,
         eventType: evt.type,
+        tabId: this.tabId,
       });
     };
 


### PR DESCRIPTION
### Related Issue
Closes #10157 

### Description of Changes
- I added `tabId: this.tabId` to the `broadcastMessage` call for `SSE_MESSAGE`
  inside `openEventSource` in `sseMultiplexer.js`.
- I added `"tabId"` to `MESSAGE_REQUIRED_FIELDS.SSE_MESSAGE` so the
  `isValidBroadcastMessage` validator enforces its presence on all future
  `SSE_MESSAGE` broadcasts.
- The existing self-filter `msg.tabId === this.tabId` in `handleBroadcastMessage`
  now correctly drops the leader's own rebroadcast, preventing the double
  `dispatchLocalMessage` call per SSE event.