### PR TITLE
fix: add error logging to CSP violation fetch catch block

### DIFF
--- a/src/components/admin/CSPViolationDashboard.jsx
+++ b/src/components/admin/CSPViolationDashboard.jsx
@@ -9,7 +9,7 @@ const CSPViolationDashboard = () => {
   useEffect(() => {
     fetch('/api/admin/csp-reports', {
       headers: { Authorization: `Bearer ${token}` }
-    }).then(res => res.json()).then(setViolations).catch(() => {});
+    }).then(res => res.json()).then(setViolations).catch(err => console.error("[CSP] Failed to fetch violations:", err));
   }, [token]);
 
   return (


### PR DESCRIPTION
Replaces empty catch in CSP violation fetch with console.error logging to aid debugging.