### PR TITLE
fix(navbar): fix mobile menu scrolling and layout clipping near footer

### DIFF
--- a/src/components/navbar/MobileDrawer.jsx
+++ b/src/components/navbar/MobileDrawer.jsx
@@ -71,25 +71,6 @@ const MobileDrawer = ({
     };
   }, [closeMenu, isOpen]);
 
-  // Scroll lock
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const scrollY = window.scrollY;
-    document.body.style.overflow = "hidden";
-    document.body.style.position = "fixed";
-    document.body.style.top = `-${scrollY}px`;
-    document.body.style.width = "100%";
-
-    return () => {
-      document.body.style.overflow = "";
-      document.body.style.position = "";
-      document.body.style.top = "";
-      document.body.style.width = "";
-      window.scrollTo(0, scrollY);
-    };
-  }, [isOpen]);
-
   return (
     <div
       className={`fixed inset-0 z-50 ${
@@ -111,12 +92,12 @@ const MobileDrawer = ({
         role="dialog"
         aria-modal="true"
         aria-label="Mobile navigation"
-        className={`mobile-drawer-panel fixed right-0 top-0 flex max-h-dvh w-full max-w-sm flex-col bg-navbar shadow-premium-lg transition-transform duration-200 ease-out overflow-y-auto ${
+        className={`mobile-drawer-panel fixed right-0 top-0 inset-y-0 flex h-dvh w-full max-w-sm flex-col bg-navbar shadow-premium-lg transition-transform duration-200 ease-out ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >
         {/* Header */}
-        <div className="sticky top-0 z-10 flex min-h-[64px] items-center justify-between gap-3 border-b border-border bg-navbar px-4 py-3">
+        <div className="sticky top-0 z-10 flex min-h-[64px] shrink-0 items-center justify-between gap-3 border-b border-border bg-navbar px-4 py-3">
           <div className="flex min-w-0 items-center gap-2">
             <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-card-bg p-1 ring-1 ring-border">
               <img
@@ -140,7 +121,7 @@ const MobileDrawer = ({
           </button>
         </div>
 
-        <div className="flex flex-col px-4 py-5">
+        <div className="mobile-drawer-scroll flex flex-1 flex-col overflow-y-auto px-4 py-5 overscroll-contain">
           <div className="lg:hidden mb-2">
             <NavbarLinks vertical items={PRIMARY_NAV_ITEMS} onClick={closeMenu} />
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -535,7 +535,6 @@ html.lenis {
 /* Overrides the dynamic inline body overflow: auto rules */
 body[style] {
   overflow-x: hidden;
-  position: relative;
   max-width: 100%;
 }
 


### PR DESCRIPTION
Fixes #10715

## 📌 Description
This PR resolves an issue where the mobile navigation drawer (three-line hamburger menu) could not be scrolled up and down, and would get visually clipped at the bottom when opened near the page footer.

---

## 🛠️ Changes Made
- **Removed CSS `body[style]` Position Override**: Removed `position: relative` override on `body[style]` in `src/index.css` that broke JavaScript `document.body.style.position = "fixed"` scroll locking when scrolled down to the footer.
- **Full-Height Drawer Layout**: Refactored `MobileDrawer.jsx` panel container classes to `fixed inset-y-0 right-0 h-dvh flex flex-col` to ensure consistent full-viewport height coverage.
- **Scroll Container Structuring**: Wrapped navigation items inside `mobile-drawer-scroll flex-1 overflow-y-auto overscroll-contain` for smooth vertical scrolling across all screen heights.
- **Cleaned Up Duplicate Scroll Locks**: Removed redundant inline body fixed positioning in `MobileDrawer.jsx` to rely cleanly on `useBodyScrollLock`.

---

## 🧪 How to Test
1. Switch to a mobile viewport (`< 1024px`).
2. Scroll to the bottom of any page (e.g. `/hackathons` or `/about`) until the footer is visible.
3. Click the three-line hamburger icon in the navbar.
4. Verify that:
   - The menu panel extends completely from top to bottom.
   - All options scroll smoothly up and down.
   - No background page displacement occurs when toggling the drawer.

---

## 🌐 Checklist
- [x] Code follows project guidelines and contribution standards
- [x] Tested on desktop and mobile viewports (< 1024px)
- [x] Keyboard navigation and focus trap verified (`Escape` key closes drawer)
- [x] No breaking changes introduced