### PR TITLE
[Fix] syncPendingRecoverySessions: keep failed sessions for retry

### DIFF
--- a/src/services/sessionRecoveryService.js
+++ b/src/services/sessionRecoveryService.js
@@ -292,6 +292,7 @@ export const syncPendingRecoverySessions = async (
       synced.push(saved);
     } catch (err) {
       console.error('[sessionRecoveryService] Sync failed for session', session?.sessionId, err);
+      failed.push(session);
     }
   }
 


### PR DESCRIPTION
## Problem

`syncPendingRecoverySessions` declared a `failed` array but never added anything to it, so every sync failure silently cleared the pending queue and the failed session was never retried. The `catch` block only logged the error; because `failed.length` was always `0`, the code always ran `clearPendingRecoveryQueue(storage)` and the `CLOUD_RECOVERY_PENDING_KEY` retry list was never written. Failed sessions were permanently dropped, defeating the offline-recovery/retry mechanism.

## Fix

Push the failed session into the `failed` array inside the `catch` block so failed syncs are collected, persisted under `CLOUD_RECOVERY_PENDING_KEY`, and retried on a later sync pass:

```js
} catch (err) {
  console.error('[sessionRecoveryService] Sync failed for session', session?.sessionId, err);
  failed.push(session);
}
```

## Files changed

- `src/services/sessionRecoveryService.js`

## Testing

- On a `saveRecoverySession` failure, the session now stays in the pending queue (`failed.length > 0` writes the failed list instead of clearing the queue), so it will be retried on the next sync pass.
- Successful syncs are unaffected and the queue is still cleared when there are no failures.

Closes #11236
