### PR TITLE
fix: trim full name before ticket holder fallback

### DIFF
--- a/src/utils/ticketQrPayload.js
+++ b/src/utils/ticketQrPayload.js
@@ -1,5 +1,5 @@
 export const getTicketHolderName = (user) =>
-  user?.fullName || `${user?.firstName || ""} ${user?.lastName || ""}`.trim() || user?.username || "Eventra Guest";
+  user?.fullName?.trim() || `${user?.firstName || ""} ${user?.lastName || ""}`.trim() || user?.username || "Eventra Guest";
 
 /**
  * Build the QR payload for an event ticket.


### PR DESCRIPTION
# Summary

Fixes ticket holder name resolution when `fullName` contains only whitespace characters.

## Related Issue

Closes #11566

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Trim `fullName` before evaluating it.
- Allow fallback to first name/last name, username, or the default guest name when `fullName` is empty after trimming.
- Prevent blank ticket holder names in generated QR payloads.

## Technical Details

### Frontend

Updated:

- `src/utils/ticketQrPayload.js`

## Testing

### Manual Testing

- [x] Verified whitespace-only `fullName` falls back correctly.
- [x] Verified valid full names remain unchanged.
- [x] Verified username and `"Eventra Guest"` are still used when appropriate.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project conventions
- [x] Issue fixed as described
- [x] Ready for review