### PR TITLE
fix: restrict public event GET routes

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -127,7 +127,14 @@ public class SecurityConfig {
                         // ── Public: Event read-only endpoints ────────────────
                         // Anyone can view an event or check its availability;
                         // only authenticated users can register (POST).
-                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/events/**").permitAll()
+                        .requestMatchers(
+                                org.springframework.http.HttpMethod.GET,
+                                "/api/events",
+                                "/api/events/{id}",
+                                "/api/events/{id}/availability",
+                                "/api/events/{id}/seats",
+                                "/api/events/stream"
+                        ).permitAll()
                         // ── Public: Projects endpoint ────────────────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/{id}").permitAll()


### PR DESCRIPTION
# Summary

Replaces the broad public GET rule for `/api/events/**` with explicit public endpoints to prevent unintentionally exposing protected event APIs.

## Related Issue

Closes #11293

## Type of Change

- [x] Bug Fix
- [x] Security Fix

## Changes Implemented

- Removed the wildcard `GET /api/events/**` permit rule.
- Added explicit public GET endpoints:
  - `/api/events`
  - `/api/events/{id}`
  - `/api/events/{id}/availability`
  - `/api/events/{id}/seats`
  - `/api/events/stream`
- Ensured protected endpoints continue to require authentication and authorization.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java`

The security configuration now exposes only intended public event endpoints instead of permitting every GET request under `/api/events/**`.

## Testing

### Manual Testing

- [x] Verified public event listing remains accessible.
- [x] Verified event details remain publicly accessible.
- [x] Verified availability and seat endpoints remain public.
- [x] Verified protected event-related GET endpoints are no longer accessible without proper authorization.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review