### PR TITLE
Fix counter animations for hackathons and events landing pages

### DIFF
--- a/src/Pages/Events/EventHero.js
+++ b/src/Pages/Events/EventHero.js
@@ -26,7 +26,7 @@ const TRENDING_SEARCHES = [
   "Web Development",
 ];
 
-const StatCounter = ({ stat, shouldAnimate }) => {
+const StatCounter = ({ stat, shouldAnimate, delay = 0 }) => {
   const prefix = stat.prefix || "";
   const suffix = stat.suffix || "";
 
@@ -46,6 +46,7 @@ const StatCounter = ({ stat, shouldAnimate }) => {
       prefix={prefix}
       suffix={suffix}
       startOnMount
+      delay={delay}
     />
   );
 };
@@ -349,7 +350,11 @@ function EventHero({
                   <stat.icon className={`h-5 w-5 sm:h-6 sm:w-6 ${darkTheme.textSecondary}`} />
                 </div>
                 <p className={`text-xl sm:text-2xl md:text-3xl font-bold tracking-tight ${darkTheme.textPrimary}`}>
-                  <StatCounter stat={stat} shouldAnimate={hasMounted && isStatsInView} />
+                  <StatCounter 
+                    stat={stat} 
+                    shouldAnimate={hasMounted && isStatsInView} 
+                    delay={prefersReducedMotion ? 0 : i * 0.1}
+                  />
                 </p>
                 <p className={`mt-1 text-xs sm:text-sm font-medium ${darkTheme.textSecondary}`}>
                   {stat.label}

--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -1,6 +1,7 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useInView } from "framer-motion";
 import { Award, Calendar, Code2, Sparkles, Users, X, Rocket } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { useRef, useState, useEffect } from "react";
 import ModernSearchInput from "../../components/common/ModernSearchInput";
 import { useAuth } from "../../context/AuthContext";
 import CountUpLib from "react-countup";
@@ -8,6 +9,30 @@ import ErrorBoundary from "../../components/common/ErrorBoundary";
 import useReducedMotion from "../../hooks/useReducedMotion.js";
 
 const CountUp = CountUpLib.default || CountUpLib;
+
+const StatCounter = ({ stat, shouldAnimate, delay = 0 }) => {
+  const prefix = stat.prefix || "";
+  const suffix = stat.suffix || "";
+
+  if (!shouldAnimate) {
+    return (
+      <>
+        {prefix}0{suffix}
+      </>
+    );
+  }
+
+  return (
+    <CountUp
+      start={0}
+      end={stat.value}
+      duration={2.5}
+      prefix={prefix}
+      suffix={suffix}
+      delay={delay}
+    />
+  );
+};
 // Tag component for selected tags in search bar
 const Tag = ({ tag, onRemove }) => (
   <motion.div
@@ -41,6 +66,14 @@ export default function HackathonHero({
   const prefersReducedMotion = useReducedMotion();
   const navigate = useNavigate();
   const { user } = useAuth();
+
+  const statsRef = useRef(null);
+  const isStatsInView = useInView(statsRef, { once: true, margin: "-100px" });
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   return (
     <div className="relative overflow-hidden bg-linear-to-b from-slate-50 via-indigo-50/40 to-slate-50 dark:from-slate-950 dark:via-indigo-950/60 dark:to-slate-950 text-slate-900 dark:text-white py-16 sm:py-20 md:py-24 border-b border-slate-200 dark:border-indigo-900/40 transition-colors duration-300">
@@ -224,7 +257,7 @@ export default function HackathonHero({
       {/* STATS SECTION */}
       {searchQuery.trim() === "" && selectedTags.length === 0 && (
         <ErrorBoundary level="section" label="Hackathon Statistics">
-          <div className="relative max-w-6xl mx-auto px-4 sm:px-6 mt-14 sm:mt-20 mb-12 sm:mb-16 grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+          <div ref={statsRef} className="relative max-w-6xl mx-auto px-4 sm:px-6 mt-14 sm:mt-20 mb-12 sm:mb-16 grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
             {[
               { label: "Hackathons Hosted", value: 120, suffix: "+", icon: Calendar, color: "from-blue-500 to-indigo-500" },
               { label: "Participants", value: 50, suffix: "k+", icon: Users, color: "from-violet-500 to-purple-500" },
@@ -261,12 +294,10 @@ export default function HackathonHero({
                 </motion.div>
 
                 <p className="text-3xl font-bold text-slate-900 dark:text-white tracking-tight">
-                  <CountUp
-                    start={0}
-                    end={stat.value}
-                    duration={2.5}
-                    prefix={stat.prefix}
-                    suffix={stat.suffix}
+                  <StatCounter 
+                    stat={stat} 
+                    shouldAnimate={hasMounted && isStatsInView} 
+                    delay={prefersReducedMotion ? 0 : 0.15 + idx * 0.12}
                   />
                 </p>
                 <p className="mt-1 text-sm font-medium text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
This PR resolves an issue on both the Hackathons and Events landing pages where the counters for Projects Built (8k+) and Prizes Awarded ($1M+) appeared static and did not trigger their count-up animations.

Root Cause
The react-countup animations were starting immediately when the parent container (statsRef) entered the viewport. However, the stats cards fade in with a progressive stagger delay (up to 0.51s). Because the target values for Projects Built (8) and Prizes Awarded (1) are small, their animations completed very quickly (under 0.63s and 0.51s respectively) before the cards actually became visible. As a result, they appeared static once faded in.

Proposed Changes
Staggered Delay Propagation: Modified the StatCounter component in 

HackathonHero.js
 and 

EventHero.js
 to accept a delay prop.
Component Synchronisation: Passed the calculated delay based on the card's stagger index (prefersReducedMotion ? 0 : 0.15 + idx * 0.12) directly to the delay prop of <CountUp />.
Behavioral Invariance: Existing animations for "Hackathons Hosted" and "Participants" are unaffected but are now also perfectly synchronized with their entrance transitions.