### PR TITLE
fix: prevent PollResultsList crash when poll has no votes

### DIFF
--- a/src/components/admin/LivePollController.jsx
+++ b/src/components/admin/LivePollController.jsx
@@ -32,7 +32,7 @@ function PollResultsList({ activePoll, totalVotes }) {
   return (
     <div className="flex flex-col gap-4">
       {activePoll.options.map((opt) => {
-        const votes = activePoll.results[opt] || 0;
+        const votes = activePoll.results?.[opt] || 0;
         const percentage = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
         return (
           <div key={opt} className="flex flex-col gap-1">


### PR DESCRIPTION
# Summary

Prevents `PollResultsList` from crashing when a newly created poll has no vote results by safely handling missing or undefined `results` data.

## Related Issue

Fixes #11032

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added a null-safe check when accessing `activePoll.results`.
- Defaulted vote counts to `0` when no results are available.
- Prevented runtime `TypeError` for newly created polls.
- Preserved existing vote calculation behavior.

## Technical Details

### Frontend

- Updated `src/components/admin/LivePollController.jsx`.
- Replaced direct property access with optional chaining when reading vote counts.

## Testing

### Manual Testing

- [x] Verified newly created polls with no votes render successfully.
- [x] Verified vote counts display `0` before any votes are received.
- [x] Verified polls with existing votes continue to display correct counts.
- [x] Confirmed no runtime errors occur when `results` is `undefined` or `null`.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes generate no new warnings or errors.
- [x] Performed self-review.
- [x] No unrelated files or code changes are included.
- [x] Ready for review.