### PR TITLE
[codex] guard token expiry redirect for SSR

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -21,7 +21,9 @@ export function useTokenExpiry({ token, user, onExpired }) {
       toastId: "session-expired",
       autoClose: 4000,
     });
-    setTimeout(() => window.location.replace("/login"), 1500);
+    setTimeout(() => {
+      if (typeof window !== "undefined") window.location.replace("/login");
+    }, 1500);
   }, [onExpired]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- guard the delayed login redirect in useTokenExpiry so it only runs in the browser
- prevent the timeout callback from touching window during SSR

Closes #9630

## Validation
- git diff --check
- node --check src/hooks/useTokenExpiry.js
