### PR TITLE
fix: trim search query before highlighting matches

### DIFF
--- a/src/utils/highlightMatch.js
+++ b/src/utils/highlightMatch.js
@@ -35,8 +35,11 @@ const highlightMatch = (text, query) => {
   // Nothing to highlight — return the original text unchanged
   if (!query || !text) return text;
 
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return text;
+
   // Escape the query so metacharacters are treated as literals, not regex syntax
-  const safeQuery = escapeRegex(query);
+  const safeQuery = escapeRegex(normalizedQuery);
 
   // Capture group around safeQuery so Array.split() retains the matched segments
   const regex = new RegExp(`(${safeQuery})`, "gi");
@@ -44,7 +47,7 @@ const highlightMatch = (text, query) => {
   const parts = text.split(regex);
 
   return parts.map((part, index) =>
-    part.toLowerCase() === query.toLowerCase() ? (
+    part.toLowerCase() === normalizedQuery.toLowerCase() ? (
       <span
         key={`${part}-${index}`}
         className="


### PR DESCRIPTION
## Description

### Summary

This PR improves the search highlighting utility by trimming leading and trailing whitespace from the search query before building the regular expression and performing text comparisons.

Previously, queries containing accidental surrounding whitespace (for example, `" react "`) failed to highlight otherwise valid matches because the whitespace was included in both the regex and comparison logic.

### Changes Made

- Normalize the search query using `trim()`.
- Return early if the normalized query is empty after trimming.
- Use the normalized query when:
  - Escaping regex characters.
  - Building the search regular expression.
  - Comparing matched text segments.

### Impact

- Correctly highlights matches when users accidentally include leading or trailing whitespace.
- Preserves existing highlighting behavior for valid queries.
- Improves overall search usability without affecting existing functionality.

Closes #11972