### PR TITLE
fix: return 413 for oversized file uploads

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -15,6 +15,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;
@@ -129,6 +130,15 @@ public class GlobalExceptionHandler {
             AccessDeniedException ex,
             HttpServletRequest request) {
         return buildError(HttpStatus.FORBIDDEN, "Forbidden", "You do not have permission to access this resource", request);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(
+            MaxUploadSizeExceededException ex,
+            HttpServletRequest request) {
+        logger.warn("File upload size exceeded: {}", ex.getMessage());
+        return buildError(HttpStatus.PAYLOAD_TOO_LARGE, "Payload Too Large",
+                "Uploaded file size exceeds the maximum permitted limit. Please upload a smaller file.", request);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary

Fixes #12339 by handling oversized multipart file uploads with the correct HTTP status code.

## Problem

When an uploaded file exceeds the configured multipart upload limit, Spring throws `MaxUploadSizeExceededException`.

Previously, this exception was handled by the generic exception handler, causing the API to return HTTP 500 Internal Server Error.

An oversized request is a client-side payload size issue and should return HTTP 413 Payload Too Large.

## Changes

- Added a dedicated `MaxUploadSizeExceededException` handler.
- Return `HTTP 413 Payload Too Large` for oversized uploads.
- Added a clear error message instructing users to upload a smaller file.
- Log oversized upload attempts at warning level.
- Preserve the existing generic exception handler for other unexpected exceptions.
