### PR TITLE
fix: normalize collaboration room IDs for message validation

### DIFF
--- a/src/utils/collaborationTransport.js
+++ b/src/utils/collaborationTransport.js
@@ -12,7 +12,8 @@ export const createCollaborationTransport = (
     onMessage,
   } = {},
 ) => {
-  const channelName = `eventra-collaboration-${roomId}`;
+  const normalizedRoomId = String(roomId);
+  const channelName = `eventra-collaboration-${normalizedRoomId}`;
   const channel = BroadcastChannelImpl
     ? new BroadcastChannelImpl(channelName)
     : null;
@@ -48,7 +49,7 @@ export const createCollaborationTransport = (
       channel.postMessage({
         action,
         data,
-        roomId,
+        roomId: normalizedRoomId,
         clientId,
       });
 


### PR DESCRIPTION
Fixes #11871

## Summary

This PR fixes collaboration message validation when numeric room IDs are used.

## Changes Made

- Normalize the room ID to a string when creating the collaboration transport.
- Use the normalized room ID when:
  - Creating the BroadcastChannel name.
  - Sending collaboration messages.

## Problem

Incoming collaboration messages were validated expecting `roomId` to be a string. When numeric room IDs were used, messages were rejected even though they belonged to the correct collaboration room.

## Result

Room identifiers are now handled consistently regardless of whether they are provided as numbers or strings, allowing collaboration messages to be processed correctly.

