### PR TITLE
fix: validate authenticated user before hackathon authorization

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -78,14 +78,13 @@ public class HackathonService {
         Hackathon hackathon = hackathonRepository.findById(id)
                 .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
 
-        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
+        User currentUser = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
 
-        if (currentUser != null) {
-            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-            if (!isAdmin && hackathon.getOwnerId() != null && !hackathon.getOwnerId().equals(currentUser.getId())) {
-                throw new AccessDeniedException(
-                        "Only the hackathon's own organizer (or an administrator) can manage this hackathon.");
-            }
+        boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
+        if (!isAdmin && hackathon.getOwnerId() != null && !hackathon.getOwnerId().equals(currentUser.getId())) {
+            throw new AccessDeniedException(
+                    "Only the hackathon's own organizer (or an administrator) can manage this hackathon.");
         }
 
         hackathon.setTitle(request.getTitle());


### PR DESCRIPTION
# Summary

Fixes a security issue where authorization checks could be bypassed if the authenticated user could not be resolved from the database.

## Related Issue

Closes #11525

## Type of Change

- [x] Security Fix
- [x] Bug Fix

## Changes Implemented

- Replaced the nullable user lookup with `orElseThrow(...)`.
- Throw `UsernameNotFoundException` when the authenticated user does not exist.
- Ensure ownership and administrator authorization checks always execute for authenticated requests.

## Technical Details

### Backend

Updated:

- `Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java`

## Testing

### Manual Testing

- [x] Verified existing owners can update their hackathons.
- [x] Verified administrators can still manage hackathons.
- [x] Verified requests from unresolved users now fail immediately.
- [x] Confirmed authorization checks can no longer be skipped.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project conventions
- [x] Security issue resolved
- [x] Ready for review