### PR TITLE
Call registered reauth handler

### DIFF
--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -59,8 +59,15 @@ export const createResponseInterceptor = (API) => {
   const reject = async (error) => {
     const config = error.config || {};
     const status = error?.response?.status;
+    const errorCode = error?.response?.data?.code;
 
-    if (status === 401 && onUnauthorized) onUnauthorized();
+    if (status === 401) {
+      if (errorCode === "REQUIRES_REAUTH" && _onRequiresReauth) {
+        _onRequiresReauth();
+      } else if (onUnauthorized) {
+        onUnauthorized();
+      }
+    }
 
     const retryCount = config._retryCount || 0;
     const isNonMutating = RETRYABLE_METHODS.has(config.method?.toUpperCase() ?? "");


### PR DESCRIPTION
## Summary
- read the response error code in the legacy response interceptor
- call the registered reauth handler for `REQUIRES_REAUTH` responses
- keep the unauthorized handler for other 401 responses

## Issue
Closes #10601

## Validation
- `npx eslint src\config\api\interceptors.js --max-warnings=0`
