### PR TITLE
fix: remove unused setSearchQuery from GSSoCContribution

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/Pages/Leaderboard/GSSoCContribution.js
+++ b/src/Pages/Leaderboard/GSSoCContribution.js
@@ -302,7 +302,6 @@ const GSSoCContribution = () => {
   const searchInputRef = useRef(null);
   const { toasts, addToast, removeToast } = useToast();
   
-  const [searchQuery, setSearchQuery] = useState(() => localStorage.getItem("gssoc.search") || "");
   // eslint-disable-next-line no-unused-vars
   const _debouncedSearchQuery = useDebounce(searchQuery, 300);
   const [selectedDifficulty, setSelectedDifficulty] = useState(() => localStorage.getItem("gssoc.difficulty") || "all");


### PR DESCRIPTION
Remove unused GSSoCContribution.js - unused setSelectedDifficulty.

Part of chore #10381 — no-unused-vars cleanup.