### PR TITLE
ci: add Node.js matrix testing for supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,18 @@ permissions:
 
 jobs:
   validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - '20.x'
+          - '22.x'
+          - '24.x'
+
     uses: ./.github/workflows/reusable-setup.yml
+
     with:
-      node-version: '22'
+      node-version: ${{ matrix.node-version }}
       test-command: |
         npm run lint
         npm run test


### PR DESCRIPTION
## Summary

This PR updates the CI workflow to use a GitHub Actions matrix strategy, enabling validation across multiple supported Node.js versions.

## Changes Made

* Added a matrix strategy to the `CI Validation` workflow.
* Configured the workflow to run on:

  * Node.js `20.x`
  * Node.js `22.x`
  * Node.js `24.x`
* Passed the matrix Node.js version to the reusable workflow through the `node-version` input.
* Enabled `fail-fast: false` so failures are reported independently for each Node.js version without cancelling the remaining matrix jobs.
* Kept the existing CI steps unchanged, including:

  * Dependency installation
  * Linting
  * Unit tests
  * End-to-end tests
  * Build process
  * Artifact upload

## Why This Change?

Running the CI pipeline against multiple supported Node.js versions helps ensure compatibility across different runtime environments, detects version-specific issues earlier, and improves confidence when upgrading Node.js versions in the future.

## Checklist

* [x] Added a GitHub Actions matrix strategy.
* [x] Configured CI to run on Node.js `20.x`, `22.x`, and `24.x`.
* [x] Preserved the existing validation workflow.
* [x] Configured independent reporting for each matrix job using `fail-fast: false`.
* [x] No changes to the project's application logic.

Closes #10951
