### PR TITLE
feat(collaboration): validate incoming BroadcastChannel messages

### DIFF
--- a/src/utils/collaborationTransport.js
+++ b/src/utils/collaborationTransport.js
@@ -1,30 +1,60 @@
 export const createCollaborationTransport = (
   roomId,
   {
-    BroadcastChannelImpl = typeof BroadcastChannel === "undefined"
-      ? null
-      : BroadcastChannel,
-    clientId = typeof crypto !== "undefined" && crypto.randomUUID
-      ? crypto.randomUUID()
-      : `client-${Date.now()}`,
+    BroadcastChannelImpl =
+      typeof BroadcastChannel === "undefined"
+        ? null
+        : BroadcastChannel,
+    clientId =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `client-${Date.now()}`,
     onMessage,
   } = {},
 ) => {
   const channelName = `eventra-collaboration-${roomId}`;
-  const channel = BroadcastChannelImpl ? new BroadcastChannelImpl(channelName) : null;
+  const channel = BroadcastChannelImpl
+    ? new BroadcastChannelImpl(channelName)
+    : null;
+
+  const isValidMessage = (message) => {
+    if (!message || typeof message !== "object") return false;
+
+    if (typeof message.action !== "string") return false;
+
+    if (typeof message.roomId !== "string") return false;
+
+    if (typeof message.clientId !== "string") return false;
+
+    return true;
+  };
 
   if (channel && onMessage) {
-    channel.onmessage = (event) => {
-      if (event.data?.clientId !== clientId) onMessage(event.data);
-    };
-  }
+  channel.onmessage = (event) => {
+    const message = event.data;
+
+    if (!isValidMessage(message)) return;
+
+    if (message.clientId !== clientId) {
+      onMessage(message);
+    }
+  };
+}
 
   return {
     broadcast(action, data) {
       if (!channel || !action) return false;
-      channel.postMessage({ action, data, roomId, clientId });
+
+      channel.postMessage({
+        action,
+        data,
+        roomId,
+        clientId,
+      });
+
       return true;
     },
+
     close() {
       channel?.close();
     },


### PR DESCRIPTION
## Summary

This PR adds runtime validation for incoming `BroadcastChannel` messages before they are processed by the collaboration transport.

## Changes

- Added validation for incoming BroadcastChannel messages.
- Ignored malformed payloads safely.
- Improved collaboration robustness by preventing invalid payloads from reaching the message handler.

## Why

Previously, incoming BroadcastChannel messages were forwarded directly to the collaboration handler without validating their structure.

This enhancement ensures only well-formed collaboration messages are processed while preserving the existing behavior for valid messages.

Closes #10488