### PR TITLE
fix: add warning log to empty catch in legacy IndexedDB migration

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -358,8 +358,8 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
           }
           await idbDel("eventra_notifications");
         }
-      } catch {
-        // fail silently in environments without IndexedDB support
+      } catch (e) {
+        console.warn('[useNotificationPoller] Legacy IndexedDB migration failed', e);
       }
     };
 


### PR DESCRIPTION
Adds a warning log to the empty catch block in the legacy IndexedDB migration so failures are visible during debugging.