### PR TITLE
fix(events): allow SUPER_ADMIN to update events (closes #11780)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -103,10 +103,10 @@ public class EventController {
     // ── Issue #2099 — PUT /api/events/{id} ──────────────────────────────────
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     @Operation(
             summary = "Update an existing event",
-            description = "Allows an ORGANIZER or ADMIN to update event details.",
+            description = "Allows an ORGANIZER, ADMIN or SUPER_ADMIN to update event details.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -133,7 +133,7 @@ public class EventController {
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "Forbidden - User does not have ORGANIZER or ADMIN role",
+                    description = "Forbidden - User does not have ORGANIZER, ADMIN or SUPER_ADMIN role",
                     content = @Content(
                             schema = @Schema(implementation = ErrorResponse.class)
                     )

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
@@ -78,6 +78,15 @@ public class EventUpdateTests {
                 .build());
 
         userRepository.save(User.builder()
+                .firstName("Super")
+                .lastName("Admin")
+                .email("superadmin@example.com")
+                .username("superadmin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.SUPER_ADMIN)
+                .build());
+
+        userRepository.save(User.builder()
                 .firstName("Organizer")
                 .lastName("User")
                 .email("organizer@example.com")
@@ -146,6 +155,26 @@ public class EventUpdateTests {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("Admin Updated Title"));
+    }
+
+    @Test
+    @DisplayName("SUPER_ADMIN can update any event (#11780)")
+    void testSuperAdminCanUpdateEvent() throws Exception {
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Super Admin Updated Title")
+                .description("Updated Description")
+                .location("Updated Location")
+                .eventDate(LocalDateTime.now().plusDays(10))
+                .capacity(250)
+                .isPublic(true)
+                .build();
+
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
+                        .with(user("superadmin@example.com").authorities(() -> "SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Super Admin Updated Title"));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`PUT /api/events/{id}` declares `@PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN')")` at the controller — SUPER_ADMIN is not listed — so a platform SUPER_ADMIN is blocked before reaching the service. This contradicts every other event-management action (`cancelEvent`, `deleteEvent`, waitlist endpoints), all of which include `SUPER_ADMIN`.

Note: the service-layer owner-check cited in the issue is outdated on master — `updateEvent` now routes through `eventRoleService.requireRole(id, userEmail, EventRole.ORGANIZER)`, the same path `cancelEvent` uses (which bypasses platform admins). Only the controller annotation was missing SUPER_ADMIN.

## Fix

Add `SUPER_ADMIN` to the `@PreAuthorize` on `PUT /{id}`, and update the endpoint's OpenAPI summary/403 text accordingly. Super admins can now update any event, consistent with cancel/delete/waitlist.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java`

## Testing

- Added `testSuperAdminCanUpdateEvent` (seeds a SUPER_ADMIN user and asserts 200 + updated fields).
- `EventUpdateTests`: 7 run, 6 pass including the new SUPER_ADMIN case. The one failure (`testOrganizerCanUpdateEvent`) is pre-existing on master — the test seeds an event with no owner, so an organizer cannot be the owner and the service correctly denies 403; it is unrelated to this change.

Closes #11780
