### PR TITLE
fix(auth): return 400 for invalid Google tokens instead of 500 (closes #12079)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -79,6 +79,13 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(InvalidGoogleTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidGoogleToken(
+            InvalidGoogleTokenException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(RegistrationClosedException.class)
     public ResponseEntity<ErrorResponse> handleRegistrationClosed(
             RegistrationClosedException ex,

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLoginTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLoginTests.java
@@ -111,4 +111,14 @@ public class AuthLoginTests {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("POST /api/auth/google with an invalid token returns 400, not 500 (#12079)")
+    void testGoogleLoginInvalidTokenReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/auth/google")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"token\":\"not-a-valid-google-token\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Invalid Google token"));
+    }
 }


### PR DESCRIPTION
## Problem

`POST /api/auth/google` returns `500 Internal Server Error` when an invalid or malformed Google ID token is submitted, because the exception handler that maps `InvalidGoogleTokenException` to `400 Bad Request` was lost during a later merge. The generic `@ExceptionHandler(Exception.class)` now catches it and reports it as a server error, even though an invalid token is a client error.

## Fix

Restore the dedicated handler in `GlobalExceptionHandler` that maps `InvalidGoogleTokenException` to `400 Bad Request`. `GoogleAuthService` already throws `InvalidGoogleTokenException` for unverifiable tokens and `AuthService.googleLogin` already lets it propagate, so the handler is the only missing piece.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java` — added `@ExceptionHandler(InvalidGoogleTokenException.class)` returning `400 Bad Request`.
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLoginTests.java` — regression test asserting invalid Google token returns 400 (not 500).

## Testing

- Added `POST /api/auth/google` with an invalid token now returns `400` with message "Invalid Google token".
- Ran the backend test suite (AuthLoginTests) against the `test` profile (H2).

Closes #12079
