### PR TITLE
fix: validate security event storage before use

### DIFF
--- a/src/utils/securityEventLogger.js
+++ b/src/utils/securityEventLogger.js
@@ -27,6 +27,10 @@ export const logSecurityEvent = (
       localStorage.removeItem(STORAGE_KEY);
     }
 
+    if (!Array.isArray(existing)) {
+      existing = [];
+    }
+
     existing.unshift(event);
 
     localStorage.setItem(


### PR DESCRIPTION
Closes #11795


## Summary

This PR fixes a runtime crash in the security event logger caused by invalid values stored in `localStorage`.

Previously, the logger assumed that the parsed value from `localStorage` was always an array. If the stored value was `null` (for example, the literal string `"null"`), `JSON.parse()` returned `null`, causing a runtime `TypeError` when `.unshift()` was called.

## Changes

- Validate that the parsed storage value is an array before using it.
- Fall back to an empty array when the stored value is invalid.
- Preserve existing behavior for valid stored event arrays.

## Before

```javascript
existing.unshift(event);
```

If `localStorage` contained:

```text
null
```

then:

```javascript
JSON.parse("null");
// null
```

would result in:

```text
TypeError: Cannot read properties of null (reading 'unshift')
```

## After

```javascript
if (!Array.isArray(existing)) {
    existing = [];
}

existing.unshift(event);
```

The logger now safely handles malformed or legacy storage values without crashing and continues recording new security events as expected.

```