### PR TITLE
fix: Preserve auth tokens during ErrorBoundary cache reset

### DIFF
--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -302,7 +302,7 @@ class ErrorBoundary extends React.Component {
     saveAppStateSnapshot();
     try {
       const preserved = {};
-      ["theme", "cursor", "eventra_user_prefs"].forEach((key) => {
+      ["theme", "cursor", "eventra_user_prefs", "token", "user", "eventra:key-material", "eventra:key-salt"].forEach((key) => {
         const val = localStorage.getItem(key);
         if (val) preserved[key] = val;
       });


### PR DESCRIPTION
### Description
**Fix: Preserve auth tokens during ErrorBoundary cache reset**
This PR fixes a critical bug where triggering a "Reset Cache" action from the ErrorBoundary fallback UI would indiscriminately clear the entire `localStorage`, forcefully logging the user out. The `handleResetCache` method now explicitly preserves authentication keys (`token`, `user`, `eventra:key-material`, `eventra:key-salt`) alongside UI preferences to ensure session continuity after a crash recovery.
### Fixes Issue
Closes #10678
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas