### PR TITLE
[codex] guard EventsTab recentEvents parsing

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -371,18 +371,14 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   );
 
   useEffect(() => {
-    const stored = JSON.parse(
-      localStorage.getItem("recentEvents") || "[]"
-    );
+    const stored = safeParseJson(localStorage.getItem("recentEvents"), []);
     setRecentEvents(stored);
     const saved = safeParseJson(localStorage.getItem("recentSearches"), []);
     setRecentSearches(saved);
   }, []);
 
   const addToRecentEvents = (event) => {
-    const existing = JSON.parse(
-      localStorage.getItem("recentEvents") || "[]"
-    );
+    const existing = safeParseJson(localStorage.getItem("recentEvents"), []);
 
     const filtered = existing.filter((e) => e.id !== event.id);
     const updated = [event, ...filtered].slice(0, 6);

--- a/tests/eventsTabStorageSafety.test.mjs
+++ b/tests/eventsTabStorageSafety.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../src/components/user/EventsTab.js", import.meta.url),
+  "utf8"
+);
+
+assert.match(
+  source,
+  /safeParseJson\(localStorage\.getItem\("recentEvents"\), \[\]\)/,
+  "EventsTab must parse recentEvents with the safe JSON helper"
+);
+
+assert.doesNotMatch(
+  source,
+  /JSON\.parse\(\s*localStorage\.getItem\("recentEvents"\)\s*\|\|\s*"\[\]"\s*\)/,
+  "EventsTab must not use raw JSON.parse for recentEvents storage"
+);
+
+console.log("EventsTab storage safety tests passed");


### PR DESCRIPTION
Fixes #10186

This replaces the raw recentEvents JSON.parse calls in EventsTab with the repo safe JSON helper, so malformed storage falls back to an empty list instead of crashing the page.

Validation:
- git diff --check
- node --test tests/eventsTabStorageSafety.test.mjs
