### PR TITLE
feat: add onError callback and gradient fallback for broken event thumbnails

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -166,6 +166,7 @@ const CapacityBar = ({ attendees, maxAttendees }) => {
 
 const EventCard = ({ event, matchScore, matchReasons }) => {
   const [isBookmarked, setIsBookmarked] = useState(() => isEventBookmarked(event.id));
+  const [imageFailed, setImageFailed] = useState(false);
   const titleId = useId();
   const { myEvents, isRegistered } = useMyEvents();
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
@@ -221,12 +222,13 @@ const EventCard = ({ event, matchScore, matchReasons }) => {
       <div className="relative h-44 overflow-hidden bg-slate-900">
         <div className={`absolute inset-0 bg-gradient-to-br ${gradient} ${eventImage ? "opacity-25" : "opacity-80"}`} />
 
-        {eventImage ? (
+        {eventImage && !imageFailed ? (
           <LazyImage
             src={eventImage}
             alt={`${event.title} event banner`}
             className="absolute inset-0 w-full h-full"
             imgClassName="object-cover w-full h-full opacity-90 group-hover:scale-105 transition-transform duration-700"
+            onError={() => setImageFailed(true)}
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center">

--- a/src/components/common/LazyImage.jsx
+++ b/src/components/common/LazyImage.jsx
@@ -11,7 +11,7 @@ import '../../styles/lazy-image.css';
  *   - layout shift prevention via width, height, and aspectRatio support
  *   - accessibility (a11y) compliance — pass a descriptive `alt` for content images;
  *     use `alt=""` only for decorative images
- *   - broken image fallback error handling
+ *   - broken image fallback with gradient placeholder and error callback
  */
 const LazyImage = ({
   src,
@@ -62,65 +62,72 @@ const LazyImage = ({
     if (onError) onError(e);
   };
 
-const webpSrc =
-  useWebP && src && src.match(/\.(jpe?g|png)$/i)
-    ? src.replace(/\.(jpe?g|png)$/i, ".webp")
-    : null;
+  const webpSrc =
+    useWebP && src && src.match(/\.(jpe?g|png)$/i)
+      ? src.replace(/\.(jpe?g|png)$/i, ".webp")
+      : null;
 
-// Resolve container styles to prevent Cumulative Layout Shift (CLS)
-const containerStyle = {
-  position: "relative",
-  overflow: "hidden",
-  ...style,
-};
+  // Resolve container styles to prevent Cumulative Layout Shift (CLS)
+  const containerStyle = {
+    position: "relative",
+    overflow: "hidden",
+    ...style,
+  };
 
-if (width !== undefined) {
-  containerStyle.width =
-    typeof width === "number" ? `${width}px` : width;
-}
+  if (width !== undefined) {
+    containerStyle.width =
+      typeof width === "number" ? `${width}px` : width;
+  }
 
-if (height !== undefined) {
-  containerStyle.height =
-    typeof height === "number" ? `${height}px` : height;
-}
+  if (height !== undefined) {
+    containerStyle.height =
+      typeof height === "number" ? `${height}px` : height;
+  }
 
-if (aspectRatio) {
-  containerStyle.aspectRatio = aspectRatio;
-}
+  if (aspectRatio) {
+    containerStyle.aspectRatio = aspectRatio;
+  }
 
-const handleOnError = (e) => {
-  handleError?.(e);
-  onError?.(e);
+  const handleOnError = (e) => {
+    handleError(e);
 
-  e.target.onerror = null;
-  e.target.src =
-    'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" fill="%23f3f4f6"><rect width="100%" height="100%"/><text x="50%" y="50%" fill="%239ca3af" font-family="sans-serif" font-size="24" text-anchor="middle" dominant-baseline="middle">Image Not Available</text></svg>';
-};
+    // Set a polished gradient SVG fallback with "Image Not Available" text
+    e.target.onerror = null;
+    e.target.src =
+      'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400">' +
+      '<defs><linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">' +
+      '<stop offset="0%" style="stop-color:%236366f1;stop-opacity:0.15"/>' +
+      '<stop offset="100%" style="stop-color:%238b5cf6;stop-opacity:0.15"/>' +
+      '</linearGradient></defs>' +
+      '<rect width="100%" height="100%" fill="url(%23g)"/>' +
+      '<text x="50%" y="50%" fill="%239ca3af" font-family="system-ui,sans-serif" font-size="16" font-weight="500" text-anchor="middle" dominant-baseline="middle">Image Not Available</text>' +
+      '</svg>';
+  };
 
-const imgElement = (
-  <img
-    ref={imgRef}
-    src={src}
-    alt={alt}
-    loading={loading}
-    decoding={decoding}
-    onLoad={(e) => {
-      setLoaded(true);
-      handleLoad?.(e);
-    }}
-    onError={handleOnError}
-    className={`lazy-img ${
-      loaded ? "lazy-img--loaded" : "lazy-img--loading"
-    } ${imgClassName || className || ""}`}
-    style={{
-      width: "100%",
-      height: "100%",
-      display: "block",
-      ...imgStyle,
-    }}
-    {...props}
-  />
-);
+  const imgElement = (
+    <img
+      ref={imgRef}
+      src={src}
+      alt={alt}
+      loading={loading}
+      decoding={decoding}
+      onLoad={(e) => {
+        setLoaded(true);
+        handleLoad?.(e);
+      }}
+      onError={handleOnError}
+      className={`lazy-img ${
+        loaded ? "lazy-img--loaded" : "lazy-img--loading"
+      } ${imgClassName || className || ""}`}
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "block",
+        ...imgStyle,
+      }}
+      {...props}
+    />
+  );
   return (
     <div className={`lazy-img-container ${className}`} style={containerStyle}>
       {/* Shimmer skeleton layer */}

--- a/src/styles/lazy-image.css
+++ b/src/styles/lazy-image.css
@@ -86,7 +86,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #f3f4f6;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.08) 0%, rgba(139, 92, 246, 0.08) 100%);
   color: #9ca3af;
   width: 100%;
   height: 100%;
@@ -95,12 +95,12 @@
 
 :global(.dark) .lazy-img-error,
 .dark .lazy-img-error {
-  background-color: #1f2937;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12) 0%, rgba(139, 92, 246, 0.12) 100%);
   color: #6b7280;
 }
 
 .lazy-img-error-icon {
-  opacity: 0.8;
+  opacity: 0.7;
   animation: lazy-image-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 


### PR DESCRIPTION
## Summary

Fixes #10241 — adds an onError callback to LazyImage and updates EventCard to show a polished category icon fallback when event thumbnails fail to load.

## Problem

When an event image URL is broken or fails to load, the LazyImage component showed a basic SVG placeholder with flat gray background. While functional, this degraded the premium UI experience of the EventCard.

## Solution

1. Added onError prop to LazyImage so parent components can react to image failures
2. Improved the inline SVG fallback with a subtle indigo-to-purple gradient background
3. Updated EventCard to track image failure state and gracefully fall back to the category icon with gradient (matching the existing no-image behavior)
4. Improved error state CSS with gradient backgrounds instead of flat colors

## Files Changed

- src/components/common/LazyImage.jsx — added onError prop, improved SVG fallback
- src/styles/lazy-image.css — gradient backgrounds for error state
- src/Pages/Events/EventCard.js — imageFailed state, onError callback

## Behavior

- Broken image: shows category icon with card gradient (same as no-image events)
- Error CSS: subtle indigo/purple gradient instead of flat gray
- Existing image loading: unchanged