### PR TITLE
fix(security): dedupe offline check-ins per ticket, not per operator 

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -327,21 +327,39 @@ export const pushToQueue = async (item, userId = null) => {
     return false;
   }
   const isDuplicate = queue.some((existing) => {
-  if (actionItem.idempotencyKey && existing.idempotencyKey) {
-    return existing.idempotencyKey === actionItem.idempotencyKey;
-  }
+    if (actionItem.idempotencyKey && existing.idempotencyKey) {
+      return existing.idempotencyKey === actionItem.idempotencyKey;
+    }
 
-  return (
-    existing.eventId === actionItem.eventId &&
-    existing.userId === actionItem.userId &&
-    existing.actionType === actionItem.actionType
-  );
-});
+    // SECURITY (Issue #11074): offline check-ins must dedupe per attendee
+    // ticket, not per operator. Every offline scan for the same event shares
+    // the same eventId + operator userId + actionType, so the generic key
+    // below would collapse the second and every later attendee into the first
+    // item and they would never be synced.
+    if (actionItem.actionType === "TICKET_CHECK_IN") {
+      return (
+        existing.actionType === "TICKET_CHECK_IN" &&
+        existing.eventId === actionItem.eventId &&
+        Boolean(actionItem.payload?.ticketId) &&
+        existing.payload?.ticketId === actionItem.payload?.ticketId
+      );
+    }
+
+    return (
+      existing.eventId === actionItem.eventId &&
+      existing.userId === actionItem.userId &&
+      existing.actionType === actionItem.actionType
+    );
+  });
 
 if (isDuplicate) {
+  const identity =
+    actionItem.actionType === "TICKET_CHECK_IN"
+      ? `ticket ${actionItem.payload?.ticketId}`
+      : `user ${actionItem.userId}`;
   logger.warn(
     `[OfflineQueue] Duplicate action detected for event ${actionItem.eventId} ` +
-      `(user ${actionItem.userId}, type ${actionItem.actionType}). Skipping enqueue.`
+      `(${identity}, type ${actionItem.actionType}). Skipping enqueue.`
   );
   return true;
 }
@@ -414,7 +432,12 @@ export const setQueue = async (newQueue) => {
           return;
         }
 
-        try {\n          newQueue.forEach((item) => store.put(item));\n        } catch (err) {\n          if (err.name === "QuotaExceededError") logger.error("[OfflineQueue] IndexedDB quota exceeded during setQueue", err);\n          throw err;\n        }
+        try {
+          newQueue.forEach((item) => store.put(item));
+        } catch (err) {
+          if (err.name === "QuotaExceededError") logger.error("[OfflineQueue] IndexedDB quota exceeded during setQueue", err);
+          throw err;
+        }
 
         tx.oncomplete = () => resolve();
         tx.onerror = (e) => reject(e.target?.error || new Error('IndexedDB transaction failed'));

--- a/tests/offlineQueue.test.mjs
+++ b/tests/offlineQueue.test.mjs
@@ -160,6 +160,52 @@ assert.deepEqual(
   "validateQueueSession() still rejects stale session snapshots"
 );
 
+// ── TICKET_CHECK_IN dedupe (Issue #11074) ───────────────────────────────────
+// Offline check-ins for the same event share the same eventId + operator
+// userId + actionType, so they must dedupe per attendee ticket — never per
+// operator — otherwise every attendee after the first is silently dropped.
+reset();
+await pushToQueue(
+  {
+    actionType: "TICKET_CHECK_IN",
+    eventId: "evt-checkin",
+    endpoint: "/api/tickets/checkin",
+    payload: { ticketId: "ticket-1" },
+  },
+  "operator-1"
+);
+assert.equal(getQueue().length, 1, "first offline check-in is queued");
+
+await pushToQueue(
+  {
+    actionType: "TICKET_CHECK_IN",
+    eventId: "evt-checkin",
+    endpoint: "/api/tickets/checkin",
+    payload: { ticketId: "ticket-2" },
+  },
+  "operator-1"
+);
+assert.equal(
+  getQueue().length,
+  2,
+  "second attendee for the same event is queued, not collapsed as a duplicate"
+);
+
+await pushToQueue(
+  {
+    actionType: "TICKET_CHECK_IN",
+    eventId: "evt-checkin",
+    endpoint: "/api/tickets/checkin",
+    payload: { ticketId: "ticket-1" },
+  },
+  "operator-1"
+);
+assert.equal(
+  getQueue().length,
+  2,
+  "re-scanning the same ticket is still deduped to a single queue item"
+);
+
 reset();
 localStorage.setItem(
   "eventra_offline_queue",


### PR DESCRIPTION
## Summary
Queued `TICKET_CHECK_IN` items now carry an `endpoint` and the operator's
`userId` (from #10933), but the generic dedupe key
`(eventId, userId, actionType)` still collapsed every offline scan of the same
event by the same operator into a single item — the second and every later
attendee was silently dropped and never synced.

## Changes
- `src/utils/offlineQueue.js`
  - `pushToQueue` dedupe now special-cases `TICKET_CHECK_IN`: items are treated
    as duplicates only when `eventId` **and** `payload.ticketId` both match, so
    distinct attendees for the same event are all queued and replayed while
    re-scanning the same ticket is still deduped.
  - Duplicate log message now reports the ticket identity for check-ins.
  - Also fixed a pre-existing source corruption in `setQueue` (literal `\n`
    inside the `try` block) that made the module unparseable and kept
    `tests/offlineQueue.test.mjs` from loading.
- `tests/offlineQueue.test.mjs`
  - Added regression tests: two different tickets by the same operator for the
    same event both queue; re-scanning the same ticket stays deduped.

## Verification
- `node --test tests/offlineQueue.test.mjs` → all pass.
- ESLint: 0 errors.

Closes #11074