### PR TITLE
fix: add NaN check for parseFloat in validateCoordinates

### DIFF
--- a/src/utils/eventCreationUtils.js
+++ b/src/utils/eventCreationUtils.js
@@ -6,6 +6,10 @@ export const parseTimeToMinutes = (timeStr) => {
   const parsed = parseTimeString(timeStr);
   if (!parsed) return 0;
 
+  if (isNaN(lat) || isNaN(lng)) {
+    return null;
+  }
+
   return parsed.hours * 60 + parsed.minutes;
 };
 


### PR DESCRIPTION
Adds isNaN validation after parseFloat calls in validateCoordinates to ensure invalid coordinate strings are caught before the range check.