### PR TITLE
Use available storage in registration helpers

### DIFF
--- a/src/utils/registerUtils.js
+++ b/src/utils/registerUtils.js
@@ -4,10 +4,21 @@ const STORAGE_KEY = "eventRegistrations";
 
 const normalizeEmail = (email) => (email || "").trim().toLowerCase();
 
+const getStorage = () => {
+  if (typeof globalThis !== "undefined" && globalThis.localStorage) {
+    return globalThis.localStorage;
+  }
+  if (typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage;
+  }
+  return null;
+};
+
 const readRegistrations = () => {
-  if (typeof window === "undefined") return {};
+  const storage = getStorage();
+  if (!storage) return {};
   try {
-    const data = localStorage.getItem(STORAGE_KEY);
+    const data = storage.getItem(STORAGE_KEY);
     const parsed = safeJsonParse(data, {});
     // Migrate legacy array-based storage to Set-based storage
     const migrated = {};
@@ -23,9 +34,10 @@ const readRegistrations = () => {
 };
 
 const writeRegistrations = (registrations) => {
-  if (typeof window === "undefined") return;
+  const storage = getStorage();
+  if (!storage) return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(registrations));
+    storage.setItem(STORAGE_KEY, JSON.stringify(registrations));
   } catch {
     // localStorage may be unavailable or full; keep the UI functional.
   }


### PR DESCRIPTION
## Summary
- resolves local storage from the current global environment
- keeps duplicate registration checks working without requiring a full browser window

## Validation
- `node --test tests\registerUtils-robustness.test.mjs tests\registerUtils.edge.test.mjs`

Fixes #10347
