### PR TITLE
fix: rotateCSRFToken Secure flag only set on HTTPS (#10389)

### DIFF
--- a/src/utils/csrfToken.js
+++ b/src/utils/csrfToken.js
@@ -158,7 +158,7 @@ export function rotateCSRFToken(newToken) {
     // Update cookies
     setCookie(CSRF_COOKIE_NAME, newToken, {
       path: "/",
-      secure: true,
+      secure: typeof location !== "undefined" && location.protocol === "https:",
     });
   }
 }


### PR DESCRIPTION
Fix rotateCSRFToken hardcoding secure:true which drops cookies on HTTP origins.

Fixes #10389