### PR TITLE
Fix token expiry utility imports

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback } from "react";
 import { toast } from "react-toastify";
-import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils";
-import { syncSecureStorage } from "../utils/secureStorage";
+import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils.js";
+import { syncSecureStorage } from "../utils/secureStorage.js";
 
 export const MAX_TOKEN_EXPIRY_TIMEOUT_MS = 2_147_483_647;
 const TOKEN_EXPIRY_BUFFER_MS = 1_000;


### PR DESCRIPTION
## Summary
- updates token expiry hook utility imports to explicit module paths
- keeps timeout clamping and session expiry behavior unchanged

## Validation
- `node --test tests\useTokenExpiryTimeout.test.mjs`

Fixes #10565
