### PR TITLE
fix: preserve valid primitive values in safeParseJson

### DIFF
--- a/src/utils/jsonUtils.js
+++ b/src/utils/jsonUtils.js
@@ -6,7 +6,7 @@
  * @returns {any} The parsed object or the fallback value.
  */
 export const safeParseJson = (jsonString, fallback = null) => {
-  if (!jsonString) return fallback;
+  if (jsonString === null || jsonString === undefined || jsonString === "") return fallback;
   try {
     return JSON.parse(jsonString);
   } catch {


### PR DESCRIPTION
## Description

### Summary

This PR updates `safeParseJson` to distinguish between missing values and valid primitive values.

Previously, the function treated all falsy values as invalid input:

```js
if (!jsonString) return fallback;
```

This caused valid primitive values such as `0` and `false` to incorrectly return the fallback value.

### Changes Made

- Replaced the generic falsy check with explicit validation for:
  - `null`
  - `undefined`
  - empty strings (`""`)
- Preserved parsing behavior for valid primitive values such as `0` and `false`.

### Impact

- Prevents valid JSON primitive values from being discarded unexpectedly.
- Improves parsing correctness while maintaining existing behavior for missing or empty inputs.

Closes #11970