### PR TITLE
fix: restrict analytics endpoints to authorized roles

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
@@ -6,6 +6,7 @@ import com.sandeep.eventrabackend.dto.OrganizerInsightDTO;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
 import com.sandeep.eventrabackend.service.AnalyticsService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,6 +16,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/analytics")
+@PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
 public class AnalyticsController {
 
     private final AnalyticsService analyticsService;


### PR DESCRIPTION
# Summary

Restricts analytics endpoints to authorized management roles by adding class-level authorization to the analytics controller.

## Related Issue

Fixes #11119

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added class-level `@PreAuthorize` authorization to the `AnalyticsController`.
- Restricted analytics endpoints to users with `ADMIN`, `SUPER_ADMIN`, or `ORGANIZER` authority.
- Prevented regular authenticated users from accessing operational analytics.
- Applied authorization consistently across all controller endpoints.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java`

## Testing

### Manual Testing

- [x] Verified users with the `ADMIN` role can access analytics endpoints.
- [x] Verified users with the `SUPER_ADMIN` role can access analytics endpoints.
- [x] Verified users with the `ORGANIZER` role can access analytics endpoints.
- [x] Verified regular authenticated users receive an authorization error when accessing analytics endpoints.
- [x] Verified existing analytics functionality continues to work for authorized roles.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] Ready for review.