### PR TITLE
fix: add missing endpoint for offline event registrations (#10717)

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -335,7 +335,7 @@ const useEventRegistration = (eventIdParam) => {
         const success = await pushToQueue(
           {
             actionType: "REGISTER_EVENT",
-            // Fixed: Removed undefined 'endpoint' variable which would cause a crash
+            endpoint: `/api/events/${eventId}/register`,
             eventId: parseInt(eventId),
             payload: queuePayload,
           },


### PR DESCRIPTION
## Description
This PR fixes a critical bug where offline event registrations were silently dropped when the application reconnected to the internet. The `endpoint` property was unintentionally missing from the payload sent to the offline queue, causing the sync request to fail because it lacked a destination URL.

## Changes Made
- Restored the `endpoint: \`/api/events/\${eventId}/register\`` property to the `REGISTER_EVENT` payload inside `src/hooks/useEventRegistration.js`.

## Related Issue
Fixes #10717

## Type of Change
- [x] Bug fix