### PR TITLE
fix: Prevent EventCard tooltip from being clipped by overflow

### DIFF
--- a/src/components/user/EventCard.jsx
+++ b/src/components/user/EventCard.jsx
@@ -120,7 +120,7 @@ const EventCard = memo(({
 
   return (
     <motion.div
-      className="group relative bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-3xl shadow-xl flex flex-col overflow-hidden"
+      className="group relative bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-3xl shadow-xl flex flex-col"
       custom={index}
       variants={fadeUpVariants}
       initial="hidden"
@@ -128,7 +128,7 @@ const EventCard = memo(({
       layout
     >
       {event?.image && (
-        <div className="relative h-48 overflow-hidden">
+        <div className="relative h-48 overflow-hidden rounded-t-3xl">
           <LazyImage
             src={event.image}
             alt={event.title}


### PR DESCRIPTION
### Description
**Fix: Prevent EventCard tooltip from being clipped by overflow**
This PR resolves a UI bug where the "View Event Details" tooltip on `EventCard` components was being clipped by the parent container's `overflow-hidden` property. By shifting the overflow constraints to the inner image wrapper, the tooltip now correctly floats above the card without being truncated, while preserving the image hover zoom effect.
### Fixes Issue
Closes #10677
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas