### PR TITLE
feat: add calendar view for registered events in user dashboard

### DIFF
--- a/src/components/user/UserDashboard.css
+++ b/src/components/user/UserDashboard.css
@@ -784,6 +784,244 @@
   flex-wrap: wrap;
 }
 
+.ud-schedule-card {
+  min-width: 0;
+}
+
+.ud-schedule-head {
+  align-items: flex-start;
+}
+
+.ud-schedule-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.ud-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.2rem;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--hover-bg);
+}
+
+.ud-view-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  min-height: 30px;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-color-light);
+  cursor: pointer;
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1;
+  transition: all 0.18s ease;
+}
+
+.ud-view-toggle-btn:hover,
+.ud-view-toggle-active {
+  background: var(--card-bg-color);
+  color: #6366f1;
+  border-color: rgba(99, 102, 241, 0.22);
+  box-shadow: 0 6px 16px rgba(99, 102, 241, 0.1);
+}
+
+.ud-calendar-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+.ud-calendar-toolbar {
+  display: grid;
+  grid-template-columns: 32px 1fr 32px;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ud-calendar-month {
+  margin: 0;
+  text-align: center;
+  color: var(--text-color);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.ud-calendar-nav-btn {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--card-bg-color);
+  color: var(--text-color-light);
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+
+.ud-calendar-nav-btn:hover {
+  color: #6366f1;
+  border-color: rgba(99, 102, 241, 0.32);
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.ud-calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.ud-calendar-weekday {
+  color: var(--text-color-light);
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ud-calendar-day {
+  min-width: 0;
+  min-height: 70px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.25rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--card-bg-color);
+  color: var(--text-color);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+
+.ud-calendar-day:hover {
+  border-color: rgba(99, 102, 241, 0.35);
+  background: rgba(99, 102, 241, 0.06);
+  transform: translateY(-1px);
+}
+
+.ud-calendar-day-muted {
+  opacity: 0.45;
+}
+
+.ud-calendar-day-selected {
+  border-color: #6366f1;
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.3);
+}
+
+.ud-calendar-day-today .ud-calendar-day-number {
+  background: #6366f1;
+  color: #ffffff;
+}
+
+.ud-calendar-day-number {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.ud-calendar-event-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.ud-calendar-event-chip,
+.ud-calendar-more {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 6px;
+  padding: 0.15rem 0.3rem;
+  background: rgba(99, 102, 241, 0.12);
+  color: #4f46e5;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.ud-calendar-more {
+  background: rgba(14, 165, 233, 0.12);
+  color: #0369a1;
+}
+
+.ud-calendar-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding-top: 0.25rem;
+}
+
+.ud-calendar-details h4 {
+  margin: 0;
+  color: var(--text-color);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.ud-calendar-details-empty {
+  margin: 0;
+  color: var(--text-color-light);
+  font-size: 0.8rem;
+}
+
+.ud-calendar-detail-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ud-space-sm);
+  padding: 0.65rem;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: var(--hover-bg);
+}
+
+.dark .ud-view-toggle {
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.dark .ud-view-toggle-btn:hover,
+.dark .ud-view-toggle-active,
+.dark .ud-calendar-nav-btn,
+.dark .ud-calendar-day {
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.dark .ud-calendar-event-chip {
+  color: #c7d2fe;
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.dark .ud-calendar-more {
+  color: #bae6fd;
+  background: rgba(14, 165, 233, 0.18);
+}
+
 .ud-empty {
   font-size: 0.85rem;
   color: var(--text-color-light);

--- a/src/components/user/UserDashboard.jsx
+++ b/src/components/user/UserDashboard.jsx
@@ -4,7 +4,8 @@ import { getSmartDateLabel } from "utils/relativeTime";
 import {
   Calendar, Trophy, FolderOpen, Users, Settings,
   Clock, Zap, Activity, Bell, ChevronRight,
-  LogOut, User, Plus, Search, X, CheckCircle2
+  LogOut, User, Plus, Search, X, CheckCircle2,
+  ChevronLeft, List
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { useState, useEffect, useMemo } from "react";
@@ -29,6 +30,7 @@ import {
   DashboardStatCardSkeleton,
 } from "../common/SkeletonLoaders";
 import useDashboardFilters from "hooks/useDashboardFilters";
+import { parseEventDateTime } from "utils/calendarExport";
 import "./UserDashboard.css";
 import EventTicket from "./EventTicket";
 import EmptyState from "../common/EmptyState";
@@ -65,6 +67,49 @@ const QUICK_ACTIONS = [
   { label: "Settings", icon: <Settings size={22} />, to: "/settings", color: "#f59e0b" },
 ];
 
+const formatDateKey = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const isSameMonth = (date, monthDate) =>
+  date.getFullYear() === monthDate.getFullYear() && date.getMonth() === monthDate.getMonth();
+
+const formatMonthLabel = (date) =>
+  date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+
+const formatDayLabel = (dateKey) => {
+  const date = new Date(`${dateKey}T00:00:00`);
+  return date.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" });
+};
+
+const buildMonthDays = (monthDate) => {
+  const firstDay = new Date(monthDate.getFullYear(), monthDate.getMonth(), 1);
+  const start = new Date(firstDay);
+  start.setDate(firstDay.getDate() - firstDay.getDay());
+
+  return Array.from({ length: 42 }, (_, index) => {
+    const date = new Date(start);
+    date.setDate(start.getDate() + index);
+    return date;
+  });
+};
+
+const getRegistrationEvent = (registration) =>
+  registration?.event || registration?.eventSummary || registration || null;
+
+const getCalendarDateTime = (event) => {
+  const dateValue = event?.startDate || event?.date;
+  if (!dateValue) return null;
+
+  const parsed = parseEventDateTime(String(dateValue), String(event?.startTime || event?.time || ""));
+  if (Number.isNaN(parsed.getTime()) || parsed.getTime() === 0) return null;
+
+  return parsed;
+};
+
 export default function UserDashboard() {
   const prefersReducedMotion = useReducedMotion();
   const { user, logout } = useAuth();
@@ -76,6 +121,9 @@ export default function UserDashboard() {
   const [notifOpen, setNotifOpen] = useState(false);
   const [selectedTicketEvent, setSelectedTicketEvent] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [scheduleView, setScheduleView] = useState("list");
+  const [calendarMonth, setCalendarMonth] = useState(() => new Date());
+  const [selectedCalendarDate, setSelectedCalendarDate] = useState(() => formatDateKey(new Date()));
   const [pushEnabled, setPushEnabled] = useState(() => readNotificationPreferences().push);
 
   // Γ£à Get real user data from contexts
@@ -199,6 +247,56 @@ export default function UserDashboard() {
 
   // Γ£à Use real data for filters
   const dashboardFilters = useDashboardFilters(userRegistrations, { debounceMs: 300 });
+
+  const registeredCalendarEvents = useMemo(() => {
+    const records = Array.isArray(myEvents) ? myEvents : [];
+
+    return records
+      .map((registration) => {
+        const event = getRegistrationEvent(registration);
+        const dateTime = getCalendarDateTime(event);
+        if (!event || !dateTime) return null;
+
+        return {
+          id: registration?.id || event.id || `${event.title}-${formatDateKey(dateTime)}`,
+          title: event.title || "Untitled Event",
+          date: dateTime,
+          dateKey: formatDateKey(dateTime),
+          time: event.startTime || event.time || "",
+          location: event.location || event.venue || "Online",
+          type: event.type || "Event",
+          status: getEventStatus(event) || "Upcoming",
+          participationType: registration?.participationType || "Registered",
+        };
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.date - b.date);
+  }, [myEvents]);
+
+  const calendarDays = useMemo(() => buildMonthDays(calendarMonth), [calendarMonth]);
+
+  const calendarEventsByDate = useMemo(() => {
+    return registeredCalendarEvents.reduce((grouped, event) => {
+      const events = grouped.get(event.dateKey) || [];
+      events.push(event);
+      grouped.set(event.dateKey, events);
+      return grouped;
+    }, new Map());
+  }, [registeredCalendarEvents]);
+
+  const selectedDayEvents = calendarEventsByDate.get(selectedCalendarDate) || [];
+
+  const goToPreviousMonth = () => {
+    setCalendarMonth((current) => new Date(current.getFullYear(), current.getMonth() - 1, 1));
+  };
+
+  const goToNextMonth = () => {
+    setCalendarMonth((current) => new Date(current.getFullYear(), current.getMonth() + 1, 1));
+  };
+
+  const selectCalendarDay = (date) => {
+    setSelectedCalendarDate(formatDateKey(date));
+  };
 
   const togglePushNotifications = async () => {
     if (pushEnabled) {
@@ -435,30 +533,134 @@ export default function UserDashboard() {
 
                   <div className="ud-three-col">
                     {/* Upcoming Events */}
-                    <motion.section custom={2} variants={fadeUp(prefersReducedMotion)} className="ud-card backdrop-blur-md bg-white/10 border border-white/20 shadow-lg">
-                      <div className="ud-card-head">
+                    <motion.section custom={2} variants={fadeUp(prefersReducedMotion)} className="ud-card ud-schedule-card backdrop-blur-md bg-white/10 border border-white/20 shadow-lg">
+                      <div className="ud-card-head ud-schedule-head">
                         <span className="ud-card-icon" style={{ background: "#6366f118", color: "#6366f1" }}><Clock size={16} /></span>
                         <h3>Upcoming Events</h3>
-                        <Link to="/events" className="ud-card-link">See all <ChevronRight size={13} /></Link>
-                      </div>
-                      {upcomingEvents.length === 0 ? (
-                        <EmptyState
-                          compact={true}
-                          icon={<Calendar size={32} className="text-indigo-500" />}
-                          title="No Upcoming Events"
-                          message="You haven't registered or joined any events yet. Check out the Events tab to find one!"
-                          onBrowseAll={() => navigate("/events")}
-                        />
-                      ) : (
-                        upcomingEvents.map(ev => (
-                          <div key={ev.id} className="ud-list-item">
-                            <div className="min-w-0 flex-1">
-                              <p className="ud-list-title" title={ev.title}>{ev.title}</p>
-                              <p className="ud-list-meta"><Calendar size={12} /> {getSmartDateLabel(ev.date)}</p>
-                            </div>
-                            <StatusBadge status={ev.participationType} />
+                        <div className="ud-schedule-actions">
+                          <div className="ud-view-toggle" aria-label="Schedule view mode">
+                            <button
+                              type="button"
+                              className={`ud-view-toggle-btn ${scheduleView === "list" ? "ud-view-toggle-active" : ""}`}
+                              onClick={() => setScheduleView("list")}
+                              aria-pressed={scheduleView === "list"}
+                            >
+                              <List size={14} />
+                              <span>List</span>
+                            </button>
+                            <button
+                              type="button"
+                              className={`ud-view-toggle-btn ${scheduleView === "calendar" ? "ud-view-toggle-active" : ""}`}
+                              onClick={() => setScheduleView("calendar")}
+                              aria-pressed={scheduleView === "calendar"}
+                            >
+                              <Calendar size={14} />
+                              <span>Calendar</span>
+                            </button>
                           </div>
-                        ))
+                          <Link to="/events" className="ud-card-link">See all <ChevronRight size={13} /></Link>
+                        </div>
+                      </div>
+
+                      {scheduleView === "calendar" ? (
+                        registeredCalendarEvents.length === 0 ? (
+                          <EmptyState
+                            compact={true}
+                            icon={<Calendar size={32} className="text-indigo-500" />}
+                            title="No Registered Events"
+                            message="Register for an event to see it on your monthly calendar."
+                            onBrowseAll={() => navigate("/events")}
+                          />
+                        ) : (
+                          <div className="ud-calendar-wrap">
+                            <div className="ud-calendar-toolbar">
+                              <button type="button" className="ud-calendar-nav-btn" onClick={goToPreviousMonth} aria-label="Previous month">
+                                <ChevronLeft size={15} />
+                              </button>
+                              <p className="ud-calendar-month">{formatMonthLabel(calendarMonth)}</p>
+                              <button type="button" className="ud-calendar-nav-btn" onClick={goToNextMonth} aria-label="Next month">
+                                <ChevronRight size={15} />
+                              </button>
+                            </div>
+
+                            <div className="ud-calendar-grid" role="grid" aria-label={`${formatMonthLabel(calendarMonth)} registered events`}>
+                              {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
+                                <div key={day} className="ud-calendar-weekday">{day}</div>
+                              ))}
+                              {calendarDays.map((date) => {
+                                const dateKey = formatDateKey(date);
+                                const dayEvents = calendarEventsByDate.get(dateKey) || [];
+                                const isSelected = dateKey === selectedCalendarDate;
+                                const inCurrentMonth = isSameMonth(date, calendarMonth);
+                                const isToday = dateKey === formatDateKey(new Date());
+
+                                return (
+                                  <button
+                                    key={dateKey}
+                                    type="button"
+                                    className={`ud-calendar-day ${inCurrentMonth ? "" : "ud-calendar-day-muted"} ${isSelected ? "ud-calendar-day-selected" : ""} ${isToday ? "ud-calendar-day-today" : ""}`}
+                                    onClick={() => selectCalendarDay(date)}
+                                    aria-label={`${date.toLocaleDateString(undefined, { month: "long", day: "numeric" })}, ${dayEvents.length} registered event${dayEvents.length === 1 ? "" : "s"}`}
+                                    aria-pressed={isSelected}
+                                  >
+                                    <span className="ud-calendar-day-number">{date.getDate()}</span>
+                                    <span className="ud-calendar-event-stack">
+                                      {dayEvents.slice(0, 2).map((event) => (
+                                        <span key={event.id} className="ud-calendar-event-chip" title={event.title}>
+                                          {event.title}
+                                        </span>
+                                      ))}
+                                      {dayEvents.length > 2 && (
+                                        <span className="ud-calendar-more">+{dayEvents.length - 2}</span>
+                                      )}
+                                    </span>
+                                  </button>
+                                );
+                              })}
+                            </div>
+
+                            <div className="ud-calendar-details" aria-live="polite">
+                              <h4>{formatDayLabel(selectedCalendarDate)}</h4>
+                              {selectedDayEvents.length === 0 ? (
+                                <p className="ud-calendar-details-empty">No registered events on this day.</p>
+                              ) : (
+                                selectedDayEvents.map((event) => (
+                                  <div key={event.id} className="ud-calendar-detail-item">
+                                    <div className="min-w-0 flex-1">
+                                      <p className="ud-list-title" title={event.title}>{event.title}</p>
+                                      <p className="ud-list-meta">
+                                        <Clock size={12} /> {event.time || "Time TBA"}
+                                        <span>&middot;</span>
+                                        {event.location}
+                                      </p>
+                                    </div>
+                                    <StatusBadge status={event.participationType} />
+                                  </div>
+                                ))
+                              )}
+                            </div>
+                          </div>
+                        )
+                      ) : (
+                        upcomingEvents.length === 0 ? (
+                          <EmptyState
+                            compact={true}
+                            icon={<Calendar size={32} className="text-indigo-500" />}
+                            title="No Upcoming Events"
+                            message="You haven't registered or joined any events yet. Check out the Events tab to find one!"
+                            onBrowseAll={() => navigate("/events")}
+                          />
+                        ) : (
+                          upcomingEvents.map(ev => (
+                            <div key={ev.id} className="ud-list-item">
+                              <div className="min-w-0 flex-1">
+                                <p className="ud-list-title" title={ev.title}>{ev.title}</p>
+                                <p className="ud-list-meta"><Calendar size={12} /> {getSmartDateLabel(ev.date)}</p>
+                              </div>
+                              <StatusBadge status={ev.participationType} />
+                            </div>
+                          ))
+                        )
                       )}
                     </motion.section>
 

--- a/src/utils/calendarExport.ts
+++ b/src/utils/calendarExport.ts
@@ -21,7 +21,7 @@ import type { Event } from "../components/EventTimeline";
  *
  * Falls back to midnight on the given date when `timeStr` is absent or unparseable.
  */
-const parseEventDateTime = (dateStr: string, timeStr: string): Date => {
+export const parseEventDateTime = (dateStr: string, timeStr = ""): Date => {
   const base = new Date(dateStr);
   if (isNaN(base.getTime())) return new Date(0);
 


### PR DESCRIPTION
Closes #10286

Adds a list/calendar toggle to the dashboard overview so users can view registered events on a monthly grid and inspect events for a selected day.