### PR TITLE
fix: enforce maximum page size for admin pagination

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -72,7 +72,8 @@ public class AdminController {
             @Parameter(description = "Filter by role: CLIENT | ORGANIZER | ADMIN | SUPER_ADMIN")
             @RequestParam(required = false) String role
     ) {
-        return ResponseEntity.ok(adminService.getUsers(page, size, role));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getUsers(page, clampedSize, role));
     }
 
     @GetMapping("/users/{id}")
@@ -156,7 +157,8 @@ public class AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(adminService.getEvents(page, size));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getEvents(page, clampedSize));
     }
 
     @GetMapping("/events/{id}/attendees")
@@ -216,7 +218,8 @@ public class AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(adminService.getHackathons(page, size));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getHackathons(page, clampedSize));
     }
 
     @DeleteMapping("/hackathons/{id}")
@@ -315,7 +318,8 @@ public class AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return ResponseEntity.ok(adminService.getAllFeedback(page, size));
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return ResponseEntity.ok(adminService.getAllFeedback(page, clampedSize));
     }
 
     @DeleteMapping("/feedback/{id}")


### PR DESCRIPTION
# Summary

Prevents excessive pagination requests by enforcing a safe page size limit across admin pagination endpoints.

## Related Issue

Fixes #11332

## Type of Change

- [x] Security Fix
- [x] Performance Improvement

## Changes Implemented

- Added page size validation using `Math.min()` and `Math.max()`.
- Enforced a minimum page size of `1`.
- Enforced a maximum page size of `100`.
- Updated all affected admin pagination endpoints to use the validated page size.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java`.

## Testing

### Manual Testing

- [x] Verified requests with `size > 100` are clamped to `100`.
- [x] Verified requests with `size <= 0` are clamped to `1`.
- [x] Verified normal pagination behavior remains unchanged.
- [x] Verified all affected admin endpoints use the validated page size.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review