### PR TITLE
fix: add missing useContext call in useLiveAudienceStream (#10276)

### DIFF
--- a/src/context/RealTimeContext.js
+++ b/src/context/RealTimeContext.js
@@ -323,6 +323,7 @@ export const useAnalyticsStream = () => {
 };
 
 export const useLiveAudienceStream = () => {
+  const ctx = useContext(LiveAudienceContext);
   if (typeof globalThis !== "undefined" && typeof globalThis.mockLiveAudienceStream === "function") {
     return globalThis.mockLiveAudienceStream();
   }


### PR DESCRIPTION
## Summary

The `useLiveAudienceStream` hook in `RealTimeContext.js` references a variable `ctx` that is never declared, causing a guaranteed `ReferenceError` on every invocation. The sibling hooks `useLeaderboardStream` and `useAnalyticsStream` both correctly call `const ctx = useContext(...)` before using `ctx`, but this was missing from `useLiveAudienceStream`.

## Changes

- Added `const ctx = useContext(LiveAudienceContext);` as the first line of `useLiveAudienceStream` to match the pattern used by the other two hooks.

## Testing

- The hook no longer throws `ReferenceError: ctx is not defined`.
- Live Audience Q&A and polling features now function correctly when consumed by components.

Fixes #10276