### PR TITLE
fix: extract unmemoized default options causing infinite loop in useFormSubmit

### DIFF
--- a/src/hooks/useFormSubmit.js
+++ b/src/hooks/useFormSubmit.js
@@ -37,7 +37,9 @@ const isOfflineSubmissionError = (error) =>
  * );
  */
 
-export function useFormSubmit(submitFn, offlineOptions = {}) {
+const defaultOfflineOptions = {};
+
+export function useFormSubmit(submitFn, offlineOptions = defaultOfflineOptions) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);


### PR DESCRIPTION
 (#10722)## Description
This PR resolves an infinite render loop bug caused by `useFormSubmit`. The `offlineOptions` parameter defaulted to an inline empty object (`{}`), destroying reference equality on every render and forcing `handleSubmit` to be recreated infinitely if passed as a dependency to a `useEffect`.

## Changes Made
- Extracted the default offline options out of the function signature into a stable module-level constant (`const defaultOfflineOptions = {}`) in `src/hooks/useFormSubmit.js`.

## Related Issue
Fixes #10722

## Type of Change
- [x] Bug fix (Performance)