### PR TITLE
Fix: feature-offline-sync-budget

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -311,6 +311,10 @@ const useOfflineSync = () => {
         });
 
         for (const item of sessionValidatedQueue) {
+        if (Date.now() - syncStartTime > SYNC_BUDGET_MS) {
+          logger.warn("[useOfflineSync] Sync budget exceeded, stopping.");
+          break;
+        }
           // Halt the zombie loop immediately if the session changed or component unmounted.
           // This prevents making requests with stale tokens and protects IndexedDB from being falsely overwritten below.
           if (conflictController.signal.aborted) {


### PR DESCRIPTION
## Description
Enhances `useOfflineSync.js` by adding a maximum sync budget (60 seconds) to `executeSync`. Previously, the sync loop could run indefinitely, blocking the main thread or causing performance degradation.

## Changes Made
* Added a `SYNC_BUDGET_MS = 60_000` limit and a check inside the sync loop to break if the elapsed time exceeds the budget.

## Related Issue
Fixes #11193