### PR TITLE
feat: Add Clear All button to NotificationDropdown

### DIFF
--- a/src/components/notifications/NotificationDropdown.jsx
+++ b/src/components/notifications/NotificationDropdown.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { Bell, CheckCheck, ExternalLink, Settings } from "lucide-react";
+import { Bell, CheckCheck, ExternalLink, Settings, Trash } from "lucide-react";
 import { useNotification } from "context/NotificationContext";
 import EmptyState from "../common/EmptyState";
 import NotificationItem from "./NotificationItem";
@@ -66,6 +66,17 @@ const NotificationDropdown = ({ isOpen, onClose }) => {
                 aria-label="Mark all notifications as read"
               >
                 <CheckCheck className="h-4 w-4" />
+              </button>
+            )}
+            {notifications.length > 0 && (
+              <button
+                type="button"
+                onClick={() => notifications.forEach(n => deleteNotification(n.id))}
+                className="rounded-lg p-2 text-gray-500 transition-colors hover:bg-white hover:text-red-600 dark:hover:bg-gray-700"
+                title="Clear all notifications"
+                aria-label="Clear all notifications"
+              >
+                <Trash className="h-4 w-4" />
               </button>
             )}
             <Link


### PR DESCRIPTION
### Description
**Feat: Implement "Clear All" button in notification dropdown**
Improves inbox management for high-traffic users by adding a "Clear All" (Trash) button directly into the `NotificationDropdown` header. Rather than just marking notifications as read, users can now instantly clear their entire visible notification list in a single click, invoking `deleteNotification` iteratively over their inbox. 
### Fixes Issue
Closes #10687
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas