### PR TITLE
Guard error trigger in development

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,20 @@ const OfflineSyncManager = () => {
   return null;
 };
 
+function ErrorButton() {
+  return (
+    <button
+      type="button"
+      className="sr-only"
+      onClick={() => {
+        throw new Error("This is your first error!");
+      }}
+    >
+      Trigger error
+    </button>
+  );
+}
+
 function App() {
   const { t } = useTranslation();
   const location = useLocation();
@@ -277,6 +291,7 @@ function App() {
                 <Suspense fallback={null}>
                   <SessionRecovery />
                 </Suspense>
+                {import.meta.env.DEV && <ErrorButton />}
 
                 {isDesktop && (
                   <ErrorBoundary level="section" label="Custom Cursor" silent>


### PR DESCRIPTION
## Summary
- adds the local error trigger expected by the app safety contract
- renders it only when `import.meta.env.DEV` is true

## Validation
- `node --test tests\errorButtonProductionSafety.test.mjs`

Fixes #10344
