### PR TITLE
fix: normalize event ID comparisons in recommendations

### DIFF
--- a/src/utils/eventRecommendationUtils.js
+++ b/src/utils/eventRecommendationUtils.js
@@ -110,11 +110,11 @@ export const getRecommendedEvents = ({
   referenceDate = new Date(),
 }) => {
   const currentEvent =
-    events.find((event) => event.id === currentEventId) ||
+    events.find((event) => String(event.id) === String(currentEventId)) ||
     (currentCategory ? { category: currentCategory, type: currentCategory, tags: [] } : null);
 
   return events
-    .filter((event) => event.id !== currentEventId)
+    .filter((event) => String(event.id) !== String(currentEventId))
     .map((event) => ({
       ...event,
       recommendationScore: scoreRecommendedEvent({


### PR DESCRIPTION
Closes #11798


## Summary

This PR fixes an issue where the currently viewed event could appear in the recommendations list due to inconsistent ID types.

Previously, the recommendation utility compared `event.id` and `currentEventId` using strict equality and inequality. When one value was a number and the other was a string (for example, `12` vs `"12"`), the comparison failed, causing the current event to be incorrectly included in its own recommendations.

## Changes

- Normalize both `event.id` and `currentEventId` using `String()` before comparing them.
- Apply the same normalization when locating the current event and when filtering it out from the recommendation list.
- Preserve existing behavior for matching ID types.

## Before

```javascript
events.find((event) => event.id === currentEventId);

events.filter((event) => event.id !== currentEventId);
```

If:

```javascript
event.id = 12;
currentEventId = "12";
```

The comparisons failed, and the current event appeared in the recommendations.

## After

```javascript
events.find(
  (event) => String(event.id) === String(currentEventId)
);

events.filter(
  (event) => String(event.id) !== String(currentEventId)
);
```

By normalizing both IDs before comparison, the current event is consistently identified and excluded from recommendations regardless of whether the values are strings or numbers.

```