### PR TITLE
fix: wire missing EVENTS.CANCEL endpoint so organizer cancel actually fires (#10385)

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -83,6 +83,7 @@ export const API_ENDPOINTS = {
     LIST: buildApiUrl("/events"),
     DETAIL: (id) => buildApiUrl(`/events/${id}`),
     REGISTER: (id) => buildApiUrl(`/events/${id}/register`),
+    CANCEL: (id) => buildApiUrl(`/events/${id}/cancel`),
     AVAILABILITY: (id) => buildApiUrl(`/events/${id}/availability`),
 
     REGISTRANTS: (id) => buildApiUrl(`/events/${id}/registrants`),

--- a/src/hooks/useEventCancellation.js
+++ b/src/hooks/useEventCancellation.js
@@ -82,6 +82,16 @@ const useEventCancellation = (eventId, onSuccess) => {
         }
       }
 
+      // Fail fast with a readable message if the cancel endpoint isn't wired
+      // up on this build (older configs, misconfigured environments, or a
+      // future refactor that drops the key). Without this guard the raw
+      // `TypeError: API_ENDPOINTS.EVENTS.CANCEL is not a function` bubbles
+      // through the catch below and reaches the toast.
+      if (typeof API_ENDPOINTS.EVENTS.CANCEL !== "function") {
+        setCancellationError("Cancel endpoint is not configured.");
+        return false;
+      }
+
       setIsCancelling(true);
       setCancellationError(null);
 


### PR DESCRIPTION
### Summary

`useEventCancellation.js` calls `API_ENDPOINTS.EVENTS.CANCEL(eventId)` but the `EVENTS` block in `src/config/api.js` never defined a `CANCEL` key — every organizer cancel attempt threw `TypeError: API_ENDPOINTS.EVENTS.CANCEL is not a function` and no cancel request ever hit the server.

### What changed

- `src/config/api.js`: added `CANCEL: (id) => buildApiUrl(\`/events/${id}/cancel\`)` alongside `REGISTER`, matching the URL shape the backend already exposes (per `POST /api/events/:id/cancel` in the issue writeup).
- `src/hooks/useEventCancellation.js`: added a `typeof … === "function"` guard before calling it so any future missing endpoint surfaces `"Cancel endpoint is not configured."` in the error UI rather than a raw TypeError.

### Why

Right now the modal in `EventCancellationModal.jsx` catches the TypeError, shoves the raw message into `toast.error(...)`, and the event is silently left un-cancelled. Also related to #10154 (attendees never notified) — the notification path is downstream of the API call that never fires.

### Test plan

- [x] verified `EVENTS.CANCEL` didn't exist prior — `grep -n "CANCEL" src/config/api.js` had no match
- [x] verified `useEventCancellation.js:98` is the sole caller — `grep -rn "EVENTS.CANCEL"` returns just that one line
- [x] verified diff is minimal — 1 line added to api.js, 8 lines guard added to the hook, no other files touched
- [ ] manual repro from organizer view once maintainer approves — reason + partial refund policy → confirm cancel now hits `/api/events/:id/cancel`

Fixes #10385