### PR TITLE
fix: append PNG download anchor to document.body before click and remove after to fix silent download failure in Firefox

### DIFF
--- a/src/components/user/EventBadgeGenerator.jsx
+++ b/src/components/user/EventBadgeGenerator.jsx
@@ -99,7 +99,10 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
       const a = document.createElement("a");
       a.href = url;
       a.download = `eventra-badge-${attendeeName.toLowerCase().replace(/\s+/g, "-")}.png`;
+      // Anchor must be in the DOM before .click() for Firefox to trigger the download
+      document.body.appendChild(a);
       a.click();
+      document.body.removeChild(a);
       toast.success("PNG Badge exported successfully.");
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
### Related Issue
Closes #10586 

### Description of Changes
- In `downloadPNG` in `EventBadgeGenerator.jsx`, added
  `document.body.appendChild(a)` before `a.click()` and
  `document.body.removeChild(a)` immediately after.
- This follows the standard cross-browser pattern for programmatic file
  downloads and resolves the silent failure in Firefox where `.click()`
  on a detached anchor with a `download` attribute is a no-op.