### PR TITLE
fix: stop sending the literal %CSRF_TOKEN% placeholder as the CSRF header

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,6 @@
     <meta property="og:url" content="https://eventra.sandeepvashishtha.in/" />
     <meta property="og:image" content="https://eventra.sandeepvashishtha.in/logo_transparent.png" />
 
-    <!-- CSRF Protection -->
-    <meta name="csrf-token" content="%CSRF_TOKEN%" />
-
-
   </head>
 <body>
   <div id="root"></div>

--- a/src/utils/csrfToken.js
+++ b/src/utils/csrfToken.js
@@ -44,12 +44,23 @@ export const getCSRFEnforcementMode = () => {
 /**
  * Reads the CSRF token from the page's <meta> tag.
  * Expected: <meta name="csrf-token" content="TOKEN_VALUE">
+ *
+ * Build placeholders (e.g. "%CSRF_TOKEN%") are treated as absent: a literal
+ * placeholder is a predictable constant and must never be used as a token.
+ *
  * @returns {string|null}
  */
+const PLACEHOLDER_PATTERN = /^%[A-Z_][A-Z0-9_]*%$/;
+
 export function getCSRFTokenFromMeta() {
   if (typeof document === "undefined") return null;
   const meta = document.querySelector(`meta[name="${CSRF_META_NAME}"]`);
-  return meta ? meta.getAttribute("content") : null;
+  if (!meta) return null;
+  const content = meta.getAttribute("content");
+  if (typeof content !== "string" || PLACEHOLDER_PATTERN.test(content)) {
+    return null;
+  }
+  return content;
 }
 
 /**
@@ -69,12 +80,17 @@ export function getCSRFTokenFromCookie(name = CSRF_COOKIE_NAME) {
 }
 
 /**
- * Gets the CSRF token from meta tag or cookie (in that order).
+ * Gets the CSRF token from cookie or meta tag (in that order).
+ *
+ * The cookie is the source of truth: it is the per-session token issued by the
+ * server. The meta tag is only consulted as a fallback for environments that
+ * inject a real token server-side (e.g. server-rendered pages).
+ *
  * @returns {string|null}
  */
 export function getCSRFToken() {
   if (typeof document === "undefined") return null;
-  return getCSRFTokenFromMeta() || getCSRFTokenFromCookie();
+  return getCSRFTokenFromCookie() || getCSRFTokenFromMeta();
 }
 
 /**

--- a/tests/csrfTokenRotation.test.mjs
+++ b/tests/csrfTokenRotation.test.mjs
@@ -1,15 +1,77 @@
 import assert from "node:assert/strict";
-import { rotateCSRFToken, getCSRFTokenFromCookie } from "../src/utils/csrfToken.js";
+import {
+  rotateCSRFToken,
+  getCSRFToken,
+  getCSRFTokenFromMeta,
+  getCSRFTokenFromCookie,
+} from "../src/utils/csrfToken.js";
 
-globalThis.document = {
-  cookie: "",
-  querySelector() { return null; }
-};
+function setupDocument({ cookie = "", metaContent = null }) {
+  globalThis.document = {
+    cookie,
+    querySelector() {
+      if (metaContent === null) return null;
+      return { getAttribute: (name) => (name === "content" ? metaContent : null) };
+    },
+  };
+}
 
 try {
+  // ── rotateCSRFToken writes the cookie ─────────────────────────────────────
+  setupDocument({ cookie: "" });
   rotateCSRFToken("new-secure-token-12345");
-  assert.equal(document.cookie.includes("XSRF-TOKEN=new-secure-token-12345"), true, "Should write token to document.cookie");
-  console.log("csrfToken rotation tests passed ✓");
+  assert.equal(
+    document.cookie.includes("XSRF-TOKEN=new-secure-token-12345"),
+    true,
+    "Should write token to document.cookie",
+  );
+
+  // ── getCSRFToken prefers the cookie over the meta tag ─────────────────────
+  setupDocument({ cookie: "XSRF-TOKEN=cookie-token-abc", metaContent: "meta-token-def" });
+  assert.equal(
+    getCSRFToken(),
+    "cookie-token-abc",
+    "getCSRFToken() must prefer the cookie (source of truth) over the meta tag",
+  );
+
+  // ── getCSRFToken falls back to a real meta token when no cookie exists ────
+  setupDocument({ cookie: "", metaContent: "real-server-injected-token" });
+  assert.equal(
+    getCSRFToken(),
+    "real-server-injected-token",
+    "getCSRFToken() should fall back to a real server-injected meta token",
+  );
+
+  // ── Literal build placeholders are never treated as a token ───────────────
+  setupDocument({ cookie: "", metaContent: "%CSRF_TOKEN%" });
+  assert.equal(
+    getCSRFTokenFromMeta(),
+    null,
+    "getCSRFTokenFromMeta() must return null for a literal %CSRF_TOKEN% placeholder",
+  );
+  assert.equal(
+    getCSRFToken(),
+    null,
+    "getCSRFToken() must not use a literal placeholder as a token",
+  );
+
+  // ── When the cookie holds a real token, a placeholder meta cannot shadow it ─
+  setupDocument({ cookie: "XSRF-TOKEN=cookie-token-abc", metaContent: "%CSRF_TOKEN%" });
+  assert.equal(
+    getCSRFToken(),
+    "cookie-token-abc",
+    "A placeholder meta tag must never shadow the real cookie token",
+  );
+
+  // ── Cookie reader parses the XSRF-TOKEN value ─────────────────────────────
+  setupDocument({ cookie: "foo=1; XSRF-TOKEN=per-session-token; bar=2" });
+  assert.equal(
+    getCSRFTokenFromCookie(),
+    "per-session-token",
+    "getCSRFTokenFromCookie() parses the XSRF-TOKEN cookie value",
+  );
+
+  console.log("csrfToken rotation + preference tests passed ✓");
 } finally {
   delete globalThis.document;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -50,6 +50,25 @@ export default defineConfig(({ mode }) => {
         // Only .jsx/.tsx — .js files are handled above
         include: /\.(jsx|tsx)$/,
       }),
+      // Fail the build if an un-substituted %PLACEHOLDER% survives into the
+      // final index.html. Vite only auto-replaces %VITE_*% values, so any other
+      // %...% token is a build mistake — historically a literal %CSRF_TOKEN%
+      // was shipped and sent as the CSRF header on every mutating request.
+      {
+        name: "assert-no-html-placeholders",
+        enforce: "post",
+        transformIndexHtml(html) {
+          const placeholder = html.match(/%[A-Z_][A-Z0-9_]*%/g);
+          if (placeholder && placeholder.length > 0) {
+            throw new Error(
+              `[assert-no-html-placeholders] Un-substituted build placeholder(s) found in index.html: ` +
+                `${placeholder.join(", ")}. Vite only replaces %VITE_*% tokens; remove the ` +
+                `placeholder or define it as a VITE_ prefixed environment variable.`,
+            );
+          }
+          return html;
+        },
+      },
     ],
 
     // Path aliases — cleaner imports and faster resolution


### PR DESCRIPTION
## Description

`index.html` shipped `<meta name="csrf-token" content="%CSRF_TOKEN%">`. Vite
only substitutes `%VITE_*%` variables, so the literal `%CSRF_TOKEN%` string
was sent as the `X-CSRF-Token` header on every mutating request, shadowing
the real `XSRF-TOKEN` cookie.

## Changes

- `index.html`: remove the never-substituted CSRF meta tag
- `src/utils/csrfToken.js`: `getCSRFToken()` is now cookie-first, and
  `getCSRFTokenFromMeta()` treats `%...%` placeholders as null
- `vite.config.js`: new `assert-no-html-placeholders` plugin that fails the
  build if any un-substituted `%...%` placeholder survives in HTML
- `tests/csrfTokenRotation.test.mjs`: cookie-preference, meta-fallback,
  placeholder-rejection and cookie-parse coverage

Closes #10934