### PR TITLE
fix(waitlist): fall back to {} on corrupt persisted JSON (closes #11778)

### DIFF
--- a/src/hooks/useWaitlist.js
+++ b/src/hooks/useWaitlist.js
@@ -34,8 +34,9 @@ function readPersistedWaitlist(storageKey) {
     const raw = safeLocalStorage.getItem(storageKey);
     return raw ? JSON.parse(raw) : {};
   } catch (err) {
-      console.warn("[useWaitlist] Waitlist operation failed:", err);
-    }
+    console.warn("[useWaitlist] Waitlist operation failed:", err);
+    return {};
+  }
 }
 
 let persistTimeout = null;


### PR DESCRIPTION
## Problem

`readPersistedWaitlist` in `src/hooks/useWaitlist.js` returns `undefined` when `localStorage` contains invalid JSON, because the `catch` branch does not return a value. Callers consume the value as a plain object (property access / spread / `Object.entries`), so a single corrupted storage value throws a runtime `TypeError` instead of falling back to a sane default. This is inconsistent with the rest of the codebase, which guarantees a fallback via `safeJsonParse`.

## Fix

Return `{}` in the `catch` branch so corrupt or unreadable persisted waitlist state falls back to an empty object rather than `undefined`.

## Files changed

- `src/hooks/useWaitlist.js`

## Testing

- Corrupt persisted JSON now resolves to `{}` (no `undefined`), matching the `if (!raw) return {}` path.
- `node --check src/hooks/useWaitlist.js` passes.

Closes #11778
