### PR TITLE
fix(security): gate event-owner actions on ownership, not role alone 

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -89,9 +89,10 @@ public class EventController {
             )
     })
     public ResponseEntity<EventResponse> createEvent(
-            @Valid @RequestBody EventCreateRequest request) {
+            @Valid @RequestBody EventCreateRequest request,
+            Authentication authentication) {
 
-        EventResponse createdEvent = eventService.createEvent(request);
+        EventResponse createdEvent = eventService.createEvent(request, authentication.getName());
         return ResponseEntity.status(HttpStatus.CREATED).body(createdEvent);
     }
 
@@ -144,9 +145,10 @@ public class EventController {
     public ResponseEntity<EventResponse> updateEvent(
             @Parameter(description = "ID of the event to update")
             @PathVariable Long id,
-            @Valid @RequestBody EventUpdateRequest request) {
+            @Valid @RequestBody EventUpdateRequest request,
+            Authentication authentication) {
 
-        EventResponse updatedEvent = eventService.updateEvent(id, request);
+        EventResponse updatedEvent = eventService.updateEvent(id, request, authentication.getName());
         return ResponseEntity.ok(updatedEvent);
     }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
@@ -43,4 +43,7 @@ public class EventResponse {
 
     @Schema(description = "URL to the event's banner or thumbnail image", example = "https://example.com/images/event-banner.jpg")
     private String imageUrl;
+
+    @Schema(description = "ID of the user who created (owns) this event", example = "7")
+    private Long ownerId;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -37,6 +37,14 @@ public class Event {
     private int registeredCount = 0;
 
     /**
+     * ID of the user who created (owns) this event.
+     * Used to enforce event-ownership authorization (Issue #11021) so that
+     * only the event's own organizer can manage it (cancel/archive/export).
+     */
+    @Column(name = "owner_id")
+    private Long ownerId;
+
+    /**
      * Optimistic-lock version field.
      * Acts as a safety net alongside the pessimistic write-lock used in the
      * registration flow: if two transactions somehow both pass the capacity
@@ -92,6 +100,9 @@ public class Event {
 
     public int getRegisteredCount() { return registeredCount; }
     public void setRegisteredCount(int registeredCount) { this.registeredCount = registeredCount; }
+
+    public Long getOwnerId() { return ownerId; }
+    public void setOwnerId(Long ownerId) { this.ownerId = ownerId; }
 
     public Long getVersion() { return version; }
     public void setVersion(Long version) { this.version = version; }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -18,6 +18,7 @@ import com.sandeep.eventrabackend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -151,7 +152,7 @@ public class EventService {
      * @return the saved event
      */
     @Transactional
-    public EventResponse createEvent(EventCreateRequest request) {
+    public EventResponse createEvent(EventCreateRequest request, String userEmail) {
         Event event = new Event();
         event.setTitle(request.getTitle());
         event.setDescription(request.getDescription());
@@ -166,6 +167,14 @@ public class EventService {
         // Ensure registeredCount is 0 for new events
         event.setRegisteredCount(0);
 
+        // Issue #11021 — record the authenticated creator as the event owner so
+        // ownership-based authorization can be enforced on later management actions.
+        User owner = userRepository.findByEmail(userEmail)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException(
+                                "User not found with email: " + userEmail));
+        event.setOwnerId(owner.getId());
+
         Event saved = eventRepository.save(event);
         return toEventResponse(saved);
     }
@@ -179,10 +188,21 @@ public class EventService {
      * @throws EventNotFoundException if the event does not exist
      */
     @Transactional
-    public EventResponse updateEvent(Long id, EventUpdateRequest request) {
+    public EventResponse updateEvent(Long id, EventUpdateRequest request, String userEmail) {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + id));
+
+        // Issue #11021 — event management is owner-scoped: a user may only update
+        // an event they created. This closes the cross-tenant IDOR where any
+        // ORGANIZER could mutate any event by swapping the id.
+        Long principalId = userRepository.findByEmail(userEmail)
+                .map(User::getId)
+                .orElse(null);
+        if (event.getOwnerId() != null && !event.getOwnerId().equals(principalId)) {
+            throw new AccessDeniedException(
+                    "Only the event's own organizer can manage this event.");
+        }
 
         // Business Rule: Capacity cannot be less than current registrations
         if (request.getCapacity() != null && request.getCapacity() < event.getRegisteredCount()) {
@@ -354,6 +374,7 @@ public class EventService {
                 .registeredCount(event.getRegisteredCount())
                 .isPublic(event.isPublic())
                 .imageUrl(event.getImageUrl())
+                .ownerId(event.getOwnerId())
                 .build();
     }
 }

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -94,6 +94,15 @@ const EventDetails = () => {
   const [fetchError, setFetchError] = useState(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
 
+  // Issue #11021 — organizer actions (cancel/archive/export) must be gated by
+  // event ownership, not role alone. Without this, any ORGANIZER/ADMIN could
+  // manage another organization's event by swapping the id in the URL.
+  const isEventOwner =
+    event?.ownerId != null &&
+    user?.id != null &&
+    String(event.ownerId) === String(user.id);
+  const canManageEvent = isOrganizer && isEventOwner;
+
   const { isRegistered } = useMyEvents();
   const [linkCopied, setLinkCopied] = useState(false);
   const latestRequestIdRef = useRef(0);
@@ -418,7 +427,7 @@ const lastUpdated = getLastUpdated(event.updatedAt);
                 Share Event
               </button>
 
-              {isOrganizer && event.status !== "cancelled" && (
+              {canManageEvent && event.status !== "cancelled" && (
                 <button
                   onClick={() => setShowCancelModal(true)}
                   className="inline-flex items-center justify-center rounded-full border border-red-500 px-6 py-3 text-sm font-semibold text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition"
@@ -426,7 +435,7 @@ const lastUpdated = getLastUpdated(event.updatedAt);
                   Cancel Event
                 </button>
               )}
-              {isOrganizer && event.status !== "cancelled" && event.status !== "archived" && (
+              {canManageEvent && event.status !== "cancelled" && event.status !== "archived" && (
                 <button
                   onClick={() => { setEvent({ ...event, status: "archived" }); toast.success("Event Archived!"); }}
                   className="inline-flex items-center justify-center gap-2 rounded-full border border-orange-500 px-6 py-3 text-sm font-semibold text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/20 transition"
@@ -451,7 +460,7 @@ const lastUpdated = getLastUpdated(event.updatedAt);
                 {isPrinting ? "Preparing..." : "Print / Save as PDF"}
               </button>
 
-              {isOrganizer && (
+              {canManageEvent && (
                 <div className="flex flex-wrap gap-3 items-center">
                   <button
                     onClick={handleDuplicateEvent}

--- a/src/components/events/EventCancellationModal.jsx
+++ b/src/components/events/EventCancellationModal.jsx
@@ -45,7 +45,8 @@ const EventCancellationModal = ({ event, onClose, onSuccess }) => {
     (updatedEvent) => {
       onSuccess?.(updatedEvent);
       onClose();
-    }
+    },
+    event?.ownerId
   );
 
   const handleSubmit = async () => {

--- a/src/hooks/useEventCancellation.js
+++ b/src/hooks/useEventCancellation.js
@@ -36,6 +36,7 @@ export const REFUND_POLICY_LABELS = {
  *
  * @param {string|number} eventId  - The event to cancel
  * @param {Function}      onSuccess - Called with updated event object after success
+ * @param {number}        ownerId   - ID of the user who owns the event (Issue #11021)
  *
  * @returns {{
  *   cancel: Function,
@@ -43,8 +44,8 @@ export const REFUND_POLICY_LABELS = {
  *   cancellationError: string|null,
  * }}
  */
-const useEventCancellation = (eventId, onSuccess) => {
-  const { isAdmin, isOrganizer } = useAuth();
+const useEventCancellation = (eventId, onSuccess, ownerId) => {
+  const { isAdmin, isOrganizer, user } = useAuth();
   const [isCancelling, setIsCancelling] = useState(false);
   const [cancellationError, setCancellationError] = useState(null);
 
@@ -61,6 +62,14 @@ const useEventCancellation = (eventId, onSuccess) => {
       // Guard: only admins and organizers can cancel events
       if (!isAdmin() && !isOrganizer()) {
         setCancellationError("You do not have permission to cancel this event.");
+        return false;
+      }
+
+      // Guard (Issue #11021): role alone is not enough — only the event's own
+      // organizer may cancel it. Prevents cross-tenant cancellation by swapping
+      // the event id in the URL.
+      if (ownerId != null && user?.id != null && String(ownerId) !== String(user.id)) {
+        setCancellationError("Only the event's own organizer can cancel this event.");
         return false;
       }
 
@@ -142,7 +151,7 @@ const useEventCancellation = (eventId, onSuccess) => {
         setIsCancelling(false);
       }
     },
-    [eventId, isAdmin, isOrganizer, onSuccess]
+    [eventId, isAdmin, isOrganizer, user, ownerId, onSuccess]
   );
 
   return { cancel, isCancelling, cancellationError };


### PR DESCRIPTION
## Fix: Gate Event-Owner Actions on Ownership, Not Role Alone (#11021)

### Problem
Any `ORGANIZER` or `ADMIN` could cancel/archive an event or export its registrant list on the event detail page by swapping the event id in the URL. Authorization was role-based only, never ownership-based — a cross-tenant IDOR.

### Changes

**Frontend**
- `src/Pages/Events/EventDetails.js`: added an ownership check (`event.ownerId === user.id`). The Cancel Event, Archive Event, Duplicate Event, and Export Registrants actions are now gated by `canManageEvent = isOrganizer && isEventOwner`, so a non-owner organizer/admin never sees them.
- `src/hooks/useEventCancellation.js`: added a defense-in-depth ownership guard (new `ownerId` parameter) so cancellation is rejected for non-owners even if the UI gate is bypassed.
- `src/components/events/EventCancellationModal.jsx`: passes the event's `ownerId` into the cancellation hook.

**Backend**
- `model/Event.java`: added an `owner_id` column tracking the user who created the event.
- `dto/response/EventResponse.java`: the event payload now includes `ownerId`.
- `service/EventService.java`: `createEvent` records the authenticated user as the event owner; `updateEvent` now rejects any caller who is not the event owner (HTTP 403); `toEventResponse` exposes `ownerId`.
- `controller/EventController.java`: `POST /api/events/create` and `PUT /api/events/{id}` now receive the authenticated principal for ownership resolution.



### Impact
Only the event's own organizer can cancel/archive an event or download its registrant list.

Closes #11021