### PR TITLE
fix: add word-boundary anchors to keywordPattern to prevent substring matches

### DIFF
--- a/src/config/chatbotKnowledge.js
+++ b/src/config/chatbotKnowledge.js
@@ -37,7 +37,9 @@ const keywordIndex = knowledgeBaseConfig.reduce((acc, item) => {
 const sortedKeywords = [...keywordIndex.keys()].sort((a, b) => b.length - a.length);
 
 const keywordPattern = new RegExp(
-  sortedKeywords.map((kw) => kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|"),
+  sortedKeywords
+    .map((kw) => `\\b${kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`)
+    .join("|"),
   "i"
 );
 


### PR DESCRIPTION
### Related Issue
Closes #10220 

### Description of Changes
- I wrapped each keyword with `\\b...\\b` in the `keywordPattern` `RegExp`
  constructor in `chatbotKnowledge.js`.
- It eliminates substring false-positives (e.g. `"ghost"` triggering the
  `"host"` knowledge entry) while preserving all legitimate full-word matches.
- No impact on inflected forms users intentionally type (`"hosting"`,
  `"attending"`, `"registered"`) — `\b` anchors at the START of the keyword
  still allow suffix continuations to match (e.g. `\bhost\b` does NOT match
  `"hosting"`, which may be desirable to tighten further if needed).