### PR TITLE
fix: clear active poll to create a new one (#10720)

### DIFF
--- a/src/components/admin/LivePollController.jsx
+++ b/src/components/admin/LivePollController.jsx
@@ -84,7 +84,7 @@ function PollStatusButtons({ activePoll, handleStatusChange }) {
         </button>
       )}
       <button
-        onClick={() => handleStatusChange("closed")}
+        onClick={() => handleStatusChange("cleared")}
         className="ml-auto flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-semibold text-slate-950 bg-linear-to-r from-cyan-400 to-primary hover:brightness-110 active:scale-95 transition-all duration-300 shadow-glow-sm cursor-pointer"
       >
         <RefreshCw className="h-4 w-4 text-slate-950" /><span>Create New Poll</span>


### PR DESCRIPTION
## Description
This PR addresses an issue where an organizer gets permanently stuck on the poll results screen after closing an active poll. Previously, clicking "Create New Poll" was improperly triggering the "closed" handler instead of clearing the poll state, preventing the `PollCreateForm` from rendering.

## Changes Made
- Changed the `onClick` handler of the "Create New Poll" button in `src/components/admin/LivePollController.jsx` to dispatch `"cleared"` instead of `"closed"`.

## Related Issue
Fixes #10720

## Type of Change
- [x] Bug fix