### PR TITLE
fix: point testimonials CTA to existing /feedback route (#10185)

### DIFF
--- a/src/Pages/Home/components/Testimonials.js
+++ b/src/Pages/Home/components/Testimonials.js
@@ -441,7 +441,7 @@ const ModernTestimonialTrain = () => {
             Have a story to share?
           </span>
           <Link
-            to="/submit-testimonial"
+            to="/feedback"
             className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors shadow-md hover:shadow-lg"
           >
             Share Your Story <ExternalLink className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary  The testimonials CTA was linking to a non-existent `/submit-testimonial` route, resulting in a 404 when users clicked Share Your Story. This PR points it to the existing `/feedback` route so users can actually submit their testimonials.  ## Changes  - `src/Pages/Home/components/Testimonials.js`: changed `to   ` to `to  `  ## Validation  - Verified `/feedback` route exists in `PublicRoutes.js`  - No syntax errors  Closes #10185