### PR TITLE
fix: scope analytics to owned/managed events; restrict global endpoints to admins

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/analytics")
-@PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
+@PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
 public class AnalyticsController {
 
     private final AnalyticsService analyticsService;
@@ -43,6 +43,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/organizers")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
     public ResponseEntity<List<OrganizerInsightDTO>> getOrganizerInsights() {
         return ResponseEntity.ok(analyticsService.getOrganizerInsights());
     }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
@@ -45,4 +45,16 @@ public interface EventAnalyticsRepository extends JpaRepository<Event, Long> {
     // Total unique participants via the join table
     @Query("SELECT COUNT(DISTINCT a.id) FROM Event e JOIN e.attendees a")
     long countUniqueParticipants();
+
+    // Events a user owns or manages (owner or member of the event team)
+    @Query("""
+        SELECT DISTINCT e
+        FROM Event e
+        WHERE e.ownerId = :userId
+           OR e.id IN (SELECT tm.event.id FROM EventTeamMember tm WHERE tm.user.id = :userId)
+        """)
+    List<Event> findAccessibleToUser(@Param("userId") Long userId);
+
+    @Query("SELECT DISTINCT e.ownerId FROM Event e WHERE e.ownerId IS NOT NULL")
+    List<Long> findDistinctOwnerIds();
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
@@ -14,6 +14,9 @@ public interface FeedbackAnalyticsRepository extends JpaRepository<Feedback, Lon
     @Query("SELECT AVG(f.rating) FROM Feedback f")
     Double findOverallAverageRating();
 
+    @Query("SELECT AVG(f.rating) FROM Feedback f WHERE f.event.id IN :eventIds")
+    Double findAverageRatingForEvents(@Param("eventIds") java.util.Collection<Long> eventIds);
+
     @Query("SELECT COUNT(f) FROM Feedback f")
     long countTotalFeedback();
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
@@ -4,17 +4,26 @@ import com.sandeep.eventrabackend.dto.DashboardStatsDTO;
 import com.sandeep.eventrabackend.dto.FeedbackAnalyticsDTO;
 import com.sandeep.eventrabackend.dto.OrganizerInsightDTO;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventAnalyticsRepository;
 import com.sandeep.eventrabackend.repository.FeedbackAnalyticsRepository;
 import com.sandeep.eventrabackend.repository.RegistrationAnalyticsRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -25,6 +34,7 @@ public class AnalyticsService {
     private final EventAnalyticsRepository eventRepo;
     private final RegistrationAnalyticsRepository regRepo;
     private final FeedbackAnalyticsRepository feedbackRepo;
+    private final UserRepository userRepository;
 
     // ── 1. Dashboard ──────────────────────────────────────────────────────────
     public DashboardStatsDTO getDashboardStats() {
@@ -138,8 +148,71 @@ public class AnalyticsService {
     }
 
     // ── 6. Organizer insights ────────────────────────────────────────────────
+    /**
+     * Returns analytics scoped to the events the caller owns or manages.
+     * ADMIN / SUPER_ADMIN receive the full per-organizer breakdown; a
+     * regular ORGANIZER only sees their own events (ownerId or event team).
+     */
     public List<OrganizerInsightDTO> getOrganizerInsights() {
-        return List.of();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AccessDeniedException("Unable to determine the authenticated user");
+        }
+
+        User caller = userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new UsernameNotFoundException(
+                        "User not found with email: " + authentication.getName()));
+
+        if (caller.getRole() == Role.ADMIN || caller.getRole() == Role.SUPER_ADMIN) {
+            return eventRepo.findDistinctOwnerIds().stream()
+                    .map(ownerId -> userRepository.findById(ownerId)
+                            .map(owner -> buildOrganizerInsight(
+                                    owner.getId(),
+                                    owner.getFirstName(),
+                                    owner.getLastName(),
+                                    eventRepo.findAccessibleToUser(owner.getId())))
+                            .orElse(null))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+        }
+
+        return List.of(buildOrganizerInsight(
+                caller.getId(),
+                caller.getFirstName(),
+                caller.getLastName(),
+                eventRepo.findAccessibleToUser(caller.getId())));
+    }
+
+    private OrganizerInsightDTO buildOrganizerInsight(
+            Long organizerId,
+            String firstName,
+            String lastName,
+            List<Event> events) {
+
+        List<Long> eventIds = events.stream()
+                .map(Event::getId)
+                .collect(Collectors.toList());
+
+        Double avgRating = eventIds.isEmpty()
+                ? null
+                : feedbackRepo.findAverageRatingForEvents(eventIds);
+
+        double avgCapacityUtilization = events.stream()
+                .filter(e -> e.getCapacity() != null && e.getCapacity() > 0)
+                .mapToDouble(e -> (double) e.getRegisteredCount() / e.getCapacity())
+                .average()
+                .orElse(0.0);
+
+        return OrganizerInsightDTO.builder()
+                .organizerId(organizerId)
+                .organizerName(firstName + " " + lastName)
+                .totalEvents(events.size())
+                .totalRegistrations(events.stream()
+                        .mapToLong(Event::getRegisteredCount)
+                        .sum())
+                .averageRating(avgRating != null ? avgRating : 0.0)
+                .avgCapacityUtilization(avgCapacityUtilization)
+                .build();
     }
 }
 


### PR DESCRIPTION
## Problem

`AnalyticsController` gates the entire `/api/analytics` namespace with `@PreAuthorize(hasAnyAuthority('ADMIN','SUPER_ADMIN','ORGANIZER'))`, but none of the `AnalyticsService` queries filter by `event.ownerId` or `EventTeamMember` membership. Any global ORGANIZER could read per-event ratings, rating distributions, satisfaction scores, registration counts and capacity utilization for every event on the platform — a cross-tenant data leak.

## Fix

- `AnalyticsController`: class-level rule narrowed to `ADMIN, SUPER_ADMIN` so the un-scoped global endpoints (`/dashboard`, `/registrations/trends`, `/feedback`) are admin-only. `/organizers` keeps `ORGANIZER` access via a method-level rule.
- `AnalyticsService.getOrganizerInsights`: now resolves the authenticated caller and scopes the result. An `ORGANIZER` sees only events they own or manage (`ownerId` or `event_team_members` membership) via the new `EventAnalyticsRepository.findAccessibleToUser`; `ADMIN`/`SUPER_ADMIN` get the full per-organizer breakdown. Average rating uses `FeedbackAnalyticsRepository.findAverageRatingForEvents` scoped to those events.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java`

## Testing

Verified with a temporary `@SpringBootTest` against the H2 test profile: an ORGANIZER caller receives only their own events' insights (one DTO, correct totals), while an ADMIN caller receives the full per-organizer breakdown across all distinct event owners.

Closes #11531