### PR TITLE
fix: add radix 10 to parseInt in SurveyAnalytics rating calculation

### DIFF
--- a/src/components/admin/SurveyAnalytics.jsx
+++ b/src/components/admin/SurveyAnalytics.jsx
@@ -60,7 +60,7 @@ const SurveyAnalytics = ({ questions = [], surveyTitle = "Survey" }) => {
         let total = 0;
         let sum = 0;
         Object.entries(distribution).forEach(([score, count]) => {
-          sum += parseInt(score) * count;
+          sum += parseInt(score, 10) * count;
           total += count;
         });
         ratings[q.id] = {


### PR DESCRIPTION
Adds the radix 10 parameter to parseInt(score) in SurveyAnalytics.jsx to avoid potential octal interpretation and follow best practices.