### PR TITLE
Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-assign issue to commenter (robust)
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const cfg = {

--- a/.github/workflows/difficulty.yml
+++ b/.github/workflows/difficulty.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Analyze PR and assign difficulty label
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const pr      = context.payload.pull_request;

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Assign PR to creator and add gssoc:approved label
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const pr     = context.payload.pull_request;

--- a/.github/workflows/pr-label-inheritance.yml
+++ b/.github/workflows/pr-label-inheritance.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inherit Labels from Issues and Add Special Labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/quality-labeler.yml
+++ b/.github/workflows/quality-labeler.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Detect and apply quality label
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/stale-assignees.yml
+++ b/.github/workflows/stale-assignees.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Unassign stale assignees (nuanced)
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const cfg = {

--- a/.github/workflows/type-labeler.yml
+++ b/.github/workflows/type-labeler.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Detect and apply type labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/welcome-new-issues.yml
+++ b/.github/workflows/welcome-new-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post Discord invite comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb
         with:
           script: |
             const body = [


### PR DESCRIPTION
## Problem
Historically, our GitHub Actions workflows have referenced third-party actions using mutable version tags (e.g., `@v7`). Because tags can be moved or rewritten by the repository owner at any time, this exposes our CI/CD pipelines to software supply chain risks. A compromised action repository could silently overwrite a tag to point to malicious code, which our workflows would then execute without warning.

## Solution
This PR hardens our CI/CD pipelines by pinning all third-party GitHub Actions to their immutable, cryptographically secure commit SHAs.

## Changes Introduced
- Audited all existing GitHub Actions workflows in `.github/workflows/`.
- Replaced mutable tag references (like `actions/github-script@v7`) with their absolute, immutable commit SHAs (e.g., `actions/github-script@608b4d96cb27c244ac5db97669d0d34638a169eb`).
- Kept the workflow behavior completely identical while removing the underlying tag dependency.

## Benefits
- **Supply Chain Security:** We are now mathematically guaranteed to run the exact code that was audited at the time the SHA was pinned.
- **Reproducibility:** Prevents unpredictable build failures caused by an upstream maintainer accidentally breaking a major version tag.
- **Dependabot Compatibility:** This works perfectly in tandem with our recently added Dependabot configuration, which will now automatically open PRs to update these SHAs when newer versions are released.

## Issue #10943 