### PR TITLE
fix: add warning log to silent catch in WaitlistButton

### DIFF
--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -18,8 +18,8 @@ const useWaitlist = ({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated,
       .then(data => {
         if (!cancelled) setWaitlistCount(data.count);
       })
-      .catch(() => {
-        // Silently ignore — default count of 0 is already set
+      .catch((err) => {
+        console.warn('Failed to fetch waitlist data:', err);
       });
 
     if (isAuthenticated && token) {


### PR DESCRIPTION
Adds warning logging when fetching waitlist data fails instead of silently swallowing the error.