### PR TITLE
[codex] guard desktop state for SSR

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,7 +80,10 @@ function App() {
   });
   const [showKeyboardModal, setShowKeyboardModal] = useState(false);
   const [showChatbot, setShowChatbot] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(window.innerWidth >= 1024);
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth >= 1024;
+  });
 
   useLenis();
   useRoutePrefetch(); // Predictive route pre-loading


### PR DESCRIPTION
## Summary
- replace the eager window.innerWidth initializer with a lazy SSR-safe initializer
- prevent App.jsx from crashing when rendered without window

Closes #9631

## Validation
- git diff --check
- npm exec eslint src/App.jsx (blocked: this checkout does not have local node_modules, so ESLint could not load globals from eslint.config.js)
