### PR TITLE
fix: validate cached P2P file chunks before restore

### DIFF
--- a/src/utils/p2pFileTransfer.js
+++ b/src/utils/p2pFileTransfer.js
@@ -153,7 +153,16 @@ export async function getCachedFile(fileId) {
         if (chunks.length > 0) {
           // Sort chunks by index
           chunks.sort((a, b) => a.chunkIndex - b.chunkIndex);
-          resolve(chunks);
+
+          const totalExpected = chunks[0].totalChunks;
+          if (chunks.length === totalExpected) {
+            resolve(chunks);
+          } else {
+            logger.warn(
+              `[P2P Cache] Incomplete file cache found for ${fileId} (${chunks.length}/${totalExpected} chunks)`
+            );
+            resolve(null);
+          }
         } else {
           resolve(null);
         }


### PR DESCRIPTION
# Summary

Prevents interrupted P2P file transfers from being restored from incomplete cached chunk data by validating that all expected chunks are available before returning the cached file.

## Related Issue

Fixes #12335

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Updated the cached file retrieval logic in `p2pFileTransfer.js`.
- Compared the number of cached chunks with the expected `totalChunks` value.
- Return the cached chunks only when the complete file cache is available.
- Return `null` when the cache is incomplete instead of returning partial file data.
- Added a warning message to help identify incomplete cached file transfers.

## Technical Details

### Frontend

- Updated `src/utils/p2pFileTransfer.js`.
- Cached chunks are sorted by `chunkIndex` before completeness validation.
- The expected number of chunks is obtained from the cached metadata.
- Incomplete caches are rejected so they can be handled by the normal transfer/recovery flow.

## Testing

### Manual Testing

- [x] Verified complete cached files are returned successfully.
- [x] Verified incomplete cached files return `null`.
- [x] Verified interrupted transfers do not return partial chunk arrays as complete files.
- [x] Verified cached chunks are ordered by `chunkIndex`.
- [x] Verified a warning is logged when an incomplete cache is detected.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards.
- [x] Changes are limited to the reported issue.
- [x] Self-review completed.
- [x] No unrelated files or changes are included.
- [x] Ready for review.