### PR TITLE
fix: resolve race conditions in useDebouncedSearch by adding sequence tracking

### DIFF
--- a/src/hooks/useDebouncedSearch.js
+++ b/src/hooks/useDebouncedSearch.js
@@ -17,7 +17,7 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
   const [searchTerm, setSearchTerm] = useState(initialValue);
   const [debouncedTerm, setDebouncedTerm] = useState(prepareSafeSearchQuery(initialValue));
   const [isDebouncing, setIsDebouncing] = useState(false);
-  const timerRef = useRef(null);
+  const timerRef = useRef(null);\n  const sequenceRef = useRef(0);
 
   useEffect(() => {
     const safeSearchTerm = prepareSafeSearchQuery(searchTerm);
@@ -34,7 +34,7 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
     }
 
     timerRef.current = setTimeout(() => {
-      setDebouncedTerm(safeSearchTerm);
+      sequenceRef.current += 1;\n      setDebouncedTerm(safeSearchTerm);
       setIsDebouncing(false);
     }, delay);
 
@@ -59,7 +59,7 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
     debouncedTerm,
     setSearchTerm,
     isDebouncing,
-    clear,
+    clear,\n    sequence: sequenceRef.current,
   };
 }
 


### PR DESCRIPTION
**Describe the bug or feature:**
A clear and concise description of what the bug is.
The `useDebouncedSearch` hook could suffer from race conditions when debounced queries resolved out of order due to asynchronous search implementations that didn't know which query was the latest.
**To Reproduce / Implementation Details:**
1. Modified `src/hooks/useDebouncedSearch.js`.
2. Added a `sequenceRef` counter that increments on every debounced term update.
3. Exported the `sequence` identifier alongside the hook's return value, allowing callers to discard outdated API responses.
**Expected behavior:**
Search components can now bind responses to the `sequence` ID, ensuring only the most recent debounced search results are displayed.
Fixes #10863