### PR TITLE
fix: enforce owner authorization for event waitlist access

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -317,9 +317,10 @@ public class EventController {
             @Parameter(description = "ID of the event")
             @PathVariable Long id,
             @Parameter(description = "ID of the waitlist entry")
-            @PathVariable Long waitlistId) {
+            @PathVariable Long waitlistId,
+            Authentication authentication) {
 
-        return ResponseEntity.ok(eventService.promoteWaitlistedUser(id, waitlistId));
+        return ResponseEntity.ok(eventService.promoteWaitlistedUser(id, waitlistId, authentication.getName()));
     }
 
     // ── Issue #2102 — POST /api/events/{id}/register ─────────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -286,9 +286,10 @@ public class EventController {
     )
     public ResponseEntity<List<WaitlistResponse>> getWaitlist(
             @Parameter(description = "ID of the event")
-            @PathVariable Long id) {
+            @PathVariable Long id,
+            Authentication authentication) {
 
-        return ResponseEntity.ok(eventService.getEventWaitlist(id));
+        return ResponseEntity.ok(eventService.getEventWaitlist(id, authentication.getName()));
     }
 
     @DeleteMapping("/{id}/waitlist")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -17,6 +17,7 @@ import com.sandeep.eventrabackend.model.Notification;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
@@ -341,10 +342,19 @@ public class EventService {
     }
 
     @Transactional
-    public RegistrationResponse promoteWaitlistedUser(Long eventId, Long waitlistId) {
+    public RegistrationResponse promoteWaitlistedUser(Long eventId, Long waitlistId, String userEmail) {
         Event event = eventRepository.findByIdWithLock(eventId)
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + eventId));
+
+        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
+        if (currentUser != null) {
+            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
+            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
+                throw new AccessDeniedException(
+                        "Only the event's own organizer (or an administrator) can manage this event.");
+            }
+        }
 
         EventWaitlist entry = eventWaitlistRepository.findById(waitlistId)
                 .filter(waitlist -> waitlist.getEvent().getId().equals(eventId))

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -318,9 +318,17 @@ public class EventService {
     }
 
     @Transactional(readOnly = true)
-    public List<WaitlistResponse> getEventWaitlist(Long eventId) {
-        if (!eventRepository.existsById(eventId)) {
-            throw new EventNotFoundException("Event not found with id: " + eventId);
+    public List<WaitlistResponse> getEventWaitlist(Long eventId, String userEmail) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+
+        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
+        if (currentUser != null) {
+            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
+            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
+                throw new AccessDeniedException(
+                        "Only the event's own organizer (or an administrator) can view this waitlist.");
+            }
         }
 
         return eventWaitlistRepository


### PR DESCRIPTION
# Summary

Implements object-level authorization for event waitlist retrieval by ensuring only the event owner or administrators can access waitlist data.

## Related Issue

Fixes #11117

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Passed the authenticated user's identity from the controller to the service layer.
- Added ownership validation before returning event waitlist entries.
- Allowed `ADMIN` and `SUPER_ADMIN` users to bypass ownership validation.
- Prevented unauthorized organizers from accessing attendee waitlist information by throwing `AccessDeniedException`.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

### Manual Testing

- [x] Verified event owners can retrieve their own event waitlists.
- [x] Verified unrelated organizers are denied access to other organizers' waitlists.
- [x] Verified `ADMIN` and `SUPER_ADMIN` users can access all event waitlists.
- [x] Verified authorized waitlist retrieval continues to function correctly.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] Ready for review.