### PR TITLE
Fix: fix-rate-limiter-refill-cap

### DIFF
--- a/src/utils/rateLimiter.js
+++ b/src/utils/rateLimiter.js
@@ -53,7 +53,7 @@ export function createRateLimiter({
 
   function refill() {
     const now = Date.now();
-    const elapsed = Math.max(0, (now - lastRefill) / 1000);
+    const elapsed = Math.min(Math.max(0, (now - lastRefill) / 1000), 60);
     if (elapsed === 0) return;
     tokens = Math.min(maxTokens, tokens + elapsed * refillRate);
     lastRefill = now;


### PR DESCRIPTION
## Description
Fixes a bug in `rateLimiter.js` where the `elapsed` time calculated since the last refill was not capped. If a user left the tab open in the background or put their computer to sleep, the elapsed time could be massive, flooding the token bucket and rendering the rate limiter useless for a sudden burst.

## Changes Made
* Capped the elapsed time calculation using `Math.min(elapsed, 60)` to limit the maximum refill back-credit to 60 seconds.

## Related Issue
Fixes #11452