### PR TITLE
fix: handle missing user ID in feedback status

### DIFF
--- a/src/utils/feedbackUtils.js
+++ b/src/utils/feedbackUtils.js
@@ -85,12 +85,12 @@ export const saveFeedback = (eventId, feedback) => {
  */
 export const hasUserSubmittedFeedback = (eventId, userId = null) => {
   try {
-    const feedback = getEventFeedback(eventId);
     if (!userId) {
-      return feedback.length > 0;
+      return false;
     }
-    const userIdSet = new Set(feedback.map((f) => f.userId));
-    return userIdSet.has(userId);
+    const feedback = getEventFeedback(eventId);
+    const userIdSet = new Set(feedback.map((f) => String(f.userId)));
+    return userIdSet.has(String(userId));
   } catch (error) {
     console.warn("Error checking feedback status:", error);
     return false;


### PR DESCRIPTION

Fixes #12341

## Summary

Fixes an issue where `hasUserSubmittedFeedback()` could incorrectly report that feedback was already submitted when no `userId` was provided.

## Problem

The function accepts `userId` as an optional parameter. When `userId` is missing, the existing logic could still perform the feedback lookup and potentially match an invalid or missing user ID.

This could prevent users from submitting feedback even though they had not submitted feedback themselves.

## Changes

- Return `false` immediately when `userId` is missing.
- Normalize feedback user IDs to strings before comparison.
- Normalize the provided `userId` to a string before checking the set.

## Expected Behavior

```js
hasUserSubmittedFeedback(eventId, null);

should return:

false

The function should only return true when the specified user has actually submitted feedback for the event.



