### PR TITLE
fix: preserve midnight Do Not Disturb preferences

### DIFF
--- a/src/utils/dndUtils.js
+++ b/src/utils/dndUtils.js
@@ -10,8 +10,8 @@ export const isDndActive = () => {
     if (!prefs.dndEnabled) return false;
     const now = new Date();
     const currentHour = now.getHours();
-    const start = prefs.dndStart || 22;
-    const end = prefs.dndEnd || 8;
+    const start = Number.isInteger(prefs.dndStart) ? prefs.dndStart : 22;
+    const end = Number.isInteger(prefs.dndEnd) ? prefs.dndEnd : 8;
     if (start > end) {
       return currentHour >= start || currentHour < end;
     }


### PR DESCRIPTION
Fixes #12340

## Summary

Fixes an issue where valid Do Not Disturb (DND) preferences could be incorrectly replaced by default values.

## Problem

The DND utility previously used the `||` operator:

```js
const start = prefs.dndStart || 22;
const end = prefs.dndEnd || 8;

This treats valid falsy values such as 0 as missing and replaces them with the default value.