### PR TITLE
fix: add textarea fallback for clipboard copy in share components (#10189)

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -36,11 +36,21 @@ const ShareModal = ({ isOpen, onClose, event }) => {
     if (!shareData?.shareUrl) return;
 
     try {
-      if (!navigator?.clipboard) {
-        throw new Error("Clipboard API unavailable.");
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(shareData.shareUrl);
+      } else {
+        const textArea = document.createElement("textarea");
+        textArea.value = shareData.shareUrl;
+        textArea.style.position = "absolute";
+        textArea.style.left = "-999999px";
+        document.body.prepend(textArea);
+        textArea.select();
+        try {
+          document.execCommand("copy");
+        } finally {
+          textArea.remove();
+        }
       }
-
-      await navigator.clipboard.writeText(shareData.shareUrl);
       toast.success("Link copied to clipboard");
     } catch (error) {
       console.error("Failed to copy share link:", error);

--- a/src/components/common/SocialShareButtons.jsx
+++ b/src/components/common/SocialShareButtons.jsx
@@ -29,11 +29,21 @@ const SocialShareButtons = ({ event, layout = "grid" }) => {
     if (!shareData?.shareUrl) return;
 
     try {
-      if (!navigator?.clipboard) {
-        throw new Error("Clipboard API unavailable.");
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(shareData.shareUrl);
+      } else {
+        const textArea = document.createElement("textarea");
+        textArea.value = shareData.shareUrl;
+        textArea.style.position = "absolute";
+        textArea.style.left = "-999999px";
+        document.body.prepend(textArea);
+        textArea.select();
+        try {
+          document.execCommand("copy");
+        } finally {
+          textArea.remove();
+        }
       }
-
-      await navigator.clipboard.writeText(shareData.shareUrl);
       toast.success("Link copied to clipboard");
     } catch (error) {
       console.error("Failed to copy share link:", error);


### PR DESCRIPTION
## Summary
Adds a textarea + execCommand fallback for copying share links when navigator.clipboard is unavailable (HTTP, older browsers, restricted iframes).

## Changes
- ShareModal.jsx: replaced hard throw with textarea fallback + toast error on final failure
- SocialShareButtons.jsx: same fallback pattern applied
- Pattern already existed in CopyLinkButton.jsx; now all three copy paths are consistent

## Validation
- Code compiles (no syntax errors)
- Matches existing fallback in CopyLinkButton.jsx

Closes #10189