### PR TITLE
fix(events): block register/waitlist on private events

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -189,6 +189,14 @@ public class EventService {
          * Retrieves a page of public events with optional search / status / sort.
          */
         @Transactional(readOnly = true)
+
+        private Event requirePublicEvent(Long id) {
+                return eventRepository.findById(id)
+                                .filter(Event::isPublic)
+                                .orElseThrow(() -> new EventNotFoundException(
+                                                "Event not found with id: " + id));
+        }
+
         public PagedResponse<EventResponse> getAllEvents(
                         int page,
                         int size,
@@ -537,6 +545,10 @@ public class EventService {
                 Event event = eventRepository.findByIdWithLock(eventId)
                                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
 
+                if (!event.isPublic()) {
+                        throw new EventNotFoundException("Event not found with id: " + eventId);
+                }
+
                 User user = userRepository.findByEmail(userEmail)
                                 .orElseThrow(() -> new UsernameNotFoundException(
                                                 "User not found with email: " + userEmail));
@@ -746,6 +758,10 @@ public class EventService {
                 Event event = eventRepository.findByIdWithLock(eventId)
                                 .orElseThrow(() -> new EventNotFoundException(
                                                 "Event not found with id: " + eventId));
+
+                if (!event.isPublic()) {
+                        throw new EventNotFoundException("Event not found with id: " + eventId);
+                }
 
                 // Registration is only valid for events that have not already ended.
                 // Without this guard the API accepted registrations for past events,


### PR DESCRIPTION
## Summary
Registration and waitlist joins now treat non-public events as not found, matching the public read path.

Closes #12437

## Test plan
- [ ] Register on private event id → not found / rejected
- [ ] Join waitlist on private event id → rejected
- [ ] Public event register/waitlist unchanged

Made with [Cursor](https://cursor.com)