### PR TITLE
fix: replace regex HTML fallback with DOMParser

### DIFF
--- a/src/utils/sanitizeHtml.js
+++ b/src/utils/sanitizeHtml.js
@@ -107,8 +107,29 @@ const getDOMPurify = () => {
  * @param {string} dirty - Raw HTML from an untrusted source (API, user input)
  * @returns {string} Sanitised HTML safe for injection into the DOM
  */
-const stripAllHtml = (text) =>
-  text.replace(/<[^>]*>/g, '');
+const stripAllHtml = (text) => {
+  if (typeof window !== "undefined" && typeof DOMParser !== "undefined") {
+    try {
+      const parser = new DOMParser();
+      const parsedDoc = parser.parseFromString(text, "text/html");
+      return parsedDoc.body.textContent || "";
+    } catch {
+      // Fallback if parsing fails
+    }
+  }
+
+  // Safe fallback if DOMParser is unavailable (e.g. Node.js environment)
+  // Strips tags recursively to prevent nested tag bypass, and handles unclosed tags
+  let sanitized = text;
+  let previous;
+  let limit = 0;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(/<[^>]*>?/g, '');
+    limit++;
+  } while (sanitized !== previous && limit < 10);
+  return sanitized;
+};
 
 export function sanitizeHtml(dirty) {
   if (!dirty || typeof dirty !== "string") return "";


### PR DESCRIPTION
# Summary

Replaces the regex-based HTML fallback sanitizer with a parser-based implementation using `DOMParser` to improve protection against malformed or nested HTML.

## Related Issue

Fixes #11122

## Changes Implemented

- Replaced the regex-only fallback sanitizer with a `DOMParser`-based implementation.
- Safely extracts plain text using `textContent` instead of relying on regular expressions.
- Added graceful error handling if HTML parsing fails.
- Added a defensive fallback for environments where `DOMParser` is unavailable.
- Reduced the risk of malformed or nested HTML bypassing fallback sanitization.

## Technical Details

### Frontend

- Updated `src/utils/sanitizeHtml.js`

## Testing

### Manual Testing

- [x] Verified normal HTML input is converted to plain text correctly.
- [x] Verified malformed and nested HTML no longer relies on regex stripping.
- [x] Verified fallback behavior works when `DOMParser` is available.
- [x] Verified sanitization continues to function without runtime errors.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] Ready for review.