### PR TITLE
Fix session recovery api import

### DIFF
--- a/src/services/sessionRecoveryService.js
+++ b/src/services/sessionRecoveryService.js
@@ -1,6 +1,6 @@
-import { API_ENDPOINTS, apiUtils } from "../config/api";
-import { sanitizeSessionState } from "../utils/sessionSanitization";
-import { safeJsonParse } from "../utils/safeJsonParse";
+import { API_ENDPOINTS, apiUtils } from "../config/api.js";
+import { sanitizeSessionState } from "../utils/sessionSanitization.js";
+import { safeJsonParse } from "../utils/safeJsonParse.js";
 
 export const CLOUD_RECOVERY_PENDING_KEY = "eventra:cloud-session-recovery:pending:v1";
 export const CLOUD_RECOVERY_CACHE_KEY = "eventra:cloud-session-recovery:cache:v1";


### PR DESCRIPTION
## Summary
- updates session recovery service to import the API module through an explicit file path
- keeps cloud recovery behavior unchanged

## Validation
- `node --test tests\multiSessionRecovery.test.mjs tests\sessionExportImport.test.mjs`

Fixes #10529
