### PR TITLE
Feature/upload artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Project Dependencies
+        run: npm ci
+
+      - name: Run Code Quality Checks
+        run: npm run lint
+
+      - name: Run Automated Tests
+        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,14 @@ jobs:
 
       - name: Run Automated Tests
         run: npm run test
+
+      - name: Build Project
+        run: npm run build
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: build-artifacts
+          path: dist
+          retention-days: 7


### PR DESCRIPTION
## 📦 Upload Build Artifacts from CI Workflow

### Description
This PR enhances the GitHub Actions CI workflow by compiling the project and preserving the generated outputs as downloadable artifacts. 

Previously, the pipeline validated the codebase but discarded the resulting build files. By adding an explicit build step and utilizing GitHub's artifact storage, developers can now easily inspect generated assets or download the build directly from the GitHub Actions run summary.

### Changes Made
- Added a `Build Project` step that runs `npm run build` to compile the Vite application.
- Integrated the official `actions/upload-artifact@v4` action to package and upload the `dist` directory.
- Configured the upload to happen only upon a successful workflow run (`if: success()`).
- Set an artifact `retention-days` policy of `7` days to ensure assets are available for immediate review while avoiding unnecessary long-term storage consumption.

### Benefits
- **Effortless Debugging:** Enables maintainers to download and inspect exactly what was built in the CI environment.
- **Enhanced Code Reviews:** Reviewers can easily download the build output from the PR interface without needing to check out the branch and build it locally.
- **Pipeline Extensibility:** Lays the groundwork for future continuous deployment (CD) workflows to consume the built artifacts seamlessly.

##Issue #11401 