### PR TITLE
fix(hooks): remove duplicate const declarations in useFormValidation

### DIFF
--- a/src/hooks/useFormValidation.js
+++ b/src/hooks/useFormValidation.js
@@ -36,10 +36,6 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
   const [isFormValid, setIsFormValid] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
 
-  // Fix: valuesRef must be declared AFTER values useState to avoid
-  // "used before declared" React Compiler error.
-  const valuesRef = useRef(initialState);
-
   useEffect(() => {
     validationRulesRef.current = validationRules;
   }, [validationRules]);
@@ -55,12 +51,6 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
   useEffect(() => {
     valuesRef.current = values;
   }, [values]);
-
-  const [values, setValues] = useState(initialState);
-  const [errors, setErrors] = useState({});
-  const [touched, setTouched] = useState({});
-  const [isFormValid, setIsFormValid] = useState(false);
-  const [isValidating, setIsValidating] = useState(false);
 
   const clearValidationTimer = useCallback(() => {
     validationRunRef.current += 1;


### PR DESCRIPTION
Closes #12232

Resolves: [Bug] Duplicate const declarations in useFormValidation.js cause a SyntaxError and break EventRegistration