### PR TITLE
fix: remove unused ThemeToggleButton

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -4,7 +4,6 @@ import { useAuth } from "../../context/AuthContext";
 import { useTheme } from "../../context/ThemeContext";
 import DesktopNavbar from "./DesktopNavbar";
 import MobileNavbar from "./MobileNavbar";
-import ThemeToggleButton from "../Layout/ThemeToggleButton";
 import InstallAppButton from "../common/InstallAppButton";
 import AuthButtons from "./AuthButtons";
 import LanguageSelector from "../LanguageSelector";


### PR DESCRIPTION
Remove unused Navbar.jsx - unused ThemeToggleButton.

Part of chore #10379 — no-unused-vars cleanup.