### PR TITLE
fix(hooks): resolve React Hook violations in useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -95,37 +95,36 @@ const useLocalStorage = (key, initialValue) => {
     }
   }, [key]);
 
-  useEffect(() => {
-    const handleStorageChange = (event) => {
-      // 🔥 FIX: Reset the internal-write flag UNCONDITIONALLY first.
-      // Previously the flag was only reset when bailing out at this check,
-      // so if a foreign `local-storage` event arrived for a different key
-      // (another useLocalStorage instance on the page) the flag would get
-      // stuck at `true` and every subsequent legitimate cross-tab update for
-      // THIS key would be silently dropped.
-      if (isInternalWrite.current) {
-        isInternalWrite.current = false;
-        return;
-      }
+  const handleStorageChange = useCallback((event) => {
+    // 🔥 FIX: Reset the internal-write flag UNCONDITIONALLY first.
+    // Previously the flag was only reset when bailing out at this check,
+    // so if a foreign `local-storage` event arrived for a different key
+    // (another useLocalStorage instance on the page) the flag would get
+    // stuck at `true` and every subsequent legitimate cross-tab update for
+    // THIS key would be silently dropped.
+    if (isInternalWrite.current) {
+      isInternalWrite.current = false;
+      return;
+    }
 
-      if (event.key === key || (event.type === "local-storage" && event.detail?.key === key)) {
-        setStoredValue(readValue());
-      }
-    };
-
-    const handlerRef = useRef(handleStorageChange);
-    handlerRef.current = handleStorageChange;
-    
-    useEffect(() => {
-      const handler = (e) => handlerRef.current(e);
-      window.addEventListener("storage", handler);
-      window.addEventListener("local-storage", handler);
-      return () => {
-        window.removeEventListener("storage", handler);
-        window.removeEventListener("local-storage", handler);
-      };
-    }, []);
+    if (event.key === key || (event.type === "local-storage" && event.detail?.key === key)) {
+      setStoredValue(readValue());
+    }
   }, [key, readValue]);
+
+  const handlerRef = useRef(handleStorageChange);
+  handlerRef.current = handleStorageChange;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = (e) => handlerRef.current(e);
+    window.addEventListener("storage", handler);
+    window.addEventListener("local-storage", handler);
+    return () => {
+      window.removeEventListener("storage", handler);
+      window.removeEventListener("local-storage", handler);
+    };
+  }, []);
 
   return [storedValue, setValue, removeValue];
 };


### PR DESCRIPTION
## Fix React Hooks Violation in `useLocalStorage`

### Overview
This Pull Request addresses a critical architectural bug in the `useLocalStorage` custom hook (`src/hooks/useLocalStorage.js`) where React's Rules of Hooks were being violated. 

Previously, a `useRef` and a `useEffect` were dynamically instantiated *inside* of a parent `useEffect` block. Because React relies on the exact order in which hooks are called to preserve state and side-effects across renders, nesting them conditionally or within callbacks can lead to unpredictable application state, memory leaks, and severe re-render bugs.

### Changes Implemented
1. **Un-nested React Hooks:** Extracted the inner `useRef` and `useEffect` hooks so they execute cleanly and unconditionally at the top level of the custom hook.
2. **Stable Reference with `useCallback`:** Wrapped the `handleStorageChange` logic inside a `useCallback` to ensure the function reference doesn't unnecessarily recreate itself across re-renders unless its dependencies (`key` and `readValue`) change.
3. **Latest-Closure Pattern (`handlerRef`):** Utilized the `handlerRef` pattern (often referred to as `useLatest`) to maintain a reference to the freshest version of the `handleStorageChange` callback. This allows the `window` event listeners (`storage` and `local-storage`) to maintain access to the latest state variables without needing to be torn down and re-attached on every render cycle.

### Validation & Testing
- **Linter Checks:** Ran `npm run lint` (`eslint src/hooks/useLocalStorage.js`) which now passes with 0 warnings and 0 errors, officially resolving the `react-hooks/rules-of-hooks` violation.
- **Event Listeners:** Verified that the cross-tab `local-storage` synchronization logic remains fully functional and will not drop events for other instances.

### Related Issues
- Fixes #12093 

### Deployment Notes
This is a non-breaking structural refactor. Components consuming `useLocalStorage` (such as user preferences, auth state, or theme toggles) will continue to work exactly as expected but with improved stability and performance.
