### PR TITLE
fix: add warning log to empty catch in useNotificationDelivery.js

### DIFF
--- a/src/hooks/useNotificationDelivery.js
+++ b/src/hooks/useNotificationDelivery.js
@@ -37,8 +37,8 @@ export function useNotificationDelivery(preferences) {
           new Notification(title, options);
         }
         return true;
-      } catch {
-        return false;
+      } catch (err) {
+        console.warn("[useNotificationDelivery] Delivery check failed:", err);
       }
     },
     [preferences],


### PR DESCRIPTION
Adds warning logging when delivery check fails.