### PR TITLE
chore(lint): remove unused waitlist variables in useWaitlist hook

### DIFF
--- a/src/hooks/useWaitlist.js
+++ b/src/hooks/useWaitlist.js
@@ -80,7 +80,9 @@ function persistWaitlist(map, storageKey) {
  *   leave: () => Promise<void>,
  * }}
  */
-export default function useWaitlist(eventId, { capacity: _capacity, attendees: _attendees } = {}) {
+export default function useWaitlist(eventId, { 
+  // capacity: _capacity, attendees: _attendees 
+} = {}) {
   const { user } = useAuth();
   const userId = user?.id;
 


### PR DESCRIPTION
## 📋 Description

Fixes #10620

### What does this PR do?

This PR resolves `no-unused-vars` ESLint warnings in the `useWaitlist` hook by removing unused variables that were being destructured but never referenced.

### File Modified

- `src/hooks/useWaitlist.js`

### Changes Made

- Removed the unused `_capacity` variable.
- Removed the unused `_attendees` variable.
- No functional or behavioral changes were introduced.
- Improves code quality by resolving ESLint warnings.

### Type of Change

- [x] Lint cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

### Checklist

- [x] Fixes #10620
- [x] No functional changes
- [x] ESLint warnings resolved
- [x] Code style remains consistent with the existing codebase