### PR TITLE
fix: safely handle invalid VAPID key input in urlBase64ToUint8Array 

### DIFF
--- a/src/utils/notificationPreferences.js
+++ b/src/utils/notificationPreferences.js
@@ -158,7 +158,9 @@ export const playNotificationSound = (soundKey) => {
 };
 
 export const urlBase64ToUint8Array = (base64String) => {
-  if (typeof window === "undefined") return new Uint8Array();
+  if (typeof window === "undefined" || !base64String || typeof base64String !== "string") {
+    return new Uint8Array();
+  }
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
   const rawData = window.atob(base64);


### PR DESCRIPTION
# Summary

Fixes a crash in `urlBase64ToUint8Array` when the supplied VAPID public key is missing, undefined, or not a valid string.

## Related Issue

Closes #11562

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added validation for the VAPID key input before processing.
- Return an empty `Uint8Array` when the input is missing or invalid.
- Prevent runtime `TypeError` caused by accessing `.length` on undefined values.

## Technical Details

### Frontend

Updated:

- `src/utils/notificationPreferences.js`

## Testing

### Manual Testing

- [x] Verified no exception is thrown when the VAPID key is `undefined`.
- [x] Verified `null` and non-string inputs are handled safely.
- [x] Confirmed valid Base64 VAPID keys continue to decode correctly.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project conventions
- [x] Issue fixed as described
- [x] Ready for review
```