### PR TITLE
Fix fetch timeout logger import

### DIFF
--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -1,4 +1,4 @@
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 
 const DEFAULT_TIMEOUT = 10000;
 


### PR DESCRIPTION
## Summary
- updates fetch timeout helper to import the logger through an explicit module path
- keeps existing timeout, abort, and response handling unchanged

## Validation
- `node --test tests\fetchWithTimeout.test.mjs`

Fixes #10528
