### PR TITLE
[Fix] Add DELETE /api/notifications/{id} endpoint (fixes 405)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -74,5 +75,33 @@ public class NotificationController {
             Authentication authentication) {
         String email = authentication.getName();
         return ResponseEntity.ok(notificationService.markAsRead(id, email));
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "Delete a notification",
+            description = "Deletes the specified notification for the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Notification deleted successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Notification not found or does not belong to the user"
+            )
+    })
+    public ResponseEntity<Void> deleteNotification(
+            @PathVariable Long id,
+            Authentication authentication) {
+        String email = authentication.getName();
+        notificationService.deleteNotification(id, email);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
@@ -36,6 +36,13 @@ public class NotificationService {
         return mapToResponse(updatedNotification);
     }
 
+    @Transactional
+    public void deleteNotification(Long id, String email) {
+        Notification notification = notificationRepository.findByIdAndUserEmail(id, email)
+                .orElseThrow(() -> new NotificationNotFoundException("Notification not found with id: " + id));
+        notificationRepository.delete(notification);
+    }
+
     private NotificationResponse mapToResponse(Notification notification) {
         return NotificationResponse.builder()
                 .id(notification.getId())


### PR DESCRIPTION
## Problem

The frontend deletes notifications with `DELETE /api/notifications/{id}` (`src/config/api.js:124`, `src/hooks/useNotificationPoller.js:248-249`), but the backend `NotificationController` exposed no `DELETE` mapping — every delete returned `405 Method Not Allowed`, so notifications were only removed from local state and reappeared on the next fetch.

## Fix

Added a `@DeleteMapping(/{id})` handler to `NotificationController` and a matching `deleteNotification(id, email)` method to `NotificationService`:
- The service looks up the notification with `findByIdAndUserEmail(id, email)`, so only the authenticated user's notification can be deleted (404 otherwise), then deletes it.
- The controller returns `204 No Content` on success and includes the appropriate Swagger `@ApiResponses`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java`

## Testing

- The new route matches the frontend's `DELETE /api/notifications/{id}` call, so deletes now reach the server and the notification stays deleted across devices/sessions.
- Ownership is enforced per-user via the existing `findByIdAndUserEmail` repository query.
- Note: no Maven installation is available in this environment, so a full build could not be executed locally.

Closes #11237
