### PR TITLE
fix: Prevent fetch execution when abort signal is already triggered

### DIFF
--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -27,6 +27,7 @@ export const fetchWithTimeout = async (
   if (options.signal) {
     if (options.signal.aborted) {
       controller.abort();
+      throw new DOMException("Aborted", "AbortError");
     } else {
       options.signal.addEventListener("abort", handleUserAbort);
     }


### PR DESCRIPTION
### Description
**Fix: Prevent fetch execution when abort signal is already triggered**
Resolves an edge case in `fetchWithTimeout.js` where passing an already `aborted` AbortSignal would abort the internal controller but still fall through to execute the actual `fetch()` call. This resulted in unnecessary network request initialization and unhandled `AbortError` stack traces deeper in the network layer. The function now correctly throws a `DOMException` immediately if the signal is preemptively aborted.
### Fixes Issue
Closes #10679
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas