### PR TITLE
fix: require authentication before project upvotes

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -66,26 +66,26 @@ public class ProjectService {
         Project project = projectRepository.findById(id)
                 .orElseThrow(() -> new ProjectNotFoundException("Project not found with id: " + id));
 
-        User user = userRepository.findByEmail(userEmail).orElse(null);
-        if (user != null) {
-            if (projectUpvoteRepository.existsByProject_IdAndUser_Id(id, user.getId())) {
-                throw new RegistrationConflictException("You have already upvoted this project.");
-            }
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("Authentication required to upvote projects."));
 
-            ProjectUpvote upvote = ProjectUpvote.builder()
-                    .project(project)
-                    .user(user)
-                    .build();
+        if (projectUpvoteRepository.existsByProject_IdAndUser_Id(id, user.getId())) {
+            throw new RegistrationConflictException("You have already upvoted this project.");
+        }
 
-            // Two concurrent requests from the same user can both pass the
-            // existsBy guard before either insert commits; the second insert
-            // then violates the (project_id, user_id) unique constraint.
-            // Surface that as a friendly conflict instead of a 500 (#11776).
-            try {
-                projectUpvoteRepository.save(upvote);
-            } catch (DataIntegrityViolationException ex) {
-                throw new RegistrationConflictException("You have already upvoted this project.");
-            }
+        ProjectUpvote upvote = ProjectUpvote.builder()
+                .project(project)
+                .user(user)
+                .build();
+
+        // Two concurrent requests from the same user can both pass the
+        // existsBy guard before either insert commits; the second insert
+        // then violates the (project_id, user_id) unique constraint.
+        // Surface that as a friendly conflict instead of a 500 (#11776).
+        try {
+            projectUpvoteRepository.save(upvote);
+        } catch (DataIntegrityViolationException ex) {
+            throw new RegistrationConflictException("You have already upvoted this project.");
         }
 
         // The bulk UPDATE below is marked clearAutomatically so the subsequent


### PR DESCRIPTION
## Summary

This PR fixes a security issue where unauthenticated requests could increment project upvote counts.

### Changes

- Require a valid authenticated user before processing project upvotes.
- Replace the nullable user lookup with `orElseThrow(...)`.
- Prevent vote count increments when authentication fails.
- Preserve existing duplicate upvote validation for authenticated users.

### Result

- Blocks unauthenticated project upvotes.
- Ensures vote counts are updated only after successful authentication.
- Preserves duplicate vote protection.

Closes #12163