### PR TITLE
Automate release note generation using Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,46 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+  - title: '📚 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
+  - title: '⚡ Performance'
+    labels:
+      - 'performance'
+      - 'perf'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '🧹 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+      - 'refactor'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## What's Changed
+  $CHANGES
+
+  ## Contributors
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -593,6 +593,10 @@ Licensed under Apache 2.0. See [LICENSE](LICENSE).
   </a>
 </p>
 
+## Release Management
+
+Eventra uses [Release Drafter](https://github.com/release-drafter/release-drafter) to automate the generation of release notes. When a pull request is merged into the `master` branch, a draft release is automatically created or updated. The draft categorizes merged pull requests based on their labels (e.g., Features, Bug Fixes, Documentation) and acknowledges contributors automatically. Maintainers can review the draft and publish the release with minimal manual effort.
+
 ## Deployment Security
 
 Before deploying Eventra, review the deployment checklist:


### PR DESCRIPTION
## Problem
Preparing release notes manually for each release is a time-consuming and error-prone process. Maintainers have to manually comb through git history, locate merged pull requests, categorize them, attribute the correct contributors, and format the changelog. As the project scales, this manual overhead bottlenecks our release process and leaves room for human error.

## Solution
This PR introduces **Release Drafter**, a GitHub Action that automatically drafts release notes in the background as pull requests are merged.

## Changes Introduced
- Added a `.github/release-drafter.yml` configuration file that categorizes incoming pull requests into clean, organized buckets (e.g., `🚀 Features`, `🐛 Bug Fixes`, `🔒 Security`, `🧹 Maintenance`) based on their GitHub labels.
- Configured version resolution labels (`major`, `minor`, `patch`) to dynamically determine the next Semantic Version tag.
- Added a `.github/workflows/release-drafter.yml` GitHub Actions workflow that executes the Release Drafter action automatically whenever a PR is merged into `master`.
- Updated the `README.md` to document our new automated Release Management workflow.

## Benefits
- **Zero-touch Changelogs:** A draft release is perpetually maintained and kept up-to-date in the Releases tab without any manual intervention.
- **Accurate Attribution:** Contributors are automatically credited with links to their profiles and PRs, improving community engagement.
- **Faster Releases:** When maintainers are ready to cut a release, they simply review the auto-generated draft and click "Publish".

# Issue #10941 