### PR TITLE
fix: clamp admin pagination size parameters 

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -72,7 +72,8 @@ public class AdminController {
             @Parameter(description = "Filter by role: CLIENT | ORGANIZER | ADMIN | SUPER_ADMIN")
             @RequestParam(required = false) String role
     ) {
-        return ResponseEntity.ok(adminService.getUsers(page, size, role));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getUsers(page, clampedSize, role));
     }
 
     @GetMapping("/users/{id}")
@@ -156,7 +157,8 @@ public class AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(adminService.getEvents(page, size));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getEvents(page, clampedSize));
     }
 
     @GetMapping("/events/{id}/attendees")
@@ -216,7 +218,8 @@ public class AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(adminService.getHackathons(page, size));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getHackathons(page, clampedSize));
     }
 
     @DeleteMapping("/hackathons/{id}")
@@ -315,7 +318,8 @@ public class AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(adminService.getAllFeedback(page, size));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getAllFeedback(page, clampedSize));
     }
 
     @DeleteMapping("/feedback/{id}")


### PR DESCRIPTION
# Summary

Prevents unbounded pagination requests by clamping page size parameters to a safe range before creating pageable queries, reducing the risk of excessive memory usage and resource exhaustion.

## Related Issue

Closes #11291

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added server-side validation for pagination size parameters.
- Clamped requested page sizes to a minimum of `1` and a maximum of `100`.
- Applied consistent pagination limits across admin listing endpoints.
- Prevented excessively large page sizes from reaching the service layer.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java`.
- Added:
  ```java
  int clampedSize = Math.min(Math.max(size, 1), 100);
  ```
- Replaced direct usage of `size` with `clampedSize` when invoking service methods.

## Testing

### Manual Testing

- [x] Verified negative page sizes are clamped to `1`.
- [x] Verified `0` is clamped to `1`.
- [x] Verified values greater than `100` are clamped to `100`.
- [x] Verified valid page sizes continue to work as expected.
- [x] Verified all affected admin pagination endpoints return expected results.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review