### PR TITLE
fix: scope useWaitlist storage key per authenticated user (#10388)

### DIFF
--- a/src/hooks/useWaitlist.js
+++ b/src/hooks/useWaitlist.js
@@ -14,16 +14,23 @@ import { useState, useEffect, useCallback } from "react";
 import { toast } from "react-toastify";
 import { apiUtils, API_ENDPOINTS } from "../config/api.js";
 import { safeLocalStorage } from "../utils/safeStorage";
+import { useAuth } from "../context/AuthContext";
+import { getOrMigrateKey } from "../utils/storageKeyManager";
 
-const STORAGE_KEY = "eventra_waitlist_positions";
+// Legacy unscoped key the hook used before #10388. Kept around so
+// getOrMigrateKey can adopt any data left under it into the user's namespaced
+// key on first login after this fix.
+const LEGACY_STORAGE_KEY = "eventra_waitlist_positions";
+const WAITLIST_NAMESPACE = "eventra_waitlist_positions";
 
 /**
- * Read the persisted waitlist map from localStorage.
+ * Read the persisted waitlist map for a given storage key.
  * Returns an object keyed by eventId with { position, joinedAt }.
  */
-function readPersistedWaitlist() {
+function readPersistedWaitlist(storageKey) {
+  if (!storageKey) return {};
   try {
-    const raw = safeLocalStorage.getItem(STORAGE_KEY);
+    const raw = safeLocalStorage.getItem(storageKey);
     return raw ? JSON.parse(raw) : {};
   } catch {
     return {};
@@ -33,17 +40,19 @@ function readPersistedWaitlist() {
 let persistTimeout = null;
 
 /**
- * Persist the waitlist map.
+ * Persist the waitlist map to the given storage key. No-op if the key is
+ * falsy (e.g. logged-out state where we want in-memory only, so nothing
+ * leaks to the next user of a shared browser).
  */
-function persistWaitlist(map) {
-  if (typeof window === "undefined") return;
+function persistWaitlist(map, storageKey) {
+  if (typeof window === "undefined" || !storageKey) return;
   if (persistTimeout) {
     clearTimeout(persistTimeout);
   }
   persistTimeout = setTimeout(() => {
     const runWrite = () => {
       try {
-        safeLocalStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+        safeLocalStorage.setItem(storageKey, JSON.stringify(map));
       } catch {
         // ignore quota errors
       }
@@ -72,7 +81,20 @@ function persistWaitlist(map) {
  * }}
  */
 export default function useWaitlist(eventId, { capacity: _capacity, attendees: _attendees } = {}) {
-  const [waitlistMap, setWaitlistMap] = useState(readPersistedWaitlist);
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  // Scope the persistence key to the authenticated user. For guests, `storageKey`
+  // is `undefined` so `persistWaitlist` becomes a no-op — the state stays in
+  // memory for the session and never touches localStorage, so a guest can't leak
+  // their positions to the next person on a shared browser. Authenticated
+  // users go through getOrMigrateKey, which also adopts anything left under the
+  // legacy unscoped `eventra_waitlist_positions` key on first login.
+  const storageKey = userId
+    ? getOrMigrateKey(WAITLIST_NAMESPACE, userId, LEGACY_STORAGE_KEY)
+    : undefined;
+
+  const [waitlistMap, setWaitlistMap] = useState(() => readPersistedWaitlist(storageKey));
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -81,10 +103,16 @@ export default function useWaitlist(eventId, { capacity: _capacity, attendees: _
   const isOnWaitlist = Boolean(entry);
   const position = entry?.position ?? null;
 
-  // Persist on every change
+  // On sign-in/out, re-seed the map from the new key so user B doesn't see
+  // user A's in-memory state after a session swap on the same tab.
   useEffect(() => {
-    persistWaitlist(waitlistMap);
-  }, [waitlistMap]);
+    setWaitlistMap(readPersistedWaitlist(storageKey));
+  }, [storageKey]);
+
+  // Persist on every change (no-op for guests via the storageKey check)
+  useEffect(() => {
+    persistWaitlist(waitlistMap, storageKey);
+  }, [waitlistMap, storageKey]);
 
   /**
    * Estimate wait in human-readable form.


### PR DESCRIPTION
### Summary

`useWaitlist.js` persisted the whole `{eventId: {position, joinedAt}}` map to a single unscoped `eventra_waitlist_positions` localStorage key, so on a shared browser user A's positions became visible to user B. Worse, if B clicked "leave" on an event A had joined, the hook fired `apiUtils.delete` under B's session against an event B never joined, and B's `joinedAt` timestamps of A leaked as UI.

### What changed

- pull `user` from `useAuth()` and scope the storage key via `getOrMigrateKey("eventra_waitlist_positions", user.id, legacyKey)` — same pattern already in `useBookmarks`, `useEventForm`, `MyEventsContext`, and `waitlistUtils`, so no new utility introduced
- `getOrMigrateKey` automatically adopts any data left under the legacy unscoped key into the new user-scoped key on first authenticated read
- on `user?.id` change (login/logout), re-seed `waitlistMap` from the new key so in-tab session swaps don't carry A's state over to B
- for guests (`user?.id` is nullish), `storageKey` is `undefined` → `persistWaitlist` becomes a no-op and state stays in memory only. Nothing hits localStorage, so a guest can't leak state to the next person on the browser

### Why the guest-in-memory-only choice

Storing guest state under an `_guest` key still leaks between guests. The waitlist API needs auth anyway (`apiUtils.post` uses the httpOnly session cookie), so guests can't actually meaningfully use this hook — an in-memory-only fallback is both correct and safer.

### Test plan

- [x] verified `getOrMigrateKey` migration path in `storageKeyManager.js:58-72` — moves from legacy to new key iff new key is empty, so multi-account rehydration doesn't clobber
- [x] verified all `STORAGE_KEY` references are now parameterized (2 read sites, 1 write site)
- [x] `persistTimeout` still module-level so debounce logic is preserved
- [x] no other files reference `useWaitlist.STORAGE_KEY` — checked with `grep -rn "eventra_waitlist_positions" src`; only `waitlistUtils.js` uses `my_events` namespace, unrelated
- [ ] once maintainer approves, manual test: user A joins event 42 waitlist → logout → user B logs in → user B's tray is empty and no stale "leave" button

Fixes #10388