### PR TITLE
fix: compare JWT and password timestamps using epoch seconds

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 
@@ -63,7 +64,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Date tokenIssuedAt = jwtTokenProvider.getIssuedAtDateFromToken(token);
                 Optional<User> userOpt = userRepository.findByEmail(username);
                 if (userOpt.isPresent() && userOpt.get().getPasswordChangedAt() != null) {
-                    if (tokenIssuedAt.before(userOpt.get().getPasswordChangedAt())) {
+                    long tokenIssuedSec = tokenIssuedAt.getTime() / 1000;
+                    long passwordChangedSec = userOpt.get().getPasswordChangedAt()
+                            .atZone(ZoneId.systemDefault())
+                            .toEpochSecond();
+                    if (tokenIssuedSec < passwordChangedSec) {
                         logger.warn("Token issued before password change for user: {}", username);
                         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                         response.getWriter().write("Token invalidated by password change");


### PR DESCRIPTION
## Summary

This PR fixes timestamp precision inconsistencies when validating JWTs after a password change.

### Changes Made

- Compare JWT issued-at (`iat`) and `passwordChangedAt` using epoch seconds.
- Eliminate false token invalidation caused by sub-second precision differences.
- Preserve the existing password-change token invalidation logic.

Fixes #12145