### PR TITLE
fix: handle empty waitlists when assigning first position

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -341,7 +341,8 @@ public class EventService {
         EventWaitlist entry = new EventWaitlist();
         entry.setEvent(event);
         entry.setUser(user);
-        entry.setPosition(eventWaitlistRepository.findMaxPositionByEventId(eventId) + 1);
+        Integer maxPosition = eventWaitlistRepository.findMaxPositionByEventId(eventId);
+        entry.setPosition(maxPosition != null ? maxPosition + 1 : 1);
         entry.setStatus("WAITING");
 
         return toWaitlistResponse(eventWaitlistRepository.save(entry));


### PR DESCRIPTION
## Summary

This PR fixes a NullPointerException that occurred when adding the first user to an event waitlist.

### Changes
- Handle `null` values returned by `findMaxPositionByEventId()`.
- Assign position `1` when the waitlist is empty.
- Preserve existing behavior by assigning `maxPosition + 1` when entries already exist.

### Result

- Prevents `NullPointerException` for empty waitlists.
- Allows the first waitlist entry to be created successfully.
- Maintains sequential waitlist ordering.

Closes #12162