### PR TITLE
fix: add fallback icon for unknown or missing registration types

### DIFF
--- a/src/components/user/RegistrationsTab.jsx
+++ b/src/components/user/RegistrationsTab.jsx
@@ -26,6 +26,9 @@ const TYPE_ICON = {
   Project: <FolderOpen className="ud-type-icon" style={{ color: "#8b5cf6" }} />,
 };
 
+// Fallback for unrecognized or missing item.type values
+const DEFAULT_TYPE_ICON = <FolderOpen className="ud-type-icon" style={{ color: "#94a3b8" }} />;
+
 // Helper to render status badge
 const renderStatusBadge = (item) => {
   const status = item.projectStatus !== "-" ? item.projectStatus : item.status;
@@ -78,8 +81,8 @@ const renderTableRow = (item, setSelectedTicketEvent) => (
   <tr key={item.id}>
     <td>
       <span className="ud-table-type">
-        {TYPE_ICON[item.type]}
-        {item.type}
+      {TYPE_ICON[item.type] ?? DEFAULT_TYPE_ICON}
+      {item.type ?? "Unknown"}
       </span>
     </td>
     <td className="ud-table-title" title={item.title}>


### PR DESCRIPTION
### Related Issue

Closes #10640 

### Description of Changes

* Added a `DEFAULT_TYPE_ICON` (neutral grey `<FolderOpen>`) in `RegistrationsTab.jsx`.
* Updated the Type column to use `TYPE_ICON[item.type] ?? DEFAULT_TYPE_ICON`, ensuring unknown or missing types display a fallback icon.
* Changed `item.type` to `item.type ?? "Unknown"` so missing type values render meaningful text instead of a blank cell.
* Prevents the Type column from silently rendering empty for unrecognized or undefined registration types.
