### PR TITLE
Fix/useofflinesync zombie tasks 

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -322,7 +322,7 @@ const useOfflineSync = () => {
 
           if (retries >= MAX_RETRIES) {
             droppedCount++;
-            failedQueue.push(item);
+            logger.warn(`[useOfflineSync] Item ${item.id} exceeded MAX_RETRIES (${MAX_RETRIES}). Dropping from queue.`);
             continue;
           }
 


### PR DESCRIPTION
## Description
Fixes an issue in `useOfflineSync.js` where offline queue items that exceeded `MAX_RETRIES` were accidentally pushed back into the active queue instead of being discarded. This created "zombie" tasks that persisted in local storage indefinitely and triggered error toasts on every network reconnection.

## Changes Made
- Updated retry evaluation logic in `useOfflineSync.js` to log and discard permanently failed items when `retries >= MAX_RETRIES`.
- Prevented permanently failed items from being re-saved to IndexedDB.

Closes #11050