### PR TITLE
chore: clean up remaining utility and test no-unused-vars warnings (#10382)

### DIFF
--- a/src/Pages/utils/logger.js
+++ b/src/Pages/utils/logger.js
@@ -21,7 +21,7 @@ const sanitizeLogData = (data) => {
     
     recursivelyMaskKeys(cleanData, sensitiveKeys);
     return cleanData;
-  } catch (_e) {
+  } catch {
     return '[Unparsable Data - Securely Masked]';
   }
 };

--- a/src/__tests__/cookieUtils.test.js
+++ b/src/__tests__/cookieUtils.test.js
@@ -11,7 +11,7 @@
  * - HTTPS vs HTTP behavior
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   buildCookieString,
   setCookie,

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -185,7 +185,7 @@ const wrapAxiosResponse = (response) => {
       if (typeof response.data === "string") {
         try {
           return JSON.parse(response.data);
-        } catch (_e) {
+        } catch {
           throw new Error("Received non-JSON response from server");
         }
       }

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -10,7 +10,7 @@ const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 1_000;
 
 let onUnauthorized = null;
-let _onRequiresReauth = null;
+
 let _authToken = null;
 
 export const setOnUnauthorizedHandler = (handler) => { onUnauthorized = handler; };
@@ -129,7 +129,7 @@ const normalizeApiErrorWithTimeout = (error, timeoutMs) => {
   );
 };
 
-export function setupRequestInterceptor(api, { isDev, buildApiUrl, getAuthToken, getOnUnauthorized: _getOnUnauthorized }) {
+export function setupRequestInterceptor(api, { isDev, buildApiUrl, getAuthToken,   }) {
   api.interceptors.request.use((config) => {
     if (isDev) {
       logger.info(`[API ${config.method?.toUpperCase()}]`, buildApiUrl(config.url || ""));


### PR DESCRIPTION
Fixes no-unused-vars ESLint warnings in utility modules, test files, and API config:
- logger.js: unused catch binding _e
- cookieUtils.test.js: unused vi import
- api.js: unused catch binding _e
- interceptors.js: unused _getOnUnauthorized parameter

Fixes #10382