### PR TITLE
Align request signature validation

### DIFF
--- a/src/utils/signatureValidator.js
+++ b/src/utils/signatureValidator.js
@@ -7,46 +7,15 @@
  * the bundle on load.
  */
 
+import CryptoJS from "crypto-js";
+
 const usedNonces = new Map();
 
 const MAX_REQUEST_AGE_MS = 5 * 60 * 1000;
 
-// Resolve a crypto-like object available in the current environment.
-const getCrypto = () => {
-  if (typeof globalThis !== "undefined" && globalThis.crypto?.subtle) {
-    return globalThis.crypto;
-  }
-  if (typeof window !== "undefined" && window.crypto?.subtle) {
-    return window.crypto;
-  }
-  return null;
-};
+const hmacSha256Hex = (secret, data) => CryptoJS.HmacSHA256(data, secret).toString();
 
-/**
- * Compute HMAC-SHA256 using the Web Crypto API.
- * Returns a hex string identical to what crypto.createHmac('sha256', secret)
- * would produce, but works in browsers.
- */
-const hmacSha256Hex = async (secret, data) => {
-  const c = getCrypto();
-  if (!c) {
-    throw new Error("HMAC: Web Crypto API is not available in this environment");
-  }
-  const enc = new TextEncoder();
-  const key = await c.subtle.importKey(
-    "raw",
-    enc.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const signature = await c.subtle.sign("HMAC", key, enc.encode(data));
-  return Array.from(new Uint8Array(signature))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-};
-
-export async function validateSignature(
+export function validateSignature(
   payload,
   timestamp,
   nonce,
@@ -78,7 +47,7 @@ export async function validateSignature(
     };
   }
 
-  const expectedSignature = await hmacSha256Hex(
+  const expectedSignature = hmacSha256Hex(
     secret,
     JSON.stringify(payload) + timestamp + nonce
   );


### PR DESCRIPTION
## Summary
- makes signature validation return a direct validation result
- keeps awaited validator callers compatible
- aligns the validator with request signatures produced by the signing helper

## Validation
- `node --test tests\requestSignature.test.mjs tests\signatureValidator.test.mjs`

Fixes #10348
