### PR TITLE
fix: improve countdown display for sub-minute events

### DIFF
--- a/src/utils/getCountdown.js
+++ b/src/utils/getCountdown.js
@@ -17,6 +17,13 @@ export function getCountdown(eventDate) {
   const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
   const minutes = Math.floor((diff / (1000 * 60)) % 60);
 
+  if (days === 0 && hours === 0 && minutes === 0) {
+    return {
+      status: "UPCOMING",
+      text: "Starting in under a minute",
+    };
+  }
+
   return {
     status: "UPCOMING",
     text:


### PR DESCRIPTION
Closes #11797

## Summary

This PR improves the countdown utility by providing a user-friendly message for events that are less than one minute away.

Previously, when an event had fewer than 60 seconds remaining, the calculated days, hours, and minutes all evaluated to zero, causing the countdown to display **"Starts in: 0 Hours 0 Minutes"** instead of a meaningful message.

## Changes

- Added a special case for sub-minute countdowns.
- Return a friendly countdown message when days, hours, and minutes are all zero.
- Preserve the existing countdown formatting for events with one minute or more remaining.

## Before

For an event starting in **30 seconds**, the countdown displayed:

```text
Starts in: 0 Hours 0 Minutes
```

## After

For an event starting in **less than one minute**, the countdown now displays:

```text
Starting in under a minute
```

Events with one minute or more remaining continue to use the existing countdown formatting.

This provides a clearer and more intuitive user experience while maintaining existing functionality.

