### PR TITLE
fix: enforce owner-based authorization for hackathon updates

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -124,8 +124,9 @@ public class HackathonController {
             )
     })
     public ResponseEntity<HackathonResponse> createHackathon(
-            @Valid @RequestBody HackathonCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.createHackathon(request));
+            @Valid @RequestBody HackathonCreateRequest request,
+            Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.createHackathon(request, authentication.getName()));
     }
 
     @PutMapping("/{id}")
@@ -175,8 +176,9 @@ public class HackathonController {
     public ResponseEntity<HackathonResponse> updateHackathon(
             @Parameter(description = "ID of the hackathon to update")
             @PathVariable Long id,
-            @Valid @RequestBody HackathonUpdateRequest request) {
-        return ResponseEntity.ok(hackathonService.updateHackathon(id, request));
+            @Valid @RequestBody HackathonUpdateRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(hackathonService.updateHackathon(id, request, authentication.getName()));
     }
 
     @GetMapping

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonResponse.java
@@ -47,4 +47,7 @@ public class HackathonResponse {
 
     @Schema(description = "URL to the hackathon's promotional image", example = "https://example.com/hackathon.png")
     private String imageUrl;
+
+    @Schema(description = "ID of the user who owns/created this hackathon", example = "10")
+    private Long ownerId;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Hackathon.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Hackathon.java
@@ -42,4 +42,7 @@ public class Hackathon {
     private LocalDateTime registrationDeadline;
 
     private String imageUrl;
+
+    @Column(name = "owner_id")
+    private Long ownerId;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -14,6 +14,8 @@ import com.sandeep.eventrabackend.repository.HackathonRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.security.access.AccessDeniedException;
+import com.sandeep.eventrabackend.model.Role;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -50,7 +52,9 @@ public class HackathonService {
     }
 
     @Transactional
-    public HackathonResponse createHackathon(HackathonCreateRequest request) {
+    public HackathonResponse createHackathon(HackathonCreateRequest request, String userEmail) {
+        User creator = userRepository.findByEmail(userEmail).orElse(null);
+
         Hackathon hackathon = Hackathon.builder()
                 .title(request.getTitle())
                 .description(request.getDescription())
@@ -62,6 +66,7 @@ public class HackathonService {
                 .prizePool(request.getPrizePool())
                 .registrationDeadline(request.getRegistrationDeadline())
                 .imageUrl(request.getImageUrl())
+                .ownerId(creator != null ? creator.getId() : null)
                 .build();
 
         Hackathon saved = hackathonRepository.save(hackathon);
@@ -69,9 +74,19 @@ public class HackathonService {
     }
 
     @Transactional
-    public HackathonResponse updateHackathon(Long id, com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest request) {
+    public HackathonResponse updateHackathon(Long id, com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest request, String userEmail) {
         Hackathon hackathon = hackathonRepository.findById(id)
                 .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
+
+        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
+
+        if (currentUser != null) {
+            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
+            if (!isAdmin && hackathon.getOwnerId() != null && !hackathon.getOwnerId().equals(currentUser.getId())) {
+                throw new AccessDeniedException(
+                        "Only the hackathon's own organizer (or an administrator) can manage this hackathon.");
+            }
+        }
 
         hackathon.setTitle(request.getTitle());
         hackathon.setDescription(request.getDescription());
@@ -146,6 +161,7 @@ public class HackathonService {
                 .prizePool(hackathon.getPrizePool())
                 .registrationDeadline(hackathon.getRegistrationDeadline())
                 .imageUrl(hackathon.getImageUrl())
+                .ownerId(hackathon.getOwnerId())
                 .build();
     }
 }


### PR DESCRIPTION
# Summary

Implements object-level authorization for hackathon creation and updates by associating each hackathon with its creator and validating ownership before allowing modifications.

## Related Issue

Fixes #11115

## Changes Implemented

- Added ownership tracking for hackathons using an `ownerId` field.
- Passed the authenticated user's identity to the hackathon creation flow.
- Passed the authenticated user's identity to the update flow.
- Updated the service layer to validate ownership before allowing updates.
- Included owner information in the response model where required.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/model/Hackathon.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonResponse.java`

## Testing

### Manual Testing

- [x] Verified hackathon creation stores the authenticated owner.
- [x] Verified owners can successfully update their own hackathons.
- [x] Verified ownership information is persisted correctly.
- [x] Verified the application builds successfully after the changes.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] Ready for review.