### PR TITLE
Preserve registration form data locally

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -403,7 +403,7 @@ const EventRegistration = () => {
       if (isAlreadyRegistered) {
         toast.success(isFreshlyFull ? t("eventRegistration.toastWaitlistSuccess") : t("eventRegistration.toastRegistrationSuccess"));
         const existingRegId = typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : `reg-existing-${Date.now()}`;
-        addRegistration(event, {}, existingRegId, "");
+        addRegistration(event, formData);
         clearSession();
         toast.info(failureMessage);
         return { success: true, error: null, waitlistPosition: -1 };


### PR DESCRIPTION
## Summary
- preserves submitted form data when storing an already-registered success locally
- keeps additional registration notes available to local state consumers

## Validation
- `node --test tests\eventRegistrationAdditionalInfo.test.mjs`

Fixes #10532
