### PR TITLE
fix: add null/type guard to getAssistantReply to prevent TypeError crash when input is null, undefined, or non-string

### DIFF
--- a/src/config/chatbotKnowledge.js
+++ b/src/config/chatbotKnowledge.js
@@ -88,6 +88,15 @@ export function getInitialMessages(t, pathname = "") {
 }
 
 export function getAssistantReply(input, t) {
+  if (!input || typeof input !== "string") {
+    return {
+      answer: t("chatbot.knowledge.default"),
+      actions: [
+        { label: t("chatbot.knowledge.exploreEvents"), to: "/events", icon: "CalendarDays" },
+      ],
+    };
+  }
+
   const match = input.match(keywordPattern);
   const matchedKeyword = match ? match[0].toLowerCase() : null;
   const matchedItem = matchedKeyword ? keywordIndex.get(matchedKeyword) : null;


### PR DESCRIPTION
### Related Issue
Closes #10222 

### Description of Changes
- I added `if (!input || typeof input !== "string")` guard at the top of
  `getAssistantReply` in `chatbotKnowledge.js`.
- It returns the same default fallback `{ answer, actions }` object the function
  already returns for unrecognised input — no new code path, just an early
  exit before `input.match()` can throw.