### PR TITLE
fix: validate exported timestamp type in session backups

### DIFF
--- a/src/utils/sessionExportImport.js
+++ b/src/utils/sessionExportImport.js
@@ -103,7 +103,7 @@ export const validateSessionBackup = (backup) => {
     return { ok: false, error: "Unsupported session backup version." };
   }
 
-  if (!backup.exportedAt || Number.isNaN(new Date(backup.exportedAt).getTime())) {
+  if (typeof backup.exportedAt !== "string" || Number.isNaN(new Date(backup.exportedAt).getTime())) {
     return { ok: false, error: "Backup export timestamp is missing or invalid." };
   }
 


### PR DESCRIPTION
Closes #11648


## Summary

This PR fixes session backup validation by ensuring the `exportedAt` field is a string before attempting date parsing.

### Changes Made

- Added a type check for `backup.exportedAt`.
- Rejects non-string timestamp values before creating a `Date`.
- Preserves existing validation for invalid date strings.

### Problem

Previously, the validation only checked whether `new Date(backup.exportedAt)` produced a valid date.

Because JavaScript accepts values such as:

```json
{
  "exportedAt": true
}
```

`new Date(true)` produces a valid timestamp, allowing malformed backups to pass validation.

### Solution

Validate the input type before parsing the date.

```javascript
if (
  typeof backup.exportedAt !== "string" ||
  Number.isNaN(new Date(backup.exportedAt).getTime())
) {
  return {
    ok: false,
    error: "Backup export timestamp is missing or invalid.",
  };
}
```

### Result

- ✅ Rejects non-string timestamp values.
- ✅ Prevents malformed backups from passing validation.
- ✅ Maintains validation for invalid date strings.
- ✅ Improves robustness of session backup import validation.

```