### PR TITLE
[Fix] Admin 'User Growth' analytics now reports new user signups, not registrations

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -261,7 +261,7 @@ public class AdminController {
     @GetMapping("/analytics/users/growth")
     @Operation(
             summary = "User growth trend",
-            description = "Returns monthly registration trend data for the past N months. " +
+            description = "Returns the number of newly created user accounts per month for the past N months. " +
                           "Useful for plotting user growth charts in the admin panel."
     )
     @ApiResponses({

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
@@ -5,9 +5,12 @@ import com.sandeep.eventrabackend.model.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,4 +36,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** Count users by role — used for admin dashboard breakdown. */
     long countByRole(Role role);
+
+    /** Returns the number of newly created user accounts grouped by month. */
+    @Query("""
+        SELECT FUNCTION('DATE_FORMAT', u.createdAt, '%Y-%m') AS period,
+               COUNT(u) AS userCount
+        FROM User u
+        WHERE u.createdAt >= :from
+        GROUP BY period
+        ORDER BY period ASC
+        """)
+    List<Object[]> findMonthlySignupTrend(@Param("from") LocalDateTime from);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -203,12 +203,13 @@ public class AdminService {
     }
 
     /**
-     * Returns user registration growth trend (monthly by default).
+     * Returns user growth trend (monthly new signups by default).
+     * Counts newly created {@link User} accounts grouped by the month of
+     * their {@code createdAt}, not event registrations (Issue #11232).
      */
     public List<RegistrationTrendDTO> getUserGrowthTrend(int months) {
-        // Reuse existing registration trend from AnalyticsService logic
         LocalDateTime from = LocalDateTime.now().minusMonths(months);
-        List<Object[]> raw = regRepo.findMonthlyTrend(from);
+        List<Object[]> raw = userRepository.findMonthlySignupTrend(from);
 
         final long[] cumulative = {0};
         return raw.stream().map(row -> {


### PR DESCRIPTION
## Problem

The admin "User Growth" analytics endpoint (`GET /api/admin/analytics/users/growth?months=N`) reported the number of **event registrations** (confirmed) instead of the number of **new users/signups**, because `AdminService.getUserGrowthTrend` reused the event-registration trend query (`RegistrationAnalyticsRepository.findMonthlyTrend`). A signup spike on an empty calendar month was reported as zero user growth, and a heavily-attended event inflated the number.

## Fix

Implemented a true user-count trend against the `User` entity:
- Added `UserRepository.findMonthlySignupTrend(from)` which groups newly created `User` accounts by the month of their `createdAt`.
- `AdminService.getUserGrowthTrend` now queries this user repository method instead of the registration repository.
- Updated the `AdminController` Swagger description for the endpoint to reflect that it returns new user accounts per month.

The shared `RegistrationTrendDTO` shape (`period`, `registrationCount`, `cumulativeTotal`) is preserved so the API response contract and any consumers remain compatible.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java`

## Testing

- The new query mirrors the existing `DATE_FORMAT` monthly-trend pattern used elsewhere in the analytics layer and is only invoked on the MySQL production database where `DATE_FORMAT` is supported.
- Note: no Maven installation is available in this environment, so a full build could not be executed locally.

Closes #11232
