### PR TITLE
fix(security): scope and encrypt waitlist cache, strip PII, purge on logout

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -320,7 +320,7 @@ const EventRegistration = () => {
       try {
         const { joinWaitlist, getQueuePosition } = await import("utils/waitlistUtils");
         await joinWaitlist(eventId, user, { ...formData, eventTitle: event?.title || "the event" });
-        const pos = getQueuePosition(eventId, user.id);
+        const pos = await getQueuePosition(eventId, user.id);
         toast.success(t("eventRegistration.toastWaitlistSuccess"));
         clearSession();
         return { success: true, error: null, waitlistPosition: pos };
@@ -458,7 +458,7 @@ const EventRegistration = () => {
           const isFull = await checkEventCapacity(eventId, event);
           if (isFull) {
             const { getGlobalWaitlist } = await import("utils/waitlistUtils");
-            const records = getGlobalWaitlist();
+            const records = await getGlobalWaitlist(user.id);
             const onWaitlist = records.some(
               (r) => r.userId === user.id && r.eventId === parseInt(eventId, 10) && r.status === "waiting"
             );

--- a/src/components/OrganizerWaitlistManagement.jsx
+++ b/src/components/OrganizerWaitlistManagement.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { toast } from 'react-toastify';
+import { useAuth } from 'context/AuthContext';
 import {
-  getEventWaitlist,
   syncWaitlistFromServer,
   organizerRemoveUser,
   promoteNextUser,
@@ -14,6 +14,7 @@ import {
  * Provides organizers with tools to manage event waitlists and auto-promotions
  */
 const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0, maxAttendees = 0 }) => {
+  const { user } = useAuth();
   const [waitlist, setWaitlist] = useState([]);
   const [analytics, setAnalytics] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -30,11 +31,10 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
 
   const loadWaitlistData = async () => {
     try {
-      await syncWaitlistFromServer(eventId);
-      const data = getEventWaitlist(eventId);
+      const data = await syncWaitlistFromServer(eventId, user?.id);
       setWaitlist(data);
 
-      const analyticsData = getWaitlistAnalytics(eventId);
+      const analyticsData = await getWaitlistAnalytics(eventId, user?.id);
       setAnalytics(analyticsData);
     } catch (error) {
       console.error('Failed to load waitlist data:', error);
@@ -54,7 +54,7 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
     setIsProcessing(true);
     try {
       const event = { id: eventId, title: eventName };
-      const promoted = await promoteNextUser(eventId, event);
+      const promoted = await promoteNextUser(eventId, event, user?.id);
 
       if (promoted) {
         toast.success(`${promoted.userName} has been promoted from the waitlist!`);
@@ -85,7 +85,7 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
         attendees: currentAttendees,
       };
 
-      const promotedCount = await handleCapacityIncrease(event, newCapacity);
+      const promotedCount = await handleCapacityIncrease(event, newCapacity, user?.id);
 
       if (promotedCount > 0) {
         toast.success(`${promotedCount} user(s) promoted from waitlist!`);
@@ -111,7 +111,7 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
     }
 
     try {
-      await organizerRemoveUser(eventId, userId);
+      await organizerRemoveUser(eventId, userId, user?.id);
       toast.success(`${userName} has been removed from the waitlist`);
       loadWaitlistData();
     } catch (error) {

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -141,13 +141,13 @@ const AdminDashboard = () => {
         getWaitlistAnalytics,
         syncWaitlistFromServer,
       }) => {
-        await syncWaitlistFromServer(eventId);
+        await syncWaitlistFromServer(eventId, user?.id);
         setWaitlistUsers(
-          getEventWaitlist(eventId)
+          await getEventWaitlist(eventId, user?.id)
         );
 
         setWaitlistAnalytics(
-          getWaitlistAnalytics(eventId)
+          await getWaitlistAnalytics(eventId, user?.id)
         );
       }
     )
@@ -155,7 +155,7 @@ const AdminDashboard = () => {
       setWaitlistUsers([]);
       setWaitlistAnalytics(null);
     });
-}, []);
+}, [user]);
 
   const openWaitlistModal = (event) => {
     setSelectedWaitlistEvent(event);
@@ -167,7 +167,7 @@ const AdminDashboard = () => {
     if (window.confirm("Are you sure you want to remove this user from the waitlist?")) {
       try {
         const { organizerRemoveUser } = await import("utils/waitlistUtils.js");
-        await organizerRemoveUser(selectedWaitlistEvent.id, userId);
+        await organizerRemoveUser(selectedWaitlistEvent.id, userId, user?.id);
         toast.success("User removed from waitlist.");
         loadWaitlist(selectedWaitlistEvent.id);
       } catch (err) {
@@ -195,7 +195,7 @@ const AdminDashboard = () => {
         attendees: selectedWaitlistEvent.attendees
       };
 
-      const promotedCount = await handleCapacityIncrease(updatedEvent, newCap);
+      const promotedCount = await handleCapacityIncrease(updatedEvent, newCap, user?.id);
 
       const cacheKey = `event_detail_${selectedWaitlistEvent.id}`;
       const raw = localStorage.getItem(cacheKey);

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -248,9 +248,8 @@ const WaitlistCard = memo(({ event, index, onLeaveWaitlist }) => {
   useEffect(() => {
     if (!user) return;
     import("utils/waitlistUtils")
-      .then(({ getQueuePosition }) => {
-        setQueuePos(getQueuePosition(event.id, user.id || user.email));
-      })
+      .then(({ getQueuePosition }) => getQueuePosition(event.id, user.id || user.email))
+      .then(setQueuePos)
       .catch(() => setQueuePos(-1));
   }, [event.id, user]);
 
@@ -444,8 +443,8 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
     setIsLoading(true);
     if (user) {
       import("utils/waitlistUtils.js")
-        .then(({ getGlobalWaitlist }) => {
-          const records = getGlobalWaitlist();
+        .then(async ({ getGlobalWaitlist }) => {
+          const records = await getGlobalWaitlist(user.id || user.email);
           const userId = user.id || user.email;
           const userWaitlists = records.filter(r => r.userId === userId && r.status === 'waiting');
           const resolved = userWaitlists.map(w => {
@@ -563,7 +562,7 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
     try {
       const { getGlobalWaitlist, saveGlobalWaitlist, leaveWaitlist } = await import("utils/waitlistUtils.js");
       const userId = user.id || user.email;
-      const records = getGlobalWaitlist();
+      const records = await getGlobalWaitlist(userId);
       const recordIndex = records.findIndex(
         (record) => String(record.eventId) === String(eventId) && record.userId === userId && record.status === "waiting"
       );
@@ -576,22 +575,22 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
           status: "removed",
           removedAt: new Date().toISOString(),
         };
-        saveGlobalWaitlist(optimisticRecords);
+        await saveGlobalWaitlist(optimisticRecords, userId);
       }
 
       triggerWaitlistUpdate();
       showUndoToast({
         message: `Left the waitlist for "${eventTitle}".`,
         toastId: `dashboard-leave-waitlist-${eventId}`,
-        onUndo: () => {
+        onUndo: async () => {
           if (!previousRecord) return;
-          const latest = getGlobalWaitlist();
+          const latest = await getGlobalWaitlist(userId);
           const restoreIndex = latest.findIndex(
             (record) => String(record.eventId) === String(eventId) && record.userId === userId
           );
           const restored = restoreIndex >= 0 ? [...latest] : [previousRecord, ...latest];
           if (restoreIndex >= 0) restored[restoreIndex] = previousRecord;
-          saveGlobalWaitlist(restored);
+          await saveGlobalWaitlist(restored, userId);
           triggerWaitlistUpdate();
         },
         onCommit: async () => {
@@ -599,9 +598,9 @@ const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
             await leaveWaitlist(eventId, userId);
           } catch (err) {
             if (previousRecord) {
-              const latest = getGlobalWaitlist();
+              const latest = await getGlobalWaitlist(userId);
               if (!latest.some((record) => String(record.eventId) === String(eventId) && record.userId === userId && record.status === "waiting")) {
-                saveGlobalWaitlist([previousRecord, ...latest]);
+                await saveGlobalWaitlist([previousRecord, ...latest], userId);
               }
               triggerWaitlistUpdate();
             }

--- a/src/components/user/WaitlistCard.jsx
+++ b/src/components/user/WaitlistCard.jsx
@@ -28,9 +28,8 @@ const WaitlistCard = memo(({ event, index, onLeaveWaitlist }) => {
   useEffect(() => {
     if (!user) return;
     import("utils/waitlistUtils")
-      .then(({ getQueuePosition }) => {
-        setQueuePos(getQueuePosition(event.id, user.id || user.email));
-      })
+      .then(({ getQueuePosition }) => getQueuePosition(event.id, user.id || user.email))
+      .then(setQueuePos)
       .catch(() => setQueuePos(-1));
   }, [event.id, user]);
 

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useCallback, useRef, use
 import { setOnUnauthorizedHandler, setRequiresReauthHandler, setAuthToken, apiUtils } from "../config/api.js";
 import { authService } from "../services/authService.js";
 import { syncSecureStorage } from "../utils/secureStorage.js";
+import { clearWaitlistCache } from "../utils/waitlistUtils.js";
 import { usePermissions, normalizeRoles } from "../hooks/usePermissions.js";
 import { useTokenExpiry } from "../hooks/useTokenExpiry.js";
 import { isTokenValid } from "../utils/tokenUtils.js";
@@ -90,6 +91,12 @@ export const AuthProvider = ({ children }) => {
   // Ref to track mounting status and prevent setting state on unmounted components
   const isMountedRef = useRef(true);
 
+  // Ref so session-clear flows can purge the current user's waitlist PII cache
+  const userIdRef = useRef(null);
+  useEffect(() => {
+    userIdRef.current = user?.id || user?.email || null;
+  }, [user]);
+
   // Ref to track whether session expired toast has already been displayed to prevent spamming
   const expiryToastShownRef = useRef(false);
 
@@ -121,6 +128,11 @@ export const AuthProvider = ({ children }) => {
 
     // Clear user metadata from secure/local storage manager
     syncSecureStorage.removeItem("user");
+
+    // Purge the current user's waitlist PII cache so it does not outlive the session
+    if (userIdRef.current) {
+      clearWaitlistCache(userIdRef.current);
+    }
     return true;
   }, []);
 

--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -3,6 +3,7 @@ import { safeJsonParse } from "./safeJsonParse.js";
 import { apiUtils, API_ENDPOINTS } from "../config/api.js";
 import { logger } from "./logger.js";
 import { getOrMigrateKey } from "./storageKeyManager.js";
+import { syncSecureStorage } from "./secureStorage.js";
 
 const GLOBAL_WAITLIST_KEY = "eventra_global_waitlists";
 const NOTIFICATION_INBOX_PREFIX = "eventra_notification_inbox";
@@ -31,6 +32,42 @@ const parseEventId = (eventId) => {
     );
   }
   return id;
+};
+
+/**
+ * Resolve the per-user storage key for the waitlist offline cache.
+ *
+ * The legacy key was a single unscoped, shared value (`eventra_global_waitlists`)
+ * that mixed every user's waitlist records in one place. The key is now scoped
+ * to the current user so a logged-in browser only ever holds the current
+ * user's own waitlist data. `getOrMigrateKey` migrates any legacy plaintext
+ * into the new scoped key once and then removes the legacy key.
+ *
+ * @param {string} userId - The current user id (falls back to email in the app).
+ * @returns {string} The user-scoped storage key.
+ */
+export const getWaitlistStorageKey = (userId) => {
+  return getOrMigrateKey("waitlists", userId, GLOBAL_WAITLIST_KEY);
+};
+
+/**
+ * Strip PII fields that must never be persisted to localStorage.
+ *
+ * The server remains the source of truth for contact details. The offline
+ * cache only needs enough data to render positions, status and timestamps, so
+ * emails and phone numbers are removed on every write. Combined with the
+ * AES-GCM encryption applied by `syncSecureStorage`, this ensures no contact
+ * PII can leak out of a localStorage read even when Web Crypto is unavailable.
+ *
+ * @param {Object} record - A raw waitlist record.
+ * @returns {Object} The record without `userEmail` / `phone` fields.
+ */
+const sanitizeRecord = (record) => {
+  if (!record || typeof record !== "object") return record;
+  const safe = { ...record };
+  delete safe.userEmail;
+  delete safe.phone;
+  return safe;
 };
 
 const getNotificationStorageKeys = (userId) => {
@@ -93,8 +130,8 @@ const getPositionMap = (waitlist) =>
     return positions;
   }, new Map());
 
-const notifyWaitlistPositionChanges = async (eventId, beforeWaitlist, eventOrTitle) => {
-  const afterWaitlist = getEventWaitlist(eventId);
+const notifyWaitlistPositionChanges = async (eventId, beforeWaitlist, eventOrTitle, cacheOwnerId) => {
+  const afterWaitlist = await getEventWaitlist(eventId, cacheOwnerId);
   if (!beforeWaitlist.length || !afterWaitlist.length) return;
 
   const previousPositions = getPositionMap(beforeWaitlist);
@@ -125,11 +162,25 @@ const notifyWaitlistPositionChanges = async (eventId, beforeWaitlist, eventOrTit
   );
 };
 
-// Retrieve all waitlist entries across all events and users
-export const getGlobalWaitlist = () => {
+// Retrieve the current user's waitlist entries across all events
+export const getGlobalWaitlist = async (userId) => {
   try {
-    const raw = localStorage.getItem(GLOBAL_WAITLIST_KEY);
-    return raw ? safeJsonParse(raw, []) : [];
+    const key = getWaitlistStorageKey(userId);
+    const stored = await syncSecureStorage.getItemAsync(key);
+    let records = stored ? safeJsonParse(stored, []) : [];
+    if (!Array.isArray(records)) records = [];
+
+    const sanitized = records.map(sanitizeRecord);
+
+    // One-time migration: if the scoped key still holds plaintext (copied over
+    // from the legacy unscoped key by getOrMigrateKey), re-encrypt the
+    // sanitized copy so no plaintext PII survives on disk.
+    const raw = syncSecureStorage.getItem(key);
+    if (raw !== null && !raw.includes('"version"')) {
+      await saveGlobalWaitlist(sanitized, userId);
+    }
+
+    return sanitized;
   } catch (err) {
     // localStorage throws SecurityError or QuotaExceededError — never HTTP errors.
     // Log and return empty array so the UI degrades gracefully.
@@ -138,10 +189,12 @@ export const getGlobalWaitlist = () => {
   }
 };
 
-// Persist waitlist entries globally (offline cache only)
-export const saveGlobalWaitlist = (records) => {
+// Persist the current user's waitlist entries (encrypted offline cache only)
+export const saveGlobalWaitlist = async (records, userId) => {
   try {
-    localStorage.setItem(GLOBAL_WAITLIST_KEY, JSON.stringify(records));
+    const key = getWaitlistStorageKey(userId);
+    const sanitized = (Array.isArray(records) ? records : []).map(sanitizeRecord);
+    await syncSecureStorage.setItem(key, JSON.stringify(sanitized));
   } catch (error) {
     if (error.name === 'QuotaExceededError') {
       throw error;
@@ -150,8 +203,26 @@ export const saveGlobalWaitlist = (records) => {
   }
 };
 
+/**
+ * Purge the current user's waitlist cache.
+ *
+ * Invoked on logout / session clear so waitlist PII does not outlive the
+ * session in the browser. Removal is synchronous and targeted to the
+ * user-scoped key.
+ *
+ * @param {string} userId - The user whose cache should be purged.
+ */
+export const clearWaitlistCache = (userId) => {
+  if (!userId) return;
+  try {
+    syncSecureStorage.removeItem(getWaitlistStorageKey(userId));
+  } catch (error) {
+    logger.error("[WaitlistUtils] Failed to clear waitlist cache:", error);
+  }
+};
+
 // Sync waitlist from server, falling back to localStorage cache
-export const syncWaitlistFromServer = async (eventId) => {
+export const syncWaitlistFromServer = async (eventId, cacheOwnerId) => {
   const id = parseEventId(eventId);
   try {
     const response = await apiUtils.get(`${API_ENDPOINTS.EVENTS.ALL}/${id}/waitlist`);
@@ -160,32 +231,32 @@ export const syncWaitlistFromServer = async (eventId) => {
         Array.isArray(response.data) ? response.data : response.data.entries || []
       ).map((r) => ({ ...r, eventId: parseInt(r.eventId, 10) }));
       // Reconcile: replace stale local records for this event with server state
-      const records = getGlobalWaitlist();
+      const records = await getGlobalWaitlist(cacheOwnerId);
       const reconciled = [
         ...records.filter((r) => r.eventId !== id),
         ...serverData,
       ];
-      saveGlobalWaitlist(reconciled);
+      await saveGlobalWaitlist(reconciled, cacheOwnerId);
       return serverData;
     }
   } catch {
     logger.warn("[WaitlistUtils] Server sync failed, using localStorage cache");
   }
-  return getEventWaitlist(id);
+  return getEventWaitlist(id, cacheOwnerId);
 };
 
 // Get waitlist entries for a specific event with 'waiting' status
-export const getEventWaitlist = (eventId) => {
+export const getEventWaitlist = async (eventId, userId) => {
   const id = parseEventId(eventId);
-  const records = getGlobalWaitlist();
+  const records = await getGlobalWaitlist(userId);
   return records
     .filter((r) => r.eventId === id && r.status === "waiting")
     .sort((a, b) => new Date(a.joinedAt) - new Date(b.joinedAt));
 };
 
 // Calculate queue position (1-indexed) for a user on a specific event
-export const getQueuePosition = (eventId, userId) => {
-  const eventWaitlist = getEventWaitlist(eventId);
+export const getQueuePosition = async (eventId, userId) => {
+  const eventWaitlist = await getEventWaitlist(eventId, userId);
   const index = eventWaitlist.findIndex((r) => r.userId === userId);
   return index !== -1 ? index + 1 : -1;
 };
@@ -266,9 +337,9 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
         joinedAt: new Date().toISOString(),
         status: "waiting",
       };
-      const records = getGlobalWaitlist();
+      const records = await getGlobalWaitlist(userId);
       records.push(newEntry);
-      saveGlobalWaitlist(records);
+      await saveGlobalWaitlist(records, userId);
       await addLocalNotification(
         "Waitlist Joined",
         `You have successfully joined the waitlist for ${registrationForm.eventTitle || "the event"}.`,
@@ -301,7 +372,7 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
     if (e.message.includes("already registered")) throw e;
   }
 
-  const records = getGlobalWaitlist();
+  const records = await getGlobalWaitlist(userId);
   const existing = records.find(
     (r) => r.userId === userId && r.eventId === id && r.status === "waiting"
   );
@@ -325,7 +396,7 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
   };
 
   records.push(newEntry);
-  saveGlobalWaitlist(records);
+  await saveGlobalWaitlist(records, userId);
 
   await addLocalNotification(
     "Waitlist Joined (Offline)",
@@ -339,29 +410,29 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
 // Leave waitlist - tries server first, falls back to localStorage
 export const leaveWaitlist = async (eventId, userId) => {
   const id = parseEventId(eventId);
-  const beforeWaitlist = getEventWaitlist(id);
+  const beforeWaitlist = await getEventWaitlist(id, userId);
 
   try {
     const response = await apiUtils.post(`${API_ENDPOINTS.EVENTS.ALL}/${id}/waitlist/leave`, { userId });
     if (response.ok) {
-      const records = getGlobalWaitlist();
+      const records = await getGlobalWaitlist(userId);
       const matchIndex = records.findIndex(
         (r) => r.userId === userId && r.eventId === id && r.status === "waiting"
       );
       if (matchIndex !== -1) {
         records[matchIndex].status = "removed";
         records[matchIndex].removedAt = new Date().toISOString();
-        saveGlobalWaitlist(records);
+        await saveGlobalWaitlist(records, userId);
       }
       await addLocalNotification("Left Waitlist", "You have left the waitlist.", { userId });
-      await notifyWaitlistPositionChanges(id, beforeWaitlist);
+      await notifyWaitlistPositionChanges(id, beforeWaitlist, undefined, userId);
       return true;
     }
   } catch {
     // Fall through to localStorage-only path
   }
 
-  const records = getGlobalWaitlist();
+  const records = await getGlobalWaitlist(userId);
   const matchIndex = records.findIndex(
     (r) => r.userId === userId && r.eventId === id && r.status === "waiting"
   );
@@ -370,22 +441,22 @@ export const leaveWaitlist = async (eventId, userId) => {
   }
   records[matchIndex].status = "removed";
   records[matchIndex].removedAt = new Date().toISOString();
-  saveGlobalWaitlist(records);
+  await saveGlobalWaitlist(records, userId);
   await addLocalNotification("Left Waitlist", "You have left the waitlist.", { userId });
-  await notifyWaitlistPositionChanges(id, beforeWaitlist);
+  await notifyWaitlistPositionChanges(id, beforeWaitlist, undefined, userId);
   return true;
 };
 
 // Helper to perform local waitlist status promotion and updates
-const performLocalPromotion = async (record, event) => {
-  const records = getGlobalWaitlist();
+const performLocalPromotion = async (record, event, cacheOwnerId) => {
+  const records = await getGlobalWaitlist(cacheOwnerId);
   const match = records.find(
     (r) => r.userId === record.userId && r.eventId === record.eventId && r.status === "waiting"
   );
   if (match) {
     match.status = "promoted";
     match.promotedAt = new Date().toISOString();
-    saveGlobalWaitlist(records);
+    await saveGlobalWaitlist(records, cacheOwnerId);
   }
   addRegistrationToUserStorage(record.userId, event);
   incrementEventAttendees(event.id);
@@ -400,14 +471,14 @@ const performLocalPromotion = async (record, event) => {
 // Mark a waitlist record as pending server sync (offline path).
 // The record stays "waiting" — a confirmed promotion is never fabricated, so
 // no fake registration or attendee count is created while offline.
-const markPromotionPendingSync = (record) => {
-  const records = getGlobalWaitlist();
+const markPromotionPendingSync = async (record, cacheOwnerId) => {
+  const records = await getGlobalWaitlist(cacheOwnerId);
   const match = records.find(
     (r) => r.userId === record.userId && r.eventId === record.eventId && r.status === "waiting"
   );
   if (match) {
     match.promotionPendingSync = true;
-    saveGlobalWaitlist(records);
+    await saveGlobalWaitlist(records, cacheOwnerId);
   }
   return !!match;
 };
@@ -424,19 +495,19 @@ const checkIfOffline = (error) => {
 };
 
 // Promote a specific record to a confirmed registration
-export const promoteRecord = async (record, event, options = {}) => {
+export const promoteRecord = async (record, event, options = {}, cacheOwnerId) => {
   const shouldNotifyPositionChanges = options.notifyPositionChanges !== false;
   const beforeWaitlist = shouldNotifyPositionChanges
-    ? getEventWaitlist(record.eventId)
+    ? await getEventWaitlist(record.eventId, cacheOwnerId)
     : [];
   try {
     const response = await apiUtils.post(`${API_ENDPOINTS.EVENTS.ALL}/${event.id}/waitlist/promote`, {
       userId: record.userId,
     });
     if (response.ok) {
-      const promoted = await performLocalPromotion(record, event);
+      const promoted = await performLocalPromotion(record, event, cacheOwnerId);
       if (promoted && shouldNotifyPositionChanges) {
-        await notifyWaitlistPositionChanges(record.eventId, beforeWaitlist, event);
+        await notifyWaitlistPositionChanges(record.eventId, beforeWaitlist, event, cacheOwnerId);
       }
       return true;
     }
@@ -451,7 +522,7 @@ export const promoteRecord = async (record, event, options = {}) => {
   // Offline: do not fabricate a confirmed promotion — the server never issued
   // a registration. Clearly mark the record as pending sync and report the
   // failure so the organizer can retry once the connection is restored.
-  markPromotionPendingSync(record);
+  await markPromotionPendingSync(record, cacheOwnerId);
   await addLocalNotification(
     "Waitlist Promotion Pending",
     `The promotion for "${event.title || "your event"}" is pending — it will complete once the connection is restored.`,
@@ -461,9 +532,9 @@ export const promoteRecord = async (record, event, options = {}) => {
 };
 
 // Promote the next user in queue when a spot opens up
-export const promoteNextUser = async (eventId, eventData = null) => {
+export const promoteNextUser = async (eventId, eventData = null, cacheOwnerId) => {
   const id = parseEventId(eventId);
-  const eventWaitlist = getEventWaitlist(id);
+  const eventWaitlist = await getEventWaitlist(id, cacheOwnerId);
   if (eventWaitlist.length === 0) return null;
 
   const nextUserRecord = eventWaitlist[0];
@@ -487,11 +558,11 @@ export const promoteNextUser = async (eventId, eventData = null) => {
     event = { id, title: "Event" };
   }
 
-  const success = await promoteRecord(nextUserRecord, event);
+  const success = await promoteRecord(nextUserRecord, event, {}, cacheOwnerId);
   if (!success) {
     return null;
   }
-  const updatedRecord = getGlobalWaitlist().find(
+  const updatedRecord = (await getGlobalWaitlist(cacheOwnerId)).find(
     (r) =>
       r.userId === nextUserRecord.userId &&
       r.eventId === nextUserRecord.eventId
@@ -501,56 +572,56 @@ export const promoteNextUser = async (eventId, eventData = null) => {
 };
 
 // Handle event capacity increase by promoting N users to confirmed attendees
-export const handleCapacityIncrease = async (event, newCapacity) => {
+export const handleCapacityIncrease = async (event, newCapacity, cacheOwnerId) => {
   const currentAttendees = Number(event.attendees || 0);
   const spotsToFill = newCapacity - currentAttendees;
   if (spotsToFill <= 0) return 0;
 
-  const eventWaitlist = getEventWaitlist(event.id);
+  const eventWaitlist = await getEventWaitlist(event.id, cacheOwnerId);
   const beforeWaitlist = [...eventWaitlist];
   const countToPromote = Math.min(spotsToFill, eventWaitlist.length);
 
   for (let i = 0; i < countToPromote; i++) {
-    await promoteRecord(eventWaitlist[i], event, { notifyPositionChanges: false });
+    await promoteRecord(eventWaitlist[i], event, { notifyPositionChanges: false }, cacheOwnerId);
   }
 
-  await notifyWaitlistPositionChanges(event.id, beforeWaitlist, event);
+  await notifyWaitlistPositionChanges(event.id, beforeWaitlist, event, cacheOwnerId);
 
   return countToPromote;
 };
 
 // Organizer action to manually remove a user
-export const organizerRemoveUser = async (eventId, userId) => {
+export const organizerRemoveUser = async (eventId, userId, cacheOwnerId) => {
   const id = parseEventId(eventId);
-  const beforeWaitlist = getEventWaitlist(id);
+  const beforeWaitlist = await getEventWaitlist(id, cacheOwnerId);
 
   try {
     const response = await apiUtils.post(`${API_ENDPOINTS.EVENTS.ALL}/${id}/waitlist/remove`, {
       userId,
     });
     if (response.ok) {
-      const records = getGlobalWaitlist();
+      const records = await getGlobalWaitlist(cacheOwnerId);
       const matchIndex = records.findIndex(
         (r) => r.userId === userId && r.eventId === id && r.status === "waiting"
       );
       if (matchIndex !== -1) {
         records[matchIndex].status = "removed_by_organizer";
         records[matchIndex].removedAt = new Date().toISOString();
-        saveGlobalWaitlist(records);
+        await saveGlobalWaitlist(records, cacheOwnerId);
       }
       await addLocalNotification(
         "Removed from Waitlist",
         `You have been removed from the waitlist for Event #${id} by the organizer.`,
         { userId }
       );
-      await notifyWaitlistPositionChanges(id, beforeWaitlist);
+      await notifyWaitlistPositionChanges(id, beforeWaitlist, undefined, cacheOwnerId);
       return true;
     }
   } catch {
     // Fall through to localStorage-only path
   }
 
-  const records = getGlobalWaitlist();
+  const records = await getGlobalWaitlist(cacheOwnerId);
   const matchIndex = records.findIndex(
     (r) => r.userId === userId && r.eventId === id && r.status === "waiting"
   );
@@ -561,22 +632,22 @@ export const organizerRemoveUser = async (eventId, userId) => {
 
   records[matchIndex].status = "removed_by_organizer";
   records[matchIndex].removedAt = new Date().toISOString();
-  saveGlobalWaitlist(records);
+  await saveGlobalWaitlist(records, cacheOwnerId);
 
   await addLocalNotification(
     "Removed from Waitlist",
     `You have been removed from the waitlist for Event #${id} by the organizer.`,
     { userId }
   );
-  await notifyWaitlistPositionChanges(id, beforeWaitlist);
+  await notifyWaitlistPositionChanges(id, beforeWaitlist, undefined, cacheOwnerId);
 
   return true;
 };
 
 // Waitlist Analytics
-export const getWaitlistAnalytics = (eventId) => {
+export const getWaitlistAnalytics = async (eventId, cacheOwnerId) => {
   const id = parseEventId(eventId);
-  const records = getGlobalWaitlist();
+  const records = await getGlobalWaitlist(cacheOwnerId);
 
   const eventRecords = records.filter(
     (record) => record.eventId === id

--- a/src/utils/waitlistUtils.test.js
+++ b/src/utils/waitlistUtils.test.js
@@ -7,12 +7,22 @@ import {
   promoteNextUser,
   handleCapacityIncrease,
   getGlobalWaitlist,
+  getWaitlistStorageKey,
 } from "./waitlistUtils";
 
 // idb-keyval is async; stub it so the test environment doesn't need IndexedDB
-jest.mock("idb-keyval", () => ({
-  get: jest.fn().mockResolvedValue(null),
-  set: jest.fn().mockResolvedValue(undefined),
+vi.mock("idb-keyval", () => ({
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined),
+}));
+
+// apiUtils must fail fast so offline fallback paths are exercised
+vi.mock("../config/api.js", () => ({
+  apiUtils: {
+    get: vi.fn().mockRejectedValue({ isNetworkError: true }),
+    post: vi.fn().mockRejectedValue({ isNetworkError: true }),
+  },
+  API_ENDPOINTS: { EVENTS: { ALL: "/api/events" } },
 }));
 
 const GLOBAL_KEY = "eventra_global_waitlists";
@@ -28,8 +38,8 @@ const makeEntry = (overrides = {}) => ({
   ...overrides,
 });
 
-const seedWaitlist = (entries) => {
-  localStorage.setItem(GLOBAL_KEY, JSON.stringify(entries));
+const seedWaitlist = (entries, userId = "u1") => {
+  localStorage.setItem(getWaitlistStorageKey(userId), JSON.stringify(entries));
 };
 
 const makeUser = (overrides = {}) => ({
@@ -41,17 +51,17 @@ const makeUser = (overrides = {}) => ({
 
 beforeEach(() => {
   localStorage.clear();
-  jest.spyOn(console, "error").mockImplementation(() => {});
-  jest.spyOn(console, "warn").mockImplementation(() => {});
-  jest.spyOn(window, "dispatchEvent").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(window, "dispatchEvent").mockImplementation(() => {});
 });
 
 afterEach(() => {
-  jest.restoreAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("getEventWaitlist", () => {
-  it("returns waiting entries sorted by joinedAt for a valid numeric id", () => {
+  it("returns waiting entries sorted by joinedAt for a valid numeric id", async () => {
     const t1 = new Date(Date.now() - 2000).toISOString();
     const t2 = new Date(Date.now() - 1000).toISOString();
     seedWaitlist([
@@ -59,63 +69,65 @@ describe("getEventWaitlist", () => {
       makeEntry({ eventId: 42, joinedAt: t1, userId: "u1" }),
       makeEntry({ eventId: 99, joinedAt: t1, userId: "u3" }),
     ]);
-    const result = getEventWaitlist(42);
+    const result = await getEventWaitlist(42, "u1");
     expect(result).toHaveLength(2);
     expect(result[0].userId).toBe("u1"); // earlier joinedAt comes first
     expect(result[1].userId).toBe("u2");
   });
 
-  it("accepts a numeric string and coerces it correctly", () => {
+  it("accepts a numeric string and coerces it correctly", async () => {
     seedWaitlist([makeEntry({ eventId: 42 })]);
-    expect(getEventWaitlist("42")).toHaveLength(1);
+    expect(await getEventWaitlist("42", "u1")).toHaveLength(1);
   });
 
-  it("excludes entries that are not in 'waiting' status", () => {
+  it("excludes entries that are not in 'waiting' status", async () => {
     seedWaitlist([
       makeEntry({ status: "promoted" }),
       makeEntry({ status: "removed" }),
       makeEntry({ status: "waiting" }),
     ]);
-    expect(getEventWaitlist(42)).toHaveLength(1);
+    expect(await getEventWaitlist(42, "u1")).toHaveLength(1);
   });
 
-  it("throws TypeError for null eventId instead of silently returning []", () => {
+  it("throws TypeError for null eventId instead of silently returning []", async () => {
     seedWaitlist([makeEntry()]);
-    expect(() => getEventWaitlist(null)).toThrow(TypeError);
-    expect(() => getEventWaitlist(null)).toThrow(/Invalid eventId/);
+    await expect(getEventWaitlist(null, "u1")).rejects.toThrow(TypeError);
+    await expect(getEventWaitlist(null, "u1")).rejects.toThrow(/Invalid eventId/);
   });
 
-  it("throws TypeError for undefined eventId", () => {
-    expect(() => getEventWaitlist(undefined)).toThrow(TypeError);
+  it("throws TypeError for undefined eventId", async () => {
+    await expect(getEventWaitlist(undefined, "u1")).rejects.toThrow(TypeError);
   });
 
-  it("throws TypeError for a non-numeric string", () => {
-    expect(() => getEventWaitlist("abc")).toThrow(TypeError);
+  it("throws TypeError for a non-numeric string", async () => {
+    await expect(getEventWaitlist("abc", "u1")).rejects.toThrow(TypeError);
   });
 
-  it("throws TypeError for an empty string", () => {
-    expect(() => getEventWaitlist("")).toThrow(TypeError);
+  it("throws TypeError for an empty string", async () => {
+    await expect(getEventWaitlist("", "u1")).rejects.toThrow(TypeError);
   });
 
-  it("returns [] when no matching entries exist (empty waitlist)", () => {
+  it("returns [] when no matching entries exist (empty waitlist)", async () => {
     seedWaitlist([makeEntry({ eventId: 99 })]);
-    expect(getEventWaitlist(42)).toEqual([]);
+    expect(await getEventWaitlist(42, "u1")).toEqual([]);
   });
 });
 
 describe("getQueuePosition", () => {
-  it("returns 1-based position for the first user in queue", () => {
+  it("returns 1-based position for the first user in queue", async () => {
     seedWaitlist([
       makeEntry({ userId: "u1", joinedAt: new Date(1000).toISOString() }),
       makeEntry({ userId: "u2", joinedAt: new Date(2000).toISOString() }),
-    ]);
-    expect(getQueuePosition(42, "u1")).toBe(1);
-    expect(getQueuePosition(42, "u2")).toBe(2);
+    ], "u2");
+    expect(await getQueuePosition(42, "u2")).toBe(2);
+
+    seedWaitlist([makeEntry({ userId: "u1", joinedAt: new Date(1000).toISOString() })], "u1");
+    expect(await getQueuePosition(42, "u1")).toBe(1);
   });
 
-  it("returns -1 for a user not on the waitlist", () => {
+  it("returns -1 for a user not on the waitlist", async () => {
     seedWaitlist([makeEntry()]);
-    expect(getQueuePosition(42, "unknown")).toBe(-1);
+    expect(await getQueuePosition(42, "unknown")).toBe(-1);
   });
 });
 
@@ -150,7 +162,7 @@ describe("leaveWaitlist", () => {
     seedWaitlist([makeEntry()]);
     const result = await leaveWaitlist(42, "u1");
     expect(result).toBe(true);
-    const stored = getGlobalWaitlist();
+    const stored = await getGlobalWaitlist("u1");
     expect(stored[0].status).toBe("removed");
   });
 
@@ -169,20 +181,21 @@ describe("leaveWaitlist", () => {
 describe("organizerRemoveUser", () => {
   it("sets status to removed for a valid entry", async () => {
     seedWaitlist([makeEntry()]);
-    const result = await organizerRemoveUser(42, "u1");
+    const result = await organizerRemoveUser(42, "u1", "u1");
     expect(result).toBe(true);
-    expect(getGlobalWaitlist()[0].status).toBe("removed");
+    // apiUtils is mocked to fail → offline fallback marks removed_by_organizer
+    expect((await getGlobalWaitlist("u1"))[0].status).toBe("removed_by_organizer");
   });
 
   it("throws when user is not in the active waitlist", async () => {
     seedWaitlist([]);
-    await expect(organizerRemoveUser(42, "u1")).rejects.toThrow(
+    await expect(organizerRemoveUser(42, "u1", "u1")).rejects.toThrow(
       "not in the active waitlist"
     );
   });
 
   it("throws TypeError for invalid eventId", async () => {
-    await expect(organizerRemoveUser(undefined, "u1")).rejects.toThrow(
+    await expect(organizerRemoveUser(undefined, "u1", "u1")).rejects.toThrow(
       TypeError
     );
   });
@@ -213,7 +226,35 @@ describe("handleCapacityIncrease", () => {
     ]);
     const event = { id: 42, attendees: 8, title: "Test Event" };
     // newCapacity=10 → 2 spots, waitlist has 2 → promotes 2
-    const promoted = await handleCapacityIncrease(event, 10);
+    const promoted = await handleCapacityIncrease(event, 10, "u1");
     expect(promoted).toBe(2);
+  });
+});
+
+describe("PII protection & per-user scoping", () => {
+  it("does not persist userEmail or phone to localStorage", async () => {
+    seedWaitlist([makeEntry({ userEmail: "alice@example.com", phone: "12345" })]);
+    const records = await getGlobalWaitlist("u1");
+    expect(records[0].userEmail).toBeUndefined();
+    expect(records[0].phone).toBeUndefined();
+    // The raw bytes on disk must not contain the contact PII either
+    const raw = localStorage.getItem(getWaitlistStorageKey("u1"));
+    expect(raw).not.toContain("alice@example.com");
+    expect(raw).not.toContain("12345");
+  });
+
+  it("scopes the cache per user", async () => {
+    seedWaitlist([makeEntry({ userId: "u1" })], "u1");
+    seedWaitlist([makeEntry({ userId: "u2" })], "u2");
+    expect(await getEventWaitlist(42, "u1")).toHaveLength(1);
+    const u1Records = await getGlobalWaitlist("u1");
+    expect(u1Records.some((r) => r.userId === "u2")).toBe(false);
+  });
+
+  it("migrates legacy unscoped data into the per-user key and removes the legacy key", async () => {
+    localStorage.setItem(GLOBAL_KEY, JSON.stringify([makeEntry()]));
+    const records = await getGlobalWaitlist("u1");
+    expect(records).toHaveLength(1);
+    expect(localStorage.getItem(GLOBAL_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
The global waitlist cache (`eventra_global_waitlists`) stored plaintext PII
(`userEmail`, `phone`) in `localStorage` under a single unscoped key shared by
every user on the device. This PR scopes the cache per authenticated user,
encrypts it at rest, strips PII on every write, and purges it on logout.

## Changes
- `src/utils/waitlistUtils.js`
  - Per-user storage key via `getOrMigrateKey("waitlists", userId, GLOBAL_WAITLIST_KEY)`.
  - Reads/writes routed through `syncSecureStorage` (AES-GCM, plaintext fallback
    only when Web Crypto is unavailable).
  - `sanitizeRecord` deletes `userEmail`/`phone` on every write.
  - `clearWaitlistCache(userId)` exported; legacy unscoped data is migrated into
    the per-user key and the legacy key is removed.
  - Storage API is now async; all read/mutation helpers accept the owning
    `userId`/`cacheOwnerId`.
- `src/context/AuthContext.js` — purges the waitlist cache in `clearSession`.
- Consumers updated to await and pass `user?.id`:
  `EventsTab.js`, `WaitlistCard.jsx`, `EventRegistration.js`,
  `AdminDashboard.js`, `OrganizerWaitlistManagement.jsx`.
- `src/utils/waitlistUtils.test.js` — converted to vitest; PII-stripping,
  per-user scoping, and legacy-key migration covered.

## Verification
- `npx vitest run src/utils/waitlistUtils.test.js` → 27/27 pass.
- ESLint: 0 errors on all changed files.

Closes #11076