### PR TITLE
fix: handle missing survey answers in CSV export

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -142,7 +142,7 @@ export const exportSurveyToCSV = (questions, responses, surveyTitle = "Survey") 
   // Rows: Each anonymous attendee submission
   const rows = responses.map((resp) => [
     resp.timestamp || "",
-    ...questions.map((q) => resp.answers[q.id] ?? ""),
+    ...questions.map((q) => resp.answers?.[q.id] ?? ""),
   ]);
 
   const csvContent = [headers, ...rows]


### PR DESCRIPTION
# Summary

Fixes a runtime `TypeError` in the survey CSV exporter by safely handling survey responses that have a missing or `null` `answers` object. The exporter now falls back to an empty value instead of crashing during CSV generation.

## Related Issue

Fixes #11026

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Replaced direct access to `resp.answers[q.id]` with optional chaining.
- Added a fallback empty string for missing or null answers.
- Prevented runtime crashes during CSV export.
- Preserved the existing CSV output format for valid survey responses.

## Technical Details

### Frontend

- Updated `src/utils/exportCsv.js`.
- Changed:
  ```js
  resp.answers[q.id]
  ```
  to:
  ```js
  resp.answers?.[q.id] ?? ""
  ```

## Testing

### Manual Testing

- [x] Verified CSV export works with valid survey responses.
- [x] Verified CSV export succeeds when `answers` is `null`.
- [x] Verified CSV export succeeds when `answers` is missing.
- [x] Confirmed no runtime errors occur during export.
- [x] Verified exported CSV format remains unchanged for valid data.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Performed self-review of the changes.
- [x] No unrelated files or code changes are included.
- [x] Ready for review.