### PR TITLE
fix: handle undefined storage quota in quota checker

### DIFF
--- a/src/utils/quotaChecker.js
+++ b/src/utils/quotaChecker.js
@@ -4,6 +4,9 @@ export async function isStorageQuotaAvailable(bytesNeeded = 50000) {
   }
   try {
     const estimate = await navigator.storage.estimate();
+    if (!Number.isFinite(estimate.quota)) {
+      return true;
+    }
     const available = estimate.quota - estimate.usage;
     return available >= bytesNeeded;
   } catch {


### PR DESCRIPTION
Fixes #11967

## Summary

This PR fixes an edge case in the storage quota checker where browsers may not expose valid storage quota information through the Storage Manager API.

Previously, the implementation assumed that `navigator.storage.estimate()` always returned finite `quota` and `usage` values. In browsers such as Safari and certain private browsing environments, `estimate.quota` may be `undefined`. Performing arithmetic with an undefined value produced `NaN`, causing the quota check to incorrectly report that storage was exhausted.

This update validates the returned quota before performing calculations and gracefully handles browsers that do not provide storage quota information.

## Changes

- Added validation for `estimate.quota` using `Number.isFinite()`.
- Skip quota arithmetic when the browser does not expose a valid quota.
- Return `true` in unsupported environments instead of incorrectly reporting insufficient storage.
- Prevent false storage quota failures caused by `NaN` calculations.

## Before

```javascript
const estimate = await navigator.storage.estimate();
const available = estimate.quota - estimate.usage;
return available >= bytesNeeded;
```

If `estimate.quota` was `undefined`:

```javascript
undefined - estimate.usage // NaN
NaN >= bytesNeeded // false
```

This caused the application to incorrectly assume that storage was unavailable.

## After

```javascript
const estimate = await navigator.storage.estimate();

if (!Number.isFinite(estimate.quota)) {
  return true;
}

const available = estimate.quota - estimate.usage;
return available >= bytesNeeded;
```

The quota calculation is now performed only when a valid numeric quota is available.


