### PR TITLE
fix: auto-focus email input on mount using emailInputRef

### DIFF
--- a/src/components/auth/PasswordReset.js
+++ b/src/components/auth/PasswordReset.js
@@ -85,6 +85,12 @@ const PasswordReset = () => {
     return () => clearAllTimers(); // Safely clean up everything on unmount
   }, [clearAllTimers]);
 
+  // Auto-focus the email input on mount for keyboard and accessibility UX.
+  // emailInputRef was already wired to the input but the focus call was missing.
+  useEffect(() => {
+    emailInputRef.current?.focus();
+  }, []);
+
   // FIX (Issue #5720): On mount, if a persisted cooldown is still active,
   // start the countdown timer so the UI reflects the correct remaining time.
   useEffect(() => {


### PR DESCRIPTION
### Related Issue
Closes #10662 

### Description of Changes
- Added a `useEffect` to auto-focus the email input on mount.
- Activated the existing `emailInputRef` by calling `emailInputRef.current?.focus()`.
- Used optional chaining for safe focus behavior.