### PR TITLE
Fix event creation timezone import

### DIFF
--- a/src/utils/eventCreationUtils.js
+++ b/src/utils/eventCreationUtils.js
@@ -1,4 +1,4 @@
-import { parseTimeString, resolveEventInstant } from "./timezoneUtils";
+import { parseTimeString, resolveEventInstant } from "./timezoneUtils.js";
 
 export const parseTimeToMinutes = (timeStr) => {
   if (!timeStr) return 0;


### PR DESCRIPTION
## Summary
- updates the event creation utility to import timezone helpers through an explicit module path
- keeps the existing payload and date handling behavior unchanged

## Validation
- `node --test tests\eventCreationUtils.test.mjs`

Fixes #10526
