### PR TITLE
fix: use strict null check in safeStorage

### DIFF
--- a/src/utils/safeStorage.js
+++ b/src/utils/safeStorage.js
@@ -79,7 +79,7 @@ const createSafeStorage = (getStorage) => {
 
     getJson(key, fallback = null) {
       const raw = this.getItem(key);
-      if (raw == null) return fallback;
+      if (raw === null || raw === undefined) return fallback;
 
       try {
         return safeJsonParse(raw, {});


### PR DESCRIPTION
Replaces loose equality == null with strict === null || === undefined to avoid unintended coercion.