### PR TITLE
fix: handle invalid CSS selectors in scrollToElement

### DIFF
--- a/src/utils/lenisUtils.js
+++ b/src/utils/lenisUtils.js
@@ -12,7 +12,12 @@ const isBrowser = () => typeof window !== "undefined";
  */
 export const scrollToElement = (selector, options = {}) => {
   if (!isBrowser()) return;
-  const element = document.querySelector(selector);
+  let element;
+  try {
+    element = document.querySelector(selector);
+  } catch {
+    return;
+  }
   if (element && window.lenis) {
     window.lenis.scrollTo(element, {
       offset: 0,


### PR DESCRIPTION
## Description

### Summary

This PR improves the `scrollToElement` utility by gracefully handling invalid CSS selectors passed to `document.querySelector()`.

Previously, malformed or unescaped selectors caused `document.querySelector()` to throw a `DOMException`, interrupting scrolling behavior and potentially crashing navigation components.

### Changes Made

- Wrapped the `document.querySelector()` call in a `try...catch` block.
- Return early when an invalid selector causes an exception.
- Preserve the existing scrolling behavior for valid selectors.

### Impact

- Prevents runtime `DOMException`s caused by malformed CSS selectors.
- Makes scrolling utilities more robust against invalid or dynamically generated selectors.
- Does not affect behavior for valid selectors.

Closes #11973