### PR TITLE
fix: remove unused useCallback

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -31,10 +31,7 @@ import { useMyEvents } from "../../context/MyEventsContext";
 import ReminderControls from "../../components/reminders/ReminderControls";
 import MatchScoreBadge from "../../components/common/MatchScoreBadge";
 import {
-  addBookmarkedEvent,
   isEventBookmarked,
-  removeBookmarkedEvent,
-  subscribeToBookmarkChanges,
 } from "../../utils/bookmarkUtils";
 import { checkRegistrationConflict } from "../../utils/conflictDetection";
 

--- a/src/hooks/useRoutePrefetch.js
+++ b/src/hooks/useRoutePrefetch.js
@@ -2,7 +2,6 @@
  * @fileoverview useRoutePrefetch - Route prefetching hook based on current location
  * @module hooks/useRoutePrefetch
  */
-import { useEffect, useCallback } from "react";
 import { useLocation } from "react-router-dom";
 import { prefetchRoute } from "../utils/prefetchUtils";
 


### PR DESCRIPTION
Remove unused useRoutePrefetch.js - unused useCallback import.

Part of chore #10382 — no-unused-vars cleanup.