### PR TITLE
fix: add warning log to empty catch in useWaitlist.js

### DIFF
--- a/src/hooks/useWaitlist.js
+++ b/src/hooks/useWaitlist.js
@@ -33,9 +33,9 @@ function readPersistedWaitlist(storageKey) {
   try {
     const raw = safeLocalStorage.getItem(storageKey);
     return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
+  } catch (err) {
+      console.warn("[useWaitlist] Waitlist operation failed:", err);
+    }
 }
 
 let persistTimeout = null;
@@ -59,8 +59,8 @@ function persistWaitlist(map, storageKey) {
           mapToPersist[key] = rest;
         }
         safeLocalStorage.setItem(storageKey, JSON.stringify(mapToPersist));
-      } catch {
-        // ignore quota errors
+      } catch (err) {
+        console.warn("[useWaitlist] Waitlist operation failed:", err);
       }
     };
     if (typeof window.requestIdleCallback === "function") {


### PR DESCRIPTION
Adds warning logging when waitlist operations fail.