### PR TITLE
feat: add missing Alt+D/E/P and / shortcuts to keyboard shortcuts ove…

### DIFF
--- a/src/components/common/KeyboardShortcutsModal.jsx
+++ b/src/components/common/KeyboardShortcutsModal.jsx
@@ -13,6 +13,34 @@ const shortcutData = [
     workflow: "Help & Guidance"
   },
   {
+    action: "Go to Dashboard",
+    shortcut: "Alt + D",
+    keys: ["alt", "d"],
+    category: "Navigation",
+    workflow: "Quick Access"
+  },
+  {
+    action: "Go to Events",
+    shortcut: "Alt + E",
+    keys: ["alt", "e"],
+    category: "Navigation",
+    workflow: "Quick Access"
+  },
+  {
+    action: "Go to Profile",
+    shortcut: "Alt + P",
+    keys: ["alt", "p"],
+    category: "Navigation",
+    workflow: "Quick Access"
+  },
+  {
+    action: "Focus Search",
+    shortcut: "/",
+    keys: ["/"],
+    category: "General",
+    workflow: "Quick Search"
+  },
+  {
     action: "Close modal / Cancel",
     shortcut: "Esc",
     keys: ["escape"],


### PR DESCRIPTION
## Summary

The `KeyboardShortcutsModal` component already exists and is already triggered by the `Shift+?` shortcut. However, several keyboard shortcuts registered in `useKeyboardShortcuts.js` were missing from the modal's `shortcutData` array, making them undiscoverable to users.

## Changes

Added the following missing shortcut entries to the `shortcutData` array in `KeyboardShortcutsModal.jsx`:

- **Alt + D** — Go to Dashboard (quick navigation)
- **Alt + E** — Go to Events (quick navigation)
- **Alt + P** — Go to Profile (quick navigation)
- **/** — Focus Search (general quick access)

These shortcuts are all already functional via `useKeyboardShortcuts.js` but were not listed in the overlay.

## Testing

- Opening the keyboard shortcuts modal (`Shift + ?`) now shows the four new shortcuts.
- Search filtering in the modal correctly includes/excludes the new entries.
- The interactive keyboard matrix correctly highlights keys when pressed.

Fixes #10283