### PR TITLE
feat: Add automatic GitHub Actions artifact cleanup workflow

### DIFF
--- a/.github/workflows/artifact-cleanup.yml
+++ b/.github/workflows/artifact-cleanup.yml
@@ -1,0 +1,60 @@
+name: Artifact Cleanup
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Run weekly on Sunday at midnight
+  workflow_dispatch:    # Allow manual triggering
+
+permissions:
+  actions: write # Required to delete artifacts
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup Expired Artifacts
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const retentionDays = 30; // configurable retention period
+            const keepDate = new Date();
+            keepDate.setDate(keepDate.getDate() - retentionDays);
+            
+            console.log(`Starting cleanup of artifacts older than ${retentionDays} days (${keepDate.toISOString()})...`);
+            
+            let artifactsDeleted = 0;
+            
+            try {
+              // Iterate over all artifacts using pagination
+              const iterator = github.paginate.iterator(github.rest.actions.listArtifactsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              });
+              
+              for await (const { data: artifacts } of iterator) {
+                for (const artifact of artifacts) {
+                  const createdAt = new Date(artifact.created_at);
+                  
+                  if (createdAt < keepDate) {
+                    try {
+                      await github.rest.actions.deleteArtifact({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        artifact_id: artifact.id,
+                      });
+                      console.log(`✅ Deleted artifact: ${artifact.name} (ID: ${artifact.id}) created at ${artifact.created_at}`);
+                      artifactsDeleted++;
+                    } catch (err) {
+                      console.error(`❌ Failed to delete artifact: ${artifact.name} (ID: ${artifact.id})`, err);
+                    }
+                  }
+                }
+              }
+              
+              console.log(`🎉 Cleanup complete. Total artifacts deleted: ${artifactsDeleted}`);
+            } catch (error) {
+              console.error("Error fetching artifacts:", error);
+              core.setFailed(`Artifact cleanup failed: ${error.message}`);
+            }


### PR DESCRIPTION
# 🗑️ Add Automatic Cleanup for GitHub Actions Artifacts

## Overview
GitHub Actions artifacts can accumulate over time, consuming repository storage and making it harder to locate relevant build outputs. This PR introduces an automated cleanup workflow to remove expired or unnecessary artifacts while preserving recent ones, helping to stay within GitHub storage limits.

## Changes Made
- Created a new workflow at `.github/workflows/artifact-cleanup.yml`.
- Scheduled the workflow to run weekly (`0 0 * * 0`).
- Implemented a custom inline script via `actions/github-script` to query the GitHub REST API and securely delete old artifacts using `GITHUB_TOKEN`.
- Configured the script to target and delete artifacts older than a 30-day retention period.
- Integrated logging to detail which artifacts were deleted and summarize the total cleanup numbers.

## Verification
- Validated YAML syntax for the workflow and the GitHub script logic.
- Included `workflow_dispatch` trigger to allow maintainers to test/run the cleanup manually if needed.
- Existing workflows are unaffected as this is a standalone maintenance job.

fixes #11941 