### PR TITLE
[Fix] Notification delete Undo: resolve removedNotification ReferenceError

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -250,9 +250,10 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
 
       const restoreNotification = () => {
         if (!isMounted.current) return;
+        if (!target) return;
         setNotifications((prev) => {
           if (prev.some((n) => n.id === id)) return prev;
-          const updated = [...prev, removedNotification].sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+          const updated = [...prev, target].sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
           persist(updated, storageKeyRef.current);
           notificationsRef.current = updated;
           return updated;


### PR DESCRIPTION
## Problem

Clicking Undo on the delete-notification toast threw `ReferenceError: removedNotification is not defined`, so the notification could not be restored. The deleted notification object is captured as `target` (`useNotificationPoller.js:240`), but the undo handler referenced an undeclared variable `removedNotification` at line 255, so `restoreNotification` threw immediately and the notification stayed deleted.

## Fix

Replaced the undefined `removedNotification` with the captured `target` in `restoreNotification`. Also added a `target == null` guard (the `find` can return `undefined`), so the undo path is a safe no-op when the notification was never found.

## Files changed

- `src/hooks/useNotificationPoller.js`

## Testing

- Undo now re-inserts the deleted notification into the list, persists it, and restores the unread count as originally intended.
- The `target == null` guard prevents a crash when the notification is no longer present in `notificationsRef.current`.

Closes #11233
