### PR TITLE
fix: repair TeamWorkspace short-polling syntax errors

### DIFF
--- a/src/components/hackathons/TeamWorkspace.jsx
+++ b/src/components/hackathons/TeamWorkspace.jsx
@@ -58,7 +58,8 @@ const TeamWorkspace = () => {
   // SSE Simulator & Fallback Hook
   useEffect(() => {
     let sseSource = null;
-    let fallbackInterval = null;\n      let isMounted = true;
+    let fallbackInterval = null;
+    let isMounted = true;
     let idleTimeout = null;
 
     setConnectionStatus("connecting");
@@ -70,7 +71,8 @@ const TeamWorkspace = () => {
         "SSE connection error. Started HTTP short-polling fallback stream every 4s.",
       ]);
 
-      const fetchState = async () => {\n          if (!isMounted) return;
+      const fetchState = async () => {
+        if (!isMounted) return;
         try {
           const response = await fetch("/api/hackathons/team/sync", {
             method: "POST",


### PR DESCRIPTION
# Description

Resolves #11146. 

This PR resolves literal `\n` sequence characters written directly in the code block of `TeamWorkspace.jsx`, which was causing compiling issues and breaking short-polling fallback functionality.

## Changes
* **`src/components/hackathons/TeamWorkspace.jsx`**: Replaced literal `\n` escapes with correct carriage returns to restore valid JavaScript syntax.

## Verification
* Verified that the component compiles and imports correctly without syntax errors.