### PR TITLE
Add automated Slack deployment notifications

### DIFF
--- a/.github/workflows/deployment-notifications.yml
+++ b/.github/workflows/deployment-notifications.yml
@@ -1,0 +1,23 @@
+name: Deployment Notifications
+
+on:
+  deployment_status:
+
+jobs:
+  notify:
+    # Only notify when the deployment has reached a terminal state
+    if: github.event.deployment_status.state == 'success' || github.event.deployment_status.state == 'failure' || github.event.deployment_status.state == 'error'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_COLOR: ${{ github.event.deployment_status.state == 'success' && 'good' || 'danger' }}
+          SLACK_TITLE: "Deployment ${{ github.event.deployment_status.state }} to ${{ github.event.deployment.environment }}"
+          SLACK_MESSAGE: |
+            *Workflow:* ${{ github.workflow }}
+            *Branch:* ${{ github.event.deployment.ref }}
+            *Commit:* ${{ github.sha }}
+            *Triggered by:* ${{ github.actor }}
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Problem
Although our CI/CD pipelines automate deployments to our environments, maintainers currently have no visibility into the actual success or failure of those deployments without proactively checking the GitHub Actions dashboard. This lack of operational awareness leads to delayed responses when deployments fail and hinders cross-team transparency when new versions are successfully released.

## Solution
This PR introduces a standalone Deployment Notification workflow that automatically pushes rich alerts to Slack based on GitHub deployment events.

## Changes Introduced
- Created `.github/workflows/deployment-notifications.yml`.
- Configured the workflow to run exclusively on `deployment_status` events and only when the deployment reaches a terminal state (`success`, `failure`, `error`).
- Integrated the popular `rtCamp/action-slack-notify` action to broadcast the alert.
- Structured the payload to include critical contextual data: the environment name, the triggering user, branch, commit SHA, and a direct link to the workflow logs.
- Color-coded the Slack alert dynamically (green for success, red for failure).

## Setup Required
Once merged, an organization admin will need to create an incoming webhook URL in Slack (or a compatible endpoint like Microsoft Teams/Discord) and save it as a repository secret named `SLACK_WEBHOOK_URL`.

## Benefits
- **Immediate Visibility:** The engineering team is instantly notified in their communication channels when a deployment succeeds or fails.
- **Faster Triage:** With the direct workflow link and commit SHA embedded in the alert, debugging a failed deployment is a one-click process.
- **Isolated execution:** Because this listens for `deployment_status` asynchronously, it adds zero time overhead to the actual deployment jobs themselves.

## Issue #10953 