### PR TITLE
fix: handle string indices in trending badge utility

### DIFF
--- a/src/utils/trendingRankUtils.js
+++ b/src/utils/trendingRankUtils.js
@@ -5,5 +5,6 @@ export const getTrendingBadge = (index) => {
     2: "🥉 #3 Trending",
   };
 
-  return badges[index] || `#${index + 1} Trending`;
+  const numIndex = Number(index);
+  return badges[numIndex] || `#${numIndex + 1} Trending`;
 };


### PR DESCRIPTION
## Summary

This PR fixes the fallback badge generation in the trending badge utility when the provided index is a string instead of a number.

Previously, the utility assumed that the input index was always numeric. If a string value (for example, from URL parameters or dataset attributes) was passed, JavaScript performed string concatenation when calculating the fallback rank, producing incorrect labels such as `#31 Trending` instead of `#4 Trending`.

## Changes

- Convert the provided index to a numeric value using `Number(index)` before generating the fallback badge.
- Preserve the existing behavior for valid numeric inputs.
- Ensure fallback badge labels are calculated consistently regardless of whether the input is a string or number.

## Before

```javascript
getTrendingBadge("3");
// "#31 Trending"
```

## After

```javascript
getTrendingBadge("3");
// "#4 Trending"
```

## Why this change?

Route parameters, DOM dataset values, and other external inputs are commonly represented as strings in JavaScript. Normalizing the index before performing arithmetic prevents unintended string concatenation and guarantees correct fallback badge generation.

Closes #11793