### PR TITLE
feat: add loading skeletons for event dashboard cards

### DIFF
--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -18,6 +18,12 @@ import { Link } from "react-router-dom";
 import { useMyEvents } from "context/MyEventsContext";
 import { useAuth } from "context/AuthContext";
 import StatusBadge from "../common/StatusBadge";
+import {
+  DashboardSectionTitleSkeleton,
+  DashboardStatCardSkeleton,
+  SkeletonBlock,
+  SkeletonEventCard,
+} from "../common/SkeletonLoaders";
 import { safeParseJson } from "utils/jsonUtils";
 import StyledDropdown from "../StyledDropdown";
 import SearchEmptyState from "../common/SearchEmptyState";
@@ -309,10 +315,47 @@ const EventsLoading = () => (
     <div className="ud-tab-header">
       <h2><Calendar /> Events</h2>
     </div>
-    <div className="flex items-center justify-center min-h-[400px]">
-      <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto" />
-        <p className="mt-4 text-gray-600 dark:text-gray-400">Loading your events...</p>
+
+    <div role="status" aria-live="polite" aria-label="Loading your events">
+      <div className="ud-stats-grid">
+        {[...Array(4)].map((_, i) => (
+          <DashboardStatCardSkeleton key={`event-stat-skeleton-${i}`} />
+        ))}
+      </div>
+
+      <div className="my-events-container mt-8">
+        <div className="my-events-toolbar">
+          <div className="ud-search-wrap my-events-search">
+            <SkeletonBlock className="h-10 w-full rounded-2xl" />
+          </div>
+          {[...Array(3)].map((_, i) => (
+            <SkeletonBlock key={`event-filter-skeleton-${i}`} className="h-10 w-36 rounded-2xl" />
+          ))}
+        </div>
+
+        <section className="space-y-4 mt-6">
+          <div className="ud-tab-header">
+            <DashboardSectionTitleSkeleton />
+            <SkeletonBlock className="h-5 w-20 rounded-full" />
+          </div>
+          <div className="ud-items-grid">
+            {[...Array(3)].map((_, i) => (
+              <SkeletonEventCard key={`registered-event-card-skeleton-${i}`} />
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4 mt-8">
+          <div className="ud-tab-header">
+            <DashboardSectionTitleSkeleton />
+            <SkeletonBlock className="h-5 w-20 rounded-full" />
+          </div>
+          <div className="ud-items-grid">
+            {[...Array(3)].map((_, i) => (
+              <SkeletonEventCard key={`hosted-event-card-skeleton-${i}`} />
+            ))}
+          </div>
+        </section>
       </div>
     </div>
   </div>

--- a/tests/eventsDashboardSkeleton.test.mjs
+++ b/tests/eventsDashboardSkeleton.test.mjs
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const eventsTabPath = path.resolve(__dirname, "../src/components/user/EventsTab.js");
+
+test("Events dashboard loading state uses skeleton placeholders instead of a centered spinner", () => {
+  const source = readFileSync(eventsTabPath, "utf8");
+  const loadingComponent = source.slice(
+    source.indexOf("const EventsLoading"),
+    source.indexOf("/* ---------------- Stats Component ---------------- */"),
+  );
+
+  assert.match(loadingComponent, /role="status"/, "loading skeleton should announce loading status");
+  assert.match(loadingComponent, /DashboardStatCardSkeleton/, "loading state should include stat skeletons");
+  assert.match(loadingComponent, /SkeletonEventCard/, "loading state should include event card skeletons");
+  assert.match(loadingComponent, /my-events-toolbar/, "loading state should preserve toolbar layout");
+  assert.doesNotMatch(loadingComponent, /animate-spin/, "Events dashboard loading should not use a spinner");
+  assert.doesNotMatch(loadingComponent, /Loading your events\.\.\./, "Events dashboard loading should not render loading text in place of skeletons");
+});


### PR DESCRIPTION
Implemented the skeleton loading feature for issue #8919.

## Changed 
- [EventsTab.js](https://github.com/SandeepVashishtha/Eventra/blob/master/src/components/user/EventsTab.js) so the Events dashboard loading state now shows:
    - stat card skeletons
    - toolbar/filter skeletons
    - registered/hosted event card skeleton grids
- Also added `/tests/eventsDashboardSkeleton.test.mjs` to prevent the loading state from regressing back to a centered spinner.