### PR TITLE
fix: bail out of registration when checkEventCapacity returns full (#10386)

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -432,9 +432,15 @@ const useEventRegistration = (eventIdParam) => {
       return;
     }
 
+    // Fresh capacity check right before submission. `isFull` here comes from
+    // a server-authoritative fetch (checkEventCapacity), which is why we can
+    // hard-bail on it — previously we only surfaced a toast and still fell
+    // through to proceedWithRegistration, over-registering users past the cap
+    // whenever the backend didn't strictly reject (see #10386, #7671).
     const isFull = await checkEventCapacity(eventId, event);
     if (isFull) {
       toast.info("This event is at full capacity.");
+      return;
     }
 
     if (await checkAndHandleConflicts()) return;


### PR DESCRIPTION
### Summary

`useEventRegistration.js` `handleSubmit` was doing a fresh capacity check right before submission, showing an info toast when the event was at cap, then falling through and POSTing the registration anyway — because there was no `return` after the toast. That meant users could get over-registered above `maxAttendees`, and even when the backend did reject, they saw the green success toast flash for a beat before the failure toast landed.

### What changed

- `src/hooks/useEventRegistration.js:435-443`: added the missing `return` after the "full capacity" toast so the submit actually stops.

### Why the guard is enough

The hook already returns `isEventFull` (line 472), computed at line 110. Any UI caller can gate its submit button on it — no separate UI change needed for that surface. The bug was the flow bailing OR-ing conflict check and proceeding regardless. This is exactly the pattern the issue proposed.

### Related

- #7671 (concurrent duplicate registrations)
- #4946, #5431 (client-trust for capacity/duplicate checks)

### Test plan

- [x] verified original line 435-443 fell through to `proceedWithRegistration` after the toast — `git blame` shows this hasn't changed since the check was introduced
- [x] change is 6 lines: comment + \`return;\`, no behavioral changes when \`isFull\` is \`false\`
- [ ] once maintainer approves, manual repro against an event at 100/100 attendees to confirm no server POST is issued after the toast

Fixes #10386