### PR TITLE
feat: Add actionlint workflow to validate GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,26 @@
+name: Actionlint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
+          level: error


### PR DESCRIPTION
# ✅ Add actionlint for GitHub Actions Workflow Validation

## Overview
GitHub Actions workflows should be validated prior to execution to catch syntax errors, invalid expressions, and common configuration mistakes. This PR introduces `actionlint` into the CI pipeline to statically analyze all workflow files and ensure correctness, improving overall pipeline reliability.

## Changes Made
- Created a new workflow at `.github/workflows/actionlint.yml`.
- Configured the workflow to trigger on `push` and `pull_request` events affecting files in the `.github/workflows/` directory.
- Integrated the popular `reviewdog/action-actionlint` action to run `actionlint` against all workflow files.
- The pipeline is explicitly configured to fail (`fail_on_error: true`) if any validation errors are detected, preventing broken workflows from being merged to `master`.
- `reviewdog` is configured to report linting errors directly in the GitHub PR check interface for immediate feedback.

## Verification
- Checked that the `actionlint.yml` file has correct YAML syntax.
- Existing workflows continue to operate normally; this workflow simply serves as a fast static analysis gate specifically for `.github/workflows/**/*.yml` changes.

fixes #11945 