### PR TITLE
fix: use logger.warn instead of console.warn in useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -51,7 +51,7 @@ const useLocalStorage = (key, initialValue) => {
     const item = window.localStorage.getItem(key);
     return safeJsonParse(item, initialValue);
   } catch (error) {
-    console.warn(`useLocalStorage: error reading key "${key}":`, error);
+    logger.warn(`useLocalStorage: error reading key "${key}":`, error);
     return initialValue;
   }
   });


### PR DESCRIPTION
Replaces console.warn with logger.warn in useLocalStorage to use project's logging abstraction.