### PR TITLE
fix: normalize skills to empty array in EditProfile

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -87,7 +87,7 @@ const EditProfile = () => {
   const { user, setUser } = useAuth();
 
   // Initialize with fallback progression to prevent undefined fields
-  const [form, setForm] = useState(user ? { ...initialFormState, ...user } : initialFormState);
+  const [form, setForm] = useState(user ? { ...initialFormState, ...user, skills: user.skills || [] } : initialFormState);
 
   const [errors, setErrors] = useState({});
   const [loading, setLoading] = useState(false);
@@ -136,12 +136,12 @@ const EditProfile = () => {
           if (saved) {
             const parsed = safeJsonParse(saved, null);
             if (parsed) {
-              setForm(parsed);
+              setForm({ ...initialFormState, ...parsed, skills: parsed.skills || [] });
               return;
             }
           }
           if (user) {
-            setForm((prev) => ({ ...prev, ...user }));
+            setForm((prev) => ({ ...prev, ...user, skills: user.skills || [] }));
           }
         }
       } catch (error) {


### PR DESCRIPTION
# Summary

Fixes a runtime `TypeError` that occurred when editing a user profile with a missing or `null` `skills` array. The profile form now consistently normalizes the `skills` field to an empty array before it is used.

## Related Issue

Fixes #11029

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Normalized `skills` to an empty array during form initialization.
- Normalized `skills` when loading saved profile data.
- Normalized `skills` when updating the form from the authenticated user.
- Prevented runtime crashes caused by calling array methods on `null`.

## Technical Details

### Frontend

- Updated `src/components/user/EditProfile.js`.
- Added `skills: user.skills || []` and `skills: parsed.skills || []` to all form initialization paths.

## Testing

### Manual Testing

- [x] Verified editing a profile with `skills: null` no longer crashes.
- [x] Verified adding new skills works correctly.
- [x] Verified existing skills continue to load and edit properly.
- [x] Confirmed no new console or runtime errors were introduced.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Performed self-review of the changes.
- [x] No unrelated files or code changes are included.
- [x] Ready for review.