### PR TITLE
Feat/remindercontrols disabled state fix 

### DIFF
--- a/src/components/reminders/ReminderControls.js
+++ b/src/components/reminders/ReminderControls.js
@@ -161,7 +161,7 @@ const ReminderControls = ({ event, canSetReminder, compact = false }) => {
         {REMINDER_TIMINGS.map((timing) => {
           const isActive = activeTimingSet.has(timing.value);
           // 🔥 FIX: Disable if event passed OR if this specific button is currently processing
-          const isDisabled = eventHasPassed || processingTiming === timing.value;
+          const isDisabled = eventHasPassed || processingTiming !== null;
 
           return (
             <button


### PR DESCRIPTION
## Description
Fixes a misleading UI state in `ReminderControls.js` where only the actively clicked timing button showed a disabled state during async permission prompts, while sibling timing buttons remained visually active but failed silently when clicked.

## Changes Made
- Updated `isDisabled` logic from `processingTiming === timing.value` to `processingTiming !== null`, disabling all timing buttons whenever any processing is in progress.

Closes #11057