### PR TITLE
feat: Add Gitleaks secret scanning workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,32 @@
+name: Gitleaks Secret Scanner
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all tags and branches so Gitleaks can scan properly
+
+      - name: Run Gitleaks
+        id: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+      - name: Upload Gitleaks Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: results.sarif # The gitleaks action outputs results to results.sarif by default
+          retention-days: 30


### PR DESCRIPTION
# 🔒 Add Secret Scanning with Gitleaks

## Overview
To drastically improve repository security and align with DevSecOps best practices, this PR adds an automated secret scanning workflow that detects accidentally committed API keys, tokens, passwords, and other sensitive information before changes are permitted to merge.

## Changes Made
- Created a new workflow at `.github/workflows/gitleaks.yml`.
- Configured the workflow to trigger on `push` to the default branch and `pull_request` events.
- Integrated the official `gitleaks/gitleaks-action` to scan the repository during CI seamlessly.
- Configured checkout with `fetch-depth: 0` to ensure Gitleaks can analyze all commits in the PR history effectively.
- Designed the workflow to automatically fail if any secrets are detected to prevent catastrophic credential leaks.
- Integrated an artifact upload step (`actions/upload-artifact`) to store the generated scan report (`results.sarif`) for 30 days, providing early feedback and visibility to contributors.

## Verification
- Validated YAML syntax for the workflow.
- Verified that existing CI workflows remain entirely unaffected, as this is an independent, non-intrusive security analysis job.

fixes #11949 