### PR TITLE
Fix test utils auth import

### DIFF
--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider } from '../context/AuthContext';
+import { AuthProvider } from './context/AuthContext';
 
 export function renderWithRouter(ui, options = {}) {
   return render(ui, {


### PR DESCRIPTION
## Summary
- fixes `src/test-utils.js` to import `AuthProvider` from the correct `src/context` path
- restores module resolution for helpers that render with auth context

## Validation
- `Test-Path src\context\AuthContext.js`
- `git diff --check`

Fixes #10465
