### PR TITLE
fix: keep device fingerprint stable across UTC midnight

### DIFF
--- a/src/utils/deviceFingerprint.js
+++ b/src/utils/deviceFingerprint.js
@@ -74,11 +74,8 @@ export const getDeviceFingerprint = () => {
 
     const fingerprintRaw = `${screenInfo}_${navInfo}_${canvasHash}`;
 
-    // Per-origin salt with time-based rotation: combines origin with a day offset
-    // so fingerprints rotate every 24 hours. The dayOffset uses a fixed epoch
-    // (2020-01-01) for consistent buckets across sessions.
-    const dayOffset = Math.floor((Date.now() - 1577836800000) / 86400000);
-    const salt = `eventra:fingerprint:${window.location.origin}:${dayOffset}`;
+    // Per-origin salt — stable across sessions and UTC day boundaries.
+    const salt = `eventra:fingerprint:${window.location.origin}`;
 
     _memoizedFingerprint = CryptoJS.SHA256(fingerprintRaw + salt).toString();
     return _memoizedFingerprint;
@@ -114,8 +111,7 @@ export const getFastFingerprint = () => {
   try {
     const screenInfo = `${window.screen?.width || 0}x${window.screen?.height || 0}x${window.screen?.colorDepth || 0}`;
     const navInfo = `${window.navigator?.userAgent || ""}_${window.navigator?.language || ""}_${window.navigator?.hardwareConcurrency || 0}`;
-    const dayOffset = Math.floor((Date.now() - 1577836800000) / 86400000);
-    const salt = `eventra:fast-fingerprint:${window.location.origin}:${dayOffset}`;
+    const salt = `eventra:fast-fingerprint:${window.location.origin}`;
     _memoizedFastFingerprint = CryptoJS.SHA256(`${screenInfo}_${navInfo}_${salt}`).toString();
     return _memoizedFastFingerprint;
   } catch {
@@ -143,6 +139,5 @@ export const _clearFingerprintCache = () => {
  */
 export const _getFingerprintSalt = () => {
   if (typeof window === "undefined") return "eventra:fingerprint:test";
-  const dayOffset = Math.floor((Date.now() - 1577836800000) / 86400000);
-  return `eventra:fingerprint:${window.location.origin}:${dayOffset}`;
+  return `eventra:fingerprint:${window.location.origin}`;
 };


### PR DESCRIPTION
## Summary

Fixes an issue where device fingerprints changed automatically at UTC midnight because the fingerprint salt included a time-based day offset.

## Problem

The device fingerprint was generated using a salt containing a `dayOffset` derived from the current UTC date.

Because the offset changes every 24 hours, the generated fingerprint could change at UTC midnight even though the user's device and browser characteristics remained unchanged.

This could cause existing fingerprint-based session or verification checks to fail after midnight.

## Changes

- Removed the time-based `dayOffset` from the fingerprint salt.
- Use the browser origin as the stable salt component.
- Keep the fingerprint dependent on the existing device/browser characteristics.
- Preserve memoization of the generated fingerprint.

## Expected Behavior

The same device should produce a stable fingerprint throughout the browser session and should not generate a different fingerprint solely because the UTC date changes.

## Testing

- Verified the fingerprint generation no longer depends on the current UTC day.
- Verified the fingerprint salt remains stable across UTC midnight.
- Confirmed the existing fingerprint generation flow remains unchanged otherwise.

## Related Issue

Fixes #12342