### PR TITLE
fix(events): reject registration for events that already ended (closes #11781)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -361,6 +361,13 @@ public class EventController {
                     )
             ),
             @ApiResponse(
+                    responseCode = "400",
+                    description = "Registration closed - the event has already ended",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "401",
                     description = "Unauthorized - JWT token missing or invalid",
                     content = @Content(

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -11,6 +11,7 @@ import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
 import com.sandeep.eventrabackend.dto.response.WaitlistResponse;
 import com.sandeep.eventrabackend.exception.EventFullException;
 import com.sandeep.eventrabackend.exception.EventNotFoundException;
+import com.sandeep.eventrabackend.exception.RegistrationClosedException;
 import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
@@ -482,6 +483,13 @@ public class EventService {
                 .orElseThrow(() ->
                         new EventNotFoundException(
                                 "Event not found with id: " + eventId));
+
+        // Registration is only valid for events that have not already ended.
+        // Without this guard the API accepted registrations for past events,
+        // inflating registeredCount and creating stale registration rows (#11781).
+        if (event.isEventPast()) {
+            throw new RegistrationClosedException("Registration is closed for this event.");
+        }
 
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() ->

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
@@ -370,6 +370,22 @@ public class EventRegistrationTests {
     }
 
     @Test
+    @DisplayName("#11781 — POST /register returns 400 for an event that has already ended")
+    void testRegistrationPastEventRejected() throws Exception {
+        Event past = new Event();
+        past.setTitle("Past Event");
+        past.setCapacity(100);
+        past.setEventDate(LocalDateTime.now().minusDays(1)); // already ended
+        past.setPublic(true);
+        past = eventRepository.save(past);
+
+        mockMvc.perform(post("/api/events/" + past.getId() + "/register")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Registration is closed for this event."));
+    }
+
+    @Test
     @DisplayName("#2102 — POST /register returns 409 when event is full")
     void testRegistrationEventFull() throws Exception {
         // Fill the event (capacity = 5) with users 1..5


### PR DESCRIPTION
## Problem

`POST /api/events/{id}/register` accepts registrations for events whose date has already passed. `executeRegistration` validates user existence, duplicate registration, seat availability, and capacity — but never checks the event date. A client can register for an event that already ended, inflating `registeredCount` and creating stale registration rows. Existing fixes were frontend-only (disabling the Register button) and do not protect the API. The service already computes `eventPassed` via `event.isEventPast()` for availability, so registration simply ignored it.

## Fix

Add a guard at the top of `executeRegistration`: if `event.isEventPast()`, throw `RegistrationClosedException` (mapped to 400 with a clear message) before any seat/capacity logic runs. Also document the 400 response in the register endpoint's OpenAPI annotations.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java`

## Testing

- Added `testRegistrationPastEventRejected`: registering for a past-dated event returns 400 with `Registration is closed for this event.`
- `EventRegistrationTests`: 24/25 pass including the new case (the one failure, `testAdminManualPromotion`, is a pre-existing master waitlist-promotion issue unrelated to this change).
- `EventRegistrationConcurrencyIntegrationTest`: 2/2 pass (future-dated concurrency tests unaffected by the new guard).

Closes #11781
