### PR TITLE
fix(auth): set auth cookie on refresh

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -121,7 +121,7 @@ public class AuthController {
                 }
             }
             AuthResponse response = authService.refresh(refreshToken);
-            return ResponseEntity.ok(response);
+            return withAuthCookie(ResponseEntity.ok(), response);
         } catch (Exception ex) {
             ErrorResponse error = ErrorResponse.builder()
                     .status(HttpStatus.UNAUTHORIZED.value())


### PR DESCRIPTION
## Summary
`POST /api/auth/refresh` now uses `withAuthCookie` so cookie-managed browser sessions pick up the new access JWT.

Closes #12438

## Test plan
- [ ] Login, expire access token, refresh, confirm `Set-Cookie` updates `token`
- [ ] Subsequent cookie-authenticated requests succeed

Made with [Cursor](https://cursor.com)