### PR TITLE
fix: add key prop to CountUp to trigger animation for Projects Built and Prizes Awarded counters (closes #10485)

### DIFF
--- a/src/Pages/Hackathons/HackathonHero.js
+++ b/src/Pages/Hackathons/HackathonHero.js
@@ -23,7 +23,14 @@ const StatCounter = ({ stat, shouldAnimate, delay = 0 }) => {
   }
 
   return (
+    // Fix (Issue #10485): Add key prop to force CountUp to remount when
+    // shouldAnimate becomes true. Without this, CountUp renders once with
+    // shouldAnimate=false (static "0"), then when isStatsInView fires,
+    // React re-renders the parent but CountUp never restarts its animation
+    // because the component instance was already mounted — causing the 3rd
+    // and 4th counters (Projects Built, Prizes Awarded) to stay frozen at 0.
     <CountUp
+      key={`${stat.label}-animated`}
       start={0}
       end={stat.value}
       duration={2.5}


### PR DESCRIPTION
## Description

The Hackathons page stats section had all 4 counters defined correctly in the
array, but only the first two (Hackathons Hosted, Participants) animated. The
last two (Projects Built, Prizes Awarded) stayed frozen at 0.

Root cause: `StatCounter` renders `null`/static-0 when `shouldAnimate` is
false (before the section enters the viewport). When `isStatsInView` fires and
`shouldAnimate` becomes true, React re-renders the parent but `CountUp` does
not restart because it was already mounted — it only runs its animation on
initial mount. The first two counters happened to animate because of timing
differences in how React batched the state updates.

Fix: added `key={stat.label + "-animated"}` to the `CountUp` component inside
`StatCounter`. This forces React to unmount and remount `CountUp` when
`shouldAnimate` transitions to `true`, triggering the animation fresh for
every counter reliably.

One line added. All 4 counters now animate correctly.

Fixes #10485

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports