### PR TITLE
[Fix] Google OAuth: normalize email before lookup to prevent duplicate accounts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -106,7 +106,7 @@ public AuthResponse googleLogin(GoogleAuthRequest request) {
         GoogleIdToken.Payload payload =
                 googleAuthService.verifyToken(request.getToken());
 
-        String email = payload.getEmail();
+        String email = payload.getEmail().toLowerCase();
 
        String firstName =
         (String) payload.get("given_name");


### PR DESCRIPTION
## Problem

`AuthService.googleLogin` looked up existing users with the **raw** email returned by Google but stored newly created users with the email **lowercased**. When Google returned a mixed-case address, `findByEmail(John@example.com)` returned `null` and a second account was created for the same mailbox, producing duplicate accounts, duplicate usernames, and orphaned registrations/tickets.

## Fix

Normalized the email once at the start of `googleLogin`: `payload.getEmail().toLowerCase()`. The lookup (`findByEmail`) now uses the normalized value and matches accounts stored by every other code path (`signup`, `login`), so an existing account is found and logged into instead of duplicating it. New users are still persisted with the normalized email.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`

## Testing

- Code review: the email is lowercased before `findByEmail`, matching the normalization used in `signup` (line 56) and `login` (line 96) paths.
- Note: no Maven installation is available in this environment, so a full build could not be executed locally.

Closes #11231
