### PR TITLE
fix: replace SearchEmptyState with EmptyState in HackathonsTab

### DIFF
--- a/src/components/user/HackathonsTab.jsx
+++ b/src/components/user/HackathonsTab.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { Trophy, Calendar, MapPin, Plus } from "lucide-react";
 import StatusBadge from "../common/StatusBadge";
 import { DashboardItemCardSkeleton } from "../common/SkeletonLoaders";
-import SearchEmptyState from "../common/SearchEmptyState";
+import EmptyState from "../common/EmptyState";
 
 const HackathonsTab = ({ hackathons, loading, fadeUp }) => (
   <motion.div key="hackathons" initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }} className="ud-content">
@@ -14,17 +14,12 @@ const HackathonsTab = ({ hackathons, loading, fadeUp }) => (
     
     {!loading && hackathons.length === 0 ? (
       <div className="w-full mt-4">
-        <SearchEmptyState
-          query=""
-          itemLabel="hackathons"
-          browseLabel="Browse Hackathons"
-          browsePath="/hackathons"
-          onClear={() => {}}
-          suggestions={[
-            "Explore upcoming hackathons",
-            "Join a team to participate",
-            "Host your own hackathon",
-          ]}
+        <EmptyState
+          icon={<Trophy size={48} className="text-pink-500" />}
+          title="No Hackathons Yet"
+          description="You haven't joined any hackathons yet. Explore upcoming hackathons, form a team, and start building!"
+          actionLabel="Browse Hackathons"
+          actionPath="/hackathons"
         />
       </div>
     ) : (


### PR DESCRIPTION
### Related Issue

Closes #10648 

### Description of Changes

* Replaced `SearchEmptyState` with `EmptyState` in `HackathonsTab.jsx`.
* Updated the initial empty state to display a **"No Hackathons Yet"** message with a **"Browse Hackathons"** call to action linking to `/hackathons`.
* Removed the unused search-specific props (`query` and `onClear`).
* Aligns the initial empty-state experience with the pattern used in `RegistrationsTab.jsx`.
