### PR TITLE
[codex] guard ApiDocs env access

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -3,6 +3,9 @@ import { motion } from "framer-motion";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import useReducedMotion from "../hooks/useReducedMotion.js";
 import { Server, AlertCircle, BookOpen, Users, Trophy, Play, RefreshCw, Terminal, Settings } from "lucide-react";
+import { ENV } from "../config/env";
+
+const API_URL = ENV.API_URL || "";
 
 const endpoints = [
   {
@@ -32,7 +35,7 @@ const endpoints = [
     desc: "Retrieve projects submitted to hackathons.",
     method: "GET",
     url: "/mock-api/projects?hackathonId=<id>",
-example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
+    example: `curl -X GET ${API_URL}/projects?hackathonId=1`,
     response: `[
   {
     "id": 42,
@@ -48,7 +51,7 @@ example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
     desc: "Get a list of top contributors and GSOC participants.",
     method: "GET",
     url: "/mock-api/contributors",
-  example: `fetch("${process.env.REACT_APP_API_URL}/contributors", {
+  example: `fetch("${API_URL}/contributors", {
   headers: { Authorization: "Bearer <API_KEY>" }
 })`,
     response: `[
@@ -66,7 +69,7 @@ example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
     desc: "Fetch leaderboard rankings of participants.",
     method: "GET",
     url: "/mock-api/leaderboard?limit=10",
-    example: `curl -X GET \${process.env.REACT_APP_API_URL}/leaderboard?limit=10`,
+    example: `curl -X GET \${API_URL}/leaderboard?limit=10`,
     response: `[
   {
     "rank": 1,

--- a/tests/apiDocsEnvSafety.test.mjs
+++ b/tests/apiDocsEnvSafety.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../src/Pages/ApiDocs.js", import.meta.url),
+  "utf8"
+);
+
+assert.match(
+  source,
+  /import\s+\{\s*ENV\s*\}\s+from\s+"\.{2}\/config\/env"/,
+  "ApiDocs must import the centralized env helper"
+);
+
+assert.match(
+  source,
+  /const API_URL = ENV\.API_URL \|\| "";/,
+  "ApiDocs must derive a browser-safe API_URL constant"
+);
+
+assert.doesNotMatch(
+  source,
+  /process\.env\.REACT_APP_API_URL/,
+  "ApiDocs must not reference REACT_APP_API_URL directly in browser code"
+);
+
+console.log("ApiDocs env safety tests passed");


### PR DESCRIPTION
Fixes #10184

This removes direct browser references to process.env.REACT_APP_API_URL from ApiDocs and routes the examples through the repo-safe ENV.API_URL helper instead.

Validation:
- git diff --check
- node --test tests/apiDocsEnvSafety.test.mjs
