### PR TITLE
Fix: feature-export-attendees-empty-feedback

### DIFF
--- a/src/utils/exportCsv.js
+++ b/src/utils/exportCsv.js
@@ -67,7 +67,10 @@ const sanitizeCSVField = (field) => {
  */
 export const exportAttendeesToCSV = (attendees, filename = "event-attendees.csv") => {
   if (!attendees || attendees.length === 0) {
-    return;
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("eventra-toast", { detail: { message: "No attendees to export", type: "warning" } }));
+    }
+    return { success: false, reason: "empty" };
   }
 
   // Sanitize the filename: strip OS reserved characters and path separators.


### PR DESCRIPTION
## Description
Enhances the user experience when attempting to export an empty attendees list. Previously, `exportAttendeesToCSV` would silently return `undefined`, leaving the user wondering if the export failed or is still loading.

## Changes Made
* Added a check to dispatch an `eventra-toast` warning ("No attendees to export") and return `{ success: false, reason: "empty" }` when the attendees array is empty or undefined.

## Related Issue
Fixes #11453