### PR TITLE
fix: enable servlet registration for rate limiting filter

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -33,17 +33,14 @@ import org.springframework.beans.factory.annotation.Value;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final RateLimitingFilter rateLimitingFilter;
     private final UserDetailsService userDetailsService;
 
     @Value("${app.cors.allowed-origins:http://localhost:3000,https://eventra.vercel.app,https://eventra.sandeepvashishtha.tech}")
     private String allowedOrigins;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
-            RateLimitingFilter rateLimitingFilter,
             UserDetailsService userDetailsService) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-        this.rateLimitingFilter = rateLimitingFilter;
         this.userDetailsService = userDetailsService;
     }
 
@@ -101,7 +98,8 @@ public class SecurityConfig {
     public FilterRegistrationBean<RateLimitingFilter> rateLimitingFilterRegistration(
             RateLimitingFilter filter) {
         FilterRegistrationBean<RateLimitingFilter> registration = new FilterRegistrationBean<>(filter);
-        registration.setEnabled(false);
+        registration.setEnabled(true);
+        registration.addUrlPatterns("/api/*");
         return registration;
     }
 
@@ -154,8 +152,6 @@ public class SecurityConfig {
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(unauthorizedEntryPoint()))
                 .authenticationProvider(authenticationProvider())
-                .addFilterBefore(rateLimitingFilter,
-                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
# Summary

Enables servlet registration for the rate limiting filter so it is applied to all API requests instead of relying solely on the Spring Security filter chain.

## Related Issue

Closes #11310

## Type of Change

- [x] Bug Fix
- [x] Security Fix

## Changes Implemented

- Enabled automatic servlet registration for the `RateLimitingFilter`.
- Registered the filter for `/api/*` URL patterns.
- Removed the explicit Spring Security filter-chain registration to avoid duplicate execution.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java`

Key improvements:

- Changed `registration.setEnabled(false)` to `registration.setEnabled(true)`.
- Added URL mapping:

  ```java
  registration.addUrlPatterns("/api/*");
  ```

- Removed:

  ```java
  .addFilterBefore(rateLimitingFilter, UsernamePasswordAuthenticationFilter.class)
  ```

  since the filter is now registered as a servlet filter.

## Testing

### Manual Testing

- [x] Verified the rate limiting filter is registered.
- [x] Verified requests to `/api/*` pass through the filter.
- [x] Verified application starts successfully without duplicate filter registration.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project coding standards.
- [x] Self-reviewed the implementation.
- [x] Ready for review.