### PR TITLE
Fix: fix-sse-teardown-heartbeat-removal

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -797,7 +797,13 @@ class SseMultiplexer {
     // Remove the heartbeat key from localStorage when this tab was the leader.
     if (this.isLeader) {
       try {
-        localStorage.removeItem(HEARTBEAT_KEY);
+        const raw = localStorage.getItem(HEARTBEAT_KEY);
+        if (raw) {
+           const parsed = JSON.parse(raw);
+           if (parsed.tabId === this.tabId) {
+             localStorage.removeItem(HEARTBEAT_KEY);
+           }
+        }
       } catch {
         // Non-fatal — the timeout mechanism in checkLeader will handle expiry
       }


### PR DESCRIPTION
## Description
Fixes a race condition in `sseMultiplexer.js` teardown. The multiplexer unconditionally removed the heartbeat key if it thought it was the leader. However, due to async locks, a new tab could have already claimed leadership and written a new heartbeat, causing this tab to wrongly delete the new leader's heartbeat on exit.

## Changes Made
* Updated the `removeItem(HEARTBEAT_KEY)` logic to first parse the current heartbeat and verify that `parsed.tabId === this.tabId` before removing it.

## Related Issue
Fixes #11435 