### PR TITLE
feat: add 'Add to Calendar' utility button

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -29,11 +29,11 @@ import { ROLES } from "config/roles";
 import { marked } from "marked";
 import ShareModal from "components/common/ShareModal";
 import SocialShareButtons from "components/common/SocialShareButtons";
-import { downloadICSFile, generateGoogleCalendarLink, generateOutlookLink } from "utils/calendarExporter";
 import { RecentlyViewedTracker } from "components/common/RecentlyViewedEvents";
 import { apiUtils, API_ENDPOINTS } from "config/api";
 import { getLastUpdated } from "utils/LastUpdatedUtils";
 import CopyButton from 'components/ui/CopyButton';
+import AddToCalendar from "components/common/AddToCalendar";
 
 const formatEventDate = (dateValue) => {
   if (!dateValue) return { short: "TBD", full: "Date TBD", relative: "" };
@@ -75,6 +75,46 @@ const isRequestCanceled = (error, signal) =>
   error?.name === "AbortError" ||
   error?.name === "CanceledError" ||
   error?.code === "ERR_CANCELED";
+
+const toCalendarDate = (dateValue) => {
+  if (!dateValue) return "";
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+};
+
+const toCalendarTime = (event, dateValue) => {
+  if (event?.time) return event.time;
+
+  if (!dateValue) return "";
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  });
+};
+
+const getDurationMinutes = (startValue, endValue) => {
+  if (!startValue || !endValue) return 60;
+  const start = new Date(startValue);
+  const end = new Date(endValue);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end <= start) {
+    return 60;
+  }
+  return Math.round((end - start) / (1000 * 60));
+};
+
+const getCalendarLocation = (event) => {
+  if (!event?.location) return event?.venue || "Online";
+  if (typeof event.location === "string") return event.location;
+
+  return [event.location.name, event.location.address]
+    .filter(Boolean)
+    .join(", ") || event.venue || "Online";
+};
 
 const EventDetails = () => {
   const { eventId } = useParams();
@@ -340,6 +380,16 @@ ${window.location.href}
   : null;
   const eventDate = event.date || event.eventDate || event.startDate || null;
   const dateInfo = formatEventDate(eventDate);
+  const calendarEvent = {
+    id: event.id,
+    title: event.title,
+    description: event.description,
+    date: toCalendarDate(eventDate),
+    time: toCalendarTime(event, eventDate),
+    durationMinutes: event.durationMinutes || getDurationMinutes(eventDate, event.endDate),
+    location: getCalendarLocation(event),
+    joiningLink: event.joiningLink || event.virtualLink || window.location.href,
+  };
 
 const hoursLeft = registrationEnd
   ? Math.ceil((registrationEnd - new Date()) / (1000 * 60 * 60))
@@ -637,25 +687,7 @@ const lastUpdated = getLastUpdated(event.updatedAt);
                 <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">Add to Calendar</h3>
                 
                 <div className="flex flex-col gap-2">
-                  <button onClick={() => { downloadICSFile(event); toast.success("Calendar invite downloaded!"); }} className="w-full inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2.5 text-sm font-semibold text-gray-800 dark:text-gray-100 shadow-sm hover:bg-green-50 dark:hover:bg-green-900/20 hover:border-green-300 dark:hover:border-green-700 transition-all duration-200" aria-label="Download .ics calendar invite">
-                    <CalendarPlus size={15} className="text-green-500" /> Download .ics Invite
-                  </button>
-                  {generateGoogleCalendarLink(event) && (
-                    <a href={generateGoogleCalendarLink(event)} target="_blank" rel="noopener noreferrer" className="w-full inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2.5 text-sm font-semibold text-gray-800 dark:text-gray-100 shadow-sm hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-all duration-200" aria-label="Add to Google Calendar">
-                      <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
-                        <path fill="#4285F4" d="M22 12c0-5.52-4.48-10-10-10S2 6.48 2 12s4.48 10 10 10 10-4.48 10-10z" />
-                        <path fill="#fff" d="M13 7h-2v6l5.25 3.15.75-1.23-4-2.37z" />
-                      </svg> Add to Google Calendar
-                    </a>
-                  )}
-                  {generateOutlookLink(event) && (
-                    <a href={generateOutlookLink(event)} target="_blank" rel="noopener noreferrer" className="w-full inline-flex items-center justify-center gap-2 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-2.5 text-sm font-semibold text-gray-800 dark:text-gray-100 shadow-sm hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-all duration-200" aria-label="Add to Outlook Calendar">
-                      <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
-                        <path fill="#0078D4" d="M2 6l10-4 10 4v12l-10 4L2 18z" />
-                        <path fill="#fff" d="M12 4L4 7v10l8 3 8-3V7z" />
-                      </svg> Add to Outlook
-                    </a>
-                  )}
+                  <AddToCalendar event={calendarEvent} className="w-full" />
                 </div>
 
                 <div className="pt-2">

--- a/src/components/common/AddToCalendar.jsx
+++ b/src/components/common/AddToCalendar.jsx
@@ -1,50 +1,25 @@
 import { useState, useRef, useEffect } from 'react';
-import { Calendar, ChevronDown, X } from 'lucide-react';
-import { getGoogleCalendarUrl, getOutlookCalendarUrl, getWebcalSubscriptionUrl } from 'utils/calendarUrlUtils';
+import { Calendar, ChevronDown, Download, ExternalLink, X } from 'lucide-react';
+import { generateIcsFileBlobUrl, getGoogleCalendarUrl, getOutlookCalendarUrl } from 'utils/calendarUrlUtils';
 
-const generateICalContent = (event) => {
-  const formatICalDate = (dateStr, timeStr) => {
-    if (!dateStr) return '';
-    const dt = new Date(`${dateStr}T${timeStr || '00:00'}:00`);
-    return dt.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-  };
-  const start = formatICalDate(event.date, event.time);
-  const durationMs = (event.durationMinutes || 60) * 60 * 1000;
-  const endDate = new Date(new Date(`${event.date}T${event.time || '00:00'}:00`).getTime() + durationMs);
-  const end = endDate.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
-  return [
-    'BEGIN:VCALENDAR',
-    'VERSION:2.0',
-    'PRODID:-//Eventra//EN',
-    'BEGIN:VEVENT',
-    `DTSTART:${start}`,
-    `DTEND:${end}`,
-    `SUMMARY:${event.title || 'Event'}`,
-    `DESCRIPTION:${(event.description || '').replace(/\n/g, '\\n')}`,
-    `LOCATION:${event.location || ''}`,
-    `URL:${event.joiningLink || window.location.href}`,
-    `UID:${event.id || Date.now()}@eventra`,
-    'BEGIN:VALARM',
-    'TRIGGER:-PT30M',
-    'ACTION:DISPLAY',
-    'DESCRIPTION:Reminder',
-    'END:VALARM',
-    'END:VEVENT',
-    'END:VCALENDAR',
-  ].join('\r\n');
-};
+const toSafeFilename = (value) =>
+  (value || 'event')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'event';
 
 const downloadIcal = (event) => {
-  const content = generateICalContent(event);
-  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
+  const url = generateIcsFileBlobUrl(event);
+  if (!url) return false;
+
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${(event.title || 'event').replace(/\s+/g, '-')}.ics`;
+  a.download = `${toSafeFilename(event.title)}.ics`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 200);
+  return true;
 };
 
 export default function AddToCalendar({ event, className = '', iconOnly = false }) {
@@ -56,27 +31,26 @@ export default function AddToCalendar({ event, className = '', iconOnly = false 
   if (!event) return null;
 
   const handleGoogle = () => {
-    window.open(getGoogleCalendarUrl(event), '_blank', 'noopener,noreferrer');
+    const url = getGoogleCalendarUrl(event);
+    if (!url) return;
+    window.open(url, '_blank', 'noopener,noreferrer');
     setAdded('Google Calendar');
     timeoutRef.current = setTimeout(() => setOpen(false), 800);
   };
 
   const handleOutlook = () => {
-    window.open(getOutlookCalendarUrl(event), '_blank', 'noopener,noreferrer');
+    const url = getOutlookCalendarUrl(event);
+    if (!url) return;
+    window.open(url, '_blank', 'noopener,noreferrer');
     setAdded('Outlook');
     timeoutRef.current = setTimeout(() => setOpen(false), 800);
   };
 
   const handleIcal = () => {
-    if (event.id) {
-      const webcalUrl = getWebcalSubscriptionUrl(event.id);
-      window.location.href = webcalUrl;
-    } else {
-      // Fallback to static download when event has no ID
-      downloadIcal(event);
+    if (downloadIcal(event)) {
+      setAdded('iCal file');
+      timeoutRef.current = setTimeout(() => setOpen(false), 800);
     }
-    setAdded('Apple / ICS');
-    timeoutRef.current = setTimeout(() => setOpen(false), 800);
   };
 
   return (
@@ -85,7 +59,7 @@ export default function AddToCalendar({ event, className = '', iconOnly = false 
         onClick={() => setOpen(!open)}
         className={iconOnly
           ? "rounded-full border border-gray-200 bg-white/90 p-2 shadow backdrop-blur-sm hover:border-indigo-200 dark:border-gray-700 dark:bg-gray-800/90 dark:hover:border-indigo-500 transition-all duration-200 focus-visible:ring-2 focus-visible:ring-indigo-500 cursor-pointer"
-          : "flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"}
+          : "flex w-full items-center justify-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"}
         aria-haspopup="true"
         aria-expanded={open}
         title="Add to Calendar"
@@ -108,16 +82,16 @@ export default function AddToCalendar({ event, className = '', iconOnly = false 
             </button>
           </div>
           <button onClick={handleGoogle} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left">
-            <img src="https://www.google.com/favicon.ico" alt="" className="w-4 h-4" loading="lazy" />
+            <ExternalLink className="w-4 h-4 text-blue-500" />
             Google Calendar
           </button>
           <button onClick={handleOutlook} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left border-t border-gray-100 dark:border-gray-800">
-            <img src="https://outlook.live.com/favicon.ico" alt="" className="w-4 h-4" loading="lazy" />
+            <ExternalLink className="w-4 h-4 text-sky-600" />
             Outlook Calendar
           </button>
           <button onClick={handleIcal} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left border-t border-gray-100 dark:border-gray-800">
-            <Calendar className="w-4 h-4 text-gray-400" />
-            Export to Apple Calendar (.ics)
+            <Download className="w-4 h-4 text-gray-400" />
+            Download iCal (.ics)
           </button>
           {added && (
             <div className="px-4 py-2 bg-green-50 dark:bg-green-900/20 border-t border-green-100 dark:border-green-800">

--- a/tests/eventDetails.test.mjs
+++ b/tests/eventDetails.test.mjs
@@ -170,6 +170,24 @@ describe('EventDetails — stale request cancellation', () => {
   });
 });
 
+describe('EventDetails — add to calendar utility', () => {
+  it('renders the shared AddToCalendar action on the event details page', () => {
+    assert.ok(
+      src.includes('components/common/AddToCalendar') && src.includes('<AddToCalendar event={calendarEvent}'),
+      'EventDetails should render the shared AddToCalendar utility with normalized event data',
+    );
+  });
+
+  it('normalizes loaded event details for calendar URL and iCal generation', () => {
+    assert.ok(
+      src.includes('const calendarEvent = {') &&
+        src.includes('durationMinutes') &&
+        src.includes('joiningLink'),
+      'EventDetails should pass title, dates, duration, location, and link data into AddToCalendar',
+    );
+  });
+});
+
 describe('EventDetails — API fetch logic unit tests', () => {
   // Simulate the core loadEvent logic in isolation
   const buildFetchResult = (ok, status, data) => ({


### PR DESCRIPTION
Implemented the Add to Calendar feature for the Event Details page.
Closes #9412 

## Changed:
- [AddToCalendar.jsx](https://github.com/SandeepVashishtha/Eventra/blob/master/src/components/common/AddToCalendar.jsx): now uses shared calendar URL utilities, opens Google/Outlook links, and downloads a real `.ics` file for iCal/native calendar apps.
- [EventDetails.js](https://github.com/SandeepVashishtha/Eventra/blob/master/src/Pages/Events/EventDetails.js): replaced the duplicated calendar UI with the shared `AddToCalendar` button and normalized event date, time, duration, location, and joining link.
- [eventDetails.test.mjs](https://github.com/SandeepVashishtha/Eventra/blob/master/tests/eventDetails.test.mjs): added source-level checks for the Event Details calendar integration.