### PR TITLE
Guard realtime polling stream setup

### DIFF
--- a/src/components/events/RealtimePolling.jsx
+++ b/src/components/events/RealtimePolling.jsx
@@ -6,6 +6,8 @@ const RealtimePolling = ({ eventId }) => {
   const [activePoll, setActivePoll] = useState(null);
 
   useEffect(() => {
+    if (!eventId) return undefined;
+
     // Simulated SSE connection for active polls
     const evtSource = new EventSource(`/api/events/${eventId}/polls/stream`);
     evtSource.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- skip realtime poll stream setup until an event id is available
- prevent requests to undefined event stream paths

Closes #10190

## Checks
- not run; dependency install is not present in this checkout