### PR TITLE
fix: compensate network latency during time sync

### DIFF
--- a/src/utils/timeSync.js
+++ b/src/utils/timeSync.js
@@ -25,14 +25,23 @@ export const getServerNow = () => Date.now() + serverClockOffsetMs;
 
 export const getServerTime = () => new Date(getServerNow());
 
-export const syncServerTimeFromHeader = (headerValue) => {
+export const syncServerTimeFromHeader = (headerValue, requestSentAt) => {
   if (!headerValue || typeof headerValue !== "string") return false;
 
   const parsed = Date.parse(headerValue);
   if (Number.isNaN(parsed)) return false;
 
   const localNow = Date.now();
-  setServerClockOffsetMs(parsed - localNow);
+
+  // Compensate for network latency if request timing is available
+  if (typeof requestSentAt === "number" && requestSentAt > 0) {
+    const roundTripMs = localNow - requestSentAt;
+    // Assume symmetric latency: server time was received halfway through the round trip
+    const latencyCompensationMs = Math.round(roundTripMs / 2);
+    setServerClockOffsetMs(parsed + latencyCompensationMs - localNow);
+  } else {
+    setServerClockOffsetMs(parsed - localNow);
+  }
   return true;
 };
 


### PR DESCRIPTION
## Summary

This PR improves client-server time synchronization by compensating for estimated network round-trip latency when calculating the server clock offset.

## Changes Made

- Updated `syncServerTimeFromHeader` to accept an optional `requestSentAt` timestamp.
- Calculated the network round-trip time (RTT).
- Estimated one-way latency by using half of the RTT.
- Applied latency compensation when computing the server clock offset.
- Preserved the previous behavior when request timing information is unavailable.

## Problem

The previous implementation calculated the server clock offset using the local time when the response was received.

On high-latency connections, this introduced a permanent clock offset that affected:

- countdown timers
- synchronized timestamps
- relative time calculations

## Result

Time synchronization is now more accurate on slow or high-latency network connections while remaining backward compatible.

Fixes #11874