### PR TITLE
fix: handle failed SSE initialization gracefully

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
@@ -40,6 +40,7 @@ public class EventStreamService {
         } catch (IOException e) {
             log.error("Failed to send initial connection event", e);
             emitter.completeWithError(e);
+            throw new RuntimeException("Failed to initialize SSE connection", e);
         }
 
         return emitter;


### PR DESCRIPTION
## Summary

This PR fixes the SSE initialization flow to prevent returning a completed `SseEmitter` after an initialization failure.

### Changes Made

- Throw a runtime exception after `completeWithError(...)` when sending the initial SSE event fails.
- Prevent returning an already completed `SseEmitter` to the controller.
- Allow Spring MVC to generate an appropriate HTTP error response.

### Problem

Previously, if sending the initial SSE connection event threw an `IOException`, the emitter was completed with an error but was still returned to the controller.

Returning an already completed `SseEmitter` could result in an `IllegalStateException` during request processing and lead to unexpected server errors.

### Solution

The service now throws a `RuntimeException` immediately after completing the emitter with an error.

This prevents invalid emitters from being returned and allows the framework to handle initialization failures with a proper HTTP error response.

Closes #11894