### PR TITLE
Fix: fix-api-build-url-double-slash

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -20,7 +20,8 @@ const buildApiUrl = (path = "") => {
   if (/^https?:\/\//i.test(path)) return path;
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   if (!API_BASE_URL) return normalizedPath;
-  return `${API_BASE_URL}${normalizedPath}`;
+  const url = `${API_BASE_URL}${normalizedPath}`;
+  return url.replace(/([^:]\/)\/+/g, "$1");
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Fixes a bug in `api.js` where `buildApiUrl` would construct URLs with double slashes (e.g., `http://api//path`) if the path already started with a slash and `API_BASE_URL` ended with one.

## Changes Made
* Added a regex replacement `url.replace(/([^:]\/)\/+/g, "$1")` to normalize double slashes in the constructed URL.

## Related Issue
Fixes #11190