### PR TITLE
fix: prevent stale state in handleSubmit closure when network toggles

### DIFF
--- a/src/hooks/useFormSubmit.js
+++ b/src/hooks/useFormSubmit.js
@@ -23,11 +23,11 @@ const isOfflineSubmissionError = (error) =>
  *
  * @param {Function} submitFn - Async function that performs the submission
  * @param {Object} [offlineOptions={}] - Optional offline queuing configuration
- * @param {boolean} [offlineOptions.queueOffline] - Enable offline queuing on network failure
- * @param {string} [offlineOptions.actionType] - Action type label for the queue item
- * @param {string} [offlineOptions.endpoint] - API endpoint for the queue item
- * @param {string} [offlineOptions.userId] - User ID to associate with the queue item
- * @param {Function} [offlineOptions.createQueueItem] - Custom queue item factory function
+ * @param {boolean} [offlineOptionsRef.current.queueOffline] - Enable offline queuing on network failure
+ * @param {string} [offlineOptionsRef.current.actionType] - Action type label for the queue item
+ * @param {string} [offlineOptionsRef.current.endpoint] - API endpoint for the queue item
+ * @param {string} [offlineOptionsRef.current.userId] - User ID to associate with the queue item
+ * @param {Function} [offlineOptionsRef.current.createQueueItem] - Custom queue item factory function
  * @returns {{ handleSubmit: Function, isSubmitting: boolean, error: string|null, success: boolean }}
  *
  * @example
@@ -43,7 +43,7 @@ export function useFormSubmit(submitFn, offlineOptions = defaultOfflineOptions) 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
-  const isInFlight = useRef(false);
+  const isInFlight = useRef(false);\n  const submitFnRef = useRef(submitFn);\n  const offlineOptionsRef = useRef(offlineOptions);\n\n  useEffect(() => {\n    submitFnRef.current = submitFn;\n    offlineOptionsRef.current = offlineOptions;\n  }, [submitFn, offlineOptions]);
   const isMounted = useRef(true);
 
   useEffect(() => {
@@ -63,22 +63,22 @@ export function useFormSubmit(submitFn, offlineOptions = defaultOfflineOptions) 
     setSuccess(false);
 
     try {
-      await submitFn(data);
+      await submitFnRef.current(data);
       if (isMounted.current) {
         setSuccess(true);
       }
     } catch (err) {
-      if (offlineOptions.queueOffline && isOfflineSubmissionError(err)) {
+      if (offlineOptionsRef.current.queueOffline && isOfflineSubmissionError(err)) {
         const queueItem =
-          typeof offlineOptions.createQueueItem === "function"
-            ? offlineOptions.createQueueItem(data, err)
+          typeof offlineOptionsRef.current.createQueueItem === "function"
+            ? offlineOptionsRef.current.createQueueItem(data, err)
             : {
-              actionType: offlineOptions.actionType || "FORM_SUBMISSION",
-              endpoint: offlineOptions.endpoint,
+              actionType: offlineOptionsRef.current.actionType || "FORM_SUBMISSION",
+              endpoint: offlineOptionsRef.current.endpoint,
               payload: data,
             };
 
-        const queued = await pushToQueue(queueItem, offlineOptions.userId || null);
+        const queued = await pushToQueue(queueItem, offlineOptionsRef.current.userId || null);
         if (queued) {
           if (isMounted.current) {
             setSuccess(true);


### PR DESCRIPTION
**Describe the bug or feature:**
A clear and concise description of what the bug is.
The `useFormSubmit` hook was capturing stale state inside the `handleSubmit` closure when the network toggled mid-typing or offline options changed, leading to incorrect submissions.
**To Reproduce / Implementation Details:**
1. Added `submitFnRef` and `offlineOptionsRef` in `src/hooks/useFormSubmit.js`.
2. Wrapped the latest dependencies inside a `useEffect`.
3. Updated the `handleSubmit` callback to strictly invoke `submitFnRef.current` and read from `offlineOptionsRef.current`.
**Expected behavior:**
Form submissions always execute the latest bound submit function with the freshest offline options, avoiding stale closures.

Fixes #10866