### PR TITLE
fix: add warning log to empty catch in playNotificationSound

### DIFF
--- a/src/utils/soundHelper.js
+++ b/src/utils/soundHelper.js
@@ -14,7 +14,7 @@ export function playNotificationSound() {
     
     osc.start();
     osc.stop(audioCtx.currentTime + 0.15);
-  } catch {
-    // Audio Context blocked or not supported
+  } catch (e) {
+    console.warn('[soundHelper] AudioContext not available', e);
   }
 }


### PR DESCRIPTION
Adds a warning log to the empty catch block in playNotificationSound so AudioContext failures are visible during debugging.