### PR TITLE
fix: add jitter when reclaiming leadership on corrupt heartbeat (#10747)

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -156,7 +156,10 @@ class SseMultiplexer {
             // Active leader exists
             return;
           }
-        } catch {}
+        } catch {
+          setTimeout(() => this.claimLocalStorageLeadership(), Math.random() * 500);
+          return;
+        }
       }
 
       // Try to claim leadership


### PR DESCRIPTION
Fixes #10747. Introduces a randomized jitter delay when a malformed heartbeat is detected in `sseMultiplexer.js`. This prevents multiple follower tabs from simultaneously attempting to claim leadership and causing a fast-toggling broadcast loop.