### PR TITLE
fix(notifications): implement mark-all-as-read end to end (closes #11774)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -77,6 +77,27 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.markAsRead(id, email));
     }
 
+    @PutMapping("/read-all")
+    @Operation(
+            summary = "Mark all notifications as read",
+            description = "Marks every notification of the authenticated user as read.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "All notifications marked as read successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid"
+            )
+    })
+    public ResponseEntity<List<NotificationResponse>> markAllAsRead(Authentication authentication) {
+        String email = authentication.getName();
+        return ResponseEntity.ok(notificationService.markAllAsRead(email));
+    }
+
     @DeleteMapping("/{id}")
     @Operation(
             summary = "Delete a notification",

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
@@ -2,6 +2,9 @@ package com.sandeep.eventrabackend.repository;
 
 import com.sandeep.eventrabackend.model.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +15,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByUserEmailOrderByCreatedAtDesc(String email);
     Optional<Notification> findByIdAndUserEmail(Long id, String email);
     void deleteByUser_Id(Long userId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.user.email = :email AND n.isRead = false")
+    int markAllAsReadByUserEmail(@Param("email") String email);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
@@ -37,6 +37,12 @@ public class NotificationService {
     }
 
     @Transactional
+    public List<NotificationResponse> markAllAsRead(String email) {
+        notificationRepository.markAllAsReadByUserEmail(email);
+        return getNotificationsForUser(email);
+    }
+
+    @Transactional
     public void deleteNotification(Long id, String email) {
         Notification notification = notificationRepository.findByIdAndUserEmail(id, email)
                 .orElseThrow(() -> new NotificationNotFoundException("Notification not found with id: " + id));

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java
@@ -223,4 +223,71 @@ public class NotificationControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.read").value(true));
     }
+
+    @Test
+    @DisplayName("PUT /api/notifications/read-all marks every notification as read (#11774)")
+    void testMarkAllAsRead() throws Exception {
+        Notification n1 = Notification.builder()
+                .user(testUser1)
+                .title("Unread 1")
+                .message("Msg")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n1);
+
+        Notification n2 = Notification.builder()
+                .user(testUser1)
+                .title("Unread 2")
+                .message("Msg")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n2);
+
+        mockMvc.perform(put("/api/notifications/read-all")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].read").value(true))
+                .andExpect(jsonPath("$[1].read").value(true));
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/read-all only affects the authenticated user (#11774)")
+    void testMarkAllAsReadIsolation() throws Exception {
+        Notification n1 = Notification.builder()
+                .user(testUser1)
+                .title("User 1 Unread")
+                .message("Msg")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n1);
+
+        Notification n2 = Notification.builder()
+                .user(testUser2)
+                .title("User 2 Unread")
+                .message("Msg")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n2);
+
+        mockMvc.perform(put("/api/notifications/read-all")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title").value("User 1 Unread"))
+                .andExpect(jsonPath("$[0].read").value(true));
+
+        // User 2's notification must remain unread
+        mockMvc.perform(get("/api/notifications")
+                        .with(user("user2@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].read").value(false));
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/read-all returns 401 for unauthenticated request (#11774)")
+    void testMarkAllAsReadUnauthorized() throws Exception {
+        mockMvc.perform(put("/api/notifications/read-all"))
+                .andExpect(status().isUnauthorized());
+    }
 }

--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -211,17 +211,19 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
   const markAllAsRead = useCallback(async () => {
     if (!token) return;
     const t = token;
-    let hasUnread = false;
+    // Read unread state from the ref OUTSIDE the state updater. Reading it
+    // inside setNotifications would be deferred by React until the render
+    // phase, so the check below would always see false and the action would
+    // become a no-op (#11774).
+    const hasUnread = notificationsRef.current.some((n) => !n.isRead);
+    if (!hasUnread) return;
+    const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.READ_ALL;
+    if (!endpoint) return;
     setNotifications((prev) => {
-      hasUnread = prev.some((n) => !n.isRead);
-      if (!hasUnread) return prev;
       const updated = prev.map((n) => ({ ...n, isRead: true }));
       persist(updated, storageKeyRef.current);
       return updated;
     });
-    if (!hasUnread) return;
-    const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.READ_ALL;
-    if (!endpoint) return;
     setUnreadCount(0);
     try {
       await apiUtils.put(endpoint, {});


### PR DESCRIPTION
## Problem

The "Mark all as read" action in the notification poller is effectively a no-op. `markAllAsRead` computes `hasUnread` inside a React state updater and reads it immediately after `setNotifications(...)` returns — but React defers updater functions to the render phase, so the outer variable is still `false` and the function always returns early. The API call and `setUnreadCount(0)` never execute, and the backend had no `/read-all` endpoint anyway, so the badge never clears and the server is never notified.

## Fix

- Compute unread state from `notificationsRef.current` **outside** the state updater, then perform the `PUT` and update `unreadCount` in the same pass.
- Add a real backend endpoint `PUT /api/notifications/read-all` (controller mapping + `NotificationService.markAllAsRead` + a repository bulk `UPDATE` scoped to the caller's email), returning the updated notification list.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java`
- `src/hooks/useNotificationPoller.js`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java`

## Testing

- Extended `NotificationControllerTests` with mark-all-as-read coverage (marks all, user isolation, existing single-read behavior still works, unauthenticated 401).
- `NotificationControllerTests`: 13/13 pass.
- `node --check src/hooks/useNotificationPoller.js` passes.

Closes #11774
