### PR TITLE
fix: resolve invalid token compilation crash in useFormSubmit hook

### DIFF
--- a/src/hooks/useFormSubmit.js
+++ b/src/hooks/useFormSubmit.js
@@ -43,7 +43,14 @@ export function useFormSubmit(submitFn, offlineOptions = defaultOfflineOptions) 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
-  const isInFlight = useRef(false);\n  const submitFnRef = useRef(submitFn);\n  const offlineOptionsRef = useRef(offlineOptions);\n\n  useEffect(() => {\n    submitFnRef.current = submitFn;\n    offlineOptionsRef.current = offlineOptions;\n  }, [submitFn, offlineOptions]);
+  const isInFlight = useRef(false);
+  const submitFnRef = useRef(submitFn);
+  const offlineOptionsRef = useRef(offlineOptions);
+
+  useEffect(() => {
+    submitFnRef.current = submitFn;
+    offlineOptionsRef.current = offlineOptions;
+  }, [submitFn, offlineOptions]);
   const isMounted = useRef(true);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Resolves #11147.

This PR cleans up raw `\n` sequence characters written directly in `useFormSubmit.js` on line 46, which was causing compilation errors during builds.

## Changes
* **`src/hooks/useFormSubmit.js`**: Separated inline ref declarations and synchronization `useEffect` onto their own formatted lines.

## Verification
* Checked that the hook compiles correctly during `npx vite build` without unexpected token errors.