### PR TITLE
Fix: fix-notification-poller-normalize-id

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -30,7 +30,7 @@ const getStorageKey = (userId) => {
 
 const normalize = (n = {}) => ({
   ...n,
-  id: n.id || n._id || `${n.timestamp || n.createdAt || Date.now()}-${getNotificationMessage(n)}`,
+  id: n.id || n._id || `${n.timestamp || n.createdAt || Date.now()}-${Math.random().toString(36).slice(2)}`,
   timestamp: n.timestamp || n.createdAt || n.updatedAt || new Date().toISOString(),
 });
 


### PR DESCRIPTION
## Description
Fixes a bug in `useNotificationPoller.js` where the fallback ID generation passed the raw notification object into `getNotificationMessage`. Since that function expects a string type, it resulted in `undefined` stringified fallback IDs, breaking notification deduplication.

## Changes Made
* Changed the fallback ID suffix to use `Math.random().toString(36).slice(2)` instead of incorrectly invoking `getNotificationMessage(n)`.

## Related Issue
Fixes #11447