### PR TITLE
fix: add warning log to empty catch in getRegistration

### DIFF
--- a/src/hooks/usePushSubscription.js
+++ b/src/hooks/usePushSubscription.js
@@ -24,12 +24,12 @@ const getRegistration = async () => {
   if (existing) return existing;
   try {
     return await navigator.serviceWorker.register("/service-worker.js");
-  } catch {
-    return null;
-  }
-};
-
-export function usePushSubscription(updatePreferences) {
+    try {
+      return await navigator.serviceWorker.register('/service-worker.js');
+    } catch (err) {
+      logger.warn('[usePushSubscription] SW registration failed:', err);
+      return null;
+    }
   const { token } = useAuth();
   const [pushStatus, setPushStatus] = useState({
     supported: false,


### PR DESCRIPTION
Adds a warning log to the empty catch block in service worker getRegistration so failures are visible during debugging.