### PR TITLE
Add multi-architecture Docker image builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Multi-Arch Docker Build and Publish
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem
Historically, our Docker images were built exclusively for the `linux/amd64` (x86_64) architecture. As ARM-based hardware becomes ubiquitous—from developers using Apple Silicon (M1/M2/M3) Macs to cost-effective AWS Graviton/ARM64 cloud instances and Raspberry Pi deployments—our single-architecture images cause compatibility headaches. Users attempting to run the application on ARM devices either face slow emulation penalties or outright failures.

## Solution
This PR updates our Docker deployment pipeline to leverage **Docker Buildx** and **QEMU**, automatically building and publishing multi-architecture container images.

## Changes Introduced
- Added `.github/workflows/docker-publish.yml` to standardize our multi-arch builds.
- Integrated `docker/setup-qemu-action` to enable hardware emulation for cross-compilation.
- Integrated `docker/setup-buildx-action` to utilize the modern BuildKit backend.
- Configured the `docker/build-push-action` to target both `linux/amd64` and `linux/arm64` platforms simultaneously.
- Configured dynamic metadata tagging (`docker/metadata-action`) to ensure images are tagged intelligently with Git SHAs, branch names, and `latest` (only on `master`).
- Implemented `gha` cache backend (`cache-from` and `cache-to`) to aggressively cache Docker layers, significantly offsetting the time penalty of building for multiple architectures.

## Benefits
- **Universal Compatibility:** Developers and end-users can seamlessly pull and run our images on ARM64 and x86_64 hardware natively without modification.
- **Future-Proofing:** Prepares our deployment artifacts for modern, cost-efficient cloud environments.
- **Optimized Pipeline:** The addition of GitHub Actions Docker caching ensures our multi-arch builds remain performant.

## Issue #10945 