### PR TITLE
fix: detect inline event handler payloads in CSP validator

### DIFF
--- a/src/utils/cspReportValidator.js
+++ b/src/utils/cspReportValidator.js
@@ -12,7 +12,7 @@ export function isValidCspReport(report) {
   // Prevent script/HTML tag injection in reports
   const blockedUri = payload["blocked-uri"];
   if (typeof blockedUri === "string") {
-    if (/<script|javascript:|data:/i.test(blockedUri)) {
+    if (/<script|javascript:|data:|<[a-z]+[^>]*on[a-z]+/i.test(blockedUri)) {
       return false;
     }
   }


### PR DESCRIPTION
## Description

### Summary

This PR strengthens the CSP report validator by extending the validation pattern to detect HTML payloads containing inline JavaScript event handler attributes.

Previously, the validator only rejected payloads containing:

- `<script`
- `javascript:`
- `data:`

As a result, HTML such as:

```html
<img src=x onerror=alert(1)>
<svg onload=alert(1)>
```

could bypass validation because inline event handlers were not matched.

### Changes Made

- Extended the validation regex to detect HTML tags containing inline event handler attributes (e.g. `onclick`, `onload`, `onerror`).
- Preserved existing validation behavior for previously blocked payloads.

### Impact

- Prevents unsafe HTML payloads containing inline event handlers from bypassing validation.
- Improves CSP report validation without changing existing API behavior.

Closes #11969