### PR TITLE
fix: validate analytics periods before date calculations

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
@@ -55,10 +55,11 @@ public class AnalyticsService {
 
     // ── 2. Registration trends ────────────────────────────────────────────────
     public List<RegistrationTrendDTO> getRegistrationTrend(String granularity, int periods) {
+        int safePeriods = Math.max(1, Math.min(periods, 365));
         LocalDateTime from = switch (granularity.toLowerCase()) {
-            case "daily"  -> LocalDateTime.now().minusDays(periods);
-            case "weekly" -> LocalDateTime.now().minusWeeks(periods);
-            default       -> LocalDateTime.now().minusMonths(periods);
+            case "daily"  -> LocalDateTime.now().minusDays(safePeriods);
+            case "weekly" -> LocalDateTime.now().minusWeeks(safePeriods);
+            default       -> LocalDateTime.now().minusMonths(safePeriods);
         };
 
         List<Object[]> raw = switch (granularity.toLowerCase()) {


### PR DESCRIPTION
Closes #11799

## Summary

This PR fixes an issue where negative or invalid `periods` values could produce future date ranges in analytics queries.

Previously, the analytics service directly used the user-provided `periods` value when calculating the starting date for daily, weekly, and monthly registration trends. Passing a negative value caused methods such as `minusDays()` and `minusWeeks()` to move the timestamp forward instead of backward, resulting in invalid future date ranges and empty analytics results.

## Changes

- Introduced a validated `safePeriods` value.
- Clamp the requested period to a minimum of **1** and a maximum of **365**.
- Use the validated value for all daily, weekly, and monthly date calculations.
- Preserve the existing behavior for valid requests.

## Before

```java
case "daily"  -> LocalDateTime.now().minusDays(periods);
case "weekly" -> LocalDateTime.now().minusWeeks(periods);
default       -> LocalDateTime.now().minusMonths(periods);
```

A request such as:

```
GET /api/analytics/registrations/trends?periods=-5
```

generated a future date range because `minusDays(-5)` effectively added five days.

## After

```java
int safePeriods = Math.max(1, Math.min(periods, 365));

case "daily"  -> LocalDateTime.now().minusDays(safePeriods);
case "weekly" -> LocalDateTime.now().minusWeeks(safePeriods);
default       -> LocalDateTime.now().minusMonths(safePeriods);
```

By validating the input before performing date calculations, analytics queries now always use a safe historical period and avoid invalid future ranges.

```