### PR TITLE
fix: add warning log to empty catch in useLocalStorage.js

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -132,7 +132,9 @@ export const isLocalStorageAvailable = () => {
     window.localStorage.setItem(testKey, testKey);
     window.localStorage.removeItem(testKey);
     return true;
-  } catch {
+  } catch (err) {
+      console.warn("[useLocalStorage] Storage operation failed:", err);
+    }
     return false;
   }
 };


### PR DESCRIPTION
Adds warning logging when storage operation fails.