### PR TITLE
fix: remove all selection highlights from exported floor plans

### DIFF
--- a/src/utils/floorPlanExport.js
+++ b/src/utils/floorPlanExport.js
@@ -8,10 +8,9 @@ export const getCleanExportSvgString = (canvasRef) => {
   clonedSvg.style.transition = "none";
   clonedSvg.setAttribute("width", "1000");
   clonedSvg.setAttribute("height", "800");
-  const selectedShape = clonedSvg.querySelector(".fp-svg-element-selected");
-  if (selectedShape) {
-    selectedShape.classList.remove("fp-svg-element-selected");
-  }
+  clonedSvg.querySelectorAll(".fp-svg-element-selected").forEach((el) => {
+    el.classList.remove("fp-svg-element-selected");
+  });
   const serializer = new XMLSerializer();
   return serializer.serializeToString(clonedSvg);
 };


### PR DESCRIPTION
## Summary

This PR fixes SVG export so that selection highlights are removed from all selected floor plan elements before export.

### Changes Made

- Replaced `querySelector()` with `querySelectorAll()`.
- Removed the selection class from every selected element instead of only the first one.
- Ensured exported SVGs and PNGs no longer contain leftover selection highlights.

### Problem

Previously the export logic removed the selection class only from the first matched element:

```javascript
const selectedShape = clonedSvg.querySelector(".fp-svg-element-selected");
if (selectedShape) {
  selectedShape.classList.remove("fp-svg-element-selected");
}
```

When multiple elements were selected, only the first lost its highlight while the remaining selected elements kept their selection borders in the exported output.

### Solution

Iterate over every selected element and remove the selection class before serialization:

```javascript
clonedSvg
  .querySelectorAll(".fp-svg-element-selected")
  .forEach((el) => {
    el.classList.remove("fp-svg-element-selected");
  });
```

### Result

- ✅ Removes selection highlights from all selected elements.
- ✅ Produces clean SVG and PNG exports.
- ✅ Preserves existing export behavior for single-element selections.
- ✅ Prevents unwanted selection borders in exported floor plans.

Closes #11645
```