### PR TITLE
fix: validate empty bearer tokens in logout endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -159,7 +159,10 @@ public ResponseEntity<AuthResponse> googleLogin(
     })
     public ResponseEntity<String> logout(@RequestHeader("Authorization") String bearerToken) {
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            String token = bearerToken.substring(7);
+            String token = bearerToken.substring(7).trim();
+            if (token.isEmpty()) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Bearer token cannot be empty");
+            }
             authService.logout(token);
             return ResponseEntity.ok("Logged out successfully");
         }


### PR DESCRIPTION
# Summary

Adds validation for empty Bearer tokens in the logout endpoint to prevent invalid requests from reaching the authentication service.

## Related Issue

Closes #11311

## Type of Change

- [x] Bug Fix
- [x] Security Fix

## Changes Implemented

- Trimmed the extracted Bearer token.
- Added validation to reject empty or whitespace-only tokens.
- Returned HTTP 401 Unauthorized when an empty Bearer token is provided.
- Prevented invalid logout requests from reaching the service layer.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java`

Key improvements:

```java
String token = bearerToken.substring(7).trim();

if (token.isEmpty()) {
    return ResponseEntity
            .status(HttpStatus.UNAUTHORIZED)
            .body("Bearer token cannot be empty.");
}
```

This ensures only valid Bearer tokens are processed.

## Testing

### Manual Testing

- [x] Verified valid Bearer tokens continue to logout successfully.
- [x] Verified `Authorization: Bearer` returns **401 Unauthorized**.
- [x] Verified whitespace-only Bearer tokens are rejected.
- [x] Confirmed no regression in the logout flow.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project coding standards.
- [x] Self-reviewed the implementation.
- [x] Ready for review.