### PR TITLE
fix(events): gate availability and seats behind public filter

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -188,6 +188,14 @@ public class EventService {
          * Retrieves a page of public events with optional search / status / sort.
          */
         @Transactional(readOnly = true)
+
+        private Event requirePublicEvent(Long id) {
+                return eventRepository.findById(id)
+                                .filter(Event::isPublic)
+                                .orElseThrow(() -> new EventNotFoundException(
+                                                "Event not found with id: " + id));
+        }
+
         public PagedResponse<EventResponse> getAllEvents(
                         int page,
                         int size,

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -133,8 +133,7 @@ public class EventService {
         }
 
         public EventAvailabilityResponse getEventAvailability(Long id, String userEmail) {
-                Event event = eventRepository.findById(id)
-                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
+                Event event = requirePublicEvent(id);
 
                 Integer capacity = event.getCapacity();
                 int registeredCount = event.getRegisteredCount();
@@ -898,6 +897,7 @@ public class EventService {
          */
         @Transactional(readOnly = true)
         public List<String> getOccupiedSeats(Long eventId) {
+                requirePublicEvent(eventId);
                 return eventRegistrationRepository.findByEvent_Id(eventId)
                                 .stream()
                                 .map(EventRegistration::getSeatId)


### PR DESCRIPTION
## Summary
`/availability` and `/seats` now use the same public-event lookup as `getPublicEventById`, so private event capacity/seat data is not world-readable.

Closes #12436

## Test plan
- [ ] Private event id → availability/seats return not found
- [ ] Public event still returns availability and seats

Made with [Cursor](https://cursor.com)