### PR TITLE
fix: replace SearchEmptyState with EmptyState for initial no-projects state

### DIFF
--- a/src/components/user/ProjectsTab.jsx
+++ b/src/components/user/ProjectsTab.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { FolderOpen, Plus } from "lucide-react";
 import StatusBadge from "../common/StatusBadge";
 import { DashboardItemCardSkeleton } from "../common/SkeletonLoaders";
-import SearchEmptyState from "../common/SearchEmptyState";
+import EmptyState from "../common/EmptyState";
 
 const ProjectsTab = ({ projects, loading, fadeUp }) => (
   <motion.div key="projects" initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0 }} className="ud-content">
@@ -14,17 +14,12 @@ const ProjectsTab = ({ projects, loading, fadeUp }) => (
     
     {!loading && projects.length === 0 ? (
       <div className="w-full mt-4">
-        <SearchEmptyState
-          query=""
-          itemLabel="projects"
-          browseLabel="Browse Projects"
-          browsePath="/projects"
-          onClear={() => {}}
-          suggestions={[
-            "Check out open source projects",
-            "Submit your own project",
-            "Collaborate with others",
-          ]}
+        <EmptyState
+          icon={<FolderOpen size={48} className="text-violet-500" />}
+          title="No Projects Yet"
+          description="You haven't submitted any projects yet. Share your work, collaborate with others, and showcase your builds!"
+          actionLabel="Submit a Project"
+          actionPath="/submit-project"
         />
       </div>
     ) : (


### PR DESCRIPTION
### Related Issue
Closes #10655 

### Description of Changes
- Replaced `SearchEmptyState` with `EmptyState` in `ProjectsTab`.
- Added a contextual empty state with a "Submit a Project" CTA.
- Reused the existing `FolderOpen` icon.
- Aligned with the pattern used in other dashboard tabs.