### PR TITLE
fix: prevent duplicate seat reservations under concurrent requests 

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -24,6 +24,7 @@ import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -502,14 +503,6 @@ public class EventService {
                     "You are already registered for this event.");
         }
 
-        if (seatId != null && !seatId.isBlank()) {
-            eventRegistrationRepository.findByEvent_IdAndSeatId(eventId, seatId)
-                    .ifPresent(existing -> {
-                        throw new RegistrationConflictException(
-                                "Seat " + seatId + " is already taken.");
-                    });
-        }
-
         if (event.getCapacity() != null
                 && event.getRegisteredCount() >= event.getCapacity()) {
 
@@ -529,7 +522,12 @@ public class EventService {
         registration.setStatus("CONFIRMED");
         registration.setSeatId(seatId);
 
-        registration = eventRegistrationRepository.save(registration);
+        try {
+            registration = eventRegistrationRepository.saveAndFlush(registration);
+        } catch (DataIntegrityViolationException ex) {
+            throw new RegistrationConflictException(
+                    "Seat " + seatId + " is already taken.");
+        }
 
         Integer spotsRemaining =
                 (saved.getCapacity() == null)


### PR DESCRIPTION
# Summary

Prevents duplicate seat assignments during concurrent event registrations by handling database constraint violations and returning a meaningful conflict response instead of allowing inconsistent registrations.

## Related Issue

Closes #11304

## Type of Change

- [x] Bug Fix
- [x] Concurrency Fix

## Changes Implemented

- Replaced direct `save()` with `saveAndFlush()` during event registration.
- Added handling for `DataIntegrityViolationException`.
- Converted duplicate seat conflicts into a `RegistrationConflictException` with a clear error message.
- Ensures duplicate seat reservations are handled gracefully during concurrent requests.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

Key changes:

- Persist registrations using `saveAndFlush()`.
- Catch database constraint violations.
- Return a user-friendly conflict response when the requested seat has already been reserved.

## Testing

### Manual Testing

- [x] Verified normal seat reservations continue to work.
- [x] Verified duplicate seat reservation attempts return a conflict.
- [x] Verified application no longer exposes database exceptions to clients.
- [x] Verified registration flow behaves correctly after the changes.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project coding standards.
- [x] Ready for review.