### PR TITLE
fix: Severe memory leak in offlineQueue combineAbortSignals (#10364)

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -598,9 +598,13 @@ export const processQueueItem = async (item, fetchFn, options = {}) => {
       timeoutId = setTimeout(() => {
         if (controller) controller.abort();
       }, REQUEST_TIMEOUT_MS);
-      const combinedSignal = signal
-        ? combineAbortSignals(signal, controller.signal)
-        : controller.signal;
+      let combinedSignal = controller.signal;
+      let cleanupCombined = null;
+      if (signal) {
+        const combined = combineAbortSignals(signal, controller.signal);
+        combinedSignal = combined.signal;
+        cleanupCombined = combined.cleanup;
+      }
 
       const response = await fetchFn(url, {
         method: "POST",
@@ -610,6 +614,7 @@ export const processQueueItem = async (item, fetchFn, options = {}) => {
       });
 
       clearPendingTimeout();
+      if (cleanupCombined) cleanupCombined();
 
       if (response.ok) return { status: "success", item };
 
@@ -619,24 +624,25 @@ export const processQueueItem = async (item, fetchFn, options = {}) => {
 
         if (typeof onConflict === "function") {
           const resolution = await onConflict(item, serverState);
-          if (resolution === "retry") { clearPendingTimeout(); continue; }
-          if (resolution === "discard") { clearPendingTimeout(); return { status: "dropped", item }; }
-          clearPendingTimeout(); return { status: "success", item };
+          if (resolution === "retry") { clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); continue; }
+          if (resolution === "discard") { clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); return { status: "dropped", item }; }
+          clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); return { status: "success", item };
         }
-        clearPendingTimeout(); return { status: "conflict", item, serverState };
+        clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); return { status: "conflict", item, serverState };
       }
 
       if (response.status >= 400 && response.status < 500) {
         logger.warn(
           `[OfflineQueue] Server rejected item ${item.id} with ${response.status} — dropping.`
         );
-        clearPendingTimeout(); return { status: "dropped", item };
+        clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); return { status: "dropped", item };
       }
 
       // 5xx — retry with backoff
-      clearPendingTimeout(); continue;
+      clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); continue;
     } catch (error) {
       clearPendingTimeout();
+      if (cleanupCombined) cleanupCombined();
       if (error.name === "AbortError") return { status: "error", item, error };
       logger.error(`[OfflineQueue] Network error processing item ${item.id}:`, error);
       // Retry on network errors
@@ -754,10 +760,16 @@ const combineAbortSignals = (...signals) => {
   for (const signal of signals) {
     if (signal.aborted) {
       controller.abort();
-      return controller.signal;
+      return { signal: controller.signal, cleanup: () => {} };
     }
     signal.addEventListener("abort", onAbort, { once: true });
   }
 
-  return controller.signal;
+  const cleanup = () => {
+    for (const signal of signals) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  };
+
+  return { signal: controller.signal, cleanup };
 };


### PR DESCRIPTION
### Description
Fixes a severe memory leak in `offlineQueue.js` caused by dangling `abort` event listeners in `combineAbortSignals` that were never removed when successful requests completed.

### Changes Made
- Refactored `combineAbortSignals` to return a `cleanup` function.
- Updated `processQueueItem` to invoke the cleanup function whenever a fetch succeeds or otherwise completes, effectively removing the lingering event listeners from the underlying AbortSignals.

### Related Issue
Fixes #10364