### PR TITLE
Fix EventsTab toast import

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -25,7 +25,7 @@ import EmptyState from "../common/EmptyState";
 import { useDebouncedSearch } from "../../hooks/useDebouncedSearch";
 import { useOfflineStatus } from "../../hooks/useOfflineStatus";
 import LazyImage from "../common/LazyImage";
-import toast from "react-hot-toast";
+import { toast } from "react-toastify";
 
 /* ---------------- Helper Functions (Extracted to reduce complexity) ---------------- */
 


### PR DESCRIPTION
## Summary
- switch EventsTab to the toast package already declared by the project
- remove the dependency on an undeclared package

Closes #10181

## Checks
- not run; dependency install is not present in this checkout