### PR TITLE
fix: remove unused toast

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/common/CopyLinkButton.jsx
+++ b/src/components/common/CopyLinkButton.jsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Link2, Check } from "lucide-react";
-import { toast } from "react-toastify";
 
 const CopyLinkButton = () => {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
Remove unused CopyLinkButton.jsx - unused toast import.

Part of chore #10380 — no-unused-vars cleanup.