### PR TITLE
fix: clean up dependent records before deleting users

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -21,4 +21,6 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
     List<EventRegistration> findByEvent_Id(Long eventId);
 
     void deleteByEventId(Long eventId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
@@ -32,4 +32,6 @@ public interface EventWaitlistRepository extends JpaRepository<EventWaitlist, Lo
     int findMaxPositionByEventId(@Param("eventId") Long eventId);
 
     void deleteByEvent_Id(Long eventId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
@@ -40,4 +40,6 @@ public interface FeedbackAnalyticsRepository extends JpaRepository<Feedback, Lon
     List<Object[]> findRatingDistributionByEvent(@Param("eventId") Long eventId);
 
     boolean existsByEvent_IdAndUser_Email(Long eventId, String email);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRegistrationRepository.java
@@ -10,4 +10,6 @@ public interface HackathonRegistrationRepository extends JpaRepository<Hackathon
     boolean existsByHackathon_IdAndUser_Email(Long hackathonId, String userEmail);
 
     void deleteByHackathonId(Long hackathonId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserEmailOrderByCreatedAtDesc(String email);
     Optional<Notification> findByIdAndUserEmail(Long id, String email);
+    void deleteByUser_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/ProjectUpvoteRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/ProjectUpvoteRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProjectUpvoteRepository extends JpaRepository<ProjectUpvote, Long> {
     boolean existsByProject_IdAndUser_Id(Long projectId, Long userId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -39,6 +39,11 @@ public class AdminService {
     private final FeedbackAnalyticsRepository feedbackRepository;
     private final EventAnalyticsRepository    eventAnalyticsRepo;
     private final RegistrationAnalyticsRepository regRepo;
+    private final EventRegistrationRepository eventRegistrationRepository;
+    private final EventWaitlistRepository     eventWaitlistRepository;
+    private final HackathonRegistrationRepository hackathonRegistrationRepository;
+    private final ProjectUpvoteRepository     projectUpvoteRepository;
+    private final NotificationRepository      notificationRepository;
 
     // ══════════════════════════════════════════════════════════════════════
     // 1. USER MANAGEMENT
@@ -106,6 +111,14 @@ public class AdminService {
         if (!userRepository.existsById(id)) {
             throw new EntityNotFoundException("User not found with id: " + id);
         }
+
+        eventRegistrationRepository.deleteByUser_Id(id);
+        eventWaitlistRepository.deleteByUser_Id(id);
+        hackathonRegistrationRepository.deleteByUser_Id(id);
+        projectUpvoteRepository.deleteByUser_Id(id);
+        notificationRepository.deleteByUser_Id(id);
+        feedbackRepository.deleteByUser_Id(id);
+
         userRepository.deleteById(id);
     }
 


### PR DESCRIPTION
# Summary

Prevents user deletion failures caused by foreign key constraint violations by removing dependent records before deleting the user.

## Related Issue

Closes #11290

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added repository methods to delete records associated with a user.
- Removed dependent registrations, waitlist entries, notifications, and related records before deleting the user.
- Prevented database integrity violations during user deletion.
- Improved reliability of the administrative user deletion workflow.

## Technical Details

### Backend

- Updated repository interfaces to support deletion by user ID.
- Updated the admin user deletion flow to clean up dependent records before deleting the user.

## Testing

### Manual Testing

- [x] Verified users without related records can be deleted successfully.
- [x] Verified users with dependent records can be deleted without foreign key constraint errors.
- [x] Verified associated registrations, waitlist entries, notifications, and related data are removed correctly.
- [x] Verified no database integrity exceptions occur during deletion.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review