### PR TITLE
Add automated post-deployment health checks

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -1,0 +1,41 @@
+name: Post-Deployment Health Check
+
+on:
+  deployment_status:
+
+jobs:
+  health-check:
+    if: github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify Application is Reachable
+        run: |
+          TARGET_URL="${{ github.event.deployment_status.target_url }}"
+          
+          if [ -z "$TARGET_URL" ]; then
+            echo "No target URL provided by the deployment event. Cannot perform health check."
+            exit 1
+          fi
+          
+          echo "Target URL: $TARGET_URL"
+          echo "Starting health check with retries..."
+          
+          MAX_RETRIES=5
+          RETRY_DELAY=10
+          
+          for ((i=1; i<=MAX_RETRIES; i++)); do
+            echo "Attempt $i/$MAX_RETRIES..."
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$TARGET_URL" || echo "000")
+            
+            if [ "$HTTP_STATUS" -eq 200 ]; then
+              echo "✅ Health check passed! Received HTTP 200 OK."
+              exit 0
+            fi
+            
+            echo "⚠️ Received HTTP $HTTP_STATUS. Retrying in $RETRY_DELAY seconds..."
+            sleep $RETRY_DELAY
+          done
+          
+          echo "❌ Health check failed. Application did not return HTTP 200 after $MAX_RETRIES attempts."
+          exit 1


### PR DESCRIPTION
## Problem
Currently, our CI pipeline ensures that code is linted, tested, and containerized before merging, and our deployment infrastructure puts that code on the servers. However, there is a missing link: verifying that the application is *actually* operational and responding properly in the live environment. A deployment might succeed structurally while the application remains unreachable due to runtime crashes or misconfigurations.

## Solution
This PR introduces a crucial Continuous Deployment practice: automated post-deployment health checks. 

## Changes Introduced
- Added a new GitHub Actions workflow at `.github/workflows/health-check.yml`.
- The workflow leverages GitHub's `deployment_status` event to automatically trigger exclusively when a production deployment reports as `success`.
- Extracts the deployed application's URL (`target_url`) securely from the deployment context.
- Performs automated HTTP requests (`curl`) to the deployed application to verify it's reachable and responding with HTTP 200 OK.
- Implements a resilient retry mechanism (5 attempts, 10-second delays) to account for DNS propagation and application startup delays before marking a deployment as failed.

## Benefits
- **Zero-Touch Verification:** Developers no longer need to manually check if the production URL is alive after a deployment finishes.
- **Rapid Incident Response:** Configuration or runtime issues that bring down the site immediately trigger a workflow failure, ensuring maintainers are alerted immediately.
- **Higher Confidence:** We now have a true end-to-end pipeline that not only deploys code but verifies the operational health of the application.

## Issue #10913 