### PR TITLE
fix: handle date-only inputs in calendar exporter

### DIFF
--- a/src/utils/calendarExporter.js
+++ b/src/utils/calendarExporter.js
@@ -18,13 +18,18 @@
 // Helper to format Date objects into YYYYMMDDTHHmmSSZ format required by RFC 5545
 const formatToICSDate = (dateInput) => {
   if (!dateInput) return null;
-  const str =
-    dateInput instanceof Date
-      ? dateInput.toISOString()
-      : String(dateInput || "");
-  const date = new Date(str);
-  if (isNaN(date.getTime())) return null;
-  return str.replace(/[-:]/g, "").split(".")[0] + "Z";
+
+  let dateObj;
+  if (dateInput instanceof Date) {
+    dateObj = dateInput;
+  } else {
+    dateObj = new Date(dateInput);
+  }
+
+  if (Number.isNaN(dateObj.getTime())) return null;
+
+  const iso = dateObj.toISOString();
+  return iso.replace(/[-:]/g, "").split(".")[0] + "Z";
 };
 
 // Helper to safely escape special characters in ICS strings (RFC 5545 compliant).


### PR DESCRIPTION
# Summary

Fixes calendar export formatting for date-only string inputs by normalizing all valid date values through JavaScript `Date` objects before generating RFC 5545-compatible UTC timestamps.

## Related Issue

Fixes #12334


## Changes Implemented

- Updated `formatToICSDate` in `src/utils/calendarExporter.js`.
- Added explicit handling for JavaScript `Date` objects.
- Normalized string date inputs using the JavaScript `Date` constructor.
- Added validation for invalid date values using `Number.isNaN(dateObj.getTime())`.
- Converted valid dates to ISO UTC timestamps using `toISOString()`.
- Preserved the existing RFC 5545 timestamp formatting.

## Technical Details

### Frontend

- Updated `src/utils/calendarExporter.js`.
- Date-only inputs such as `2026-08-15` are now normalized through a `Date` object before ICS formatting.

## Testing

### Manual Testing

- [x] Verified JavaScript `Date` inputs are formatted correctly.
- [x] Verified date-only string inputs are normalized before formatting.
- [x] Verified valid dates produce complete UTC date-time values.
- [x] Verified invalid date inputs return `null`.
- [x] Verified existing ICS formatting behavior remains unchanged.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] No unrelated files or changes are included.
- [x] Ready for review.