### PR TITLE
Fix/graceful bulk certificate errors

### DIFF
--- a/src/components/BulkCertificateGenerator.jsx
+++ b/src/components/BulkCertificateGenerator.jsx
@@ -24,7 +24,15 @@ const BulkCertificateGenerator = ({ eventName, eventDate, eventType, organizerNa
         const attendee = attendees[i];
         const participantName = `${attendee.firstName || ""} ${attendee.lastName || attendee.name || ""}`.trim() || "Participant";
         const doc = generateCertificatePDF({ participantName, eventName, eventDate, eventType, organizerName, template });
-        const safeFileName = `${participantName.replace(/[^a-zA-Z0-9]/g, "_")}_${(eventName || "Event").replace(/[^a-zA-Z0-9]/g, "_")}_Certificate.pdf`;
+        const baseName = participantName.replace(/[^a-zA-Z0-9]/g, "_");
+        const safeEventName = (eventName || "Event").replace(/[^a-zA-Z0-9]/g, "_");
+        let safeFileName = `${baseName}_${safeEventName}_Certificate.pdf`;
+        
+        let counter = 1;
+        while (zip.file(safeFileName)) {
+          safeFileName = `${baseName}_${safeEventName}_Certificate_${counter}.pdf`;
+          counter++;
+        }
         
         const pdfBlob = doc.output("blob");
         zip.file(safeFileName, pdfBlob);

--- a/src/components/BulkCertificateGenerator.jsx
+++ b/src/components/BulkCertificateGenerator.jsx
@@ -20,26 +20,40 @@ const BulkCertificateGenerator = ({ eventName, eventDate, eventType, organizerNa
 
     try {
       const zip = new JSZip();
+      let successCount = 0;
+      let failureCount = 0;
+
       for (let i = 0; i < attendees.length; i++) {
-        const attendee = attendees[i];
-        const participantName = `${attendee.firstName || ""} ${attendee.lastName || attendee.name || ""}`.trim() || "Participant";
-        const doc = generateCertificatePDF({ participantName, eventName, eventDate, eventType, organizerName, template });
-        const baseName = participantName.replace(/[^a-zA-Z0-9]/g, "_");
-        const safeEventName = (eventName || "Event").replace(/[^a-zA-Z0-9]/g, "_");
-        let safeFileName = `${baseName}_${safeEventName}_Certificate.pdf`;
-        
-        let counter = 1;
-        while (zip.file(safeFileName)) {
-          safeFileName = `${baseName}_${safeEventName}_Certificate_${counter}.pdf`;
-          counter++;
+        try {
+          const attendee = attendees[i] || {};
+          const participantName = `${attendee.firstName || ""} ${attendee.lastName || attendee.name || ""}`.trim() || "Participant";
+          const doc = generateCertificatePDF({ participantName, eventName, eventDate, eventType, organizerName, template });
+          const baseName = participantName.replace(/[^a-zA-Z0-9]/g, "_");
+          const safeEventName = (eventName || "Event").replace(/[^a-zA-Z0-9]/g, "_");
+          let safeFileName = `${baseName}_${safeEventName}_Certificate.pdf`;
+          
+          let counter = 1;
+          while (zip.file(safeFileName)) {
+            safeFileName = `${baseName}_${safeEventName}_Certificate_${counter}.pdf`;
+            counter++;
+          }
+          
+          const pdfBlob = doc.output("blob");
+          zip.file(safeFileName, pdfBlob);
+          successCount++;
+        } catch (err) {
+          console.error(`Failed to generate certificate for attendee at index ${i}:`, err);
+          failureCount++;
         }
-        
-        const pdfBlob = doc.output("blob");
-        zip.file(safeFileName, pdfBlob);
 
         setProgress(i + 1);
         toast.update(toastId, { render: `Generating ${i + 1}/${attendees.length} certificates...` });
         await new Promise(r => setTimeout(r, 50));
+      }
+
+      if (successCount === 0) {
+        toast.update(toastId, { render: "❌ Failed to generate any certificates.", type: "error", isLoading: false, autoClose: 4000 });
+        return;
       }
 
       toast.update(toastId, { render: "Packaging certificates into ZIP..." });
@@ -58,7 +72,11 @@ const BulkCertificateGenerator = ({ eventName, eventDate, eventType, organizerNa
 
       setTimeout(() => URL.revokeObjectURL(url), 100);
 
-      toast.update(toastId, { render: `✅ ${attendees.length} certificates generated and downloaded!`, type: "success", isLoading: false, autoClose: 4000 });
+      const statusMsg = failureCount > 0
+        ? `⚠️ Generated ${successCount}/${attendees.length} certificates (${failureCount} failed)`
+        : `✅ ${attendees.length} certificates generated and downloaded!`;
+
+      toast.update(toastId, { render: statusMsg, type: failureCount > 0 ? "warning" : "success", isLoading: false, autoClose: 4000 });
     } catch (error) {
       console.error(error);
       toast.update(toastId, { render: "Bulk generation failed.", type: "error", isLoading: false, autoClose: 3000 });


### PR DESCRIPTION


## Description
In `src/components/BulkCertificateGenerator.jsx`, the bulk certificate generation loop previously ran inside a single outer `try/catch` block. If an error occurred while rendering a PDF for a single corrupt attendee object (e.g. invalid properties or rendering throw), the entire process aborted immediately and discarded all valid certificates generated up to that point.

This PR fixes the issue by wrapping each individual attendee's PDF generation logic in an inner `try/catch` block. Valid certificates continue to be generated and packaged into the `.zip` archive, while errors on single attendee items are caught gracefully and reported via toast alerts.
##fixes #10671 
## Changes Made
- **Bulk Certificate Generator** (`src/components/BulkCertificateGenerator.jsx`):
  - Isolated each attendee's certificate rendering inside an inner `try/catch` block inside `handleBulkGenerate`.
  - Tracked `successCount` and `failureCount` during the loop execution.
  - Ensured valid certificates are still compiled into the `.zip` archive even if partial failures occur.
  - Updated progress toast notifications to inform the organizer of partial successes (e.g., `⚠️ Generated 99/100 certificates (1 failed)`).

## Verification
- Verified build via `npm run build`.
- Tested with mixed arrays containing both valid and corrupt attendee objects to confirm valid certificates are packaged without process termination.