### PR TITLE
fix: normalize session bookmark id comparisons

### DIFF
--- a/src/utils/sessionBookmarks.js
+++ b/src/utils/sessionBookmarks.js
@@ -26,7 +26,7 @@ const writeBookmarks = (bookmarks) => {
 export const addSessionBookmark = (event) => {
   if (!event?.id) return readBookmarks();
   const bookmarks = readBookmarks();
-  if (bookmarks.some((b) => b.id === event.id)) return bookmarks;
+  if (bookmarks.some((b) => String(b.id) === String(event.id))) return bookmarks;
   const entry = {
     id: event.id,
     title: event.title || "",
@@ -40,7 +40,7 @@ export const addSessionBookmark = (event) => {
 };
 
 export const removeSessionBookmark = (eventId) => {
-  const next = readBookmarks().filter((b) => b.id !== eventId);
+  const next = readBookmarks().filter((b) => String(b.id) !== String(eventId));
   writeBookmarks(next);
   return next;
 };
@@ -48,7 +48,7 @@ export const removeSessionBookmark = (eventId) => {
 export const getSessionBookmarks = () => readBookmarks();
 
 export const isSessionBookmarked = (eventId) => {
-  return readBookmarks().some((b) => b.id === eventId);
+  return readBookmarks().some((b) => String(b.id) === String(eventId));
 };
 
 export const clearSessionBookmarks = () => {


### PR DESCRIPTION
## Summary

This PR fixes inconsistent session bookmark behavior by normalizing bookmark and event IDs before performing comparisons.

## Changes Made

- Normalized bookmark IDs and event IDs using `String(...)` before equality checks.
- Updated:
  - duplicate bookmark detection
  - bookmark removal
  - bookmark existence checks

## Problem

Session bookmarks compared IDs using strict equality. When bookmark IDs were stored as numbers while route parameters were strings, comparisons failed, causing:

- duplicate bookmarks
- failed bookmark removal
- incorrect bookmarked state

## Result

Bookmark operations now work correctly regardless of whether IDs are stored as strings or numbers.

Fixes #11873