### PR TITLE
fix: append and remove PNG download anchor to support Firefox downloads

### DIFF
--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -136,7 +136,10 @@ const EventTicket = ({ event, user, onClose }) => {
         const link = document.createElement("a");
         link.download = `eventra-ticket-${cleanTitle}.png`;
         link.href = imgData;
+        // Must be in the DOM before .click() for Firefox to trigger the download
+        document.body.appendChild(link);
         link.click();
+        document.body.removeChild(link);
         toast.success("PNG Ticket downloaded successfully!");
       }
     } catch (error) {


### PR DESCRIPTION
### Related Issue

Closes #10615 

### Description of Changes

* Appended the PNG download link to `document.body` before calling `link.click()`.
* Removed the link immediately after the download is triggered.
* Applied the fix in the PNG export path of `handleDownload` in `EventTicket.js`.
* Resolves Firefox's detached-anchor download issue and aligns with the fix used in `EventBadgeGenerator.jsx`.
