### PR TITLE
fix: normalize timestamp strings before date comparison

### DIFF
--- a/src/utils/hostHackathonValidation.js
+++ b/src/utils/hostHackathonValidation.js
@@ -18,6 +18,11 @@ const LENGTH_RULES = [
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[a-zA-Z]{2,}$/;
 const URL_REGEX = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?$/i;
 
+const toDateString = (value) => {
+  if (!value) return "";
+  return value.includes("T") ? value.split("T")[0] : value;
+};
+
 const isOutOfBounds = (value, min, max) => {
   const length = value.trim().length;
   return length < min || length > max;
@@ -56,12 +61,12 @@ const validateWebsite = (data) => {
 
 const isStartInPast = (data, today) => {
   if (!data.startDate) return false;
-  return data.startDate < today;
+  return toDateString(data.startDate) < toDateString(today);
 };
 
 const isEndBeforeStart = (data) => {
   if (!data.endDate || !data.startDate) return false;
-  return data.endDate < data.startDate;
+  return toDateString(data.endDate) < toDateString(data.startDate);
 };
 
 const validateDateRange = (data, today) => {


### PR DESCRIPTION
## Summary

This PR fixes date validation in the hackathon hosting utility by normalizing timestamp strings before performing date comparisons.

### Changes Made

- Added a helper to normalize date values to the `YYYY-MM-DD` format.
- Updated start date validation to compare normalized values.
- Updated end date validation to compare normalized values.
- Preserved existing validation behavior for date-only inputs.

### Problem

Previously, the validation logic compared raw date strings directly.

When one value included a timestamp (for example, `2026-08-10T14:00:00.000Z`) and the other contained only a calendar date (`2026-08-10`), lexicographical comparison could produce incorrect validation results.

### Solution

The validation logic now normalizes all date inputs to `YYYY-MM-DD` before performing comparisons. This ensures consistent behavior regardless of whether the input contains a timestamp or only the calendar date.

Closes #11897
