### PR TITLE
Fix event utils time import

### DIFF
--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -31,7 +31,7 @@ const mapStatusKey = (status = "") => {
   return explicitStatusMap[normalized] ?? null;
 };
 
-import { getServerTime } from "./timeSync";
+import { getServerTime } from "./timeSync.js";
 
 const parseEventDate = (dateValue) => {
   if (!dateValue) return null;


### PR DESCRIPTION
## Summary
- updates event status utilities to import time sync through an explicit module path
- preserves existing status calculation behavior

## Validation
- `node --test tests\eventUtils.test.mjs`

Fixes #10527
