### PR TITLE
fix: use logger.warn instead of console.warn in useTokenExpiry

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -26,7 +26,7 @@ export function useTokenExpiry({ token, user, onExpired }) {
 
     let hadPreviousSession = false;
     try { hadPreviousSession = !!syncSecureStorage.getItem("user"); } catch {}
-    console.warn("[useTokenExpiry] Session expired. Clearing state.");
+    logger.warn("[useTokenExpiry] Session expired. Clearing state.");
     onExpired();
     if (!hadPreviousSession) return;
     if (expiryToastShownRef.current) return;


### PR DESCRIPTION
Replaces console.warn with logger.warn in useTokenExpiry to use project's logging abstraction.