### PR TITLE
fix(events): sanitize search/filter params before hitting the backend

### DIFF
--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -14,8 +14,12 @@ import {
 } from "utils/advancedFilterUtils";
 import { getRouteSearchResults } from "utils/searchUtils.mjs";
 import { getBookmarkedEvents } from "utils/bookmarkUtils";
+import { sanitizeFilterQuery } from "utils/querySanitizer";
 
 const DEFAULT_EVENTS_PER_PAGE = 20;
+
+const MAX_SEARCH_LENGTH = 100;
+const MAX_TAG_LENGTH = 50;
 
 const SORT_MAPPING = {
   Newest: "date,desc",
@@ -64,42 +68,48 @@ const useEventListing = () => {
     params.append("page", currentPage - 1);
     params.append("size", eventsPerPage);
 
-    if (debouncedSearchQuery.trim()) {
-      params.append("search", debouncedSearchQuery.trim());
+    // Sanitize every user-supplied filter before it reaches the backend query
+    // string. sanitizeFilterQuery strips $, &, <, > (src/utils/querySanitizer.js)
+    // and length caps reject oversized values, closing the injection/DoS surface.
+    const safeFilters = sanitizeFilterQuery(advancedFilters);
+    const safeSearch = sanitizeFilterQuery({ search: debouncedSearchQuery }).search || "";
+
+    if (safeSearch.trim()) {
+      params.append("search", safeSearch.trim().slice(0, MAX_SEARCH_LENGTH));
     }
 
     if (filterType && filterType !== "all") {
       params.append("status", filterType.toUpperCase());
     }
 
-    if (advancedFilters?.categories?.length) {
-      advancedFilters.categories.forEach((category) => {
-        params.append("category", category);
+    if (safeFilters?.categories?.length) {
+      safeFilters.categories.forEach((category) => {
+        if (category) params.append("category", category);
       });
     }
 
-    if (advancedFilters?.statuses?.length) {
-      advancedFilters.statuses.forEach((status) => {
+    if (safeFilters?.statuses?.length) {
+      safeFilters.statuses.forEach((status) => {
         params.append("status", status.toUpperCase());
       });
     }
 
-    if (advancedFilters?.skillLevels?.length) {
-      advancedFilters.skillLevels.forEach((level) => {
+    if (safeFilters?.skillLevels?.length) {
+      safeFilters.skillLevels.forEach((level) => {
         params.append("skillLevel", level.toLowerCase());
       });
     }
 
-    if (advancedFilters?.tags?.length) {
-      advancedFilters.tags.forEach((tag) => {
-        params.append("tag", tag);
+    if (safeFilters?.tags?.length) {
+      safeFilters.tags.forEach((tag) => {
+        if (tag) params.append("tag", tag.slice(0, MAX_TAG_LENGTH));
       });
     }
 
-    const sortValue = SORT_MAPPING[sortType];
-    if (sortValue) {
-      params.append("sort", sortValue);
-    }
+    // Whitelist-guard the sort: only known SORT_MAPPING keys are honored,
+    // any other value falls back to the safe default instead of being echoed.
+    const sortValue = SORT_MAPPING[sortType] ?? SORT_MAPPING.Newest;
+    params.append("sort", sortValue);
 
     return params.toString();
   }, [


### PR DESCRIPTION
## Fix: Sanitize Search/Filter Params Before Hitting the Backend (#11024)

### Problem
The event-listing page echoed user-supplied search, category, status, skill level, and tag values straight into the backend query string, and echoed an unknown `sortType` as-is — an injection/DoS surface (`$`, `&`, `<`, `>` characters and oversized input passed through unfiltered).

### Changes
- `src/Pages/Events/useEventListing.js`
  - Wired the purpose-built `sanitizeFilterQuery` (previously dead code in `utils/querySanitizer`) into `buildQueryParams` so every search/category/status/skillLevel/tag value has `$`, `&`, `<`, `>` stripped before entering the query string.
  - Capped the search term at 100 characters and each tag at 50 characters to reject oversized input.
  - `sortType` is now whitelist-guarded against `SORT_MAPPING`: only known keys are honored, anything else falls back to `Newest` instead of being echoed.

### Impact
User-controlled filter values can no longer smuggle special characters or oversized payloads into the backend request.

Closes #11024
