### PR TITLE
fix(calendar): prevent exporting corrupt empty bulk .ics files

### DIFF
--- a/src/utils/calendarExporter.js
+++ b/src/utils/calendarExporter.js
@@ -203,6 +203,7 @@ export const downloadBulkICSFile = (events, filename = "registered-events") => {
     "METHOD:PUBLISH"
   ];
 
+  let validEventsCount = 0;
   events.forEach((item) => {
     const eventObj = item.event ? item.event : item;
     const { title, description, date, endDate, location, id } = eventObj;
@@ -210,6 +211,7 @@ export const downloadBulkICSFile = (events, filename = "registered-events") => {
     const formattedStart = formatToICSDate(date);
     if (!formattedStart) return;
     
+    validEventsCount++;
     const formattedEnd = endDate ? formatToICSDate(endDate) : formatToICSDate(new Date(new Date(date).getTime() + 2 * 60 * 60 * 1000));
 
     icsLines.push(
@@ -231,6 +233,11 @@ export const downloadBulkICSFile = (events, filename = "registered-events") => {
       "END:VEVENT"
     );
   });
+
+  if (validEventsCount === 0) {
+    console.error("No valid event dates found for bulk ICS export.");
+    return;
+  }
 
   icsLines.push("END:VCALENDAR");
 


### PR DESCRIPTION


## Description
In `src/utils/calendarExporter.js`, `downloadBulkICSFile` iterates through a list of events to compile an iCalendar (.ics) file. If all events contain invalid start dates, `formattedStart` evaluates to `null`, and the loop skips each event. 

However, the exporter still continues to compile the file containing only the `BEGIN:VCALENDAR` and `END:VCALENDAR` tags, initiating the download of an empty, corrupt calendar file. These empty envelopes trigger errors or crashes when imported into calendar clients (e.g. Google Calendar, Apple Calendar).

This PR fixes the issue by tracking the count of valid events added to the `.ics` lines, logging an error, and aborting the export if no valid events are found.
## Fixes #10733 

## Changes Made
- **Calendar Exporter** (`src/utils/calendarExporter.js`):
  - Track `validEventsCount` inside `downloadBulkICSFile`.
  - Check if `validEventsCount === 0` after looping through the events list.
  - Abort the export process and log an error if no valid event entries exist, preventing empty `.ics` downloads.

## Verification
- Verified build via `npm run build`.
- Confirmed that triggering a bulk calendar export for events with invalid start dates aborts the download cleanly and prints a message to the console.