### PR TITLE
feat: add copy link button for event and hackathon detail pages

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -106,7 +106,20 @@ const EventDetails = () => {
   const [linkCopied, setLinkCopied] = useState(false);
   const latestRequestIdRef = useRef(0);
   const abortControllerRef = useRef(null);
+const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setLinkCopied(true);
 
+      setTimeout(() => {
+        setLinkCopied(false);
+      }, 2000);
+
+      alert("Link copied successfully!");
+    } catch (error) {
+      alert("Unable to copy link.");
+    }
+  };
   const loadEvent = useCallback(async () => {
     abortControllerRef.current?.abort();
 
@@ -463,6 +476,14 @@ const lastUpdated = getLastUpdated(event.updatedAt);
                   >
                     <CalendarPlus size={18} /> Duplicate Event
                   </button>
+                  <button
+    type="button"
+    onClick={copyLink}
+    className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-800 shadow-sm hover:bg-gray-50 transition dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+    aria-label="Copy event link"
+  >
+    {linkCopied ? "Copied!" : "Copy Link"}
+  </button>
                   <div className="relative print-hide">
                     <button
                       onClick={() => setShowExportDropdown(!showExportDropdown)}

--- a/src/Pages/Hackathons/HackathonDetailsPage.js
+++ b/src/Pages/Hackathons/HackathonDetailsPage.js
@@ -22,7 +22,14 @@ const HackathonDetailsPage = () => {
   const prefersReducedMotion = useReducedMotion();
   const { hackathonId } = useParams();
   const foundHackathon = hackathonsData.find((item) => String(item.id) === hackathonId);
-
+  const copyLink = async () => {
+  try {
+    await navigator.clipboard.writeText(window.location.href);
+    alert("Link copied successfully!");
+  } catch (error) {
+    alert("Unable to copy link.");
+  }
+};
   if (!foundHackathon) {
     return (
       <div className="min-h-screen bg-bg text-text flex items-center justify-center px-4 py-24">
@@ -124,6 +131,13 @@ const HackathonDetailsPage = () => {
                 >
                   Browse Hackathons
                 </Link>
+                <button
+    onClick={copyLink}
+    className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium hover:bg-gray-100"
+  >
+    Copy Link
+  </button>
+
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

This PR adds a Copy Link button to both Event and Hackathon detail pages.

### Changes

- Added Copy Link button
- Uses Clipboard API
- Copies current page URL
- Provides success feedback
- Matches existing UI design
- Responsive for desktop and mobile

Fixes #11194