### PR TITLE
fix: remove duplicate handleClose declaration in Chatbot

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -285,13 +285,6 @@ export default function Chatbot() {
     setIsMinimized(false);
   };
 
-  const handleClose = useCallback(() => {
-    clearReplyTimer();
-    setIsTyping(false);
-    setIsOpen(false);
-    setIsMinimized(false);
-  }, [clearReplyTimer]);
-
   const handleMinimize = () => setIsMinimized((v) => !v);
 
   // ── Unified single portal rendering ─────────────────────────────────────────


### PR DESCRIPTION
# Summary

Removes the duplicate `handleClose` declaration from `Chatbot.jsx`, fixing a compile-time `SyntaxError` that prevented the application from building successfully.

## Related Issue

Fixes #11027

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Removed the duplicate `handleClose` declaration.
- Eliminated the duplicate identifier from the component scope.
- Restored successful application compilation.
- Preserved the existing chatbot close behavior.

## Technical Details

### Frontend

- Updated `src/components/Chatbot.jsx`.
- Removed the redundant `handleClose` callback declared later in the component.

## Testing

### Manual Testing

- [x] Verified the project builds successfully.
- [x] Verified `npm run dev` starts without compilation errors.
- [x] Verified the chatbot can still be opened and closed normally.
- [x] Confirmed no runtime or console errors were introduced.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Performed self-review of the changes.
- [x] No unrelated files or code changes are included.
- [x] Ready for review.