### PR TITLE
fix: validate Google OAuth email before processing

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -108,6 +108,11 @@ public AuthResponse googleLogin(GoogleAuthRequest request) {
 
         String email = payload.getEmail();
 
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Google account must provide a valid email address.");
+        }
+
        String firstName =
         (String) payload.get("given_name");
 


### PR DESCRIPTION
# Summary

Prevents Google OAuth registration from crashing when the authenticated account does not provide a valid email claim by validating the email before further processing.

## Related Issue

Closes #11292

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added validation for the Google OAuth email claim.
- Rejected null or blank email values before parsing.
- Prevented runtime exceptions caused by invalid email data.
- Improved the robustness of the Google OAuth authentication flow.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`.
- Added validation to ensure the email is present before processing the OAuth payload.

## Testing

### Manual Testing

- [x] Verified Google OAuth login succeeds with a valid email.
- [x] Verified requests with a missing email are rejected gracefully.
- [x] Verified blank email values are rejected.
- [x] Verified no server-side runtime exceptions occur due to missing email claims.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review