### PR TITLE
fix: prevent multiple owner roles during ownership transfer

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventTeamMemberRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventTeamMemberRepository.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.repository;
 
+import com.sandeep.eventrabackend.model.EventRole;
 import com.sandeep.eventrabackend.model.EventTeamMember;
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +10,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EventTeamMemberRepository extends JpaRepository<EventTeamMember, Long> {
     Optional<EventTeamMember> findByEvent_IdAndUser_Id(Long eventId, Long userId);
+
+    Optional<EventTeamMember> findByEvent_IdAndRole(Long eventId, EventRole role);
 
     List<EventTeamMember> findByEvent_IdOrderByRoleDescAssignedAtDesc(Long eventId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
@@ -77,6 +77,18 @@ public class EventRoleService {
             throw new AccessDeniedException("Only the event owner can transfer ownership.");
         }
 
+        // If assigning OWNER, downgrade the current owner to ORGANIZER
+        if (newRole == EventRole.OWNER) {
+            eventTeamMemberRepository.findByEvent_IdAndRole(eventId, EventRole.OWNER)
+                    .filter(member -> !member.getUser().getEmail().equals(request.getUserEmail()))
+                    .ifPresent(currentOwner -> {
+                        currentOwner.setRole(EventRole.ORGANIZER);
+                        currentOwner.setAssignedAt(LocalDateTime.now());
+                        eventTeamMemberRepository.save(currentOwner);
+                        auditLogRepository.save(toAuditLog(eventId, currentOwner.getUser().getId(), actor, EventRole.OWNER, EventRole.ORGANIZER, "DOWNGRADED"));
+                    });
+        }
+
         User target = findUser(request.getUserEmail());
         EventTeamMember member = upsertRole(event, target, newRole, actor, "ASSIGNED");
         return toTeamMemberResponse(member);


### PR DESCRIPTION
## Summary

This PR fixes the event ownership transfer flow to ensure only one user can hold the `OWNER` role for an event at any given time.

### Changes Made

- Added a repository method to retrieve the current event owner.
- Downgraded the existing owner to `ORGANIZER` before assigning a new owner.
- Updated the assignment timestamp for the downgraded member.
- Recorded the ownership transfer in the audit log.
- Preserved the existing role assignment flow for the new owner.

### Problem

Previously, transferring ownership assigned the `OWNER` role to the target user without revoking it from the existing owner.

As a result, multiple users could simultaneously hold the `OWNER` role for the same event, leading to inconsistent authorization and ownership ambiguity.

### Solution

Before assigning the new owner, the service now locates the current owner and downgrades their role to `ORGANIZER`. The ownership transfer is also recorded in the audit log to maintain a complete history of role changes.

This guarantees that only one `OWNER` exists per event after every ownership transfer.

Closes #11893