### PR TITLE
Fix: fix-cookie-secure-default

### DIFF
--- a/src/utils/cookieUtils.js
+++ b/src/utils/cookieUtils.js
@@ -14,7 +14,7 @@
 const DEFAULT_OPTIONS = {
   path: "/",
   sameSite: import.meta.env?.VITE_COOKIE_SAME_SITE || "Strict",
-  secure: false,
+  
 };
 
 /**


### PR DESCRIPTION
## Description
Fixes a security issue in `cookieUtils.js` where `DEFAULT_OPTIONS` explicitly defined `secure: false`. This disabled the auto-detection logic in `setCookie`, meaning authentication and session cookies could mistakenly be set without the Secure flag even in production HTTPS environments.

## Changes Made
* Removed the explicit `secure: false` from `DEFAULT_OPTIONS` so that the `setCookie` fallback auto-detection can properly enable it on HTTPS connections.

## Related Issue
Fixes #11446