### PR TITLE
Feat/onboardingchecklist immediate dismissal 

### DIFF
--- a/src/components/user/OnboardingChecklist.jsx
+++ b/src/components/user/OnboardingChecklist.jsx
@@ -301,15 +301,14 @@ export default function OnboardingChecklist() {
   const handleDismiss = () => {
     setIsDismissed(true);
     setIsOpen(false);
+    try { localStorage.setItem("eventra_onboarding_dismissed", "true"); } catch {}
     showUndoToast({
       message: "Onboarding quest dismissed.",
       toastId: "dismiss-onboarding-checklist",
       onUndo: () => {
         setIsDismissed(false);
         setIsOpen(true);
-      },
-      onCommit: () => {
-        localStorage.setItem("eventra_onboarding_dismissed", "true");
+        try { localStorage.removeItem("eventra_onboarding_dismissed"); } catch {}
       },
     });
   };


### PR DESCRIPTION
## Description
Fixes an issue in `OnboardingChecklist.jsx` where hiding the checklist delayed saving the dismissal flag to `localStorage` until the undo toast expired. If the user navigated away before the toast committed, the checklist reappeared on next load.

## Changes Made
- Updated `handleDismiss()` to write `eventra_onboarding_dismissed` to `localStorage` immediately upon clicking "Dismiss".
- The "Undo" callback now removes the flag, restoring the checklist.

Closes #11056