### PR TITLE
fix: allow organizers to access team and audit logs

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
@@ -84,7 +84,7 @@ public class EventRoleService {
 
     @Transactional(readOnly = true)
     public List<EventTeamMemberResponse> getTeam(Long eventId, String actorEmail) {
-        requireRole(eventId, actorEmail, EventRole.OWNER);
+        requireRole(eventId, actorEmail, EventRole.ORGANIZER);
         return eventTeamMemberRepository.findByEvent_IdOrderByRoleDescAssignedAtDesc(eventId)
                 .stream()
                 .map(this::toTeamMemberResponse)
@@ -93,7 +93,7 @@ public class EventRoleService {
 
     @Transactional(readOnly = true)
     public List<EventRoleAuditResponse> getAuditLog(Long eventId, String actorEmail) {
-        requireRole(eventId, actorEmail, EventRole.OWNER);
+        requireRole(eventId, actorEmail, EventRole.ORGANIZER);
         return auditLogRepository.findByEventIdOrderByChangedAtDesc(eventId)
                 .stream()
                 .map(this::toAuditResponse)


### PR DESCRIPTION
## Summary

This PR fixes the authorization requirement for event team management endpoints.

### Changes Made

- Updated `getTeam()` to require `EventRole.ORGANIZER` instead of `EventRole.OWNER`.
- Updated `getAuditLog()` to require `EventRole.ORGANIZER` instead of `EventRole.OWNER`.

### Problem

Previously, only event owners could view the event team and role audit history.

Organizers and co-hosts responsible for managing an event were denied access even though they should be able to manage these resources.

### Solution

Lowered the required role from `OWNER` to `ORGANIZER`, allowing authorized event managers to access team members and audit logs while preserving role-based authorization.

Closes #11890