### PR TITLE
fix: add missing logger import in useTokenExpiry to prevent ReferenceError on token expiry (closes #11185)

### DIFF
--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { toast } from "react-toastify";
 import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils";
 import { syncSecureStorage } from "../utils/secureStorage";
-
+import { logger } from "../utils/logger";
 export const MAX_TOKEN_EXPIRY_TIMEOUT_MS = 2_147_483_647;
 const TOKEN_EXPIRY_BUFFER_MS = 1_000;
 


### PR DESCRIPTION
## Description

In `src/hooks/useTokenExpiry.js`, `logger.warn()` was called inside `clearExpiredSession` on line 29 but `logger` was never imported. When a JWT token expired, this threw `ReferenceError: logger is not defined`, silently preventing the session from being cleared and leaving the user stuck in an expired-but-not-logged-out state.

Fix: added `import { logger } from "../utils/logger"` after the existing imports. One line change.

Fixes #11185

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports