### PR TITLE
fix: move analytics authorization to endpoint level

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/analytics")
-@PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
 public class AnalyticsController {
 
     private final AnalyticsService analyticsService;
@@ -26,11 +25,13 @@ public class AnalyticsController {
     }
 
     @GetMapping("/dashboard")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<DashboardStatsDTO> getDashboardStats() {
         return ResponseEntity.ok(analyticsService.getDashboardStats());
     }
 
     @GetMapping("/registrations/trends")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<List<RegistrationTrendDTO>> getRegistrationTrends(
             @RequestParam(defaultValue = "monthly") String granularity,
             @RequestParam(defaultValue = "6") int periods) {
@@ -38,6 +39,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/feedback")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<List<FeedbackAnalyticsDTO>> getFeedbackAnalytics() {
         return ResponseEntity.ok(analyticsService.getFeedbackAnalytics());
     }


### PR DESCRIPTION
Closes #11800

## Summary

This PR fixes an authorization issue where a class-level `@PreAuthorize` annotation prevented organizer users from accessing analytics endpoints that were explicitly intended to allow them.

Previously, `AnalyticsController` was annotated with:

```java
@PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
```

Because Spring Security evaluates class-level authorization before method-level authorization, requests from users with the `ORGANIZER` role were rejected before reaching endpoints that declared organizer access.

## Changes

- Removed the class-level `@PreAuthorize` annotation from `AnalyticsController`.
- Added explicit method-level authorization to endpoints that should remain restricted to `ADMIN` and `SUPER_ADMIN`.
- Preserved organizer access for endpoints that explicitly grant the `ORGANIZER` role.
- Allowed each endpoint to define its own authorization requirements independently.

## Before

A request from an `ORGANIZER` user to an endpoint such as:

```text
GET /api/analytics/organizers
```

returned **HTTP 403 Forbidden** because the class-level authorization was evaluated first.

## After

Authorization is enforced per endpoint:

- Admin-only endpoints remain restricted to `ADMIN` and `SUPER_ADMIN`.
- Organizer-specific endpoints correctly allow users with the `ORGANIZER` role.

This restores the intended authorization behavior while maintaining access restrictions for administrative analytics endpoints.

