### PR TITLE
feat: add undo toast for destructive actions

### DIFF
--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { joinWaitlist, leaveWaitlist, getWaitlistStatus, getWaitlistCount } from 'services/waitlistService';
+import { showUndoToast } from 'utils/toast';
 
 // Custom hook - args grouped into single options object (fixes Excess Function Arguments)
 const useWaitlist = ({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated, token }) => {
@@ -45,10 +46,28 @@ const useWaitlist = ({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated,
     setLoading(true);
     try {
       if (onWaitlist) {
-        await leaveWaitlist(eventId, token);
         setOnWaitlist(false);
         setPosition(null);
         setWaitlistCount(prev => prev - 1);
+        showUndoToast({
+          message: 'Removed from waitlist.',
+          toastId: `common-leave-waitlist-${eventId}`,
+          onUndo: () => {
+            setOnWaitlist(true);
+            setPosition(position);
+            setWaitlistCount(prev => prev + 1);
+          },
+          onCommit: async () => {
+            try {
+              await leaveWaitlist(eventId, token);
+            } catch (err) {
+              setOnWaitlist(true);
+              setPosition(position);
+              setWaitlistCount(prev => prev + 1);
+              alert(err.message);
+            }
+          },
+        });
       } else {
         const data = await joinWaitlist(eventId, token);
         setOnWaitlist(true);

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -25,6 +25,7 @@ import EmptyState from "../common/EmptyState";
 import { useDebouncedSearch } from "hooks/useDebouncedSearch";
 import { useOfflineStatus } from "hooks/useOfflineStatus";
 import LazyImage from "../common/LazyImage";
+import { showUndoToast } from "utils/toast";
 import toast from "react-hot-toast";
 
 /* ---------------- Helper Functions (Extracted to reduce complexity) ---------------- */
@@ -368,7 +369,7 @@ const EventsEmptyState = () => (
 const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   const prefersReducedMotion = useReducedMotion();
   const staggerVariants = stagger(prefersReducedMotion);
-  const { myEvents, removeRegistration, loading: myEventsLoading } = useMyEvents();
+  const { myEvents, removeRegistration, restoreRegistration, loading: myEventsLoading } = useMyEvents();
   const { user } = useAuth();
 
   const [waitlistEvents, setWaitlistEvents] = useState([]);
@@ -536,10 +537,17 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   const handleCancelDismiss = () => setCancelTarget(null);
   const handleCancelConfirm = useCallback(() => {
     if (!cancelTarget) return;
+    const registration = myEvents.find((event) => event.eventId === cancelTarget.id);
     removeRegistration(cancelTarget.id);
     setCancelTarget(null);
-    toast.success("Registration cancelled successfully");
-  }, [cancelTarget, removeRegistration]);
+    showUndoToast({
+      message: "Registration cancelled.",
+      toastId: `cancel-registration-${cancelTarget.id}`,
+      onUndo: () => {
+        if (registration) restoreRegistration(registration);
+      },
+    });
+  }, [cancelTarget, myEvents, removeRegistration, restoreRegistration]);
 
   const handleCopyLink = async (event) => {
     try {
@@ -552,15 +560,57 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   };
 
   const handleLeaveWaitlist = async (eventId, eventTitle) => {
-    if (window.confirm(`Are you sure you want to leave the waitlist for "${eventTitle}"?`)) {
-      try {
-        const { leaveWaitlist } = await import("utils/waitlistUtils.js");
-        await leaveWaitlist(eventId, user.id || user.email);
-        toast.success("Left the waitlist successfully.");
-        triggerWaitlistUpdate();
-      } catch (err) {
-        toast.error(err.message || "Failed to leave waitlist.");
+    try {
+      const { getGlobalWaitlist, saveGlobalWaitlist, leaveWaitlist } = await import("utils/waitlistUtils.js");
+      const userId = user.id || user.email;
+      const records = getGlobalWaitlist();
+      const recordIndex = records.findIndex(
+        (record) => String(record.eventId) === String(eventId) && record.userId === userId && record.status === "waiting"
+      );
+      const previousRecord = recordIndex >= 0 ? { ...records[recordIndex] } : null;
+
+      if (recordIndex >= 0) {
+        const optimisticRecords = [...records];
+        optimisticRecords[recordIndex] = {
+          ...optimisticRecords[recordIndex],
+          status: "removed",
+          removedAt: new Date().toISOString(),
+        };
+        saveGlobalWaitlist(optimisticRecords);
       }
+
+      triggerWaitlistUpdate();
+      showUndoToast({
+        message: `Left the waitlist for "${eventTitle}".`,
+        toastId: `dashboard-leave-waitlist-${eventId}`,
+        onUndo: () => {
+          if (!previousRecord) return;
+          const latest = getGlobalWaitlist();
+          const restoreIndex = latest.findIndex(
+            (record) => String(record.eventId) === String(eventId) && record.userId === userId
+          );
+          const restored = restoreIndex >= 0 ? [...latest] : [previousRecord, ...latest];
+          if (restoreIndex >= 0) restored[restoreIndex] = previousRecord;
+          saveGlobalWaitlist(restored);
+          triggerWaitlistUpdate();
+        },
+        onCommit: async () => {
+          try {
+            await leaveWaitlist(eventId, userId);
+          } catch (err) {
+            if (previousRecord) {
+              const latest = getGlobalWaitlist();
+              if (!latest.some((record) => String(record.eventId) === String(eventId) && record.userId === userId && record.status === "waiting")) {
+                saveGlobalWaitlist([previousRecord, ...latest]);
+              }
+              triggerWaitlistUpdate();
+            }
+            toast.error(err.message || "Failed to leave waitlist.");
+          }
+        },
+      });
+    } catch (err) {
+      toast.error(err.message || "Failed to leave waitlist.");
     }
   };
 

--- a/src/components/user/OnboardingChecklist.jsx
+++ b/src/components/user/OnboardingChecklist.jsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { safeJsonParse } from "utils/safeJsonParse";
 import { syncSecureStorage } from "utils/secureStorage";
+import { showUndoToast } from "utils/toast";
 
 // Confetti Component for celebration
 const OnboardingConfetti = () => {
@@ -298,9 +299,19 @@ export default function OnboardingChecklist() {
   }, [checkTaskStatus]);
 
   const handleDismiss = () => {
-    localStorage.setItem("eventra_onboarding_dismissed", "true");
     setIsDismissed(true);
     setIsOpen(false);
+    showUndoToast({
+      message: "Onboarding quest dismissed.",
+      toastId: "dismiss-onboarding-checklist",
+      onUndo: () => {
+        setIsDismissed(false);
+        setIsOpen(true);
+      },
+      onCommit: () => {
+        localStorage.setItem("eventra_onboarding_dismissed", "true");
+      },
+    });
   };
 
 

--- a/src/context/MyEventsContext.js
+++ b/src/context/MyEventsContext.js
@@ -199,6 +199,14 @@ export const MyEventsProvider = ({ children }) => {
     setMyEvents((prev) => prev.filter((r) => r.eventId !== eventId));
   }, []);
 
+  const restoreRegistration = useCallback((registration) => {
+    if (!registration?.eventId) return;
+    setMyEvents((prev) => {
+      if (prev.some((r) => r.eventId === registration.eventId)) return prev;
+      return [...prev, registration];
+    });
+  }, []);
+
   /**
    * isRegistered — returns true if the user is already registered for eventId.
    */
@@ -219,6 +227,7 @@ export const MyEventsProvider = ({ children }) => {
         myEvents,
         addRegistration,
         removeRegistration,
+        restoreRegistration,
         isRegistered,
         loading,
         waitlistUpdated,

--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -7,6 +7,7 @@ import seedNotifications from "../data/mockNotifications.json";
 import { safeJsonParse } from "../utils/safeJsonParse.js";
 import { getNotificationMessage } from "../utils/notificationPreferences.js";
 import { get as idbGet, del as idbDel } from "idb-keyval";
+import { showUndoToast } from "../utils/toast.js";
 
 const POLLING_INTERVAL_MS = 60_000;
 const MAX_SEEN_IDS = 500;
@@ -59,11 +60,13 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
   const tokenRef = useRef(token);
   const isPageVisibleRef = useRef(isPageVisible);
   const storageKeyRef = useRef(getStorageKey(user?.id));
+  const notificationsRef = useRef([]);
 
   useEffect(() => { isMounted.current = true; return () => { isMounted.current = false; }; }, []);
   useEffect(() => { tokenRef.current = token; }, [token]);
   useEffect(() => { isPageVisibleRef.current = isPageVisible; }, [isPageVisible]);
   useEffect(() => { storageKeyRef.current = getStorageKey(user?.id); }, [user?.id]);
+  useEffect(() => { notificationsRef.current = notifications; }, [notifications]);
 
   // One-shot migration: when a user first logs in, adopt any inbox that was
   // still sitting under the guest key (because the old code path routed every
@@ -234,27 +237,49 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
     async (id) => {
       if (!id) return;
       const t = token;
-      let removedWasUnread = false;
-      setNotifications((prev) => {
-        const target = prev.find((n) => n.id === id);
-        removedWasUnread = target ? !target.isRead : false;
-        const updated = prev.filter((n) => n.id !== id);
-        persist(updated, storageKeyRef.current);
-        return updated;
-      });
+      const currentNotifications = notificationsRef.current;
+      const removedIndex = currentNotifications.findIndex((n) => n.id === id);
+      const removedNotification = removedIndex >= 0 ? currentNotifications[removedIndex] : null;
+      if (!removedNotification) return;
+      const removedWasUnread = !removedNotification.isRead;
+      const optimisticallyUpdated = currentNotifications.filter((n) => n.id !== id);
+      setNotifications(optimisticallyUpdated);
+      notificationsRef.current = optimisticallyUpdated;
+      persist(optimisticallyUpdated, storageKeyRef.current);
       if (removedWasUnread) setUnreadCount((p) => Math.max(0, p - 1));
       const fn = API_ENDPOINTS?.NOTIFICATIONS?.DELETE;
-      if (!token || typeof fn !== "function") return;
-      const endpoint = fn(id);
-      if (!endpoint) return;
-      try { await apiUtils.delete(endpoint); }
-      catch (err) {
-        pushToNotificationQueue("delete", { endpoint });
-        if (isMounted.current && tokenRef.current === t) {
-          console.error("[useNotificationPoller] delete:", err);
-          refetchRef.current({ isBackground: true });
-        }
-      }
+      const endpoint = token && typeof fn === "function" ? fn(id) : null;
+
+      const restoreNotification = () => {
+        if (!isMounted.current) return;
+        setNotifications((prev) => {
+          if (prev.some((n) => n.id === id)) return prev;
+          const updated = [...prev];
+          const insertAt = removedIndex >= 0 ? Math.min(removedIndex, updated.length) : 0;
+          updated.splice(insertAt, 0, removedNotification);
+          persist(updated, storageKeyRef.current);
+          notificationsRef.current = updated;
+          return updated;
+        });
+        if (removedWasUnread) setUnreadCount((p) => p + 1);
+      };
+
+      showUndoToast({
+        message: "Notification deleted.",
+        toastId: `delete-notification-${id}`,
+        onUndo: restoreNotification,
+        onCommit: async () => {
+          if (!endpoint) return;
+          try { await apiUtils.delete(endpoint); }
+          catch (err) {
+            pushToNotificationQueue("delete", { endpoint });
+            if (isMounted.current && tokenRef.current === t) {
+              console.error("[useNotificationPoller] delete:", err);
+              refetchRef.current({ isBackground: true });
+            }
+          }
+        },
+      });
     },
     [token],
   );

--- a/src/hooks/useWaitlist.js
+++ b/src/hooks/useWaitlist.js
@@ -16,6 +16,7 @@ import { apiUtils, API_ENDPOINTS } from "../config/api.js";
 import { safeLocalStorage } from "../utils/safeStorage";
 import { useAuth } from "../context/AuthContext";
 import { getOrMigrateKey } from "../utils/storageKeyManager";
+import { showUndoToast } from "../utils/toast";
 
 // Legacy unscoped key the hook used before #10388. Kept around so
 // getOrMigrateKey can adopt any data left under it into the user's namespaced
@@ -185,26 +186,35 @@ export default function useWaitlist(eventId, { capacity: _capacity, attendees: _
       return next;
     });
 
-    try {
-      const res = await apiUtils.delete(
-        API_ENDPOINTS.EVENTS?.WAITLIST
-          ? API_ENDPOINTS.EVENTS.WAITLIST(id)
-          : `/api/events/${id}/waitlist`,
-        {}
-      );
-      if (!res.ok) {
-        throw new Error(res.data?.message || "Failed to leave waitlist.");
-      }
-      toast.info("You've been removed from the waitlist.");
-    } catch (err) {
-      // Roll back
-      setWaitlistMap((prev) => ({ ...prev, [id]: prevEntry }));
-      const msg = err.message || "Unable to leave waitlist right now.";
-      setError(msg);
-      toast.error(msg);
-    } finally {
-      setIsLoading(false);
-    }
+    showUndoToast({
+      message: "Removed from waitlist.",
+      toastId: `leave-waitlist-${id}`,
+      onUndo: () => {
+        setWaitlistMap((prev) => ({ ...prev, [id]: prevEntry }));
+        setIsLoading(false);
+        toast.info("Waitlist removal undone.");
+      },
+      onCommit: async () => {
+        try {
+          const res = await apiUtils.delete(
+            API_ENDPOINTS.EVENTS?.WAITLIST
+              ? API_ENDPOINTS.EVENTS.WAITLIST(id)
+              : `/api/events/${id}/waitlist`,
+            {}
+          );
+          if (!res.ok) {
+            throw new Error(res.data?.message || "Failed to leave waitlist.");
+          }
+        } catch (err) {
+          setWaitlistMap((prev) => ({ ...prev, [id]: prevEntry }));
+          const msg = err.message || "Unable to leave waitlist right now.";
+          setError(msg);
+          toast.error(msg);
+        } finally {
+          setIsLoading(false);
+        }
+      },
+    });
   }, [id, isOnWaitlist, isLoading, waitlistMap]);
 
   return {

--- a/src/index.css
+++ b/src/index.css
@@ -1323,6 +1323,37 @@ html:not(.dark) ::placeholder {
   border: 1px solid #1e293b;
 }
 
+.eventra-undo-toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.eventra-undo-toast__message {
+  flex: 1;
+  min-width: 0;
+}
+
+.eventra-undo-toast__button {
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 9999px;
+  background: #111827;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.45rem 0.7rem;
+}
+
+.eventra-undo-toast__button:hover,
+.eventra-undo-toast__button:focus-visible {
+  background: #4338ca;
+  outline: none;
+}
+
 /* Accessibility: Keyboard Outlines on Close Button */
 .Toastify__close-button:focus-visible {
   outline: 2px solid #38bdf8;
@@ -1348,4 +1379,3 @@ html:not(.dark) ::placeholder {
 .dark #fluid {
   mix-blend-mode: plus-lighter; /* Extra premium neon glow on dark backgrounds */
 }
-

--- a/src/utils/toast.js
+++ b/src/utils/toast.js
@@ -1,20 +1,18 @@
+import { createElement } from "react";
+import { toast as toastifyToast } from "react-toastify";
+
 const AUTH_TOAST_ID = "auth-feedback";
+export const UNDO_TOAST_AUTO_CLOSE_MS = 5000;
 
 // Lazy import to avoid SSR crash — react-toastify relies on window internals
-let _toast = null;
 const getToast = () => {
-  if (!_toast) {
-     
-    const mod = require("react-toastify");
-    _toast = mod.toast;
-  }
-  return _toast;
+  return toastifyToast;
 };
 
-const isSSR = typeof window === "undefined";
+const isSSR = () => typeof window === "undefined";
 
 export function showAuthToast(message, onAfterClose) {
-  if (isSSR) return;
+  if (isSSR()) return;
   const toast = getToast();
   toast.dismiss(AUTH_TOAST_ID);
   toast.success(message, {
@@ -25,7 +23,7 @@ export function showAuthToast(message, onAfterClose) {
 }
 
 export function showErrorToast(message, onAfterClose) {
-  if (isSSR) return;
+  if (isSSR()) return;
   const toast = getToast();
   toast.dismiss("error-feedback");
   toast.error(message, {
@@ -36,7 +34,7 @@ export function showErrorToast(message, onAfterClose) {
 }
 
 export function showInfoToast(message, onAfterClose) {
-  if (isSSR) return;
+  if (isSSR()) return;
   const toast = getToast();
   toast.dismiss("info-feedback");
   toast.info(message, {
@@ -47,7 +45,7 @@ export function showInfoToast(message, onAfterClose) {
 }
 
 export function showSuccessToast(message, options = {}) {
-  if (isSSR) return;
+  if (isSSR()) return;
   const { autoClose = 2500, toastId, onClose } = options;
   const toast = getToast();
   if (toastId) toast.dismiss(toastId);
@@ -55,15 +53,76 @@ export function showSuccessToast(message, options = {}) {
 }
 
 export function showWarningToast(message, options = {}) {
-  if (isSSR) return;
+  if (isSSR()) return;
   const { autoClose = 3000, toastId, onClose } = options;
   const toast = getToast();
   if (toastId) toast.dismiss(toastId);
   toast.warning(message, { toastId, autoClose, onClose });
 }
 
+export function showUndoToast({
+  message,
+  undoLabel = "Undo",
+  toastId,
+  autoClose = UNDO_TOAST_AUTO_CLOSE_MS,
+  onUndo,
+  onCommit,
+  onError,
+} = {}) {
+  if (isSSR() || !message) return undefined;
+
+  const toast = getToast();
+  let settled = false;
+  let id;
+
+  const commitTimer = setTimeout(async () => {
+    if (settled) return;
+    settled = true;
+    try {
+      await onCommit?.();
+    } catch (error) {
+      onError?.(error);
+    }
+  }, autoClose);
+
+  const handleUndo = () => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(commitTimer);
+    onUndo?.();
+    if (id !== undefined) toast.dismiss(id);
+  };
+
+  const content = createElement(
+    "div",
+    { className: "eventra-undo-toast", role: "status" },
+    createElement("span", { className: "eventra-undo-toast__message" }, message),
+    createElement(
+      "button",
+      {
+        type: "button",
+        className: "eventra-undo-toast__button",
+        onClick: handleUndo,
+      },
+      undoLabel
+    )
+  );
+
+  if (toastId) toast.dismiss(toastId);
+  id = toast.info(content, {
+    toastId,
+    autoClose,
+    closeOnClick: false,
+    pauseOnHover: false,
+    pauseOnFocusLoss: false,
+    draggable: false,
+  });
+
+  return id;
+}
+
 export function dismissToastsByGroup(groupId) {
-  if (isSSR) return;
+  if (isSSR()) return;
   if (typeof window !== "undefined" && window.__EVENTRA_TOASTS__) {
     const list = window.__EVENTRA_TOASTS__[groupId] || [];
     list.forEach((_id) => {


### PR DESCRIPTION
Closes #10285

This PR adds the new feature: "Undo" toast for destructive actions (leave waitlist, delete notification, cancel registration).