### PR TITLE
fix: add warning log to empty catch in bookmarkUtils.js

### DIFF
--- a/src/utils/bookmarkUtils.js
+++ b/src/utils/bookmarkUtils.js
@@ -25,9 +25,9 @@ const readBookmarks = () => {
     const rawBookmarks = window.localStorage.getItem(BOOKMARKS_STORAGE_KEY);
     const parsed = safeJsonParse(rawBookmarks, []);
     return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
+  } catch (err) {
+      console.warn("[bookmarkUtils] Bookmark operation failed:", err);
+    }
 };
 
 const writeBookmarks = (bookmarks) => {
@@ -36,8 +36,9 @@ const writeBookmarks = (bookmarks) => {
   try {
     window.localStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(bookmarks));
     window.dispatchEvent(new CustomEvent(BOOKMARKS_CHANGED_EVENT, { detail: bookmarks }));
-  } catch {
-  }
+  } catch (err) {
+      console.warn("[bookmarkUtils] Bookmark operation failed:", err);
+    }
 };
 
 export const getBookmarkedEvents = () => readBookmarks();


### PR DESCRIPTION
Adds warning logging when bookmark operations fail.