### PR TITLE
fix: fail closed waitlist view/promotion authorization

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -14,6 +14,8 @@ import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
 import com.sandeep.eventrabackend.model.EventRole;
+import com.sandeep.eventrabackend.model.EventWaitlist;
+import com.sandeep.eventrabackend.model.Notification;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
@@ -25,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,6 +72,8 @@ public class EventService {
     public EventService(
             EventRepository eventRepository,
             EventRegistrationRepository eventRegistrationRepository,
+            EventWaitlistRepository eventWaitlistRepository,
+            NotificationRepository notificationRepository,
             UserRepository userRepository,
             EventRoleService eventRoleService) {
         this.eventRepository = eventRepository;
@@ -372,14 +377,7 @@ public class EventService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
 
-        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
-        if (currentUser != null) {
-            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
-                throw new AccessDeniedException(
-                        "Only the event's own organizer (or an administrator) can view this waitlist.");
-            }
-        }
+        eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER);
 
         return eventWaitlistRepository
                 .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId, "WAITING")
@@ -405,14 +403,7 @@ public class EventService {
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + eventId));
 
-        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
-        if (currentUser != null) {
-            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
-                throw new AccessDeniedException(
-                        "Only the event's own organizer (or an administrator) can manage this event.");
-            }
-        }
+        eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER);
 
         EventWaitlist entry = eventWaitlistRepository.findById(waitlistId)
                 .filter(waitlist -> waitlist.getEvent().getId().equals(eventId))


### PR DESCRIPTION
## Problem

`EventService.getEventWaitlist` and `EventService.promoteWaitlistedUser` authorized with `if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId()))`. When `event.ownerId` is null (legacy/seeded events), the guard short-circuits OPEN and grants access. Because the routes are gated only by global role, any ORGANIZER could read another organizer's ownerless event waitlist (including every waitlisted user's email) and promote arbitrary waitlisted users into confirmed registrations.

## Fix

Route both paths through `eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER)`, the same RBAC gate already used by `updateEvent`. This fails closed: the caller must be a platform admin, the event's legacy owner (`ownerId`), or an `event_team_members` member with at least `ORGANIZER` — a null `ownerId` no longer bypasses the check.

Also fixes the pre-existing compile errors in `EventService.java`: adds the missing `EventWaitlist`/`Notification`/`AccessDeniedException` imports and the two constructor parameters (`EventWaitlistRepository`, `NotificationRepository`) that the constructor body already referenced but the signature was missing.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

Verified with a temporary `@SpringBootTest` against H2:
- outsider ORGANIZER is denied `getEventWaitlist` on an ownerless event and on another organizer's event;
- outsider ORGANIZER is denied `promoteWaitlistedUser`;
- the event owner and a platform admin are still allowed.

Closes #11532