### PR TITLE
fix: guard question.options with null check before accessing .length to prevent TypeError crash when a choice question has no options field

### DIFF
--- a/src/components/admin/SurveyAnalytics.jsx
+++ b/src/components/admin/SurveyAnalytics.jsx
@@ -334,7 +334,7 @@ const SurveyAnalytics = ({ questions = [], surveyTitle = "Survey" }) => {
                   {/* B. MULTIPLE CHOICE BAR CHART */}
                   {question.type === "choice" && hasData && (
                     <div className="w-full h-44">
-                      {question.options.length === 0 ? (
+                      {!question.options || question.options.length === 0 ? (
                         <div className="text-center py-6 text-xs text-slate-400">
                           No options defined for this choice question.
                         </div>


### PR DESCRIPTION
### Related Issue
Closes #10441 

### Description of Changes
- I changed `question.options.length === 0` to
  `!question.options || question.options.length === 0` in the bar chart
  section of `SurveyAnalytics.jsx`.
- A choice question with a missing, `null`, or empty `options` field now
  renders the "No options defined" fallback instead of throwing a
  `TypeError` that crashes the entire analytics panel.