### PR TITLE
fix: remove duplicate /api prefix from USERS endpoints (#10277)

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -221,10 +221,10 @@ export const API_ENDPOINTS = {
     PUSH_UNSUBSCRIBE: buildApiUrl("/notifications/push-subscriptions/unsubscribe"),
   },
   USERS: {
-    PROFILE: buildApiUrl("/api/users/profile"),
-    ACHIEVEMENTS: buildApiUrl("/api/users/achievements"),
+    PROFILE: buildApiUrl("/users/profile"),
+    ACHIEVEMENTS: buildApiUrl("/users/achievements"),
     // (#7653) Endpoint for persisting user preferences (theme, etc.) across devices
-    PREFERENCES: buildApiUrl("/api/users/preferences"),
+    PREFERENCES: buildApiUrl("/users/preferences"),
   },
   TICKETS: {
     VALIDATE: buildApiUrl("/tickets/validate"),


### PR DESCRIPTION
## Summary

The `USERS` section in `API_ENDPOINTS` (in `src/config/api.js`) passed paths like `/api/users/profile` into `buildApiUrl()`. However, `buildApiUrl()` prepends `API_BASE_URL`, which is constructed by `buildApiBase()` as `${BACKEND_ORIGIN}/api`. This resulted in double-prefixed URLs like `/api/api/users/profile`, causing 404 errors for theme sync, profile fetches, and user preferences.

## Changes

- Changed `USERS.PROFILE` from `buildApiUrl("/api/users/profile")` → `buildApiUrl("/users/profile")`
- Changed `USERS.ACHIEVEMENTS` from `buildApiUrl("/api/users/achievements")` → `buildApiUrl("/users/achievements")`
- Changed `USERS.PREFERENCES` from `buildApiUrl("/api/users/preferences")` → `buildApiUrl("/users/preferences")`

This makes the USERS endpoints consistent with every other endpoint group (EVENTS, NOTIFICATIONS, ADMIN, etc.) which all omit the `/api` prefix.

## Testing

- Theme sync via `syncThemeToProfile` now hits the correct endpoint `/api/users/preferences` instead of `/api/api/users/preferences`.

Fixes #10277