### PR TITLE
fix: remove duplicate API prefix from endpoint URLs

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -78,14 +78,14 @@ export const API_ENDPOINTS = {
     REFRESH: buildApiUrl("/auth/refresh"),
   },
   EVENTS: {
-    CREATE: buildApiUrl("/api/events/create"),
-    ALL: buildApiUrl("/api/events"),
-    LIST: buildApiUrl("/api/events"),
-    DETAIL: (id) => buildApiUrl(`/api/events/${id}`),
-    REGISTER: (id) => buildApiUrl(`/api/events/${id}/register`),
-    AVAILABILITY: (id) => buildApiUrl(`/api/events/${id}/availability`),
+    CREATE: buildApiUrl("/events/create"),
+    ALL: buildApiUrl("/events"),
+    LIST: buildApiUrl("/events"),
+    DETAIL: (id) => buildApiUrl(`/events/${id}`),
+    REGISTER: (id) => buildApiUrl(`/events/${id}/register`),
+    AVAILABILITY: (id) => buildApiUrl(`/events/${id}/availability`),
 
-    REGISTRANTS: (id) => buildApiUrl(`/api/events/${id}/registrants`),
+    REGISTRANTS: (id) => buildApiUrl(`/events/${id}/registrants`),
     // Convenience helper — appends ?page=&size= for callers that build the
     // URL manually rather than going through eventFetchUtils.buildPaginatedUrl.
     PAGINATED: (page, size) => buildApiUrl(`/events?page=${page}&size=${size}`),
@@ -125,10 +125,10 @@ export const API_ENDPOINTS = {
     PUSH_UNSUBSCRIBE: buildApiUrl("/notifications/push-subscriptions/unsubscribe"),
   },
   USERS: {
-    PROFILE: buildApiUrl("/api/users/profile"),
-    ACHIEVEMENTS: buildApiUrl("/api/users/achievements"),
+    PROFILE: buildApiUrl("/users/profile"),
+    ACHIEVEMENTS: buildApiUrl("/users/achievements"),
     // (#7653) Endpoint for persisting user preferences (theme, etc.) across devices
-    PREFERENCES: buildApiUrl("/api/users/preferences"),
+    PREFERENCES: buildApiUrl("/users/preferences"),
   },
   TICKETS: {
     VALIDATE: buildApiUrl("/tickets/validate"),
@@ -150,9 +150,9 @@ export const API_ENDPOINTS = {
     STATS: buildApiUrl("/admin/stats"),
   },
   VALIDATION: {
-    EMAIL: (email) => buildApiUrl(`/api/validate/email/${encodeURIComponent(email)}`),
-    USERNAME: (username) => buildApiUrl(`/api/validate/username/${encodeURIComponent(username)}`),
-    PHONE: buildApiUrl("/api/validate/phone"),
+    EMAIL: (email) => buildApiUrl(`/validate/email/${encodeURIComponent(email)}`),
+    USERNAME: (username) => buildApiUrl(`/validate/username/${encodeURIComponent(username)}`),
+    PHONE: buildApiUrl("/validate/phone"),
   },
 };
 


### PR DESCRIPTION
## Description

This PR fixes incorrect API endpoint generation caused by duplicate `/api` prefixes in the centralized endpoint configuration.

`buildApiUrl()` already prefixes every relative path with `API_BASE_URL`, which itself includes the `/api` base path in both proxy and direct backend configurations. Several endpoint definitions were still passing paths that began with `/api`, producing invalid URLs such as `/api/api/...` and causing requests to fail.

### Changes Made

- Removed the redundant `/api` prefix from affected endpoint definitions.
- Updated the **Events** endpoints to use paths relative to `API_BASE_URL`.
- Updated the **Users** endpoints to use paths relative to `API_BASE_URL`.
- Updated the **Validation** endpoints to use paths relative to `API_BASE_URL`.
- Preserved the existing endpoint structure, Axios configuration, interceptors, and request handling.

This ensures endpoint URLs are generated consistently in both proxy mode and direct backend mode.

Fixes #10412 

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Screenshots / Video (if applicable)

N/A (API configuration fix)

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified that endpoint URLs are generated correctly in both proxy (`/api`) and direct backend (`https://<backend>/api`) configurations.