### PR TITLE
Fix: fix-waitlist-sort-invalid-date

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -251,7 +251,7 @@ export const getEventWaitlist = async (eventId, userId) => {
   const records = await getGlobalWaitlist(userId);
   return records
     .filter((r) => r.eventId === id && r.status === "waiting")
-    .sort((a, b) => new Date(a.joinedAt) - new Date(b.joinedAt));
+    .sort((a, b) => (new Date(a.joinedAt).getTime() || Infinity) - (new Date(b.joinedAt).getTime() || Infinity));
 };
 
 // Calculate queue position (1-indexed) for a user on a specific event


### PR DESCRIPTION
## Description
Fixes a subtle bug in `getEventWaitlist` where sorting by `joinedAt` using `new Date(joinedAt) - new Date(...)` could result in `NaN` if a record was missing the `joinedAt` field. A `NaN` result completely breaks the sorting algorithm for the entire array in many JS engines.

## Changes Made
* Replaced the subtraction with `.getTime() || Infinity` to safely handle missing or invalid dates by pushing them to the end of the sorted list.

## Related Issue
Fixes #11451