### PR TITLE
fix: add missing lazy import for ThemeCustomizer in App.jsx (#10274)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,7 @@ const FeedbackButton = lazy(() => import("./components/FeedbackButton"));
 const BackToTop = lazy(() => import("./components/common/BackToTop"));
 const ReminderChecker = lazy(() => import("./components/reminders/ReminderChecker"));
 const SessionRecovery = lazy(() => import("./components/SessionRecovery"));
+const ThemeCustomizer = lazy(() => import("./components/Layout/ThemeCustomizer"));
 
 
 const OfflineSyncManager = () => {


### PR DESCRIPTION
## Summary

The `ThemeCustomizer` component was rendered in `App.jsx` (line 281) inside a `<Suspense>` block, but had no corresponding import — neither a regular import nor a lazy import. This caused a `ReferenceError: ThemeCustomizer is not defined` at runtime, preventing the theme customizer from rendering.

The component itself exists at `src/components/Layout/ThemeCustomizer.jsx` and is fully functional.

## Changes

- Added `const ThemeCustomizer = lazy(() => import("./components/Layout/ThemeCustomizer"));` to the lazy imports section of `App.jsx`.

## Testing

- The ThemeCustomizer panel now loads correctly when triggered.
- No runtime errors related to undefined `ThemeCustomizer`.

Fixes #10274