### PR TITLE
Guard global asset listener

### DIFF
--- a/src/utils/globalErrorHandler.js
+++ b/src/utils/globalErrorHandler.js
@@ -36,25 +36,27 @@ function buildFingerprint(error) {
 export const initializeGlobalErrorHandling = () => {
   if (typeof window === "undefined") return;
 
-  window.addEventListener(
-    "error",
-    (event) => {
-      const target = event.target;
-      const tagName = target?.tagName?.toLowerCase();
-      if (!["img", "script", "link", "source", "video", "audio"].includes(tagName)) {
-        return;
-      }
+  if (typeof window.addEventListener === "function") {
+    window.addEventListener(
+      "error",
+      (event) => {
+        const target = event.target;
+        const tagName = target?.tagName?.toLowerCase();
+        if (!["img", "script", "link", "source", "video", "audio"].includes(tagName)) {
+          return;
+        }
 
-      const url = target?.src || target?.href || target?.currentSrc || "";
-      const assetError = new Error(`Asset failed to load: ${url || tagName}`);
-      logCategorizedError(assetError, null, {
-        type: "asset",
-        tagName,
-        url,
-      });
-    },
-    true,
-  );
+        const url = target?.src || target?.href || target?.currentSrc || "";
+        const assetError = new Error(`Asset failed to load: ${url || tagName}`);
+        logCategorizedError(assetError, null, {
+          type: "asset",
+          tagName,
+          url,
+        });
+      },
+      true,
+    );
+  }
 
   window.onerror = (message, source, lineno, colno, error) => {
     const fp = buildFingerprint(error || message);


### PR DESCRIPTION
## Summary
- checks for `window.addEventListener` before registering asset load errors
- still installs global error and rejection handlers when a minimal window exists

## Validation
- `node --test tests\globalErrorHandler.test.mjs`

Fixes #10346
