### PR TITLE
fix: repair TeamWorkspace polling syntax

### DIFF
--- a/src/components/hackathons/TeamWorkspace.jsx
+++ b/src/components/hackathons/TeamWorkspace.jsx
@@ -58,7 +58,8 @@ const TeamWorkspace = () => {
   // SSE Simulator & Fallback Hook
   useEffect(() => {
     let sseSource = null;
-    let fallbackInterval = null;\n      let isMounted = true;
+    let fallbackInterval = null;
+    let isMounted = true;
     let idleTimeout = null;
 
     setConnectionStatus("connecting");
@@ -70,7 +71,8 @@ const TeamWorkspace = () => {
         "SSE connection error. Started HTTP short-polling fallback stream every 4s.",
       ]);
 
-      const fetchState = async () => {\n          if (!isMounted) return;
+      const fetchState = async () => {
+        if (!isMounted) return;
         try {
           const response = await fetch("/api/hackathons/team/sync", {
             method: "POST",


### PR DESCRIPTION
## Summary
- Replace the literal escape sequences in TeamWorkspace with valid line breaks.
- Restore parsing of the SSE polling fallback effect.

Closes #11100

## Validation
- Focused ESLint check passes with two existing warnings in the file.
- esbuild parses TeamWorkspace successfully.
- Full Vite build remains blocked by unrelated pre-existing syntax errors in offlineQueue, useLocalStorage, ReAuthModal, useFormSubmit, and useDebouncedSearch.