### PR TITLE
Fix: fix-build-paginated-url-split

### DIFF
--- a/src/utils/eventFetchUtils.js
+++ b/src/utils/eventFetchUtils.js
@@ -58,7 +58,9 @@ export function buildPaginatedUrl(baseUrl, page, size) {
   // The old logic used string concatenation which blindly appended duplicate 'page' parameters
   // (e.g., ?category=tech&page=0&page=1). Backend frameworks (like Spring) often extract the
   // *first* instance of a parameter, permanently freezing the UI on page 0.
-  const [urlWithoutHash, hash] = baseUrl.split("#");
+  const hashIdx = baseUrl.indexOf("#");
+  const urlWithoutHash = hashIdx === -1 ? baseUrl : baseUrl.slice(0, hashIdx);
+  const hash = hashIdx === -1 ? "" : baseUrl.slice(hashIdx + 1);
   const [path, queryString] = urlWithoutHash.split("?");
 
   const params = new URLSearchParams(queryString || "");


### PR DESCRIPTION
## Description
Fixes an issue in `buildPaginatedUrl` where it incorrectly extracted the hash fragment by using `.split("#")`, which only works correctly if there's exactly one hash. It could corrupt URLs or drop segments if the path structure changes or has multiple special characters.

## Changes Made
* Replaced `.split("#")` with `.indexOf("#")` and string slicing to safely and accurately isolate the hash from the base URL.

## Related Issue
Fixes #11592