### PR TITLE
feat: skeleton loading enhancement for dashboard sections

### DIFF
--- a/src/components/common/SkeletonLoaders.jsx
+++ b/src/components/common/SkeletonLoaders.jsx
@@ -6,7 +6,10 @@ export const SkeletonBlock = ({ className = "", ...props }) => (
 );
 
 export const SkeletonEventCard = () => (
-  <div aria-hidden="true" className="group relative bg-white dark:bg-gray-900 rounded-3xl shadow-xl flex flex-col overflow-hidden border border-gray-100 dark:border-gray-800">
+  <div
+    aria-hidden="true"
+    className="group relative bg-white dark:bg-gray-900 rounded-3xl shadow-xl flex flex-col overflow-hidden border border-gray-100 dark:border-gray-800"
+  >
     <div className="flex items-center px-5 py-4 gap-4 bg-linear-to-r from-white/80 to-indigo-50/60 dark:from-gray-900/80 dark:to-indigo-950/60 border-b border-gray-100 dark:border-gray-800">
       <SkeletonBlock className="w-10 h-10 rounded-xl" />
       <SkeletonBlock className="h-6 flex-1" />
@@ -39,7 +42,10 @@ export const SkeletonEventCard = () => (
 export const EventCardSkeleton = SkeletonEventCard;
 
 export const HomeCardSkeleton = () => (
-  <div aria-hidden="true" className="flex flex-col rounded-xl overflow-hidden shadow-md bg-white dark:bg-black/60 min-h-[300px] sm:min-h-[360px] ring-2 ring-sky-200 dark:ring-sky-700/60 animate-pulse">
+  <div
+    aria-hidden="true"
+    className="flex flex-col rounded-xl overflow-hidden shadow-md bg-white dark:bg-black/60 min-h-[300px] sm:min-h-[360px] ring-2 ring-sky-200 dark:ring-sky-700/60 animate-pulse"
+  >
     <div className="p-4 sm:p-6 flex-1 flex flex-col">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 sm:mb-4 gap-2 sm:gap-0">
         <SkeletonBlock className="h-6 w-24 rounded-full" />
@@ -69,7 +75,11 @@ export const HomeCardSkeleton = () => (
 );
 
 export const ContributorCardSkeleton = ({ className = "", style = {} }) => (
-  <div style={style} aria-hidden="true" className={`relative bg-white/95 dark:bg-gray-800/90 backdrop-blur-xl p-6 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 flex flex-col items-center text-center animate-pulse ${className}`}>
+  <div
+    style={style}
+    aria-hidden="true"
+    className={`relative bg-white/95 dark:bg-gray-800/90 backdrop-blur-xl p-6 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700 flex flex-col items-center text-center animate-pulse ${className}`}
+  >
     <div className="absolute -top-8 left-1/2 -translate-x-1/2">
       <SkeletonBlock className="w-20 h-20 rounded-full border-4 border-white dark:border-gray-800 shadow-xl" />
     </div>
@@ -104,7 +114,10 @@ export const ContributorCardSkeleton = ({ className = "", style = {} }) => (
 );
 
 export const GitHubStatCardSkeleton = () => (
-  <div aria-hidden="true" className="group flex flex-col items-center justify-center bg-white dark:bg-gray-800 rounded-2xl px-3 py-4 sm:px-6 sm:py-6 md:px-8 shadow-lg border border-gray-100 dark:border-gray-700 relative overflow-hidden animate-pulse">
+  <div
+    aria-hidden="true"
+    className="group flex flex-col items-center justify-center bg-white dark:bg-gray-800 rounded-2xl px-3 py-4 sm:px-6 sm:py-6 md:px-8 shadow-lg border border-gray-100 dark:border-gray-700 relative overflow-hidden animate-pulse"
+  >
     <div className="z-10 flex flex-col items-center space-y-2 sm:space-y-3 w-full">
       <SkeletonBlock className="p-2 sm:p-3 md:p-4 h-12 w-12 sm:h-16 sm:w-16 md:h-20 md:w-20 rounded-full" />
       <SkeletonBlock className="h-6 w-16" />
@@ -114,7 +127,10 @@ export const GitHubStatCardSkeleton = () => (
 );
 
 export const LeaderboardStatCardSkeleton = () => (
-  <div aria-hidden="true" className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-linear-to-br from-indigo-50 to-gray-50 dark:from-gray-800 dark:to-gray-900">
+  <div
+    aria-hidden="true"
+    className="p-6 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 bg-linear-to-br from-indigo-50 to-gray-50 dark:from-gray-800 dark:to-gray-900"
+  >
     <div className="flex items-center">
       <SkeletonBlock className="h-12 w-12 rounded-xl mr-4" />
       <div className="flex-1">
@@ -195,10 +211,7 @@ export const SkeletonCalendar = ({ listItems = 3 }) => (
         </div>
         <div className="grid grid-cols-7 gap-2">
           {[...Array(35)].map((_, i) => (
-            <SkeletonBlock
-              key={i}
-              className="aspect-square rounded-xl sm:rounded-2xl"
-            />
+            <SkeletonBlock key={i} className="aspect-square rounded-xl sm:rounded-2xl" />
           ))}
         </div>
       </div>
@@ -225,7 +238,10 @@ export const SkeletonCalendar = ({ listItems = 3 }) => (
 );
 
 export const SkeletonProfileCard = () => (
-  <div aria-hidden="true" className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-6 shadow-sm">
+  <div
+    aria-hidden="true"
+    className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-6 shadow-sm"
+  >
     <div className="flex items-center gap-4">
       <SkeletonBlock className="h-16 w-16 rounded-full" />
       <div className="flex-1">
@@ -259,7 +275,10 @@ export const SkeletonTableRows = ({ rows = 5, columns = 4 }) => (
 );
 
 export const HackathonCardSkeleton = () => (
-  <div aria-hidden="true" className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-blue-200 dark:border-gray-700 overflow-hidden">
+  <div
+    aria-hidden="true"
+    className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-blue-200 dark:border-gray-700 overflow-hidden"
+  >
     <div className="p-6 flex flex-col gap-5">
       <div className="flex justify-between items-center">
         <div className="flex gap-2">
@@ -337,7 +356,10 @@ export const HackathonCardSkeleton = () => (
 );
 
 export const ProjectCardSkeleton = () => (
-  <div aria-hidden="true" className="bg-white dark:bg-indigo-950 rounded-xl shadow-md border border-blue-200 dark:border-gray-700 overflow-hidden flex flex-col">
+  <div
+    aria-hidden="true"
+    className="bg-white dark:bg-indigo-950 rounded-xl shadow-md border border-blue-200 dark:border-gray-700 overflow-hidden flex flex-col"
+  >
     <div className="flex items-center justify-between px-5 py-4 border-b border-gray-300 dark:border-gray-700">
       <SkeletonBlock className="w-10 h-10 rounded-full" />
       <SkeletonBlock className="h-5 flex-1 mx-3" />
@@ -383,12 +405,64 @@ export const ProjectCardSkeleton = () => (
 );
 
 export const DashboardStatCardSkeleton = () => (
-  <div aria-hidden="true" className="flex items-center p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 animate-pulse">
+  <div
+    aria-hidden="true"
+    className="flex items-center p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 animate-pulse"
+  >
     <SkeletonBlock className="h-14 w-14 rounded-xl flex-shrink-0" />
     <div className="flex-1 ml-4">
       <SkeletonBlock className="h-3 w-20 mb-2" />
       <SkeletonBlock className="h-8 w-14 mb-2" />
       <SkeletonBlock className="h-3 w-32" />
+    </div>
+  </div>
+);
+
+export const DashboardChartSkeleton = () => (
+  <div
+    aria-hidden="true"
+    className="bg-white dark:bg-gray-800 p-5 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm animate-pulse"
+  >
+    <SkeletonBlock className="h-4 w-40 mb-4" />
+    <div className="h-64">
+      <SkeletonBlock className="h-full w-full rounded-2xl" />
+    </div>
+  </div>
+);
+
+export const DashboardSummarySkeleton = () => (
+  <div
+    aria-hidden="true"
+    className="bg-white dark:bg-gray-800 p-5 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm lg:col-span-2 animate-pulse"
+  >
+    <SkeletonBlock className="h-4 w-36 mb-4" />
+    <SkeletonBlock className="h-4 w-72 mb-4" />
+    <div className="space-y-3">
+      {[...Array(3)].map((_, i) => (
+        <div key={i} className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <SkeletonBlock className="w-3 h-3 rounded-full" />
+            <SkeletonBlock className="h-4 w-28" />
+          </div>
+          <SkeletonBlock className="h-4 w-10" />
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export const DashboardAnalyticsSkeleton = () => (
+  <div className="space-y-6">
+    <div className="ud-stats-grid">
+      {[...Array(3)].map((_, i) => (
+        <DashboardStatCardSkeleton key={i} />
+      ))}
+    </div>
+
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <DashboardChartSkeleton />
+      <DashboardChartSkeleton />
+      <DashboardSummarySkeleton />
     </div>
   </div>
 );
@@ -438,9 +512,7 @@ export const DashboardProfileSkeleton = () => (
   </div>
 );
 
-export const DashboardSectionTitleSkeleton = () => (
-  <SkeletonBlock className="h-6 w-40 mb-4" />
-);
+export const DashboardSectionTitleSkeleton = () => <SkeletonBlock className="h-6 w-40 mb-4" />;
 
 export const AdminStatCardSkeleton = () => (
   <div aria-hidden="true" className="ad-stat-card">
@@ -492,11 +564,9 @@ export const DashboardTableSkeleton = ({ rows = 5 }) => (
     <table className="ud-table">
       <thead>
         <tr>
-          {["Type", "Title", "Date", "Location", "Status", "Participation"].map(
-            (col) => (
-              <th key={col}>{col}</th>
-            ),
-          )}
+          {["Type", "Title", "Date", "Location", "Status", "Participation"].map((col) => (
+            <th key={col}>{col}</th>
+          ))}
         </tr>
       </thead>
       <tbody>

--- a/src/components/user/AnalyticsTab.jsx
+++ b/src/components/user/AnalyticsTab.jsx
@@ -1,10 +1,20 @@
 // import React from "react";
-import { 
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer,
-  LineChart, Line, PieChart, Pie, Cell 
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  PieChart,
+  Pie,
+  Cell,
 } from "recharts";
 import { Users, Eye, TrendingUp, Calendar as CalendarIcon } from "lucide-react";
-import { DashboardStatCardSkeleton } from "../common/SkeletonLoaders";
+import { DashboardAnalyticsSkeleton } from "../common/SkeletonLoaders";
 
 const MOCK_REGISTRATION_DATA = [
   { name: "Mon", registrations: 12 },
@@ -29,17 +39,11 @@ const MOCK_DEMOGRAPHICS = [
   { name: "Academics", value: 10 },
 ];
 
-const COLORS = ['#6366f1', '#ec4899', '#8b5cf6', '#10b981'];
+const COLORS = ["#6366f1", "#ec4899", "#8b5cf6", "#10b981"];
 
 export default function AnalyticsTab({ loading }) {
   if (loading) {
-    return (
-      <div className="space-y-6">
-        <div className="ud-stats-grid">
-          {[...Array(3)].map((_, i) => <DashboardStatCardSkeleton key={i} />)}
-        </div>
-      </div>
-    );
+    return <DashboardAnalyticsSkeleton />;
   }
 
   return (
@@ -47,7 +51,9 @@ export default function AnalyticsTab({ loading }) {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-bold text-gray-900 dark:text-white">Organizer Analytics</h2>
-          <p className="text-sm text-gray-500 dark:text-gray-400">Track your event performance and audience insights.</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Track your event performance and audience insights.
+          </p>
         </div>
       </div>
 
@@ -57,9 +63,13 @@ export default function AnalyticsTab({ loading }) {
             <Users size={24} />
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Total Registrations</p>
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+              Total Registrations
+            </p>
             <h3 className="text-2xl font-bold text-gray-900 dark:text-white">1,245</h3>
-            <p className="text-xs text-green-500 flex items-center gap-1 mt-1"><TrendingUp size={12} /> +12% this week</p>
+            <p className="text-xs text-green-500 flex items-center gap-1 mt-1">
+              <TrendingUp size={12} /> +12% this week
+            </p>
           </div>
         </div>
 
@@ -70,7 +80,9 @@ export default function AnalyticsTab({ loading }) {
           <div>
             <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Page Views</p>
             <h3 className="text-2xl font-bold text-gray-900 dark:text-white">8,432</h3>
-            <p className="text-xs text-green-500 flex items-center gap-1 mt-1"><TrendingUp size={12} /> +24% this week</p>
+            <p className="text-xs text-green-500 flex items-center gap-1 mt-1">
+              <TrendingUp size={12} /> +24% this week
+            </p>
           </div>
         </div>
 
@@ -88,14 +100,28 @@ export default function AnalyticsTab({ loading }) {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="bg-white dark:bg-gray-800 p-5 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm">
-          <h3 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-4">Registration Trends</h3>
+          <h3 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-4">
+            Registration Trends
+          </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={MOCK_REGISTRATION_DATA}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
-                <XAxis dataKey="name" axisLine={false} tickLine={false} tick={{ fill: '#6b7280', fontSize: 12 }} />
-                <YAxis axisLine={false} tickLine={false} tick={{ fill: '#6b7280', fontSize: 12 }} />
-                <RechartsTooltip cursor={{ fill: 'rgba(99, 102, 241, 0.05)' }} contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }} />
+                <XAxis
+                  dataKey="name"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: "#6b7280", fontSize: 12 }}
+                />
+                <YAxis axisLine={false} tickLine={false} tick={{ fill: "#6b7280", fontSize: 12 }} />
+                <RechartsTooltip
+                  cursor={{ fill: "rgba(99, 102, 241, 0.05)" }}
+                  contentStyle={{
+                    borderRadius: "12px",
+                    border: "none",
+                    boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                  }}
+                />
                 <Bar dataKey="registrations" fill="#6366f1" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
@@ -103,15 +129,35 @@ export default function AnalyticsTab({ loading }) {
         </div>
 
         <div className="bg-white dark:bg-gray-800 p-5 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm">
-          <h3 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-4">Page Views over Time</h3>
+          <h3 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-4">
+            Page Views over Time
+          </h3>
           <div className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={MOCK_PAGE_VIEWS}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e5e7eb" />
-                <XAxis dataKey="name" axisLine={false} tickLine={false} tick={{ fill: '#6b7280', fontSize: 12 }} />
-                <YAxis axisLine={false} tickLine={false} tick={{ fill: '#6b7280', fontSize: 12 }} />
-                <RechartsTooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }} />
-                <Line type="monotone" dataKey="views" stroke="#ec4899" strokeWidth={3} dot={{ r: 4, strokeWidth: 2 }} activeDot={{ r: 6 }} />
+                <XAxis
+                  dataKey="name"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: "#6b7280", fontSize: 12 }}
+                />
+                <YAxis axisLine={false} tickLine={false} tick={{ fill: "#6b7280", fontSize: 12 }} />
+                <RechartsTooltip
+                  contentStyle={{
+                    borderRadius: "12px",
+                    border: "none",
+                    boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="views"
+                  stroke="#ec4899"
+                  strokeWidth={3}
+                  dot={{ r: 4, strokeWidth: 2 }}
+                  activeDot={{ r: 6 }}
+                />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -119,16 +165,25 @@ export default function AnalyticsTab({ loading }) {
 
         <div className="bg-white dark:bg-gray-800 p-5 rounded-2xl border border-gray-100 dark:border-gray-700 shadow-sm lg:col-span-2 flex flex-col md:flex-row items-center gap-8">
           <div className="flex-1 w-full">
-            <h3 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-4">Audience Demographics</h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">Understand who is attending your events. Most of your audience consists of students.</p>
+            <h3 className="text-sm font-bold text-gray-800 dark:text-gray-200 mb-4">
+              Audience Demographics
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              Understand who is attending your events. Most of your audience consists of students.
+            </p>
             <div className="space-y-3">
               {MOCK_DEMOGRAPHICS.map((entry, index) => (
                 <div key={entry.name} className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-3 h-3 rounded-full" style={{ backgroundColor: COLORS[index % COLORS.length] }} />
+                    <div
+                      className="w-3 h-3 rounded-full"
+                      style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                    />
                     <span className="text-sm text-gray-700 dark:text-gray-300">{entry.name}</span>
                   </div>
-                  <span className="text-sm font-medium text-gray-900 dark:text-white">{entry.value}%</span>
+                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                    {entry.value}%
+                  </span>
                 </div>
               ))}
             </div>
@@ -149,7 +204,13 @@ export default function AnalyticsTab({ loading }) {
                     <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Pie>
-                <RechartsTooltip contentStyle={{ borderRadius: '12px', border: 'none', boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)' }} />
+                <RechartsTooltip
+                  contentStyle={{
+                    borderRadius: "12px",
+                    border: "none",
+                    boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                  }}
+                />
               </PieChart>
             </ResponsiveContainer>
           </div>


### PR DESCRIPTION
Closes #8923 

Added a dedicated analytics loading skeleton so the dashboard no longer drops from empty space into full charts and cards. The new placeholders preserve the analytics section layout while data is loading, with the same subtle shimmer/pulse style already used elsewhere in Eventra.