### PR TITLE
fix: add SSR guards for offline registration sync

### DIFF
--- a/src/utils/offlineRegistrationSync.js
+++ b/src/utils/offlineRegistrationSync.js
@@ -2,7 +2,12 @@
 import { logger } from './logger';
 
 export const registerOfflineSync = async () => {
-  if ('serviceWorker' in navigator && 'SyncManager' in window) {
+  if (
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    'serviceWorker' in navigator &&
+    'SyncManager' in window
+  ) {
     try {
       const registration = await navigator.serviceWorker.ready;
       await registration.sync.register('sync-offline-registrations');


### PR DESCRIPTION
## Summary

This PR prevents runtime errors when the offline registration sync utility is imported in server-side rendering (SSR) or non-browser environments.

## Changes Made

- Added guards for `window` and `navigator` before accessing browser-specific APIs.
- Ensured Service Worker and Background Sync APIs are only used when running in a browser environment.

## Problem

The previous implementation directly accessed browser globals:

- `window`
- `navigator`

When imported during SSR or Node.js execution, these globals are unavailable, resulting in a `ReferenceError` before the application finished loading.

## Result

The offline registration sync utility now safely skips browser-specific logic in SSR and non-browser environments while preserving the existing behavior in supported browsers.

Fixes #11876