### PR TITLE
fix: replace index-based React keys with stable IDs in TicketTiersSection and TagsInput

### DIFF
--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -906,9 +906,9 @@ const EventCreation = () => {
                   </button>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {formData.tags.map((tag, index) => (
+                  {formData.tags.map((tag) => (
                     <span
-                      key={index}
+                      key={tag}
                       className="inline-flex items-center gap-1 bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 px-3 py-1 rounded-full text-sm font-medium"
                     >
                       #{tag}

--- a/src/components/common/EventCreation/components/TagsInput.jsx
+++ b/src/components/common/EventCreation/components/TagsInput.jsx
@@ -41,9 +41,9 @@ export default function TagsInput({ tags, newTag, onNewTagChange, onAdd, onRemov
         </button>
       </div>
       <div className="flex flex-wrap gap-2">
-        {tags.map((tag, index) => (
+        {tags.map((tag) => (
           <span
-            key={index}
+            key={tag}
             className="inline-flex items-center gap-1 bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 px-3 py-1 rounded-full text-sm font-medium"
           >
             #{tag}

--- a/src/components/common/EventCreation/components/TicketTiersSection.jsx
+++ b/src/components/common/EventCreation/components/TicketTiersSection.jsx
@@ -11,19 +11,19 @@ const TicketTiersSection = ({
   setErrors,
 }) => {
 
-  const handleTicketTierChange = (index, field, value) => {
+  const handleTicketTierChange = (id, field, value) => {
     setFormData((prev) => ({
       ...prev,
-      ticketTiers: prev.ticketTiers.map((tier, i) =>
-        i === index ? { ...tier, [field]: value } : tier
+      ticketTiers: prev.ticketTiers.map((tier) =>
+        tier.id === id ? { ...tier, [field]: value } : tier
       ),
     }));
 
     const errorKey =
     field === "price"
-        ? `ticketPrice_${index}`
+        ? `ticketPrice_${id}`
         : field === "capacity"
-        ? `ticketCapacity_${index}`
+        ? `ticketCapacity_${id}`
         : null;
 
     if (errorKey && errors[errorKey]) {
@@ -40,6 +40,7 @@ const TicketTiersSection = ({
       ticketTiers: [
         ...prev.ticketTiers,
         {
+          id: crypto.randomUUID(),
           name: "",
           price: 0,
           capacity: "",
@@ -49,11 +50,11 @@ const TicketTiersSection = ({
     }));
   };
 
-  const removeTicketTier = (index) => {
+  const removeTicketTier = (id) => {
     if (formData.ticketTiers.length > 1) {
       setFormData((prev) => ({
         ...prev,
-        ticketTiers: prev.ticketTiers.filter((_, i) => i !== index),
+        ticketTiers: prev.ticketTiers.filter((tier) => tier.id !== id),
       }));
     }
   };
@@ -77,7 +78,7 @@ const TicketTiersSection = ({
 <div className="space-y-6">
   {formData.ticketTiers.map((tier, index) => (
     <div
-      key={index}
+      key={tier.id}
       className="border border-gray-200 dark:border-gray-700 rounded-xl p-5 bg-gray-50 dark:bg-gray-800"
     >
       <div className="flex justify-between items-center mb-4">
@@ -88,7 +89,7 @@ const TicketTiersSection = ({
         {formData.ticketTiers.length > 1 && (
           <button
             type="button"
-            onClick={() => removeTicketTier(index)}
+            onClick={() => removeTicketTier(tier.id)}
             className="text-red-500 hover:text-red-700 text-sm font-medium"
           >
             Remove
@@ -107,7 +108,7 @@ const TicketTiersSection = ({
             type="text"
             value={tier.name}
             onChange={(e) =>
-              handleTicketTierChange(index, "name", e.target.value)
+              handleTicketTierChange(tier.id, "name", e.target.value)
             }
             placeholder="VIP / Early Bird / General"
             className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
@@ -125,18 +126,18 @@ const TicketTiersSection = ({
             min="0"
             value={tier.price}
             onChange={(e) =>
-              handleTicketTierChange(index, "price", e.target.value)
+              handleTicketTierChange(tier.id, "price", e.target.value)
             }
             className={`w-full border ${
-              errors[`ticketPrice_${index}`]
+              errors[`ticketPrice_${tier.id}`]
                 ? "border-red-500"
                 : "border-gray-300 dark:border-gray-600"
             } rounded-lg p-3 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100`}
           />
 
-          {errors[`ticketPrice_${index}`] && (
+          {errors[`ticketPrice_${tier.id}`] && (
             <span className="text-red-500 text-sm mt-1">
-              {errors[`ticketPrice_${index}`]}
+              {errors[`ticketPrice_${tier.id}`]}
             </span>
           )}
         </div>
@@ -152,19 +153,19 @@ const TicketTiersSection = ({
             min="1"
             value={tier.capacity}
             onChange={(e) =>
-              handleTicketTierChange(index, "capacity", e.target.value)
+              handleTicketTierChange(tier.id, "capacity", e.target.value)
             }
             placeholder="100"
             className={`w-full border ${
-              errors[`ticketCapacity_${index}`]
+              errors[`ticketCapacity_${tier.id}`]
                 ? "border-red-500"
                 : "border-gray-300 dark:border-gray-600"
             } rounded-lg p-3 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100`}
           />
 
-          {errors[`ticketCapacity_${index}`] && (
+          {errors[`ticketCapacity_${tier.id}`] && (
             <span className="text-red-500 text-sm mt-1">
-              {errors[`ticketCapacity_${index}`]}
+              {errors[`ticketCapacity_${tier.id}`]}
             </span>
           )}
         </div>
@@ -180,7 +181,7 @@ const TicketTiersSection = ({
             maxLength={200}
             value={tier.description}
             onChange={(e) =>
-              handleTicketTierChange(index, "description", e.target.value)
+              handleTicketTierChange(tier.id, "description", e.target.value)
             }
             placeholder="Describe perks and benefits"
             className="w-full border border-gray-300 dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 resize-none"

--- a/src/constants/eventDefaults.js
+++ b/src/constants/eventDefaults.js
@@ -36,7 +36,7 @@ export const mockAttendees = [
   },
 ];
 
-// Factory function — always returns a fresh object so callers never share
+// Factory function - always returns a fresh object so callers never share
 // references to nested arrays/objects across form sessions.
 export const getInitialFormData = () => ({
   title: "",
@@ -64,6 +64,7 @@ export const getInitialFormData = () => ({
   tags: [],
   ticketTiers: [
     {
+      id: crypto.randomUUID(),
       name: "General Admission",
       price: 0,
       capacity: "",
@@ -74,12 +75,12 @@ export const getInitialFormData = () => ({
   bannerPreview: null,
 });
 
-// Backward-compatible alias for existing callers — each access returns a new copy
+// Backward-compatible alias for existing callers - each access returns a new copy
 export const initialFormData = getInitialFormData();
 
 // Computed on every call so date validations stay accurate across midnight
 // on long-running sessions without a page refresh.
 export const getTodayString = () => new Date().toISOString().split("T")[0];
 
-// Backward-compatible alias — evaluates fresh on access via getter
+// Backward-compatible alias - evaluates fresh on access via getter
 export const todayString = getTodayString();

--- a/src/utils/eventFormValidation.js
+++ b/src/utils/eventFormValidation.js
@@ -81,16 +81,16 @@ export const validateForm = (formData) => {
   }
 
   if (formData.ticketTiers && formData.ticketTiers.length > 0) {
-    formData.ticketTiers.forEach((tier, index) => {
+    formData.ticketTiers.forEach((tier) => {
       if (tier.name && tier.name.trim()) {
         const price = Number(tier.price);
         if (price < 0) {
-          newErrors[`ticketPrice_${index}`] = "Ticket price cannot be negative";
+          newErrors[`ticketPrice_${tier.id}`] = "Ticket price cannot be negative";
         }
         if (tier.capacity) {
           const capacity = Number(tier.capacity);
           if (capacity <= 0) {
-            newErrors[`ticketCapacity_${index}`] = "Ticket capacity must be greater than 0";
+            newErrors[`ticketCapacity_${tier.id}`] = "Ticket capacity must be greater than 0";
           }
         }
       }


### PR DESCRIPTION
Fixes #10990

Both `TicketTiersSection.jsx` and `TagsInput.jsx` were using the array index as the React `key` when rendering list items. This works fine when items are only ever added at the end, but breaks the moment one is removed from the middle.

When a tier is deleted from the middle of the list, every tier after it shifts up by one position. React sees the same keys it had before and reuses the existing DOM nodes for those slots, so field values, focus state, and validation errors all end up mapped to the wrong tier. Since the error keys were also index-based (`ticketPrice_${index}`, `ticketCapacity_${index}`), a validation error belonging to the third tier would render under the second tier's fields after the shift. This is the kind of bug that only surfaces once you start removing items from the middle, which is probably why it went unnoticed for a while.

## Changes

**`TicketTiersSection.jsx`**
- Each tier now gets a `crypto.randomUUID()` when it is created inside `addTicketTier`
- `handleTicketTierChange` now matches tiers by `tier.id` instead of index
- `removeTicketTier` now filters by `tier.id` instead of index
- All error key lookups (`ticketPrice_*`, `ticketCapacity_*`) now use the stable `id` instead of the position in the array
- The `key` prop on the rendered tier card is now `tier.id`

**`eventDefaults.js`**
- The default initial tier inside `getInitialFormData` also gets a `crypto.randomUUID()` so it is consistent with newly added tiers from the start

**`TagsInput.jsx`**
- Tags are already unique strings so no new ids are needed here
- Switched `key={index}` to `key={tag}`, which is stable and correct

## Type of change

- [x] Bug fix
