### PR TITLE
fix: use shared notification preferences storage key

### DIFF
--- a/src/utils/dndUtils.js
+++ b/src/utils/dndUtils.js
@@ -1,10 +1,12 @@
+import { NOTIFICATION_PREFERENCES_KEY } from "./notificationPreferences";
+
 export const isDndActive = () => {
   if (typeof window === "undefined" || !window.localStorage) {
     return false;
   }
 
   try {
-    const prefs = JSON.parse(localStorage.getItem('eventra_notification_prefs') || '{}');
+    const prefs = JSON.parse(localStorage.getItem(NOTIFICATION_PREFERENCES_KEY) || '{}');
     if (!prefs.dndEnabled) return false;
     const now = new Date();
     const currentHour = now.getHours();


### PR DESCRIPTION
# Summary

Fixes an issue where the Do Not Disturb (DND) utility read notification preferences using a different localStorage key than the one used when saving them.

## Related Issue

Closes #11527

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Imported the shared `NOTIFICATION_PREFERENCES_KEY` constant.
- Replaced the hardcoded localStorage key with the shared constant.
- Ensured both modules use the same storage key for notification preferences.

## Technical Details

### Frontend

Updated:

- `src/utils/dndUtils.js`

## Testing

### Manual Testing

- [x] Verified DND preferences are loaded correctly.
- [x] Verified saved notification preferences persist after refresh.
- [x] Confirmed quiet hours are respected when DND is enabled.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project conventions
- [x] Issue fixed as described
- [x] Ready for review