### PR TITLE
fix: stop no-arg reconnect() from shadowing per-path reconnect

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -116,7 +116,7 @@ class SseMultiplexer {
           if (document.visibilityState === "hidden") {
             this.teardown(true);
           } else if (document.visibilityState === "visible") {
-            this.reconnect();
+            this.reconnectOnVisibility();
           }
         }
       };
@@ -708,7 +708,7 @@ class SseMultiplexer {
     this.lastSeenFollowers = null;
   }
 
-  reconnect() {
+  reconnectOnVisibility() {
     logger.log(`[SSE Multiplexer] Tab ${this.tabId} became visible, reconnecting...`);
     if (typeof window !== "undefined") {
       if (!this.channel) {

--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -148,6 +148,55 @@ const testStatusSyncOnSubscribe = async () => {
   }
 };
 
+const testReconnectRequestUsesPerPathReconnect = async () => {
+  // A RECONNECT_REQUEST from a follower must re-establish only the requested
+  // path via the parameterized reconnect(path) -> openEventSource(path) flow,
+  // not the no-arg visibility reconnect that re-runs leader election.
+  sseMultiplexer.isLeader = true;
+  sseMultiplexer.channel = new globalThis.BroadcastChannel("eventra_sse_multiplexer");
+  sseMultiplexer.channel.onmessage = (e) => sseMultiplexer.handleBroadcastMessage(e.data);
+  sseMultiplexer.activeEventSources.clear();
+
+  const opened = [];
+  const originalOpen = sseMultiplexer.openEventSource.bind(sseMultiplexer);
+  sseMultiplexer.openEventSource = (path) => {
+    opened.push(path);
+    return originalOpen(path);
+  };
+
+  try {
+    sseMultiplexer.activeEventSources.set(
+      "/stream/leaderboard",
+      new globalThis.EventSource("https://api.example.test/stream/leaderboard")
+    );
+
+    sseMultiplexer.handleReconnectRequest({
+      type: "RECONNECT_REQUEST",
+      tabId: "tab_b",
+      path: "/stream/leaderboard",
+    });
+
+    assert.ok(
+      opened.includes("/stream/leaderboard"),
+      "Reconnect request must re-open the requested path's EventSource"
+    );
+    assert.equal(
+      opened.length,
+      1,
+      "Only the requested path should be re-opened, not every path"
+    );
+    assert.equal(
+      sseMultiplexer.isLeader,
+      true,
+      "Per-path reconnect must not re-run the visibility/leader-election flow"
+    );
+  } finally {
+    sseMultiplexer.openEventSource = originalOpen;
+    sseMultiplexer.channel?.close();
+    channels.clear();
+  }
+};
+
 const runTests = async () => {
   process.env.REACT_APP_API_URL = "https://api.example.test";
 
@@ -340,6 +389,8 @@ const runTests = async () => {
   }
 
   await testStatusSyncOnSubscribe();
+
+  await testReconnectRequestUsesPerPathReconnect();
 
   console.log("🟢 All SSE Multiplexer unit tests completed successfully!");
 };


### PR DESCRIPTION
## Problem

`src/utils/sseMultiplexer.js` declares a parameterized `reconnect(path)` at line 351 and a later no-arg `reconnect()` at line 711 (the visibility-change handler from #11069). In JavaScript the later class-method definition shadows the earlier one, so `this.reconnect(msg.path)` at line 457 (leader handling a `RECONNECT_REQUEST`) dispatched to the no-arg version, silently discarding `path`. Per-path reconnection — attempt counters and exponential backoff — was unreachable, and a reconnect request for one path tore down/re-elected everything instead of re-establishing only that path.

## Fix

- Renamed the no-arg visibility method to `reconnectOnVisibility()` and updated its call site (visibility change → visible), so `reconnect(path)` is the only `reconnect` method.
- `handleReconnectRequest` now reaches the parameterized per-path reconnect: close + reopen only the requested path's EventSource, preserving per-path backoff/attempt state.
- Added a regression test in `tests/sseMultiplexer.test.mjs` asserting a `RECONNECT_REQUEST` re-opens only the requested path and does not re-run the leader-election/visibility flow.

## Files changed

- `src/utils/sseMultiplexer.js`
- `tests/sseMultiplexer.test.mjs`

## Testing

`node --test tests/sseMultiplexer.test.mjs` passes (including the new regression test); `npx eslint` on both files reports no errors.

Closes #11533