### PR TITLE
Fix: fix-feedback-response-json

### DIFF
--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -12,7 +12,7 @@ const FEEDBACK_STORAGE_KEY = 'eventra_feedback';
 
 export const fetchEventFeedback = async (eventId) => {
   const response = await apiUtils.get(API_ENDPOINTS.FEEDBACK.BY_EVENT(eventId));
-  return response.json();
+  return response.data;
 };
 
 export const submitEventFeedback = async ({ eventId, rating, comment, tags = [] }) => {
@@ -22,7 +22,7 @@ export const submitEventFeedback = async ({ eventId, rating, comment, tags = [] 
     comment,
     tags,
   });
-  return response.json();
+  return response.data;
 };
 
 /**


### PR DESCRIPTION
## Description
Resolves an issue in `feedbackUtils.js` where `fetchEventFeedback` and `submitEventFeedback` were calling `.json()` on an Axios response object (wrapped via `apiUtils`). This resulted in returning a raw Promise rather than the resolved data, silently breaking feedback loading.

## Changes Made
* Replaced `.json()` with `.data` to correctly read the pre-parsed payload returned by Axios.

## Related Issue
Fixes #11442