### PR TITLE
Fix/notificationbell badge sync 10923

### DIFF
--- a/src/components/notifications/NotificationBell.jsx
+++ b/src/components/notifications/NotificationBell.jsx
@@ -9,6 +9,16 @@ const NotificationBell = () => {
   const wrapperRef = useRef(null);
 
   useEffect(() => {
+    const handleStorage = (e) => {
+      if (e.key === "eventra_unread_count") {
+        setUnreadCount(parseInt(e.newValue || "0", 10));
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  useEffect(() => {
     if (!isOpen) return;
 
     const handleClickOutside = (event) => {


### PR DESCRIPTION
## Description
Fixes a state desynchronization issue where reading or clearing notifications in one browser tab did not update the `NotificationBell` badge count in other open tabs.
## Changes Made
- Added a `storage` window event listener in `NotificationBell` to listen for cross-tab notification updates and update unread count in real-time.
## Verification
- Opened two browser windows with the app.
- Marked notifications as read in window A and observed instantaneous badge update in window B.
-Fixes #10923