### PR TITLE
fix: accept numeric certificate UIDs during verification

### DIFF
--- a/src/utils/certificateUtils.js
+++ b/src/utils/certificateUtils.js
@@ -1,8 +1,8 @@
 import { API_BASE_URL, validateBackendConfig } from "../config/backendConfig.js";
 
 const sanitizeUid = (uid) => {
-  if (typeof uid !== "string") return "";
-  return uid.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 128);
+  if (uid === null || uid === undefined) return "";
+  return String(uid).replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 128);
 };
 
 export async function verifyCertificate(uid) {


### PR DESCRIPTION
## Summary

This PR fixes certificate verification for numeric certificate IDs.

### Changes Made

- Updated `sanitizeUid()` to accept both string and numeric UID inputs.
- Converted non-null inputs to strings before sanitization.
- Preserved existing sanitization logic and maximum length restriction.
- Continued returning an empty string for `null` and `undefined` inputs.

### Problem

Previously, `sanitizeUid()` only accepted string inputs:

```js
if (typeof uid !== "string") return "";