### PR TITLE
fix: award highest difficulty points for multi-labeled pull requests

### DIFF
--- a/src/utils/leaderboardUtils.js
+++ b/src/utils/leaderboardUtils.js
@@ -40,7 +40,7 @@ export function calculatePrPoints(labels) {
 
   const difficultyPts =
     difficultyValues.length > 0
-      ? Math.min(...difficultyValues)
+      ? Math.max(...difficultyValues)
       : DEFAULT_MERGED_PR_POINTS;
 
   const multiplier = normalised.reduce((best, label) => {


### PR DESCRIPTION
# Summary

Fixes leaderboard scoring by awarding the highest applicable difficulty score when a pull request contains multiple difficulty labels.

## Related Issue

Fixes #11523

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Replaced `Math.min()` with `Math.max()` when calculating difficulty points.
- Ensured contributors receive the highest applicable difficulty score for multi-labeled pull requests.
- Preserved the existing fallback to `DEFAULT_MERGED_PR_POINTS` when no difficulty labels are present.

## Technical Details

### Frontend

- Updated `src/utils/leaderboardUtils.js`.

## Testing

### Manual Testing

- [x] Verified pull requests with multiple difficulty labels award the highest difficulty score.
- [x] Verified single difficulty labels continue to produce the correct score.
- [x] Verified fallback scoring still works when no difficulty labels are present.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review