### PR TITLE
Add automated code coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI Validation
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run tests with coverage
+        run: npx -y c8 --reporter=lcov --reporter=text-summary npm run test
+
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage/
+          retention-days: 7
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage/lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright E2E tests
+        run: npm run test:e2e
+
+      - name: Run production build
+        run: npm run build
+


### PR DESCRIPTION
## Problem
Although we have automated unit tests running in our CI pipeline, we lack visibility into our actual code coverage. Without a quantifiable coverage metric, it is difficult to determine whether critical paths of our codebase are adequately tested. This makes it challenging for reviewers to assess whether new PRs include sufficient tests and increases the risk of deploying untested code.

## Solution
This PR enhances our existing CI workflow by automatically generating code coverage reports and integrating them into our GitHub Actions and Codecov ecosystem.

## Changes Introduced
- Replaced the standard `npm run test` step with an instrumented execution using `c8` (`npx -y c8 --reporter=lcov --reporter=text-summary npm run test`).
- Configured a new workflow step to upload the raw generated `coverage/` directory as a GitHub Actions artifact for manual inspection and debugging.
- Integrated the `codecov/codecov-action@v4` action to automatically ingest the `lcov.info` report, enabling visual coverage summaries, historical trend tracking, and granular PR comments directly in the GitHub UI.

## Benefits
- **Actionable Insights:** Developers can immediately see a visual text-summary of coverage in the CI logs and detailed annotations in Codecov.
- **Improved Code Quality:** By surfacing untested lines of code directly on pull requests, reviewers can more effectively encourage contributors to write thorough tests.
- **Trend Tracking:** We now have a baseline to measure our testing efforts against, helping us incrementally improve the overall reliability of the application over time.

## Issue #10949 