### PR TITLE
fix: Native EventShareButtons uses window.location.origin instead of canonical URL (#10366) 

### DIFF
--- a/src/components/events/EventShareButtons.jsx
+++ b/src/components/events/EventShareButtons.jsx
@@ -32,8 +32,7 @@ import useCopyToClipboard from "../../hooks/useCopyToClipboard";
 // ---------------------------------------------------------------------------
 
 function getEventUrl(event) {
-  const base =
-    typeof window !== "undefined" ? window.location.origin : "https://eventra.app";
+  const base = process.env.REACT_APP_PUBLIC_URL || "https://eventra.app";
   return `${base}/events/${event.id}`;
 }
 


### PR DESCRIPTION
Description
Fixes an issue where social share links incorrectly defaulted to `window.location.origin` (e.g. localhost during dev or non-canonical URLs) instead of the canonical public URL in `EventShareButtons.jsx`.

### Changes Made
- Replaced `typeof window !== "undefined" ? window.location.origin : "https://eventra.app"` with the canonical public base URL configured in `.env` (`process.env.REACT_APP_PUBLIC_URL`).

### Related Issue
Fixes #10366