### PR TITLE
fix: add null guard and word-boundary anchors to chatbot keyword matching (#10222 #10220)

### DIFF
--- a/src/config/chatbotKnowledge.js
+++ b/src/config/chatbotKnowledge.js
@@ -37,7 +37,9 @@ const keywordIndex = knowledgeBaseConfig.reduce((acc, item) => {
 const sortedKeywords = [...keywordIndex.keys()].sort((a, b) => b.length - a.length);
 
 const keywordPattern = new RegExp(
-  sortedKeywords.map((kw) => kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|"),
+  "\\b(" +
+    sortedKeywords.map((kw) => kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|") +
+    ")\\b",
   "i"
 );
 
@@ -88,6 +90,9 @@ export function getInitialMessages(t, pathname = "") {
 }
 
 export function getAssistantReply(input, t) {
+  if (typeof input !== "string" || !input.trim()) {
+    return null;
+  }
   const match = input.match(keywordPattern);
   const matchedKeyword = match ? match[0].toLowerCase() : null;
   const matchedItem = matchedKeyword ? keywordIndex.get(matchedKeyword) : null;


### PR DESCRIPTION
## Summary
Prevents chatbot crashes from null/undefined input and fixes false-positive keyword matches on substrings.

## Changes
- `getAssistantReply`: added `typeof input !== "string" || !input.trim()` guard before calling `.match()` (#10222)
- `keywordPattern`: wrapped alternation group with `\b...\b` word-boundary anchors so "host" no longer matches inside "ghost" and "event" no longer matches inside "eventually" (#10220)

## Validation
- Code compiles
- Regex pattern is valid (no unescaped special characters in sortedKeywords)

Closes #10222, closes #10220