### PR TITLE
fix(env): remove SENTRY_DSN hardcoded fallback, move validateEnvironment out of module scope, and throw on missing required vars in production

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -20,7 +20,7 @@ const optionalEnvVars = {
   },
   SENTRY_DSN: {
     keys: ["VITE_SENTRY_DSN", "REACT_APP_SENTRY_DSN"],
-    fallback: "https://0f5776d794dcf89120ca6b00a5923f93@o4511372299075584.ingest.de.sentry.io/4511556614946896",
+    fallback: "", // No fallback — absence means Sentry is intentionally disabled
   },
 };
 
@@ -53,9 +53,10 @@ const getEnvVar = (keys, fallback = "", { required = false, label } = {}) => {
   }
 
   if (required && !isDevelopment) {
-    console.error(
-      `[ENV ERROR] Missing required environment variable: ${label || keyList.join(" or ")}`
-    );
+    const varName = label || keyList.join(" or ");
+    // Throw in production so a misconfigured deployment fails immediately
+    // rather than silently using "" as a base URL for every API call.
+    throw new Error(`[ENV] Missing required environment variable: ${varName}`);
   }
 
   return "";
@@ -75,7 +76,9 @@ export const validateEnvironment = () => {
   }
 };
 
-validateEnvironment();
+// validateEnvironment() is NOT called here automatically.
+// Call it explicitly at app startup (e.g. in main.jsx) to avoid
+// polluting console output in test and SSR environments.
 
 export const ENV = {
   API_URL: getEnvVar(requiredEnvVars.API_URL, isDevelopment ? DEV_API_FALLBACK : "", {


### PR DESCRIPTION
### Related Issues
Closes #10317 

### Summary of Changes

**Fix 1 — Removed the hardcoded SENTRY_DSN fallback. Sentry is now enabled only when VITE_SENTRY_DSN is explicitly set.

**Fix 2 — Removed the top-level validateEnvironment() call to avoid unnecessary logs in tests and SSR. It should now be called explicitly from main.jsx.

**Fix 3 — getEnvVar now throws for missing required environment variables in production instead of silently returning an empty string, allowing misconfigured deployments to fail fast.