### PR TITLE
fix: use the reason string as the React key instead of reasonIndex for recommendation tags

### DIFF
--- a/src/components/user/RecommendedEvents.jsx
+++ b/src/components/user/RecommendedEvents.jsx
@@ -112,10 +112,10 @@ const RecommendedEvents = () => {
                 >
 
                   {hackathon.recommendationReasons?.map(
-                    (reason, reasonIndex) => (
+                    (reason) => (
 
                       <span
-                        key={reasonIndex}
+                        key={reason}
                         className="
                           text-xs
                           bg-primary/10


### PR DESCRIPTION
### Related Issue
Closes #10624 

### Description of Changes

* Replaced `key={reasonIndex}` with `key={reason}` for recommendation reason tags.
* Removed the unused `reasonIndex` parameter.
* Used a stable, descriptive key to prevent incorrect DOM reuse when reasons change.
