### PR TITLE
Fix: fix-sse-tab-id-crypto

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -7,7 +7,7 @@ const HEARTBEAT_KEY = "eventra_sse_leader_heartbeat";
 const LOCAL_STORAGE_CONFIRM_MIN_MS = 25;
 const LOCAL_STORAGE_CONFIRM_JITTER_MS = 75;
 // Unique identifier for this tab instance
-const TAB_ID = Math.random().toString(36).substring(2, 9);
+const TAB_ID = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : Math.random().toString(36).substring(2, 9);
 
 const ALLOWED_MESSAGE_TYPES = new Set([
   "SUBSCRIBE",


### PR DESCRIPTION
## Description
Resolves an issue in `sseMultiplexer.js` where the `TAB_ID` was being generated using a non-cryptographically secure PRNG (`Math.random().toString(36)`), creating a small but real chance of collision in multi-tab scenarios. A collision causes the leader tab's broadcasts to be incorrectly ignored by the follower.

## Changes Made
* Replaced the `TAB_ID` generation with `crypto.randomUUID()` when available, falling back to `Math.random` only if Web Crypto is completely missing.

## Related Issue
Fixes #11434