### PR TITLE
Fix/hackathondetailspage invalid date 11086

### DIFF
--- a/src/Pages/Hackathons/HackathonDetailsPage.js
+++ b/src/Pages/Hackathons/HackathonDetailsPage.js
@@ -7,10 +7,12 @@ import hackathonsData from "./hackathonMockData.json";
 
 import useReducedMotion from "hooks/useReducedMotion.js";
 const getHackathonStatus = (hackathon) => {
+  if (!hackathon?.startDate || !hackathon?.endDate) return "upcoming";
   const now = new Date();
   const startDate = new Date(hackathon.startDate);
   const endDate = new Date(hackathon.endDate);
 
+  if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return "upcoming";
   if (endDate < now) return "completed";
   if (startDate <= now && now <= endDate) return "live";
   return "upcoming";


### PR DESCRIPTION
## Description
Fixes a potential crash or invalid status return in `HackathonDetailsPage.js` when hackathon items contain missing or invalid date strings.

## Changes Made
- Added `isNaN(startDate.getTime())` and `isNaN(endDate.getTime())` validation checks inside `getHackathonStatus()`.
- Defaulted status safely to `"upcoming"` when date parsing fails.

## Verification
- Tested with valid, invalid, and missing hackathon date properties.
Fixes #11086
