### PR TITLE
feat: web share api integration for event invites

### DIFF
--- a/src/components/common/CopyLinkButton.jsx
+++ b/src/components/common/CopyLinkButton.jsx
@@ -1,31 +1,26 @@
 import { useState } from "react";
 import { Link2, Check } from "lucide-react";
+import useEventShare from "hooks/useEventShare";
 
-const CopyLinkButton = () => {
+const CopyLinkButton = ({ title = "Event", text = "Check out this event!", url }) => {
   const [copied, setCopied] = useState(false);
+  const { canNativeShare, shareEvent, copyInviteLink } = useEventShare({
+    fallbackMessage: "Event invite link copied to clipboard",
+  });
 
   const handleCopy = async () => {
-  try {
-    if (navigator.share) {
-      await navigator.share({
-        title: "Event",
-        text: "Check out this event!",
-        url: textToCopy,
-      });
-      return;
+    const shareUrl = url || (typeof window !== "undefined" ? window.location.href : "");
+    const ok = canNativeShare
+      ? await shareEvent({ title, text, url: shareUrl })
+      : await copyInviteLink(shareUrl);
+
+    if (ok && !canNativeShare) {
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
     }
-
-    await navigator.clipboard.writeText(textToCopy);
-
-    setCopied(true);
-
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
-  } catch (err) {
-    console.error(err);
-  }
-};
+  };
 
   return (
     <button
@@ -36,7 +31,7 @@ const CopyLinkButton = () => {
           ? "bg-green-600 text-white"
           : "bg-indigo-600 hover:bg-indigo-700 text-white"
       }`}
-      aria-label="Copy event link"
+      aria-label={canNativeShare ? "Share event invite" : "Copy event link"}
     >
       {copied ? (
         <>
@@ -46,7 +41,7 @@ const CopyLinkButton = () => {
       ) : (
         <>
           <Link2 size={18} />
-          Copy Link
+          {canNativeShare ? "Share Event" : "Copy Link"}
         </>
       )}
     </button>

--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -12,7 +12,7 @@ import {
   Twitter,
   X,
 } from "lucide-react";
-import { toast } from "react-toastify";
+import useEventShare from "hooks/useEventShare";
 import { createShareModalData } from "utils/shareModalUtils.js";
 const ModalCloseButton = memo(({ onClick }) => (
   <button
@@ -32,40 +32,18 @@ const ShareModal = ({ isOpen, onClose, event }) => {
   const shareData = useMemo(() => {
     return createShareModalData(event);
   }, [event]);
-  const supportsWebShare = typeof navigator !== "undefined" && Boolean(navigator.share);
+  const { canNativeShare, copyInviteLink, isSharing, shareEvent } = useEventShare({
+    fallbackMessage: "Event invite link copied to clipboard",
+  });
 
   const shareViaSystem = useCallback(async () => {
-    if (!supportsWebShare || !shareData?.shareUrl) return;
-
-    try {
-      await navigator.share({
-        title: shareData.title,
-        text: shareData.description || shareData.shareText,
-        url: shareData.shareUrl,
-      });
-    } catch (error) {
-      if (error?.name === "AbortError") return;
-
-      console.error("Failed to share event via system share sheet:", error);
-      toast.error("Could not open system share");
-    }
-  }, [shareData, supportsWebShare]);
+    await shareEvent(shareData);
+  }, [shareData, shareEvent]);
 
   const copyLink = useCallback(async () => {
     if (!shareData?.shareUrl) return;
-
-    try {
-      if (!navigator?.clipboard) {
-        throw new Error("Clipboard API unavailable.");
-      }
-
-      await navigator.clipboard.writeText(shareData.shareUrl);
-      toast.success("Link copied to clipboard");
-    } catch (error) {
-      console.error("Failed to copy share link:", error);
-      toast.error("Could not copy the link");
-    }
-  }, [shareData]);
+    await copyInviteLink(shareData.shareUrl);
+  }, [copyInviteLink, shareData]);
 
   useEffect(() => {
     if (!isOpen) return undefined;
@@ -130,14 +108,15 @@ const ShareModal = ({ isOpen, onClose, event }) => {
             </div>
 
             <div className="mt-6 grid grid-cols-2 gap-3">
-              {supportsWebShare ? (
+              {canNativeShare ? (
                 <button
                   type="button"
                   onClick={shareViaSystem}
+                  disabled={isSharing}
                   aria-label="Share this event using your device's native share sheet"
-                  className="col-span-2 flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                  className="col-span-2 flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition-all hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70 dark:focus:ring-offset-gray-900"
                 >
-                  <Share2 size={16} /> Share via System
+                  <Share2 size={16} /> {isSharing ? "Sharing..." : "Share via System"}
                 </button>
               ) : null}
               <a href={shareData.links.twitter} target="_blank" rel="noopener noreferrer" className="flex items-center justify-center gap-2 rounded-xl bg-black px-4 py-3 text-sm font-medium text-white transition-all hover:bg-slate-800">

--- a/src/components/events/EventShareButtons.jsx
+++ b/src/components/events/EventShareButtons.jsx
@@ -27,8 +27,7 @@
 import { useCallback, useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Share2, Twitter, Linkedin, MessageCircle, Link2, Check, Eye, X, Calendar, MapPin, Mail } from "lucide-react";
-import { toast } from "react-toastify";
-import useCopyToClipboard from "../../hooks/useCopyToClipboard";
+import useEventShare from "../../hooks/useEventShare";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,7 +56,9 @@ function getDynamicOgImageUrl(event) {
 // ---------------------------------------------------------------------------
 
 export default function EventShareButtons({ event }) {
-  const { copy, copied } = useCopyToClipboard({ resetMs: 2500 });
+  const { canNativeShare, copied, copyInviteLink, isSharing, shareEvent } = useEventShare({
+    fallbackMessage: "Event invite link copied to clipboard",
+  });
   const [showPreview, setShowPreview] = useState(false);
 
   const url = getEventUrl(event);
@@ -103,28 +104,18 @@ export default function EventShareButtons({ event }) {
 
   // Native Web Share API
   const handleNativeShare = useCallback(async () => {
-    if (!navigator.share) return;
-    try {
-      await navigator.share({ title: event.title, text, url });
-    } catch (err) {
-      if (err.name !== "AbortError") {
-        toast.error("Could not share this event.");
-      }
-    }
-  }, [event.title, text, url]);
+    await shareEvent({ title: event.title, text, url });
+  }, [event.title, shareEvent, text, url]);
 
   // Copy link
   const handleCopyLink = useCallback(async () => {
-    const ok = await copy(url);
-    if (ok) toast.success("Link copied to clipboard!");
-  }, [copy, url]);
+    await copyInviteLink(url);
+  }, [copyInviteLink, url]);
 
   // Social share URLs
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
   const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
   const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(`${text} ${url}`)}`;
-
-  const supportsWebShare = typeof navigator !== "undefined" && Boolean(navigator.share);
 
   const containerVariants = {
     hidden: { opacity: 0, y: 8 },
@@ -157,16 +148,17 @@ export default function EventShareButtons({ event }) {
         className="flex flex-wrap items-center gap-2"
       >
         {/* Native Web Share */}
-        {supportsWebShare && (
+        {canNativeShare && (
           <motion.button
             variants={itemVariants}
             type="button"
             onClick={handleNativeShare}
+            disabled={isSharing}
             aria-label="Share this event using your device's native share menu"
-            className="share-btn inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition-all hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-300"
+            className="share-btn inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition-all hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-300 disabled:cursor-not-allowed disabled:opacity-70"
           >
             <Share2 className="h-4 w-4" aria-hidden="true" />
-            Share
+            {isSharing ? "Sharing..." : "Share"}
           </motion.button>
         )}
 

--- a/src/hooks/useEventShare.js
+++ b/src/hooks/useEventShare.js
@@ -1,0 +1,93 @@
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "react-toastify";
+import { copyToClipboard } from "utils/shareUtils.js";
+
+const isAbortError = (error) => {
+  return error?.name === "AbortError" || error?.name === "NotAllowedError";
+};
+
+const normalizeSharePayload = (shareData = {}) => {
+  const url = shareData.url || shareData.shareUrl || "";
+  const title = shareData.title || "Eventra event";
+  const text = shareData.text || shareData.description || shareData.shareText || "Check out this event on Eventra.";
+
+  return { title, text, url };
+};
+
+export default function useEventShare({ fallbackMessage = "Event link copied to clipboard" } = {}) {
+  const [copied, setCopied] = useState(false);
+  const [isSharing, setIsSharing] = useState(false);
+
+  const canNativeShare = useMemo(() => {
+    return typeof navigator !== "undefined" && typeof navigator.share === "function";
+  }, []);
+
+  const copyInviteLink = useCallback(
+    async (url) => {
+      if (!url) {
+        toast.error("No event link available to copy");
+        return false;
+      }
+
+      const copiedToClipboard = await copyToClipboard(url);
+      if (copiedToClipboard) {
+        setCopied(true);
+        toast.success(fallbackMessage);
+        setTimeout(() => setCopied(false), 2500);
+        return true;
+      }
+
+      toast.error("Could not copy the event link");
+      return false;
+    },
+    [fallbackMessage],
+  );
+
+  const shareEvent = useCallback(
+    async (shareData) => {
+      const payload = normalizeSharePayload(shareData);
+
+      if (!payload.url) {
+        toast.error("No event link available to share");
+        return false;
+      }
+
+      if (canNativeShare) {
+        const nativePayload = {
+          title: payload.title,
+          text: payload.text,
+          url: payload.url,
+        };
+
+        try {
+          setIsSharing(true);
+          if (!navigator.canShare || navigator.canShare(nativePayload)) {
+            await navigator.share(nativePayload);
+            return true;
+          }
+        } catch (error) {
+          if (isAbortError(error)) {
+            return false;
+          }
+
+          console.error("Failed to share event via native share sheet:", error);
+          toast.error("Could not open system share");
+          return false;
+        } finally {
+          setIsSharing(false);
+        }
+      }
+
+      return copyInviteLink(payload.url);
+    },
+    [canNativeShare, copyInviteLink],
+  );
+
+  return {
+    canNativeShare,
+    copied,
+    copyInviteLink,
+    isSharing,
+    shareEvent,
+  };
+}


### PR DESCRIPTION
Implemented the Web Share API feature for issue #8731.

## What changed:
- Added `src/hooks/useEventShare.js` 
    - Uses `navigator.share` when available.
   - Falls back to copying the event invite link.
   - Shows success/error toasts.
   - Ignores user-cancelled native share dialogs.

- Integrated the hook into:
   - `src/components/events/EventShareButtons.jsx`
   - `src/components/common/ShareModal.jsx`
   - `src/components/common/CopyLinkButton.jsx`

Fixed `CopyLinkButton`’s existing `textToCopy` undefined bug.