### PR TITLE
fix: validate profile preference arrays before returning

### DIFF
--- a/src/utils/userProfileAnalyzer.js
+++ b/src/utils/userProfileAnalyzer.js
@@ -23,13 +23,13 @@ export const getUserProfile = () => {
 
   return {
     interests:
-      saved.interests || [],
+      Array.isArray(saved.interests) ? saved.interests : [],
 
     techStack:
-      saved.techStack || [],
+      Array.isArray(saved.techStack) ? saved.techStack : [],
 
     eventTypes:
-      saved.eventTypes || [],
+      Array.isArray(saved.eventTypes) ? saved.eventTypes : [],
 
     level:
       saved.level || "Beginner",


### PR DESCRIPTION
Closes #11794


## Summary

This PR fixes a runtime crash caused by invalid profile preference types loaded from localStorage.

Previously, the profile analyzer assumed that `interests`, `techStack`, and `eventTypes` were always stored as arrays. If corrupted, legacy, or manually edited localStorage data contained these values as strings, objects, or other non-array types, downstream components calling `.map()` would throw runtime errors.

## Changes

- Validate `interests` using `Array.isArray()`.
- Validate `techStack` using `Array.isArray()`.
- Validate `eventTypes` using `Array.isArray()`.
- Fall back to empty arrays when invalid values are encountered.

## Before

```javascript
interests: saved.interests || [],
techStack: saved.techStack || [],
eventTypes: saved.eventTypes || [],
```

A value such as:

```json
{
  "interests": "Web Development"
}
```

would later cause:

```
TypeError: userProfile.interests.map is not a function
```

## After

```javascript
interests: Array.isArray(saved.interests) ? saved.interests : [],
techStack: Array.isArray(saved.techStack) ? saved.techStack : [],
eventTypes: Array.isArray(saved.eventTypes) ? saved.eventTypes : [],
```

Invalid values now safely fall back to empty arrays, preventing runtime crashes while preserving expected behavior for valid profile data.

```