### PR TITLE
fix: enforce owner authorization for waitlist promotion

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -317,9 +317,10 @@ public class EventController {
             @Parameter(description = "ID of the event")
             @PathVariable Long id,
             @Parameter(description = "ID of the waitlist entry")
-            @PathVariable Long waitlistId) {
+            @PathVariable Long waitlistId,
+            Authentication authentication) {
 
-        return ResponseEntity.ok(eventService.promoteWaitlistedUser(id, waitlistId));
+        return ResponseEntity.ok(eventService.promoteWaitlistedUser(id, waitlistId, authentication.getName()));
     }
 
     // ── Issue #2102 — POST /api/events/{id}/register ─────────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -17,6 +17,7 @@ import com.sandeep.eventrabackend.model.Notification;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
@@ -341,10 +342,19 @@ public class EventService {
     }
 
     @Transactional
-    public RegistrationResponse promoteWaitlistedUser(Long eventId, Long waitlistId) {
+    public RegistrationResponse promoteWaitlistedUser(Long eventId, Long waitlistId, String userEmail) {
         Event event = eventRepository.findByIdWithLock(eventId)
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + eventId));
+
+        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
+        if (currentUser != null) {
+            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
+            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
+                throw new AccessDeniedException(
+                        "Only the event's own organizer (or an administrator) can manage this event.");
+            }
+        }
 
         EventWaitlist entry = eventWaitlistRepository.findById(waitlistId)
                 .filter(waitlist -> waitlist.getEvent().getId().equals(eventId))


### PR DESCRIPTION
# Summary

Implements object-level authorization for waitlist promotions by verifying that the authenticated organizer owns the target event before allowing waitlisted users to be promoted.

## Related Issue

Fixes #11116

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Passed the authenticated user's identity from the controller to the service layer.
- Added ownership validation before promoting waitlisted users.
- Allowed administrators (`ADMIN` and `SUPER_ADMIN`) to bypass ownership validation.
- Rejected unauthorized organizers with `AccessDeniedException`.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

### Manual Testing

- [x] Verified event owners can successfully promote users from their own event's waitlist.
- [x] Verified organizers cannot promote users from events they do not own.
- [x] Verified `ADMIN` and `SUPER_ADMIN` users can promote waitlisted users regardless of ownership.
- [x] Verified existing waitlist promotion functionality continues to work correctly for authorized users.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] Ready for review.