### PR TITLE
Show event details loading spinner

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -268,7 +268,15 @@ ${window.location.href}
     s: () => setShowShareModal(true),
     p: handlePrint,
   });
-  if (fetchLoading) return <EventDetailSkeleton />;
+  if (fetchLoading) {
+    return (
+      <div role="status" aria-live="polite">
+        <span className="sr-only">Loading event details</span>
+        <div className="mx-auto my-6 h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        <EventDetailSkeleton />
+      </div>
+    );
+  }
 
   if (fetchError || !event) {
     return (


### PR DESCRIPTION
## Summary
- adds an accessible loading status wrapper to event details
- includes a visible spinner while the event request is in progress

## Validation
- `node --test tests\eventDetails.test.mjs`

Fixes #10345
