### PR TITLE
fix: add missing imports for SocialShareButtons, AddToCalendar

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -27,6 +27,8 @@ import LazyImage from "../../components/common/LazyImage";
 import ShareModal from "../../components/common/ShareModal";
 import StatusBadge from "../../components/common/StatusBadge";
 import { getEventStatus } from "../../utils/eventUtils";
+import SocialShareButtons from "../../components/common/SocialShareButtons";
+import AddToCalendar from "../../components/common/AddToCalendar";
 import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
@@ -200,14 +202,16 @@ const EventCard = ({ event, matchScore, matchReasons }) => {
       e.preventDefault();
       e.stopPropagation();
       if (isBookmarked) {
-        toggleBookmark(event);
+        removeBookmarkedEvent(event.id);
+        setIsBookmarked(false);
         toast.info("Removed from saved events.", { toastId: `bookmark-${event.id}`, autoClose: 1800 });
       } else {
-        toggleBookmark({ ...event, status: computedStatus });
+        addBookmarkedEvent({ ...event, status: computedStatus });
+        setIsBookmarked(true);
         toast.success("Event saved!", { toastId: `bookmark-${event.id}`, autoClose: 1800 });
       }
     },
-    [isBookmarked, event, computedStatus, toggleBookmark]
+    [isBookmarked, event, computedStatus]
   );
 
   return (


### PR DESCRIPTION
## Summary

`EventCard.js` had three undeclared references causing runtime crashes:

1. **`SocialShareButtons`** — used on line 385 but never imported.
2. **`AddToCalendar`** — used on line 386 but never imported.
3. **`toggleBookmark`** — used in `handleBookmarkToggle` but never defined or imported.

## Changes

- Added import for `SocialShareButtons` from `../../components/common/SocialShareButtons`
- Added import for `AddToCalendar` from `../../components/common/AddToCalendar`
- Replaced undefined `toggleBookmark(event)` / `toggleBookmark({...event, status})` calls with the already-imported `removeBookmarkedEvent(event.id)` and `addBookmarkedEvent({...event, status: computedStatus})` functions respectively, and added `setIsBookmarked` state updates.
- Cleaned up the `useCallback` dependency array to remove the non-existent `toggleBookmark`.

## Testing

- EventCard renders without runtime errors.
- Bookmark toggle correctly adds/removes events.
- Social share buttons and calendar dropdown render in the card footer.

Fixes #10269