### PR TITLE
fix: preserve Cloudinary fetch source URLs

### DIFF
--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -44,7 +44,7 @@ export const getOptimizedImageUrl = (originalUrl, options = {}) => {
   // Relative paths (/images/hero.jpg), blob: URLs, and data: URIs cannot
   // be Cloudinary-transformed and are returned unchanged.
   if (originalUrl.startsWith("http")) {
-    return `https://res.cloudinary.com/${cloudName}/image/fetch/${transformations}/${encodeURIComponent(originalUrl)}`;
+    return `https://res.cloudinary.com/${cloudName}/image/fetch/${transformations}/${originalUrl}`;
   }
 
   // Fallback for local assets


### PR DESCRIPTION
## Summary

This PR fixes Cloudinary Fetch URL generation by preserving the original source URL instead of URL-encoding it before constructing the fetch URL.

### Changes Made

- Removed `encodeURIComponent()` when constructing Cloudinary Fetch URLs.
- Preserved the original source URL format expected by Cloudinary.
- Left all other image optimization behavior unchanged.

### Problem

Previously, the fetch URL was generated as:

```javascript
encodeURIComponent(originalUrl)
```

This encoded the protocol (`https://`) into `https%3A%2F%2F`, resulting in invalid Cloudinary Fetch URLs and HTTP 400 responses for remote images.

### Solution

Use the original source URL directly when building the Cloudinary Fetch URL.

### Result

- ✅ Cloudinary Fetch URLs are generated in the expected format.
- ✅ Remote images load successfully through Cloudinary transformations.
- ✅ Existing image optimization functionality remains unchanged.

Closes #11643