### PR TITLE
fix: round countdown values before milestone checks

### DIFF
--- a/src/utils/countdownAnnouncer.js
+++ b/src/utils/countdownAnnouncer.js
@@ -1,6 +1,7 @@
 export function shouldAnnounceCountdown(secondsLeft) {
   if (secondsLeft <= 0) return true;
-  if (secondsLeft === 60 || secondsLeft === 300 || secondsLeft === 600 || secondsLeft === 3600) {
+  const rounded = Math.round(secondsLeft);
+  if (rounded === 60 || rounded === 300 || rounded === 600 || rounded === 3600) {
     return true; // Announce major intervals (1m, 5m, 10m, 1h)
   }
   return false;


### PR DESCRIPTION
Fixes #11968

## Summary

This PR fixes the countdown accessibility milestone detection by rounding floating-point countdown values before comparing them against announcement thresholds.

## Changes Made

- Rounded `secondsLeft` using `Math.round()` before milestone evaluation.
- Updated milestone comparisons to use the rounded countdown value.
- Preserved the existing announcement thresholds (1 minute, 5 minutes, 10 minutes, and 1 hour).
- Ensured accessibility announcements are triggered reliably for countdown values derived from timestamp calculations.

## Problem

Previously, the countdown announcer compared `secondsLeft` directly against milestone values using strict equality.

Since countdown values are often calculated from timestamp differences, they frequently contain floating-point values (for example, `59.8` or `60.001`). As a result, milestone comparisons failed, preventing important accessibility announcements from being triggered.

## Solution

The countdown value is now rounded before evaluating milestone thresholds.

By comparing rounded values instead of raw floating-point values, accessibility announcements are triggered correctly when the countdown reaches the configured milestones, while preserving the existing announcement behavior.