### PR TITLE
Fix feedback demo imports

### DIFF
--- a/src/Pages/FeedbackSystemDemo.jsx
+++ b/src/Pages/FeedbackSystemDemo.jsx
@@ -6,7 +6,7 @@ import {
   FeedbackButton,
   FeedbackSummary,
   StarRating,
-} from '../../components/feedback';
+} from '../components/feedback';
 import {
   getEventFeedback,
   getAverageRating,
@@ -15,7 +15,7 @@ import {
   exportFeedbackAsCSV,
   clearAllFeedback,
   saveFeedback,
-} from '../../utils/feedbackUtils';
+} from '../utils/feedbackUtils';
 
 // Demo event definition moved outside the component for a stable reference
 const demoEvent = {


### PR DESCRIPTION
## Summary
- fixes the feedback demo page imports so they resolve inside `src`
- points feedback components and utilities at their current project locations

## Validation
- `git diff --check`

Fixes #10292
