### PR TITLE
fix: prevent Google OAuth null email NullPointerException

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -113,12 +113,12 @@ public AuthResponse googleLogin(GoogleAuthRequest request) {
         GoogleIdToken.Payload payload =
                 googleAuthService.verifyToken(request.getToken());
 
-        String email = payload.getEmail().toLowerCase();
-
-        if (email == null || email.isBlank()) {
+        if (payload == null || payload.getEmail() == null || payload.getEmail().isBlank()) {
             throw new IllegalArgumentException(
                     "Google account must provide a valid email address.");
         }
+
+        String email = payload.getEmail().toLowerCase();
 
        String firstName =
         (String) payload.get("given_name");


### PR DESCRIPTION
## Summary

Fixes #12337 by validating the Google OAuth token payload and email claim before performing string operations.

## Problem

`googleLogin()` called `.toLowerCase()` directly on the email returned from the Google ID token.

When the token did not contain an email claim, `payload.getEmail()` returned `null`, causing a `NullPointerException`.

## Changes

- Validate that the Google token payload is not null.
- Validate that the email claim is present.
- Reject blank email values.
- Only normalize the email after successful validation.

## Expected Behavior

Invalid or incomplete Google OAuth payloads now result in a controlled `IllegalArgumentException` instead of an unhandled `NullPointerException`.
