### PR TITLE
fix: remove unused Home

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/navbar/constants/navItems.js
+++ b/src/components/navbar/constants/navItems.js
@@ -1,5 +1,4 @@
 import {
-  Home,
   Calendar,
   CalendarDays,
   Clock,


### PR DESCRIPTION
Remove unused navItems.js - unused Home.

Part of chore #10378 — no-unused-vars cleanup.