### PR TITLE
Fix: fix-feedback-save-fallback-id

### DIFF
--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -60,12 +60,14 @@ export const saveFeedback = (eventId, feedback) => {
     // Use a Map for O(1) userId lookups instead of O(N) findIndex
     const feedbackMap = new Map(rawList.map((f) => [f.userId, f]));
 
+    const userId = feedback.userId || crypto.randomUUID();
     const feedbackObject = {
       ...feedback,
+      userId,
       submittedAt: new Date().toISOString(),
     };
 
-    feedbackMap.set(feedback.userId, feedbackObject);
+    feedbackMap.set(userId, feedbackObject);
     allFeedback[eventId] = Array.from(feedbackMap.values());
     localStorage.setItem(FEEDBACK_STORAGE_KEY, JSON.stringify(allFeedback));
     return true;


### PR DESCRIPTION
## Description
Fixes a bug in `saveFeedback` where if the user was anonymous (no `feedback.userId` provided), the feedback map would key it by `undefined`. This meant multiple anonymous submissions would continually overwrite each other in the `feedbackMap`.

## Changes Made
* Added `const userId = feedback.userId || crypto.randomUUID()` to generate a stable, unique ID for anonymous feedback before saving it to the map.

## Related Issue
Fixes #11449