### PR TITLE
fix(events): pass filteredEvents to calendar view renderer

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -62,10 +62,11 @@ const renderCardSection = (
   loadError,
   onRetry,
   paginatedEvents,
+  filteredEvents,
   viewMode,
   searchQuery,
   onClearSearch,
-  matchScoreMap       // (#7437) Map of eventId → { score, reasons }
+  matchScoreMap
 ) => {
   if (isLoading) {
     return <ExploreEventsSkeleton />;
@@ -409,15 +410,16 @@ const EventsPage = () => {
         />
 
         <ErrorBoundary level="section" label="Events">
-     {renderCardSection(
+    {renderCardSection(
   isLoading,
   listing.loadError,
   listing.fetchEvents,
   listing.paginatedEvents,
+  listing.filteredEvents,
   listing.viewMode,
   listing.searchQuery,
   clearSearchAndFilters,
-  listing.matchScoreMap   // (#7437) pass score map for badge rendering
+  listing.matchScoreMap
 )}
 
           {!listing.isLoading && listing.totalPages > 1 && (


### PR DESCRIPTION
## Summary

- Fixed undefined `filteredEvents` reference inside `renderCardSection`.
- Passed `listing.filteredEvents` to the renderer.
- Ensures Calendar View receives the complete filtered event list.
- No UI or behavior changes to Grid View.

## Testing

- [x] Grid View
- [x] Calendar View
- [x] Empty State
- [x] Search
- [x] No console errors