### PR TITLE
feat: Keyword highlighting and auto-tagging in LiveQABoard for event speakers (#10371)

### DIFF
--- a/src/components/events/LiveQABoard.jsx
+++ b/src/components/events/LiveQABoard.jsx
@@ -71,6 +71,17 @@ function ModeratorButtons({ q, onFlag, onDelete }) {
   );
 }
 
+function highlightKeywords(text) {
+  const keywords = ['bug', 'feature', 'question', 'pricing', 'roadmap'];
+  const regex = new RegExp(`\\b(${keywords.join('|')})\\b`, 'gi');
+  const parts = text.split(regex);
+  return parts.map((part, i) => 
+    keywords.includes(part.toLowerCase()) 
+      ? <span key={i} className="px-1.5 py-0.5 rounded bg-indigo-500/20 text-indigo-400 font-bold border border-indigo-500/30 text-[10px] uppercase tracking-widest mx-0.5">{part}</span> 
+      : part
+  );
+}
+
 function QuestionCard({ q, isModerator, onUpvote, onFlag, onDelete }) {
   return (
     <div
@@ -84,7 +95,7 @@ function QuestionCard({ q, isModerator, onUpvote, onFlag, onDelete }) {
             <AlertTriangle className="h-3 w-3" /> Flagged for moderation
           </span>
         )}
-        <p className="text-sm text-slate-200 break-words leading-relaxed font-sans">{q.text}</p>
+        <p className="text-sm text-slate-200 break-words leading-relaxed font-sans">{isModerator ? highlightKeywords(q.text) : q.text}</p>
         <span className="text-[10px] text-slate-500 font-medium">{formatTime(q.createdAt)}</span>
       </div>
 


### PR DESCRIPTION
### Description
Adds an automatic keyword highlighting and tagging system to the Live Q&A board. This helps moderators and speakers quickly spot recurring themes (e.g., "pricing", "bug", "roadmap") inside user questions.

### Changes Made
- Implemented a `highlightKeywords` utility within `LiveQABoard.jsx`.
- When viewing as a moderator/speaker, matching keywords inside question texts are now rendered as distinct, highlighted inline tags.

### Related Issue
Fixes #10371