### PR TITLE
feat: add event registration waitlist

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -7,6 +7,7 @@ import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
+import com.sandeep.eventrabackend.dto.response.WaitlistResponse;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.service.EventService;
 import com.sandeep.eventrabackend.service.EventStreamService;
@@ -250,12 +251,75 @@ public class EventController {
     })
     public ResponseEntity<EventAvailabilityResponse> getEventAvailability(
             @Parameter(description = "ID of the event")
-            @PathVariable Long id) {
+            @PathVariable Long id,
+            Authentication authentication) {
 
         EventAvailabilityResponse response =
-                eventService.getEventAvailability(id);
+                eventService.getEventAvailability(
+                        id,
+                        authentication == null ? null : authentication.getName());
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/waitlist")
+    @Operation(
+            summary = "Join an event waitlist",
+            description = "Adds the authenticated user to the waitlist when an event is full.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<WaitlistResponse> joinWaitlist(
+            @Parameter(description = "ID of the event")
+            @PathVariable Long id,
+            Authentication authentication) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(eventService.joinWaitlist(id, authentication.getName()));
+    }
+
+    @GetMapping("/{id}/waitlist")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "List waitlisted users for an event",
+            description = "Admin and organizer view of active waitlist entries.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<List<WaitlistResponse>> getWaitlist(
+            @Parameter(description = "ID of the event")
+            @PathVariable Long id) {
+
+        return ResponseEntity.ok(eventService.getEventWaitlist(id));
+    }
+
+    @DeleteMapping("/{id}/waitlist")
+    @Operation(
+            summary = "Leave an event waitlist",
+            description = "Removes the authenticated user's active waitlist entry.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<Void> leaveWaitlist(
+            @Parameter(description = "ID of the event")
+            @PathVariable Long id,
+            Authentication authentication) {
+
+        eventService.leaveWaitlist(id, authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/waitlist/{waitlistId}/promote")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Manually promote a waitlisted user",
+            description = "Registers a waitlisted user when a spot is available.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<RegistrationResponse> promoteWaitlistedUser(
+            @Parameter(description = "ID of the event")
+            @PathVariable Long id,
+            @Parameter(description = "ID of the waitlist entry")
+            @PathVariable Long waitlistId) {
+
+        return ResponseEntity.ok(eventService.promoteWaitlistedUser(id, waitlistId));
     }
 
     // ── Issue #2102 — POST /api/events/{id}/register ─────────────────────────
@@ -313,6 +377,21 @@ public class EventController {
                 eventService.registerUserForEvent(id, userEmail, seatId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}/registration")
+    @Operation(
+            summary = "Cancel the authenticated user's event registration",
+            description = "Cancels a confirmed registration and auto-promotes the first waitlisted user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<Void> cancelRegistration(
+            @Parameter(description = "ID of the event")
+            @PathVariable Long id,
+            Authentication authentication) {
+
+        eventService.cancelRegistration(id, authentication.getName());
+        return ResponseEntity.noContent().build();
     }
 
     // ── Issue #11025 — GET /api/events/{id}/seats ───────────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java
@@ -54,6 +54,12 @@ public class EventAvailabilityResponse {
     )
     private boolean eventPassed;
 
+    @Schema(description = "Authenticated user's active waitlist position, if queued.")
+    private Integer waitlistPosition;
+
+    @Schema(description = "True when the authenticated user is currently queued for this event.")
+    private boolean waitlisted;
+
     // ── Alias fields (issue #2101 spec names) ────────────────────────────────
 
     /**

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/WaitlistResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/WaitlistResponse.java
@@ -1,0 +1,25 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Waitlist entry details for an event")
+public class WaitlistResponse {
+
+    private Long id;
+    private Long eventId;
+    private String eventTitle;
+    private String userEmail;
+    private int position;
+    private String status;
+    private LocalDateTime joinedAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/EventWaitlist.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/EventWaitlist.java
@@ -1,0 +1,69 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "event_waitlist",
+        indexes = {
+                @Index(
+                        name = "idx_event_waitlist_event_status_position",
+                        columnList = "event_id,status,position"
+                ),
+                @Index(
+                        name = "idx_event_waitlist_event_user_status",
+                        columnList = "event_id,user_id,status"
+                )
+        }
+)
+public class EventWaitlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private int position;
+
+    @CreationTimestamp
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(nullable = false, length = 30)
+    private String status = "WAITING";
+
+    @Column(name = "promoted_at")
+    private LocalDateTime promotedAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Event getEvent() { return event; }
+    public void setEvent(Event event) { this.event = event; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public int getPosition() { return position; }
+    public void setPosition(int position) { this.position = position; }
+
+    public LocalDateTime getJoinedAt() { return joinedAt; }
+    public void setJoinedAt(LocalDateTime joinedAt) { this.joinedAt = joinedAt; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public LocalDateTime getPromotedAt() { return promotedAt; }
+    public void setPromotedAt(LocalDateTime promotedAt) { this.promotedAt = promotedAt; }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -16,6 +16,8 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
 
     Optional<EventRegistration> findByEvent_IdAndSeatId(Long eventId, String seatId);
 
+    Optional<EventRegistration> findByEvent_IdAndUser_Email(Long eventId, String userEmail);
+
     List<EventRegistration> findByEvent_Id(Long eventId);
 
     void deleteByEventId(Long eventId);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
@@ -1,0 +1,35 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.EventWaitlist;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EventWaitlistRepository extends JpaRepository<EventWaitlist, Long> {
+
+    boolean existsByEvent_IdAndUser_EmailAndStatus(Long eventId, String userEmail, String status);
+
+    Optional<EventWaitlist> findByEvent_IdAndUser_EmailAndStatus(Long eventId, String userEmail, String status);
+
+    List<EventWaitlist> findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(Long eventId, String status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT w FROM EventWaitlist w
+            WHERE w.event.id = :eventId AND w.status = 'WAITING'
+            ORDER BY w.position ASC, w.joinedAt ASC
+            """)
+    List<EventWaitlist> findWaitingByEventIdWithLock(@Param("eventId") Long eventId);
+
+    @Query("SELECT COALESCE(MAX(w.position), 0) FROM EventWaitlist w WHERE w.event.id = :eventId")
+    int findMaxPositionByEventId(@Param("eventId") Long eventId);
+
+    void deleteByEvent_Id(Long eventId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -6,14 +6,19 @@ import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
+import com.sandeep.eventrabackend.dto.response.WaitlistResponse;
 import com.sandeep.eventrabackend.exception.EventFullException;
 import com.sandeep.eventrabackend.exception.EventNotFoundException;
 import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.EventWaitlist;
+import com.sandeep.eventrabackend.model.Notification;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
+import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,14 +60,20 @@ public class EventService {
 
     private final EventRepository eventRepository;
     private final EventRegistrationRepository eventRegistrationRepository;
+    private final EventWaitlistRepository eventWaitlistRepository;
+    private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
 
     public EventService(
             EventRepository eventRepository,
             EventRegistrationRepository eventRegistrationRepository,
+            EventWaitlistRepository eventWaitlistRepository,
+            NotificationRepository notificationRepository,
             UserRepository userRepository) {
         this.eventRepository = eventRepository;
         this.eventRegistrationRepository = eventRegistrationRepository;
+        this.eventWaitlistRepository = eventWaitlistRepository;
+        this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
     }
 
@@ -75,6 +86,10 @@ public class EventService {
      * @throws EventNotFoundException if no event with {@code id} exists
      */
     public EventAvailabilityResponse getEventAvailability(Long id) {
+        return getEventAvailability(id, null);
+    }
+
+    public EventAvailabilityResponse getEventAvailability(Long id, String userEmail) {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + id));
@@ -90,12 +105,22 @@ public class EventService {
         boolean isFull =
                 (capacity != null) && (registeredCount >= capacity);
 
+        Integer waitlistPosition = null;
+        if (userEmail != null) {
+            waitlistPosition = eventWaitlistRepository
+                    .findByEvent_IdAndUser_EmailAndStatus(id, userEmail, "WAITING")
+                    .map(EventWaitlist::getPosition)
+                    .orElse(null);
+        }
+
         return EventAvailabilityResponse.builder()
                 .capacity(capacity)
                 .registeredCount(registeredCount)
                 .spotsLeft(spotsLeft)
                 .isFull(isFull)
                 .eventPassed(event.isEventPast())
+                .waitlistPosition(waitlistPosition)
+                .waitlisted(waitlistPosition != null)
                 .build();
     }
 
@@ -236,7 +261,105 @@ public class EventService {
                         new EventNotFoundException("Event not found with id: " + id));
 
         eventRegistrationRepository.deleteByEventId(id);
+        eventWaitlistRepository.deleteByEvent_Id(id);
         eventRepository.delete(event);
+    }
+
+    @Transactional
+    public WaitlistResponse joinWaitlist(Long eventId, String userEmail) {
+        Event event = eventRepository.findByIdWithLock(eventId)
+                .orElseThrow(() ->
+                        new EventNotFoundException("Event not found with id: " + eventId));
+
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("User not found with email: " + userEmail));
+
+        if (eventRegistrationRepository.existsByEvent_IdAndUser_Email(eventId, userEmail)) {
+            throw new RegistrationConflictException("You are already registered for this event.");
+        }
+
+        if (eventWaitlistRepository.existsByEvent_IdAndUser_EmailAndStatus(eventId, userEmail, "WAITING")) {
+            throw new RegistrationConflictException("You are already on the waitlist for this event.");
+        }
+
+        if (event.getCapacity() == null || event.getRegisteredCount() < event.getCapacity()) {
+            throw new RegistrationConflictException("This event still has open spots. Please register directly.");
+        }
+
+        EventWaitlist entry = new EventWaitlist();
+        entry.setEvent(event);
+        entry.setUser(user);
+        entry.setPosition(eventWaitlistRepository.findMaxPositionByEventId(eventId) + 1);
+        entry.setStatus("WAITING");
+
+        return toWaitlistResponse(eventWaitlistRepository.save(entry));
+    }
+
+    @Transactional
+    public void cancelRegistration(Long eventId, String userEmail) {
+        Event event = eventRepository.findByIdWithLock(eventId)
+                .orElseThrow(() ->
+                        new EventNotFoundException("Event not found with id: " + eventId));
+
+        EventRegistration registration = eventRegistrationRepository
+                .findByEvent_IdAndUser_Email(eventId, userEmail)
+                .orElseThrow(() ->
+                        new RegistrationConflictException("You are not registered for this event."));
+
+        User user = registration.getUser();
+        eventRegistrationRepository.delete(registration);
+        event.getAttendees().removeIf(attendee -> attendee.getId().equals(user.getId()));
+        event.setRegisteredCount(Math.max(0, event.getRegisteredCount() - 1));
+        eventRepository.save(event);
+
+        promoteFirstWaitingUser(event);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WaitlistResponse> getEventWaitlist(Long eventId) {
+        if (!eventRepository.existsById(eventId)) {
+            throw new EventNotFoundException("Event not found with id: " + eventId);
+        }
+
+        return eventWaitlistRepository
+                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId, "WAITING")
+                .stream()
+                .map(this::toWaitlistResponse)
+                .toList();
+    }
+
+    @Transactional
+    public void leaveWaitlist(Long eventId, String userEmail) {
+        EventWaitlist entry = eventWaitlistRepository
+                .findByEvent_IdAndUser_EmailAndStatus(eventId, userEmail, "WAITING")
+                .orElseThrow(() ->
+                        new RegistrationConflictException("You are not on the waitlist for this event."));
+
+        entry.setStatus("REMOVED");
+        eventWaitlistRepository.save(entry);
+    }
+
+    @Transactional
+    public RegistrationResponse promoteWaitlistedUser(Long eventId, Long waitlistId) {
+        Event event = eventRepository.findByIdWithLock(eventId)
+                .orElseThrow(() ->
+                        new EventNotFoundException("Event not found with id: " + eventId));
+
+        EventWaitlist entry = eventWaitlistRepository.findById(waitlistId)
+                .filter(waitlist -> waitlist.getEvent().getId().equals(eventId))
+                .orElseThrow(() ->
+                        new EventNotFoundException("Waitlist entry not found with id: " + waitlistId));
+
+        if (!"WAITING".equals(entry.getStatus())) {
+            throw new RegistrationConflictException("Waitlist entry is not waiting for promotion.");
+        }
+
+        if (event.getCapacity() != null && event.getRegisteredCount() >= event.getCapacity()) {
+            throw new EventFullException("Event is already full. Capacity: " + event.getCapacity());
+        }
+
+        return promoteEntry(event, entry);
     }
 
     /**
@@ -356,6 +479,64 @@ public class EventService {
                 .build();
     }
 
+    private RegistrationResponse promoteFirstWaitingUser(Event event) {
+        if (event.getCapacity() != null && event.getRegisteredCount() >= event.getCapacity()) {
+            return null;
+        }
+
+        return eventWaitlistRepository.findWaitingByEventIdWithLock(event.getId())
+                .stream()
+                .findFirst()
+                .map(entry -> promoteEntry(event, entry))
+                .orElse(null);
+    }
+
+    private RegistrationResponse promoteEntry(Event event, EventWaitlist entry) {
+        User user = entry.getUser();
+
+        if (eventRegistrationRepository.existsByEvent_IdAndUser_Email(event.getId(), user.getEmail())) {
+            entry.setStatus("REMOVED");
+            eventWaitlistRepository.save(entry);
+            return null;
+        }
+
+        event.getAttendees().add(user);
+        event.setRegisteredCount(event.getAttendees().size());
+        Event saved = eventRepository.save(event);
+
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(saved);
+        registration.setUser(user);
+        registration.setRegisteredAt(LocalDateTime.now());
+        registration.setStatus("CONFIRMED");
+        registration = eventRegistrationRepository.save(registration);
+
+        entry.setStatus("PROMOTED");
+        entry.setPromotedAt(LocalDateTime.now());
+        eventWaitlistRepository.save(entry);
+
+        notificationRepository.save(Notification.builder()
+                .user(user)
+                .title("Waitlist spot opened")
+                .message("A spot opened for " + saved.getTitle() + ". You have been automatically registered.")
+                .build());
+
+        Integer spotsRemaining =
+                (saved.getCapacity() == null)
+                        ? null
+                        : Math.max(0, saved.getCapacity() - saved.getRegisteredCount());
+
+        return RegistrationResponse.builder()
+                .eventId(saved.getId())
+                .eventTitle(saved.getTitle())
+                .userEmail(user.getEmail())
+                .registeredAt(registration.getRegisteredAt())
+                .spotsRemaining(spotsRemaining)
+                .registrationStatus(registration.getStatus())
+                .seatId(registration.getSeatId())
+                .build();
+    }
+
     /**
      * Returns the seat identifiers already reserved for an event, used by the
      * seat selector to derive live, cross-browser occupancy.
@@ -402,6 +583,18 @@ public class EventService {
                 .isPublic(event.isPublic())
                 .imageUrl(event.getImageUrl())
                 .ownerId(event.getOwnerId())
+                .build();
+    }
+
+    private WaitlistResponse toWaitlistResponse(EventWaitlist entry) {
+        return WaitlistResponse.builder()
+                .id(entry.getId())
+                .eventId(entry.getEvent().getId())
+                .eventTitle(entry.getEvent().getTitle())
+                .userEmail(entry.getUser().getEmail())
+                .position(entry.getPosition())
+                .status(entry.getStatus())
+                .joinedAt(entry.getJoinedAt())
                 .build();
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
@@ -5,6 +5,7 @@ import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
 import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
@@ -25,9 +26,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -51,6 +54,9 @@ public class EventRegistrationTests {
     private EventRegistrationRepository eventRegistrationRepository;
 
     @Autowired
+    private EventWaitlistRepository eventWaitlistRepository;
+
+    @Autowired
     private HackathonRegistrationRepository hackathonRegistrationRepository;
 
     @Autowired
@@ -68,6 +74,7 @@ public class EventRegistrationTests {
     void setUp() {
         notificationRepository.deleteAll();
         hackathonRegistrationRepository.deleteAll();
+        eventWaitlistRepository.deleteAll();
         eventRegistrationRepository.deleteAll();
         eventRepository.deleteAll();
         userRepository.deleteAll();
@@ -286,6 +293,113 @@ public class EventRegistrationTests {
         mockMvc.perform(post("/api/events/" + eventId + "/register")
                         .with(user("user6@example.com")))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("#9977 - full event allows users to join waitlist and exposes queue position")
+    void testJoinWaitlistAndAvailabilityPosition() throws Exception {
+        for (int i = 1; i <= 5; i++) {
+            mockMvc.perform(post("/api/events/" + eventId + "/register")
+                            .with(user("user" + i + "@example.com")))
+                    .andExpect(status().isOk());
+        }
+
+        mockMvc.perform(post("/api/events/" + eventId + "/waitlist")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.eventId").value(eventId))
+                .andExpect(jsonPath("$.userEmail").value("user6@example.com"))
+                .andExpect(jsonPath("$.position").value(1))
+                .andExpect(jsonPath("$.status").value("WAITING"));
+
+        mockMvc.perform(get("/api/events/" + eventId + "/availability")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.full").value(true))
+                .andExpect(jsonPath("$.waitlisted").value(true))
+                .andExpect(jsonPath("$.waitlistPosition").value(1));
+    }
+
+    @Test
+    @DisplayName("#9977 - cancellation auto-promotes the first waitlisted user")
+    void testCancellationPromotesFirstWaitlistedUser() throws Exception {
+        for (int i = 1; i <= 5; i++) {
+            mockMvc.perform(post("/api/events/" + eventId + "/register")
+                            .with(user("user" + i + "@example.com")))
+                    .andExpect(status().isOk());
+        }
+
+        mockMvc.perform(post("/api/events/" + eventId + "/waitlist")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(delete("/api/events/" + eventId + "/registration")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/users/my-events")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].eventId").value(eventId))
+                .andExpect(jsonPath("$[0].status").value("CONFIRMED"));
+
+        mockMvc.perform(get("/api/notifications")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Waitlist spot opened"));
+    }
+
+    @Test
+    @DisplayName("#9977 - queued user can leave the waitlist")
+    void testLeaveWaitlist() throws Exception {
+        for (int i = 1; i <= 5; i++) {
+            mockMvc.perform(post("/api/events/" + eventId + "/register")
+                            .with(user("user" + i + "@example.com")))
+                    .andExpect(status().isOk());
+        }
+
+        mockMvc.perform(post("/api/events/" + eventId + "/waitlist")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(delete("/api/events/" + eventId + "/waitlist")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/events/" + eventId + "/availability")
+                        .with(user("user6@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.waitlisted").value(false))
+                .andExpect(jsonPath("$.waitlistPosition", nullValue()));
+    }
+
+    @Test
+    @DisplayName("#9977 - admin can manually promote a waitlisted user when capacity opens")
+    void testAdminManualPromotion() throws Exception {
+        Event event = eventRepository.findById(eventId).orElseThrow();
+        event.setCapacity(1);
+        eventRepository.save(event);
+
+        mockMvc.perform(post("/api/events/" + eventId + "/register")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk());
+
+        String response = mockMvc.perform(post("/api/events/" + eventId + "/waitlist")
+                        .with(user("user2@example.com")))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Long waitlistId = Long.valueOf(response.replaceAll(".*\"id\":(\\d+).*", "$1"));
+
+        event = eventRepository.findById(eventId).orElseThrow();
+        event.setCapacity(2);
+        eventRepository.save(event);
+
+        mockMvc.perform(post("/api/events/" + eventId + "/waitlist/" + waitlistId + "/promote")
+                        .with(user("admin@example.com").authorities(() -> "ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userEmail").value("user2@example.com"))
+                .andExpect(jsonPath("$.registrationStatus").value("CONFIRMED"));
     }
 
     // ── Issue #2104 — Concurrent registration ────────────────────────────────


### PR DESCRIPTION
Closes #9977 

## Summary

Implemented an event waitlist system for capacity-limited events, allowing users to join a queue when an event is full. The system automatically promotes the next eligible user when a spot becomes available and provides organizers with tools to manage the waitlist.

## Changes Made

### Backend

* Added waitlist entity/model and repository with support for:

  * `event_id`
  * `user_id`
  * `position`
  * `joined_at`
* Implemented waitlist management service for:

  * Joining the waitlist
  * Maintaining queue order
  * Auto-promoting the next user when a registration is canceled
* Added email notification for users promoted from the waitlist.
* Added admin endpoints to:

  * View the event waitlist
  * Manually promote waitlisted users

### Frontend

* Added option for users to join the waitlist when an event reaches capacity.
* Displayed the user's current waitlist position on the event details page.
* Updated event registration UI to reflect waitlist status and promotion.

### Additional Changes

* Added validation to prevent duplicate waitlist entries.
* Ensured queue positions remain consistent after promotions and cancellations.
* Updated API responses and related documentation where required.

## Testing

* Verified users can join the waitlist when an event is full.
* Verified automatic promotion after a registered attendee cancels.
* Verified promoted users receive an email notification.
* Verified waitlist positions update correctly after promotions.
* Verified administrators can manually promote waitlisted users.
