### PR TITLE
fix(sync): keep exhausted offline items in local drafts

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -359,7 +359,8 @@ const useOfflineSync = () => {
 
           if (retries >= MAX_RETRIES) {
             droppedCount++;
-            logger.warn(`[useOfflineSync] Item ${item.id} exceeded MAX_RETRIES (${MAX_RETRIES}). Dropping from queue.`);
+            logger.warn(`[useOfflineSync] Item ${item.id} exceeded MAX_RETRIES (${MAX_RETRIES}). Retaining in failed queue.`);
+            failedQueue.push({ ...item, retryCount: retries, exhausted: true });
             continue;
           }
 
@@ -401,8 +402,11 @@ const useOfflineSync = () => {
               }
             }
 
-            if (res.status === "success" || res.status === "dropped") {
+            if (res.status === "success") {
               successCount++;
+            } else if (res.status === "dropped") {
+              droppedCount++;
+              failedQueue.push({ ...item, retryCount: retries + 1, exhausted: true });
             } else {
               failedQueue.push({ ...item, retryCount: retries + 1 });
             }
@@ -413,21 +417,20 @@ const useOfflineSync = () => {
         }
 
         if (failedQueue.length > 0) {
-        await saveQueue(failedQueue);
+          await saveQueue(failedQueue);
           notify.warning(
             `Synced ${successCount} registration(s). ${failedQueue.length} remaining in local draft queue.`,
           );
+          if (droppedCount > 0) {
+            notify.error(
+              `${droppedCount} registration(s) paused after ${MAX_RETRIES} failed attempts. Retained in local drafts.`,
+            );
+          }
         } else {
           await emptyQueue();
           if (successCount > 0) {
             notify.success("All offline actions successfully synchronized!");
           }
-        }
-
-        if (droppedCount > 0) {
-          notify.error(
-            `${droppedCount} registration(s) paused after ${MAX_RETRIES} failed attempts. Retained in local drafts.`,
-          );
         }
       } catch (error) {
         // A crash anywhere in the replay run must never surface as a


### PR DESCRIPTION
## Summary
Exhausted offline retries are pushed into the failed/draft queue instead of being skipped and wiped by `emptyQueue()`. Toast copy only claims retention when items were actually saved. Permanent `dropped` responses no longer inflate `successCount`.

Closes #12432

## Test plan
- [ ] Force MAX_RETRIES failures → items remain in IndexedDB queue
- [ ] Toast matches retained draft behavior

Made with [Cursor](https://cursor.com)