### PR TITLE
fix: add worker-src blob: to CSP to allow blob-URL worker creation

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,9 +24,7 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=(), payment=(), usb=(), bluetooth=()"
     Cross-Origin-Opener-Policy = "same-origin-allow-popups"
     Cross-Origin-Resource-Policy = "same-site"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://o4511372299075584.ingest.de.sentry.io; frame-src 'self' https://accounts.google.com"
-
-[[headers]]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://accounts.google.com https://cdn.jsdelivr.net; style-src 'self' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://api.github.com https://o4511372299075584.ingest.de.sentry.io; frame-src 'self' https://accounts.google.com; worker-src 'self' blob:"
   for = "/"
   [headers.values]
     Link = "</.well-known/api-catalog>; rel=\"api-catalog\", </apiDocs>; rel=\"service-doc\""


### PR DESCRIPTION
Fixes #10079
Root Cause
The CSP had no explicit worker-src directive. Per spec, when worker-src is unset, script-src is used as a fallback for worker creation — and script-src doesn't permit blob:, so the browser blocks any Worker created from a blob URL. This showed up as a console violation on the Login page.
vercel.json already had worker-src blob:; set for this exact reason. netlify.toml was missing it, which is why the violation only reproduced on the Netlify-served production deployment.
Fix
Added worker-src 'self' blob: to the CSP header in netlify.toml, bringing it in line with vercel.json.
Scope / Not Included
This only adds the missing worker-src directive. netlify.toml's connect-src is also missing a few origins present in vercel.json (backend API, Google APIs) — that looks like a separate drift issue between the two configs and is out of scope here; can file separately if useful.
Tested

Confirmed netlify.toml CSP now matches vercel.json's worker-src value
No other directives changed; header string otherwise identical