### PR TITLE
fix: add safe JSON parsing for contributor search history (#10187)

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -227,8 +227,12 @@ const ContributorsInner = () => {
     fetchContributors();
   }, [fetchContributors]);
 useEffect(() => {
-  const saved =
-    JSON.parse(localStorage.getItem("contributorSearchHistory")) || [];
+  let saved;
+  try {
+    saved = JSON.parse(localStorage.getItem("contributorSearchHistory")) || [];
+  } catch {
+    saved = [];
+  }
 
   setRecentSearches(saved);
 }, []);


### PR DESCRIPTION
## Summary
Prevents the Contributors page from crashing when `contributorSearchHistory` localStorage contains malformed JSON.

## Changes
- Wrapped `JSON.parse(localStorage.getItem("contributorSearchHistory"))` in `try/catch`
- Falls back to empty array on parse failure

## Validation
- No syntax errors
- Consistent with safe parsing pattern used elsewhere in the codebase

Closes #10187