### PR TITLE
[codex] guard p2p IndexedDB access for SSR

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -21,7 +21,7 @@ let dbInstance = null;
 // Initialize IndexedDB
 const getDB = () => {
   if (dbInstance) return Promise.resolve(dbInstance);
-  if (typeof indexedDB === "undefined") {
+  if (typeof window === "undefined" || typeof indexedDB === "undefined") {
     return Promise.reject(new Error("IndexedDB is not available in this environment"));
   }
   return new Promise((resolve, reject) => {

--- a/tests/p2pFileTransfer.test.mjs
+++ b/tests/p2pFileTransfer.test.mjs
@@ -71,6 +71,12 @@ globalThis.BroadcastChannel = MockBroadcastChannel;
 // Now import the coordinator
 const { P2PFileTransferCoordinator } = await import("../src/utils/p2pFileTransfer.js");
 
+const savedWindow = globalThis.window;
+delete globalThis.window;
+const ssrModule = await import("../src/utils/p2pFileTransfer.js?ssr");
+assert.equal(await ssrModule.isFileCached("ssr-file"), false, "SSR cache lookup should fall back cleanly");
+globalThis.window = savedWindow;
+
 // Define test cases
 async function runTests() {
   console.log("Starting P2PFileTransferCoordinator tests...");


### PR DESCRIPTION
## Summary
- guard IndexedDB access in getDB with a window check before touching browser-only APIs
- keep browser behavior unchanged while making SSR and non-window environments safe
- extend the existing P2P test file with an SSR import path that verifies cache lookup degrades cleanly

Closes #9515

## Validation
- git diff --check
- node --test tests/p2pFileTransfer.test.mjs
