### PR TITLE
feat(events): improve submit button accessibility during registration

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -1057,6 +1057,8 @@ const EventRegistration = () => {
                 <button
                   type="submit"
                   disabled={isPending || !isFormValid}
+                  aria-disabled={isPending || !isFormValid}
+                  aria-busy={isPending}
                   className="flex-1 px-6 py-3 bg-black text-white rounded-lg hover:bg-zinc-800 transition-all font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                   aria-label={t("eventRegistration.formSubmitAriaLabel")}
                 >


### PR DESCRIPTION
## Description

While working on #10228, I found that the duplicate submission prevention has already been implemented in the current codebase (`useActionState`, disabled submit button during pending state, and loading feedback).

This PR focuses on improving the accessibility of the existing implementation by:

- Added `aria-disabled` to expose the disabled state to assistive technologies.
- Added `aria-busy` to indicate that the registration request is in progress.

These changes are non-functional UI/accessibility improvements and do not alter the existing registration flow.