### PR TITLE
Fix floor plan modal import

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Layout, Save, RotateCcw, Plus, Minus, Move, AlertTriangle, Undo2, Redo2 } from "lucide-react";
 import { toast } from "react-toastify";
-import ConfirmationModal from "../../common/ConfirmationModal";
+import ConfirmationModal from "../common/ConfirmationModal";
 import ElementPalette from "./FloorPlan/ElementPalette";
 import PropertiesPanel from "./FloorPlan/PropertiesPanel";
 import { PRESETS } from "../../constants/floorPlanPresets";


### PR DESCRIPTION
## Summary
- corrects the `ConfirmationModal` import used by the floor plan designer
- points the designer at the shared component under `src/components/common`

## Validation
- `git diff --check`

Fixes #10290
