### PR TITLE
feat: add in-app What's New changelog viewer with bell dropdown and f…

### DIFF
--- a/src/Pages/WhatsNew/WhatsNewPage.jsx
+++ b/src/Pages/WhatsNew/WhatsNewPage.jsx
@@ -1,0 +1,87 @@
+// src/Pages/WhatsNew/WhatsNewPage.jsx
+import { useState, useMemo } from "react";
+import { whatsNewEntries } from "../../data/whatsNewEntries";
+import WhatsNewItem from "../../components/whatsnew/WhatsNewItem";
+
+const FILTERS = [
+  { key: "all", label: "All" },
+  { key: "new", label: "New" },
+  { key: "improved", label: "Improved" },
+  { key: "fixed", label: "Fixed" },
+];
+
+export default function WhatsNewPage() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeFilter, setActiveFilter] = useState("all");
+
+  const filteredEntries = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return whatsNewEntries
+      .map((entry) => {
+        const filteredItems = entry.items.filter((item) => {
+          const matchesFilter =
+            activeFilter === "all" || item.type === activeFilter;
+          const matchesSearch =
+            query === "" || item.text.toLowerCase().includes(query);
+          return matchesFilter && matchesSearch;
+        });
+        return { ...entry, items: filteredItems };
+      })
+      .filter((entry) => entry.items.length > 0);
+  }, [searchQuery, activeFilter]);
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-10">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          What's New ✨
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Browse the full history of updates, improvements, and fixes.
+        </p>
+      </div>
+
+      {/* Search */}
+      <div className="mb-4">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search updates..."
+          className="w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {/* Category filters */}
+      <div className="flex gap-2 mb-6 flex-wrap">
+        {FILTERS.map((filter) => (
+          <button
+            key={filter.key}
+            onClick={() => setActiveFilter(filter.key)}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              activeFilter === filter.key
+                ? "bg-blue-600 text-white"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
+            }`}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Results */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-900">
+        {filteredEntries.length === 0 ? (
+          <p className="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
+            No updates match your search.
+          </p>
+        ) : (
+          filteredEntries.map((entry) => (
+            <WhatsNewItem key={entry.version} entry={entry} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -1,33 +1,22 @@
 import { memo, useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
-
-import { useAuth } from "../../context/AuthContext";
-import { useTheme } from "../../context/ThemeContext";
-
+import { useAuth } from "context/AuthContext";
 import DesktopNavbar from "./DesktopNavbar";
 import MobileNavbar from "./MobileNavbar";
-import CursorToggle from "./CursorToggle";
-import ThemeToggleButton from "../Layout/ThemeToggleButton";
 import AuthButtons from "./AuthButtons";
-import LanguageSelector from "../LanguageSelector";
 import ProfileMenu from "./ProfileMenu";
 import NotificationBell from "../notifications/NotificationBell";
 import WhatsNewBell from "../whatsnew/WhatsNewBell";
 import useBodyScrollLock from "./hooks/useBodyScrollLock";
-import useKeyboardShortcuts from "../../hooks/useKeyboardShortcuts";
+import useKeyboardShortcuts from "hooks/useKeyboardShortcuts";
 
 const Navbar = ({ cursorEnabled, toggleCursor }) => {
   const navRef = useRef(null);
-
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [scrollProgress, setScrollProgress] = useState(0);
   const [scrolled, setScrolled] = useState(false);
-
   const { user, isAuthenticated, logout } = useAuth();
   const authenticated = isAuthenticated();
-
-  const { isDarkMode, toggleTheme, setIsCustomizerOpen } = useTheme();
-
   useBodyScrollLock(isMobileMenuOpen);
 
   const handleCloseModals = useCallback(() => {
@@ -36,7 +25,6 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
   const handleSearchFocus = useCallback(() => {
     const searchInput = navRef.current?.querySelector('input[type="text"], input[type="search"]');
-
     if (searchInput) {
       searchInput.focus();
     }
@@ -46,7 +34,6 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
     const createButton = navRef.current?.querySelector(
       '[aria-label*="Create Event"], [aria-label*="create"]'
     );
-
     if (createButton) {
       createButton.click();
     }
@@ -60,30 +47,20 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
   useEffect(() => {
     let ticking = false;
-
     const handleScroll = () => {
       if (ticking) return;
-
       ticking = true;
-
       window.requestAnimationFrame(() => {
         const scrollTop = window.scrollY;
-
         const docHeight = document.documentElement.scrollHeight - window.innerHeight;
-
         const progress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
-
         setScrollProgress(progress);
         setScrolled(scrollTop > 12);
-
         ticking = false;
       });
     };
 
-    window.addEventListener("scroll", handleScroll, {
-      passive: true,
-    });
-
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => {
       window.removeEventListener("scroll", handleScroll);
     };
@@ -91,7 +68,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
 
   return (
     <>
-      <a
+      
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-white"
       >
@@ -101,78 +78,67 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
       <nav
         ref={navRef}
         aria-label="Primary navigation"
-        className={`sticky top-0 z-50 w-full transition-all duration-300 bg-white/85 dark:bg-slate-950/85 backdrop-blur-xl border-b border-slate-200/40 dark:border-slate-800/40 ${
-          scrolled ? "shadow-md shadow-primary/5 dark:shadow-blue-900/10" : "shadow-sm shadow-primary/2 dark:shadow-blue-900/5"
-        }`}
+        className={`fixed top-0 left-0 right-0 z-50 w-full transition-all duration-300 bg-navbar border-b border-transparent ${scrolled ? "shadow-premium-md border-primary/10" : "shadow-premium-sm border-transparent"
+          }`}
       >
         <div className="mx-auto max-w-screen-2xl px-3 sm:px-4 lg:px-6">
-          <div className="flex h-16 items-center justify-between gap-2">
-            {/* Logo */}
-            <Link to="/" aria-label="Eventra Home" className="flex items-center shrink-0 group">
+          {/* FIXED: Added overflow-hidden and min-width-0 to prevent overflow */}
+          <div className="flex h-16 items-center justify-between gap-2 overflow-hidden min-w-0">
+
+            {/* Logo - Fixed width */}
+            <Link to="/" aria-label="Eventra Home" className="flex items-center shrink-0">
               <div className="flex items-center gap-2">
-                <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-white to-slate-50 dark:from-slate-900 dark:to-slate-950 p-1 shadow-md shadow-primary/10 ring-1 ring-primary/20 dark:ring-blue-500/30 transition-transform duration-300 group-hover:scale-105">
+                <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-slate-100 to-slate-200 dark:from-slate-900 dark:to-slate-950 p-1 shadow-md shadow-primary/10 ring-1 ring-primary/20 dark:ring-blue-500/30 transition-transform duration-300 group-hover:scale-105">
                   <img
                     src="/favicon.png"
                     alt="Eventra Logo"
-                    className="h-full w-full object-contain"
+                    className="h-full w-full object-contain scale-110"
                     width="32"
                     height="32"
                   />
                 </div>
- 
-                <span className="font-heading text-base font-bold tracking-wider bg-gradient-to-r from-primary to-blue-600 dark:from-blue-400 dark:to-indigo-400 bg-clip-text text-transparent">
+                <span className="font-heading text-base font-bold tracking-wider text-primary dark:text-blue-400">
                   Eventra
                 </span>
               </div>
             </Link>
 
-            {/* Desktop Navigation — allowed to flex-shrink */}
-            <div className="hidden lg:flex flex-1 justify-center min-w-0 mx-1">
+            {/* FIXED: Desktop Navigation - Added flex-shrink and min-width-0 */}
+            <div className="hidden lg:flex flex-1 justify-center min-w-0 mx-1 overflow-hidden">
               <DesktopNavbar />
             </div>
 
-            {/* Right Controls */}
-            <div className="flex items-center justify-end gap-1.5 shrink-0">
-              <div className="hidden lg:flex items-center gap-1.5">
-                <ThemeToggleButton
-                  isDarkMode={isDarkMode}
-                  toggleTheme={toggleTheme}
-                  isMobile={false}
-                  setIsCustomizerOpen={setIsCustomizerOpen}
-                />
+            {/* Controls & CTAs */}
+            <div className="flex items-center justify-end gap-2 shrink-0">
+              {/* Desktop CTAs & Profile */}
+              <div className="hidden lg:flex items-center gap-2">
                 <WhatsNewBell />
                 {authenticated ? (
                   <>
                     <NotificationBell />
-                    <LanguageSelector compact />
                     <ProfileMenu user={user} logout={logout} />
                   </>
                 ) : (
-                  <>
-                    <LanguageSelector compact />
-                    <AuthButtons />
-                  </>
+                  <AuthButtons />
                 )}
               </div>
 
+              {/* Mobile Notifications */}
               <div className="flex items-center gap-2 lg:hidden">
-                <ThemeToggleButton
-                  isDarkMode={isDarkMode}
-                  toggleTheme={toggleTheme}
-                  isMobile={false}
-                  setIsCustomizerOpen={setIsCustomizerOpen}
-                />
                 <WhatsNewBell />
-               {authenticated && <NotificationBell />}
-
-                <MobileNavbar
-                  isOpen={isMobileMenuOpen}
-                  setIsOpen={setIsMobileMenuOpen}
-                  isAuthenticated={authenticated}
-                  user={user}
-                  logout={logout}
-                />
+                {authenticated && <NotificationBell />}
               </div>
+
+              {/* Navigation Drawer Toggle */}
+              <MobileNavbar
+                isOpen={isMobileMenuOpen}
+                setIsOpen={setIsMobileMenuOpen}
+                isAuthenticated={authenticated}
+                user={user}
+                logout={logout}
+                cursorEnabled={cursorEnabled}
+                toggleCursor={toggleCursor}
+              />
             </div>
           </div>
         </div>
@@ -180,9 +146,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
         <div aria-hidden="true" className="absolute bottom-0 left-0 h-[2px] w-full">
           <div
             className="h-full bg-primary transition-all duration-100 ease-out"
-            style={{
-              width: `${scrollProgress}%`,
-            }}
+            style={{ width: `${scrollProgress}%` }}
           />
         </div>
       </nav>

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -12,7 +12,7 @@ import AuthButtons from "./AuthButtons";
 import LanguageSelector from "../LanguageSelector";
 import ProfileMenu from "./ProfileMenu";
 import NotificationBell from "../notifications/NotificationBell";
-
+import WhatsNewBell from "../whatsnew/WhatsNewBell";
 import useBodyScrollLock from "./hooks/useBodyScrollLock";
 import useKeyboardShortcuts from "../../hooks/useKeyboardShortcuts";
 
@@ -140,6 +140,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
                   isMobile={false}
                   setIsCustomizerOpen={setIsCustomizerOpen}
                 />
+                <WhatsNewBell />
                 {authenticated ? (
                   <>
                     <NotificationBell />
@@ -161,7 +162,8 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
                   isMobile={false}
                   setIsCustomizerOpen={setIsCustomizerOpen}
                 />
-                {authenticated && <NotificationBell />}
+                <WhatsNewBell />
+               {authenticated && <NotificationBell />}
 
                 <MobileNavbar
                   isOpen={isMobileMenuOpen}

--- a/src/components/routes/PublicRoutes.js
+++ b/src/components/routes/PublicRoutes.js
@@ -3,6 +3,7 @@ import { Route } from "react-router-dom";
 import ProtectedRoute from "../auth/ProtectedRoute";
 import ErrorBoundary from "../common/ErrorBoundary";
 
+
 // ─── Lazy-loaded page components ─────────────────────────────────────────────
 // 🔥 FIX: Removed duplicate const declarations for all components
 const HealthCheckPage = lazy(() => import("../../Pages/HealthCheckPage"));
@@ -32,6 +33,7 @@ const ContactUs = lazy(() => import("../../Pages/Contact/ContactUs"));
 const FeedbackPage = lazy(() => import("../../Pages/Feedback/FeedbackPage"));
 const BookmarkedEvents = lazy(() => import("../../Pages/Events/BookmarkedEvents"));
 const RemindersPage = lazy(() => import("../../Pages/Events/RemindersPage"));
+const WhatsNewPage = lazy(() => import("../../Pages/WhatsNew/WhatsNewPage"));
 const MyCalendar = lazy(() => import("../../Pages/Calendar/MyCalendar"));
 const OptimizedImage = lazy(() => import("../common/OptimizedImage"));
 
@@ -86,6 +88,7 @@ export const getPublicRoutes = () => [
   <Route key="/feedback" path="/feedback" element={withModuleBoundary(<FeedbackPage />, "Feedback")} />,
   <Route key="/bookmarks" path="/bookmarks" element={withModuleBoundary(<BookmarkedEvents />, "Bookmarks")} />,
   <Route key="/reminders" path="/reminders" element={withModuleBoundary(<RemindersPage />, "Reminders")} />,
+  <Route key="/whats-new" path="/whats-new" element={withModuleBoundary(<WhatsNewPage />, "What's New")} />,
   <Route key="/calendar" path="/calendar" element={withModuleBoundary(<MyCalendar />, "Calendar")} />,
   // 🔥 FIX: Wrapped naked image test route with Suspense
   <Route key="/image-test" path="/image-test" element={withPublicSuspense(<OptimizedImage src="https://images.unsplash.com/photo-1540575861501-7c90b707a27d" alt="Test" />)} />,

--- a/src/components/whatsnew/WhatsNewBell.jsx
+++ b/src/components/whatsnew/WhatsNewBell.jsx
@@ -1,0 +1,58 @@
+// src/components/whatsnew/WhatsNewBell.jsx
+import { useState, useRef, useEffect } from "react";
+import { Sparkles } from "lucide-react";
+import { useWhatsNew } from "../../hooks/useWhatsNew";
+import WhatsNewDropdown from "./WhatsNewDropdown";
+
+export default function WhatsNewBell() {
+  const { entries, hasUnread, markAsRead } = useWhatsNew();
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef(null);
+
+  const handleToggle = () => {
+    const nextOpen = !isOpen;
+    setIsOpen(nextOpen);
+    if (nextOpen && hasUnread) {
+      markAsRead();
+    }
+  };
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative" ref={wrapperRef}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-label="What's New"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        className="relative p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <Sparkles className="w-5 h-5 text-gray-700 dark:text-gray-200" />
+        {hasUnread && (
+          <span
+            className="absolute top-1 right-1 w-2 h-2 rounded-full bg-red-500"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+
+      {isOpen && (
+        <WhatsNewDropdown
+          entries={entries}
+          onClose={() => setIsOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/whatsnew/WhatsNewDropdown.jsx
+++ b/src/components/whatsnew/WhatsNewDropdown.jsx
@@ -1,0 +1,44 @@
+// src/components/whatsnew/WhatsNewDropdown.jsx
+import { Link } from "react-router-dom";
+import WhatsNewItem from "./WhatsNewItem";
+
+const MAX_PREVIEW_RELEASES = 2;
+
+export default function WhatsNewDropdown({ entries, onClose }) {
+  const previewEntries = entries.slice(0, MAX_PREVIEW_RELEASES);
+
+  return (
+    <div
+      className="absolute right-0 mt-2 w-80 max-h-96 overflow-y-auto rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 z-50"
+      role="menu"
+    >
+      <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          What's New ✨
+        </h3>
+      </div>
+
+      <div className="divide-y divide-gray-100 dark:divide-gray-800">
+        {previewEntries.length === 0 ? (
+          <p className="px-4 py-4 text-sm text-gray-500 dark:text-gray-400">
+            No updates yet.
+          </p>
+        ) : (
+          previewEntries.map((entry) => (
+            <WhatsNewItem key={entry.version} entry={entry} />
+          ))
+        )}
+      </div>
+
+      <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700">
+        <Link
+          to="/whats-new"
+          onClick={onClose}
+          className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          View all updates →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/whatsnew/WhatsNewItem.jsx
+++ b/src/components/whatsnew/WhatsNewItem.jsx
@@ -1,0 +1,51 @@
+// src/components/whatsnew/WhatsNewItem.jsx
+
+const TYPE_STYLES = {
+  new: "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300",
+  improved: "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+  fixed: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+};
+
+const TYPE_LABELS = {
+  new: "New",
+  improved: "Improved",
+  fixed: "Fixed",
+};
+
+export default function WhatsNewItem({ entry }) {
+  const { version, date, items } = entry;
+
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          v{version}
+        </span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {new Date(date).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })}
+        </span>
+      </div>
+
+      <ul className="space-y-1.5">
+        {items.map((item, idx) => (
+          <li key={idx} className="flex items-start gap-2 text-sm">
+            <span
+              className={`shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase ${
+                TYPE_STYLES[item.type] || TYPE_STYLES.fixed
+              }`}
+            >
+              {TYPE_LABELS[item.type] || item.type}
+            </span>
+            <span className="text-gray-700 dark:text-gray-300">
+              {item.text}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/data/whatsNewEntries.js
+++ b/src/data/whatsNewEntries.js
@@ -1,0 +1,32 @@
+// src/data/whatsNewEntries.js
+
+/**
+ * Structured "What's New" release notes.
+ * Add a new entry at the TOP of the array whenever a new version ships.
+ * Keep entries user-facing and readable — not raw commit messages.
+ *
+ * type: "new" | "improved" | "fixed"
+ */
+
+export const whatsNewEntries = [
+  {
+    version: "1.0.0",
+    date: "2026-07-01",
+    items: [
+      {
+        type: "fixed",
+        text: "Fixed event registration incorrectly limiting sign-ups when an event was meant to have unlimited capacity.",
+      },
+      {
+        type: "fixed",
+        text: "Fixed a rate-limiting bug where repeatedly blocked requests could accidentally lock a user out permanently.",
+      },
+      {
+        type: "fixed",
+        text: "Fixed a rare timing issue that could cause background tasks to expire before they finished processing.",
+      },
+    ],
+  },
+];
+
+export const getLatestVersion = () => whatsNewEntries[0]?.version ?? null;

--- a/src/hooks/useWhatsNew.js
+++ b/src/hooks/useWhatsNew.js
@@ -1,0 +1,43 @@
+// src/hooks/useWhatsNew.js
+import { useState, useEffect, useCallback } from "react";
+import { whatsNewEntries, getLatestVersion } from "../data/whatsNewEntries";
+
+const STORAGE_KEY = "eventra_whats_new_last_seen_version";
+
+/**
+ * Tracks whether the user has seen the latest "What's New" release.
+ * Returns:
+ *  - hasUnread: true if the user hasn't viewed the latest version yet
+ *  - markAsRead: call this when the dropdown/page is opened, to clear the badge
+ *  - entries: the full list of release notes
+ *  - latestVersion: the current latest version string
+ */
+export function useWhatsNew() {
+  const latestVersion = getLatestVersion();
+  const [hasUnread, setHasUnread] = useState(false);
+
+  useEffect(() => {
+    try {
+      const lastSeen = localStorage.getItem(STORAGE_KEY);
+      setHasUnread(lastSeen !== latestVersion);
+    } catch (err) {
+      setHasUnread(false);
+    }
+  }, [latestVersion]);
+
+  const markAsRead = useCallback(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, latestVersion);
+      setHasUnread(false);
+    } catch (err) {
+      // ignore storage errors silently
+    }
+  }, [latestVersion]);
+
+  return {
+    entries: whatsNewEntries,
+    latestVersion,
+    hasUnread,
+    markAsRead,
+  };
+}


### PR DESCRIPTION
## What
Adds an in-app "What's New" changelog viewer so users can see recent updates without digging through CHANGELOG.md.

## Changes
- ✨ `WhatsNewBell` — navbar bell icon with unread indicator dot
- 📋 `WhatsNewDropdown` — preview panel showing the latest release
- 📄 `WhatsNewItem` — single release row with category badges (New/Improved/Fixed)
- 🗂️ `/whats-new` full page with search and category filters
- 🪝 `useWhatsNew` hook — tracks last-seen version via localStorage
- 📦 Structured release data in `src/data/whatsNewEntries.js`

## Screenshots
<img width="1600" height="710" alt="WhatsApp Image 2026-07-11 at 10 52 52" src="https://github.com/user-attachments/assets/4507a20c-623b-4490-b3f1-74b30de63d18" />
<img width="1590" height="692" alt="WhatsApp Image 2026-07-11 at 10 53 27" src="https://github.com/user-attachments/assets/4d97218f-cb52-49ee-b64a-e422309cd00a" />


## How to test
1. Click the ✨ bell icon in the navbar
2. Verify the unread dot clears after opening
3. Visit `/whats-new` and test search + category filters

Closes #10373 