### PR TITLE
Fix abuse logger storage guard

### DIFF
--- a/src/utils/abuseLogger.js
+++ b/src/utils/abuseLogger.js
@@ -1,7 +1,6 @@
 import { safeLocalStorage } from "./safeStorage.js";
 
 export const logAbuseAttempt = (type, details = {}) => {
-  if (typeof window === "undefined" || !window.localStorage) return;
   try {
     let existing;
     try {


### PR DESCRIPTION
## Summary
- lets `logAbuseAttempt` rely on the shared storage wrapper
- keeps logger behavior available in browser and non-browser test contexts

## Validation
- `node --test tests\abuseLogger.test.mjs`
- `node tests\abuseLoggerThrottling.test.mjs`

Fixes #10296
