### PR TITLE
feat: Add markdown linting workflow and config

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,26 @@
+name: Markdown Lint
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+  pull_request:
+    paths:
+      - '**/*.md'
+  workflow_dispatch:
+
+jobs:
+  markdown-lint:
+    name: Lint Markdown files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: |
+            **/*.md
+            !node_modules/**
+            !.git/**

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,10 @@
+default: true
+
+# Exclude line length rule
+MD013: false
+
+# Exclude allowing inline HTML (common in GitHub docs)
+MD033: false
+
+# Exclude first line must be a top level heading
+MD041: false


### PR DESCRIPTION
# 📝 Add Markdown Linting Workflow

## Overview
The repository contains many Markdown files, but there was currently no automated validation to ensure consistent formatting and documentation quality. This PR adds a Markdown linting workflow to help maintain clean, readable, and standardized documentation and enhance the contributor experience.

## Changes Made
- Created a new workflow at `.github/workflows/markdown-lint.yml`.
- Configured the workflow to trigger on `push` and `pull_request` events that modify `**/*.md` files.
- Used the official `DavidAnson/markdownlint-cli2-action` to lint Markdown files rapidly.
- Created a root `.markdownlint.yaml` configuration file to customize the rules. Explicitly disabled overly strict rules (e.g. line length limits `MD013` and inline HTML `MD033`) to ensure existing documentation doesn't immediately break the CI pipeline.
- Linting errors are now reported directly in the workflow output.

## Verification
- Validated YAML syntax for the workflow and the configuration file.
- Included `workflow_dispatch` trigger to allow maintainers to run the lint manually if needed.
- Existing CI workflows remain unaffected as this is a new, standalone verification job.

fixes #11943 