### PR TITLE
Add projects to home carousel and refactor scrolling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -195,7 +195,7 @@ function App() {
 
                 <main
                   id="main-content"
-                  className="relative z-10 min-h-[85vh] bg-bg text-text transition-colors duration-300"
+                  className="relative z-10 min-h-[85vh] pt-16 bg-bg text-text transition-colors duration-300"
                 >
                   <PageTransition>
                     <ErrorBoundary>

--- a/src/Pages/Home/HomePage.jsx
+++ b/src/Pages/Home/HomePage.jsx
@@ -21,7 +21,7 @@ const SITE_DESCRIPTION =
 // ─── MAIN COMPONENT ─────────────────────────────────────────────────────────
 const HomePage = () => {
   useDocumentTitle("Home | Eventra");
-  const { eventsData, isLoading } = useHomeEventsData();
+  const { eventsData, hackathonsData, projectsData, isLoading } = useHomeEventsData();
 
   return (
     <main className="min-h-screen bg-bg">
@@ -60,7 +60,12 @@ const HomePage = () => {
 
       {/* ─── PAGE CONTENT ───────────────────────────────────────────────── */}
       <Hero />
-      <WhatsHappening eventsData={eventsData} isLoading={isLoading} />
+      <WhatsHappening
+        eventsData={eventsData}
+        hackathonsData={hackathonsData}
+        projectsData={projectsData}
+        isLoading={isLoading}
+      />
       <TrendingEvents title="Trending Events" limit={6} fetchSize={24} />
       <HomeEventSearch eventsData={eventsData} />
       <RecommendationBanner />

--- a/src/Pages/Home/components/WhatsHappening.js
+++ b/src/Pages/Home/components/WhatsHappening.js
@@ -1,5 +1,5 @@
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { useState, useEffect, useCallback, useMemo, memo } from "react";
 import { Link } from "react-router-dom";
 import { useInView } from "react-intersection-observer";
@@ -7,9 +7,8 @@ import { HomeCardSkeleton } from "../../../components/common/SkeletonLoaders";
 import { CheckCircle2, Hourglass } from "lucide-react";
 
 import useReducedMotion from "../../../hooks/useReducedMotion.js";
-import hackathonsData from "../../Hackathons/hackathonMockData.json";
 
-const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
+const WhatsHappening = ({ eventsData = [], hackathonsData = [], projectsData = [], isLoading = true }) => {
   const prefersReducedMotion = useReducedMotion();
   const [ref, inView] = useInView({
     triggerOnce: true,
@@ -17,8 +16,8 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
   });
 
   const [current, setCurrent] = useState(0);
-  const [direction, setDirection] = useState(1);
   const [isAutoPlaying, setIsAutoPlaying] = useState(!prefersReducedMotion);
+
   useEffect(() => {
     if (prefersReducedMotion) {
       setIsAutoPlaying(false);
@@ -129,11 +128,40 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
       }));
   };
 
-  const upcomingEvents = useMemo(() => [
-    ...formatEventsData(eventsData),
-    ...formatHackathonsData(hackathonsData),
-  ].sort((a, b) => new Date(a.rawDate) - new Date(b.rawDate)),
-  [eventsData]);
+  const formatProjectsData = (projects) => {
+    return projects.map((project) => ({
+      id: `project-${project.id}`,
+      title: project.title || "Untitled Project",
+      description: project.description || "No description provided.",
+      timeLeft: "Active",
+      date: project.createdAt
+        ? new Date(project.createdAt).toLocaleDateString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })
+        : "Recently Added",
+      rawDate: project.createdAt || new Date(0).toISOString(),
+      type: "Project",
+      status: project.status || "Active",
+      link: `/projects/${project.id}`,
+      featured: (project.stars || project.upvotes || 0) > 20,
+      location: project.category || "Open Source",
+      participants: project.forks || 0,
+      upvotes: project.stars || project.upvotes || 0,
+    }));
+  };
+
+  const upcomingEvents = useMemo(() => {
+    const formattedEvents = formatEventsData(eventsData);
+    const formattedHackathons = formatHackathonsData(hackathonsData);
+    const formattedProjects = formatProjectsData(projectsData);
+    return [
+      ...formattedEvents,
+      ...formattedHackathons,
+      ...formattedProjects,
+    ].sort((a, b) => new Date(a.rawDate) - new Date(b.rawDate));
+  }, [eventsData, hackathonsData, projectsData]);
 
   const [cardsPerView, setCardsPerView] = useState(1);
 
@@ -153,33 +181,29 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
     return () => window.removeEventListener("resize", updateCardsPerView);
   }, []);
 
+  // Limit how far we can scroll: up to (length - cardsPerView)
+  const maxIndex = Math.max(0, upcomingEvents.length - cardsPerView);
+
   const nextSlide = useCallback(() => {
-    setDirection(1);
-    setCurrent((prev) => (prev + cardsPerView) % upcomingEvents.length);
-  }, [upcomingEvents.length, cardsPerView]);
+    setCurrent((prev) => (prev >= maxIndex ? 0 : prev + 1));
+  }, [maxIndex]);
 
   const prevSlide = () => {
-    setDirection(-1);
-    setCurrent((prev) => {
-      const newIndex = prev - cardsPerView;
-      return newIndex < 0
-        ? Math.max(0, upcomingEvents.length - cardsPerView)
-        : newIndex;
-    });
+    setCurrent((prev) => (prev <= 0 ? maxIndex : prev - 1));
     setIsAutoPlaying(false);
   };
 
   useEffect(() => {
     let timer;
-    if (isAutoPlaying) {
+    if (isAutoPlaying && maxIndex > 0) {
       timer = setInterval(() => {
         nextSlide();
-      }, 2500);
+      }, 3000);
     }
     return () => {
       if (timer) clearInterval(timer);
     };
-  }, [isAutoPlaying, nextSlide]);
+  }, [isAutoPlaying, nextSlide, maxIndex]);
 
   useEffect(() => {
     if (isAutoPlaying) return;
@@ -189,19 +213,11 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
     return () => clearTimeout(timeout);
   }, [isAutoPlaying]);
 
-  const cardVariants = {
-    enter: (dir) => ({ opacity: 0, x: prefersReducedMotion ? 0 : dir > 0 ? 300 : -300 }),
-    center: { opacity: 1, x: 0 },
-    exit: (dir) => ({ opacity: 0, x: prefersReducedMotion ? 0 : dir > 0 ? -300 : 300 }),
-  };
+  const activeDotIndex = Math.min(current, maxIndex);
 
-  const activeDotIndex =
-    Math.floor(current / cardsPerView) %
-    Math.ceil(upcomingEvents.length / cardsPerView);
-
-  const totalGroups = Math.ceil(upcomingEvents.length / cardsPerView);
-  const currentGroup = Math.floor(current / cardsPerView) + 1;
-  const liveMessage = `Showing slide group ${currentGroup} of ${totalGroups}`;
+  const totalGroups = upcomingEvents.length;
+  const currentGroup = current + 1;
+  const liveMessage = `Showing item ${currentGroup} of ${totalGroups}`;
 
   return (
     <section
@@ -235,7 +251,7 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
           </h2>
           <p className="mt-4 max-w-2xl mx-auto text-base sm:text-lg leading-relaxed text-text-light">
             Stay updated with {upcomingEvents.length} upcoming events, community
-            programs, and opportunities to contribute to Eventra
+            programs, and projects in Eventra
           </p>
         </motion.div>
 
@@ -267,7 +283,7 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
           <button
             onClick={prevSlide}
             className="absolute left-0 sm:-left-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-card-bg border border-border shadow-premium-md hover:bg-bg-secondary z-10 text-text transition-all duration-200"
-            aria-label="Previous events"
+            aria-label="Previous event"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
@@ -276,12 +292,11 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
 
           <button
             onClick={() => {
-              setDirection(1);
-              setCurrent((prev) => (prev + cardsPerView) % upcomingEvents.length);
+              nextSlide();
               setIsAutoPlaying(false);
             }}
             className="absolute right-0 sm:-right-4 top-1/2 -translate-y-1/2 p-3 rounded-full bg-card-bg border border-border shadow-premium-md hover:bg-bg-secondary z-10 text-text transition-all duration-200"
-            aria-label="Next events"
+            aria-label="Next event"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
@@ -290,166 +305,143 @@ const WhatsHappening = ({ eventsData = [], isLoading = true }) => {
 
           {/* Content Area */}
           <div
-            className="overflow-hidden px-4 sm:px-8 py-6"
+            className="overflow-hidden px-1 sm:px-4 py-4"
             onMouseEnter={() => setIsAutoPlaying(false)}
             onMouseLeave={() => setIsAutoPlaying(true)}
           >
-            <AnimatePresence mode="wait" custom={direction}>
+            <div className="relative w-full overflow-hidden">
               <motion.div
-                key={Math.floor(current / cardsPerView)}
-                variants={cardVariants}
-                custom={direction}
-                initial="enter"
-                animate="center"
-                exit="exit"
-                transition={{ duration: prefersReducedMotion ? 0 : 0.4, ease: "easeInOut" }}
-                className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 pointer-events-auto relative z-10"
-                drag="x"
-                dragConstraints={{ left: 0, right: 0 }}
-                dragElastic={0.2}
-                onDragEnd={(e, info) => {
-                  if (info.offset.x > 100) {
-                    prevSlide();
-                  } else if (info.offset.x < -100) {
-                    setDirection(1);
-                    setCurrent((prev) => (prev + cardsPerView) % upcomingEvents.length);
-                    setIsAutoPlaying(false);
-                  }
-                }}
+                animate={{ x: `calc(-${current} * (100% + 24px) / ${cardsPerView})` }}
+                transition={{ type: "spring", stiffness: 180, damping: 22 }}
+                className="flex gap-6 pointer-events-auto"
               >
                 {isLoading
                   ? [...Array(cardsPerView)].map((_, i) => (
-                      <div key={`skeleton-wrap-${i}`} className="p-1 rounded-2xl border border-border bg-bg">
+                      <div
+                        key={`skeleton-wrap-${i}`}
+                        className="w-full shrink-0 sm:w-[calc(50%-12px)] lg:w-[calc(33.333%-16px)] p-1 rounded-2xl border border-border bg-bg"
+                      >
                         <HomeCardSkeleton />
                       </div>
                     ))
-                  : upcomingEvents
-                      .slice(current, current + cardsPerView)
-                      .concat(
-                        current + cardsPerView > upcomingEvents.length
-                          ? upcomingEvents.slice(0, (current + cardsPerView) % upcomingEvents.length)
-                          : []
-                      )
-                      .slice(0, cardsPerView)
-                      .map((event) => (
-                        <motion.div
-                          key={event.id}
-                          whileHover={prefersReducedMotion ? {} : { scale: 1.01, y: -2 }}
-                          whileTap={prefersReducedMotion ? {} : { scale: 0.995 }}
-                          transition={{ type: "spring", stiffness: 300, damping: 24 }}
-                          className="group relative w-full flex flex-col rounded-2xl overflow-hidden bg-card-bg border border-border p-5 sm:p-6 shadow-premium-sm hover:shadow-premium-md hover:border-primary transition-all duration-300 flex-1 pointer-events-auto"
-                          onMouseEnter={() => setIsAutoPlaying(false)}
-                          onMouseLeave={() => setIsAutoPlaying(true)}
-                        >
-                          {/* Card Content */}
-                          <div className="flex flex-col flex-1">
-                            <div className="flex items-center justify-between mb-4 gap-2">
-                              <span
-                                className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold border ${
-                                  event.status === "Live Now" || event.status === "Live Event"
-                                    ? "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20"
-                                    : event.status === "Registration Open"
-                                    ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20"
-                                    : "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
-                                }`}
-                              >
-                                {event.status}
-                              </span>
-                              <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-bg-secondary text-text-light border border-border">
-                                {event.type}
-                              </span>
-                            </div>
-
-                            <h3 title={event.title} className="text-lg sm:text-xl font-bold text-text mb-2 leading-snug group-hover:text-primary transition-colors line-clamp-2 break-words min-w-0">
-                              {event.title}
-                            </h3>
-                            
-                            <p className="text-text-light text-sm mb-4 line-clamp-3 leading-relaxed flex-1 font-normal">
-                              {event.description}
-                            </p>
-
-                            <div className="flex flex-wrap gap-2.5 mb-4">
-                              {event.prize && (
-                                <div className="inline-flex items-center text-xs font-semibold text-rose-600 dark:text-rose-400 bg-rose-500/5 px-2.5 py-1.5 rounded-md border border-rose-500/10">
-                                  <svg className="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.251-.11a3.375 3.375 0 000-6.166l-.251-.1a3.375 3.375 0 000 6.166zm6 0l.251-.11a3.375 3.375 0 000-6.166l-.251-.1a3.375 3.375 0 000 6.166z" />
-                                  </svg>
-                                  {event.prize}
-                                </div>
-                              )}
-
-                              {(event.participants || event.attendees) && (
-                                <div className="inline-flex items-center text-xs font-semibold text-sky-700 dark:text-sky-400 bg-sky-500/5 px-2.5 py-1.5 rounded-md border border-sky-500/10">
-                                  <svg className="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.109A2.25 2.25 0 0112.75 21.5h-1.5a2.25 2.25 0 01-2.25-2.263V19.13m-2.625.372A9.336 9.336 0 011.5 18.552a4.125 4.125 0 017.533-2.493m0 0a9.38 9.38 0 012.625.372 9.336 9.336 0 004.121-.952m-4.121.952v-.002c0-1.113-.285-2.16-.786-3.07M9 10.125c0 .621.504 1.125 1.125 1.125h1.75c.621 0 1.125-.504 1.125-1.125V8.875c0-.621-.504-1.125-1.125-1.125h-1.75C9.504 7.75 9 8.254 9 8.875v1.25z" />
-                                  </svg>
-                                  {event.participants ? `${event.participants} participants` : `${event.attendees} attendees`}
-                                </div>
-                              )}
-                            </div>
-
-                            <div className="flex items-center justify-between mt-auto pt-4 border-t border-border">
-                              <div className="flex items-center text-xs font-medium text-text-light">
-                                <svg className="w-4 h-4 mr-1.5 text-text-light/50" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
-                                </svg>
-                                {event.date}
-                              </div>
-
-                              <div className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-semibold border ${
-                                event.timeLeft === "Ended"
-                                  ? "bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20"
-                                  : event.timeLeft === "Live Now"
-                                  ? "bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20"
-                                  : "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20"
-                              }`}>
-                                {event.timeLeft === "Ended" ? (
-                                  <>
-                                    <CheckCircle2 className="w-3.5 h-3.5" /> Ended
-                                  </>
-                                ) : event.timeLeft === "Live Now" ? (
-                                  <>
-                                    <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" /> Live Now
-                                  </>
-                                ) : (
-                                  <>
-                                    <Hourglass className="w-3.5 h-3.5" /> {event.timeLeft}
-                                  </>
-                                )}
-                              </div>
-                            </div>
+                  : upcomingEvents.map((event) => (
+                      <motion.div
+                        key={event.id}
+                        whileHover={prefersReducedMotion ? {} : { scale: 1.01, y: -2 }}
+                        whileTap={prefersReducedMotion ? {} : { scale: 0.995 }}
+                        transition={{ type: "spring", stiffness: 300, damping: 24 }}
+                        className="w-full shrink-0 sm:w-[calc(50%-12px)] lg:w-[calc(33.333%-16px)] group relative flex flex-col rounded-2xl overflow-hidden bg-card-bg border border-border p-5 sm:p-6 shadow-premium-sm hover:shadow-premium-md hover:border-primary transition-all duration-300 pointer-events-auto"
+                        onMouseEnter={() => setIsAutoPlaying(false)}
+                        onMouseLeave={() => setIsAutoPlaying(true)}
+                      >
+                        {/* Card Content */}
+                        <div className="flex flex-col flex-1">
+                          <div className="flex items-center justify-between mb-4 gap-2">
+                            <span
+                              className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold border ${
+                                event.status === "Live Now" || event.status === "Live Event"
+                                  ? "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20"
+                                  : event.status === "Registration Open"
+                                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20"
+                                  : "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
+                              }`}
+                            >
+                              {event.status}
+                            </span>
+                            <span className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-bg-secondary text-text-light border border-border">
+                              {event.type}
+                            </span>
                           </div>
 
-                          <Link
-                            to={event.link}
-                            className="mt-4 inline-flex items-center justify-center w-full px-4 py-2.5 rounded-lg bg-text text-bg hover:opacity-90 text-sm font-semibold transition-all duration-200"
-                          >
-                            {event.featured ? "Register Now" : "Learn More"}
-                            <svg className="ml-2 w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
-                            </svg>
-                          </Link>
-                        </motion.div>
-                      ))}
+                          <h3 title={event.title} className="text-lg sm:text-xl font-bold text-text mb-2 leading-snug group-hover:text-primary transition-colors line-clamp-2 break-words min-w-0">
+                            {event.title}
+                          </h3>
+                          
+                          <p className="text-text-light text-sm mb-4 line-clamp-3 leading-relaxed flex-1 font-normal">
+                            {event.description}
+                          </p>
+
+                          <div className="flex flex-wrap gap-2.5 mb-4">
+                            {event.prize && (
+                              <div className="inline-flex items-center text-xs font-semibold text-rose-600 dark:text-rose-400 bg-rose-500/5 px-2.5 py-1.5 rounded-md border border-rose-500/10">
+                                <svg className="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.251-.11a3.375 3.375 0 000-6.166l-.251-.1a3.375 3.375 0 000 6.166zm6 0l.251-.11a3.375 3.375 0 000-6.166l-.251-.1a3.375 3.375 0 000 6.166z" />
+                                </svg>
+                                {event.prize}
+                              </div>
+                            )}
+
+                            {(event.participants || event.attendees) ? (
+                              <div className="inline-flex items-center text-xs font-semibold text-sky-700 dark:text-sky-400 bg-sky-500/5 px-2.5 py-1.5 rounded-md border border-sky-500/10">
+                                <svg className="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.109A2.25 2.25 0 0112.75 21.5h-1.5a2.25 2.25 0 01-2.25-2.263V19.13m-2.625.372A9.336 9.336 0 011.5 18.552a4.125 4.125 0 017.533-2.493m0 0a9.38 9.38 0 012.625.372 9.336 9.336 0 004.121-.952m-4.121.952v-.002c0-1.113-.285-2.16-.786-3.07M9 10.125c0 .621.504 1.125 1.125 1.125h1.75c.621 0 1.125-.504 1.125-1.125V8.875c0-.621-.504-1.125-1.125-1.125h-1.75C9.504 7.75 9 8.254 9 8.875v1.25z" />
+                                </svg>
+                                {event.participants ? `${event.participants} forks` : `${event.attendees} attendees`}
+                              </div>
+                            ) : null}
+                          </div>
+
+                          <div className="flex items-center justify-between mt-auto pt-4 border-t border-border">
+                            <div className="flex items-center text-xs font-medium text-text-light">
+                              <svg className="w-4 h-4 mr-1.5 text-text-light/50" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+                              </svg>
+                              {event.date}
+                            </div>
+
+                            <div className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-semibold border ${
+                              event.timeLeft === "Ended"
+                                ? "bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20"
+                                : event.timeLeft === "Live Now" || event.timeLeft === "Active"
+                                ? "bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20"
+                                : "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20"
+                            }`}>
+                              {event.timeLeft === "Ended" ? (
+                                <>
+                                  <CheckCircle2 className="w-3.5 h-3.5" /> Ended
+                                </>
+                              ) : event.timeLeft === "Live Now" || event.timeLeft === "Active" ? (
+                                <>
+                                  <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" /> {event.timeLeft}
+                                </>
+                              ) : (
+                                <>
+                                  <Hourglass className="w-3.5 h-3.5" /> {event.timeLeft}
+                                </>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+
+                        <Link
+                          to={event.link}
+                          className="mt-4 inline-flex items-center justify-center w-full px-4 py-2.5 rounded-lg bg-text text-bg hover:opacity-90 text-sm font-semibold transition-all duration-200"
+                        >
+                          {event.featured ? "Register Now" : "Learn More"}
+                          <svg className="ml-2 w-4 h-4 transition-transform duration-200 group-hover:translate-x-1" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+                          </svg>
+                        </Link>
+                      </motion.div>
+                    ))}
               </motion.div>
-            </AnimatePresence>
+            </div>
           </div>
         </div>
 
         {/* Carousel Dots */}
         <div className="flex justify-center items-center mt-6 space-x-2">
           {Array.from(
-            { length: Math.ceil(upcomingEvents.length / cardsPerView) },
+            { length: Math.min(upcomingEvents.length, maxIndex + 1) },
             (_, index) => (
               <button
                 key={index}
                 onClick={() => {
-                  setCurrent(index * cardsPerView);
-                  setDirection(index * cardsPerView > current ? 1 : -1);
+                  setCurrent(index);
                   setIsAutoPlaying(false);
                 }}
                 className="relative group focus:outline-none"
-                aria-label={`Go to slide group ${index + 1}`}
+                aria-label={`Go to slide ${index + 1}`}
               >
                 <div
                   className={`w-6 h-1.5 sm:w-8 sm:h-1.5 rounded-full transition-colors duration-300 ${

--- a/src/Pages/Home/hooks/useHomeEventsData.js
+++ b/src/Pages/Home/hooks/useHomeEventsData.js
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { eventService } from "../../../services/eventService";
+import { fetchHackathons } from "../../../services/hackathonService";
+import { projectService } from "../../../services/projectService";
 
 const normalizeEvents = (rawEvents = []) =>
   rawEvents.map((e) => ({
@@ -15,29 +17,48 @@ const normalizeEvents = (rawEvents = []) =>
 
 export default function useHomeEventsData() {
   const [eventsData, setEventsData] = useState([]);
+  const [hackathonsData, setHackathonsData] = useState([]);
+  const [projectsData, setProjectsData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
 
-    eventService
-      .getAllEvents()
-      .then((res) => {
-        if (cancelled) return;
-        const raw = Array.isArray(res.data) ? res.data : res.data?.content ?? [];
-        setEventsData(normalizeEvents(raw));
-      })
-      .catch(() => {
-        if (!cancelled) setEventsData([]);
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
-      });
+    Promise.allSettled([
+      eventService.getAllEvents(),
+      fetchHackathons(),
+      projectService.getAllProjects(),
+    ]).then(([eventsRes, hackathonsRes, projectsRes]) => {
+      if (cancelled) return;
+
+      // Handle Events
+      if (eventsRes.status === "fulfilled") {
+        const rawEvents = Array.isArray(eventsRes.value.data)
+          ? eventsRes.value.data
+          : eventsRes.value.data?.content ?? [];
+        setEventsData(normalizeEvents(rawEvents));
+      }
+
+      // Handle Hackathons
+      if (hackathonsRes.status === "fulfilled") {
+        setHackathonsData(hackathonsRes.value || []);
+      }
+
+      // Handle Projects
+      if (projectsRes.status === "fulfilled") {
+        const rawProjects = Array.isArray(projectsRes.value.data)
+          ? projectsRes.value.data
+          : [];
+        setProjectsData(rawProjects);
+      }
+
+      setIsLoading(false);
+    });
 
     return () => {
       cancelled = true;
     };
   }, []);
 
-  return { eventsData, isLoading };
+  return { eventsData, hackathonsData, projectsData, isLoading };
 }

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -77,7 +77,7 @@ const Navbar = ({ cursorEnabled, toggleCursor }) => {
       <nav
         ref={navRef}
         aria-label="Primary navigation"
-        className={`fixed top-0 left-0 right-0 z-50 w-full transition-all duration-300 bg-white dark:bg-gray-950 backdrop-blur-md border-b border-transparent ${scrolled ? "shadow-premium-md border-primary/10" : "shadow-premium-sm border-transparent"
+        className={`fixed top-0 left-0 right-0 z-50 w-full transition-all duration-300 bg-navbar border-b border-transparent ${scrolled ? "shadow-premium-md border-primary/10" : "shadow-premium-sm border-transparent"
           }`}
       >
         <div className="mx-auto max-w-screen-2xl px-3 sm:px-4 lg:px-6">


### PR DESCRIPTION
Extend 'What's Happening' carousel to display projects alongside events and hackathons. Refactor carousel from group-based (multiple cards per slide) to item-based scrolling (smooth individual item transitions). Simplify animation logic by removing direction state and AnimatePresence, update autoplay timing to 3s, and adjust padding/spacing. Add project service integration to fetch and format project data.