### PR TITLE
fix(ticket): prevent canvas tainting during export by disabling allow…

### DIFF
--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -106,7 +106,6 @@ const EventTicket = ({ event, user, onClose }) => {
       const canvas = await html2canvas(ticketRef.current, {
         scale: 3,
         useCORS: true,
-        allowTaint: true,
         backgroundColor: null,
         logging: false,
         onclone: (clonedDoc) => {


### PR DESCRIPTION
# fix(ticket): prevent canvas tainting during export by disabling allowTaint

## Description
In `src/components/user/EventTicket.js`, the `html2canvas` instance was initialized with both `useCORS: true` and `allowTaint: true`. Enabling `allowTaint: true` taints the canvas if any cross-origin resource fails to send the appropriate CORS headers, which blocks the subsequent call to `canvas.toDataURL()` with a security exception (`SecurityError: The operation is insecure.`).

This PR fixes the issue by removing `allowTaint: true` from the configuration. This ensures that cross-origin elements are strictly verified with CORS policies (handled via `useCORS: true`), preventing canvas tainting and security errors during PNG/PDF exports.
## Fixes #10734 
## Changes Made
- **Event Ticket Component** (`src/components/user/EventTicket.js`):
  - Removed the `allowTaint: true` configuration property from `html2canvas` within the `handleDownload` function.

## Verification
- Verified build via `npm run build`.
- Tested the export functionality with cross-origin assets to confirm that downloads resolve successfully without raising security exceptions.