### PR TITLE
feat: Implement matrix strategy for multi-version testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,18 @@ permissions:
 
 jobs:
   validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18', '20', '22']
     uses: ./.github/workflows/reusable-setup.yml
     with:
-      node-version: '22'
+      node-version: ${{ matrix.node-version }}
       test-command: |
         npm run lint
         npm run test
         npx playwright install --with-deps
         npm run test:e2e
       build-command: npm run build
-      artifact-name: build-artifacts
+      artifact-name: build-artifacts-node-${{ matrix.node-version }}
       artifact-path: dist


### PR DESCRIPTION
# 🧪 Implement Matrix Strategy for Multi-Version Testing

## Overview
The current CI workflow validates the project against a single runtime version (Node 22). To ensure robustness and compatibility, this PR introduces a GitHub Actions matrix strategy to validate the project across multiple supported runtime versions in parallel, reducing the risk of version-specific runtime bugs.

## Changes Made
- Updated `.github/workflows/ci.yml` to include a `strategy.matrix` definition for `node-version: ['18', '20', '22']`.
- Set `fail-fast: false` to guarantee that all matrix jobs complete entirely and provide a comprehensive pass/fail picture, even if one version encounters an error.
- Successfully routed `${{ matrix.node-version }}` to the reusable workflow call (`.github/workflows/reusable-setup.yml`).
- Adjusted the `artifact-name` property dynamically to include the specific Node version (e.g., `build-artifacts-node-18`) to ensure that artifacts uploaded by parallel jobs do not collide or override each other.

## Verification
- Verified the YAML formatting and GitHub Actions matrix syntax are correct.
- Existing CI tests and behavior will automatically trigger across all defined runtimes upon the next execution.

fixes #11951 