### PR TITLE
docs: Add CI/CD Workflow Architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Vercel configuration is checked in via [`vercel.json`](vercel.json):
 ## Documentation
 
 - [Architecture and Roles](docs/ARCHITECTURE_AND_ROLES.md)
+- [CI/CD Workflow Architecture](docs/ci-cd-architecture.md)
 - [Environment Setup Guide](docs/ENV_SETUP_GUIDE.md)
 - [Frontend Onboarding](docs/frontend-onboarding.md)
 - [Security Migration Notes](docs/SECURITY_MIGRATION.md)

--- a/docs/ci-cd-architecture.md
+++ b/docs/ci-cd-architecture.md
@@ -1,0 +1,70 @@
+# CI/CD Workflow Architecture
+
+This document describes the Continuous Integration and Continuous Deployment (CI/CD) architecture of the Eventra project, powered by GitHub Actions.
+
+## Overview Diagram
+
+The following Mermaid diagram illustrates the end-to-end CI/CD process:
+
+```mermaid
+graph TD
+    %% Triggers
+    PullRequest([Pull Request]) --> ValidationTesting
+    PullRequest --> SecurityCompliance
+    PullRequest --> LintingQuality
+    
+    PushMain([Push to Main]) --> ValidationTesting
+    PushMain --> SecurityCompliance
+    PushMain --> LintingQuality
+    PushMain --> DeploymentArtifacts
+    
+    Schedule([Scheduled Events]) --> Maint[Maintenance]
+
+    %% Build & Test
+    subgraph ValidationTesting ["Validation & Testing"]
+        CI[CI Validation]
+        CI_Matrix((Node.js Matrix))
+        CI --> CI_Matrix
+        CI_Matrix --> Build[Build App]
+        CI_Matrix --> Test[Run Tests]
+    end
+
+    %% Security
+    subgraph SecurityCompliance ["Security & Compliance"]
+        SecurityScan[Security CI]
+        CodeQL[CodeQL Analysis]
+        Dependabot[Dependency Review]
+        Gitleaks[Gitleaks Secret Scan]
+        LicenseCheck[License Compliance]
+    end
+
+    %% Code Quality
+    subgraph LintingQuality ["Linting & Quality"]
+        MarkdownLint[Markdown Lint]
+        Actionlint[Actionlint]
+    end
+
+    %% Deployment
+    subgraph DeploymentArtifacts ["Deployment & Artifacts"]
+        Build --> Upload[Upload Artifacts]
+        DockerPublish[Publish Docker Image]
+    end
+    
+    %% Maintenance
+    subgraph Maint ["Maintenance"]
+        ArtifactCleanup[Artifact Cleanup]
+    end
+```
+
+## Workflows Explained
+
+- **CI Validation (`ci.yml`)**: Compiles the source code, lints, and runs tests across a matrix of Node.js versions. Uses `.github/workflows/reusable-setup.yml` for execution.
+- **Security Validation (`security-ci.yml`)**: Includes various security checks for the underlying Node.js environment.
+- **CodeQL Analysis (`codeql.yml`)**: Runs GitHub's native static code analysis to discover deep vulnerabilities.
+- **Gitleaks (`gitleaks.yml`)**: Secret scanning tool that prevents API keys or passwords from being merged.
+- **License Compliance (`license-check.yml`)**: Prevents dependencies with overly restrictive copyleft licenses from being merged into the repository.
+- **Dependency Review (`dependency-review.yml`)**: Assesses any pull request that changes package files for vulnerable dependencies.
+- **Actionlint (`actionlint.yml`)**: Statically validates the `.yml` workflow files themselves.
+- **Markdown Lint (`markdown-lint.yml`)**: Ensures consistent Markdown formatting across all documentation files.
+- **Docker Publish (`docker-publish.yml`)**: Automatically builds and publishes Docker images to a registry upon merging into the default branch.
+- **Artifact Cleanup (`artifact-cleanup.yml`)**: A scheduled job that deletes stale workflow artifacts to save GitHub Actions storage.


### PR DESCRIPTION
# 📈 Document the CI/CD Workflow Architecture

## Overview
As the number of GitHub Actions workflows in this repository has grown—covering everything from multi-version CI validation and strict linting to automated dependency review and security scanning—it has become increasingly difficult for new contributors to understand how different pipelines interact. 

This PR adds formal architecture documentation to visually and textually explain our CI/CD topology.

## Changes Made
- Created `docs/ci-cd-architecture.md`.
- Authored a dynamic `mermaid` diagram illustrating the lifecycle of a commit, mapping out:
  - Workflow triggers (PR vs. Push to Main).
  - Build and Node.js Matrix test stages.
  - Security, license, and credential scanning (CodeQL, Gitleaks, Dependabot).
  - Code Quality linting.
  - Deployment/Artifact publishing and cleanup.
- Provided a concise, bulleted glossary explaining the precise purpose of each `.yml` workflow file located in `.github/workflows`.
- Updated the `README.md` Table of Contents (under the `## Documentation` heading) to visibly link to the new architecture document.

## Benefits
- Drastically improves contributor onboarding by painting a clear picture of what happens when they open a PR.
- Makes the CI/CD pipeline easier to maintain and encourages consistent, standard-compliant workflow development moving forward.

fixes #11957 