### PR TITLE
[codex] handle registration 429 errors

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -47,6 +47,7 @@ import {
 import { pushToQueue } from "../utils/offlineQueue";
 import { logError } from "../utils/errorLogger";
 import { logAbuseAttempt } from "../utils/abuseLogger";
+import { getRegistrationFailureMessage as formatRegistrationFailureMessage } from "../utils/registrationFailureMessage";
 import hackathonsData from "../../Pages/Hackathons/hackathonMockData.json";
 import registrationLocks from "../utils/registrationLocks";
 
@@ -55,32 +56,6 @@ export const MAX_NOTES_CHARS = 500;
 // Registration lock map to prevent concurrent registrations for the same event
 // const registrationLocks = new Map();
 // registrationLimiterRef initialized at hook scope with 3 tokens, 0.3/sec refill
-
-/**
- * Derives a user-facing error message from a failed registration API response.
- */
-const getRegistrationFailureMessage = (error) => {
-  const message = error?.data?.message || error?.data?.error || error?.message || "";
-  const normalizedMessage = message.toLowerCase();
-
-  if (error?.status === 409 && /already registered|duplicate/.test(normalizedMessage)) {
-    return "You are already registered for this event.";
-  }
-
-  if (
-    error?.status === 409 ||
-    error?.status === 423 ||
-    /capacity|full|sold out|max(?:imum)? capacity/.test(normalizedMessage)
-  ) {
-    return "This event has reached maximum capacity. Please choose another event.";
-  }
-
-  if (/conflict/.test(normalizedMessage)) {
-    return "Registration could not be completed because the server reported a conflict.";
-  }
-
-  return message || "Registration failed. Please try again.";
-};
 
 const useEventRegistration = (eventIdParam) => {
   const { eventId: routeEventId, id: routeId } = useParams();
@@ -354,7 +329,7 @@ const useEventRegistration = (eventIdParam) => {
       addRegistration(event, formData);
       clearSession();
     } catch (error) {
-      const failureMessage = getRegistrationFailureMessage(error);
+      const failureMessage = formatRegistrationFailureMessage(error);
       const isOfflineFailure = error?.isNetworkError || error?.isTimeout;
       const isAlreadyRegistered = failureMessage === "You are already registered for this event.";
 

--- a/src/utils/registrationFailureMessage.js
+++ b/src/utils/registrationFailureMessage.js
@@ -1,0 +1,32 @@
+export const getRegistrationFailureMessage = (error) => {
+  const message = error?.data?.message || error?.data?.error || error?.message || "";
+  const normalizedMessage = message.toLowerCase();
+
+  if (error?.status === 409 && /already registered|duplicate/.test(normalizedMessage)) {
+    return "You are already registered for this event.";
+  }
+
+  if (error?.status === 429) {
+    const retryAfterSeconds = Number(error?.data?.retryAfter || error?.retryAfter || error?.headers?.["retry-after"]);
+    const waitMessage = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+      ? `Please wait about ${Math.ceil(retryAfterSeconds)} seconds and try again.`
+      : "Please wait a moment and try again.";
+    return `Too many requests. ${waitMessage}`;
+  }
+
+  if (
+    error?.status === 409 ||
+    error?.status === 423 ||
+    /capacity|full|sold out|max(?:imum)? capacity/.test(normalizedMessage)
+  ) {
+    return "This event has reached maximum capacity. Please choose another event.";
+  }
+
+  if (/conflict/.test(normalizedMessage)) {
+    return "Registration could not be completed because the server reported a conflict.";
+  }
+
+  return message || "Registration failed. Please try again.";
+};
+
+export default getRegistrationFailureMessage;

--- a/tests/useEventRegistrationFailureMessage.test.mjs
+++ b/tests/useEventRegistrationFailureMessage.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { getRegistrationFailureMessage } from "../src/utils/registrationFailureMessage.js";
+
+assert.equal(
+  getRegistrationFailureMessage({ status: 429 }),
+  "Too many requests. Please wait a moment and try again.",
+);
+
+assert.equal(
+  getRegistrationFailureMessage({ status: 409, data: { message: "Already registered" } }),
+  "You are already registered for this event.",
+);
+
+console.log("useEventRegistration failure message tests passed ✓");


### PR DESCRIPTION
Surface HTTP 429 registration failures with a user-friendly message instead of letting the booking flow fail without context.

I moved the failure-message formatting into a small utility so the hook can reuse it cleanly, and added explicit 429 handling with an optional Retry-After hint when the server provides one.

Validation:
- `git diff --check`
- `node --test tests/useEventRegistrationFailureMessage.test.mjs`

Closes #9850
