### PR TITLE
fix: limit form retry queue size and expire old entries

### DIFF
--- a/src/utils/formRetryQueue.js
+++ b/src/utils/formRetryQueue.js
@@ -5,6 +5,8 @@
  */
 
 const QUEUE_KEY = "eventra_form_retry_queue";
+const MAX_QUEUE_SIZE = 20;
+const EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 // 🔥 FIX: single SSR guard, reused by every function. Previously each
 // accessor called localStorage directly without a typeof window check,
@@ -17,7 +19,18 @@ export const saveFormData = (formId, data) => {
   try {
     const queue = getQueue();
     queue[formId] = { data, savedAt: new Date().toISOString() };
-    window.localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+
+    // Enforce maximum queue size by removing oldest entries
+    const entries = Object.entries(queue);
+    if (entries.length > MAX_QUEUE_SIZE) {
+      const sorted = entries.sort(
+        (a, b) => new Date(a[1].savedAt) - new Date(b[1].savedAt)
+      );
+      const trimmed = Object.fromEntries(sorted.slice(-MAX_QUEUE_SIZE));
+      window.localStorage.setItem(QUEUE_KEY, JSON.stringify(trimmed));
+    } else {
+      window.localStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+    }
     return true;
   } catch {
     return false;
@@ -47,7 +60,28 @@ export const clearFormData = (formId) => {
 export const getQueue = () => {
   if (!isStorageAvailable()) return {};
   try {
-    return JSON.parse(window.localStorage.getItem(QUEUE_KEY) || "{}");
+    const queue = JSON.parse(window.localStorage.getItem(QUEUE_KEY) || "{}");
+    const now = Date.now();
+    let hasExpired = false;
+
+    // Filter out expired entries
+    const filtered = Object.fromEntries(
+      Object.entries(queue).filter(([, entry]) => {
+        const savedAt = new Date(entry.savedAt).getTime();
+        if (now - savedAt > EXPIRATION_MS) {
+          hasExpired = true;
+          return false;
+        }
+        return true;
+      })
+    );
+
+    // Clean up expired entries from storage
+    if (hasExpired) {
+      window.localStorage.setItem(QUEUE_KEY, JSON.stringify(filtered));
+    }
+
+    return filtered;
   } catch {
     return {};
   }


### PR DESCRIPTION
Closes #11646



## Summary

This PR prevents the form retry queue from growing indefinitely in `localStorage` by enforcing a maximum queue size and automatically removing expired entries.

### Changes Made

- Added a maximum queue size of **20** entries.
- Added a **7-day expiration** period for queued form data.
- Removes expired entries when loading the retry queue.
- Trims the queue to retain only the most recent entries before saving.

### Problem

Previously, failed form submissions were stored indefinitely in `localStorage`.

Over time, retry entries accumulated without any size limit or expiration policy, increasing storage usage and retaining outdated form data across sessions.

### Solution

- Introduced a maximum queue size (`MAX_QUEUE_SIZE = 20`).
- Added a retention period (`EXPIRATION_MS = 7 days`).
- Purged expired entries during queue retrieval.
- Kept only the newest entries when the queue exceeded the configured limit.

### Result

- ✅ Prevents unbounded localStorage growth.
- ✅ Automatically removes stale retry entries.
- ✅ Retains only the most recent retry data.
- ✅ Reduces unnecessary browser storage usage while preserving retry functionality.

```