### PR TITLE
fix(projects): return fresh upvote count and 409 on duplicate upvote (closes #11776)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.FieldError;
@@ -99,11 +100,14 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(
-            IllegalArgumentException ex,
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(
+            DataIntegrityViolationException ex,
             HttpServletRequest request) {
-        return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
+        // e.g. a concurrent duplicate upvote hitting the (project_id, user_id)
+        // unique constraint should surface as a conflict, not a 500 (#11776).
+        return buildError(HttpStatus.CONFLICT, "Conflict",
+                "This resource already exists or was modified concurrently. Please try again.", request);
     }
 
     @ExceptionHandler(FeedbackAlreadyExistsException.class)

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Project p SET p.upvotes = p.upvotes + 1 WHERE p.id = :id")
     int incrementUpvotes(@Param("id") Long id);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -10,6 +10,7 @@ import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.ProjectUpvoteRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.exception.RegistrationConflictException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,9 +76,21 @@ public class ProjectService {
                     .project(project)
                     .user(user)
                     .build();
-            projectUpvoteRepository.save(upvote);
+
+            // Two concurrent requests from the same user can both pass the
+            // existsBy guard before either insert commits; the second insert
+            // then violates the (project_id, user_id) unique constraint.
+            // Surface that as a friendly conflict instead of a 500 (#11776).
+            try {
+                projectUpvoteRepository.save(upvote);
+            } catch (DataIntegrityViolationException ex) {
+                throw new RegistrationConflictException("You have already upvoted this project.");
+            }
         }
 
+        // The bulk UPDATE below is marked clearAutomatically so the subsequent
+        // read reflects the post-increment count rather than the stale entity
+        // loaded before the increment (#11776).
         projectRepository.incrementUpvotes(id);
         return getProjectById(id);
     }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -3,13 +3,18 @@ package com.sandeep.eventrabackend.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sandeep.eventrabackend.dto.request.ProjectCreateRequest;
 import com.sandeep.eventrabackend.model.Project;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.ProjectRepository;
+import com.sandeep.eventrabackend.repository.ProjectUpvoteRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,6 +23,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -34,11 +40,22 @@ public class ProjectControllerTests {
     private ProjectRepository projectRepository;
 
     @Autowired
+    private ProjectUpvoteRepository projectUpvoteRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
+        projectUpvoteRepository.deleteAll();
         projectRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -231,5 +248,39 @@ public class ProjectControllerTests {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("Project not found with id: 999"));
+    }
+
+    @Test
+    void testUpvoteProject_DuplicateUpvote_Returns409() throws Exception {
+        userRepository.save(User.builder()
+                .firstName("Upvote")
+                .lastName("Client")
+                .email("upvote@example.com")
+                .username("upvoteclient")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        Project project = Project.builder()
+                .title("Duplicate Upvote")
+                .description("Description")
+                .category("Web Development")
+                .thumbnailUrl("http://example.com/thumb.png")
+                .githubUrl("http://github.com/test/duplicate")
+                .upvotes(5)
+                .build();
+        project = projectRepository.save(project);
+
+        // First upvote succeeds and reflects the post-increment count (#11776)
+        mockMvc.perform(post("/api/projects/" + project.getId() + "/upvote")
+                        .with(user("upvote@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.upvotes").value(6));
+
+        // A duplicate upvote returns a friendly 409, not a 500 (#11776)
+        mockMvc.perform(post("/api/projects/" + project.getId() + "/upvote")
+                        .with(user("upvote@example.com")))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("You have already upvoted this project."));
     }
 }


### PR DESCRIPTION
## Problem

`ProjectService.upvoteProject` returns a stale vote count: the `Project` entity is loaded, a bulk `@Modifying` UPDATE increments the denormalized count, but the response is mapped from the still-in-memory entity loaded *before* the UPDATE, so the UI shows the pre-increment value until reload.

Concurrently, two upvotes from the same user can both pass the `existsByProject_IdAndUser_Id` guard before either insert commits; the second insert then violates the `(project_id, user_id)` unique constraint. With no `DataIntegrityViolationException` handler, this falls through to the catch-all `Exception` handler and returns a 500 instead of a friendly "already upvoted" conflict.

## Fix

- `ProjectRepository.incrementUpvotes` now uses `@Modifying(clearAutomatically = true, flushAutomatically = true)` so the follow-up re-read (`getProjectById`) returns the fresh post-increment count.
- `ProjectService.upvoteProject` catches `DataIntegrityViolationException` on the upvote insert and rethrows the friendly `RegistrationConflictException` (409).
- `GlobalExceptionHandler` gains a `DataIntegrityViolationException` → 409 mapping so any other unique-constraint race surfaces as a conflict, not a 500. (This also removes a pre-existing duplicate `@ExceptionHandler(IllegalArgumentException.class)` mapper in the same file that broke compilation.)

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java`

## Testing

- Extended `ProjectControllerTests` with a duplicate-upvote test asserting the fresh count (incremented exactly once) and the resulting 409 on the second upvote.
- `ProjectControllerTests`: 13/13 pass.

Closes #11776
