### PR TITLE
ci: add workflow to delete merged branches

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -1,0 +1,40 @@
+name: Delete Merged Branches
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  delete-merged-branch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Delete branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branchName = context.payload.pull_request.head.ref;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const protectedBranches = ['main', 'master', 'develop'];
+            
+            if (protectedBranches.includes(branchName)) {
+              console.log(`Skipping deletion of protected branch: ${branchName}`);
+              return;
+            }
+            
+            try {
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/${branchName}`
+              });
+              console.log(`Successfully deleted branch: ${branchName}`);
+            } catch (error) {
+              console.error(`Failed to delete branch ${branchName}. It might have already been deleted.`, error);
+            }


### PR DESCRIPTION
## Overview
This pull request introduces a GitHub Actions workflow that automatically cleans up stale feature branches after their corresponding pull requests are merged. This helps maintain a tidy repository and reduces manual administrative overhead without impacting active work.

## Changes
- Created `.github/workflows/delete-merged-branches.yml` triggered on pull request closure.
- Added conditional checks to ensure branch deletion only occurs if the pull request was officially `merged` (not just closed).
- Added an exclusion list to protect critical long-lived branches (`main`, `master`, and `develop`) from accidental deletion.
- Utilized `actions/github-script` to securely and natively invoke the GitHub API to delete the source `ref`.

## Validation
- The workflow correctly triggers on `pull_request` types `[closed]`.
- Proper repository-level write permissions are scoped to the workflow.

##Issue #11427 