### PR TITLE
fix(lenisUtils): add SSR guards to prevent crash in server environments

### DIFF
--- a/src/utils/lenisUtils.js
+++ b/src/utils/lenisUtils.js
@@ -9,6 +9,7 @@
  * @param {Object} options - Scroll options
  */
 export const scrollToElement = (selector, options = {}) => {
+  if (typeof window === "undefined") return;
   const element = document.querySelector(selector);
   if (element && window.lenis) {
     window.lenis.scrollTo(element, {
@@ -25,6 +26,7 @@ export const scrollToElement = (selector, options = {}) => {
  * @param {Object} options - Scroll options
  */
 export const scrollToTop = (options = {}) => {
+  if (typeof window === "undefined") return;
   if (window.lenis) {
     window.lenis.scrollTo(0, {
       duration: 1.2,
@@ -43,6 +45,7 @@ export const scrollToTop = (options = {}) => {
  * Stop Lenis scrolling (useful for modals)
  */
 export const stopScroll = () => {
+  if (typeof window === "undefined") return;
   if (window.lenis) {
     window.lenis.stop();
   }
@@ -52,6 +55,7 @@ export const stopScroll = () => {
  * Start Lenis scrolling
  */
 export const startScroll = () => {
+  if (typeof window === "undefined") return;
   if (window.lenis) {
     window.lenis.start();
   }
@@ -62,5 +66,6 @@ export const startScroll = () => {
  * @returns {number} Current scroll position
  */
 export const getScrollPosition = () => {
+  if (typeof window === "undefined") return 0;
   return window.lenis ? window.lenis.scroll : window.scrollY;
 };


### PR DESCRIPTION
Fixes #9467. Adds typeof window === undefined guards to all exported functions in src/utils/lenisUtils.js to prevent crashes during Next.js server-side rendering.