### PR TITLE
fix: resolve parsing error in useDebouncedSearch hook due to literal …

### DIFF
--- a/src/hooks/useDebouncedSearch.js
+++ b/src/hooks/useDebouncedSearch.js
@@ -17,7 +17,8 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
   const [searchTerm, setSearchTerm] = useState(initialValue);
   const [debouncedTerm, setDebouncedTerm] = useState(prepareSafeSearchQuery(initialValue));
   const [isDebouncing, setIsDebouncing] = useState(false);
-  const timerRef = useRef(null);\n  const sequenceRef = useRef(0);
+  const timerRef = useRef(null);
+  const sequenceRef = useRef(0);
 
   useEffect(() => {
     const safeSearchTerm = prepareSafeSearchQuery(searchTerm);
@@ -34,7 +35,8 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
     }
 
     timerRef.current = setTimeout(() => {
-      sequenceRef.current += 1;\n      setDebouncedTerm(safeSearchTerm);
+      sequenceRef.current += 1;
+      setDebouncedTerm(safeSearchTerm);
       setIsDebouncing(false);
     }, delay);
 
@@ -59,7 +61,8 @@ export function useDebouncedSearch(initialValue = '', delay = 300) {
     debouncedTerm,
     setSearchTerm,
     isDebouncing,
-    clear,\n    sequence: sequenceRef.current,
+    clear,
+    sequence: sequenceRef.current,
   };
 }
 


### PR DESCRIPTION
# Description

Resolves #11148.

This PR cleans up raw `\n` sequence characters written directly in `useDebouncedSearch.js` on lines 20, 37, and 64, which was causing compilation and ESLint parsing failures.

## Changes
* **`src/hooks/useDebouncedSearch.js`**: Separated timer and sequence ref declarations, debounce timeout block, and hook return properties onto standard formatted lines.

## Verification
* Checked that the hook compiles correctly during `npx vite build` and passes ESLint verification without any unexpected token errors.