### PR TITLE
Add Node.js matrix testing to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI Validation
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x, 24.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright E2E tests
+        run: npm run test:e2e
+
+      - name: Run production build
+        run: npm run build


### PR DESCRIPTION
## Problem
Our primary CI workflow currently validates the application using only a single Node.js version (Node 22). As the Node.js ecosystem evolves rapidly, APIs get deprecated and dependencies drop support for older runtimes. Testing against a single version gives us a false sense of security and leaves us blind to potential compatibility issues that our users or contributors might face if they run a different active LTS release.

## Solution
This PR updates the primary CI pipeline to leverage a GitHub Actions matrix strategy, ensuring that our application is concurrently validated across all currently active and upcoming Node.js LTS releases.

## Changes Introduced
- Updated `.github/workflows/ci.yml` to define a `strategy.matrix.node-version` containing `[20.x, 22.x, 24.x]`.
- Updated the `actions/setup-node` step to dynamically pull the version from `${{ matrix.node-version }}` instead of hardcoding `22`.
- Added `fail-fast: false` to the strategy block. This ensures that if the tests fail on Node 20, the jobs for Node 22 and 24 will still complete, providing a full picture of cross-version compatibility.

## Benefits
- **Broader Compatibility:** Guarantees that the application works seamlessly on any actively supported Node.js LTS version.
- **Future-Proofing:** Testing against Node 24 (the upcoming LTS) ensures we detect breaking changes early before we are forced to upgrade.
- **Improved Developer Experience:** Contributors are no longer strictly bound to a single local Node.js version; they can be confident their changes work across the ecosystem.

## Issue #10951 