### PR TITLE
Fix: fix-notification-poller-background

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -169,13 +169,18 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
     fetchNotifications({ isBackground: true }).then(() => {
       if (isMounted.current && tokenRef.current === t) setLoading(false);
     });
+    }, [token, fetchNotifications, hasCompletedInitialFetchRef]);
+
+  useEffect(() => {
+    if (!isPageVisible || !token) return;
+    const t = token;
     const interval = setInterval(() => {
-      if (isMounted.current && tokenRef.current === t && isPageVisibleRef.current) {
+      if (isMounted.current && tokenRef.current === t) {
         refetchRef.current({ isBackground: true });
       }
     }, POLLING_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [token, fetchNotifications, hasCompletedInitialFetchRef]);
+  }, [isPageVisible, token]);
 
   useEffect(() => {
     if (!isPageVisible || !token) return;


### PR DESCRIPTION
## Description
Fixes a performance and bandwidth issue in `useNotificationPoller`. The `setInterval` was continuously firing every 60 seconds even when the user switched tabs (page became hidden), wasting background CPU and API quota.

## Changes Made
* Separated the polling `setInterval` into a dedicated `useEffect` that explicitly depends on `isPageVisible`, ensuring the interval is fully cleared when the page is hidden and restarted when visible.

## Related Issue
Fixes #11450