### PR TITLE
fix: preserve supported event filter sort options

### DIFF
--- a/src/utils/eventFilterPresets.js
+++ b/src/utils/eventFilterPresets.js
@@ -15,7 +15,7 @@ const CATEGORY_FILTERS = new Set([
   "design-ux",
   "cultural",
 ]);
-const SORT_TYPES = new Set(["Newest", "Upcoming"]);
+const SORT_TYPES = new Set(["Newest", "Upcoming", "Popular", "Oldest"]);
 const VIEW_MODES = new Set(["grid", "list"]);
 
 export const getDefaultEventFilterConfig = () => ({


### PR DESCRIPTION
## Summary

This PR fixes filter preset normalization by recognizing all supported event sort options instead of falling back to the default `"Newest"` value.

### Changes Made

- Added `"Popular"` and `"Oldest"` to the supported `SORT_TYPES` set.
- Preserved existing support for `"Newest"` and `"Upcoming"`.
- Prevented valid saved sort preferences from being overwritten during normalization.

### Problem

Previously, only the following sort options were considered valid:

```javascript
const SORT_TYPES = new Set(["Newest", "Upcoming"]);
```

As a result, presets saved using valid sort options such as `"Popular"` or `"Oldest"` were normalized back to `"Newest"` after loading.

### Solution

Expanded the supported sort types to include every valid application sort option.

```javascript
const SORT_TYPES = new Set([
  "Newest",
  "Upcoming",
  "Popular",
  "Oldest",
]);
```

### Result

- ✅ Saved `"Popular"` presets are preserved.
- ✅ Saved `"Oldest"` presets are preserved.
- ✅ Existing `"Newest"` and `"Upcoming"` behavior remains unchanged.
- ✅ Filter preset normalization now recognizes all supported sort options.

Closes #11644