### PR TITLE
Fix offline event cache import

### DIFF
--- a/src/utils/offlineEventCache.js
+++ b/src/utils/offlineEventCache.js
@@ -1,4 +1,4 @@
-import { safeJsonParse } from "./safeJsonParse";
+import { safeJsonParse } from "./safeJsonParse.js";
 
 const EVENTS_CACHE_KEY = "eventra_cached_events";
 const EVENT_DETAILS_CACHE_KEY = "eventra_cached_event_details";


### PR DESCRIPTION
## Summary
- updates offline event cache to import the JSON parser through an explicit module path
- keeps cache TTL and persistence behavior unchanged

## Validation
- `node --test tests\offlineEventCache.test.mjs`

Fixes #10564
