### PR TITLE
fix: prevent phase selection crash

### DIFF
--- a/src/Pages/Hackathons/HackathonLifecycle.jsx
+++ b/src/Pages/Hackathons/HackathonLifecycle.jsx
@@ -167,17 +167,6 @@ const HackathonLifecycle = () => {
   // Change overall active phase (organizer simulation)
   const setGlobalActivePhase = (index) => {
     setActivePhaseIndex(index);
-    setPhasesList((prev) =>
-      prev.map((phase) => {
-        if (phase.id === selectedPhaseId) {
-          return {
-            ...phase,
-            tasks: [...phase.tasks, newTask],
-          };
-        }
-        return phase;
-      })
-    );
     setSelectedPhaseId(index + 1);
 
     if (index === 4) {


### PR DESCRIPTION
## Summary
- Remove the task update from the organizer phase-selection handler.
- Keep phase selection limited to updating the active and selected phase state.

Closes #11097

## Validation
- Focused ESLint check passes.
- esbuild parses HackathonLifecycle successfully.
- Full Vite build remains blocked by unrelated pre-existing syntax errors in other source files.