### PR TITLE
fix: add missing SocialShareButtons and AddToCalendar imports in EventCard

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -30,6 +30,8 @@ import { getEventStatus } from "../../utils/eventUtils";
 import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
+import SocialShareButtons from "../../components/common/SocialShareButtons";
+import AddToCalendar from "../../components/common/AddToCalendar";
 import {
   addBookmarkedEvent,
   isEventBookmarked,


### PR DESCRIPTION
## Summary

Fixes `react/jsx-no-undef` errors by adding missing imports for `SocialShareButtons` and `AddToCalendar` components in EventCard.jsx.

Both components are already used in the JSX (lines 379-380) but were missing from the import section.