### PR TITLE
fix: validate pagination parameters before building API URLs

### DIFF
--- a/src/utils/eventFetchUtils.js
+++ b/src/utils/eventFetchUtils.js
@@ -65,9 +65,20 @@ export function buildPaginatedUrl(baseUrl, page, size) {
 
   const params = new URLSearchParams(queryString || "");
   
+  // Validate and normalize pagination parameters
+  const validPage =
+    Number.isFinite(Number(page)) && Number(page) >= 0
+      ? Math.floor(Number(page))
+      : 0;
+
+  const validSize =
+    Number.isFinite(Number(size)) && Number(size) > 0
+      ? Math.floor(Number(size))
+      : SERVER_PAGE_SIZE;
+
   // .set() explicitly overwrites existing keys, eliminating duplicate parameter pollution
-  params.set("page", page);
-  params.set("size", size);
+  params.set("page", validPage);
+  params.set("size", validSize);
 
   const newUrl = `${path}?${params.toString()}`;
   return hash ? `${newUrl}#${hash}` : newUrl;


### PR DESCRIPTION
## Summary

Fixes #12338 by validating and normalizing pagination parameters before constructing API URLs.

## Problem

`buildPaginatedUrl()` previously passed `page` and `size` directly to `URLSearchParams`.

When invalid values such as `undefined` or `NaN` were supplied, malformed query parameters could be generated:

`?page=undefined&size=NaN`

This could cause backend pagination requests to fail with HTTP 400 responses.

## Changes

- Validate the `page` parameter.
- Default invalid page values to `0`.
- Validate the `size` parameter.
- Default invalid size values to `SERVER_PAGE_SIZE`.
- Normalize fractional values using `Math.floor()`.
- Use the validated values when constructing the URL.

## Expected Behavior

Invalid pagination values are replaced with safe defaults before the API URL is generated.
