### PR TITLE
[Fix] Google login returns 400 for invalid tokens

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -71,6 +71,13 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(InvalidGoogleTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidGoogleToken(
+            InvalidGoogleTokenException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(RegistrationClosedException.class)
     public ResponseEntity<ErrorResponse> handleRegistrationClosed(
             RegistrationClosedException ex,

--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/InvalidGoogleTokenException.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/InvalidGoogleTokenException.java
@@ -1,0 +1,8 @@
+package com.sandeep.eventrabackend.exception;
+
+public class InvalidGoogleTokenException extends RuntimeException {
+
+    public InvalidGoogleTokenException(String message) {
+        super(message);
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -5,6 +5,7 @@ import com.sandeep.eventrabackend.dto.request.SignupRequest;
 import com.sandeep.eventrabackend.dto.response.AuthResponse;
 import com.sandeep.eventrabackend.exception.PasswordMismatchException;
 import com.sandeep.eventrabackend.exception.UserAlreadyExistsException;
+import com.sandeep.eventrabackend.exception.InvalidGoogleTokenException;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.UserRepository;
@@ -155,11 +156,10 @@ if (lastName == null || lastName.isBlank()) {
 
         return buildAuthResponse(user, token);
 
+    } catch (InvalidGoogleTokenException e) {
+        throw e;
     } catch (Exception e) {
-
-        throw new RuntimeException(
-                "Google authentication failed"
-        );
+        throw new RuntimeException("Google authentication failed", e);
     }
 }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/GoogleAuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/GoogleAuthService.java
@@ -4,6 +4,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
+import com.sandeep.eventrabackend.exception.InvalidGoogleTokenException;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -35,6 +36,6 @@ public class GoogleAuthService {
             return idToken.getPayload();
         }
 
-        throw new RuntimeException("Invalid Google token");
+        throw new InvalidGoogleTokenException("Invalid Google token");
     }
 }


### PR DESCRIPTION
## Problem

`AuthService.googleLogin` caught every exception and rethrew a generic `RuntimeException("Google authentication failed")` without the original cause, which the global handler converted to `500 Internal Server Error`. Invalid/malformed Google ID tokens — a client error — therefore returned 500 instead of the documented `400 Invalid Google token`, and the root cause was swallowed so operators could not tell a bad token from a Google outage or persistence problem.

## Fix

Stopped the blanket-wrapping and let invalid-token failures map to 400:
- Added a dedicated `InvalidGoogleTokenException` (`exception/InvalidGoogleTokenException.java`).
- `GoogleAuthService.verifyToken` now throws `InvalidGoogleTokenException` (instead of a generic `RuntimeException`) when the token fails verification.
- `AuthService.googleLogin` rethrows `InvalidGoogleTokenException` unchanged; genuine server-side failures are still wrapped in `RuntimeException` but now preserve the original cause.
- Added `@ExceptionHandler(InvalidGoogleTokenException.class)` in `GlobalExceptionHandler` returning `400 Bad Request`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/exception/InvalidGoogleTokenException.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/GoogleAuthService.java`

## Testing

- Invalid/expired Google tokens now propagate as `InvalidGoogleTokenException` and return `400 Bad Request` per the Swagger contract for `POST /api/auth/google`.
- Underlying causes are preserved for genuine server-side failures, which still map to 500 via the catch-all handler.
- Note: no Maven installation is available in this environment, so a full build could not be executed locally.

Closes #11238
