### PR TITLE
feat: add copy link button to hackathon details page

### DIFF
--- a/src/Pages/Hackathons/HackathonDetailsPage.js
+++ b/src/Pages/Hackathons/HackathonDetailsPage.js
@@ -22,7 +22,14 @@ const HackathonDetailsPage = () => {
   const prefersReducedMotion = useReducedMotion();
   const { hackathonId } = useParams();
   const foundHackathon = hackathonsData.find((item) => String(item.id) === hackathonId);
-
+const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      alert("Link copied successfully!");
+    } catch (error) {
+      alert("Unable to copy link.");
+    }
+  };
   if (!foundHackathon) {
     return (
       <div className="min-h-screen bg-bg text-text flex items-center justify-center px-4 py-24">
@@ -124,6 +131,13 @@ const HackathonDetailsPage = () => {
                 >
                   Browse Hackathons
                 </Link>
+                <button
+    type="button"
+    onClick={copyLink}
+    className="inline-flex items-center justify-center rounded-full border border-border bg-bg px-6 py-3 text-sm font-semibold text-text shadow-sm hover:bg-card-bg transition"
+  >
+    Copy Link
+  </button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

This PR adds a Copy Link button to the Hackathon Details page.

### Changes

- Added Copy Link button
- Uses Clipboard API
- Copies current page URL
- Provides user feedback after copying
- Matches the existing UI styling

Fixes #11194