### PR TITLE
fix(exportCsv): add SSR guards to prevent crash in server environments

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -66,6 +66,7 @@ const sanitizeCSVField = (field) => {
  * @param {string} [filename]       - Desired download filename (will be sanitized)
  */
 export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv") => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   if (!attendees || attendees.length === 0) {
     return;
   }
@@ -127,6 +128,7 @@ export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv"
  * @param {string} surveyTitle       - Raw title of the survey (will be sanitized)
  */
 export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   if (!questions || questions.length === 0 || !responses || responses.length === 0) {
     return;
   }
@@ -176,6 +178,7 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
  * @param {string} [filename]        - Desired download filename (will be sanitized)
  */
 export const exportEventsToCSV = (events, filename = "eventra-events.csv") => {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
   if (!events || events.length === 0) {
     return;
   }


### PR DESCRIPTION
Fixes #9466. Adds typeof window/document undefined guards to exportAttendeesToCSV, exportSurveyToCSV, and exportEventsToCSV in src/utils/exportCsv.js to prevent crashes during Next.js server-side rendering.