### PR TITLE
[Fix] Backend fails to compile: add missing CancelEventRequest DTO

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CancelEventRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CancelEventRequest.java
@@ -1,0 +1,35 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request payload for cancelling an existing event")
+public class CancelEventRequest {
+
+    @NotBlank(message = "Reason is required")
+    @Schema(description = "Reason for cancelling the event", example = "Venue unavailable")
+    private String reason;
+
+    @NotBlank(message = "Refund policy is required (FULL, PARTIAL or NONE)")
+    @Pattern(regexp = "FULL|PARTIAL|NONE", message = "Refund policy must be one of: FULL, PARTIAL, NONE")
+    @Schema(description = "Refund policy for registered attendees (FULL, PARTIAL, NONE)", example = "FULL")
+    private String refundPolicy;
+
+    @Min(value = 1, message = "Refund percentage must be at least 1")
+    @Max(value = 100, message = "Refund percentage cannot exceed 100")
+    @Schema(description = "Refund percentage when the refund policy is PARTIAL", example = "50")
+    private Integer refundPercent;
+
+    @Schema(description = "Optional timestamp recording when the event was cancelled (defaults to now)")
+    private LocalDateTime cancelledAt;
+}


### PR DESCRIPTION
## Problem

The backend fails to compile because `CancelEventRequest` is imported and used in `EventController` and `EventService`, but the class does not exist anywhere in the `Backend` module. The `dto/request` package contains 13 request DTOs but none named `CancelEventRequest`, so the entire backend module cannot build or start.

## Fix

Created the missing `CancelEventRequest` DTO (`Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CancelEventRequest.java`) with the fields consumed by `EventService.cancelEvent`:
- `reason` (required) — cancellation reason.
- `refundPolicy` (required, `FULL`/`PARTIAL`/`NONE`) — refund policy for registered attendees.
- `refundPercent` — required percentage when the policy is `PARTIAL`, validated to be between 1 and 100.
- `cancelledAt` — optional timestamp (defaults to now in the service).

It follows the existing request-DTO pattern (`@Data`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`, `@Schema`) and includes validation annotations so the `POST /api/events/{id}/cancel` endpoint validates its payload.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CancelEventRequest.java` (new)

## Testing

- Manual code review against the usages in `EventService.cancelEvent` (lines 287-299) and `EventController.cancelEvent` — all accessed getters are present on the new DTO.
- The missing symbol referenced by `EventService` and `EventController` is now defined, so `javac`/Maven build can succeed. Note: no Maven installation is available in this environment, so a full `mvn` build could not be executed locally.

Closes #11229
