### PR TITLE
test(notifications): pin SSE idle-status background polling (#12076)

### DIFF
--- a/src/context/NotificationContext.test.js
+++ b/src/context/NotificationContext.test.js
@@ -1,0 +1,134 @@
+import { render, act, cleanup } from "@testing-library/react";
+import { NotificationProvider, useNotification } from "./NotificationContext";
+
+const fetchNotifications = vi.fn();
+
+vi.mock("./AuthContext", () => ({
+  useAuth: () => ({ token: "tok-123" }),
+}));
+
+let realtimeStatus = "idle";
+vi.mock("../hooks/useRealTimeConnection", () => ({
+  __esModule: true,
+  default: () => ({ status: realtimeStatus }),
+  SSE_STATUS: { IDLE: "idle", CONNECTED: "connected" },
+}));
+
+vi.mock("../hooks/useNotificationPreferences", () => ({
+  useNotificationPreferences: () => ({
+    preferences: {},
+    defaultPreferences: {},
+    updatePreferences: vi.fn(),
+    savePreferences: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/usePushSubscription", () => ({
+  usePushSubscription: () => ({
+    pushStatus: "unsupported",
+    requestPushPermission: vi.fn(),
+    subscribeToPush: vi.fn(),
+    unsubscribeFromPush: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useNotificationDelivery", () => ({
+  useNotificationDelivery: () => ({
+    showBrowserNotification: vi.fn(),
+    deliverNew: vi.fn(),
+    markAsReadRef: { current: undefined },
+  }),
+}));
+
+vi.mock("../hooks/useNotificationPoller", () => ({
+  useNotificationPoller: () => ({
+    notifications: [],
+    unreadCount: 0,
+    loading: false,
+    fetchNotifications,
+    markAsRead: vi.fn(),
+    markAllAsRead: vi.fn(),
+    deleteNotification: vi.fn(),
+    applyList: vi.fn(),
+    seenIds: { current: new Set() },
+  }),
+}));
+
+vi.mock("../hooks/useAchievements", () => ({
+  useAchievements: () => ({ achievements: [], fetchAchievements: vi.fn() }),
+}));
+
+function Consumer() {
+  useNotification();
+  return null;
+}
+
+describe("useBackgroundInterval - SSE idle polling (#12076)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchNotifications.mockClear();
+    realtimeStatus = "idle";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("polls every 30s while the realtime status is SSE_STATUS.IDLE", async () => {
+    render(
+      <NotificationProvider>
+        <Consumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(fetchNotifications).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(fetchNotifications).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poll when the realtime status is connected", async () => {
+    realtimeStatus = "connected";
+    render(
+      <NotificationProvider>
+        <Consumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(fetchNotifications).not.toHaveBeenCalled();
+  });
+
+  it("stops polling once the status leaves IDLE", async () => {
+    const { rerender } = render(
+      <NotificationProvider>
+        <Consumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(fetchNotifications).toHaveBeenCalledTimes(1);
+
+    realtimeStatus = "connected";
+    rerender(
+      <NotificationProvider>
+        <Consumer />
+      </NotificationProvider>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(fetchNotifications).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem
Issue #12076: `NotificationContext` runs a 30-second background poll only while the SSE realtime status equals `SSE_STATUS.IDLE`. No test covered that the interval fires on the idle state, stays quiet while connected, and stops once the status leaves idle.

## Fix
Add `NotificationContext.test.js` rendering the `NotificationProvider` with mocked hooks and fake timers:
- While status is `SSE_STATUS.IDLE`, the poller fires every 30 s.
- While status is connected, the poller never fires.
- After the status leaves IDLE (via `rerender`), the armed interval is torn down and no further polls occur.

## Files changed
- `src/context/NotificationContext.test.js` (new)

## Testing
- `npx vitest run src/context/NotificationContext.test.js` → 3 tests pass.

Closes #12076
