### PR TITLE
fix(admin): promote waitlist after deleteUser frees seats

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -46,6 +46,7 @@ public class AdminService {
     private final HackathonRegistrationRepository hackathonRegistrationRepository;
     private final ProjectUpvoteRepository     projectUpvoteRepository;
     private final NotificationRepository      notificationRepository;
+    private final EventService                eventService;
 
     // ══════════════════════════════════════════════════════════════════════
     // 1. USER MANAGEMENT
@@ -141,6 +142,7 @@ public class AdminService {
                         .countByEvent_IdAndStatus(eventId, "CONFIRMED"));
                 eventRepository.save(event);
             });
+            eventService.promoteWaitlistAfterVacancy(eventId);
         }
 
         userRepository.deleteById(id);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -831,6 +831,18 @@ public class EventService {
                                 .toList();
         }
 
+        /**
+         * Promotes the first waitlisted user when capacity is available.
+         * Used after registration cancel and admin user deletion frees seats.
+         */
+        @Transactional
+        public void promoteWaitlistAfterVacancy(Long eventId) {
+                Event event = eventRepository.findByIdWithLock(eventId)
+                                .orElseThrow(() -> new EventNotFoundException(
+                                                "Event not found with id: " + eventId));
+                promoteFirstWaitingUser(event);
+        }
+
         private RegistrationResponse promoteFirstWaitingUser(Event event) {
                 if (event.getCapacity() != null && event.getRegisteredCount() >= event.getCapacity()) {
                         return null;


### PR DESCRIPTION
## Summary
Admin user deletion now promotes the first waitlisted attendee for each affected event after recounting capacity, matching cancel-registration behavior.

Closes #12435

## Test plan
- [ ] Full event with waitlist; delete a registered user as admin
- [ ] Waitlisted user becomes CONFIRMED and receives notification

Made with [Cursor](https://cursor.com)