### PR TITLE
fix: add missing useCopyToClipboard hook for EventShareButtons (#10289)

### DIFF
--- a/src/hooks/useCopyToClipboard.js
+++ b/src/hooks/useCopyToClipboard.js
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+
+export default function useCopyToClipboard({ resetMs = 2500 } = {}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async (text) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), resetMs);
+      return true;
+    } catch {
+      setCopied(false);
+      return false;
+    }
+  }, [resetMs]);
+
+  return { copy, copied };
+}


### PR DESCRIPTION
Create the useCopyToClipboard hook that EventShareButtons.jsx imports.

Fixes #10289