### PR TITLE
fix: preserve ampersands in query sanitizer

### DIFF
--- a/src/utils/querySanitizer.js
+++ b/src/utils/querySanitizer.js
@@ -4,9 +4,9 @@ export function sanitizeFilterQuery(queryObj) {
   Object.keys(queryObj).forEach((key) => {
     const val = queryObj[key];
     if (typeof val === "string") {
-      sanitized[key] = val.replace(/[$&<>]/g, ""); // strip sensitive characters
+      sanitized[key] = val.replace(/[$<>]/g, ""); // strip potentially dangerous characters
     } else if (Array.isArray(val)) {
-      sanitized[key] = val.map(item => (typeof item === "string" ? item.replace(/[$&<>]/g, "") : item));
+      sanitized[key] = val.map(item => (typeof item === "string" ? item.replace(/[$<>]/g, "") : item));
     } else {
       sanitized[key] = val;
     }


### PR DESCRIPTION
Fixes #11872

## Summary

This PR fixes query sanitization so that valid ampersands (`&`) are preserved in filter values while continuing to remove potentially unsafe characters.

## Changes Made

- Removed `&` from the list of stripped characters during query sanitization.
- Applied the same change to both string values and string items within arrays.

## Problem

The sanitizer removed ampersands from filter values, causing legitimate categories such as:

- DevOps & Cloud
- Design & UX
- R&D

to be modified before filtering, resulting in incorrect search behavior and missing results.

## Result

Valid filter values containing ampersands are now preserved, while potentially unsafe characters continue to be sanitized.

```