### PR TITLE
refactor: Implement Absolute Imports (baseUrl) to eliminate relative import hell

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@components/*": ["src/components/*"],
+      "@pages/*": ["src/Pages/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@utils/*": ["src/utils/*"],
+      "@context/*": ["src/context/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 // Consolidated lucide-react imports for code cleanliness
 import { Facebook, Linkedin, MessageCircle, Send, Share2, Copy, Mail, Check } from 'lucide-react';
-import { generateSharingUrl, copyToClipboard } from '../../../utils/shareUtils';
+import { generateSharingUrl, copyToClipboard } from '@utils/shareUtils';
 import { toast } from 'react-toastify';
 import './ShareMenu.css';
 


### PR DESCRIPTION
## Description
Adds `jsconfig.json` to enable absolute imports for editor IntelliSense, and refactors a demo import to show the pattern in action.

Closes #10619

## Changes
- Added `jsconfig.json` at the project root, aligned with the path aliases already configured in `vite.config.js` (`@`, `@components`, `@pages`, `@hooks`, `@utils`, `@context`) — this gives VS Code/editor IntelliSense and go-to-definition support for the aliases that Vite already resolves at build/runtime.
- Refactored `src/components/common/ShareMenu/ShareMenu.js` to use `@utils/shareUtils` instead of the deeply nested `../../../utils/shareUtils` import, as a demonstration of the cleaner pattern.

## Note
This repo uses **Vite**, not Create React App — the aliases (`@utils`, `@components`, etc.) were already defined in `vite.config.js` and working at runtime. This PR's `jsconfig.json` mirrors those exact aliases so the editor understands them too, rather than introducing a separate/competing `baseUrl: "src"` convention.

## Testing
- Ran `npm start` and confirmed the app builds and the refactored import resolves correctly with no errors.