### PR TITLE
fix: generate secure OAuth fallback passwords

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.sandeep.eventrabackend.dto.request.GoogleAuthRequest;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import java.util.UUID;
+import java.security.SecureRandom;
+import java.util.Base64;
 
 @Service
 public class AuthService {
@@ -134,16 +135,17 @@ if (lastName == null || lastName.isBlank()) {
             String username =
                     generateUniqueUsername(baseUsername);
 
+            SecureRandom secureRandom = new SecureRandom();
+            byte[] randomBytes = new byte[32];
+            secureRandom.nextBytes(randomBytes);
+            String securePassword = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+
             user = User.builder()
                     .firstName(firstName)
                     .lastName(lastName)
                     .email(email.toLowerCase())
                     .username(username)
-                    .password(
-                            passwordEncoder.encode(
-                                    UUID.randomUUID().toString()
-                            )
-                    )
+                    .password(passwordEncoder.encode(securePassword))
                     .role(Role.CLIENT)
                     .build();
 


### PR DESCRIPTION
# Summary

Improves the security of automatically generated fallback passwords for Google OAuth users by replacing UUID-based generation with cryptographically secure random bytes.

## Related Issue

Closes #11309

## Type of Change

- [x] Bug Fix
- [x] Security Fix

## Changes Implemented

- Replaced UUID-based password generation with `SecureRandom`.
- Generated a 32-byte cryptographically secure random value.
- Encoded the generated bytes using Base64 URL-safe encoding.
- Continued storing only the hashed password using the existing password encoder.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`

Key improvements:

- Added `SecureRandom` for secure entropy generation.
- Generated 32 random bytes for fallback passwords.
- Encoded the bytes using `Base64.getUrlEncoder().withoutPadding()`.
- Stored the generated password after hashing with `passwordEncoder`.

## Testing

### Manual Testing

- [x] Verified Google OAuth registration completes successfully.
- [x] Verified fallback passwords are generated securely.
- [x] Verified generated passwords are stored only in hashed form.
- [x] Verified existing authentication flow remains unaffected.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project coding standards.
- [x] Self-reviewed the implementation.
- [x] Ready for review.