### PR TITLE
fix: trim user profile fields before saving

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -129,9 +129,9 @@ public class UserController {
             throw new UserAlreadyExistsException("Username already exists: " + request.getUsername());
         }
 
-        user.setFirstName(request.getFirstName());
-        user.setLastName(request.getLastName());
-        user.setUsername(request.getUsername());
+        user.setFirstName(request.getFirstName().trim());
+        user.setLastName(request.getLastName().trim());
+        user.setUsername(request.getUsername().trim());
 
         User updatedUser = userRepository.save(user);
         return ResponseEntity.ok(mapToUserProfileResponse(updatedUser));


### PR DESCRIPTION
# Summary

Trims leading and trailing whitespace from user profile fields before persisting updates to the database.

## Related Issue

Closes #11340

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Applied `trim()` to `firstName`.
- Applied `trim()` to `lastName`.
- Applied `trim()` to `username`.
- Prevents accidental whitespace from being stored in user profile data.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java`

Changes:

```java
user.setFirstName(request.getFirstName().trim());
user.setLastName(request.getLastName().trim());
user.setUsername(request.getUsername().trim());
```

instead of:

```java
user.setFirstName(request.getFirstName());
user.setLastName(request.getLastName());
user.setUsername(request.getUsername());
```

## Benefits

- Prevents inconsistent profile data.
- Improves UI rendering and certificate generation.
- Avoids usernames that differ only by surrounding whitespace.

## Testing

### Manual Testing

- [x] Updated a user profile with leading/trailing spaces.
- [x] Verified stored values are trimmed.
- [x] Existing functionality remains unchanged.

## Breaking Changes

- [ ] Yes
- [x] No

## Checklist

- [x] Code follows project coding standards.
- [x] Related issue referenced.
- [x] Ready for review.