### PR TITLE
Fix/keyboardshortcutshelp race condition 10921

### DIFF
--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -130,7 +130,7 @@ export const useKeyboardShortcuts = (shortcuts = {}, disabled = false) => {
         } else {
           const input = document.querySelector('nav input[type="text"], nav input[type="search"]') ||
                         document.querySelector('input[type="text"], input[type="search"]');
-          if (input) input.focus();
+          if (input) requestAnimationFrame(() => input.focus());
         }
         return;
       }
@@ -144,7 +144,7 @@ export const useKeyboardShortcuts = (shortcuts = {}, disabled = false) => {
         }
         const input = document.querySelector('nav input[type="text"], nav input[type="search"]') ||
                       document.querySelector('input[type="text"], input[type="search"]');
-        if (input) input.focus();
+        if (input) requestAnimationFrame(() => input.focus());
         return;
       }
 


### PR DESCRIPTION
## Description
Fixes a race condition where calling `.focus()` on search input elements immediately after triggered shortcuts failed due to DOM render timing.
## Changes Made
- Wrapped `.focus()` execution calls in `requestAnimationFrame()` inside `useKeyboardShortcuts` hook to ensure the element exists in the DOM before focus is requested.
## Verification
- Tested global search hotkeys (`/` and `Ctrl+K`).
- Verified focus reliably attaches to the target search input across frame renders.
Fixes #10921