### PR TITLE
fix: show API timeout duration in seconds, not milliseconds

### DIFF
--- a/src/config/api/errors.js
+++ b/src/config/api/errors.js
@@ -35,7 +35,7 @@ export const normalizeApiError = (error) => {
     error.message?.includes("timeout")
   ) {
     return new ApiError(
-      `Request timed out after ${config.timeout || 15000 / 1000}s: ${config.method?.toUpperCase()} ${config.url}`,
+      `Request timed out after ${(config.timeout || 15000) / 1000}s: ${config.method?.toUpperCase()} ${config.url}`,
       { status, isTimeout: true }
     );
   }

--- a/tests/apiError.test.mjs
+++ b/tests/apiError.test.mjs
@@ -45,6 +45,12 @@ try {
   assert.equal(normalized.name, "ApiError");
   assert.equal(normalized.isTimeout, true);
   assert.ok(normalized.message.includes("timed out"));
+  assert.ok(normalized.message.includes("after 5s"), "timeout should be shown in seconds");
+  assert.ok(!normalized.message.includes("after 5000s"), "timeout must not show raw milliseconds");
+
+  const defaultTimeoutErr = { code: "ECONNABORTED", config: { method: "get", url: "/events" } };
+  const defaultNormalized = normalizeApiError(defaultTimeoutErr);
+  assert.ok(defaultNormalized.message.includes("after 15s"));
 
   // --- normalizeApiError: network error (no response) ---
   const netErr = { message: "Failed to fetch", config: { method: "post", url: "/api/login" } };


### PR DESCRIPTION
Closes #9591