### PR TITLE
Add GitHub Actions workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Modern event and hackathon platform for communities, organizers, and contributor
 [![Contributors](https://img.shields.io/github/contributors/SandeepVashishtha/Eventra?style=flat&color=green)](https://github.com/SandeepVashishtha/Eventra/graphs/contributors)
 [![Open Issues](https://img.shields.io/github/issues/SandeepVashishtha/Eventra?style=flat&color=red)](https://github.com/SandeepVashishtha/Eventra/issues)
 [![Open PRs](https://img.shields.io/github/issues-pr/SandeepVashishtha/Eventra?style=flat&color=blue)](https://github.com/SandeepVashishtha/Eventra/pulls)
+[![CI Validation](https://github.com/SandeepVashishtha/Eventra/actions/workflows/ci.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/ci.yml)
+[![Docker Build](https://github.com/SandeepVashishtha/Eventra/actions/workflows/docker-ci.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/docker-ci.yml)
+[![Docker Publish](https://github.com/SandeepVashishtha/Eventra/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/docker-publish.yml)
+[![Security Validation](https://github.com/SandeepVashishtha/Eventra/actions/workflows/security-ci.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/security-ci.yml)
+[![CodeQL Analysis](https://github.com/SandeepVashishtha/Eventra/actions/workflows/codeql.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/codeql.yml)
 
 ---
 


### PR DESCRIPTION
## Problem
While we've established a robust Continuous Integration and Deployment pipeline encompassing testing, linting, Docker builds, security scanning, and CodeQL, this status was largely hidden from the project's landing page. Without workflow status badges, it is difficult for contributors, maintainers, and users to quickly ascertain the real-time health of the repository at a glance.

## Solution
This PR enhances repository visibility and developer experience by prominently displaying GitHub Actions status badges at the top of the `README.md`.

## Changes Introduced
- Added dynamic status badges immediately below the existing repository badges in `README.md`.
- Included badges for the following critical workflows:
  - **CI Validation**
  - **Docker Build Validation**
  - **Docker Publish**
  - **Security Validation**
  - **CodeQL Analysis**
- All badges are hyperlinked to their respective workflow runs in the GitHub Actions tab, making it trivial to click through and investigate failures.

## Benefits
- **At-a-glance CI Health:** Anyone visiting the repository instantly knows if `master` is green and deployable.
- **Improved Transparency:** Demonstrates to the community that the project is actively tested, analyzed, and containerized.
- **Faster Triage:** Maintainers can spot failing pipelines without having to explicitly navigate to the Actions tab.

## Issue #10928 