### PR TITLE
fix: use Vite environment variables in security diagnostics

### DIFF
--- a/src/utils/securityHeadersDiagnostics.js
+++ b/src/utils/securityHeadersDiagnostics.js
@@ -17,16 +17,16 @@ export const getSecurityHeadersDiagnostics = () => {
   diagnostics.push({
     name: "CSP Reporting",
     value:
-      process.env.REACT_APP_CSP_REPORT_URI ||
+      import.meta.env?.VITE_CSP_REPORT_URI ||
       "Not configured",
     status:
-      process.env.REACT_APP_CSP_REPORT_URI
+      import.meta.env?.VITE_CSP_REPORT_URI
         ? "success"
         : "warning",
     recommendation:
-      process.env.REACT_APP_CSP_REPORT_URI
+      import.meta.env?.VITE_CSP_REPORT_URI
         ? "Violation reporting enabled."
-        : "Configure REACT_APP_CSP_REPORT_URI for reporting.",
+        : "Configure VITE_CSP_REPORT_URI for reporting.",
   });
 
   return diagnostics;


### PR DESCRIPTION
Closes #11796

## Summary

This PR updates the security diagnostics utility to use Vite's supported environment variable API instead of the legacy `process.env` API.

Previously, the diagnostics relied on `process.env.REACT_APP_CSP_REPORT_URI`, which is not available in Vite browser builds. Accessing `process.env` in a Vite application causes a runtime `ReferenceError`, preventing the diagnostics page from loading correctly.

## Changes

- Replaced `process.env.REACT_APP_CSP_REPORT_URI` with `import.meta.env.VITE_CSP_REPORT_URI`.
- Updated the CSP reporting value lookup.
- Updated the status check to use the Vite environment variable.
- Updated the recommendation message to reference the Vite configuration variable.

## Before

```javascript
value: process.env.REACT_APP_CSP_REPORT_URI || "Not configured";
```

Running the diagnostics in a Vite application could result in:

```text
ReferenceError: process is not defined
```

## After

```javascript
value:
  import.meta.env?.VITE_CSP_REPORT_URI ||
  "Not configured";
```

The diagnostics now use Vite's supported environment API, preventing runtime errors while preserving the existing fallback behavior when the configuration is absent.

```