### PR TITLE
chore(lint): remove unused _blob parameter in calendarUrlUtils tests

### DIFF
--- a/src/utils/calendarUrlUtils.test.js
+++ b/src/utils/calendarUrlUtils.test.js
@@ -29,7 +29,7 @@ if (typeof global.Blob === 'undefined') {
 }
 if (typeof global.URL === 'undefined' || typeof global.URL.createObjectURL === 'undefined') {
   global.URL = global.URL || class URL {};
-  global.URL.createObjectURL = (_blob) => `blob:http://localhost/${Math.random().toString(36).substring(2)}`;
+  global.URL.createObjectURL = () => `blob:http://localhost/${Math.random().toString(36).substring(2)}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 📋 Description

Fixes #10620

### What does this PR do?

This PR removes the unused `_blob` parameter from `calendarUrlUtils.test.js` to resolve the `no-unused-vars` ESLint warning.

### File Modified

- `src/utils/calendarUrlUtils.test.js`

### Changes Made

- Removed the unused `_blob` parameter from the test callback.
- No functional or behavioral changes.
- Improves code quality by eliminating an ESLint warning.

### Type of Change

- [x] Lint cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

### Checklist

- [x] Fixes Issue #10620
- [x] No functional changes
- [x] ESLint warning resolved
- [x] Existing tests remain unchanged