### PR TITLE
fix: remove unused Bookmark

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/navbar/constants/navItems.js
+++ b/src/components/navbar/constants/navItems.js
@@ -8,7 +8,6 @@ import {
   Trophy,
   MessageSquare,
   Book,
-  Bookmark,
   Info,
   HelpCircle,
   MoreHorizontal,


### PR DESCRIPTION
Remove unused navItems.js - unused Bookmark.

Part of chore #10378 — no-unused-vars cleanup.