### PR TITLE
fix: declare sync budget identifiers and catch sync-run failures

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -18,6 +18,11 @@ import { safeJsonParse } from "../utils/safeJsonParse.js";
 const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 1_000;
 
+// Total time budget (ms) for a single sync run. When exceeded, the loop stops
+// processing further items and leaves them queued for the next sync run so the
+// browser tab is never monopolised by a huge offline backlog.
+const SYNC_BUDGET_MS = 15_000;
+
 // Message types the service worker may post to request an offline queue sync.
 // EVENTRA_BACKGROUND_SYNC is posted by public/service-worker.js when the
 // browser fires the "sync" event for the eventra-offline-queue-sync tag.
@@ -310,11 +315,13 @@ const useOfflineSync = () => {
           autoClose: 2000,
         });
 
+        const syncStartTime = Date.now();
+
         for (const item of sessionValidatedQueue) {
-        if (Date.now() - syncStartTime > SYNC_BUDGET_MS) {
-          logger.warn("[useOfflineSync] Sync budget exceeded, stopping.");
-          break;
-        }
+          if (Date.now() - syncStartTime > SYNC_BUDGET_MS) {
+            logger.warn("[useOfflineSync] Sync budget exceeded, stopping.");
+            break;
+          }
           // Halt the zombie loop immediately if the session changed or component unmounted.
           // This prevents making requests with stale tokens and protects IndexedDB from being falsely overwritten below.
           if (conflictController.signal.aborted) {
@@ -395,6 +402,20 @@ const useOfflineSync = () => {
           toast.error(
             `${droppedCount} registration(s) paused after ${MAX_RETRIES} failed attempts. Retained in local drafts.`,
           );
+        }
+      } catch (error) {
+        // A crash anywhere in the replay run must never surface as a
+        // successful sync. Report every item that was not already processed as
+        // still-remaining and persist the queue so nothing is silently lost.
+        logger.error("[useOfflineSync] Sync run failed:", error);
+        const processedIds = new Set(failedQueue.map((failed) => failed.id));
+        for (const item of sessionValidatedQueue) {
+          if (!processedIds.has(item.id)) {
+            failedQueue.push(item);
+          }
+        }
+        if (failedQueue.length > 0) {
+          await setQueue(failedQueue);
         }
       } finally {
         isSyncing.current = false;


### PR DESCRIPTION
## Problem

`src/hooks/useOfflineSync.js:314` references `syncStartTime` and `SYNC_BUDGET_MS`, which are declared nowhere in the codebase (each identifier occurs exactly once). The guard sits outside the inner per-item `try` (:333), the outer `try` (:308) has no `catch`, and the `finally` (:399) always dispatches a completion event with `remaining: 0`. Consequences: every offline sync with a non-empty queue throws `ReferenceError` on the first iteration, queued `REGISTER_EVENT`/`JOIN_WAITLIST`/`TICKET_CHECK_IN` actions are never replayed, and the UI reports the queue as empty — silent loss of every offline action.

## Fix

- Defined `SYNC_BUDGET_MS` (15s) with the other constants and capture `const syncStartTime = Date.now()` before the loop, so the budget guard actually works and never throws.
- Added a `catch` to the outer `try`: on any failure the run logs the error, pushes every item that was not already processed into `failedQueue` (preserving incremented retry counts), persists the queue back to IndexedDB, and the `finally` completion event reports the true `remaining` count — a crash can no longer surface as a successful sync.
- Fixed the mis-indented budget-check block while editing.

## Files changed

- `src/hooks/useOfflineSync.js`

## Testing

Verified with a temporary Vitest suite (deleted after run), 2 cases green:
1. A 2-item queue syncs without throwing — both items replayed, queue cleared (before the fix: `ReferenceError`, 0 fetches).
2. A run that throws before the loop preserves all items via `setQueue`, never calls `clearQueue`, makes 0 fetches, and the completion event reports `remaining: 2`.

`node --check` and `npx eslint` on the file are clean.

Closes #11537