### PR TITLE
feat(ui): add floating back-to-top button for long pages

### DIFF
--- a/src/Pages/Events/EventsPage.js
+++ b/src/Pages/Events/EventsPage.js
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useMemo, useState } from "react";
+import BackToTopButton from "components/common/BackToTopButton";
 import { useSearchParams, useLocation } from "react-router-dom";
 import VirtualizedEventGrid from "components/common/VirtualizedEventGrid";
 import EventHero from "./EventHero";
@@ -433,7 +434,8 @@ const EventsPage = () => {
       </div>
 
       <EventCTA />
-      <FeedbackButton />
+<FeedbackButton />
+<BackToTopButton />
     </div>
   );
 };

--- a/src/components/common/BackToTopButton.jsx
+++ b/src/components/common/BackToTopButton.jsx
@@ -5,29 +5,44 @@ const BackToTopButton = ({ threshold = 300, positionClass = "bottom-6 right-6" }
   const [visible, setVisible] = useState(false);
 
   const handleScroll = useCallback(() => {
-    setVisible(window.scrollY > threshold);
+    const shouldShow = window.scrollY > threshold;
+    setVisible((prev) => (prev !== shouldShow ? shouldShow : prev));
   }, [threshold]);
 
   useEffect(() => {
     window.addEventListener("scroll", handleScroll);
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
+    return () => window.removeEventListener("scroll", handleScroll);
   }, [handleScroll]);
 
   const scrollToTop = () => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
     window.scrollTo({
       top: 0,
-      behavior: "smooth",
+      behavior: prefersReducedMotion ? "auto" : "smooth",
     });
   };
 
   return (
     <button
+      type="button"
       onClick={scrollToTop}
       aria-label="Back to top"
       title="Back to top"
-      className={`fixed z-50 ${positionClass} p-3 rounded-full bg-indigo-600 text-white shadow-lg transition-all duration-300 ${
+      className={`fixed z-50 ${positionClass}
+      p-3 rounded-full
+      bg-indigo-600 text-white
+      shadow-lg
+      transition-all ease-in-out duration-300
+      hover:bg-indigo-700
+      hover:scale-110
+      focus:outline-none
+      focus:ring-2
+      focus:ring-indigo-400
+      focus:ring-offset-2
+      ${
         visible
           ? "opacity-100 translate-y-0"
           : "opacity-0 translate-y-10 pointer-events-none"


### PR DESCRIPTION
## Summary

Adds a reusable floating Back-to-Top button that appears after scrolling.

### Changes

- Added reusable BackToTopButton component
- Smooth scrolling to top
- Responsive floating position
- Keyboard accessible
- Added hover and focus styles
- Supports reduced-motion preference

### Issue

Closes #11200