### PR TITLE
fix(events): persist and reserve selected seats on registration

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
 import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
+import com.sandeep.eventrabackend.dto.request.RegistrationRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.EventResponse;
@@ -300,14 +301,32 @@ public class EventController {
     public ResponseEntity<RegistrationResponse> registerForEvent(
             @Parameter(description = "ID of the event to register for")
             @PathVariable Long id,
+            @RequestBody(required = false) RegistrationRequest request,
             Authentication authentication) {
 
         String userEmail = authentication.getName();
+        String seatId = (request != null) ? request.getSeatId() : null;
 
         RegistrationResponse response =
-                eventService.registerUserForEvent(id, userEmail);
+                eventService.registerUserForEvent(id, userEmail, seatId);
 
         return ResponseEntity.ok(response);
+    }
+
+    // ── Issue #11025 — GET /api/events/{id}/seats ───────────────────────────
+
+    @GetMapping("/{id}/seats")
+    @Operation(
+            summary = "Get seats already reserved for an event",
+            description =
+                    "Returns the seat identifiers already reserved for the event, " +
+                    "used to derive live occupancy for the seat selector."
+    )
+    public ResponseEntity<List<String>> getOccupiedSeats(
+            @Parameter(description = "ID of the event")
+            @PathVariable Long id) {
+
+        return ResponseEntity.ok(eventService.getOccupiedSeats(id));
     }
 
     // ── Issue #2100 — DELETE /api/events/{id} ───────────────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/RegistrationRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/RegistrationRequest.java
@@ -1,0 +1,28 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Optional body accepted by {@code POST /api/events/{id}/register}.
+ * All fields are optional; the request is omitted entirely when no
+ * extra metadata (e.g. a selected seat) is provided.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Optional metadata sent when registering for an event")
+public class RegistrationRequest {
+
+    @Schema(
+            description = "Selected seat identifier (elementId:seatIndex) when the event offers seat selection.",
+            example = "table-1:3"
+    )
+    private String seatId;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrationResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrationResponse.java
@@ -50,4 +50,7 @@ public class RegistrationResponse {
     @Schema(description = "Registration confirmation status.", example = "CONFIRMED")
     @Builder.Default
     private String registrationStatus = "CONFIRMED";
+
+    @Schema(description = "Reserved seat identifier when the event supports seat selection.", example = "table-1:3")
+    private String seatId;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/EventRegistration.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/EventRegistration.java
@@ -8,10 +8,16 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
         name = "event_registrations",
-        uniqueConstraints = @UniqueConstraint(
-                name = "uk_event_registration_event_user",
-                columnNames = {"event_id", "user_id"}
-        )
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_event_registration_event_user",
+                        columnNames = {"event_id", "user_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_event_registration_event_seat",
+                        columnNames = {"event_id", "seat_id"}
+                )
+        }
 )
 public class EventRegistration {
 
@@ -33,6 +39,13 @@ public class EventRegistration {
 
     @Column(nullable = false, length = 30)
     private String status = "CONFIRMED";
+
+    /**
+     * Selected seat identifier (format {@code elementId:seatIndex}) when the
+     * event offers seat selection. Null when no seat was chosen.
+     */
+    @Column(name = "seat_id", length = 100)
+    private String seatId;
 
     public Long getId() {
         return id;
@@ -72,5 +85,13 @@ public class EventRegistration {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public String getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(String seatId) {
+        this.seatId = seatId;
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface EventRegistrationRepository extends JpaRepository<EventRegistration, Long> {
@@ -12,6 +13,10 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
     boolean existsByEvent_IdAndUser_Email(Long eventId, String userEmail);
 
     List<EventRegistration> findByUser_EmailOrderByRegisteredAtDesc(String userEmail);
+
+    Optional<EventRegistration> findByEvent_IdAndSeatId(Long eventId, String seatId);
+
+    List<EventRegistration> findByEvent_Id(Long eventId);
 
     void deleteByEventId(Long eventId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -235,13 +235,13 @@ public class EventService {
      * @return registration confirmation response
      */
     @Transactional
-    public RegistrationResponse registerUserForEvent(Long eventId, String userEmail) {
+    public RegistrationResponse registerUserForEvent(Long eventId, String userEmail, String seatId) {
 
         ObjectOptimisticLockingFailureException lastConflict = null;
 
         for (int attempt = 1; attempt <= MAX_REGISTRATION_RETRIES; attempt++) {
             try {
-                return executeRegistration(eventId, userEmail);
+                return executeRegistration(eventId, userEmail, seatId);
 
             } catch (ObjectOptimisticLockingFailureException ex) {
                 lastConflict = ex;
@@ -269,7 +269,8 @@ public class EventService {
 
     private RegistrationResponse executeRegistration(
             Long eventId,
-            String userEmail) {
+            String userEmail,
+            String seatId) {
 
         Event event = eventRepository.findByIdWithLock(eventId)
                 .orElseThrow(() ->
@@ -286,6 +287,14 @@ public class EventService {
 
             throw new RegistrationConflictException(
                     "You are already registered for this event.");
+        }
+
+        if (seatId != null && !seatId.isBlank()) {
+            eventRegistrationRepository.findByEvent_IdAndSeatId(eventId, seatId)
+                    .ifPresent(existing -> {
+                        throw new RegistrationConflictException(
+                                "Seat " + seatId + " is already taken.");
+                    });
         }
 
         if (event.getCapacity() != null
@@ -305,6 +314,7 @@ public class EventService {
         registration.setUser(user);
         registration.setRegisteredAt(LocalDateTime.now());
         registration.setStatus("CONFIRMED");
+        registration.setSeatId(seatId);
 
         registration = eventRegistrationRepository.save(registration);
 
@@ -322,7 +332,24 @@ public class EventService {
                 .registeredAt(registration.getRegisteredAt())
                 .spotsRemaining(spotsRemaining)
                 .registrationStatus(registration.getStatus())
+                .seatId(registration.getSeatId())
                 .build();
+    }
+
+    /**
+     * Returns the seat identifiers already reserved for an event, used by the
+     * seat selector to derive live, cross-browser occupancy.
+     *
+     * @param eventId ID of the event
+     * @return list of reserved seat identifiers (e.g. {@code table-1:3})
+     */
+    @Transactional(readOnly = true)
+    public List<String> getOccupiedSeats(Long eventId) {
+        return eventRegistrationRepository.findByEvent_Id(eventId)
+                .stream()
+                .map(EventRegistration::getSeatId)
+                .filter(seatId -> seatId != null && !seatId.isBlank())
+                .toList();
     }
 
     private MyRegisteredEventResponse toMyRegisteredEventResponse(

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -336,6 +336,12 @@ const EventRegistration = () => {
 
     const idempotencyKey = generateSecureUUID();
 
+    // The selected seat travels with the registration so the server can
+    // persist and atomically reserve it (format elementId:seatIndex).
+    const selectedSeatId = selectedSeat
+      ? `${selectedSeat.elementId}:${selectedSeat.seatIndex}`
+      : null;
+
     try {
       const response = await apiUtils.post(
         endpoint,
@@ -344,6 +350,7 @@ const EventRegistration = () => {
           priority: formData.priority,
           eventId: parseInt(eventId, 10),
           idempotencyKey,
+          seatId: selectedSeatId,
         },
         token
       );
@@ -371,6 +378,7 @@ const EventRegistration = () => {
           ...formData,
           eventId: parseInt(eventId, 10),
           idempotencyKey,
+          seatId: selectedSeatId,
         };
 
         const success = await pushToQueue(

--- a/src/components/events/SpatialSeatSelector.jsx
+++ b/src/components/events/SpatialSeatSelector.jsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import "./SpatialSeatSelector.css";
 import { safeJsonParse } from "utils/safeJsonParse";
+import { API_ENDPOINTS, apiUtils } from "config/api";
 
 // Fallback presets if no venue layout is stored yet
 const DEFAULT_PRESETS = {
@@ -51,7 +52,7 @@ const DEFAULT_PRESETS = {
       rotation: 0,
       seatsCount: 8,
       tier: "VIP Front Row",
-      assignedAttendees: { 0: "Amit Sharma", 1: "Priya Singh" },
+      assignedAttendees: {},
     },
     {
       id: "table-2",
@@ -64,7 +65,7 @@ const DEFAULT_PRESETS = {
       rotation: 0,
       seatsCount: 8,
       tier: "VIP Front Row",
-      assignedAttendees: { 2: "Rohit Verma", 3: "Neha Kapoor" },
+      assignedAttendees: {},
     },
     {
       id: "table-3",
@@ -142,6 +143,9 @@ const SpatialSeatSelector = ({
   const [zoom, setZoom] = useState(0.85);
   const [panOffset, setPanOffset] = useState({ x: 0, y: 0 });
   const [hoveredSeat, setHoveredSeat] = useState(null);
+  // Occupied seat keys ("elementId:seatIndex") loaded from the backend so
+  // occupancy is shared across browsers instead of per-browser localStorage.
+  const [occupiedSeats, setOccupiedSeats] = useState([]);
 
   const containerRef = useRef(null);
   const isDraggingRef = useRef(false);
@@ -190,6 +194,61 @@ const SpatialSeatSelector = ({
     }
     setElements(initialElements);
   }, [eventId]);
+
+  // Fetch reserved seats from the backend for real events. Skipped for the
+  // "default" fallback layout (e.g. virtual venue walkthrough) which has no
+  // event id. Best-effort: on failure the seat map still renders locally.
+  useEffect(() => {
+    if (!eventId || eventId === "default") return;
+    let isCancelled = false;
+    (async () => {
+      try {
+        const res = await apiUtils.get(
+          `${API_ENDPOINTS.EVENTS.DETAIL(eventId)}/seats`
+        );
+        if (isCancelled) return;
+        setOccupiedSeats(Array.isArray(res?.data) ? res.data : []);
+      } catch {
+        // Occupancy is best-effort; the layout remains usable without it.
+      }
+    })();
+    return () => {
+      isCancelled = true;
+    };
+  }, [eventId]);
+
+  // Map backend seat keys ("elementId:seatIndex") to their owning elements.
+  const occupiedSeatsByElement = useMemo(() => {
+    const map = new Map();
+    occupiedSeats.forEach((key) => {
+      if (typeof key !== "string") return;
+      const sep = key.lastIndexOf(":");
+      if (sep <= 0 || sep === key.length - 1) return;
+      const elId = key.slice(0, sep);
+      const idx = Number(key.slice(sep + 1));
+      if (!Number.isInteger(idx)) return;
+      if (!map.has(elId)) map.set(elId, new Set());
+      map.get(elId).add(idx);
+    });
+    return map;
+  }, [occupiedSeats]);
+
+  // Mark backend-reserved seats as occupied (anonymous) so all users see the
+  // same live occupancy instead of stale per-browser presets.
+  useEffect(() => {
+    if (!occupiedSeatsByElement.size) return;
+    setElements((prev) =>
+      prev.map((el) => {
+        const idxSet = occupiedSeatsByElement.get(el.id);
+        if (!idxSet || !idxSet.size) return el;
+        const assignedAttendees = { ...(el.assignedAttendees || {}) };
+        idxSet.forEach((idx) => {
+          if (idx >= 0 && idx < el.seatsCount) assignedAttendees[idx] = true;
+        });
+        return { ...el, assignedAttendees };
+      })
+    );
+  }, [occupiedSeatsByElement]);
 
   // Stable math projection function for seat coordinates
   const getSeatPositions = useCallback((el) => {


### PR DESCRIPTION
## Fix: Persist and Reserve Selected Seats on Registration (#11025)

### Problem
Seat selection was cosmetic: the chosen seat never traveled with the registration, occupancy came from hardcoded fake attendee names in `DEFAULT_PRESETS`, and there was no server-side reservation — two users could select the same seat.

### Changes

**Frontend**
- `src/Pages/Events/EventRegistration.js`: the selected seat (`seatId = elementId:seatIndex`) now travels with the registration POST body and the offline-queue payload.
- `src/components/events/SpatialSeatSelector.jsx`: on load it fetches reserved seats from the backend (`GET /api/events/{id}/seats`) and marks them occupied anonymously, so occupancy is shared across browsers; the hardcoded fake attendee names in `DEFAULT_PRESETS` are removed.

**Backend**
- `dto/request/RegistrationRequest.java` (new): optional `seatId` body for `POST /api/events/{id}/register`.
- `model/EventRegistration.java`: new nullable `seat_id` column plus a unique `(event_id, seat_id)` constraint so concurrent reservations fail atomically.
- `repository/EventRegistrationRepository.java`: `findByEvent_IdAndSeatId` and `findByEvent_Id` lookups.
- `service/EventService.java`: `registerUserForEvent` accepts and persists `seatId`, rejecting registration with `RegistrationConflictException` when the seat is already taken; `getOccupiedSeats` returns reserved seats.
- `controller/EventController.java`: registration endpoint accepts the request body; new `GET /api/events/{id}/seats` returns occupied seat ids.

### Impact
Selected seats are reserved atomically on the server, and every browser shows the same live occupancy.

Closes #11025