### PR TITLE
fix: remove unused ScrollToTop import from App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,6 @@ import Navbar from "./components/navbar/Navbar";
 import OfflineBanner from "./components/common/OfflineBanner";
 import OfflineConflictModal from "./components/common/OfflineConflictModal";
 import UpdateAvailableBanner from "./components/common/UpdateAvailableBanner";
-import ScrollToTop from "./components/ScrollToTop";
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import NotificationToastContainer from "./components/common/NotificationProvider";


### PR DESCRIPTION
Remove unused App.jsx - unused ScrollToTop.

Part of chore #10378 — no-unused-vars cleanup.