### PR TITLE
Fix: fix-waitlist-notification-inbox-cap

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -82,6 +82,7 @@ const writeNotificationToStorage = (notification, storageKey) => {
   const raw = localStorage.getItem(storageKey);
   const notifications = raw ? safeJsonParse(raw, []) : [];
   notifications.unshift(notification);
+  if (notifications.length > 200) notifications.length = 200;
   localStorage.setItem(storageKey, JSON.stringify(notifications));
 };
 


### PR DESCRIPTION
## Description
Resolves an issue in `waitlistUtils.js` where `writeNotificationToStorage` pushed notifications into the inbox indefinitely without a size limit. For users on many waitlists, this could grow unbounded until it hit the 5MB localStorage limit and crashed all storage operations.

## Changes Made
* Added a hard cap limit (`notifications.length = 200;`) after unshifting a new notification to prevent unbounded localStorage growth.

## Related Issue
Fixes #11445