### PR TITLE
fix: use synchronized server time for relative calculations

### DIFF
--- a/src/utils/relativeTime.js
+++ b/src/utils/relativeTime.js
@@ -13,7 +13,7 @@ export function getRelativeTime(dateInput) {
   if (typeof dateInput === "string" && dateInput.trim() === "") {
     return RELATIVE_TIME_FALLBACK;
   }
-  const now = new Date();
+  const now = new Date(getServerNow());
   const date = new Date(dateInput);
 
   if (Number.isNaN(date.getTime())) return RELATIVE_TIME_FALLBACK;


### PR DESCRIPTION
## Summary

This PR updates the relative time utility to use the synchronized server time instead of the client's local system clock.

### Changes Made

- Replaced the local system time with the synchronized server time.
- Continued using the existing relative time calculation logic.
- Ensured relative timestamps remain accurate even when the client's clock is incorrect.

### Problem

Previously, the utility calculated relative timestamps using:

```javascript
const now = new Date();
```

Although `getServerNow()` was imported, it was never used. As a result, users with incorrect local system clocks could see inaccurate relative times such as "Starting in 5 minutes" or "2 hours ago".

### Solution

Use the synchronized server time for all relative time calculations:

```javascript
const now = new Date(getServerNow());
```

### Result

- ✅ Relative timestamps are based on synchronized server time.
- ✅ Client clock skew no longer affects displayed event times.
- ✅ Existing relative time behavior is preserved for correctly synchronized clients.

Closes #11642