### PR TITLE
[codex] guard useLocalStorage removal for SSR

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -83,6 +83,7 @@ const useLocalStorage = (key, initialValue) => {
 
   const removeValue = useCallback(() => {
     try {
+      if (typeof window === "undefined") return;
       window.localStorage.removeItem(key);
       setStoredValue(initialValueRef.current);
 


### PR DESCRIPTION
## Summary
- add an SSR guard at the top of removeValue in useLocalStorage
- prevent localStorage removal from crashing when window is unavailable

Closes #9629

## Validation
- git diff --check
- node --check src/hooks/useLocalStorage.js
