### PR TITLE
fix: remove unused dropdown chevron from Events navigation item (clos…

### DIFF
--- a/src/components/navbar/constants/navItems.js
+++ b/src/components/navbar/constants/navItems.js
@@ -1,7 +1,5 @@
 import {
   Calendar,
-  CalendarDays,
-  Clock,
   FolderKanban,
   Users,
   Trophy,
@@ -13,28 +11,17 @@ import {
 } from "lucide-react";
 
 export const PRIMARY_NAV_ITEMS = [
-  {
-    nameKey: "nav.events",
-    href: "/events",
-    icon: <Calendar className="w-5 h-5" />,
-    subItems: [
-      {
-        nameKey: "nav.exploreEvents",
-        href: "/events",
-        icon: <Calendar className="w-5 h-5" />,
-      },
-      {
-        nameKey: "nav.eventCalendar",
-        href: "/calendar",
-        icon: <CalendarDays className="w-5 h-5" />,
-      },
-      {
-        nameKey: "nav.scheduler",
-        href: "/events/scheduler",
-        icon: <Clock className="w-5 h-5" />,
-      },
-    ],
-  },
+  // Fix (Issue #10497): Remove unused/misleading dropdown from Events nav item.
+// The subItems (Explore Events, Calendar, Scheduler) were either duplicating
+// the parent link or pointing to pages accessible via other nav items,
+// causing a chevron to appear with no meaningful dropdown content.
+// Events is now a direct nav link with no dropdown.
+{
+  nameKey: "nav.events",
+  href: "/events",
+  icon: <Calendar className="w-5 h-5" />,
+},
+
   {
     nameKey: "nav.hackathons",
     href: "/hackathons",


### PR DESCRIPTION
## Description

The Events nav item in the header showed a chevron dropdown indicator with
3 subItems: "Explore Events" (/events — same as the parent), "Event Calendar"
(/calendar), and "Scheduler" (/events/scheduler). The first subItem was
identical to the parent link, and the other two point to pages already
accessible through other navigation paths. This made the dropdown
misleading — users expected a meaningful submenu but found redundant links.

Fix: removed the `subItems` array from the Events nav item in
`src/components/navbar/constants/navItems.js`, making it a direct link like
Hackathons and Projects. Also removed the now-unused `CalendarDays` and
`Clock` icon imports.

One file changed. No logic changes — purely data/config cleanup.

Fixes #10497

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run local unit tests using `npm test` and verified they pass
- [x] I have run `npm run lint` and resolved any new errors or warnings
- [x] I have verified responsiveness and visual alignment on desktop and mobile viewports