### PR TITLE
fix: throw QuotaExceededError when saving offline waitlist (#10745)

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -143,6 +143,9 @@ export const saveGlobalWaitlist = (records) => {
   try {
     localStorage.setItem(GLOBAL_WAITLIST_KEY, JSON.stringify(records));
   } catch (error) {
+    if (error.name === 'QuotaExceededError') {
+      throw error;
+    }
     logger.error("[WaitlistUtils] Failed to save global waitlist:", error);
   }
 };


### PR DESCRIPTION

Fixes #10745. 
The `saveGlobalWaitlist` function now catches and re-throws `QuotaExceededError` instead of swallowing it. This ensures the UI can properly notify the user when their local storage is full, rather than displaying a false positive "Success" message for offline waitlist joins.