### PR TITLE
test(events): regression coverage for cancel request DTO (#12070)

### DIFF
--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/CancelEventRequestTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/CancelEventRequestTests.java
@@ -1,0 +1,108 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.NotificationRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #12070 — the backend failed to compile because the cancel endpoint
+ * referenced a missing {@code CancelEventRequest} DTO. This test pins the
+ * end-to-end cancel flow so a missing/renamed DTO breaks the build again.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CancelEventRequestTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private Event existingEvent;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userRepository.save(User.builder()
+                .firstName("Admin")
+                .lastName("User")
+                .email("admin@example.com")
+                .username("admin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+
+        Event event = new Event();
+        event.setTitle("Event to cancel");
+        event.setDescription("Description");
+        event.setLocation("Location");
+        event.setEventDate(LocalDateTime.now().plusDays(5));
+        event.setCapacity(100);
+        event.setPublic(true);
+        existingEvent = eventRepository.save(event);
+    }
+
+    @Test
+    @DisplayName("POST /api/events/{id}/cancel accepts a valid CancelEventRequest body")
+    void cancelEvent_WithValidRequest_Succeeds() throws Exception {
+        mockMvc.perform(post("/api/events/" + existingEvent.getId() + "/cancel")
+                        .with(user("admin@example.com").authorities(new SimpleGrantedAuthority("ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("reason", "Venue unavailable", "refundPolicy", "FULL"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(existingEvent.getId()))
+                .andExpect(jsonPath("$.status").value("CANCELLED"))
+                .andExpect(jsonPath("$.refundPolicy").value("FULL"));
+    }
+
+    @Test
+    @DisplayName("POST /api/events/{id}/cancel with a missing refund policy returns 400")
+    void cancelEvent_WithoutRefundPolicy_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/events/" + existingEvent.getId() + "/cancel")
+                        .with(user("admin@example.com").authorities(new SimpleGrantedAuthority("ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "Venue unavailable"))))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Problem
Issue #12070: the backend would not compile because the cancel-event endpoint (`POST /api/events/{id}/cancel`) referenced a `CancelEventRequest` DTO that did not exist.

## Fix
The DTO is already present in `origin/master`. Nothing in the test suite pinned the endpoint wiring, so a missing or renamed DTO could silently regress the build again. Add `CancelEventRequestTests`, an end-to-end regression test that exercises the cancel endpoint through MockMvc:
- a valid body (`reason` + `refundPolicy: FULL`) returns 200 with the event marked `CANCELLED`;
- a body without the required `refundPolicy` returns 400.

## Files changed
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/CancelEventRequestTests.java` (new)

## Testing
- Not run locally (Maven wrapper is broken in this checkout); follows the MockMvc conventions of the existing `EventCancelTests`/`EventDeleteTests`.
- Compiles against the existing `CancelEventRequest`, `EventService.cancelEvent`, and the global 400 handler for validation errors.

Closes #12070
