### PR TITLE
Harden contributor search history parsing

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -10,6 +10,7 @@ import { STORAGE_KEYS } from "../utils/storage/storageKeys";
 import { validators } from "../utils/storage/storageValidators";
 import { fetchWithTimeout } from "../utils/fetchWithTimeout";
 import EmptyState from "../common/EmptyState";
+import { safeParseJson } from "../utils/jsonUtils";
 // GitHub repo
 const GITHUB_REPO = "sandeepvashishtha/Eventra";
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hr
@@ -228,9 +229,9 @@ const ContributorsInner = () => {
   }, [fetchContributors]);
 useEffect(() => {
   const saved =
-    JSON.parse(localStorage.getItem("contributorSearchHistory")) || [];
+    safeParseJson(localStorage.getItem("contributorSearchHistory"), []);
 
-  setRecentSearches(saved);
+  setRecentSearches(Array.isArray(saved) ? saved : []);
 }, []);
   // Filter contributors based on search term
   const filteredContributors = contributors.filter(


### PR DESCRIPTION
## Summary
- parse contributor search history with the safe JSON helper
- fall back to an empty list when stored data is malformed or not an array

Closes #10187

## Checks
- not run; dependency install is not present in this checkout