### PR TITLE
fix: preserve event visibility when isPublic is omitted

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -241,7 +241,9 @@ public class EventService {
         event.setLocation(request.getLocation());
         event.setEventDate(request.getEventDate());
         event.setCapacity(request.getCapacity());
-        event.setPublic(request.getIsPublic() == null || request.getIsPublic());
+        if (request.getIsPublic() != null) {
+            event.setPublic(request.getIsPublic());
+        }
         event.setImageUrl(request.getImageUrl());
 
         Event saved = eventRepository.save(event);


### PR DESCRIPTION
# Summary

Fixes an issue where updating an event without providing the `isPublic` field unintentionally changed private events to public.

## Related Issue

Closes #11524

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Removed the implicit conversion of `null` to `true`.
- Updated event visibility only when `isPublic` is explicitly provided in the request.
- Preserved the existing visibility state when the field is omitted.

## Technical Details

### Backend

- Updated `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`.

## Testing

### Manual Testing

- [x] Verified private events remain private when `isPublic` is omitted.
- [x] Verified events become public when `isPublic=true`.
- [x] Verified events become private when `isPublic=false`.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Issue fixed as described
- [x] Ready for review