### PR TITLE
Allow clipboard fallback without window

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -175,12 +175,12 @@ export const generateEventSharingData = (event, baseUrl = null) => {
  * @returns {Promise<boolean>} Success status
  */
 export const copyToClipboard = async (text) => {
-  if (typeof window === "undefined" || typeof document === "undefined") {
+  if (typeof document === "undefined") {
     return false;
   }
 
   try {
-    if (navigator.clipboard) {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
       await navigator.clipboard.writeText(text);
       return true;
     } else {


### PR DESCRIPTION
## Summary
- allows the document-based clipboard fallback to run without requiring `window`
- keeps the modern clipboard path guarded by `navigator.clipboard`

## Validation
- `node --test tests\shareUtils-copyToClipboard.test.mjs`

Fixes #10349
