### PR TITLE
fix: remove unused handleHubMouseLeave

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -335,7 +335,6 @@ export default function CollaborationNetworkMap() {
     [pinnedHub]
   );
 
-  const handleHubMouseLeave = useCallback(() => {
     if (!pinnedHub) {
       hoverTimeoutRef.current = setTimeout(() => {
         setActiveHub(null);


### PR DESCRIPTION
Remove unused CollaborationNetworkMap.jsx - unused handleHubMouseLeave.

Part of chore #10381 — no-unused-vars cleanup.