### PR TITLE
[Fix] Notification background poller: compare against lowercase SSE_STATUS.IDLE

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -1,6 +1,6 @@
 import { createContext, useContext, useCallback, useMemo, useEffect, useRef } from "react";
 import { useAuth } from "./AuthContext";
-import useRealTimeConnection from "../hooks/useRealTimeConnection";
+import useRealTimeConnection, { SSE_STATUS } from "../hooks/useRealTimeConnection";
 import { getNotificationCategory, getNotificationMessage, getNotificationTitle } from "../utils/notificationPreferences";
 import { useNotificationPreferences } from "../hooks/useNotificationPreferences";
 import { usePushSubscription } from "../hooks/usePushSubscription";
@@ -23,7 +23,7 @@ const normalizeNotification = (n = {}) => ({
 const useBackgroundInterval = (realtimeStatus, fetchNotifications) => {
   useEffect(() => {
     const intervalId = setInterval(() => {
-      if (realtimeStatus === "IDLE") {
+      if (realtimeStatus === SSE_STATUS.IDLE) {
         fetchNotifications?.();
       }
     }, 30000);


### PR DESCRIPTION
## Problem

The background notification polling interval never fired because `NotificationContext.js` compared the realtime status against an uppercase literal `IDLE` while the actual SSE status values are lowercase (`SSE_STATUS = { IDLE: idle, CONNECTING: connecting, ... }`). Since `realtimeStatus` was always `idle` and never `IDLE`, the condition was never true, so `fetchNotifications` was never called by the 30s background interval and the notification center did not auto-refresh on the background cadence.

## Fix

Imported the shared `SSE_STATUS` constant from `../hooks/useRealTimeConnection` and compared against `SSE_STATUS.IDLE` instead of the hard-coded `IDLE` string. This matches the correct lowercase value and the pattern already used elsewhere (e.g., `NotificationCenter.jsx` compares against `connected`).

## Files changed

- `src/context/NotificationContext.js`

## Testing

- The background poller now triggers `fetchNotifications` whenever the SSE connection is idle, picking up notifications missed during a disconnect.
- Reuses the single source of truth (`SSE_STATUS.IDLE`) so the check stays consistent with the connection status values.

Closes #11235
