### PR TITLE
fix: mirror 3D tilt on the back face for correct viewer perspective

### DIFF
--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -204,7 +204,9 @@ const EventTicket = ({ event, user, onClose }) => {
             onMouseMove={handleMouseMove}
             onMouseLeave={handleMouseLeave}
             style={{
-              transform: `perspective(1200px) rotateX(${rotate.x}deg) rotateY(${rotate.y + (isFlipped ? 180 : 0)}deg)`,
+              // When flipped, both axes are mirrored from the viewer's perspective —
+              // negate rotate.x and subtract rotate.y from 180 to keep tilt natural.
+              transform: `perspective(1200px) rotateX(${isFlipped ? -rotate.x : rotate.x}deg) rotateY(${isFlipped ? 180 - rotate.y : rotate.y}deg)`,
               boxShadow: `0 30px 60px -15px rgba(0, 0, 0, 0.6), 0 0 50px ${theme.glow}`
             }}
             ref={ticketRef}


### PR DESCRIPTION
### Related Issue

Closes #10617 

### Description of Changes

* Updated the card wrapper's `transform` in `EventTicket.js`.
* Mirrored the tilt on the back face by using `-rotate.x` and `180 - rotate.y` when `isFlipped` is `true`.
* Left the front-face behavior unchanged, continuing to use `rotate.x` and `rotate.y`.
* Ensures the 3D tilt feels natural and consistent on both sides of the card.
