### PR TITLE
fix: add error log to empty catch in EventsPage filter persist

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -252,7 +252,8 @@ const EventsPage = () => {
           advancedFilters: serializeAdvancedFilters(listing.advancedFilters),
         })
       );
-    } catch {
+    } catch (err) {
+      console.error("Failed to persist filter params:", err);
     }
   }, [
     listing.currentPage,


### PR DESCRIPTION
Adds error logging when persisting filter params fails in EventsPage.