### PR TITLE
Feat/aria live regions 10927

### DIFF
--- a/src/components/notifications/NotificationBell.jsx
+++ b/src/components/notifications/NotificationBell.jsx
@@ -31,6 +31,7 @@ const NotificationBell = () => {
 
   return (
     <div className="relative" ref={wrapperRef}>
+      <div aria-live="polite" className="sr-only">{unreadCount > 0 ? `You have ${unreadCount} unread notifications` : ""}</div>
       <button
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}


### PR DESCRIPTION



## Description
Improves screen reader accessibility by announcing incoming notifications using ARIA live regions.
## Changes Made
- Added a screen-reader-only (`sr-only`) `div` with `aria-live="polite"` inside `NotificationBell` to announce updated unread counts to screen readers dynamically.
## Verification
- Inspected DOM tree for `aria-live="polite"` element.
- Verified accessibility state announcements when unread count changes.
Fixes #10927