### PR TITLE
fix: wrap attendeeName slug in encodeURIComponent for QR code URL and add empty-name fallback to prevent invalid verification URLs on the badge

### DIFF
--- a/src/components/user/EventBadgeGenerator.jsx
+++ b/src/components/user/EventBadgeGenerator.jsx
@@ -394,10 +394,16 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
                 <span className="text-[8px] font-black text-slate-400 uppercase tracking-wider block mt-1">Verified Member</span>
               </div>
               <div className="p-1 bg-white rounded-md shrink-0">
-                <QRCode 
-                  value={`https://eventra.dev/verify/attendee/${attendeeName.toLowerCase().replace(/\s+/g, "-")}`}
-                  size={36} 
-                  level="M" 
+                <QRCode
+                  value={
+                    attendeeName.trim()
+                      ? `https://eventra.dev/verify/attendee/${encodeURIComponent(
+                        attendeeName.trim().toLowerCase().replace(/\s+/g, "-")
+                      )}`
+                      : "https://eventra.dev/verify"
+                  }
+                  size={36}
+                  level="M"
                   bgColor="#ffffff"
                   fgColor="#020617"
                 />


### PR DESCRIPTION
### Related Issue
Closes #10588 

### Description of Changes
- I wrapped the `attendeeName` slug in `encodeURIComponent()` in the
  `QRCode` `value` prop in `EventBadgeGenerator.jsx`.
- I added `.trim()` before slug generation to strip leading/trailing spaces.
- I added a fallback to `"https://eventra.dev/verify"` when `attendeeName`
  is empty, preventing a trailing-slash URL from being encoded into the QR.