### PR TITLE
fix: Increase notification poller cache size to prevent duplicate alerts

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -10,7 +10,7 @@ import { get as idbGet, del as idbDel } from "idb-keyval";
 import { showUndoToast } from "../utils/toast.js";
 
 const POLLING_INTERVAL_MS = 60_000;
-const MAX_SEEN_IDS = 500;
+const MAX_SEEN_IDS = 10000; // Increased to prevent eviction loops
 const NOTIFICATION_INBOX_PREFIX = "eventra_notification_inbox";
 const GUEST_INBOX_KEY = `${NOTIFICATION_INBOX_PREFIX}_guest`;
 


### PR DESCRIPTION
### Description
**Fix: Increase notification poller cache size to prevent duplicate alerts**
This PR addresses a bug in `useNotificationPoller.js` where the `MAX_SEEN_IDS` set size was capped too low. Highly active users receiving more than 500 notifications experienced a cache eviction loop, causing older unread notifications returned by the API to be continuously treated as "new", which incorrectly inflated the unread count and re-triggered UI alerts. The cache size limit has been increased to prevent early eviction.
### Fixes Issue
Closes #10681
### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas