### PR TITLE
fix(hooks): stop seeding inbox with mock notifications on fetch failure

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -3,7 +3,6 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { apiUtils, API_ENDPOINTS } from "../config/api.js";
 import { useAuth } from "../context/AuthContext.js";
 import usePageVisibility from "./usePageVisibility.js";
-import seedNotifications from "../data/mockNotifications.json";
 import { safeJsonParse } from "../utils/safeJsonParse.js";
 import { getNotificationMessage } from "../utils/notificationPreferences.js";
 import { get as idbGet, del as idbDel } from "idb-keyval";
@@ -142,9 +141,8 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
         applyList(Array.isArray(data) ? data : data?.content || [], { deliverNew: true });
       } catch {
         if (isMounted.current && tokenRef.current === t) {
-          const persisted = loadPersisted(storageKeyRef.current);
-          const fallback = persisted?.length ? persisted : seedNotifications.map(normalize);
-          applyList(fallback, { deliverNew: false });
+          const persisted = loadPersisted(storageKeyRef.current) || [];
+          applyList(persisted, { deliverNew: false });
         }
       } finally {
         if (!options.isBackground && isMounted.current && tokenRef.current === t) setLoading(false);


### PR DESCRIPTION
Closes #12235

Resolves: [Bug] Notification inbox is seeded with hardcoded mock notifications when the fetch fails