### PR TITLE
Fix copy link URL handling

### DIFF
--- a/src/components/common/CopyLinkButton.jsx
+++ b/src/components/common/CopyLinkButton.jsx
@@ -2,27 +2,36 @@ import { useState } from "react";
 import { Link2, Check } from "lucide-react";
 import { toast } from "react-toastify";
 
-const CopyLinkButton = () => {
+const CopyLinkButton = ({ url, title = "Event", text = "Check out this event!" }) => {
   const [copied, setCopied] = useState(false);
+  const textToCopy = url || (typeof window !== "undefined" ? window.location.href : "");
+
+  const markCopied = () => {
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
 
   const handleCopy = async () => {
   try {
+    if (!textToCopy) return;
+
     if (navigator.share) {
       await navigator.share({
-        title: "Event",
-        text: "Check out this event!",
+        title,
+        text,
         url: textToCopy,
       });
+      markCopied();
+      toast.success("Link shared successfully");
       return;
     }
 
     await navigator.clipboard.writeText(textToCopy);
 
-    setCopied(true);
-
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
+    markCopied();
+    toast.success("Link copied successfully");
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
## Summary
- give CopyLinkButton a defined URL value before share or copy actions run
- keep button state feedback consistent after sharing or copying

Closes #10188

## Checks
- node --test tests/copyLinkButtonIntegrity.test.mjs