### PR TITLE
Fix stale test imports

### DIFF
--- a/src/Pages/RegistrationPage.js
+++ b/src/Pages/RegistrationPage.js
@@ -1,0 +1,1 @@
+export { default } from "./Events/EventRegistration";

--- a/src/hooks/useAdvancedEventSearch.test.js
+++ b/src/hooks/useAdvancedEventSearch.test.js
@@ -3,7 +3,7 @@
  */
 
 import { renderHook, act } from "@testing-library/react";
-import useAdvancedEventSearch, { DEFAULT_FILTERS, SORT_OPTIONS } from "../useAdvancedEventSearch";
+import useAdvancedEventSearch, { DEFAULT_FILTERS, SORT_OPTIONS } from "./useAdvancedEventSearch";
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/src/hooks/useCarouselKeyboardNav.test.js
+++ b/src/hooks/useCarouselKeyboardNav.test.js
@@ -3,7 +3,7 @@
  */
 
 import { renderHook, act } from "@testing-library/react";
-import useCarouselKeyboardNav from "../useCarouselKeyboardNav";
+import useCarouselKeyboardNav from "./useCarouselKeyboardNav";
 
 function makeKeyEvent(key, target, currentTarget) {
   return {


### PR DESCRIPTION
## Summary
- fixes colocated hook tests to import hooks from their current directory
- adds the expected registration page entry module that re-exports the current event registration page

## Validation
- `git diff --check`

Fixes #10297
