### PR TITLE
fix: handle invalid event start dates in duration utility 

### DIFF
--- a/src/utils/eventDurationUtils.js
+++ b/src/utils/eventDurationUtils.js
@@ -3,6 +3,10 @@ export const getEventDuration = (event) => {
     ? new Date(event.startDate)
     : new Date(event.date);
 
+  if (!startDate || Number.isNaN(startDate.getTime())) {
+    return "";
+  }
+
   const endDate = event.endDate
     ? new Date(event.endDate)
     : null;


### PR DESCRIPTION
# Summary

Fixes invalid duration labels caused by missing or malformed event start dates.

## Related Issue

Closes #11567

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added validation to ensure the parsed start date is valid before performing duration calculations.
- Return an empty string when the start date is invalid instead of continuing with `NaN` values.
- Prevent invalid labels such as `"NaN Weeks"` from being displayed.

## Technical Details

### Frontend

Updated:

- `src/utils/eventDurationUtils.js`

## Testing

### Manual Testing

- [x] Verified invalid start dates return an empty string.
- [x] Verified missing start dates no longer produce `"NaN Weeks"`.
- [x] Verified valid event dates continue to generate the correct duration labels.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project conventions
- [x] Issue fixed as described
- [x] Ready for review
```