### PR TITLE
feat: Add GitHub Actions job summary reports

### DIFF
--- a/.github/workflows/reusable-setup.yml
+++ b/.github/workflows/reusable-setup.yml
@@ -79,3 +79,20 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-path }}
           retention-days: 7
+
+      - name: Generate Job Summary
+        if: always()
+        run: |
+          echo "## CI Job Summary 🚀" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Details |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Node Version** | ${{ inputs.node-version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Job Status** | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Artifact Generated** | ${{ inputs.artifact-name || 'None' }} |" >> $GITHUB_STEP_SUMMARY
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "### ✅ All tasks completed successfully!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ❌ Some tasks failed. Please review the step logs." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
# 📋 Add GitHub Actions Job Summary Reports

## Overview
GitHub Actions supports job summaries through the `GITHUB_STEP_SUMMARY` environment variable, allowing workflows to generate rich Markdown reports displayed directly on the workflow run page. This PR implements this feature, significantly improving the developer experience by providing concise summaries of build and test results without requiring contributors to inspect lengthy workflow logs.

## Changes Made
- Updated `.github/workflows/reusable-setup.yml` (the core CI building block) to append a new `Generate Job Summary` step.
- Configured the step with `if: always()` to guarantee a summary is published whether the workflow succeeds or fails.
- Wrote rich Markdown to `$GITHUB_STEP_SUMMARY` that includes key metrics such as:
  - The runtime Node.js version utilized.
  - The final Job Status (Success/Failure).
  - The name of any artifacts generated (or N/A).
  - A helpful contextual message and emoji icon depending on whether the execution was successful or resulted in an error.
- Existing workflow steps, build artifacts, and test operations remain entirely unchanged.

## Verification
- Verified Markdown and bash script formatting.
- Since this is injected into the reusable setup, any workflows (like `ci.yml`) leveraging it will now automatically render these summaries in the GitHub UI.

fixes #11955 