### PR TITLE
feat: Support granular settings in notification preferences schema

### DIFF
--- a/src/utils/notificationPreferences.js
+++ b/src/utils/notificationPreferences.js
@@ -39,6 +39,9 @@ export const PUSH_SUBSCRIPTION_KEY = "eventra_push_subscription";
 export const DEFAULT_NOTIFICATION_PREFERENCES = {
   inApp: true,
   push: false,
+  marketing: true,
+  social: true,
+  updates: true,
   email: true,
   emailDigest: "daily",
   sound: "chime",


### PR DESCRIPTION

### Description
**Feat: Support granular settings in notification preferences schema**
Expands the default `eventra_user_prefs` schema within `notificationPreferences.js` to officially track granular category opt-ins (`marketing`, `social`, `updates`) rather than a simple global `push: true/false` binary. This paves the way for the settings dashboard to allow users to mute marketing notifications while still receiving critical event schedule updates.
### Fixes Issue
Closes #10688
### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas