### PR TITLE
Fix GitHub client imports

### DIFF
--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -1,4 +1,4 @@
-import { logger } from "./logger";
+import { logger } from "./logger.js";
 
 const DEFAULT_TIMEOUT = 10000;
 

--- a/src/utils/githubApiClient.js
+++ b/src/utils/githubApiClient.js
@@ -1,5 +1,5 @@
-import { fetchWithTimeout, FetchError } from "./fetchWithTimeout";
-import { logError } from "./errorLogger";
+import { fetchWithTimeout, FetchError } from "./fetchWithTimeout.js";
+import { logError } from "./errorLogger.js";
 
 const GITHUB_HOST = "github.com";
 


### PR DESCRIPTION
## Summary
- updates GitHub client utility imports to explicit module paths
- keeps proxy URL and fallback behavior unchanged

## Validation
- `node --test tests\githubApiClient.test.mjs`

Fixes #10563
