### PR TITLE
fix: prevent null hackathon owners from bypassing authorization

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -82,9 +82,11 @@ public class HackathonService {
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
 
         boolean isAdmin = currentUser.getRole() == Role.ADMIN || currentUser.getRole() == Role.SUPER_ADMIN;
-        if (!isAdmin && hackathon.getOwnerId() != null && !hackathon.getOwnerId().equals(currentUser.getId())) {
-            throw new AccessDeniedException(
-                    "Only the hackathon's own organizer (or an administrator) can manage this hackathon.");
+        if (!isAdmin) {
+            if (hackathon.getOwnerId() == null || !hackathon.getOwnerId().equals(currentUser.getId())) {
+                throw new AccessDeniedException(
+                        "Only the hackathon's own organizer (or an administrator) can manage this hackathon.");
+            }
         }
 
         hackathon.setTitle(request.getTitle());


### PR DESCRIPTION
## Summary

Fixes a Broken Object-Level Authorization (BOLA/IDOR) issue where hackathons with a missing `ownerId` could bypass the ownership check during updates.

## Related Issue

Fixes #12336

## Problem

The hackathon update authorization logic only performed the ownership comparison when `hackathon.getOwnerId()` was non-null.

For legacy hackathons where `ownerId` is missing, the ownership condition was skipped, allowing a non-admin authenticated user to modify the hackathon.

## Changes

- Treat a missing `ownerId` as unauthorized for non-admin users.
- Require the authenticated user ID to match the hackathon owner ID.
- Preserve access for `ADMIN` and `SUPER_ADMIN` users.

## Authorization Behavior

| User | ownerId | Result |
|------|---------|--------|
| ADMIN / SUPER_ADMIN | Any | Allowed |
| Organizer | Matching user ID | Allowed |
| Organizer | Different user ID | Denied |
| Organizer | `null` | Denied |

## Security Impact

Prevents unauthorized organizers from modifying legacy hackathons that do not have an assigned owner.

## Checklist

- [x] Changes are limited to the reported issue.
- [x] No unrelated functionality was modified.
- [x] Authorization behavior is preserved for administrators.
- [x] Missing ownership information is treated as unauthorized for non-admin users.