### PR TITLE
fix(api): repair mangled api.js and pin EVENTS.SCHEDULE contract (#12075)

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { ENV } from "./env";
 import { syncServerTimeFromHeader } from "../utils/timeSync";
 import { createIntegrityHeader } from "../utils/security/requestIntegrity";
-import { ApiError, RateLimitError, normalizeApiError } from "./api/errors.js";
+import { ApiError, RateLimitError } from "./api/errors.js";
 import { setupRequestInterceptor, setupResponseInterceptor, setOnRequiresReauthHandler } from "./api/interceptors.js";
 import { API_BASE_URL, validateBackendConfig } from "./backendConfig.js";
 
@@ -68,34 +68,6 @@ export const setAuthToken = (token) => {
  * backend must derive identity from the verified JWT, not from client-supplied
  * body fields.
  */
-const normalizeRequestConfig = (configOrToken = {}) => {
-  const config = typeof configOrToken === "string" ? {} : { ...configOrToken };
-
-  if ("skipAuth" in config) {
-    delete config.skipAuth;
-  }
-  return config;
-};
-
-const wrapHeaders = (headers) => {
-  if (!headers) return { get: () => null };
-  if (typeof headers.get === "function") return headers;
-  return {
-    get: (key) => headers[key] || headers[key.toLowerCase()] || null,
-  };
-};
-
-const wrapAxiosResponse = (response) => {
-  const wrappedHeaders = wrapHeaders(response.headers);
-  return {
-    ...response,
-    headers: wrappedHeaders,
-    ok: response.status >= 200 && response.status < 300,
-    json: async () => response.data,
-    text: async () =>
-      typeof response.data === "string" ? response.data : JSON.stringify(response.data),
-  };
-};
 const normalizeApiError = (error) => {
   const config = error.config || {};
   const status = error?.response?.status;
@@ -179,42 +151,15 @@ API.interceptors.response.use(
     }
     return response;
   },
-  async (error) => {
-    const config = error.config || {};
+  (error) => {
     const status = error?.response?.status;
-
     if (status === 401 && onUnauthorized) {
       onUnauthorized();
     }
-
-    const retryCount = config._retryCount || 0;
-    const isNonMutating = RETRYABLE_METHODS.has(config.method?.toUpperCase() ?? "");
-    const isRetryableStatus = RETRYABLE_STATUS_CODES.includes(status);
-    
-    // Retry only idempotent reads/probes. Do not blind-retry mutations or 429s,
-    // because those can duplicate writes or worsen server-side rate limiting.
-    if (isNonMutating && isRetryableStatus && retryCount < MAX_RETRIES) {
-      config._retryCount = retryCount + 1;
-      const delay = RETRY_DELAY_MS * Math.pow(2, retryCount);
-API.interceptors.request.use((config) => {
-  if (isDev) {
-    logger.info(`[API ${config.method?.toUpperCase()}]`, buildApiUrl(config.url || ""));
+    return Promise.reject(error);
   }
+);
 
-  if (_authToken && _authToken !== "cookie-managed") {
-    config.headers["Authorization"] = `Bearer ${_authToken}`;
-  }
-
-  const method = config.method?.toUpperCase();
-  if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
-    const csrf = getCSRFToken();
-    if (csrf) {
-      config.headers["X-CSRF-Token"] = csrf;
-    }
-  }
-
-setupRequestInterceptor(API, { isDev, buildApiUrl, getAuthToken, getOnUnauthorized });
-setupResponseInterceptor(API, { isDev, timeoutMs: REQUEST_TIMEOUT_MS, getOnUnauthorized, getOnRequiresReauth });
 setupRequestInterceptor(API, {
   isDev,
   buildApiUrl,

--- a/src/config/api.test.js
+++ b/src/config/api.test.js
@@ -1,0 +1,15 @@
+import { API_ENDPOINTS } from "./api";
+
+describe("API_ENDPOINTS.EVENTS.SCHEDULE", () => {
+  it("is a function that builds the schedule URL for an event id (#12075)", () => {
+    expect(typeof API_ENDPOINTS.EVENTS.SCHEDULE).toBe("function");
+    const url = API_ENDPOINTS.EVENTS.SCHEDULE(123);
+    expect(url).toMatch(/\/events\/123\/schedule$/);
+  });
+
+  it("produces distinct URLs for distinct events", () => {
+    const urlA = API_ENDPOINTS.EVENTS.SCHEDULE(1);
+    const urlB = API_ENDPOINTS.EVENTS.SCHEDULE(2);
+    expect(urlA).not.toBe(urlB);
+  });
+});


### PR DESCRIPTION
## Problem
Issue #12075: `API_ENDPOINTS.EVENTS.SCHEDULE` is consumed as a function by its call sites, but there was no test pinning that contract. While adding one, we found `src/config/api.js` itself is syntactically invalid on `master`: the #10258 request-integrity merge left a duplicate `normalizeApiError` declaration, a duplicate `normalizeRequestConfig`/`wrapHeaders`/`wrapAxiosResponse` block, and an unterminated response-interceptor handler that swallowed a stray interceptor paste and the `API_ENDPOINTS` export — the file cannot even be parsed (oxc/esbuild: "Unexpected export").

## Fix
Restore `api.js` to a valid state:
- Drop `normalizeApiError` from the `errors.js` import; the local implementation is the one used and re-exported.
- Remove the duplicate helper trio, keeping the canonical JSON-guarded copies.
- Close the response interceptor, keeping 401 handling and rejecting cleanly; retry/CSRF/auth-token logic already lives in `interceptors.js` via `setupRequestInterceptor`/`setupResponseInterceptor`, and the duplicated setup calls are removed.
- Add `src/config/api.test.js` asserting `EVENTS.SCHEDULE` is a function building `/events/:id/schedule` (and distinct per event id).

## Files changed
- `src/config/api.js`
- `src/config/api.test.js` (new)

## Testing
- `npx vitest run src/config/api.test.js` → 2 tests pass (previously the suite could not even load the module).
- `npx vitest run src/hooks/useNotificationPoller.test.js` → still green.
- (Pre-existing, unrelated: `secureStorage.js` has its own duplicate declaration that keeps `AuthContext.test.js`/`waitlistUtils.test.js` red on `master`.)

Closes #12075
