### PR TITLE
fix: clear persistence context after bulk notification update

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
@@ -16,7 +16,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Optional<Notification> findByIdAndUserEmail(Long id, String email);
     void deleteByUser_Id(Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.user.email = :email AND n.isRead = false")
     int markAllAsReadByUserEmail(@Param("email") String email);
 }


### PR DESCRIPTION
## Summary

This PR fixes stale notification read states returned after bulk notification updates within the same transaction.

### Changes

- Added `clearAutomatically = true` to the `@Modifying` annotation.
- Added `flushAutomatically = true` to ensure pending changes are flushed before executing the bulk update.
- Ensures the persistence context is cleared after the update so subsequent reads fetch fresh data from the database.

### Result

- Notification responses immediately reflect updated read status.
- Eliminates stale entities caused by Hibernate's first-level cache after bulk updates.
- Keeps notification state consistent within the same transaction.

Closes #12164