### PR TITLE
fix: add type=button to all four interactive buttons to prevent accidental form submission

### DIFF
--- a/src/components/user/RegistrationsTab.jsx
+++ b/src/components/user/RegistrationsTab.jsx
@@ -43,6 +43,7 @@ const renderParticipationActions = (item, setSelectedTicketEvent) => {
       <StatusBadge status={item.participationType} />
       {isEventOrHackathon && isRegistered && (
         <button
+          type="button"
           onClick={() => setSelectedTicketEvent(item)}
           className="ud-btn-ticket"
           style={{
@@ -143,7 +144,7 @@ const RegistrationsTab = ({
           id="registrations-search"
         />
         {searchTerm && (
-          <button className="ud-search-clear" onClick={() => setSearchTerm("")} aria-label="Clear search">
+          <button type="button" className="ud-search-clear" onClick={() => setSearchTerm("")} aria-label="Clear search">
             <X size={13} />
           </button>
         )}
@@ -200,6 +201,7 @@ const RegistrationsTab = ({
 
       {activeFilterCount > 0 && (
         <button
+          type="button"
           onClick={clearAll}
           className="ud-clear-filters-btn"
           style={{
@@ -266,6 +268,7 @@ const RegistrationsTab = ({
 
         {filteredData.length > 0 && (
           <button
+            type="button"
             onClick={() => downloadBulkICSFile(filteredData, "eventra-schedule")}
             style={{
               display: "inline-flex",


### PR DESCRIPTION
### Related Issue
Closes #10642 

### Description of Changes
Added `type="button"` to the following buttons in `RegistrationsTab.jsx`:
- "Export Schedule (.ics)" button in the tab header
- Clear search "X" button inside the search input wrapper
- "Clear N filters" button in the filter row
- "View Ticket" button inside `renderParticipationActions`