### PR TITLE
Fix: fix-safe-json-parse-delete

### DIFF
--- a/src/utils/safeJsonParse.js
+++ b/src/utils/safeJsonParse.js
@@ -25,11 +25,8 @@ export function safeJsonParseFromStorage(key, fallback = null) {
     return parsed;
   } catch (error) {
     console.error(`[safeJsonParseFromStorage] Failed to parse localStorage key "${key}":`, error);
-    console.error('[safeJsonParseFromStorage] Removing corrupted entry and returning fallback');
-    try {
-      localStorage.removeItem(key);
-    } catch (removeError) {
-      console.error('[safeJsonParseFromStorage] Failed to remove corrupted entry:', removeError);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("eventra-storage-parse-error", { detail: { key } }));
     }
     return fallback;
   }


### PR DESCRIPTION
## Description
Fixes a bug in `safeJsonParse.js` where `safeJsonParseFromStorage` would silently delete a corrupted `localStorage` entry on parse failure. This could lead to unintended data loss.

## Changes Made
* Removed the automatic `localStorage.removeItem(key)` call on parse failure.
* Added a custom event `eventra-storage-parse-error` dispatch to let the application handle the failure gracefully.

## Related Issue
Fixes #11189