### PR TITLE
fix: validate event ownership for JWT ticket QR codes

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -230,13 +230,50 @@ export default function TicketScanner() {
       }
     } catch {
       if (decodedText.startsWith("eyJ") && decodedText.split(".").length === 3) {
-        const activeEvent = events.find(e => String(e.id) === String(selectedEventId));
-        ticketData = {
-          ticketId: decodedText,
-          eventId: selectedEventId,
-          userName: "Attendee",
-          eventName: activeEvent ? activeEvent.title : "Active Event"
-        };
+        try {
+          const payload = JSON.parse(atob(decodedText.split(".")[1]));
+          const activeEvent = events.find(e => String(e.id) === String(selectedEventId));
+          const ticketEventId = payload.eventId || payload.event_id;
+          if (ticketEventId && String(ticketEventId) !== String(selectedEventId)) {
+            setScanResult({
+              status: "flagged",
+              message: "This ticket is for a different event.",
+              raw: decodedText,
+            });
+            toast.error("Security Alert: Ticket does not match selected event!");
+            addToHistory({
+              id: `flagged-${Date.now()}`,
+              ticketId: decodedText.slice(0, 20),
+              name: "Unknown",
+              event: activeEvent ? activeEvent.title : "Unknown",
+              status: "Flagged",
+              time: new Date().toISOString(),
+            });
+            return;
+          }
+          ticketData = {
+            ticketId: decodedText,
+            eventId: ticketEventId || selectedEventId,
+            userName: payload.userName || payload.name || "Attendee",
+            eventName: activeEvent ? activeEvent.title : "Active Event"
+          };
+        } catch {
+          setScanResult({
+            status: "flagged",
+            message: "Invalid ticket format.",
+            raw: decodedText,
+          });
+          toast.error("Security Alert: Invalid Ticket QR Code scanned!");
+          addToHistory({
+            id: `flagged-${Date.now()}`,
+            ticketId: decodedText.slice(0, 20),
+            name: "Unknown",
+            event: "Unknown",
+            status: "Flagged",
+            time: new Date().toISOString(),
+          });
+          return;
+        }
       } else {
         setScanResult({
           status: "flagged",


### PR DESCRIPTION
## Summary

This PR improves ticket scanner security by validating that scanned JWT-like ticket payloads belong to the currently selected event before accepting them.

### Changes Made

- Decode JWT-like QR payloads before constructing ticket data.
- Validate the embedded `eventId` against the selected event.
- Reject tickets that belong to a different event.
- Flag malformed or invalid ticket payloads.
- Display an appropriate security warning for invalid scans.

Fixes #12146