### PR TITLE
fix: add warning log to empty catch in activityTracker.js

### DIFF
--- a/src/utils/activityTracker.js
+++ b/src/utils/activityTracker.js
@@ -18,8 +18,9 @@ const isStorageAvailable = () => {
       localStorage.removeItem(testKey);
     }
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+      console.warn("[activityTracker] Failed to track activity:", err);
+    }
   }
 };
 


### PR DESCRIPTION
Adds warning logging when activity tracking fails.