### PR TITLE
fix(security): enforce opaque ticket QR payload in scanner

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -201,6 +201,20 @@ export default function TicketScanner() {
     let ticketData = null;
     try {
       ticketData = JSON.parse(decodedText);
+      // SECURITY (Issue #11073): only accept opaque, server-issued ticket
+      // tokens ({ ticketId }) that carry no forgeable claims. Any other JSON
+      // shape — e.g. {"ticketId":"x","userName":"Guest","role":"ADMIN"} — is
+      // rejected and routed to the same flagged path as a malformed QR.
+      const opaqueKeys = Object.keys(ticketData || {});
+      if (
+        !ticketData ||
+        typeof ticketData !== "object" ||
+        Array.isArray(ticketData) ||
+        opaqueKeys.length !== 1 ||
+        opaqueKeys[0] !== "ticketId"
+      ) {
+        throw new Error("Opaque ticket token required");
+      }
     } catch {
       if (decodedText.startsWith("eyJ") && decodedText.split(".").length === 3) {
         const activeEvent = events.find(e => String(e.id) === String(selectedEventId));


### PR DESCRIPTION
## Summary
The ticket scanner accepted any JSON object containing a `ticketId` field. Per
the opaque-QR security model (server-issued token only), a forged payload such
as `{"ticketId":"x","eventId":"<target>","userName":"Guest"}` was accepted —
carrying forgeable claims. Offline scans already report `queued` (not
`verified`); this PR hardens the format check so only genuinely opaque tokens
are accepted.

## Changes
- `src/components/admin/TicketScanner.jsx`
  - After `JSON.parse`, the payload must be exactly `{ ticketId }`:
    - non-object / array / any payload with extra keys is rejected with the
      existing flagged path ("Only secure Eventra ticket QR codes are
      accepted").
  - Legacy JWT-serial tickets (`eyJ...` three-segment) continue to be handled
    by the existing fallback branch.

## Verification
- ESLint: 0 errors.
- Existing `TicketScanner.test.jsx` (camera lifecycle) unaffected.

Closes #11073