### PR TITLE
Fix/conflictdetection negative minutes 

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -290,8 +290,9 @@ export const formatTimeRange = (timeStr, durationMinutes = 60, dateStr, timezone
   const endMinutes = startMinutes + durationMinutes;
 
   const formatMinutes = (mins) => {
-    const h = Math.floor(mins / 60) % 24;
-    const m = mins % 60;
+    const safeMins = ((mins % 1440) + 1440) % 1440;
+    const h = Math.floor(safeMins / 60);
+    const m = Math.floor(safeMins % 60);
     const period = h >= 12 ? "PM" : "AM";
     const displayH = h > 12 ? h - 12 : h === 0 ? 12 : h;
     return `${displayH}:${String(m).padStart(2, "0")} ${period}`;


### PR DESCRIPTION
## Description
Fixes an issue in `conflictDetection.js` where passing negative or invalid minute values into `formatTimeRange()` resulted in malformed time strings like `-1:30 AM`.

## Changes Made
- Normalized minute inputs in `formatMinutes()` using modulo 1440 arithmetic (`((mins % 1440) + 1440) % 1440`) to ensure formatted times remain bounded within a 24-hour cycle.

## Verification
- Tested `formatTimeRange()` with negative minute offsets and verified output formatting (`11:30 PM` instead of negative values).
Fixes #11085