### PR TITLE
fix: correct import paths in SignupFormExample (#10291)

### DIFF
--- a/src/components/auth/SignupFormExample.jsx
+++ b/src/components/auth/SignupFormExample.jsx
@@ -12,8 +12,8 @@ import {
   UserCheck, 
   Info 
 } from "lucide-react";
-import useFormValidation from "../hooks/useFormValidation.enhanced";
-import useValidationState from "../hooks/useValidationState";
+import useFormValidation from "../../hooks/useFormValidation.enhanced";
+import useValidationState from "../../hooks/useValidationState";
 
 // =========================================================================
 // INTERFACE DESIGN CONSTANTS (PREVENTING INLINE REDECLARATIONS)


### PR DESCRIPTION
Fix relative import paths to resolve to src/hooks/ instead of the non-existent src/components/hooks/.

Fixes #10291