### PR TITLE
feat: add reading time indicator for event descriptions

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -38,7 +38,11 @@ const isRequestCanceled = (error, signal) =>
   error?.name === "AbortError" ||
   error?.name === "CanceledError" ||
   error?.code === "ERR_CANCELED";
-
+const getReadingTime = (text = "") => {
+  const wordCount = text.trim().split(/\s+/).filter(Boolean).length;
+  const minutes = Math.max(1, Math.ceil(wordCount / 200));
+  return `${minutes} min read`;
+};
 const EventDetails = () => {
   const { eventId } = useParams();
   const navigate = useNavigate();
@@ -638,7 +642,15 @@ const showClosingSoon =
               </div>
 
               <div className="rounded-3xl bg-slate-50 p-5 dark:bg-gray-800">
-                <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">Summary</h3>
+                <div className="flex items-center justify-between">
+  <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500 dark:text-gray-400">
+    Summary
+  </h3>
+
+  <span className="text-xs text-gray-500 dark:text-gray-400">
+    📖 {getReadingTime(event.description)}
+  </span>
+</div>
                 <div
                   className="mt-3 text-gray-700 dark:text-gray-300 text-sm leading-6 prose prose-indigo dark:prose-invert"
                   dangerouslySetInnerHTML={{ __html: sanitizeMarkdown(event.description, marked.parse) }}


### PR DESCRIPTION
## Description

### Summary
This PR adds an estimated reading time indicator for event descriptions on the Event Details page.

### Changes Made
- Added a frontend utility to estimate reading time based on description length.
- Displayed the estimated reading time alongside the **Summary** section.
- Uses an average reading speed of 200 words per minute.
- Ensures a minimum display of **1 min read** for short descriptions.

Fixes #11000

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run local unit tests using `npm test`
- [x] I have run `npm run lint`
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports