### PR TITLE
fix: prevent project upvote counter overflow

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Project.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Project.java
@@ -32,5 +32,5 @@ public class Project {
     private String githubUrl;
 
     @Builder.Default
-    private int upvotes = 0;
+    private long upvotes = 0;
 }


### PR DESCRIPTION
# Summary

Replaces the project upvote counter type from `int` to `long` to prevent integer overflow when projects accumulate a very large number of upvotes.

## Related Issue

Closes #11339

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Changed the `upvotes` field in `Project` from `int` to `long`.
- Prevents overflow into negative values after exceeding `Integer.MAX_VALUE`.
- Improves long-term reliability of project ranking data.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/model/Project.java`

Changes:

- Replaced:

```java
private int upvotes = 0;
```

with:

```java
private long upvotes = 0;
```

## Testing

### Manual Testing

- [x] Project builds successfully.
- [x] Entity compiles without errors.
- [x] Upvote counter now supports values larger than `Integer.MAX_VALUE`.

## Breaking Changes

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows project coding standards.
- [x] Related issue referenced.
- [x] Ready for review.