### PR TITLE
fix: prevent privilege escalation to SUPER_ADMIN in admin role updates 

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -14,6 +14,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,10 +79,23 @@ public class AdminService {
      */
     @Transactional
     public AdminUserResponse updateUserRole(Long id, String newRole) {
-        User user = userRepository.findById(id)
+        Role requestedRole = parseRole(newRole);
+        User targetUser = userRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
-        user.setRole(parseRole(newRole));
-        return toAdminUserResponse(userRepository.save(user));
+
+        Role callerRole = getAuthenticatedRole();
+
+        if (callerRole != Role.SUPER_ADMIN) {
+            if (requestedRole == Role.SUPER_ADMIN) {
+                throw new AccessDeniedException("Only SUPER_ADMIN users can assign the SUPER_ADMIN role");
+            }
+            if (targetUser.getRole() == Role.SUPER_ADMIN) {
+                throw new AccessDeniedException("Only SUPER_ADMIN users can modify SUPER_ADMIN accounts");
+            }
+        }
+
+        targetUser.setRole(requestedRole);
+        return toAdminUserResponse(userRepository.save(targetUser));
     }
 
     /**
@@ -318,5 +334,13 @@ public class AdminService {
             throw new IllegalArgumentException("Invalid role: " + role +
                     ". Must be one of: CLIENT, ORGANIZER, ADMIN, SUPER_ADMIN");
         }
+    }
+
+    private Role getAuthenticatedRole() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getAuthorities().isEmpty()) {
+            throw new AccessDeniedException("Unable to determine the authenticated user's role");
+        }
+        return Role.valueOf(authentication.getAuthorities().iterator().next().getAuthority());
     }
 }


### PR DESCRIPTION
# Summary

Prevents privilege escalation in the admin role update workflow by enforcing role hierarchy checks before allowing role modifications.

## Related Issue

Fixes  #11135

## Type of Change

- [x] Security Fix
- [x] Bug Fix

## Changes Implemented

- Retrieved the authenticated user's role from the security context.
- Prevented non-`SUPER_ADMIN` users from assigning the `SUPER_ADMIN` role.
- Prevented non-`SUPER_ADMIN` users from modifying existing `SUPER_ADMIN` accounts.
- Continued allowing administrators to manage lower-privileged accounts.
- Added a helper method to safely resolve the authenticated user's role.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`
- Added role hierarchy validation before persisting role changes.
- Introduced authentication-based authorization checks using `SecurityContextHolder`.

## Testing

### Manual Testing

- [x] Verified `SUPER_ADMIN` can assign all roles.
- [x] Verified `SUPER_ADMIN` can modify existing `SUPER_ADMIN` accounts.
- [x] Verified `ADMIN` cannot assign the `SUPER_ADMIN` role.
- [x] Verified `ADMIN` cannot modify an existing `SUPER_ADMIN` account.
- [x] Verified `ADMIN` can continue managing lower-privileged users.
- [x] Verified unauthorized requests return `AccessDeniedException`.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Security validation added without affecting existing functionality
- [x] Ready for review