### PR TITLE
fix: add day-based salt rotation to device fingerprint (#10343)

### DIFF
--- a/src/utils/deviceFingerprint.js
+++ b/src/utils/deviceFingerprint.js
@@ -74,10 +74,11 @@ export const getDeviceFingerprint = () => {
 
     const fingerprintRaw = `${screenInfo}_${navInfo}_${canvasHash}`;
 
-    // Per-origin salt: different for each deployment and never a static literal
-    // in the bundle. Combining the origin with a domain-specific namespace
-    // avoids salt collisions if two deployments share the same hostname root.
-    const salt = `eventra:fingerprint:${window.location.origin}`;
+    // Per-origin salt with time-based rotation: combines origin with a day offset
+    // so fingerprints rotate every 24 hours. The dayOffset uses a fixed epoch
+    // (2020-01-01) for consistent buckets across sessions.
+    const dayOffset = Math.floor((Date.now() - 1577836800000) / 86400000);
+    const salt = `eventra:fingerprint:${window.location.origin}:${dayOffset}`;
 
     _memoizedFingerprint = CryptoJS.SHA256(fingerprintRaw + salt).toString();
     return _memoizedFingerprint;
@@ -113,7 +114,8 @@ export const getFastFingerprint = () => {
   try {
     const screenInfo = `${window.screen?.width || 0}x${window.screen?.height || 0}x${window.screen?.colorDepth || 0}`;
     const navInfo = `${window.navigator?.userAgent || ""}_${window.navigator?.language || ""}_${window.navigator?.hardwareConcurrency || 0}`;
-    const salt = `eventra:fast-fingerprint:${window.location.origin}`;
+    const dayOffset = Math.floor((Date.now() - 1577836800000) / 86400000);
+    const salt = `eventra:fast-fingerprint:${window.location.origin}:${dayOffset}`;
     _memoizedFastFingerprint = CryptoJS.SHA256(`${screenInfo}_${navInfo}_${salt}`).toString();
     return _memoizedFastFingerprint;
   } catch {
@@ -141,5 +143,6 @@ export const _clearFingerprintCache = () => {
  */
 export const _getFingerprintSalt = () => {
   if (typeof window === "undefined") return "eventra:fingerprint:test";
-  return `eventra:fingerprint:${window.location.origin}`;
+  const dayOffset = Math.floor((Date.now() - 1577836800000) / 86400000);
+  return `eventra:fingerprint:${window.location.origin}:${dayOffset}`;
 };


### PR DESCRIPTION
Add dayOffset to all fingerprint salts for 24-hour rotation.

Fixes #10343