### PR TITLE
fix(api): attach missing Idempotency-Key to fetchWithTimeout mutating requests

### DIFF
--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -62,6 +62,7 @@ export const fetchWithTimeout = async (
   try {
     const response = await fetch(url, {
       ...options,
+      headers: requestHeaders,
       signal: controller.signal, // This now responds to BOTH the timeout and the user's unmount signal
     });
 


### PR DESCRIPTION
## Description
This PR fixes a critical oversight in the `fetchWithTimeout` utility where securely generated `Idempotency-Key` headers were being completely discarded before the network request was dispatched.

Previously, the code generated the key and assigned it to a local `requestHeaders` variable, but the `fetch()` call erroneously used the unmodified `...options` object, meaning the idempotency key was never actually sent to the backend. This nullified the security patch introduced in Issue #9230.

## Changes Made
* Updated the `fetch()` options payload in `src/utils/fetchWithTimeout.js` to explicitly pass the mutated `requestHeaders` variable.

## Impact
* **Criticality**: High
* Mutating requests (`POST`, `PUT`, `PATCH`, `DELETE`) sent through this utility will now safely include their idempotency keys. 
* Prevents race conditions and severe bugs like double-submissions (e.g., duplicate event registrations or double-charges) in the event of network stutters or browser-level request retries.

## Testing Steps
1. Make any mutating network request (e.g., create an event or register).
2. Inspect the network tab in the browser developer tools.
3. Verify that the `Idempotency-Key` header is now present and contains a valid UUID format (or securely generated fallback).

Fixes #10676 
