### PR TITLE
[codex] add Vite backend URL fallback

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,13 +16,8 @@ const env = loadEnv(mode, process.cwd(), "");
   const backendTarget =
     env.BACKEND_URL ||
     env.VITE_API_URL?.replace(/\/api\/?$/, "") ||
-    env.REACT_APP_API_URL?.replace(/\/api\/?$/, "");
-
-  if (!backendTarget) {
-    throw new Error(
-      "Backend URL is not configured. Set BACKEND_URL, VITE_API_URL, or REACT_APP_API_URL before starting the application."
-    );
-  }
+    env.REACT_APP_API_URL?.replace(/\/api\/?$/, "") ||
+    "http://localhost:8080";
 
   return {
     plugins: [


### PR DESCRIPTION
## Summary
- default Vite's backend target to the documented localhost URL when no env var is provided
- keep dev startup working for fresh clones without a .env file

Closes #9594

## Validation
- git diff --check
- node --check vite.config.js
