### PR TITLE
Fix: Generate all 1–5 star ratings during survey simulation

### DIFF
--- a/src/components/admin/useSurveySimulator.js
+++ b/src/components/admin/useSurveySimulator.js
@@ -80,7 +80,15 @@ export function useSurveySimulator(questions, feedbackPool) {
       const updated = { ...prev };
       safeQuestions.forEach((q) => {
         if (q.type === "rating") {
-          const score = Math.random() > 0.4 ? (Math.random() > 0.4 ? 5 : 4) : 3;
+          // Weighted distribution across all 5 stars so every bar can grow.
+          // Biased toward positive (5★/4★) to reflect typical event feedback.
+          const rand = Math.random();
+          const score =
+            rand < 0.36 ? 5 :  // 36%
+            rand < 0.60 ? 4 :  // 24%
+            rand < 0.84 ? 3 :  // 24%
+            rand < 0.94 ? 2 :  // 10%
+                          1;   //  6%
           updated[q.id] = {
             ...updated[q.id],
             [score]: (updated[q.id]?.[score] || 0) + 1,


### PR DESCRIPTION
**Description:**

### Related Issue
Closes #10521 

### Changes

- Replaced the nested ternary with a weighted probability table.
- Enabled generation of all **1–5★** ratings.
- Fixed frozen **1★** and **2★** bars during simulated submissions.
- Retained a positive rating bias while using a single `Math.random()` call.
