### PR TITLE
Harden recent events storage parsing

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -459,7 +459,7 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
 
   // Load recent events from localStorage
   useEffect(() => {
-    const stored = JSON.parse(localStorage.getItem("recentEvents") || "[]");
+    const stored = safeParseJson(localStorage.getItem("recentEvents"), []);
     setRecentEvents(stored);
     const saved = safeParseJson(localStorage.getItem("recentSearches"), []);
     setRecentSearches(saved);
@@ -504,7 +504,7 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   const triggerWaitlistUpdate = () => setWaitlistUpdated(prev => !prev);
 
   const addToRecentEvents = (event) => {
-    const existing = JSON.parse(localStorage.getItem("recentEvents") || "[]");
+    const existing = safeParseJson(localStorage.getItem("recentEvents"), []);
     const filtered = existing.filter((e) => e.id !== event.id && e.eventId !== event.id);
     const updated = [event, ...filtered].slice(0, 6);
     localStorage.setItem("recentEvents", JSON.stringify(updated));


### PR DESCRIPTION
## Summary
- parse recentEvents with the existing safe JSON helper
- fall back to an empty list when stored data is malformed

Closes #10186

## Checks
- not run; dependency install is not present in this checkout