### PR TITLE
fix(certificate): prevent overwriting duplicate attendee filenames in ZIP archives

### DIFF
--- a/src/components/BulkCertificateGenerator.jsx
+++ b/src/components/BulkCertificateGenerator.jsx
@@ -24,7 +24,15 @@ const BulkCertificateGenerator = ({ eventName, eventDate, eventType, organizerNa
         const attendee = attendees[i];
         const participantName = `${attendee.firstName || ""} ${attendee.lastName || attendee.name || ""}`.trim() || "Participant";
         const doc = generateCertificatePDF({ participantName, eventName, eventDate, eventType, organizerName, template });
-        const safeFileName = `${participantName.replace(/[^a-zA-Z0-9]/g, "_")}_${(eventName || "Event").replace(/[^a-zA-Z0-9]/g, "_")}_Certificate.pdf`;
+        const baseName = participantName.replace(/[^a-zA-Z0-9]/g, "_");
+        const safeEventName = (eventName || "Event").replace(/[^a-zA-Z0-9]/g, "_");
+        let safeFileName = `${baseName}_${safeEventName}_Certificate.pdf`;
+        
+        let counter = 1;
+        while (zip.file(safeFileName)) {
+          safeFileName = `${baseName}_${safeEventName}_Certificate_${counter}.pdf`;
+          counter++;
+        }
         
         const pdfBlob = doc.output("blob");
         zip.file(safeFileName, pdfBlob);


### PR DESCRIPTION


## Description
When generating bulk certificates using the ZIP export functionality, certificates are added to the `JSZip` instance using the generated filename string as the key (`zip.file(safeFileName, pdfBlob)`).

If multiple selected attendees share the same name (e.g. multiple "John Smith"s) or fallback to `"Participant"`, `JSZip` overwrites earlier certificate files with identical keys. As a result, the downloaded `.zip` archive ends up missing certificates for attendees with duplicate names.

This PR fixes the bug by checking whether a filename already exists in the ZIP archive before adding it, dynamically appending numerical suffixes (`_1`, `_2`, etc.) when filename collisions occur.
## fixes #10670 

## Changes Made
- **Bulk Certificate Generator** (`src/components/BulkCertificateGenerator.jsx`):
  - Added a `while (zip.file(safeFileName))` check prior to inserting files into the `JSZip` archive.
  - Automatically appends a counter suffix (`_1`, `_2`, etc.) if a filename collision is detected.
  - Ensures every attendee receives a dedicated PDF inside the final `.zip` archive without overwrites.

## Verification
- Verified build via `npm run build`.
- Tested with duplicate attendee records to confirm output files are generated cleanly (e.g., `Participant_Event_Certificate.pdf` and `Participant_Event_Certificate_1.pdf`).