### PR TITLE
feat: native OS Web Share API integration

### DIFF
--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -8,6 +8,7 @@ import {
   Mail,
   MessageCircle,
   Send,
+  Share2,
   Twitter,
   X,
 } from "lucide-react";
@@ -31,6 +32,24 @@ const ShareModal = ({ isOpen, onClose, event }) => {
   const shareData = useMemo(() => {
     return createShareModalData(event);
   }, [event]);
+  const supportsWebShare = typeof navigator !== "undefined" && Boolean(navigator.share);
+
+  const shareViaSystem = useCallback(async () => {
+    if (!supportsWebShare || !shareData?.shareUrl) return;
+
+    try {
+      await navigator.share({
+        title: shareData.title,
+        text: shareData.description || shareData.shareText,
+        url: shareData.shareUrl,
+      });
+    } catch (error) {
+      if (error?.name === "AbortError") return;
+
+      console.error("Failed to share event via system share sheet:", error);
+      toast.error("Could not open system share");
+    }
+  }, [shareData, supportsWebShare]);
 
   const copyLink = useCallback(async () => {
     if (!shareData?.shareUrl) return;
@@ -111,6 +130,16 @@ const ShareModal = ({ isOpen, onClose, event }) => {
             </div>
 
             <div className="mt-6 grid grid-cols-2 gap-3">
+              {supportsWebShare ? (
+                <button
+                  type="button"
+                  onClick={shareViaSystem}
+                  aria-label="Share this event using your device's native share sheet"
+                  className="col-span-2 flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                >
+                  <Share2 size={16} /> Share via System
+                </button>
+              ) : null}
               <a href={shareData.links.twitter} target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2 rounded-xl bg-black px-4 py-3 text-sm font-medium text-white transition-all hover:bg-slate-800">
                 <Twitter size={16} /> Twitter/X
               </a>


### PR DESCRIPTION
Implemented the native OS Web Share API integration in `src/components/common/ShareModal.jsx`.

What changed:
- Added a `Share via System` button at the top of the share grid when `navigator.share` is available.
- Uses the event title, description/share text, and event URL from existing `shareData`.
- Ignores `AbortError` so users cancelling the native share sheet do not see an error toast.
- Shows an error toast only for actual share failures.

Closes #11059 