### PR TITLE
feat: Add manual sync trigger for offline queue in dashboard

### DIFF
--- a/src/components/user/UserDashboard.jsx
+++ b/src/components/user/UserDashboard.jsx
@@ -1,4 +1,4 @@
-﻿import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { useReducedMotion } from 'hooks/useReducedMotion';
 import { getSmartDateLabel } from "utils/relativeTime";
 import {
@@ -396,6 +396,12 @@ export default function UserDashboard() {
             <div>
               <p className="ud-greeting">{greeting},</p>
               <h1 className="ud-username">{firstName} ≡ƒæï</h1>
+            <button
+              onClick={() => window.dispatchEvent(new CustomEvent('eventra-offline-queue-sync'))}
+              className="ml-4 inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-full shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
+            >
+              Sync Offline Queue
+            </button>
             </div>
           )}
 


### PR DESCRIPTION

### Description
**Feat: Add manual sync trigger for offline queue in dashboard**
Enhances the offline registration experience by adding a "Sync Offline Queue" button directly on the `UserDashboard` greeting header. This provides transparency to users on unstable connections, allowing them to manually flush the IndexedDB queue by dispatching the `eventra-offline-queue-sync` event, rather than relying strictly on the opaque background sync intervals.
### Fixes Issue
Closes #10685
### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas