### PR TITLE
fix: encode only the opaque server token in ticket QRs, drop Math.random serial

### DIFF
--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -24,17 +24,11 @@ const EventTicket = ({ event, user, onClose }) => {
   const registration = myEvents.find((r) => r.eventId === event.id);
   const selectedSeat = registration?.formData?.selectedSeat;
 
-  // The QR payload mirrors the JSON shape consumed by TicketScanner.
-  // Generate a mock ticket serial code based on event and user details
-  const generateSerial = () => {
-    const eventPart = (event?.title || "EVT").slice(0, 3).toUpperCase();
-    const userPart = (user?.firstName || user?.username || "USR").slice(0, 3).toUpperCase();
-    const randomPart = Math.random().toString(36).substring(2, 7).toUpperCase();
-    return `${eventPart}-${userPart}-${randomPart}`;
-  };
-
-  const [serialNumber] = useState(() => registration?.registrationId || generateSerial());
-  const qrPayload = buildTicketQrPayload({ event, user, registration, serialNumber });
+  // The QR encodes only the opaque server-issued token (qrToken/registrationId).
+  // No PII is embedded, and no client-side pseudo-serial is generated: without
+  // a server-issued registration the ticket renders with no scannable QR.
+  const [serialNumber] = useState(() => registration?.registrationId || registration?.qrToken || null);
+  const qrPayload = buildTicketQrPayload({ registration, serialNumber });
   const qrValue = buildTicketQrValue(qrPayload);
   const attendeeName = getTicketHolderName(user);
 
@@ -344,18 +338,24 @@ const EventTicket = ({ event, user, onClose }) => {
               <div className="ud-ticket-footer">
                 <div className="ud-ticket-qr-wrap">
                   <div className="ud-ticket-qr-border flex items-center justify-center bg-zinc-950/20 dark:bg-white/5 rounded-xl border border-white/10" style={{ width: 110, height: 110 }}>
-                    <QRCode
-                      value={qrValue}
-                      size={90}
-                      bgColor="transparent"
-                      fgColor="#ffffff"
-                      className="ud-ticket-qr"
-                    />
+                    {qrValue ? (
+                      <QRCode
+                        value={qrValue}
+                        size={90}
+                        bgColor="transparent"
+                        fgColor="#ffffff"
+                        className="ud-ticket-qr"
+                      />
+                    ) : (
+                      <span className="text-[9px] font-bold text-zinc-400 text-center px-1 leading-tight">
+                        QR unavailable — no server-issued ticket token
+                      </span>
+                    )}
                   </div>
                 </div>
 
                 <div className="ud-ticket-stub-details">
-                  <div className="ud-ticket-serial">{serialNumber}</div>
+                  <div className="ud-ticket-serial">{serialNumber || "N/A"}</div>
                   <div className="ud-ticket-status">
                     <ShieldCheck size={14} className={isOffline ? "text-amber-400 animate-pulse" : "text-emerald-400 animate-pulse"} />
                     <span>{isOffline ? "CACHED TICKET" : "SECURE VALID PASS"}</span>
@@ -409,7 +409,7 @@ const EventTicket = ({ event, user, onClose }) => {
                 </div>
 
                 <div className="ud-ticket-back-footer mt-auto pt-4 border-t border-white/5 flex flex-col items-center gap-2">
-                  <div className="ud-ticket-serial text-center text-xs opacity-75">{serialNumber}</div>
+                  <div className="ud-ticket-serial text-center text-xs opacity-75">{serialNumber || "N/A"}</div>
                   <div className="text-[10px] text-zinc-500 uppercase tracking-widest text-center">
                     Powered by Eventra Engine
                   </div>

--- a/src/utils/ticketQrPayload.js
+++ b/src/utils/ticketQrPayload.js
@@ -1,17 +1,26 @@
 export const getTicketHolderName = (user) =>
   user?.fullName || `${user?.firstName || ""} ${user?.lastName || ""}`.trim() || user?.username || "Eventra Guest";
 
-export const buildTicketQrPayload = ({ event, user, registration, serialNumber }) => {
-  const ticketId = registration?.qrToken || registration?.registrationId || serialNumber;
-  const eventId = event?.id ?? event?.eventId;
-
-  return {
-    ticketId,
-    registrationId: registration?.registrationId || serialNumber,
-    eventId,
-    eventName: event?.title || "Eventra Event",
-    userName: getTicketHolderName(user),
-  };
+/**
+ * Build the QR payload for an event ticket.
+ *
+ * SECURITY: The QR encodes ONLY the opaque, server-issued ticket token
+ * (qrToken, or registrationId as a fallback) — no PII such as attendee names,
+ * event names, or registrations is embedded. Attendee/event details are
+ * display-only and are resolved server-side during ticket validation.
+ *
+ * Returns null when no server-issued token is available; callers must not
+ * render a QR code in that case (a generated pseudo-serial would be forgeable).
+ */
+export const buildTicketQrPayload = ({ registration, serialNumber }) => {
+  const ticketId = registration?.qrToken || registration?.registrationId || serialNumber || null;
+  if (!ticketId) return null;
+  return { ticketId };
 };
 
-export const buildTicketQrValue = (ticketData) => JSON.stringify(ticketData);
+export const buildTicketQrValue = (ticketData) => {
+  if (!ticketData || typeof ticketData !== "object" || !ticketData.ticketId) {
+    return "";
+  }
+  return JSON.stringify(ticketData);
+};

--- a/tests/ticketQrPayload.test.mjs
+++ b/tests/ticketQrPayload.test.mjs
@@ -24,30 +24,36 @@ const payload = buildTicketQrPayload({
   serialNumber: "EVT-ASH-9XY7Z",
 });
 
+// The QR must encode ONLY the opaque server-issued token — no PII.
 assert.deepStrictEqual(payload, {
   ticketId: "signed-ticket-token",
-  registrationId: "reg-123",
-  eventId: 10287,
-  eventName: "Eventra Summit",
-  userName: "Asha Rao",
 });
 
+// Round-trip through the encoded value.
 assert.deepStrictEqual(JSON.parse(buildTicketQrValue(payload)), payload);
 
-assert.deepStrictEqual(
+// PII (attendee name, event name, registration id) must never ride in the QR.
+const serialisedQr = buildTicketQrValue(payload);
+assert.ok(
+  !serialisedQr.includes("Asha") && !serialisedQr.includes("Eventra Summit") && !serialisedQr.includes("reg-123"),
+  "QR value must not embed attendee name, event name, or registration id",
+);
+
+// When no server-issued token exists, no QR payload may be produced.
+assert.equal(
   buildTicketQrPayload({
     event,
     user: {},
     registration: null,
-    serialNumber: "EVT-GUE-00001",
   }),
-  {
-    ticketId: "EVT-GUE-00001",
-    registrationId: "EVT-GUE-00001",
-    eventId: 10287,
-    eventName: "Eventra Summit",
-    userName: "Eventra Guest",
-  },
+  null,
+  "buildTicketQrPayload() returns null when no server-issued token exists",
+);
+
+assert.equal(
+  buildTicketQrValue(null),
+  "",
+  "buildTicketQrValue() returns an empty string for a null payload",
 );
 
 assert.equal(getTicketHolderName({ fullName: "Priya Shah", firstName: "Ignored" }), "Priya Shah");


### PR DESCRIPTION
## Description

Live ticket QRs encoded a JSON payload containing the attendee name, event
name and registration id, and the serial fell back to
`Math.random().toString(36).substring(2, 7)`. The QR leaked PII and could be
forged.

## Changes

- `src/utils/ticketQrPayload.js`: `buildTicketQrPayload()` returns only
  `{ ticketId }` (the server-issued `qrToken` or `registrationId`); returns
  `null` when no server token exists; `buildTicketQrValue()` returns `""`
  for a null payload
- `EventTicket.js`: remove the `Math.random` serial fallback; tickets without
  a server token render "QR unavailable" instead of a scannable QR
- The scanner still accepts legacy JSON QRs for backward compatibility;
  authenticity remains server-side via `/tickets/validate`, and offline scans
  show "Queued for Verification" (#10933)
- `tests/ticketQrPayload.test.mjs`: asserts the opaque-token contract and
  that no PII rides in the encoded QR value

Closes #10935