### PR TITLE
fix: enforce ownership checks for event cancellation

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.request.CancelEventRequest;
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
 import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.request.RegistrationRequest;
@@ -410,6 +411,70 @@ public class EventController {
             @PathVariable Long id) {
 
         return ResponseEntity.ok(eventService.getOccupiedSeats(id));
+    }
+
+    // ── Event cancellation ─ POST /api/events/{id}/cancel ─────────────────
+
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Cancel an event",
+            description = "Cancels an event. Only the event's own organizer or an " +
+                          "administrator (ADMIN / SUPER_ADMIN) may cancel an event.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Event cancelled successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = EventResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid payload (validation failed)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User is not the event owner or an administrator",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Event not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "Event is already cancelled",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<EventResponse> cancelEvent(
+            @Parameter(description = "ID of the event to cancel")
+            @PathVariable Long id,
+            @Valid @RequestBody CancelEventRequest request,
+            Authentication authentication) {
+
+        return ResponseEntity.ok(
+                eventService.cancelEvent(id, authentication.getName(), request));
     }
 
     // ── Issue #2100 — DELETE /api/events/{id} ───────────────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
@@ -46,4 +46,19 @@ public class EventResponse {
 
     @Schema(description = "ID of the user who created (owns) this event", example = "7")
     private Long ownerId;
+
+    @Schema(description = "Lifecycle status of the event", example = "SCHEDULED")
+    private String status;
+
+    @Schema(description = "Reason provided when the event was cancelled", example = "Venue unavailable")
+    private String cancellationReason;
+
+    @Schema(description = "Timestamp when the event was cancelled")
+    private LocalDateTime cancelledAt;
+
+    @Schema(description = "Refund policy chosen at cancellation (FULL / PARTIAL / NONE)", example = "FULL")
+    private String refundPolicy;
+
+    @Schema(description = "Refund percentage when the refund policy is PARTIAL", example = "50")
+    private Integer refundPercent;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -45,6 +45,32 @@ public class Event {
     private Long ownerId;
 
     /**
+     * Lifecycle status of the event. Defaults to SCHEDULED; set to CANCELLED
+     * when the event owner (or an administrator) cancels it.
+     */
+    private String status = "SCHEDULED";
+
+    /**
+     * Reason provided by the organizer when the event was cancelled.
+     */
+    private String cancellationReason;
+
+    /**
+     * Timestamp recorded when the event was cancelled.
+     */
+    private LocalDateTime cancelledAt;
+
+    /**
+     * Refund policy chosen at cancellation time (FULL / PARTIAL / NONE).
+     */
+    private String refundPolicy;
+
+    /**
+     * Refund percentage when the refund policy is PARTIAL.
+     */
+    private Integer refundPercent;
+
+    /**
      * Optimistic-lock version field.
      * Acts as a safety net alongside the pessimistic write-lock used in the
      * registration flow: if two transactions somehow both pass the capacity
@@ -103,6 +129,21 @@ public class Event {
 
     public Long getOwnerId() { return ownerId; }
     public void setOwnerId(Long ownerId) { this.ownerId = ownerId; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getCancellationReason() { return cancellationReason; }
+    public void setCancellationReason(String cancellationReason) { this.cancellationReason = cancellationReason; }
+
+    public LocalDateTime getCancelledAt() { return cancelledAt; }
+    public void setCancelledAt(LocalDateTime cancelledAt) { this.cancelledAt = cancelledAt; }
+
+    public String getRefundPolicy() { return refundPolicy; }
+    public void setRefundPolicy(String refundPolicy) { this.refundPolicy = refundPolicy; }
+
+    public Integer getRefundPercent() { return refundPercent; }
+    public void setRefundPercent(Integer refundPercent) { this.refundPercent = refundPercent; }
 
     public Long getVersion() { return version; }
     public void setVersion(Long version) { this.version = version; }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.dto.request.CancelEventRequest;
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
 import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
@@ -247,6 +248,57 @@ public class EventService {
 
         Event saved = eventRepository.save(event);
         return toEventResponse(saved);
+    }
+
+    /**
+     * Cancels an existing event.
+     *
+     * <p>Authorization (Issue #11021): only the event's own organizer or an
+     * administrator (ADMIN / SUPER_ADMIN) may cancel an event. This closes the
+     * broken object-level authorization hole where any ORGANIZER could cancel
+     * events created by other organizers.</p>
+     *
+     * @param id        ID of the event to cancel
+     * @param userEmail email extracted from JWT principal
+     * @param request   cancellation details (reason, refund policy)
+     * @return the updated (cancelled) event
+     * @throws EventNotFoundException if the event does not exist
+     */
+    @Transactional
+    public EventResponse cancelEvent(Long id, String userEmail, CancelEventRequest request) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() ->
+                        new EventNotFoundException("Event not found with id: " + id));
+
+        User currentUser = userRepository.findByEmail(userEmail)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("User not found with email: " + userEmail));
+
+        boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
+        if (!isAdmin && (event.getOwnerId() == null || !event.getOwnerId().equals(currentUser.getId()))) {
+            throw new AccessDeniedException(
+                    "Only the event's own organizer (or an administrator) can cancel this event.");
+        }
+
+        if ("CANCELLED".equals(event.getStatus())) {
+            throw new RegistrationConflictException("Event is already cancelled.");
+        }
+
+        String refundPolicy = request.getRefundPolicy().toUpperCase();
+        if ("PARTIAL".equals(refundPolicy)) {
+            if (request.getRefundPercent() == null) {
+                throw new IllegalArgumentException(
+                        "Refund percentage is required when the refund policy is PARTIAL.");
+            }
+        }
+
+        event.setStatus("CANCELLED");
+        event.setCancellationReason(request.getReason());
+        event.setCancelledAt(request.getCancelledAt() != null ? request.getCancelledAt() : LocalDateTime.now());
+        event.setRefundPolicy(refundPolicy);
+        event.setRefundPercent("PARTIAL".equals(refundPolicy) ? request.getRefundPercent() : null);
+
+        return toEventResponse(eventRepository.save(event));
     }
 
     /**
@@ -601,6 +653,11 @@ public class EventService {
                 .isPublic(event.isPublic())
                 .imageUrl(event.getImageUrl())
                 .ownerId(event.getOwnerId())
+                .status(event.getStatus())
+                .cancellationReason(event.getCancellationReason())
+                .cancelledAt(event.getCancelledAt())
+                .refundPolicy(event.getRefundPolicy())
+                .refundPercent(event.getRefundPercent())
                 .build();
     }
 


### PR DESCRIPTION
# Summary

Adds secure event cancellation by enforcing object-level authorization so that only the event owner or an administrator can cancel an event.

## Related Issue

Fixes #11137

## Type of Change

- [x] Security Fix
- [x] Bug Fix

## Changes Implemented

- Added a dedicated event cancellation endpoint.
- Enforced ownership validation before allowing event cancellation.
- Allowed `ADMIN` and `SUPER_ADMIN` users to bypass ownership checks.
- Prevented organizers from cancelling events they do not own.
- Updated the event model and response DTO to support cancellation metadata.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java`
- Updated `Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java`

## Testing

### Manual Testing

- [x] Verified event owners can successfully cancel their own events.
- [x] Verified `ADMIN` and `SUPER_ADMIN` users can cancel any event.
- [x] Verified organizers cannot cancel events owned by other organizers.
- [x] Verified unauthorized cancellation attempts return `AccessDeniedException`.
- [x] Verified cancelled event information is returned correctly in the response.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ownership validation added for event cancellation
- [x] Ready for review