### PR TITLE
Fix: fix-notification-queue-stop-failure

### DIFF
--- a/src/utils/notificationQueue.js
+++ b/src/utils/notificationQueue.js
@@ -49,17 +49,7 @@ const dispatchOne = async (item, apiUtils) => {
   if (item.action === 'delete') return apiUtils.delete(item.payload.endpoint);
 };
 
-const trySyncItem = async (item, queue, apiUtils) => {
-  try {
-    await dispatchOne(item, apiUtils);
-    return null; // success — not remaining
-  } catch (e) {
-    console.error('Failed to sync queued notification action', e);
-    // Build the remaining list: failed item + everything after it
-    const failedIndex = queue.indexOf(item);
-    return [item, ...queue.slice(failedIndex + 1)];
-  }
-};
+
 
 export const syncNotificationQueue = async (apiUtils) => {
   const queue = safeGetQueue();
@@ -71,10 +61,11 @@ export const syncNotificationQueue = async (apiUtils) => {
   // attempted.
   let remaining = [];
   for (const item of queue) {
-    const failedTail = await trySyncItem(item, queue, apiUtils);
-    if (failedTail) {
-      remaining = failedTail;
-      break;
+    try {
+      await dispatchOne(item, apiUtils);
+    } catch (e) {
+      console.error('Failed to sync queued notification action', e);
+      remaining.push(item);
     }
   }
 


### PR DESCRIPTION
## Description
Fixes an issue in `syncNotificationQueue` where a single failed network request caused the synchronization loop to break immediately. This caused all subsequent queued notifications to remain stuck, instead of skipping the failed item and continuing to sync the rest of the queue.

## Changes Made
* Modified `syncNotificationQueue` to catch individual item failures and accumulate them in the `remaining` array, allowing the loop to process the entire queue rather than breaking early.

## Related Issue
Fixes #11595