### PR TITLE
fix: remove unused ReminderControls import from EventCard

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -28,7 +28,6 @@ import ShareModal from "../../components/common/ShareModal";
 import StatusBadge from "../../components/common/StatusBadge";
 import { getEventStatus } from "../../utils/eventUtils";
 import { useMyEvents } from "../../context/MyEventsContext";
-import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
   addBookmarkedEvent,


### PR DESCRIPTION
Remove unused EventCard.js - unused ReminderControls.

Part of chore #10379 — no-unused-vars cleanup.