### PR TITLE
test(notifications): cover undo-restore of a deleted notification (#12074)

### DIFF
--- a/src/hooks/useNotificationPoller.test.js
+++ b/src/hooks/useNotificationPoller.test.js
@@ -1,8 +1,13 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useNotificationPoller } from "./useNotificationPoller";
+import { showUndoToast } from "../utils/toast.js";
 
 vi.mock("../context/AuthContext", () => ({
   useAuth: () => ({ token: "tok-123", user: { id: "user-1" } }),
+}));
+
+vi.mock("../utils/toast.js", () => ({
+  showUndoToast: vi.fn(),
 }));
 
 vi.mock("./usePageVisibility", () => ({
@@ -96,5 +101,50 @@ describe("useNotificationPoller - deleteNotification", () => {
 
     expect(result.current.unreadCount).toBe(1);
     expect(result.current.notifications.find((n) => n.id === "n2")).toBeUndefined();
+  });
+
+  it("restores a deleted notification and its unread count when undo is triggered (#12074)", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        { id: "n1", isRead: false, title: "Unread one", timestamp: "2026-01-01T00:00:00.000Z" },
+        { id: "n2", isRead: true, title: "Read one", timestamp: "2026-01-01T00:00:00.000Z" },
+      ],
+    });
+
+    const hasCompletedInitialFetchRef = { current: false };
+    const deliverNew = vi.fn();
+
+    const { result } = renderHook(() =>
+      useNotificationPoller(deliverNew, hasCompletedInitialFetchRef),
+    );
+
+    await waitFor(() => expect(result.current.notifications).toHaveLength(2));
+    expect(result.current.unreadCount).toBe(1);
+
+    await act(async () => {
+      await result.current.deleteNotification("n1");
+    });
+
+    expect(result.current.notifications.find((n) => n.id === "n1")).toBeUndefined();
+    expect(result.current.unreadCount).toBe(0);
+
+    const toastCall = vi.mocked(showUndoToast).mock.calls[0][0];
+    expect(toastCall.onUndo).toBeTypeOf("function");
+    expect(toastCall.onCommit).toBeTypeOf("function");
+
+    await act(async () => {
+      toastCall.onUndo();
+    });
+
+    const restored = result.current.notifications.find((n) => n.id === "n1");
+    expect(restored).toBeDefined();
+    expect(restored.isRead).toBe(false);
+    expect(result.current.unreadCount).toBe(1);
+
+    const persisted = JSON.parse(localStorage.getItem("eventra_notification_inbox"));
+    expect(persisted.some((n) => n.id === "n1")).toBe(true);
+
+    // Undo cancels the commit, so the delete must not reach the server.
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
Issue #12074: deleting a notification shows an undo toast whose `onUndo` restores the notification (and its unread count) from the captured target. No test exercised that restore path, and a regression would silently eat notifications.

## Fix
Add an undo-restore regression test to `useNotificationPoller.test.js`:
- Mock `showUndoToast` to capture the toast handlers.
- Delete an unread notification, verify it leaves state and the unread count drops.
- Invoke `onUndo` and assert the notification (still unread) comes back in state, the unread count is restored, and the persisted inbox contains it again.
- Assert the server-side delete is never committed after an undo.

## Files changed
- `src/hooks/useNotificationPoller.test.js`

## Testing
- `npx vitest run src/hooks/useNotificationPoller.test.js` → 3 tests pass.

Closes #12074
