### PR TITLE
fix(push): gate web-push registration behind config flag (closes #11775)

### DIFF
--- a/src/hooks/usePushSubscription.js
+++ b/src/hooks/usePushSubscription.js
@@ -18,6 +18,15 @@ const getEnv = () =>
 const VAPID_PUBLIC_KEY =
   getEnv().VITE_VAPID_PUBLIC_KEY || getEnv().REACT_APP_VAPID_PUBLIC_KEY || "";
 
+// The backend does not yet implement /api/notifications/push-subscriptions
+// (push delivery is tracked separately), so the push-subscribe flow must not
+// POST the raw subscription (including keys.auth / keys.p256dh) to routes
+// that do not exist. Server registration is only attempted when the backend
+// actually supports it and the deployment explicitly opts in (#11775).
+const PUSH_REGISTRATION_ENABLED =
+  getEnv().VITE_ENABLE_PUSH_REGISTRATION === "true" ||
+  getEnv().REACT_APP_ENABLE_PUSH_REGISTRATION === "true";
+
 const getRegistration = async () => {
   if (!("serviceWorker" in navigator)) return null;
   const existing = await navigator.serviceWorker.getRegistration();
@@ -132,7 +141,10 @@ export function usePushSubscription(updatePreferences) {
       } catch (err) {
         logger.warn("[usePushSubscription] Failed to persist subscription:", err);
       }
-      if (token && endpoint) await apiUtils.post(endpoint, subscription);
+      if (token && PUSH_REGISTRATION_ENABLED) {
+        const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.PUSH_SUBSCRIBE;
+        if (endpoint) await apiUtils.post(endpoint, subscription);
+      }
       updatePreferences((c) => ({ ...c, push: true }));
       await updatePushStatus();
       return { subscribed: true, subscription };
@@ -147,8 +159,10 @@ export function usePushSubscription(updatePreferences) {
       const subscription = await updatePushStatus();
       if (subscription) await subscription.unsubscribe();
       window.localStorage.removeItem(PUSH_SUBSCRIPTION_KEY);
-      const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.PUSH_UNSUBSCRIBE;
-      if (token && endpoint) await apiUtils.post(endpoint, {});
+      if (token && PUSH_REGISTRATION_ENABLED) {
+        const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.PUSH_UNSUBSCRIBE;
+        if (endpoint) await apiUtils.post(endpoint, {});
+      }
       updatePreferences((c) => ({ ...c, push: false }));
       await updatePushStatus();
       return { unsubscribed: true };


### PR DESCRIPTION
## Problem

The push-notification client eagerly posts a raw Web Push `PushSubscription` — including the secret `keys.auth` / `keys.p256dh` material — to backend endpoints that do not exist (`/api/notifications/push-subscriptions` and `/unsubscribe`). Every attempt 404s and repeatedly transmits the push-auth secret to a dead route. The backend has no controller mappings for these paths.

## Fix

Gate the entire web-push registration flow behind a configuration flag (`VITE_ENABLE_PUSH_REGISTRATION === "true" || REACT_APP_ENABLE_PUSH_REGISTRATION === "true"`), which is off by default. When the flag is not enabled, `usePushSubscription` performs no subscribe/unsubscribe requests, so no subscription object (or auth key material) is ever sent to a route that doesn't exist. Also fixed the subscribe path referencing an undefined `endpoint` variable that would have thrown a ReferenceError.

The existing `api.js` endpoint constants are left unchanged (they are only reachable when the flag is enabled, for deployments that do implement the endpoints).

## Files changed

- `src/hooks/usePushSubscription.js`

## Testing

- Subscribe/unsubscribe requests are confirmed no-ops unless the config flag is enabled.
- `node --check src/hooks/usePushSubscription.js` passes.

Closes #11775
