### PR TITLE
fix: replace setInterval with lazy cleanup in signatureValidator to prevent memory leak

### DIFF
--- a/src/utils/signatureValidator.js
+++ b/src/utils/signatureValidator.js
@@ -10,6 +10,7 @@
 const usedNonces = new Map();
 
 const MAX_REQUEST_AGE_MS = 5 * 60 * 1000;
+let lastCleanup = Date.now();
 
 // Resolve a crypto-like object available in the current environment.
 const getCrypto = () => {
@@ -55,6 +56,15 @@ export async function validateSignature(
 ) {
   const now = Date.now();
 
+  if (now - lastCleanup > 60000) {
+    lastCleanup = now;
+    for (const [n, ts] of usedNonces) {
+      if (now - ts > MAX_REQUEST_AGE_MS) {
+        usedNonces.delete(n);
+      }
+    }
+  }
+
   if (!timestamp || !nonce || !signature) {
     return {
       valid: false,
@@ -97,16 +107,5 @@ export async function validateSignature(
   };
 }
 
-const cleanupInterval = setInterval(() => {
-  const now = Date.now();
-
-  for (const [nonce, timestamp] of usedNonces) {
-    if (now - timestamp > MAX_REQUEST_AGE_MS) {
-      usedNonces.delete(nonce);
-    }
-  }
-}, 60000);
-
-if (cleanupInterval && typeof cleanupInterval.unref === "function") {
-  cleanupInterval.unref();
-}
+// Cleanup of expired nonces is now handled lazily within validateSignature()
+// instead of a module-scoped setInterval to prevent memory leaks in the browser.


### PR DESCRIPTION
## Description
This PR addresses a critical memory leak in the client-side bundle caused by an uncleared, module-scoped `setInterval` inside the `signatureValidator.js` utility. 

Previously, the module initialized a background garbage collection interval for nonces. While `.unref()` successfully prevented Node.js from hanging on the server, browsers lack `.unref()`, causing the interval to run indefinitely on the client side. This blocked garbage collection of the module and led to continuous memory leaks in SPA environments.

This update introduces a **lazy-evaluation cleanup strategy**, eliminating the need for a global interval entirely while preserving identical security and cache-pruning guarantees.

## Changes Made
- **[Refactor]** Completely removed the module-scoped `setInterval` from `src/utils/signatureValidator.js`.
- **[Bug Fix]** Replaced the continuous background loop with a lazy cleanup routine inside `validateSignature`.
- **[Performance]** The lazy cleanup is timestamp-throttled to execute at most once every 60 seconds (O(N) operation only when necessary) to eliminate CPU overhead.

## Impact & Types of Changes
*Please check the applicable labels for this PR:*
- [x] **Bug Fix** (Fixes an indefinite client-side memory leak).
- [x] **Performance** (Eliminates rogue background processes and CPU waking).
- [x] **Refactor** (Improves code architecture by moving from eager to lazy evaluation).
- [x] **Security / Auth** (Maintains cryptographic nonce replay-attack protections without compromising client resources).
- [x]  **Isomorphic / Universal** (Makes the utility 100% environment-agnostic; safe for both Node.js and Browser environments).

## Testing Steps
1. Import `validateSignature` in a browser-based React component.
2. Observe the browser's Memory/Performance profiler.
3. **Before:** A `setInterval` is registered globally and fires every 60s indefinitely, preventing the component/module from being garbage collected.
4. **After:** No background intervals are registered. Cleanup only runs as a lightweight operation lazily during active signature validation.

Closes #10240
