### PR TITLE
fix: add warning log to empty catch block in notification persist

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -36,7 +36,7 @@ const normalize = (n = {}) => ({
 
 const persist = (items, storageKey) => {
   if (typeof window === "undefined" || !window.localStorage || !storageKey) return;
-  try { window.localStorage.setItem(storageKey, JSON.stringify(items)); } catch {}
+  try { window.localStorage.setItem(storageKey, JSON.stringify(items)); } catch (e) { console.warn("[useNotificationPoller] Failed to persist notifications", e); }
 };
 
 const loadPersisted = (storageKey) => {
@@ -96,7 +96,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
       });
       window.localStorage.setItem(userKey, JSON.stringify(merged));
       window.localStorage.removeItem(GUEST_INBOX_KEY);
-    } catch {}
+    } catch (e) { console.warn("[useNotificationPoller] Failed to persist notifications", e); }
   }, [user?.id]);
 
   const addSeenId = (id) => {


### PR DESCRIPTION
Adds a warning log to the empty catch block in notification persist so localStorage write failures are visible during debugging.