### PR TITLE
fix: EventBadgeGenerator PDF export rendering

### DIFF
--- a/src/components/user/EventBadgeGenerator.jsx
+++ b/src/components/user/EventBadgeGenerator.jsx
@@ -127,6 +127,8 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
       const imgHeight = 135; // Badge height in mm
       const xOffset = (210 - imgWidth) / 2;
       const yOffset = (297 - imgHeight) / 2;
+      const footerTitleY = yOffset + imgHeight + 18;
+      const footerSubtitleY = footerTitleY + 10;
 
       pdf.setFillColor(15, 23, 42); // Dark slate background fill
       pdf.rect(0, 0, 210, 297, "F");
@@ -144,12 +146,20 @@ export default function EventBadgeGenerator({ onClose, userStats = {} }) {
       pdf.setTextColor(255, 255, 255);
       pdf.setFont("helvetica", "bold");
       pdf.setFontSize(16);
+<<<<<<< HEAD
       pdf.text("OFFICIAL ATTENDEE EVENT CREDENTIAL", 105, 240, { align: "center" });
+=======
+      pdf.text("OFFICIAL ATTENDEE EVENT CREDENTIAL", 105, footerTitleY, { align: "center" });
+>>>>>>> 9c106f04 (fix: EventBadgeGenerator PDF export rendering)
 
       pdf.setFont("helvetica", "normal");
       pdf.setFontSize(10);
       pdf.setTextColor(148, 163, 184);
+<<<<<<< HEAD
       pdf.text("This badge grants access to the Eventra Contribution Arena.", 105, 252, { align: "center" });
+=======
+      pdf.text("This badge grants access to the Eventra Contribution Arena.", 105, footerSubtitleY, { align: "center" });
+>>>>>>> 9c106f04 (fix: EventBadgeGenerator PDF export rendering)
       
       pdf.save(`eventra-badge-${attendeeName.toLowerCase().replace(/\s+/g, "-")}.pdf`);
       toast.success("PDF Pass generated and downloaded.");


### PR DESCRIPTION
Closes #10583 

The bug is specifically that the PDF footer text was hard-coded at `45mm` and `55mm`, while the badge starts around `81mm`, so the “footer” appeared above the badge. The change moves those text positions to be calculated from the badge bottom:

const footerTitleY = yOffset + imgHeight + 18;
const footerSubtitleY = footerTitleY + 10;