### PR TITLE
fix: prevent stale closure in OrganizerWaitlistManagement polling

### DIFF
--- a/src/components/OrganizerWaitlistManagement.jsx
+++ b/src/components/OrganizerWaitlistManagement.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { useAuth } from 'context/AuthContext';
 import {
@@ -22,14 +22,8 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
   const [newCapacity, setNewCapacity] = useState(maxAttendees);
   const [isProcessing, setIsProcessing] = useState(false);
 
-  // Load waitlist data
-  useEffect(() => {
-    loadWaitlistData();
-    const interval = setInterval(loadWaitlistData, 10000); // Refresh every 10 seconds
-    return () => clearInterval(interval);
-  }, [eventId]);
 
-  const loadWaitlistData = async () => {
+  const loadWaitlistData = useCallback(async () => {
     try {
       const data = await syncWaitlistFromServer(eventId, user?.id);
       setWaitlist(data);
@@ -42,7 +36,14 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [eventId, user?.id]);
+
+  // Load waitlist data
+  useEffect(() => {
+    loadWaitlistData();
+    const interval = setInterval(loadWaitlistData, 10000); // Refresh every 10 seconds
+    return () => clearInterval(interval);
+  }, [loadWaitlistData]);
 
   // Promote the next user manually
   const handlePromoteNext = async () => {


### PR DESCRIPTION
## Summary

This PR fixes a stale closure issue in `OrganizerWaitlistManagement` by memoizing `loadWaitlistData` with `useCallback` and updating the `useEffect` dependency array.

## Changes Made

* Wrapped `loadWaitlistData` with `useCallback`.
* Added `eventId` and `user?.id` as dependencies to `useCallback`.
* Updated the polling `useEffect` to depend on `loadWaitlistData` instead of `eventId`.
* Preserved the existing polling interval and cleanup behavior.

## Why This Fix?

Previously, `loadWaitlistData` was recreated on every render while `useEffect` depended only on `eventId`. This could cause the polling interval to retain a stale reference to the callback, resulting in outdated data being fetched when component props changed.

By memoizing the callback and including it in the effect dependencies, the polling interval is recreated whenever the callback changes, ensuring it always uses the latest `eventId` and user context.

Closes #10282
