### PR TITLE
[codex] wire current filter config in EventFiltersToolbar

### DIFF
--- a/src/Pages/Events/EventFiltersToolbar.js
+++ b/src/Pages/Events/EventFiltersToolbar.js
@@ -37,6 +37,7 @@ const EventFiltersToolbar = ({
   searchQuery,
   onSearchChange,
   onResetFilters,
+  currentFilterConfig = {},
   visibleEvents = [],
   // totalElements = 0,
 }) => {
@@ -296,4 +297,3 @@ const EventFiltersToolbar = ({
 };
 
 export default memo(EventFiltersToolbar);
-

--- a/src/tests/eventFiltersToolbar.test.js
+++ b/src/tests/eventFiltersToolbar.test.js
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect } from "vitest";
+
+const source = readFileSync(
+  new URL("../Pages/Events/EventFiltersToolbar.js", import.meta.url),
+  "utf8",
+);
+
+describe("EventFiltersToolbar source contract", () => {
+  it("accepts currentFilterConfig from props", () => {
+    expect(source).toContain("currentFilterConfig = {}");
+  });
+
+  it("forwards currentFilterConfig into useFilterSuggestions", () => {
+    expect(source).toContain("currentFilters: currentFilterConfig");
+  });
+});


### PR DESCRIPTION
Fix the EventFiltersToolbar crash by passing the already-computed `currentFilterConfig` into `useFilterSuggestions` instead of referencing an undefined variable.

This keeps the suggestion hook aligned with the filter state already built in `EventsPage` and prevents the filter panel from crashing on mount.

Validation:
- `git diff --check`
- `node -e` source contract check for the toolbar wiring

Closes #9851
