### PR TITLE
fix: add error handling to empty catch in Testimonials share

### DIFF
--- a/src/Pages/Home/components/Testimonials.js
+++ b/src/Pages/Home/components/Testimonials.js
@@ -205,7 +205,11 @@ const ModernTestimonialTrain = () => {
           text: testimonial.quote,
           url: testimonial.shareUrl,
         });
-      } catch {}
+      } catch (err) {
+        if (err.name !== 'AbortError') {
+          console.error('Failed to share testimonial:', err);
+        }
+      }
     } else {
       // Fallback: copy to clipboard
       navigator.clipboard.writeText(`${testimonial.quote} — ${testimonial.author}, ${testimonial.company}`);


### PR DESCRIPTION
Adds proper error handling to the empty catch block in Testimonials share feature, filtering AbortError (user dismissal) from real errors.