### PR TITLE
fix: allow super admins to create events

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -55,10 +55,10 @@ public class EventController {
     // ── Issue #2102 — POST /api/events/create ────────────────────────────────
 
     @PostMapping("/create")
-    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     @Operation(
             summary = "Create a new event",
-            description = "Allows an ORGANIZER or ADMIN to create a new event. " +
+            description = "Allows an ORGANIZER, ADMIN, or SUPER_ADMIN to create a new event. " +
                           "The event registeredCount defaults to 0.",
             security = @SecurityRequirement(name = "bearerAuth")
     )


### PR DESCRIPTION
Fixes #12343

## Summary

Fixes the event creation authorization issue where users with the `SUPER_ADMIN` role were incorrectly denied access.

## Problem

The event creation endpoint only allowed users with the following authorities:

- `ORGANIZER`
- `ADMIN`

As a result, authenticated users with `SUPER_ADMIN` authority received `403 Forbidden` when attempting to create an event.

## Changes

Updated the `@PreAuthorize` expression on the event creation endpoint to include `SUPER_ADMIN`.

```java
@PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")