### PR TITLE
fix: block non-SUPER_ADMIN from deleting SUPER_ADMIN accounts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -108,8 +108,12 @@ public class AdminService {
      */
     @Transactional
     public void deleteUser(Long id) {
-        if (!userRepository.existsById(id)) {
-            throw new EntityNotFoundException("User not found with id: " + id);
+        User targetUser = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
+
+        Role callerRole = getAuthenticatedRole();
+        if (callerRole != Role.SUPER_ADMIN && targetUser.getRole() == Role.SUPER_ADMIN) {
+            throw new AccessDeniedException("Only SUPER_ADMIN users can delete SUPER_ADMIN accounts");
         }
 
         eventRegistrationRepository.deleteByUser_Id(id);


### PR DESCRIPTION
## Problem

`AdminService.deleteUser` (`:110-123`) has no role-hierarchy guard, while `updateUserRole` (`:93-100`) deliberately blocks non-SUPER_ADMIN callers from touching SUPER_ADMIN accounts. Any ADMIN can therefore permanently delete a SUPER_ADMIN — or the last remaining admin — through `DELETE /api/admin/users/{id}`, bypassing the exact protection applied to role mutation.

## Fix

Mirror `updateUserRole`: load the target user, resolve the caller's role from the security context, and throw `AccessDeniedException` when the caller is not SUPER_ADMIN and the target holds the SUPER_ADMIN role. The endpoint-level `@PreAuthorize(hasAnyAuthority('ADMIN','SUPER_ADMIN'))` on `AdminController` remains correct — enforcement now happens in the service.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`

## Testing

`DeleteUserGuardVerificationTest` (temp, deleted after run) — 4 cases, all green:
1. ADMIN caller deleting a SUPER_ADMIN → `AccessDeniedException`, target intact.
2. SUPER_ADMIN caller deleting a SUPER_ADMIN → succeeds.
3. ADMIN caller deleting a CLIENT → succeeds.
4. Deleting a non-existent user → `EntityNotFoundException`.

Closes #11536