### PR TITLE
fix(api): let refresh interceptor own 401 handling

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -156,13 +156,7 @@ API.interceptors.response.use(
     }
     return response;
   },
-  (error) => {
-    const status = error?.response?.status;
-    if (status === 401 && onUnauthorized) {
-      onUnauthorized();
-    }
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
 
 setupRequestInterceptor(API, {


### PR DESCRIPTION
## Summary
Removes the early `onUnauthorized()` response handler from `api.js` so silent token refresh in `setupResponseInterceptor` can run before logout.

Closes #12430

## Test plan
- [ ] Force a 401 with a valid refresh token → request retries, session kept
- [ ] Failed refresh still logs the user out

Made with [Cursor](https://cursor.com)