### PR TITLE
fix: remove unused LanguageSelector

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -7,7 +7,6 @@ import MobileNavbar from "./MobileNavbar";
 import ThemeToggleButton from "../Layout/ThemeToggleButton";
 import InstallAppButton from "../common/InstallAppButton";
 import AuthButtons from "./AuthButtons";
-import LanguageSelector from "../LanguageSelector";
 import ProfileMenu from "./ProfileMenu";
 import NotificationBell from "../notifications/NotificationBell";
 import useBodyScrollLock from "./hooks/useBodyScrollLock";


### PR DESCRIPTION
Remove unused Navbar.jsx - unused LanguageSelector.

Part of chore #10379 — no-unused-vars cleanup.