### PR TITLE
fix: normalize email before duplicate registration check

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -52,21 +52,22 @@ public class AuthService {
             throw new PasswordMismatchException("Password and confirm password do not match");
         }
 
-        // 2. Check for duplicate email
-        if (userRepository.existsByEmail(request.getEmail())) {
+        // 2. Check for duplicate email (case-insensitive)
+        String normalizedEmail = request.getEmail().toLowerCase();
+        if (userRepository.existsByEmail(normalizedEmail)) {
             throw new UserAlreadyExistsException(
-                    "An account with email '" + request.getEmail() + "' already exists");
+                    "An account with email '" + normalizedEmail + "' already exists");
         }
 
         // 3. Derive username from email (local part) and ensure uniqueness
-        String baseUsername = request.getEmail().split("@")[0].toLowerCase();
+        String baseUsername = normalizedEmail.split("@")[0].toLowerCase();
         String username = generateUniqueUsername(baseUsername);
 
         // 4. Persist the user
         User user = User.builder()
                 .firstName(request.getFirstName())
                 .lastName(request.getLastName())
-                .email(request.getEmail().toLowerCase())
+                .email(normalizedEmail)
                 .username(username)
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(Role.CLIENT)


### PR DESCRIPTION
# Summary

Prevents duplicate account registration caused by case-insensitive email variations by normalizing email addresses before duplicate validation and persistence.

## Related Issue

Fixes #11136

## Type of Change

- [x] Bug Fix
- [x] Security Fix

## Changes Implemented

- Normalized email addresses before checking for existing accounts.
- Reused the normalized email throughout the registration flow.
- Updated username generation to derive from the normalized email.
- Persisted the normalized email instead of repeatedly converting it.
- Improved duplicate-account validation consistency.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`
- Introduced a single normalized email variable for validation and persistence.
- Ensured duplicate email checks are case-insensitive.

## Testing

### Manual Testing

- [x] Verified registration succeeds with a unique email.
- [x] Verified registering with different letter casing of an existing email is rejected.
- [x] Verified duplicate requests return the expected `UserAlreadyExistsException`.
- [x] Verified email is consistently stored in lowercase.
- [x] Verified username generation continues to work correctly.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Registration logic remains backward compatible
- [x] Ready for review