### PR TITLE
fix(home): eliminate duplicate API requests on homepage

### DIFF
--- a/src/Pages/Home/HomePage.jsx
+++ b/src/Pages/Home/HomePage.jsx
@@ -8,6 +8,7 @@ import RecommendationBanner from "./components/RecommendationBanner";
 import TrendingEvents from "../../components/TrendingEvents/TrendingEvents";
 import CollaborationNetworkMap from "../../components/visual/CollaborationNetworkMap";
 import CollaborationMap from "../../components/CollaborationMap";
+import useHomeEventsData from "./hooks/useHomeEventsData";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 // ─── CONSTANTS ──────────────────────────────────────────────────────────────
@@ -20,6 +21,7 @@ const SITE_DESCRIPTION =
 // ─── MAIN COMPONENT ─────────────────────────────────────────────────────────
 const HomePage = () => {
   useDocumentTitle("Home | Eventra");
+  const { eventsData, isLoading } = useHomeEventsData();
 
   return (
     <main className="min-h-screen bg-bg">
@@ -58,9 +60,9 @@ const HomePage = () => {
 
       {/* ─── PAGE CONTENT ───────────────────────────────────────────────── */}
       <Hero />
-      <WhatsHappening />
+      <WhatsHappening eventsData={eventsData} isLoading={isLoading} />
       <TrendingEvents title="Trending Events" limit={6} fetchSize={24} />
-      <HomeEventSearch />
+      <HomeEventSearch eventsData={eventsData} />
       <RecommendationBanner />
       <CollaborationNetworkMap />
       <CollaborationMap />

--- a/src/Pages/Home/components/HomeEventSearch.jsx
+++ b/src/Pages/Home/components/HomeEventSearch.jsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 
 import ModernSearchInput from "../../../components/common/ModernSearchInput";
 import useDebouncedSearch from "../../../hooks/useDebouncedSearch";
-import { eventService } from "../../../services/eventService";
 import hackathonsData from "../../Hackathons/hackathonMockData.json";
 import projectsData from "../../Projects/mockProjectsData.json";
 
@@ -29,26 +28,10 @@ const getItemPath = (item) => {
   return `/events/${item.id}`;
 };
 
-export default function HomeEventSearch() {
+export default function HomeEventSearch({ eventsData = [] }) {
   const { t } = useTranslation();
-  const [eventsData, setEventsData] = useState([]);
   const [searchResults, setSearchResults] = useState([]);
   const [showResults, setShowResults] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    eventService
-      .getAllEvents()
-      .then((res) => {
-        if (cancelled) return;
-        const raw = Array.isArray(res.data) ? res.data : res.data?.content ?? [];
-        setEventsData(raw);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const searchIndex = useMemo(() => {
     const allSearchItems = [

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -6,11 +6,9 @@ import { HomeCardSkeleton } from "../../../components/common/SkeletonLoaders";
 import { CheckCircle2, Hourglass } from "lucide-react";
 
 import useReducedMotion from "../../../hooks/useReducedMotion.js";
-// Fetch events from backend API instead of static mock data
-import { eventService } from "../../../services/eventService";
 import hackathonsData from "../../Hackathons/hackathonMockData.json";
 
-const WhatsHappening = () => {
+const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
   const prefersReducedMotion = useReducedMotion();
   const [ref, inView] = useInView({
     triggerOnce: true,
@@ -20,38 +18,11 @@ const WhatsHappening = () => {
   const [current, setCurrent] = useState(0);
   const [direction, setDirection] = useState(1);
   const [isAutoPlaying, setIsAutoPlaying] = useState(!prefersReducedMotion);
-  const [eventsData, setEventsData] = useState([]);
-
   useEffect(() => {
     if (prefersReducedMotion) {
       setIsAutoPlaying(false);
     }
   }, [prefersReducedMotion]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    eventService.getAllEvents().then((res) => {
-      if (cancelled) return;
-      const raw = Array.isArray(res.data) ? res.data : res.data?.content ?? [];
-      // Normalize backend shape (eventDate, capacity) to the shape formatEventsData expects
-      const normalized = raw.map((e) => ({
-        ...e,
-        date: e.date || e.eventDate,
-        startDate: e.startDate || e.eventDate,
-        type: e.type || "conference",
-        status: e.status || "upcoming",
-        attendees: e.attendees ?? e.registeredCount ?? 0,
-        description: e.description || "",
-        location: e.location || "",
-      }));
-      setEventsData(normalized);
-      setIsLoading(false);
-    }).catch(() => {
-      if (!cancelled) setIsLoading(false);
-    });
-    return () => { cancelled = true; };
-  }, []);
 
   const formatEventsData = (events) => {
     const now = new Date();

--- a/src/Pages/Home/hooks/useHomeEventsData.js
+++ b/src/Pages/Home/hooks/useHomeEventsData.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { eventService } from "../../../services/eventService";
+
+const normalizeEvents = (rawEvents = []) =>
+  rawEvents.map((e) => ({
+    ...e,
+    date: e.date || e.eventDate,
+    startDate: e.startDate || e.eventDate,
+    type: e.type || "conference",
+    status: e.status || "upcoming",
+    attendees: e.attendees ?? e.registeredCount ?? 0,
+    description: e.description || "",
+    location: e.location || "",
+  }));
+
+export default function useHomeEventsData() {
+  const [eventsData, setEventsData] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    eventService
+      .getAllEvents()
+      .then((res) => {
+        if (cancelled) return;
+        const raw = Array.isArray(res.data) ? res.data : res.data?.content ?? [];
+        setEventsData(normalizeEvents(raw));
+      })
+      .catch(() => {
+        if (!cancelled) setEventsData([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { eventsData, isLoading };
+}


### PR DESCRIPTION
## Description

This PR optimizes the homepage by eliminating duplicate API requests for event data and introducing a centralized data-fetching flow.

### Background

The homepage contains multiple components that depend on the same event dataset. Instead of allowing multiple components to fetch similar data independently, this PR centralizes the request into a single custom hook and shares the fetched data across all dependent components.

This reduces unnecessary network traffic, lowers backend load, improves initial page performance, and keeps the homepage data consistent across components.

### Changes Made

* Centralized homepage event fetching using the `useHomeEventsData` hook.
* Ensured event data is fetched only once during the initial page load.
* Reused the fetched event data across homepage components through props.
* Updated `HomeEventSearch` to consume the shared event data instead of performing its own request.
* Updated `WhatsHappening` to use the shared event dataset.
* Preserved the existing loading state using a shared `isLoading` flag.
* Maintained existing functionality while reducing redundant API calls.

### Why

* Eliminates unnecessary duplicate API requests.
* Reduces backend workload.
* Improves homepage loading performance.
* Ensures a single source of truth for homepage event data.
* Improves maintainability by centralizing data-fetching logic.

Fixes #10414 

---

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change
* [ ] Documentation update

---

## Screenshots / Video (if applicable)

N/A

---

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my code.
* [x] I have commented my code where necessary.
* [x] My changes introduce no new warnings.
* [x] I have tested the homepage and verified that event data is fetched only once during the initial page load.
* [x] Existing functionality remains unchanged.
* [x] Dependent components correctly consume the shared event data.
* [x] I have run local tests and verified they pass.
