### PR TITLE
Add Docker image publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        if: github.event_name == 'push'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem
Although Eventra is containerized and validated in CI, there is no automated process to publish the built Docker image to a registry. This means developers or CI/CD pipelines currently have to manually build and push images before they can be deployed or consumed by other environments.

## Solution
This PR extends the GitHub Actions CI/CD pipeline to automatically build and publish the Docker image to the GitHub Container Registry (GHCR) upon merges to the `master` branch.

## Changes Introduced
- Added a new GitHub Actions workflow at `.github/workflows/docker-publish.yml`.
- Automates the build and push process for `ghcr.io`.
- Uses least-privilege permissions and GitHub's built-in `GITHUB_TOKEN` for secure authentication (no long-lived PATs needed).
- Tags published images consistently with the commit SHA for traceability, and updates the `latest` tag **only** on pushes to `master`.
- Ensures pull requests safely *build* the image to validate configuration but do not *publish* untrusted code.

## Benefits
- **Automated Delivery:** Removes the need for manual image building and publishing.
- **Improved Traceability:** Images are uniquely versioned by their source commit SHA, making it easy to identify the exact application state.
- **Enhanced CI/CD Flow:** Images are immediately available in GHCR for staging or production deployments right after merging a pull request.

## Issue #10894 