### PR TITLE
fix: guard becomeLocalStorageLeader after writeHeartbeat to prevent starting leader-only intervals and broadcasting QUERY_SUBSCRIBERS when leadership is immediately revoked

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -234,6 +234,10 @@ class SseMultiplexer {
     };
     writeHeartbeat();
 
+    // Leadership may have been revoked inside writeHeartbeat if a competing
+    // leader was detected. Guard before starting any leader-only infrastructure.
+    if (!this.isLeader) return;
+
     // Heartbeat loop — keep the entry fresh while leadership is held
     if (this.heartbeatInterval) {
       clearInterval(this.heartbeatInterval);


### PR DESCRIPTION
### Related Issue
Closes #10160 

### Description of Changes
- I added `if (!this.isLeader) return` immediately after the synchronous
  `writeHeartbeat()` call in `becomeLocalStorageLeader` in `sseMultiplexer.js`.
- It prevents `setInterval(writeHeartbeat)`, `startHeartbeatChecks()`, and
  `queryGlobalSubscribers()` from running when `writeHeartbeat` detects a
  competing live leader and revokes `this.isLeader = false`.
- It eliminates the stale `globalSubscribers` pollution from spurious
  `QUERY_SUBSCRIBERS` broadcasts sent by a tab that immediately loses the
  leadership race.