### PR TITLE
[Fix] API_ENDPOINTS.EVENTS.SCHEDULE TypeError on schedule save

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -88,7 +88,7 @@ export const API_ENDPOINTS = {
 
     REGISTRANTS: (id) => buildApiUrl(`/events/${id}/registrants`),
     WAITLIST: (id) => buildApiUrl(`/events/${id}/waitlist`),
-    SCHEDULE: buildApiUrl('/events/schedule'),
+    SCHEDULE: (id) => buildApiUrl(`/events/${id}/schedule`),
     // Convenience helper — appends ?page=&size= for callers that build the
     // URL manually rather than going through eventFetchUtils.buildPaginatedUrl.
     PAGINATED: (page, size) => buildApiUrl(`/events?page=${page}&size=${size}`),


### PR DESCRIPTION
## Problem

`API_ENDPOINTS.EVENTS.SCHEDULE` was defined as a URL **string** (`buildApiUrl('/events/schedule')`) but two call sites invoke it as a **function**: `useEventScheduling.js:17-19` and `EventSchedulerCalendar.jsx:192`. Calling `SCHEDULE(eventId)` on a string threw `TypeError: API_ENDPOINTS.EVENTS.SCHEDULE is not a function` on the first schedule save, so the PATCH was never sent (and the default persist path crashed).

## Fix

Made `SCHEDULE` a function in `src/config/api.js` matching its documented call sites:

```js
SCHEDULE: (id) => buildApiUrl(`/events/${id}/schedule`),
```

Both call sites already call `API_ENDPOINTS.EVENTS.SCHEDULE(eventId)` and now receive a valid endpoint URL.

## Files changed

- `src/config/api.js`

## Testing

- The `SCHEDULE` entry now has the same callable signature as the other per-id endpoints (`DETAIL`, `REGISTER`, `CANCEL`, `AVAILABILITY`), so `useEventScheduling` and `EventSchedulerCalendar` no longer throw a `TypeError` on save.
- Verified no other call sites rely on `SCHEDULE` being a plain string (searched `src` for `SCHEDULE` usages).

Closes #11234
