### PR TITLE
fix: uncomment disabled error logs in ContributorsCarousel

### DIFF
--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -232,7 +232,7 @@ const Contributors = () => {
       if (!backgroundRefresh) setContributors([]);
 
       if (error.name === "AbortError") {
-        //console.error("Contributor request timed out");
+        console.error("Contributor request timed out");
       }
     } finally {
       if (!backgroundRefresh) setLoading(false);


### PR DESCRIPTION
Re-enables 2 commented-out console.error calls in ContributorsCarousel.js so fetch failures are visible during debugging.