### PR TITLE
[codex] guard multi-session storage defaults

### DIFF
--- a/src/utils/multiSessionRecovery.js
+++ b/src/utils/multiSessionRecovery.js
@@ -205,7 +205,7 @@ export const groupRecoverySessionsByType = (sessions = []) =>
   }, {});
 
 export const readMultiSessions = (
-  storage = globalThis.localStorage,
+  storage = null,
   key = MULTI_SESSION_RECOVERY_KEY,
 ) => {
   if (!storage?.getItem) return [];
@@ -221,7 +221,7 @@ export const readMultiSessions = (
 
 export const writeMultiSessions = (
   sessions = [],
-  storage = globalThis.localStorage,
+  storage = null,
   key = MULTI_SESSION_RECOVERY_KEY,
 ) => {
   const normalized = normalizeMultiSessions(sessions);

--- a/tests/multiSessionRecovery.test.mjs
+++ b/tests/multiSessionRecovery.test.mjs
@@ -124,6 +124,8 @@ assert.equal(cleanupExpiredRecoverySessions([eventDraft, expired], t2.getTime())
 const storage = createStorage();
 writeMultiSessions([eventDraft, profileDraft], storage, "multi");
 assert.equal(readMultiSessions(storage, "multi").length, 2);
+assert.deepEqual(readMultiSessions(), []);
+assert.deepEqual(writeMultiSessions([eventDraft]), normalizeMultiSessions([eventDraft]));
 storage.setItem("multi", "{bad json");
 assert.deepEqual(readMultiSessions(storage, "multi"), []);
 assert.equal(storage.has("multi"), false);


### PR DESCRIPTION
## Summary
- change multi-session recovery storage defaults from globalThis.localStorage to null
- keep the existing optional chaining path so SSR and non-browser imports stay harmless
- extend the existing test file with no-storage assertions for the read and write helpers

Closes #9516

## Validation
- git diff --check
- node --test tests/multiSessionRecovery.test.mjs (blocked by a pre-existing ESM directory import error from src/services/sessionRecoveryService.js -> src/config/api in this checkout)
