### PR TITLE
fix: continue waitlist auto-promotion after invalid entries

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -580,11 +580,14 @@ public class EventService {
             return null;
         }
 
-        return eventWaitlistRepository.findWaitingByEventIdWithLock(event.getId())
-                .stream()
-                .findFirst()
-                .map(entry -> promoteEntry(event, entry))
-                .orElse(null);
+        List<EventWaitlist> waitingUsers = eventWaitlistRepository.findWaitingByEventIdWithLock(event.getId());
+        for (EventWaitlist entry : waitingUsers) {
+            RegistrationResponse result = promoteEntry(event, entry);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
     private RegistrationResponse promoteEntry(Event event, EventWaitlist entry) {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -341,7 +341,8 @@ public class EventService {
         EventWaitlist entry = new EventWaitlist();
         entry.setEvent(event);
         entry.setUser(user);
-        entry.setPosition(eventWaitlistRepository.findMaxPositionByEventId(eventId) + 1);
+        Integer maxPos = eventWaitlistRepository.findMaxPositionByEventId(eventId);
+        entry.setPosition((maxPos == null ? 0 : maxPos) + 1);
         entry.setStatus("WAITING");
 
         return toWaitlistResponse(eventWaitlistRepository.save(entry));


### PR DESCRIPTION
Closes #11892

## Summary

This PR fixes the waitlist auto-promotion flow so that it continues checking additional waitlisted users when an invalid entry is encountered.

### Changes Made

- Replaced the single-entry promotion logic with iteration over all waiting users.
- Continue processing when `promoteEntry()` returns `null`.
- Promote the first eligible waitlisted user.
- Return `null` only when no eligible users remain.

### Problem

Previously, the auto-promotion logic only processed the first waitlisted user.

If that user had already been registered, `promoteEntry()` returned `null`, causing the promotion process to stop immediately and leaving available seats unfilled even when other eligible users were waiting.

### Solution

The promotion logic now iterates through the waitlist until a successful promotion occurs.

If an entry is skipped because it is no longer eligible, the service continues checking the remaining waiting users instead of terminating early.

This ensures newly available seats are assigned to the next eligible waitlisted participant.

