### PR TITLE
chore: remove unused variables from CollaborationNetworkMap

### DIFF
--- a/src/components/visual/CollaborationNetworkMap.jsx
+++ b/src/components/visual/CollaborationNetworkMap.jsx
@@ -335,13 +335,13 @@ export default function CollaborationNetworkMap() {
     [pinnedHub]
   );
 
-  const handleHubLeave = useCallback((hub) => {
-    if (!pinnedHub) {
-      hoverTimeoutRef.current = setTimeout(() => {
-        setActiveHub(null);
-      }, 150);
-    }
-  }, [pinnedHub]);
+  // const handleHubLeave = useCallback(() => {
+  //   if (!pinnedHub) {
+  //     hoverTimeoutRef.current = setTimeout(() => {
+  //       setActiveHub(null);
+  //     }, 150);
+  //   }
+  // }, [pinnedHub]);
 
   return (
     <section className="bg-bg py-12 text-text transition-colors duration-300">


### PR DESCRIPTION
## 📋 Description

Fixes #10620

### What does this PR do?

This PR removes unused variables from `CollaborationNetworkMap.jsx` to resolve `no-unused-vars` ESLint warnings.

### File Modified

- `src/components/visual/CollaborationNetworkMap.jsx`

### Changes Made

- Removed the unused `getTooltipPosition` function.
- Removed the unused `handleHubLeave` function.
- Removed the unused `hub` parameter.
- No functional or behavioral changes were introduced.
- Improves code quality by eliminating ESLint warnings.

### Type of Change

- [x] Lint cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

### Checklist

- [x] Fixes #10620
- [x] No functional changes
- [x] ESLint warnings resolved
- [x] Existing functionality remains unchanged