### PR TITLE
fix: remove unused getPopupStyle

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -283,7 +283,6 @@ export default function CollaborationNetworkMap() {
     [hubCoordinates]
   );
 
-  const getPopupStyle = useCallback((hub) => {
     if (!hub) return {};
     const xPercent = (hub.x / 1000) * 100;
     const yPercent = (hub.y / 500) * 100;


### PR DESCRIPTION
Remove unused CollaborationNetworkMap.jsx - unused getPopupStyle.

Part of chore #10381 — no-unused-vars cleanup.