### PR TITLE
fix: recover from stale lazy-loaded chunks after deploy

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, lazy, Suspense } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { lazyWithRetry } from "./utils/lazyWithRetry.js";
 import { Analytics } from "@vercel/analytics/react";
 import "./App.css";
 import "./styles/reduced-motion.css";
@@ -36,22 +37,22 @@ import {
 } from "./components/common/SkeletonLoaders";
 
 // Route-level lazy splits - loaded only when route is visited
-const Footer = lazy(() => import("./components/Layout/Footer"));
-const Chatbot = lazy(() => import("./components/Chatbot"));
-const AppRoutes = lazy(() => import("./components/AppRoutes"));
-const SavedEventsPage = lazy(() => import("./Pages/SavedEventsPage"));
-const EventRecommendation = lazy(() => import("./Pages/EventRecommendation/EventRecommendation"));
-const ExploreEvents = lazy(() => import("./Pages/Events/EventsPage"));
+const Footer = lazyWithRetry(() => import("./components/Layout/Footer"));
+const Chatbot = lazyWithRetry(() => import("./components/Chatbot"));
+const AppRoutes = lazyWithRetry(() => import("./components/AppRoutes"));
+const SavedEventsPage = lazyWithRetry(() => import("./Pages/SavedEventsPage"));
+const EventRecommendation = lazyWithRetry(() => import("./Pages/EventRecommendation/EventRecommendation"));
+const ExploreEvents = lazyWithRetry(() => import("./Pages/Events/EventsPage"));
 
 // Non-critical UI - deferred after first paint
-const FluidCursor = lazy(() => import("./components/visual/FluidCursor"));
-const KeyboardShortcutsModal = lazy(() => import("./components/common/KeyboardShortcutsModal"));
-const OnboardingChecklist = lazy(() => import("./components/user/OnboardingChecklist"));
-const FeedbackButton = lazy(() => import("./components/FeedbackButton"));
-const BackToTop = lazy(() => import("./components/common/BackToTop"));
-const ReminderChecker = lazy(() => import("./components/reminders/ReminderChecker"));
-const SessionRecovery = lazy(() => import("./components/SessionRecovery"));
-const ThemeCustomizer = lazy(() => import("./components/Layout/ThemeCustomizer"));
+const FluidCursor = lazyWithRetry(() => import("./components/visual/FluidCursor"));
+const KeyboardShortcutsModal = lazyWithRetry(() => import("./components/common/KeyboardShortcutsModal"));
+const OnboardingChecklist = lazyWithRetry(() => import("./components/user/OnboardingChecklist"));
+const FeedbackButton = lazyWithRetry(() => import("./components/FeedbackButton"));
+const BackToTop = lazyWithRetry(() => import("./components/common/BackToTop"));
+const ReminderChecker = lazyWithRetry(() => import("./components/reminders/ReminderChecker"));
+const SessionRecovery = lazyWithRetry(() => import("./components/SessionRecovery"));
+const ThemeCustomizer = lazyWithRetry(() => import("./components/Layout/ThemeCustomizer"));
 
 
 const OfflineSyncManager = () => {

--- a/src/utils/lazyWithRetry.js
+++ b/src/utils/lazyWithRetry.js
@@ -1,6 +1,19 @@
- 
 import { lazy } from "react";
 
+const isChunkLoadFailure = (error) => {
+  const message = String(error?.message || error || "");
+  return (
+    error?.name === "ChunkLoadError" ||
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("Importing a module script failed") ||
+    message.includes("error loading dynamically imported module")
+  );
+};
+
+/**
+ * Wrap React.lazy with retry logic and a hard reload when a stale deployment
+ * chunk cannot be fetched after retries.
+ */
 export function lazyWithRetry(importFn, retries = 2, delay = 1000) {
   const retryImport = async () => {
     let attempt = 0;
@@ -9,11 +22,21 @@ export function lazyWithRetry(importFn, retries = 2, delay = 1000) {
       try {
         return await importFn();
       } catch (err) {
+        if (isChunkLoadFailure(err) && typeof window !== "undefined") {
+          const reloadKey = "eventra:chunk-reload";
+          if (!sessionStorage.getItem(reloadKey)) {
+            sessionStorage.setItem(reloadKey, "1");
+            window.location.reload();
+            return new Promise(() => {});
+          }
+          sessionStorage.removeItem(reloadKey);
+        }
+
         attempt++;
         if (attempt > retries) {
           console.warn(
             `[lazyWithRetry] Failed to load chunk after ${retries + 1} attempts:`,
-            err.message
+            err?.message || err,
           );
           throw err;
         }

--- a/tests/lazyWithRetry.test.mjs
+++ b/tests/lazyWithRetry.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { lazyWithRetry } from "../src/utils/lazyWithRetry.js";
+
+const LazyComponent = lazyWithRetry(
+  () => Promise.reject(new Error("Failed to fetch dynamically imported module")),
+  0,
+  0,
+);
+assert.equal(typeof LazyComponent, "object");
+assert.equal(typeof LazyComponent.$$typeof, "symbol");
+
+console.log("lazyWithRetry tests passed ✓");


### PR DESCRIPTION
Wire lazyWithRetry into App route splits with one-time reload on chunk fetch failures so users are not stuck on a white screen after releases.

Closes #9461