### PR TITLE
fix(offline): drop unresolved 409 conflicts to prevent infinite exponential backoff loops

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -726,7 +726,10 @@ export const processQueue = async (currentUserId, fetchFn, options = {}) => {
 
     if (result.status === "success") {
       succeeded.push(item);
-    } else if (result.status === "dropped") {
+    } else if (result.status === "dropped" || result.status === "conflict") {
+      if (result.status === "conflict") {
+        logger.warn(`[OfflineQueue] Unresolved 409 conflict for item ${item.id} — dropping.`);
+      }
       dropped.push(item);
     } else {
       failed.push({ ...item, retryCount: (item.retryCount || 0) + 1 });


### PR DESCRIPTION
## Description
This PR resolves a significant architectural flaw in the offline synchronization pipeline (`offlineQueue.js`) where unresolvable server conflicts were incorrectly funneled into the network retry engine. 

Previously, when the queue engine encountered a `409 Conflict` (indicating an irreconcilable state divergence, such as modifying a deleted event) and no `onConflict` handler was able to resolve it, the function returned `{ status: "conflict" }`. However, the main `processQueue` loop lacked an explicit catch for this status, causing it to fall through to the catch-all `else` block meant for transient 5xx crashes and dropped connections. 

As a result, the client would aggressively hit the server with up to 5 automated retries using exponential backoff for an error that was physically impossible to resolve, causing severe head-of-line blocking for the rest of the queue.

## Changes Made
* Updated the conditional logic in `src/utils/offlineQueue.js` (`processQueue`) to explicitly intercept `result.status === "conflict"`.
* Routed unresolvable conflicts into the existing `dropped` pipeline to safely discard them.
* Added a dedicated `logger.warn` statement to ensure dropped conflicts leave a clear audit trail for debugging.

## Impact & Severity
* **Performance / Battery:** Eliminates up to 5 unnecessary outbound HTTP requests per conflicted item, saving mobile battery life and reducing unnecessary API rate limiting.
* **UX:** Prevents "head-of-line blocking" in the offline queue, ensuring that valid offline actions queued behind a 409 Conflict are synchronized immediately rather than waiting for the backoff timers to expire.
* **Server Health:** Stops the client from predictably spamming the backend with invalid requests.

## Testing Steps
1. Disconnect the client from the network.
2. Queue an action that will intentionally trigger a `409 Conflict` (e.g., attempt to modify a resource, then manually delete that resource directly in the database to simulate a state divergence).
3. Reconnect the network to trigger the queue flush.
4. Verify in the console that the `[OfflineQueue] Unresolved 409 conflict for item ... — dropping` warning appears exactly once, and that no subsequent retry attempts are made.

Fixes #10682 
