### PR TITLE
fix: add warning log to empty periodicSync catch block

### DIFF
--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -95,7 +95,7 @@ function registerValidSW(swUrl, config) {
       if ('periodicSync' in registration && registration.periodicSync) {
         registration.periodicSync.register('eventra-data-sync', {
           minInterval: 24 * 60 * 60 * 1000,
-        }).catch(() => {});
+        }).catch((err) => logger.warn("[SW] PeriodicSync registration failed:", err));
       }
 
       registration.onupdatefound = () => {


### PR DESCRIPTION
Adds a warning log to the empty catch block in periodicSync registration so failures are visible during debugging.