### PR TITLE
Add OpenSSF Scorecard analysis to GitHub Actions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '30 1 * * 0' # Every Sunday at 01:30
+  push:
+    branches: [ "master" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard analysis
+        uses: ossf/scorecard-action@v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -599,6 +599,10 @@ Before deploying Eventra, review the deployment checklist:
 
 - docs/SECURE_DEPLOYMENT_CHECKLIST.md
 
+### OpenSSF Scorecard
+
+To ensure our repository continuously aligns with industry-recognized open-source security best practices, Eventra integrates the **OpenSSF Scorecard** into its GitHub Actions pipeline. The Scorecard runs on every push to the default branch and on a weekly schedule. It evaluates the project against critical security metrics (like branch protection, dependency pinning, and token permissions) and automatically publishes the results to the GitHub Security tab, guiding maintainers in continuously improving our software supply chain security.
+
 ### Maintainers
 
 <table>


### PR DESCRIPTION
## Problem
While our repository has numerous security checks (CodeQL, Trivy, Dependabot) actively scanning our code and dependencies, we lack a holistic, automated mechanism to evaluate our overall repository configurations against established open-source security best practices. Without continuous evaluation, security regressions—such as misconfigured token permissions, unpinned dependencies, or missing branch protection rules—could go unnoticed.

## Solution
This PR integrates the OpenSSF Scorecard GitHub Action to continuously and automatically evaluate our repository's security posture against industry-standard metrics.

## Changes Introduced
- Added a new GitHub Actions workflow at `.github/workflows/scorecard.yml`.
- Configured the Scorecard action (`ossf/scorecard-action`) to run automatically on every push to the `master` branch and on a scheduled basis (every Sunday at 01:30).
- Configured the workflow with the least-privileged `permissions` model, requiring `id-token: write` for artifact publication and `security-events: write` to upload results directly to the GitHub Security tab.
- Generates a SARIF report that is uploaded both as a standard Actions artifact and natively integrated into GitHub Advanced Security.
- Updated the `README.md` (under "Deployment Security") to document the inclusion of the OpenSSF Scorecard.

## Benefits
- **Continuous Compliance:** Automatically highlights gaps in our repository configuration that could compromise our software supply chain.
- **Improved Transparency:** Demonstrates a commitment to following the Open Source Security Foundation's stringent guidelines.
- **Actionable Insights:** Aggregates findings directly in the GitHub Security tab so maintainers can address them as part of their standard triage process.

## Issue #10939 