### PR TITLE
Fix: fix-secure-storage-process-queue

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -703,7 +703,7 @@ export const syncSecureStorage = {
         this._writeQueue.clear();
         for (const [key, plaintext] of entries) {
           try {
-            const encrypted = await encryptValue(plaintext);
+            const encrypted = await encryptValue(key, plaintext);
             localStorage.setItem(key, encrypted);
           } catch (err) {
             console.error('[secureStorage] Encryption failed for', key, err);


### PR DESCRIPTION
## Description
Fixes a bug in `secureStorage._processQueue` where `encryptValue` was being called with only one argument (`plaintext`) instead of the required two arguments (`key`, `plaintext`). This caused the encryption to fail or use `undefined` as the key.

## Changes Made
* Updated the `encryptValue` call in `_processQueue` to pass both `key` and `plaintext`.

## Related Issue
Fixes #11186