### PR TITLE
fix: execute registration retries in new transactions

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -32,6 +32,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -431,12 +432,10 @@ public class EventService {
      * @param userEmail email extracted from JWT principal
      * @return registration confirmation response
      */
-    @Transactional
     public RegistrationResponse registerUserForEvent(Long eventId, String userEmail, String seatId) {
         return registerUserForEvent(eventId, userEmail, seatId, false);
     }
 
-    @Transactional
     public RegistrationResponse registerUserForEvent(
             Long eventId,
             String userEmail,
@@ -447,7 +446,7 @@ public class EventService {
 
         for (int attempt = 1; attempt <= MAX_REGISTRATION_RETRIES; attempt++) {
             try {
-                return executeRegistration(eventId, userEmail, seatId, showProfileInAttendeeDirectory);
+                return executeRegistrationInNewTransaction(eventId, userEmail, seatId, showProfileInAttendeeDirectory);
 
             } catch (ObjectOptimisticLockingFailureException ex) {
                 lastConflict = ex;
@@ -470,6 +469,15 @@ public class EventService {
 
         throw new RegistrationConflictException(
                 "Registration could not be completed due to high demand. Please try again.");
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RegistrationResponse executeRegistrationInNewTransaction(
+            Long eventId,
+            String userEmail,
+            String seatId,
+            boolean showProfileInAttendeeDirectory) {
+        return executeRegistration(eventId, userEmail, seatId, showProfileInAttendeeDirectory);
     }
 
 


### PR DESCRIPTION
## Summary

This PR fixes the event registration retry mechanism by executing each retry attempt in a separate transaction.

### Changes Made

- Removed transaction scope from the retry loop.
- Added a dedicated `executeRegistrationInNewTransaction()` method.
- Configured the new method with `Propagation.REQUIRES_NEW`.
- Updated the retry loop to invoke the new transactional method for every retry attempt.

This prevents retry attempts from executing inside a rollback-only transaction after an optimistic locking failure.

Fixes #12147