### PR TITLE
[codex] guard csv exports for SSR

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -69,6 +69,9 @@ export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv"
   if (!attendees || attendees.length === 0) {
     return;
   }
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
 
   // Sanitize the filename: strip OS reserved characters and path separators.
   // Fall back to a safe default if sanitization produces an empty string.
@@ -130,6 +133,9 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
   if (!questions || questions.length === 0 || !responses || responses.length === 0) {
     return;
   }
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
 
   // Sanitize the filename to strip OS path separators and reserved chars
   const sanitizedTitle = surveyTitle.replace(/[/\\:*?"<>|]/g, "_").trim() || "Survey";
@@ -177,6 +183,9 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
  */
 export const exportEventsToCSV = (events, filename = "eventra-events.csv") => {
   if (!events || events.length === 0) {
+    return;
+  }
+  if (typeof window === "undefined" || typeof document === "undefined") {
     return;
   }
 

--- a/tests/exportCsv.test.mjs
+++ b/tests/exportCsv.test.mjs
@@ -45,6 +45,17 @@ globalThis.document = {
 
 const { exportAttendeesToCSV, exportEventsToCSV } = await import("../src/utils/exportCsv.js");
 
+const savedWindow = globalThis.window;
+const savedDocument = globalThis.document;
+delete globalThis.window;
+delete globalThis.document;
+const ssrModule = await import("../src/utils/exportCsv.js?ssr");
+assert.doesNotThrow(() => ssrModule.exportAttendeesToCSV([{ name: "A" }]), "SSR attendee export is a no-op");
+assert.doesNotThrow(() => ssrModule.exportSurveyToCSV([{ id: "q1", questionText: "Q1" }], [{ answers: { q1: "A" } }]), "SSR survey export is a no-op");
+assert.doesNotThrow(() => ssrModule.exportEventsToCSV([{ id: 1 }]), "SSR event export is a no-op");
+globalThis.window = savedWindow;
+globalThis.document = savedDocument;
+
 exportAttendeesToCSV([
   {
     name: '=HYPERLINK("http://evil.com","click")',


### PR DESCRIPTION
## Summary
- add SSR guards to the CSV export helpers before they touch window or document
- keep browser downloads unchanged while making server-side imports safe
- extend the existing CSV tests with an import path that runs without browser globals

Closes #9466

## Validation
- git diff --check
- node --test tests/exportCsv.test.mjs
