### PR TITLE
fix: prevent administrators from deleting active accounts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -111,6 +111,11 @@ public class AdminService {
         User targetUser = userRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
 
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && targetUser.getEmail().equalsIgnoreCase(auth.getName())) {
+            throw new IllegalArgumentException("Administrators cannot delete their own active account.");
+        }
+
         Role callerRole = getAuthenticatedRole();
         if (callerRole != Role.SUPER_ADMIN && targetUser.getRole() == Role.SUPER_ADMIN) {
             throw new AccessDeniedException("Only SUPER_ADMIN users can delete SUPER_ADMIN accounts");


### PR DESCRIPTION
## Summary

This PR prevents administrators from deleting the account associated with their currently authenticated session.

### Changes Made

- Retrieved the currently authenticated principal from the security context.
- Compared the authenticated user's email with the target account.
- Prevented self-deletion by throwing an `IllegalArgumentException`.
- Preserved the existing role-based authorization checks for deleting other users.

This avoids inconsistent authentication state caused by active sessions referencing deleted user accounts.

Fixes #12148