### PR TITLE
Allow share copy fallback without window

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -175,13 +175,14 @@ export const generateEventSharingData = (event, baseUrl = null) => {
  * @returns {Promise<boolean>} Success status
  */
 export const copyToClipboard = async (text) => {
-  if (typeof window === "undefined" || typeof document === "undefined") {
+  if (typeof document === "undefined") {
     return false;
   }
 
   try {
-    if (navigator.clipboard) {
-      await navigator.clipboard.writeText(text);
+    const clipboard = globalThis.navigator?.clipboard;
+    if (clipboard) {
+      await clipboard.writeText(text);
       return true;
     } else {
       // Fallback for older browsers


### PR DESCRIPTION
## Summary
- allows the clipboard fallback to run when a document is available without a window object
- keeps modern navigator clipboard behavior unchanged

## Validation
- `node --test tests\shareUtils-copyToClipboard.test.mjs tests\shareUtils.test.mjs`

Fixes #10571
