### PR TITLE
fix: detach user from event_attendees on delete and base registeredCount on registrations

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -12,6 +12,8 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
 
     boolean existsByEvent_IdAndUser_Email(Long eventId, String userEmail);
 
+    long countByEvent_IdAndStatus(Long eventId, String status);
+
     List<EventRegistration> findByUser_EmailOrderByRegisteredAtDesc(String userEmail);
 
     Optional<EventRegistration> findByEvent_IdAndSeatId(Long eventId, String seatId);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.model.Event;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,12 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e FROM Event e WHERE e.id = :id")
     Optional<Event> findByIdWithLock(@Param("id") Long id);
+
+    /**
+     * Removes the given user from the event_attendees join table.
+     * Used before deleting a user so no orphaned attendee rows remain.
+     */
+    @Modifying
+    @Query(value = "DELETE FROM event_attendees WHERE user_id = :userId", nativeQuery = true)
+    void deleteAttendeeRowsByUserId(@Param("userId") Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -118,6 +118,7 @@ public class AdminService {
         projectUpvoteRepository.deleteByUser_Id(id);
         notificationRepository.deleteByUser_Id(id);
         feedbackRepository.deleteByUser_Id(id);
+        eventRepository.deleteAttendeeRowsByUserId(id);
 
         userRepository.deleteById(id);
     }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -508,12 +508,9 @@ public class EventService {
         }
 
         event.getAttendees().add(user);
-        event.setRegisteredCount(event.getAttendees().size());
-
-        Event saved = eventRepository.save(event);
 
         EventRegistration registration = new EventRegistration();
-        registration.setEvent(saved);
+        registration.setEvent(event);
         registration.setUser(user);
         registration.setRegisteredAt(LocalDateTime.now());
         registration.setStatus("CONFIRMED");
@@ -525,6 +522,10 @@ public class EventService {
             throw new RegistrationConflictException(
                     "Seat " + seatId + " is already taken.");
         }
+
+        event.setRegisteredCount((int) eventRegistrationRepository
+                .countByEvent_IdAndStatus(eventId, "CONFIRMED"));
+        Event saved = eventRepository.save(event);
 
         Integer spotsRemaining =
                 (saved.getCapacity() == null)
@@ -566,15 +567,17 @@ public class EventService {
         }
 
         event.getAttendees().add(user);
-        event.setRegisteredCount(event.getAttendees().size());
-        Event saved = eventRepository.save(event);
 
         EventRegistration registration = new EventRegistration();
-        registration.setEvent(saved);
+        registration.setEvent(event);
         registration.setUser(user);
         registration.setRegisteredAt(LocalDateTime.now());
         registration.setStatus("CONFIRMED");
         registration = eventRegistrationRepository.save(registration);
+
+        event.setRegisteredCount((int) eventRegistrationRepository
+                .countByEvent_IdAndStatus(event.getId(), "CONFIRMED"));
+        Event saved = eventRepository.save(event);
 
         entry.setStatus("PROMOTED");
         entry.setPromotedAt(LocalDateTime.now());


### PR DESCRIPTION
## Problem

`AdminService.deleteUser` deletes registrations, waitlist entries, hackathon registrations, upvotes, notifications and feedback, then calls `userRepository.deleteById(id)`. It never removes the user from the `event_attendees` join table. Because the Hibernate-generated schema has no cascade on that join table, deleting a user who ever attended an event throws `DataIntegrityViolationException` (500), and any leftover rows would silently inflate `Event.registeredCount` and skew `countUniqueParticipants` / `getEventAttendees`.

## Fix

- Added `EventRepository.deleteAttendeeRowsByUserId` (`DELETE FROM event_attendees WHERE user_id = :userId`) and call it in `AdminService.deleteUser` before the user row is removed, so no orphaned attendee rows remain and the delete succeeds for any user.
- Stopped deriving `registeredCount` from `attendees.size()` in `EventService.executeRegistration` and `EventService.promoteEntry`. It is now derived from the real registration table via the new `EventRegistrationRepository.countByEvent_IdAndStatus(eventId, CONFIRMED)`, so capacity accounting cannot drift from the registration table.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

Verified with a temporary `@SpringBootTest` against the H2 test profile: deleting a user who had a CONFIRMED registration + `event_attendees` row now succeeds, leaves no `event_attendees` row for that user, keeps the event intact, and deleting an event-organizer user also succeeds.

Closes #11530