### PR TITLE
fix: support additional valid GitHub repository URL formats

### DIFF
--- a/src/utils/submitProjectValidation.js
+++ b/src/utils/submitProjectValidation.js
@@ -15,7 +15,7 @@ const LENGTH_RULES = [
 ];
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const GITHUB_REGEX = /^(https?:\/\/)?(www\.)?github\.com\/[\w-]+\/[\w-]+(\/)?$/i;
+const GITHUB_REGEX = /^(https?:\/\/)?(www\.)?github\.com\/[\w.-]+\/[\w.-]+(\/.*)?$/i;
 const URL_REGEX = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?$/i;
 
 const isValidProjectImage = (value) => value.startsWith("data:image/") || URL_REGEX.test(value);


### PR DESCRIPTION
## Summary

This PR updates the GitHub repository URL validation regex to support additional valid GitHub URL formats.

### Changes Made

- Expanded the repository name pattern to allow dots (`.`).
- Added support for optional `.git` suffixes.
- Allowed repository subpaths such as `/tree/main`.
- Preserved validation for standard GitHub repository URLs.

### Problem

Previously, the validation regex only accepted simple repository names containing letters, numbers, underscores, and hyphens.

As a result, valid GitHub repository URLs containing dots, `.git` suffixes, or repository subpaths were incorrectly rejected during project submission.

### Solution

The regex has been updated to accept these additional valid GitHub URL formats while continuing to validate GitHub repository URLs correctly.

This improves compatibility with legitimate repository links without relaxing validation beyond GitHub URLs.

Closes #11898
