### PR TITLE
[Fix] Exclude non-public events from public GET /api/events endpoints

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -129,12 +129,17 @@ public class EventService {
     // ── Issue #2102 — Event Fetch ─────────────────────────────────────
 
     /**
-     * Retrieves an event by ID.
+     * Retrieves a public event by ID.
      *
-     * @throws EventNotFoundException if the event does not exist
+     * <p>Events that are explicitly marked not public are excluded from the
+     * public read path (Issue #11230); they are only visible to their
+     * organizer or an admin via the admin endpoints.</p>
+     *
+     * @throws EventNotFoundException if the event does not exist or is not public
      */
     public EventResponse getPublicEventById(long id) {
         return eventRepository.findById(id)
+                .filter(Event::isPublic)
                 .map(this::toEventResponse)
                 .orElseThrow(() ->
                         new EventNotFoundException(
@@ -142,13 +147,14 @@ public class EventService {
     }
 
     /**
-     * Retrieves all events.
+     * Retrieves all public events.
      *
-     * @return list of all events
+     * @return list of all events with {@code isPublic} set to true
      */
     @Transactional(readOnly = true)
     public List<EventResponse> getAllEvents() {
         return eventRepository.findAll().stream()
+                .filter(Event::isPublic)
                 .map(this::toEventResponse)
                 .toList();
     }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
@@ -144,6 +144,40 @@ public class EventRegistrationTests {
                 .andExpect(jsonPath("$.availabilityStatus").value("PAST"));
     }
 
+    // ── Issue #11230 — Public events only on public read endpoints ───────────
+
+    @Test
+    @DisplayName("#11230 — GET /api/events excludes events marked not public")
+    void testGetAllEventsExcludesPrivateEvents() throws Exception {
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Event");
+        privateEvent.setCapacity(100);
+        privateEvent.setEventDate(LocalDateTime.now().plusDays(1));
+        privateEvent.setPublic(false);
+        privateEvent = eventRepository.save(privateEvent);
+
+        mockMvc.perform(get("/api/events"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id == " + privateEvent.getId() + ")]").isEmpty());
+    }
+
+    @Test
+    @DisplayName("#11230 — GET /api/events/{id} returns 404 for a non-public event")
+    void testGetPublicEventByIdExcludesPrivateEvent() throws Exception {
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Event");
+        privateEvent.setCapacity(100);
+        privateEvent.setEventDate(LocalDateTime.now().plusDays(1));
+        privateEvent.setPublic(false);
+        privateEvent = eventRepository.save(privateEvent);
+
+        mockMvc.perform(get("/api/events/" + privateEvent.getId()))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/api/events/" + eventId))
+                .andExpect(status().isOk());
+    }
+
     // ── Issue #2102 — Registration endpoint ──────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Problem

Events explicitly marked **not public** are still returned to unauthenticated callers by the two public read endpoints. `getAllEvents()` called `eventRepository.findAll()` and mapped every event without filtering on `isPublic`, and `getPublicEventById(id)` returned any event regardless of `isPublic`. This exposed draft/private event details (schedule, capacity, location, etc.) to anyone.

## Fix

Filtered the public read paths in `EventService`:
- `getAllEvents()` now filters the stream to `Event::isPublic` so only `isPublic = true` events are returned by `GET /api/events`.
- `getPublicEventById(id)` now requires `isPublic = true` via an `Event::isPublic` filter, so `GET /api/events/{id}` returns 404 for non-public events.

The admin path (`AdminService.getEvents`) remains unfiltered, as documented, so admins still see all events.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java`

## Testing

Added two regression tests in `EventRegistrationTests`:
- `GET /api/events` excludes an event marked `isPublic = false`.
- `GET /api/events/{id}` returns 404 for a non-public event while a public event is still returned.

Note: no Maven installation is available in this environment, so the tests could not be executed locally; they follow the existing `MockMvc` integration-test pattern.

Closes #11230
