### PR TITLE
fix(auth): normalize login identifier to lowercase (closes #11772)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetailsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetailsService.java
@@ -23,10 +23,13 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String usernameOrEmail) throws UsernameNotFoundException {
-        User user = userRepository.findByEmailOrUsername(usernameOrEmail, usernameOrEmail)
+        // Emails and usernames are always persisted in lowercase, so normalize the
+        // lookup input the same way signup does to match mixed-case logins.
+        String identifier = usernameOrEmail.toLowerCase();
+        User user = userRepository.findByEmailOrUsername(identifier, identifier)
                 .orElseThrow(() ->
                         new UsernameNotFoundException(
-                                "User not found with username or email: " + usernameOrEmail));
+                                "User not found with username or email: " + identifier));
 
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())   // use email as principal

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -84,9 +84,14 @@ public class AuthService {
     }
 
     public AuthResponse login(LoginRequest request) {
+        // Signup normalizes the email to lowercase before persisting, so the
+        // login/lookup path must normalize the identifier the same way.
+        // Otherwise a user who registered with a mixed-case email can never log in.
+        String identifier = request.getUsernameOrEmail().toLowerCase();
+
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
-                        request.getUsernameOrEmail(),
+                        identifier,
                         request.getPassword()
                 )
         );
@@ -95,7 +100,7 @@ public class AuthService {
 
         // Reload user for profile info
         User user = userRepository
-                .findByEmailOrUsername(request.getUsernameOrEmail(), request.getUsernameOrEmail())
+                .findByEmailOrUsername(identifier, identifier)
                 .orElseThrow();
 
         return buildAuthResponse(user, token);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLoginTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLoginTests.java
@@ -1,0 +1,114 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.LoginRequest;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.NotificationRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #11772 — users who register with a mixed-case email must be able to
+ * log in: signup lowercases the email before persisting, so the login/lookup
+ * path has to normalize the identifier the same way.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AuthLoginTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Simulates a signup performed with a mixed-case email: signup normalizes
+        // the email to lowercase before persisting (see AuthService.signup).
+        userRepository.save(User.builder()
+                .firstName("Mixed")
+                .lastName("Case")
+                .email("user@example.com")
+                .username("user")
+                .password(passwordEncoder.encode("password123"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    private LoginRequest loginRequest(String identifier) {
+        LoginRequest request = new LoginRequest();
+        request.setUsernameOrEmail(identifier);
+        request.setPassword("password123");
+        return request;
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login with the original mixed-case email succeeds (#11772)")
+    void testLoginWithMixedCaseEmail() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest("User@Example.com"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("user@example.com"));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login with the normalized lowercase email succeeds (#11772)")
+    void testLoginWithNormalizedEmail() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest("user@example.com"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("user@example.com"));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login with a fully-uppercased email succeeds (#11772)")
+    void testLoginWithUppercaseEmail() throws Exception {
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest("USER@EXAMPLE.COM"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("user@example.com"));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login with a wrong password still fails (#11772)")
+    void testLoginWrongPassword() throws Exception {
+        LoginRequest request = loginRequest("User@Example.com");
+        request.setPassword("wrong-password");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Problem

Users who register with a mixed-case email can never log in. Signup lowercases the email before persisting, but login and the user-lookup during authentication perform an exact-match lookup against the raw, case-preserved input, so the stored normalized value is never found. Registering as `User@Example.com` stores `user@example.com`, but logging in with `User@Example.com` fails forever.

## Fix

Normalize the identifier the same way signup does. Both `AuthService.login` and `CustomUserDetailsService.loadUserByUsername` now apply `toLowerCase()` to the email/username input before `authenticationManager.authenticate` and `findByEmailOrUsername`, so a mixed-case login resolves to the persisted lowercase account.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetailsService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLoginTests.java` (new)

## Testing

- Added `AuthLoginTests` covering mixed-case, lowercase, and uppercase login variants plus an invalid-password case.
- `AuthLoginTests`: 4/4 pass.
- Full suite was run locally on a scratch verification branch (all new tests green; only pre-existing master failures remain, e.g. the `EVENT_TEAM_MEMBERS`/rate-limit test-isolation issues that exist on master independently of this PR).

Closes #11772
