### PR TITLE
fix: prevent premature scroll unlock for stacked modals

### DIFF
--- a/src/utils/scrollLock.js
+++ b/src/utils/scrollLock.js
@@ -1,9 +1,17 @@
+let lockCount = 0;
+
 export function lockBodyScroll() {
   if (typeof document === "undefined") return;
-  document.body.style.overflow = "hidden";
+  if (lockCount === 0) {
+    document.body.style.overflow = "hidden";
+  }
+  lockCount++;
 }
 
 export function unlockBodyScroll() {
   if (typeof document === "undefined") return;
-  document.body.style.overflow = "";
+  lockCount = Math.max(0, lockCount - 1);
+  if (lockCount === 0) {
+    document.body.style.overflow = "";
+  }
 }


### PR DESCRIPTION
Closes #11896

## Summary

This PR fixes the scroll lock utility to correctly handle multiple stacked modals by using a reference counter.

### Changes Made

- Added a shared `lockCount` counter.
- Apply `overflow: hidden` only when the first scroll lock is requested.
- Decrement the counter when unlocking.
- Restore page scrolling only when all active scroll locks have been released.
- Prevent the counter from becoming negative.

### Problem

Previously, every call to `unlockBodyScroll()` immediately restored page scrolling.

When multiple modal dialogs were open, closing the top modal re-enabled background scrolling even though another modal was still active.

### Solution

The scroll lock utility now tracks the number of active scroll lock requests using a reference counter.

Scrolling remains disabled until the final active modal is closed, ensuring correct behavior for stacked dialogs and nested overlays.
