### PR TITLE
fix: remove unused Analytics import from App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, lazy, Suspense } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Analytics } from "@vercel/analytics/react";
 import "./App.css";
 import "./styles/reduced-motion.css";
 import "./styles/print.css";


### PR DESCRIPTION
Remove unused App.jsx - unused Analytics.

Part of chore #10378 — no-unused-vars cleanup.