### PR TITLE
fix: guard missing projectStatus before rendering StatusBadge

### DIFF
--- a/src/components/user/RegistrationsTab.jsx
+++ b/src/components/user/RegistrationsTab.jsx
@@ -28,7 +28,13 @@ const TYPE_ICON = {
 
 // Helper to render status badge
 const renderStatusBadge = (item) => {
-  const status = item.projectStatus !== "-" ? item.projectStatus : item.status;
+  // Guard against undefined/null in addition to the "-" sentinel so that
+  // Event and Hackathon rows (which have no projectStatus) correctly fall
+  // back to item.status instead of rendering <StatusBadge status={undefined} />.
+  const status =
+    item.projectStatus && item.projectStatus !== "-"
+      ? item.projectStatus
+      : item.status;
   return <StatusBadge status={status} />;
 };
 


### PR DESCRIPTION
### Related Issue
Closes #10638 

### Description of Changes

* Updated the condition in `renderStatusBadge` in `RegistrationsTab.jsx` to check that `item.projectStatus` exists before comparing it to `"-"`.
* Added a truthiness guard so `undefined`, `null`, and empty strings correctly fall back to `item.status`.
* Prevents `undefined` from being passed to `StatusBadge`.
* Fixes broken status badges for Event and Hackathon registrations while preserving existing behavior for Project rows.
