### PR TITLE
Detach ticket modal focus listener reliably

### DIFF
--- a/src/components/common/QRTicket/QRTicketModal.jsx
+++ b/src/components/common/QRTicket/QRTicketModal.jsx
@@ -72,7 +72,8 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
   useEffect(() => {
     if (!isOpen || !modalRef.current) return;
 
-    const focusableElements = modalRef.current.querySelectorAll(
+    const modalNode = modalRef.current;
+    const focusableElements = modalNode.querySelectorAll(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
     );
     
@@ -97,16 +98,14 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
       }
     };
 
-    modalRef.current.addEventListener("keydown", handleFocusTrap);
+    modalNode.addEventListener("keydown", handleFocusTrap);
     // Focus the modal automatically
-    modalRef.current.focus();
+    modalNode.focus();
 
     return () => {
-      if (modalRef.current) {
-        modalRef.current.removeEventListener("keydown", handleFocusTrap);
-      }
+      modalNode.removeEventListener("keydown", handleFocusTrap);
     };
-  }, [isOpen, handleFocusTrap]);
+  }, [isOpen]);
 
   const handleShare = async () => {
     const shareUrl = ticket?.qrValue || window.location.href;


### PR DESCRIPTION
## Summary
- capture the modal node before attaching the focus-trap listener
- remove the listener from the same node during cleanup
- remove the stale dependency on an effect-local handler

## Issue
Closes #10598

## Validation
- `npx eslint src\components\common\QRTicket\QRTicketModal.jsx --max-warnings=0`
