### PR TITLE
fix(ticket): wrap asynchronous canvas.toBlob in a Promise to capture …

### DIFF
--- a/src/components/common/QRTicket/useTicketDownload.js
+++ b/src/components/common/QRTicket/useTicketDownload.js
@@ -48,19 +48,28 @@ export function useTicketDownload(ticketRef, ticketId = "ticket") {
     try {
       const canvas = await captureCanvas();
       
-      // Use toBlob instead of toDataURL to prevent massive base64 memory allocation
-      canvas.toBlob((blob) => {
-        if (!blob) throw new Error("Canvas rendering failed");
-        
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement("a");
-        link.download = `eventra-ticket-${ticketId}.png`;
-        link.href = url;
-        link.click();
-        
-        // Deep Fix 3: Defer revocation to prevent WebKit/Safari silent download failures
-        setTimeout(() => URL.revokeObjectURL(url), 150);
-      }, "image/png");
+      // Use toBlob inside a Promise to properly handle asynchronous errors and flow
+      await new Promise((resolve, reject) => {
+        canvas.toBlob((blob) => {
+          try {
+            if (!blob) throw new Error("Canvas rendering failed");
+            
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.download = `eventra-ticket-${ticketId}.png`;
+            link.href = url;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            
+            // Deep Fix 3: Defer revocation to prevent WebKit/Safari silent download failures
+            setTimeout(() => URL.revokeObjectURL(url), 150);
+            resolve();
+          } catch (err) {
+            reject(err);
+          }
+        }, "image/png");
+      });
     } catch (err) {
       console.error("[QRTicket] PNG download failed:", err);
       toast.error("Failed to generate PNG. Please try again.");


### PR DESCRIPTION

## Description
In `src/components/common/QRTicket/useTicketDownload.js`, the `downloadPNG` hook handles exporting the ticket image. It invokes the asynchronous `canvas.toBlob(...)` API. Since the outer `try/catch` and `finally` blocks complete synchronously before the callback executes, any asynchronous failures (such as a null blob) escape the error boundary. This leaves the loader spinner stuck in a downloading state and generates an uncaught exception in the browser console.

This PR wraps the `canvas.toBlob(...)` callback in a Promise, allowing the hook to await its completion. This ensures that any errors encountered during blob generation are correctly caught and handled, displaying a toast notification to the user and resetting the loading indicators cleanly.
## Fixes #10731 
## Changes Made
- **Ticket Download Hook** (`src/components/common/QRTicket/useTicketDownload.js`):
  - Wrapped `canvas.toBlob` in a `new Promise((resolve, reject) => { ... })` and awaited its resolution.
  - Implemented inner `try/catch` inside the callback to reject the promise on error.
  - Appended the temporary download link to `document.body` for Firefox compatibility.

## Verification
- Verified build via `npm run build`.
- Simulated canvas/blob generation failures to confirm that error toast displays and loader resets cleanly.