### PR TITLE
fix: add safe JSON parsing for recentEvents in EventsTab (#10186)

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -371,18 +371,24 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   );
 
   useEffect(() => {
-    const stored = JSON.parse(
-      localStorage.getItem("recentEvents") || "[]"
-    );
+    let stored;
+    try {
+      stored = JSON.parse(localStorage.getItem("recentEvents") || "[]");
+    } catch {
+      stored = [];
+    }
     setRecentEvents(stored);
     const saved = safeParseJson(localStorage.getItem("recentSearches"), []);
     setRecentSearches(saved);
   }, []);
 
   const addToRecentEvents = (event) => {
-    const existing = JSON.parse(
-      localStorage.getItem("recentEvents") || "[]"
-    );
+    let existing;
+    try {
+      existing = JSON.parse(localStorage.getItem("recentEvents") || "[]");
+    } catch {
+      existing = [];
+    }
 
     const filtered = existing.filter((e) => e.id !== event.id);
     const updated = [event, ...filtered].slice(0, 6);


### PR DESCRIPTION
## Summary
Prevents EventsTab from crashing when `recentEvents` localStorage contains malformed JSON.

## Changes
- `useEffect` initialization: wrapped `JSON.parse` in `try/catch` with fallback to `[]`
- `addToRecentEvents`: same safe parsing applied before reading existing events

## Validation
- No syntax errors
- Follows existing `safeParseJson` pattern already used for `recentSearches` in the same file

Closes #10186