### PR TITLE
Normalize registration storage access

### DIFF
--- a/src/utils/registerUtils.js
+++ b/src/utils/registerUtils.js
@@ -3,11 +3,18 @@ import { safeJsonParse } from "./safeJsonParse.js";
 const STORAGE_KEY = "eventRegistrations";
 
 const normalizeEmail = (email) => (email || "").trim().toLowerCase();
+const getStorage = () => {
+  if (typeof window !== "undefined" && window.localStorage) {
+    return window.localStorage;
+  }
+  return globalThis.localStorage;
+};
 
 const readRegistrations = () => {
-  if (typeof window === "undefined") return {};
+  const storage = getStorage();
+  if (!storage) return {};
   try {
-    const data = localStorage.getItem(STORAGE_KEY);
+    const data = storage.getItem(STORAGE_KEY);
     const parsed = safeJsonParse(data, {});
     // Migrate legacy array-based storage to Set-based storage
     const migrated = {};
@@ -23,9 +30,10 @@ const readRegistrations = () => {
 };
 
 const writeRegistrations = (registrations) => {
-  if (typeof window === "undefined") return;
+  const storage = getStorage();
+  if (!storage) return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(registrations));
+    storage.setItem(STORAGE_KEY, JSON.stringify(registrations));
   } catch {
     // localStorage may be unavailable or full; keep the UI functional.
   }


### PR DESCRIPTION
## Summary
- lets registration helpers use available localStorage outside full browser window contexts
- preserves email trimming and case normalization for duplicate checks

## Validation
- `node --test tests\registerUtils-robustness.test.mjs tests\registerUtils.edge.test.mjs`

Fixes #10570
