### PR TITLE
fix: add warning log to empty catch blocks in useNotifications

### DIFF
--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -53,7 +53,9 @@ export function useNotifications() {
         const existing = raw ? JSON.parse(raw) : [];
         const updated = [...queue, ...existing];
         window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
-      } catch {}
+      } catch (err) {
+        console.warn('Notification storage operation failed:', err);
+      }
       queue = [];
       flushTimeout = null;
       window.dispatchEvent(new CustomEvent("eventra-notifications-updated"));


### PR DESCRIPTION
Adds warning logging to empty catch blocks in useNotifications for storage operation failures.