### PR TITLE
Fix: fix-use-local-storage-ghost-listener

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -113,13 +113,18 @@ const useLocalStorage = (key, initialValue) => {
       }
     };
 
-    window.addEventListener("storage", handleStorageChange);
-    window.addEventListener("local-storage", handleStorageChange);
-
-    return () => {
-      window.removeEventListener("storage", handleStorageChange);
-      window.removeEventListener("local-storage", handleStorageChange);
-    };
+    const handlerRef = useRef(handleStorageChange);
+    handlerRef.current = handleStorageChange;
+    
+    useEffect(() => {
+      const handler = (e) => handlerRef.current(e);
+      window.addEventListener("storage", handler);
+      window.addEventListener("local-storage", handler);
+      return () => {
+        window.removeEventListener("storage", handler);
+        window.removeEventListener("local-storage", handler);
+      };
+    }, []);
   }, [key, readValue]);
 
   return [storedValue, setValue, removeValue];


### PR DESCRIPTION
## Description
Resolves a bug in `useLocalStorage.js` where the `storage` and `local-storage` event listeners were not properly removed on component cleanup. If the hook's `useEffect` cleanup does not correctly remove the exact same function reference that was added, the listener survives component unmount, causing ghost listeners that accumulate across re-mounts.

## Changes Made
* Extracted the `handleStorageChange` function into a stable `useRef` to ensure the exact same reference is passed to both `addEventListener` and `removeEventListener`.

## Related Issue
Fixes #11597