### PR TITLE
fix(abuseLogger): resolve storage from window or globalThis (#10296)

### DIFF
--- a/src/utils/abuseLogger.js
+++ b/src/utils/abuseLogger.js
@@ -1,7 +1,11 @@
 import { safeLocalStorage } from "./safeStorage.js";
 
+const _hasStorage = () =>
+  (typeof window !== "undefined" && window.localStorage) ||
+  (typeof globalThis !== "undefined" && globalThis.localStorage);
+
 export const logAbuseAttempt = (type, details = {}) => {
-  if (typeof window === "undefined" || !window.localStorage) return;
+  if (!_hasStorage()) return;
   try {
     let existing;
     try {


### PR DESCRIPTION
Check globalThis.localStorage as fallback so logAbuseAttempt works in Node.js test environments.

Fixes #10296