### PR TITLE
fix: remove unused useRegistrationFilters

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/user/RegistrationsTab.jsx
+++ b/src/components/user/RegistrationsTab.jsx
@@ -9,7 +9,6 @@ import { DashboardTableSkeleton } from "../common/SkeletonLoaders";
 import { getSmartDateLabel } from "../../utils/relativeTime";
 import { downloadBulkICSFile } from "../../utils/calendarExporter";
 import CertificateDownload from "../CertificateDownload";
-import { useRegistrationFilters, TYPE_OPTIONS, STATUS_OPTIONS } from "../../hooks/useRegistrationFilters";
 
 // Icon mapping (extracted to reduce complexity)
 const TYPE_ICON = {


### PR DESCRIPTION
Remove unused RegistrationsTab.jsx - unused useRegistrationFilters.

Part of chore #10380 — no-unused-vars cleanup.