### PR TITLE
docs: Add GitHub Actions status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Modern event and hackathon platform for communities, organizers, and contributor
 [![Docker Publish](https://github.com/SandeepVashishtha/Eventra/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/docker-publish.yml)
 [![Security Validation](https://github.com/SandeepVashishtha/Eventra/actions/workflows/security-ci.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/security-ci.yml)
 [![CodeQL Analysis](https://github.com/SandeepVashishtha/Eventra/actions/workflows/codeql.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/codeql.yml)
+[![Dependency Review](https://github.com/SandeepVashishtha/Eventra/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/dependency-review.yml)
+[![Markdown Lint](https://github.com/SandeepVashishtha/Eventra/actions/workflows/markdown-lint.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/markdown-lint.yml)
+[![Gitleaks](https://github.com/SandeepVashishtha/Eventra/actions/workflows/gitleaks.yml/badge.svg)](https://github.com/SandeepVashishtha/Eventra/actions/workflows/gitleaks.yml)
 
 ---
 


### PR DESCRIPTION
# 📊 Add GitHub Actions Status Badges to README

## Overview
Adding workflow status badges provides contributors and users with immediate, at-a-glance visibility into the health of the project's CI/CD pipelines right from the repository landing page. While some badges were already present, several critical compliance, security, and linting workflow statuses were missing.

## Changes Made
- Added dynamically updating workflow status badges to the top of `README.md` for:
  - Dependency Review
  - Markdown Lint
  - Gitleaks (Secret Scanning)
- Linked each new badge seamlessly to its corresponding workflow run page to make debugging and navigation faster for maintainers.
- Ensured the markdown formatting remains clean and aligned seamlessly with existing repository badges (CI, Docker, CodeQL, etc.).

## Verification
- Verified badge URLs correctly target `SandeepVashishtha/Eventra`.
- Badges will automatically reflect the state of the default branch upon the next execution.

fixes #11953 