### PR TITLE
fix: return zero read time for whitespace-only content

### DIFF
--- a/src/utils/readTimeUtils.js
+++ b/src/utils/readTimeUtils.js
@@ -15,6 +15,7 @@ export const calculateReadTime = (text) => {
   if (text == null || text === "") return 0;
 
   const wordCount = getWordCount(text);
+  if (wordCount === 0) return 0;
   return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
 };
 


### PR DESCRIPTION
Closes #11791

## Summary

This PR fixes the read time calculation for descriptions that contain only whitespace.

Previously, the utility always returned a minimum read time of one minute for any non-empty string. As a result, descriptions containing only spaces or other whitespace characters were displayed as **"1 min read"**, even though they contained no readable content.

## Changes

- Added a check to return `0` when the calculated word count is zero.
- Preserved the existing read time calculation for descriptions containing actual words.
- No changes were made to the behavior for valid content.

## Before

- `calculateReadTime("")` → `0`
- `calculateReadTime("   ")` → `1 min` ❌
- `calculateReadTime("Hello World")` → `1 min`

## After

- `calculateReadTime("")` → `0`
- `calculateReadTime("   ")` → `0` ✅
- `calculateReadTime("Hello World")` → `1 min`

## Why this change?

This ensures that whitespace-only descriptions are treated as empty content and prevents misleading read time estimates from being displayed to users.

