### PR TITLE
fix: normalize filenames before extension validation

### DIFF
--- a/src/utils/fileValidator.js
+++ b/src/utils/fileValidator.js
@@ -58,8 +58,8 @@ export function validateImageFile(file, options = {}) {
   }
 
   // Check file extension
-  const fileName = file.name.toLowerCase();
-  const ext = "." + fileName.split(".").pop();
+  const cleanName = file.name.trim().replace(/\.+$/, "");
+  const ext = "." + cleanName.split(".").pop().toLowerCase();
 
   if (DANGEROUS_EXTENSIONS.includes(ext)) {
     return {
@@ -101,8 +101,8 @@ export function validateFile(file, options = {}) {
     };
   }
 
-  const fileName = file.name.toLowerCase();
-  const ext = "." + fileName.split(".").pop();
+  const cleanName = file.name.trim().replace(/\.+$/, "");
+  const ext = "." + cleanName.split(".").pop().toLowerCase();
 
   if (DANGEROUS_EXTENSIONS.includes(ext)) {
     return {


### PR DESCRIPTION
# Summary

Prevents dangerous file extension validation bypasses by normalizing filenames before extracting their extensions.

## Related Issue

Fixes #11120

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Trimmed leading and trailing whitespace from uploaded filenames.
- Removed trailing dots before extension extraction.
- Normalized extracted extensions to lowercase.
- Applied the same validation logic to both `validateImageFile()` and `validateFile()`.

## Technical Details

### Frontend

- Updated `src/utils/fileValidator.js`.

## Testing

### Manual Testing

- [x] Verified filenames ending with trailing dots (e.g. `payload.exe.`) are correctly identified as executable files.
- [x] Verified filenames with trailing whitespace are normalized before validation.
- [x] Verified valid image and document uploads continue to pass validation.
- [x] Verified blocked extensions remain rejected after normalization.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] Ready for review.