### PR TITLE
fix: validate 12-hour time input range

### DIFF
--- a/src/utils/timezoneUtils.js
+++ b/src/utils/timezoneUtils.js
@@ -61,6 +61,8 @@ export const parseTimeString = (timeStr) => {
     const minutes = parseInt(amPmMatch[2], 10);
     const period = amPmMatch[3].toUpperCase();
 
+    if (hours < 1 || hours > 12) return null;
+
     if (period === 'PM' && hours !== 12) hours += 12;
     if (period === 'AM' && hours === 12) hours = 0;
 


### PR DESCRIPTION
# Summary

Fixes an issue where the 12-hour time parser accepted invalid hour values outside the valid range of 1–12, resulting in incorrect time conversions.

## Related Issue

Closes #11560

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added validation to ensure parsed hours are within the valid 12-hour range (1–12).
- Return `null` for invalid hour values before performing AM/PM conversion.
- Prevent invalid time strings from being interpreted as valid times.

## Technical Details

### Frontend

Updated:

- `src/utils/timezoneUtils.js`

## Testing

### Manual Testing

- [x] Verified valid inputs such as `1:30 PM` and `12:00 AM` continue to parse correctly.
- [x] Verified invalid inputs such as `13:00 AM`, `0:15 PM`, and other out-of-range hour values are rejected.
- [x] Confirmed valid time conversions remain unchanged.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project conventions
- [x] Issue fixed as described
- [x] Ready for review