### PR TITLE
fix: route cancel/waitlist management through requireRole

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -14,10 +14,11 @@ import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
 import com.sandeep.eventrabackend.model.EventRole;
+import com.sandeep.eventrabackend.model.EventWaitlist;
+import com.sandeep.eventrabackend.model.Notification;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
-import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
@@ -69,6 +70,8 @@ public class EventService {
     public EventService(
             EventRepository eventRepository,
             EventRegistrationRepository eventRegistrationRepository,
+            EventWaitlistRepository eventWaitlistRepository,
+            NotificationRepository notificationRepository,
             UserRepository userRepository,
             EventRoleService eventRoleService) {
         this.eventRepository = eventRepository;
@@ -268,15 +271,7 @@ public class EventService {
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + id));
 
-        User currentUser = userRepository.findByEmail(userEmail)
-                .orElseThrow(() ->
-                        new UsernameNotFoundException("User not found with email: " + userEmail));
-
-        boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-        if (!isAdmin && (event.getOwnerId() == null || !event.getOwnerId().equals(currentUser.getId()))) {
-            throw new AccessDeniedException(
-                    "Only the event's own organizer (or an administrator) can cancel this event.");
-        }
+        eventRoleService.requireRole(id, userEmail, EventRole.ORGANIZER);
 
         if ("CANCELLED".equals(event.getStatus())) {
             throw new RegistrationConflictException("Event is already cancelled.");
@@ -372,14 +367,7 @@ public class EventService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
 
-        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
-        if (currentUser != null) {
-            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
-                throw new AccessDeniedException(
-                        "Only the event's own organizer (or an administrator) can view this waitlist.");
-            }
-        }
+        eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER);
 
         return eventWaitlistRepository
                 .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId, "WAITING")
@@ -405,14 +393,7 @@ public class EventService {
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + eventId));
 
-        User currentUser = userRepository.findByEmail(userEmail).orElse(null);
-        if (currentUser != null) {
-            boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-            if (!isAdmin && event.getOwnerId() != null && !event.getOwnerId().equals(currentUser.getId())) {
-                throw new AccessDeniedException(
-                        "Only the event's own organizer (or an administrator) can manage this event.");
-            }
-        }
+        eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER);
 
         EventWaitlist entry = eventWaitlistRepository.findById(waitlistId)
                 .filter(waitlist -> waitlist.getEvent().getId().equals(eventId))


### PR DESCRIPTION
## Problem

`EventService` mixes two authorization models. `updateEvent` honors `event_team_members` RBAC via `eventRoleService.requireRole(..., EventRole.ORGANIZER)`, but `cancelEvent` (:276), `getEventWaitlist` (:378) and `promoteWaitlistedUser` (:411) authorize purely on `event.ownerId` + platform admin. After ownership is transferred/delegated through `EventRoleService.assignRole`, the new OWNER's id no longer equals `event.ownerId` (which still points at the original creator), so those three endpoints throw `AccessDeniedException` even for the legitimately delegated owner — while `updateEvent` succeeds.

## Fix

- `cancelEvent`, `getEventWaitlist` and `promoteWaitlistedUser` now call `eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER)`, matching `updateEvent`'s existing RBAC gate. `requireRole` already passes platform admins and the legacy owner, and team members whose assigned role includes ORGANIZER/OWNER.
- This also fails closed for the null-`ownerId` case (the old waitlist guards were fail-open when the user was null or `ownerId` was null).
- Removed the now-dead raw `ownerId`/`Role` comparisons in those endpoints (and the unused `Role` import).
- Fixed the pre-existing compile errors in `EventService.java` (missing `EventWaitlist`/`Notification` imports and constructor parameters).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

`RbacManagementVerificationTest` (temp, deleted after run) — 4 cases, all green:
1. Delegated ORGANIZER (ownerId differs) can cancel the event → status CANCELLED.
2. Delegated ORGANIZER can view the waitlist and promote an entry → registeredCount increments.
3. Outsider with no team role is denied cancel / waitlist view / promote.
4. Legacy owner still cancels after delegation.

Closes #11534