### PR TITLE
Fix waitlist loading and persist auth token

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -549,7 +549,7 @@ const EventRegistration = () => {
 
 
   // Show skeleton while joining the waitlist specifically
-  if (submitting && isEventFull) {
+  if (isPending && isEventFull) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-slate-50 dark:bg-slate-950 px-4 py-12 gap-4">
         <WaitlistSkeleton />

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -310,6 +310,7 @@ export const AuthProvider = ({ children }) => {
         setCookie("token", sessionToken, {
           path: "/",
           secure: window.location.protocol === "https:",
+          maxAge: 7 * 24 * 60 * 60, // Persist for 7 days
         });
       }
     } catch (err) {


### PR DESCRIPTION
Updates event registration to show the full-event waitlist skeleton based on `isPending` instead of `submitting`, aligning the loading UI with the actual async state. Also adds a 7-day `maxAge` to the auth session token cookie so login sessions persist across browser restarts.