### PR TITLE
fix: remove duplicate back-to-top button on hackathons page

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -355,8 +355,8 @@ const HackathonHub = () => {
   }, [loadHackathons]);
 
   const positionClass = `
-    ${isScrollVisible ? "bottom-[calc(2.5rem+var(--safe-area-bottom))] sm:bottom-40" : "bottom-[calc(1rem+var(--safe-area-bottom))] sm:bottom-24"}
-    ${isChatbotOpen ? "left-[calc(1rem+var(--safe-area-left))] sm:left-6" : "right-[calc(1rem+var(--safe-area-right))] sm:right-6"}
+    ${isScrollVisible ? "bottom-[calc(2.5rem+var(--safe-area-bottom))] sm:bottom-37" : "bottom-[calc(1rem+var(--safe-area-bottom))] sm:bottom-21"}
+    ${isChatbotOpen ? "left-[calc(1rem+var(--safe-area-left))] sm:left-15" : "right-[calc(1rem+var(--safe-area-right))] sm:right-15"}
   `;
 
   const containerVariants = {
@@ -795,7 +795,6 @@ const HackathonHub = () => {
       </div>
 
       <HackathonCTA />
-      <BackToTopButton positionClass={positionClass} />
     </div>
   );
 };


### PR DESCRIPTION
Closes #10325 

## Description 
This PR removes the duplicate Back-to-Top button from the Hackathons page and repositions the Host a Hackathon button by moving it inside the CTA box..

## Screenshot
<img width="1906" height="974" alt="image" src="https://github.com/user-attachments/assets/48085a16-fd72-4340-be54-2a84dd85dd07" />
