### PR TITLE
[codex] improve AddToCalendar icon accessibility

### DIFF
--- a/src/components/common/AddToCalendar.jsx
+++ b/src/components/common/AddToCalendar.jsx
@@ -106,11 +106,11 @@ export default function AddToCalendar({ event, className = '', iconOnly = false 
             </button>
           </div>
           <button onClick={handleGoogle} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left">
-            <img src="https://www.google.com/favicon.ico" alt="" className="w-4 h-4" loading="lazy" />
+            <img src="https://www.google.com/favicon.ico" alt="Google Calendar icon" className="w-4 h-4" loading="lazy" />
             Google Calendar
           </button>
           <button onClick={handleOutlook} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left border-t border-gray-100 dark:border-gray-800">
-            <img src="https://outlook.live.com/favicon.ico" alt="" className="w-4 h-4" loading="lazy" />
+            <img src="https://outlook.live.com/favicon.ico" alt="Outlook Calendar icon" className="w-4 h-4" loading="lazy" />
             Outlook Calendar
           </button>
           <button onClick={handleIcal} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left border-t border-gray-100 dark:border-gray-800">

--- a/tests/addToCalendarAccessibility.test.mjs
+++ b/tests/addToCalendarAccessibility.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../src/components/common/AddToCalendar.jsx", import.meta.url),
+  "utf8"
+);
+
+assert.match(source, /alt="Google Calendar icon"/, "Google Calendar icon needs descriptive alt text");
+assert.match(source, /alt="Outlook Calendar icon"/, "Outlook Calendar icon needs descriptive alt text");
+assert.doesNotMatch(source, /alt=""/, "AddToCalendar should not use empty alt text for meaningful icons");
+
+console.log("AddToCalendar accessibility tests passed");


### PR DESCRIPTION
Fixes #10034

This adds descriptive alt text to the Google Calendar and Outlook calendar icons in AddToCalendar so screen readers can identify the icons instead of encountering empty decorative alt text.

Validation:
- git diff --check
- node --test tests/addToCalendarAccessibility.test.mjs
