### PR TITLE
Fix EventRegistration title overflow handling

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -629,7 +629,7 @@ const EventRegistration = () => {
           </p>
 
           <div className="bg-slate-50/80 dark:bg-slate-950/40 border border-slate-200/40 dark:border-slate-800/50 rounded-3xl p-5 mb-8 text-left">
-            <h3 title={event.title} className="text-lg font-bold text-slate-800 dark:text-slate-200 mb-3 line-clamp-2 wrap-break-word min-w-0">
+            <h3 title={event.title} className="text-lg font-bold text-slate-800 dark:text-slate-200 mb-3 line-clamp-2 break-words wrap-break-word min-w-0">
               {event.title}
             </h3>
 
@@ -799,7 +799,7 @@ const EventRegistration = () => {
             />
             <div className="absolute inset-0 bg-linear-to-t from-black/60 to-transparent"></div>
             <div className="absolute bottom-0 left-0 right-0 p-6 text-white">
-              <h1 title={event.title} className="text-3xl font-bold mb-2 wrap-break-word">{event.title}</h1>
+              <h1 title={event.title} className="text-3xl font-bold mb-2 break-words wrap-break-word">{event.title}</h1>
               <div className="flex flex-wrap gap-4 text-sm">
                 <span className="flex items-center gap-1">
                   <Calendar className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- adds standard word breaking to EventRegistration event titles
- preserves the existing title tooltip and two-line clamp behavior

## Validation
- `node -e "const s=require('fs').readFileSync('src/Pages/Events/EventRegistration.js','utf8'); for (const x of ['line-clamp-2','break-words','title={event.title}']) if(!s.includes(x)){ console.error('missing '+x); process.exit(1); }"`

Fixes #10472
