### PR TITLE
Feat/hackathon milestones ics export 

### DIFF
--- a/src/utils/calendarExporter.js
+++ b/src/utils/calendarExporter.js
@@ -330,3 +330,12 @@ export const generateWebCalLink = (httpsUrl) => {
     return null;
   }
 };
+
+export const downloadHackathonMilestonesICS = (hackathon) => {
+  if (!hackathon) return;
+  const milestones = [
+    { title: `${hackathon.title} - Hacking Starts`, date: hackathon.startDate, description: "Official start of hacking phase." },
+    { title: `${hackathon.title} - Submission Deadline`, date: hackathon.endDate, description: "Project submission deadline." }
+  ];
+  downloadBulkICSFile(milestones, `${hackathon.title}-milestones`);
+};


### PR DESCRIPTION
## Description
Adds ICS iCalendar file export functionality for hackathon milestone schedules (Hacking Starts, Project Submission Deadline).

## Changes Made
- Added `downloadHackathonMilestonesICS()` to `src/utils/calendarExporter.js`.
- Generates a consolidated RFC 5545 compliant `.ics` calendar file with reminder alarms for all key hackathon dates.

## Verification
- Downloaded generated milestone `.ics` file and imported into Apple Calendar / Google Calendar.
Fixes #11089