### PR TITLE
feat: Redesign Hero Section to Better Communicate Value Proposition

### DIFF
--- a/src/Pages/Home/components/Hero.js
+++ b/src/Pages/Home/components/Hero.js
@@ -29,7 +29,7 @@ const Hero = () => {
   );
 
   return (
-    <section className="relative overflow-hidden pb-10 pt-6 sm:pb-14 sm:pt-8 md:pb-16 md:pt-10">
+    <section className="relative overflow-hidden pb-10 pt-2 sm:pb-12 sm:pt-4 md:pb-14 md:pt-6">
       <div className="pointer-events-none absolute -left-24 top-0 h-72 w-72 rounded-full bg-violet-300/20 blur-3xl dark:bg-violet-600/10" />
       <div className="pointer-events-none absolute -right-24 bottom-0 h-72 w-72 rounded-full bg-pink-300/20 blur-3xl dark:bg-pink-600/10" />
 
@@ -39,12 +39,12 @@ const Hero = () => {
         transition={{ duration: 0.5 }}
         className="relative mx-auto grid w-full max-w-6xl items-center gap-6 px-4 sm:gap-8 lg:grid-cols-2 lg:gap-10"
       >
-        <div className="flex flex-col gap-4 sm:gap-5">
-          <div className="inline-flex w-fit items-center gap-2 rounded-lg border border-border bg-white/[0.04] dark:bg-white/[0.02] px-3 py-1 text-xs font-semibold uppercase tracking-wider text-text-light">
+        <div className="flex flex-col">
+          <div className="inline-flex w-fit items-center gap-2 rounded-lg border border-border bg-white/[0.04] dark:bg-white/[0.02] px-3 py-1 text-xs font-semibold uppercase tracking-wider text-text-light mb-3">
             {t("landing.hero.badge")}
           </div>
 
-          <h1 className="text-4xl font-extrabold leading-tight tracking-tighter text-text sm:text-5xl lg:text-[3.25rem]">
+          <h1 className="text-4xl font-extrabold leading-tight tracking-tighter text-text sm:text-5xl lg:text-[3.25rem] mb-2 sm:mb-3">
             {t("landing.hero.headlineBefore")}{" "}
             <span className="bg-gradient-to-r from-slate-950 to-slate-600 dark:from-white dark:to-slate-400 bg-clip-text text-transparent">
               {t("landing.hero.headlineHighlight")}
@@ -52,34 +52,11 @@ const Hero = () => {
             {t("landing.hero.headlineAfter")}
           </h1>
 
-          <p className="max-w-xl text-base font-medium leading-relaxed text-text-light sm:text-lg">
-            {t("landing.hero.tagline")}
-          </p>
-
-          <p className="max-w-xl text-sm leading-relaxed text-text-light/80 sm:text-base">
+          <p className="max-w-xl text-base font-medium leading-relaxed text-text-light sm:text-lg mb-3 sm:mb-4">
             {t("landing.hero.description")}
           </p>
 
-          <p className="max-w-xl text-sm font-semibold text-primary">
-            {t("landing.hero.differentiator")}
-          </p>
-
-          <ul
-            className="flex flex-wrap gap-x-5 gap-y-2 text-sm font-medium text-text-light"
-            aria-label={t("landing.hero.platformStats")}
-          >
-            {SOCIAL_PROOF_VALUES.map((stat) => (
-              <li key={stat.key} className="flex items-center gap-1.5">
-                <Check className="h-4 w-4 shrink-0 text-emerald-500" aria-hidden="true" />
-                <span>
-                  <span className="font-bold text-text">{stat.value}</span>{" "}
-                  {t(`landing.hero.stats.${stat.key}`)}
-                </span>
-              </li>
-            ))}
-          </ul>
-
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center mb-4 sm:mb-5">
             <Link
               to="/events"
               className="group inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 hover:bg-slate-900 dark:bg-white dark:hover:bg-slate-100 text-white dark:text-slate-950 px-6 py-2.5 text-sm font-semibold shadow-premium-sm hover:shadow-premium-md transition-all duration-300 hover:scale-[1.01] active:scale-[0.99] sm:text-base"
@@ -99,20 +76,23 @@ const Hero = () => {
             </Link>
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            {categoryChips.map((chip) => (
-              <Link
-                key={chip.to + chip.label}
-                to={chip.to}
-                className="rounded-lg border border-border bg-white/30 dark:bg-white/[0.02] px-3.5 py-1.5 text-xs font-semibold text-text-light hover:text-text hover:border-border hover:bg-white/70 dark:hover:bg-white/[0.05] transition-all duration-200"
-              >
-                {chip.label}
-              </Link>
+          <ul
+            className="flex flex-wrap gap-x-6 gap-y-3 text-sm font-medium text-text-light"
+            aria-label={t("landing.hero.platformStats")}
+          >
+            {SOCIAL_PROOF_VALUES.map((stat) => (
+              <li key={stat.key} className="flex items-center gap-1.5">
+                <Check className="h-4 w-4 shrink-0 text-emerald-500" aria-hidden="true" />
+                <span>
+                  <span className="font-bold text-text">{stat.value}</span>{" "}
+                  {t(`landing.hero.stats.${stat.key}`)}
+                </span>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
 
-        <div className="order-first lg:order-last">
+        <div className="mt-8 lg:mt-0">
           <HeroVisual />
         </div>
       </motion.div>


### PR DESCRIPTION
Fixes #10268 

## Description
This PR redesigns the Hero section on the landing page to deliver a stronger first impression and a clearer value proposition for developers, strictly following the proposed layout specs.

### Changes Made:
- **Stronger Copy:** Updated the headline to *"Build. Learn. Network."* and replaced the generic feature list with a concise, platform-focused description.
- **Improved Spacing:** Removed redundant category chips and completely overhauled vertical margins to tightly pack the content (`mb-2` to `mb-4`) and pull it higher above the fold.
- **CTA Strategy:** Limited the hero to one solid primary action ("Explore Events") and one bordered secondary action ("Create Event").
- **Integrated Social Proof:** Moved platform statistics (1,500+ Developers, etc.) directly into the hero layout with checkmarks.
- **Mobile Readability:** Updated responsive ordering so the headline and text load *before* the dashboard illustration on small screens, ensuring the value proposition is seen within 5 seconds.
- **Search Context:** Verified that the search bar has been relocated to its own dedicated `<HomeEventSearch />` section, removing clutter from the hero.

## Screenshots

### 1. Desktop View (Redesigned Hero)
<img width="1712" height="999" alt="Screenshot 2026-07-09 at 12 54 57 AM" src="https://github.com/user-attachments/assets/07b279aa-3189-4805-a98c-69bc2593d951" />


### 2. Mobile View (Responsive Ordering)
<img width="573" height="948" alt="Screenshot 2026-07-09 at 12 54 41 AM" src="https://github.com/user-attachments/assets/58c92d09-c795-4c79-b250-4e55015605a6" />


### 3. Relocated Search Bar (Contextual Search)
<img width="1728" height="716" alt="Screenshot 2026-07-09 at 12 58 17 AM" src="https://github.com/user-attachments/assets/11d3ecab-22e7-4063-9022-3352e9827c8a" />


## Testing
- [x] Tested locally (`npm run dev`)
- [x] Verified responsive layout across desktop and mobile
