### PR TITLE
fix: escape ICS reserved characters in calendar exports

### DIFF
--- a/src/utils/calendarLinks.js
+++ b/src/utils/calendarLinks.js
@@ -8,6 +8,17 @@ export const formatICSDate = (dateString) => {
 };
 
 /**
+ * Escapes text for iCalendar property values per RFC 5545 §3.3.11.
+ * Backslashes, semicolons, commas, and newlines must be escaped.
+ */
+const escapeICS = (text = "") =>
+  String(text)
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+
+/**
  * Generates a standard Google Calendar template deep link URL
  */
 export const getGoogleCalendarUrl = (event) => {
@@ -35,9 +46,9 @@ export const generateRawICSContent = (event) => {
     `DTSTAMP:${formatICSDate(new Date().toISOString())}`,
     `DTSTART:${formatICSDate(event.startDateTime)}`,
     `DTEND:${formatICSDate(event.endDateTime)}`,
-    `SUMMARY:${(event.title || '').replace(/,/g, '\\,')}`,
-    `DESCRIPTION:${(event.description || '').replace(/,/g, '\\,')}`,
-    `LOCATION:${(event.location || '').replace(/,/g, '\\,')}`,
+    `SUMMARY:${escapeICS(event.title || '')}`,
+    `DESCRIPTION:${escapeICS(event.description || '')}`,
+    `LOCATION:${escapeICS(event.location || '')}`,
     'END:VEVENT',
     'END:VCALENDAR'
   ].join('\r\n');


### PR DESCRIPTION
Fixes #11869

## Summary

This PR fixes malformed iCalendar (.ics) exports by escaping all RFC 5545 reserved characters in calendar text fields.

## Changes Made

- Added a reusable `escapeICS()` helper.
- Escaped:
  - Backslashes (`\`)
  - Semicolons (`;`)
  - Commas (`,`)
  - Newlines (`\n`)
- Updated `SUMMARY`, `DESCRIPTION`, and `LOCATION` fields to use the new helper.

## Problem

Previously only commas were escaped, allowing multiline descriptions and reserved characters to generate malformed `.ics` files that could fail to import into calendar applications.

## Result

Generated calendar exports now correctly escape reserved characters according to the iCalendar specification, improving compatibility with Google Calendar, Apple Calendar, and other RFC 5545 compliant clients.

