### PR TITLE
fix: remove unused imports and variables across components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, lazy, Suspense } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Analytics } from "@vercel/analytics/react";
 import "./App.css";
 import "./styles/reduced-motion.css";
 import "./styles/print.css";
@@ -12,7 +11,6 @@ import Navbar from "./components/navbar/Navbar";
 import OfflineBanner from "./components/common/OfflineBanner";
 import OfflineConflictModal from "./components/common/OfflineConflictModal";
 import UpdateAvailableBanner from "./components/common/UpdateAvailableBanner";
-import ScrollToTop from "./components/ScrollToTop";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import NotificationToastContainer from "./components/common/NotificationProvider";

--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -8,7 +8,6 @@ import {
   Users,
   Clock,
   Code2,
-  ExternalLink,
   GitPullRequest,
   Scale,
   Eye,

--- a/src/components/OrganizerWaitlistManagement.jsx
+++ b/src/components/OrganizerWaitlistManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import {
   getEventWaitlist,

--- a/src/components/WaitlistModal.jsx
+++ b/src/components/WaitlistModal.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'react-toastify';
-import { joinWaitlist, leaveWaitlist, getQueuePosition } from '../utils/waitlistUtils.js';
+import { joinWaitlist, leaveWaitlist } from '../utils/waitlistUtils.js';
 import { useAuth } from '../context/AuthContext';
 
 /**

--- a/src/components/admin/AnalyticsDashboard.jsx
+++ b/src/components/admin/AnalyticsDashboard.jsx
@@ -46,37 +46,6 @@ const FALLBACK_CATEGORY_DATA = [
   { name: "Web3", value: 110, color: "#f59e0b" },
 ];
 
-// =========================================================================
-// SUB-COMPONENTS
-// =========================================================================
-function AnalyticsStreamBadge({ status }) {
-  if (status === SSE_STATUS.CONNECTED) {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-bold text-emerald-600 dark:text-emerald-400 normal-case">
-        <span className="relative flex h-1.5 w-1.5">
-          <span className="absolute inline-flex w-full h-full rounded-full opacity-75 animate-ping bg-emerald-400" />
-          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
-        </span>
-        SSE Live
-      </span>
-    );
-  }
-  if (status === SSE_STATUS.RECONNECTING) {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-bold text-amber-500 dark:text-amber-400 normal-case">
-        <span className="h-1.5 w-1.5 rounded-full bg-amber-400 animate-pulse" />
-        Reconnecting
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-bold text-slate-400 normal-case">
-      <span className="h-1.5 w-1.5 rounded-full bg-slate-300 dark:bg-slate-600" />
-      Simulated
-    </span>
-  );
-}
-
 const LOCAL_STORAGE_KEY = "eventra_checkins";
 
 // Pure initializers — depend only on module-level constants, safe to define outside component

--- a/src/components/admin/LivePollController.jsx
+++ b/src/components/admin/LivePollController.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useAuth } from "../../context/AuthContext.js";
 import useLiveAudience from "../../hooks/useLiveAudience.js";
 import { BarChart3, Plus, Pause, Play, XCircle, Vote, Check, Loader2, RefreshCw } from "lucide-react";
@@ -179,7 +179,7 @@ function PollModeratorPanel({ activePoll, totalVotes, pollState, handlers }) {
 }
 
 // ─── Attendee view ────────────────────────────────────────────────────────────
-function PollVotingForm({ activePoll, selectedOption, setSelectedOption, votingLoading }) {
+function PollVotingForm({ activePoll, selectedOption, setSelectedOption }) {
   return (
     <form className="flex flex-col gap-4">
       <h3 className="text-base font-bold text-slate-200 mb-2 leading-snug">Q: {activePoll.question}</h3>

--- a/src/components/common/CopyLinkButton.jsx
+++ b/src/components/common/CopyLinkButton.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Link2, Check } from "lucide-react";
-import { toast } from "react-toastify";
 
 const CopyLinkButton = () => {
   const [copied, setCopied] = useState(false);

--- a/src/components/common/EventCreation/EventMediaSection.jsx
+++ b/src/components/common/EventCreation/EventMediaSection.jsx
@@ -1,7 +1,6 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import { ImageIcon, Upload, X, Plus } from "lucide-react";
-import { logger } from "../../../utils/logger";
 
 const MAX_BANNER_SIZE = 5 * 1024 * 1024; // 5MB
 const allowedTypes = [

--- a/src/components/events/LiveQABoard.jsx
+++ b/src/components/events/LiveQABoard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useAuth } from "../../context/AuthContext.js";
 import useLiveAudience from "../../hooks/useLiveAudience.js";
 import { ThumbsUp, Trash, Flag, Send, AlertTriangle, HelpCircle, Loader2 } from "lucide-react";

--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -10,7 +10,6 @@ import {
   Moon,
   MousePointer,
   Bell,
-  PlusCircle,
   LayoutDashboard,
 } from "lucide-react";
 import { useNotification } from "../../context/NotificationContext";

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,13 +1,9 @@
 import { memo, useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
-import { useTheme } from "../../context/ThemeContext";
 import DesktopNavbar from "./DesktopNavbar";
 import MobileNavbar from "./MobileNavbar";
-import ThemeToggleButton from "../Layout/ThemeToggleButton";
-import InstallAppButton from "../common/InstallAppButton";
 import AuthButtons from "./AuthButtons";
-import LanguageSelector from "../LanguageSelector";
 import ProfileMenu from "./ProfileMenu";
 import NotificationBell from "../notifications/NotificationBell";
 import useBodyScrollLock from "./hooks/useBodyScrollLock";
@@ -20,8 +16,6 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
   const [scrolled, setScrolled] = useState(false);
   const { user, isAuthenticated, logout } = useAuth();
   const authenticated = isAuthenticated();
-  const { isDarkMode, toggleTheme, setIsCustomizerOpen } = useTheme();
-
   useBodyScrollLock(isMobileMenuOpen);
 
   const handleCloseModals = useCallback(() => {


### PR DESCRIPTION
## Summary

Batch cleanup of unused imports, variables, and dead code across 11 files, resolving no-unused-vars ESLint warnings.

### Changes:
- **App.jsx**: Removed unused `Analytics` import and `ScrollToTop` import
- **GitHubStats.jsx**: Removed unused `ExternalLink` icon import
- **AnalyticsDashboard.jsx**: Removed unused `AnalyticsStreamBadge` sub-component (27 lines of dead code)
- **Navbar.jsx**: Removed unused `ThemeToggleButton`, `InstallAppButton`, `LanguageSelector` imports and `useTheme` hook - the hook values were destructured but never used
- **LivePollController.jsx**: Removed unused `React` import and unused `votingLoading` prop from `PollVotingForm`
- **OrganizerWaitlistManagement.jsx, LiveQABoard.jsx**: Removed unused `React` imports
- **WaitlistModal.jsx**: Removed unused `React` import and unused `getQueuePosition` import
- **CopyLinkButton.jsx**: Removed unused `toast` import
- **EventMediaSection.jsx**: Removed unused `logger` import
- **MobileDrawer.jsx**: Removed unused `PlusCircle` icon import

No functionality changes.