### PR TITLE
Make request signature validation async

### DIFF
--- a/src/middleware/requestSignature.js
+++ b/src/middleware/requestSignature.js
@@ -1,6 +1,6 @@
 import { validateSignature } from "../utils/signatureValidator.js";
 
-export function verifyRequestSignature(
+export async function verifyRequestSignature(
   req,
   secret
 ) {

--- a/tests/requestSignature.test.mjs
+++ b/tests/requestSignature.test.mjs
@@ -15,7 +15,7 @@ const signed = await signRequest(
   secret
 );
 
-const result = validateSignature(
+const result = await validateSignature(
   payload,
   signed.timestamp,
   signed.nonce,


### PR DESCRIPTION
## Summary
- mark `verifyRequestSignature` as async to match the validator it returns
- await signature validation in the request signature regression test
- keep existing signature validator coverage passing

## Issue
Closes #10594

## Validation
- `node --test tests\requestSignature.test.mjs tests\signatureValidator.test.mjs`
