### PR TITLE
fix: handle future timestamps in relative time formatter

### DIFF
--- a/src/utils/LastUpdatedUtils.js
+++ b/src/utils/LastUpdatedUtils.js
@@ -6,6 +6,8 @@ export const getLastUpdated = (date) => {
 
   const seconds = Math.floor((now - updated) / 1000);
 
+  if (seconds < 0) return "Just now";
+
   const minutes = Math.floor(seconds / 60);
 
   const hours = Math.floor(minutes / 60);


### PR DESCRIPTION
## Description

### Summary

This PR updates the relative time formatter to explicitly handle timestamps that are in the future.

Previously, the utility assumed every timestamp represented a past event. If the supplied timestamp was slightly ahead of the current time (for example, due to server clock skew), the computed elapsed time became negative and the formatter incorrectly fell through to the default output.

### Changes Made

- Added an explicit check for negative elapsed time values.
- Return `"Just now"` immediately when the calculated time difference is less than zero.
- Preserve existing behavior for valid past timestamps.

### Impact

- Prevents misleading relative time formatting when timestamps are slightly ahead of the client's clock.
- Improves robustness against server/client clock differences.
- Does not affect existing behavior for normal elapsed-time calculations.

Closes #11971