### PR TITLE
Generate and publish SBOM in CI

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,40 @@
+name: Generate SBOM
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  release:
+    types: [published]
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json

--- a/README.md
+++ b/README.md
@@ -599,6 +599,10 @@ Before deploying Eventra, review the deployment checklist:
 
 - docs/SECURE_DEPLOYMENT_CHECKLIST.md
 
+### Software Bill of Materials (SBOM)
+
+Eventra automatically generates a Software Bill of Materials (SBOM) during the CI process for every push to `master` and release. The SBOM is provided in SPDX format and can be found as an attached artifact named `sbom` in the GitHub Actions run summary. This improves our software supply chain transparency and helps identify affected components when new vulnerabilities are disclosed.
+
 ### Maintainers
 
 <table>


### PR DESCRIPTION
## Problem
As Eventra depends on various third-party packages, maintaining visibility into our software supply chain is critical. Without an automatically generated Software Bill of Materials (SBOM), it is challenging to quickly audit our dependencies or identify if our application is affected by newly disclosed vulnerabilities in upstream packages.

## Solution
This PR introduces an automated GitHub Actions workflow to generate an SBOM, enhancing supply chain transparency and aligning with modern DevSecOps best practices.

## Changes Introduced
- Added a new GitHub Actions workflow at `.github/workflows/sbom.yml`.
- Integrated `anchore/sbom-action` to automatically scan dependencies and generate the SBOM in **SPDX** format.
- The workflow runs on every push to `master`, pull requests targeting `master`, and whenever a new release is published.
- Configured the workflow to upload the generated `sbom.spdx.json` file as a GitHub Actions artifact.
- Updated the `README.md` (under "Deployment Security") to document the existence of the SBOM and guide users/maintainers on how to find it.

## Benefits
- **Automated Inventory:** Every build produces an up-to-date snapshot of the software components.
- **Improved Security Posture:** Makes it significantly easier to perform vulnerability assessments and compliance audits.
- **Supply Chain Transparency:** Users and downstream consumers can reliably view the exact dependencies bundled into the application.

## Issue #10915 