### PR TITLE
fix: handle GitHub API 429 rate limit with stale cache fallback in Contributors page (closes #10500)

### DIFF
--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -13,6 +13,17 @@ import EmptyState from "./common/EmptyState";
 // GitHub repo
 const GITHUB_REPO = "sandeepvashishtha/Eventra";
 const CACHE_DURATION = 60 * 60 * 1000; // 1 hr
+// Fix (Issue #10500): Keep stale cache for up to 24h as fallback on 429
+const STALE_CACHE_DURATION = 24 * 60 * 60 * 1000;
+
+const getStaleCachedContributors = () => {
+  const cachedData = storageManager.get(
+    STORAGE_KEYS.GITHUB_CONTRIBUTORS,
+    validators.isObject,
+  );
+  if (!cachedData?.data || !cachedData?.timestamp) return null;
+  return Date.now() - cachedData.timestamp > STALE_CACHE_DURATION ? null : cachedData.data;
+};
 const REQUEST_TIMEOUT = 10000;
 const MAX_CONTRIBUTOR_PAGES = 10;
 const PROFILE_FETCH_DELAY_MS = 100; // Throttle profile API calls to avoid rate limiting
@@ -30,6 +41,14 @@ const fetchJsonWithTimeout = async (url) => {
     const { data } = await fetchWithTimeout(proxyUrl, {}, REQUEST_TIMEOUT);
     return data;
   } catch (error) {
+    // Fix (Issue #10500): Handle 429 rate limit — respect Retry-After header
+    if (error?.status === 429) {
+      const retryAfter = parseInt(error?.headers?.get?.("Retry-After") || "60", 10);
+      throw Object.assign(new Error("GitHub API rate limit exceeded"), {
+        status: 429,
+        retryAfter,
+      });
+    }
     if (url.startsWith("https://api.github.com") && (error?.status === 401 || error?.status === 403)) {
       const { data } = await fetchWithTimeout(
         buildDirectGitHubUrl(url),
@@ -211,12 +230,27 @@ const ContributorsInner = () => {
       cacheContributors(enhanced);
     } catch (err) {
       if (err.name === "AbortError") return;
-      setError(
-        err?.name === "AbortError"
-          ? "GitHub took too long to respond. Please try again."
-          : "Unable to load contributors from GitHub right now. Please try again.",
-      );
-      setContributors([]);
+
+      // Fix (Issue #10500): On 429, show stale cached data if available
+      // instead of an empty list, and show a helpful rate-limit message.
+      if (err?.status === 429) {
+        const stale = getStaleCachedContributors();
+        if (stale && stale.length > 0) {
+          setContributors(stale);
+          setError(
+            `GitHub API rate limit reached. Showing cached data. ` +
+            `Retry after ${err.retryAfter ?? 60}s.`
+          );
+        } else {
+          setError(
+            "GitHub API rate limit reached. Please wait a minute and try again."
+          );
+          setContributors([]);
+        }
+      } else {
+        setError("Unable to load contributors from GitHub right now. Please try again.");
+        setContributors([]);
+      }
     } finally {
       setLoading(false);
       isFetchingRef.current = false;


### PR DESCRIPTION
## Description

The Contributors page made unauthenticated GitHub API requests with no 429
handling. When the rate limit was hit, the catch block cleared the contributor
list entirely and showed a generic error, leaving users with an empty leaderboard
and a retry button that immediately fired more requests.

Three targeted fixes in `src/components/Contributors.js`:

1. **429 detection in `fetchJsonWithTimeout`** — parses the `Retry-After`
   header and throws a typed error with `status: 429` and `retryAfter` seconds.

2. **Stale cache helper `getStaleCachedContributors`** — returns cached data
   up to 24 hours old (vs the normal 1-hour fresh window), so previously
   loaded data survives rate-limit windows.

3. **Graceful 429 catch block** — on 429, checks for stale cache first. If
   found, renders it with a "showing cached data, retry after Xs" message.
   If no cache exists, shows a clear rate-limit explanation instead of a
   generic error.

Fixes #10500

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports