### PR TITLE
ci: add automated stale management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark Stale Issues and Pull Requests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          close-pr-message: 'This pull request was closed because it has been stalled for 7 days with no activity.'
+          days-before-stale: 60
+          days-before-close: 7
+          exempt-issue-labels: 'pinned,security,good first issue,help wanted'
+          exempt-pr-labels: 'pinned,security,good first issue,help wanted'


### PR DESCRIPTION
## 🧹 Add Automated Stale Issue and Pull Request Management

### Description
This PR introduces a new GitHub Actions workflow to automatically manage inactive issues and pull requests, helping to keep our repository organized and focused.

As the project scales, inactive items can pile up and obscure active development. By integrating the official `actions/stale` workflow, we can systematically prompt for updates on stalled items and eventually close them if there is no response. This significantly reduces manual triage work for maintainers.

### Changes Made
- Created a new workflow file `.github/workflows/stale.yml` scheduled to run daily (`cron: '0 0 * * *'`).
- Integrated `actions/stale@v9` with welcoming messages that explain why an item is being marked as stale or closed.
- Configured sensible inactivity thresholds (60 days of inactivity before marking as stale, and an additional 7 days before closing).
- Exempted crucial labels from this automation (`pinned`, `security`, `good first issue`, `help wanted`) to guarantee that important community and security items are never auto-closed.
- Maintained the principle of least privilege by scoping permissions explicitly to `issues: write` and `pull-requests: write`.

### Benefits
- **Improved Repository Hygiene:** Automatically clears out long-inactive discussions, keeping the backlog focused on current, actionable work.
- **Reduced Maintainer Toil:** Eliminates the manual burden of sweeping through and pinging old PRs and issues.
- **Better Contributor Engagement:** Politely nudges authors to provide updates on their open items, encouraging completion or proper closure.

##Issue #11406 