### PR TITLE
Fix: fix-export-utils-settimeout

### DIFF
--- a/src/utils/exportUtils.js
+++ b/src/utils/exportUtils.js
@@ -45,9 +45,8 @@ export function exportToCSV(data, filename) {
   link.click();
   document.body.removeChild(link);
 
-  // 🔥 FIX: Free up browser memory after download triggers
-  // (100ms delay ensures the browser starts the download before the blob is destroyed)
-  setTimeout(() => URL.revokeObjectURL(url), 100);
+  // Sync revokeObjectURL fixes memory leak when tab closes quickly
+  URL.revokeObjectURL(url);
 }
 
 export function exportToJSON(data, filename) {
@@ -64,6 +63,6 @@ export function exportToJSON(data, filename) {
   link.click();
   document.body.removeChild(link);
 
-  // 🔥 FIX: Free up browser memory after download triggers
-  setTimeout(() => URL.revokeObjectURL(url), 100);
+  // Sync revokeObjectURL fixes memory leak when tab closes quickly
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## Description
Fixes a memory leak in `exportUtils.js` when exporting CSV or JSON. The object URL for the Blob was being revoked inside a `setTimeout(..., 100)`, meaning if the user closed the tab immediately after clicking export, the URL was never revoked and leaked memory.

## Changes Made
* Replaced the asynchronous `setTimeout` revocation with a synchronous `URL.revokeObjectURL(url)` call immediately after the download trigger, in alignment with modern browser behavior and the fix previously applied to `exportCsv.js`.

## Related Issue
Fixes #11444