### PR TITLE
fix: replace MySQL-only JPQL functions with H2-compatible ones

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java
@@ -16,7 +16,7 @@ public interface RegistrationAnalyticsRepository
     // ── Trends — note: field is registeredAt, NOT createdAt ──────────────────
 
     @Query("""
-        SELECT FUNCTION('DATE_FORMAT', r.registeredAt, '%Y-%m') AS period,
+        SELECT FUNCTION('FORMATDATETIME', r.registeredAt, 'yyyy-MM') AS period,
                COUNT(r) AS regCount
         FROM EventRegistration r
         WHERE r.registeredAt >= :from
@@ -27,7 +27,8 @@ public interface RegistrationAnalyticsRepository
     List<Object[]> findMonthlyTrend(@Param("from") LocalDateTime from);
 
     @Query("""
-        SELECT FUNCTION('YEARWEEK', r.registeredAt, 1) AS period,
+        SELECT CAST(FUNCTION('YEAR', r.registeredAt) AS int) * 100
+             + CAST(FUNCTION('WEEK', r.registeredAt) AS int) AS period,
                COUNT(r) AS regCount
         FROM EventRegistration r
         WHERE r.registeredAt >= :from
@@ -50,7 +51,7 @@ public interface RegistrationAnalyticsRepository
 
     // ── Peak registration periods ─────────────────────────────────────────────
     @Query("""
-        SELECT FUNCTION('DAYOFWEEK', r.registeredAt) AS dow,
+        SELECT FUNCTION('DAY_OF_WEEK', r.registeredAt) AS dow,
                FUNCTION('HOUR', r.registeredAt)      AS hr,
                COUNT(r)                              AS cnt
         FROM EventRegistration r

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
@@ -39,7 +39,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /** Returns the number of newly created user accounts grouped by month. */
     @Query("""
-        SELECT FUNCTION('DATE_FORMAT', u.createdAt, '%Y-%m') AS period,
+        SELECT FUNCTION('FORMATDATETIME', u.createdAt, 'yyyy-MM') AS period,
                COUNT(u) AS userCount
         FROM User u
         WHERE u.createdAt >= :from


### PR DESCRIPTION
## Problem

The analytics queries in `RegistrationAnalyticsRepository` and `UserRepository` use MySQL-only SQL functions (`DATE_FORMAT`, `YEARWEEK`, `DAYOFWEEK`) in JPQL. The backend runs on H2 in-memory in `application.yml`, so these queries throw `SQLGrammarException` when the analytics endpoints are exercised.

## Fix

Replaced the MySQL functions with portable H2 equivalents:

- `DATE_FORMAT(x, '%Y-%m')` → `FORMATDATETIME(x, 'yyyy-MM')`
- `YEARWEEK(x, 1)` → `YEAR(x) * 100 + WEEK(x)`
- `DAYOFWEEK(x)` → `DAY_OF_WEEK(x)` (identical 1=Sunday..7=Saturday semantics, so the service mapping in `AnalyticsService.getPeakPeriods` is unchanged)

`WEEK(x)` relies on H2's default week mode 1 (Monday first day, week 1 = first week with 4+ days), which matches the MySQL `YEARWEEK(x, 1)` mode 1 semantics.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java`

## Testing

Verified by running all five affected queries (`findMonthlyTrend`, `findWeeklyTrend`, `findDailyTrend`, `findPeakPeriods`, `findMonthlySignupTrend`) against the H2 test profile via a temporary `@SpringBootTest`; all executed successfully (e.g. monthly `2026-08`, weekly `202632`, peak `dow=4 hr=17`).

Closes #11529