### PR TITLE
Fix: fix-waitlist-sync-silent-errors

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -239,7 +239,13 @@ export const syncWaitlistFromServer = async (eventId, cacheOwnerId) => {
       await saveGlobalWaitlist(reconciled, cacheOwnerId);
       return serverData;
     }
-  } catch {
+  } catch (err) {
+    if (err?.response?.status === 401 || err?.response?.status === 403) {
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("eventra-session-expired"));
+      }
+      throw err;
+    }
     logger.warn("[WaitlistUtils] Server sync failed, using localStorage cache");
   }
   return getEventWaitlist(id, cacheOwnerId);


### PR DESCRIPTION
## Description
Fixes a bug in `syncWaitlistFromServer` where the `catch` block swallowed all errors silently and fell back to the local cache. If the error was an authentication failure (e.g., 401 Unauthorized or 403 Forbidden), it prevented the application from dispatching the `eventra-session-expired` event, masking the session expiry from the user.

## Changes Made
* Added a check for `err?.response?.status === 401 || err?.response?.status === 403` inside the catch block to dispatch the session expired event and re-throw, while allowing network timeouts to fall back to the cache.

## Related Issue
Fixes #11594