### PR TITLE
Fix memory leak in QRTicketModal focus trap cleanup

### DIFF
--- a/src/components/common/QRTicket/QRTicketModal.jsx
+++ b/src/components/common/QRTicket/QRTicketModal.jsx
@@ -97,16 +97,15 @@ export default function QRTicketModal({ isOpen, onClose, ticket }) {
       }
     };
 
-    modalRef.current.addEventListener("keydown", handleFocusTrap);
+    const modalElement = modalRef.current;
+    modalElement.addEventListener("keydown", handleFocusTrap);
     // Focus the modal automatically
-    modalRef.current.focus();
+    modalElement.focus();
 
     return () => {
-      if (modalRef.current) {
-        modalRef.current.removeEventListener("keydown", handleFocusTrap);
-      }
+      modalElement.removeEventListener("keydown", handleFocusTrap);
     };
-  }, [isOpen, handleFocusTrap]);
+  }, [isOpen]);
 
   const handleShare = async () => {
     const shareUrl = ticket?.qrValue || window.location.href;


### PR DESCRIPTION
This PR addresses a potential memory leak in `src/components/common/QRTicket/QRTicketModal.jsx` related to how the focus trap's `keydown` event listener was being cleaned up.

### Changes Made
- **Cached `modalRef.current`:** In React, refs can be nullified before the `useEffect` cleanup function runs during an unmount. To ensure the event listener is always removed properly, `modalRef.current` is now cached in a local variable (`modalElement`) during the setup phase.
- **Fixed Dependency Array:** Removed the undefined `handleFocusTrap` from the dependency array, as it is locally scoped inside the `useEffect`.

### Why this matters
Previously, if `modalRef.current` evaluated to `null` during unmount, the `removeEventListener` call would be skipped, leaving the `keydown` listener orphaned in memory which could lead to ghost events and gradual memory buildup over time.

closes #10728 