### PR TITLE
Fix/attendanceprediction nan division 

### DIFF
--- a/src/utils/attendancePrediction.js
+++ b/src/utils/attendancePrediction.js
@@ -1,4 +1,7 @@
-const clamp01 = (value) => Math.max(0, Math.min(1, Number(value) || 0));
+const clamp01 = (value) => {
+  const n = Number(value);
+  return Number.isNaN(n) ? 0 : Math.max(0, Math.min(1, n));
+};
 
 const parseEventDate = (event) => {
   if (!event) return null;
@@ -156,8 +159,8 @@ export const computeAttendancePrediction = (event = {}, options = {}) => {
       getEngagementScore(event) * weights.engagement
   );
 
-  const attendanceProbability = Math.round(probability * 100);
-  const noShowProbability = Math.round((1 - probability) * 100);
+  const attendanceProbability = Number.isNaN(probability) ? 0 : Math.round(probability * 100);
+  const noShowProbability = Number.isNaN(probability) ? 100 : Math.round((1 - probability) * 100);
   
   // Deep Fix: Predict attendees based on *actual registrants*, not total venue capacity
   const predictedAttendees = attendees > 0 ? Math.round(probability * attendees) : 0;


### PR DESCRIPTION
## Description
Fixes a division by zero bug in `attendancePrediction.js` where new events with zero capacity or zero attendees resulted in `NaN` percentage metrics displayed on UI cards.

## Changes Made
- Updated `clamp01()` to explicitly return `0` when `Number.isNaN()` evaluates to `true`.
- Added safety checks to `attendanceProbability` and `noShowProbability` to ensure valid integer percentages are always returned.

## Verification
- Tested `computeAttendancePrediction` with 0 capacity and 0 attendees.
Fixes #11088