### PR TITLE
Fix/searchutils empty object drop 11054

### DIFF
--- a/src/utils/searchUtils.mjs
+++ b/src/utils/searchUtils.mjs
@@ -110,11 +110,11 @@
       _searchScore: result.score,
     }));
 
-    const matchedIds = new Set(fuseResults.map((item) => item.id));
+    const matchedIds = new Set(fuseResults.map((item) => item.id).filter((id) => id !== undefined && id !== null));
 
     const tokenResults = items
       .filter((item) => {
-        if (matchedIds.has(item.id)) return false;
+        if (item.id !== undefined && item.id !== null && matchedIds.has(item.id)) return false;
 
         const combinedText = normalizeSearchText(
           searchKeys.map((key) => getSearchableValue(item, key)).join(" ")


### PR DESCRIPTION
## Description
Fixes a bug in `searchUtils.mjs` where `matchedIds.has(item.id)` evaluated `item.id` as `undefined` for id-less search items, causing `matchedIds.has(undefined)` to return `true` and silently drop subsequent valid search matches from the token fallback results.

## Changes Made
- Filtered out `undefined` and `null` values when populating `matchedIds`.
- Added strict null/undefined checks before calling `matchedIds.has(item.id)`.

Closes #11054