### PR TITLE
Fix EventCard title overflow handling

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -321,7 +321,7 @@ const EventCard = ({ event, matchScore, matchReasons }) => {
         <h3
           id={titleId}
           title={event.title}
-          className="text-text font-bold text-base leading-snug line-clamp-2 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-200"
+          className="min-w-0 break-words text-text font-bold text-base leading-snug line-clamp-2 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-200"
         >
           {event.title}
         </h3>


### PR DESCRIPTION
## Summary
- adds word breaking to EventCard titles
- constrains the title width so long words cannot stretch the card layout

## Validation
- `node -e "const s=require('fs').readFileSync('src/Pages/Events/EventCard.js','utf8'); for (const x of ['break-words','min-w-0','title={event.title}']) if(!s.includes(x)){ console.error('missing '+x); process.exit(1); }"`

Fixes #10471
