### PR TITLE
fix: handle null waitlist position when assigning first entry

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -341,7 +341,8 @@ public class EventService {
         EventWaitlist entry = new EventWaitlist();
         entry.setEvent(event);
         entry.setUser(user);
-        entry.setPosition(eventWaitlistRepository.findMaxPositionByEventId(eventId) + 1);
+        Integer maxPos = eventWaitlistRepository.findMaxPositionByEventId(eventId);
+        entry.setPosition((maxPos == null ? 0 : maxPos) + 1);
         entry.setStatus("WAITING");
 
         return toWaitlistResponse(eventWaitlistRepository.save(entry));


### PR DESCRIPTION
## Summary

This PR fixes a `NullPointerException` that could occur when adding the first user to an event waitlist.

### Changes Made

- Stored the result of `findMaxPositionByEventId()` in a local variable.
- Added a null check before incrementing the waitlist position.
- Defaulted the first waitlist position to `1` when no existing entries are present.

### Problem

When an event had no existing waitlist entries, `findMaxPositionByEventId()` returned `null`.

The previous implementation immediately incremented this value, causing Java to auto-unbox `null` and throw a `NullPointerException`.

### Solution

Added a null-safe fallback so that:

- Empty waitlist → position `1`
- Existing waitlist → `maxPosition + 1`

This prevents the runtime exception while preserving the expected ordering of waitlist entries.

Closes #11891