### PR TITLE
fix: add .catch() blocks to WaitlistButton API calls to prevent unhandled rejections

### DIFF
--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -11,14 +11,30 @@ const useWaitlist = ({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated,
   useEffect(() => {
     if (!isFullyBooked || !waitlistEnabled) return;
 
-    getWaitlistCount(eventId).then(data => setWaitlistCount(data.count));
+    let cancelled = false;
+
+    getWaitlistCount(eventId)
+      .then(data => {
+        if (!cancelled) setWaitlistCount(data.count);
+      })
+      .catch(() => {
+        // Silently ignore — default count of 0 is already set
+      });
 
     if (isAuthenticated && token) {
-      getWaitlistStatus(eventId, token).then(data => {
-        setOnWaitlist(data.onWaitlist);
-        setPosition(data.position);
-      });
+      getWaitlistStatus(eventId, token)
+        .then(data => {
+          if (!cancelled) {
+            setOnWaitlist(data.onWaitlist);
+            setPosition(data.position);
+          }
+        })
+        .catch(() => {
+          // Silently ignore — defaults (false / null) are already set
+        });
     }
+
+    return () => { cancelled = true; };
   }, [eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token]);
 
   const handleClick = async () => {


### PR DESCRIPTION
## Summary

Fixes #10238 — adds .catch() blocks and a cancellation flag to the WaitlistButton component's useEffect API calls.

## Problem

The useWaitlist hook calls getWaitlistCount() and getWaitlistStatus() in useEffect without .catch() handlers. When the API fails or the user loses connection, this throws an Unhandled Promise Rejection, which can crash the component or leave it in an infinite loading state.

## Solution

1. Added .catch() blocks to both getWaitlistCount() and getWaitlistStatus() calls — they silently handle failures since the default state values are already reasonable (count=0, onWaitlist=false)
2. Added a cancellation flag (let cancelled = false) and cleanup function (return () => { cancelled = true }) to prevent state updates after the component unmounts
3. Wrapped state updates in the .then() callbacks with if (!cancelled) checks

## Files Changed

- src/components/common/WaitlistButton.js — .catch() blocks + cancellation flag

## Behavior

- On API failure: the component gracefully falls back to defaults (waitlist count = 0, user not on waitlist)
- On unmount during fetch: no state updates are attempted
- Existing click-to-join/leave behavior is unchanged