### PR TITLE
fix: import useRef in sponsor dashboard

### DIFF
--- a/src/Pages/Sponsors/SponsorDashboard.jsx
+++ b/src/Pages/Sponsors/SponsorDashboard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   BarChart, Users, Link as LinkIcon, MessageSquare,
   Save, Layout, Shield, Mail, Briefcase, Info, Download, Trash2, CheckCircle2


### PR DESCRIPTION
## Summary
- Import the useRef hook used by SponsorDashboard.
- Restore rendering of the protected sponsor dashboard route.

Closes #11099

## Validation
- Focused ESLint check passes.
- esbuild parses SponsorDashboard successfully.
- Full Vite build remains blocked by unrelated pre-existing syntax errors in other source files.