### PR TITLE
Fix: fix-sse-url-concatenation

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -541,7 +541,8 @@ class SseMultiplexer {
     logger.log(`[SSE Multiplexer] Leader tab opening physical EventSource: ${sseBaseUrl}${path}`);
     this.updatePathStatus(path, "connecting");
 
-    const source = new EventSource(`${sseBaseUrl}${path}`, { withCredentials: true });
+    const sseUrl = new URL(path, sseBaseUrl).href;
+    const source = new EventSource(sseUrl, { withCredentials: true });
     this.activeEventSources.set(path, source);
 
     source.onopen = () => {


### PR DESCRIPTION
## Description
Fixes a URL construction bug in `sseMultiplexer.js`. The `openEventSource` function built the EventSource URL using simple template literal string concatenation (`${sseBaseUrl}${path}`). This broke routing if `sseBaseUrl` had a trailing slash and `path` had a leading slash.

## Changes Made
* Replaced string concatenation with the standard `new URL(path, sseBaseUrl).href` constructor to ensure proper, robust URL formatting.

## Related Issue
Fixes #11448