### PR TITLE
Feat/eventservice abortcontroller cancellation

### DIFF
--- a/src/services/eventService.js
+++ b/src/services/eventService.js
@@ -1,15 +1,15 @@
 import { apiUtils, API_ENDPOINTS } from "../config/api";
 
 export const eventService = {
-  getAllEvents: async (page, size) => {
+  getAllEvents: async (page, size, config = {}) => {
     if (page !== undefined && size !== undefined) {
-      return apiUtils.get(API_ENDPOINTS.EVENTS.PAGINATED(page, size));
+      return apiUtils.get(API_ENDPOINTS.EVENTS.PAGINATED(page, size), config);
     }
-    return apiUtils.get(API_ENDPOINTS.EVENTS.LIST);
+    return apiUtils.get(API_ENDPOINTS.EVENTS.LIST, config);
   },
   
-  getEventDetails: async (eventId) => {
-    return apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
+  getEventDetails: async (eventId, config = {}) => {
+    return apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId), config);
   },
   
   createEvent: async (eventData) => {


### PR DESCRIPTION
## Description
Adds optional request configuration (`config` / `AbortSignal`) support to `getAllEvents` and `getEventDetails` in `eventService.js`, allowing UI hooks to cancel in-flight HTTP queries during rapid navigation or high-frequency filtering.

## Changes Made
- Added optional `config = {}` parameter to `getAllEvents()` and `getEventDetails()`.
- Passed config through to underlying `apiUtils.get()` calls.

Closes #11058