### PR TITLE
Use fallback share link copy

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { toast } from "react-toastify";
 import { createShareModalData } from "../../utils/shareModalUtils.js";
+import { copyToClipboard } from "../../utils/shareUtils.js";
 const ModalCloseButton = memo(({ onClick }) => (
   <button
     type="button"
@@ -36,12 +37,12 @@ const ShareModal = ({ isOpen, onClose, event }) => {
     if (!shareData?.shareUrl) return;
 
     try {
-      if (!navigator?.clipboard) {
-        throw new Error("Clipboard API unavailable.");
+      const copied = await copyToClipboard(shareData.shareUrl);
+      if (copied) {
+        toast.success("Link copied to clipboard");
+      } else {
+        toast.error("Could not copy the link");
       }
-
-      await navigator.clipboard.writeText(shareData.shareUrl);
-      toast.success("Link copied to clipboard");
     } catch (error) {
       console.error("Failed to copy share link:", error);
       toast.error("Could not copy the link");

--- a/src/components/common/SocialShareButtons.jsx
+++ b/src/components/common/SocialShareButtons.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from "react";
 import { Copy, Facebook, Linkedin, Mail, MessageCircle, Send, Twitter } from "lucide-react";
 import { toast } from "react-toastify";
-import { isValidShareUrl } from "../../utils/shareUtils";
+import { copyToClipboard, isValidShareUrl } from "../../utils/shareUtils";
 
 const SocialShareButtons = ({ event, layout = "grid" }) => {
   const shareData = useMemo(() => {
@@ -29,12 +29,12 @@ const SocialShareButtons = ({ event, layout = "grid" }) => {
     if (!shareData?.shareUrl) return;
 
     try {
-      if (!navigator?.clipboard) {
-        throw new Error("Clipboard API unavailable.");
+      const copied = await copyToClipboard(shareData.shareUrl);
+      if (copied) {
+        toast.success("Link copied to clipboard");
+      } else {
+        toast.error("Could not copy the link");
       }
-
-      await navigator.clipboard.writeText(shareData.shareUrl);
-      toast.success("Link copied to clipboard");
     } catch (error) {
       console.error("Failed to copy share link:", error);
       toast.error("Could not copy the link");


### PR DESCRIPTION
## Summary
- route share link copy actions through the existing shared clipboard helper
- keep copy working in contexts where the Clipboard API is unavailable

Closes #10189

## Checks
- not run; dependency install is not present in this checkout