### PR TITLE
fix: parse ISO eventDate in conflict detection to stop same-day false positives

### DIFF
--- a/src/context/MyEventsContext.js
+++ b/src/context/MyEventsContext.js
@@ -57,7 +57,7 @@ const storageKey = (userId) => {
 const toEventSummary = (event) => ({
   id: event?.id,
   title: event?.title ?? "",
-  date: event?.date ?? "",
+  date: event?.date ?? event?.eventDate ?? "",
   location: event?.location ?? "",
   type: event?.type ?? event?.category ?? "",
   image: event?.image ?? event?.imageUrl ?? "",

--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -42,10 +42,58 @@ const getEffectiveDuration = (event, fallbackMinutes = 60) => {
 };
 
 /**
+ * Parse a full ISO timestamp to UTC epoch ms.
+ *
+ * Handles both explicit-offset timestamps (e.g. "2026-06-01T10:00:00Z" or
+ * "2026-06-01T10:00:00+05:30", which are self-describing) and naive local
+ * wall-clock timestamps ("2026-06-01T10:00:00"), which are interpreted in the
+ * event's timezone via parseEventToUTC.
+ *
+ * @param {string} iso  - Full ISO timestamp, not a bare "YYYY-MM-DD" date
+ * @param {string} tz   - IANA timezone used for naive timestamps
+ * @returns {number|null}
+ */
+const parseIsoTimestampUTC = (iso, tz) => {
+  if (!iso || typeof iso !== "string") return null;
+
+  // Explicit offset or Z suffix → the instant is self-describing
+  if (/[zZ]|[+-]\d{2}:?\d{2}$/.test(iso)) {
+    const ms = new Date(iso).getTime();
+    return Number.isNaN(ms) ? null : ms;
+  }
+
+  // Naive "YYYY-MM-DDTHH:MM[:ss]" → treat wall-clock as local in `tz`
+  const match = iso.match(/^(\d{4}-\d{2}-\d{2})T(\d{1,2}):(\d{2})/);
+  if (!match) return null;
+
+  return parseEventToUTC(match[1], `${match[2]}:${match[3]}`, tz);
+};
+
+/**
+ * Resolve an event's start instant (UTC ms).
+ *
+ * Prefers the explicit { date, time } pair used by mock/hackathon events, then
+ * falls back to the single full ISO timestamp returned by the real API
+ * (event.eventDate / event.startDate / event.date). Returns null when neither
+ * is parseable.
+ *
+ * @param {object} event
+ * @param {string} tz
+ * @returns {number|null}
+ */
+const parseEventStartUTC = (event, tz) => {
+  const fromPair = parseEventToUTC(event?.date, event?.time, tz);
+  if (fromPair !== null) return fromPair;
+
+  const iso = event?.eventDate || event?.startDate || event?.date;
+  return parseIsoTimestampUTC(iso, tz);
+};
+
+/**
  * Convert an event to a UTC time-range { startMs, endMs }.
  * Returns null when the event lacks enough date/time data to parse.
  *
- * @param {object} event  - Event object with .date and .time fields
+ * @param {object} event  - Event object with a .date/.time pair or an ISO timestamp
  * @param {number} fallbackDuration  - Minutes to use when event.durationMinutes is absent
  * @param {string} [timezone]  - IANA tz string; defaults to browser's tz
  * @returns {{ startMs: number, endMs: number }|null}
@@ -54,7 +102,7 @@ export const getEventUTCRange = (event, fallbackDuration = 60, timezone) => {
   if (!event) return null;
 
   const tz = event.timezone || event.timeZone || timezone || getUserTimezone();
-  const startMs = parseEventToUTC(event.date, event.time, tz);
+  const startMs = parseEventStartUTC(event, tz);
 
   if (startMs === null) return null;
 
@@ -161,7 +209,7 @@ export const findConflictingEvents = (
 
   return registeredEvents
     .filter(Boolean)                           // drop null/undefined registration entries
-    .map((reg) => reg.event || reg)
+    .map((reg) => reg.event || reg.eventSummary || reg)
     .filter(Boolean)                           // drop registrations whose .event is also null
     .filter((event) => !newEvent.id || !event.id || event.id !== newEvent.id)
     .filter((event) => doEventsOverlap(newEvent, event, fallbackDuration, tz));

--- a/tests/conflictDetection.test.mjs
+++ b/tests/conflictDetection.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-const { doEventsOverlap, findConflictingEvents, checkRegistrationConflict, parseTimeToMinutes } =
+const { doEventsOverlap, findConflictingEvents, checkRegistrationConflict, parseTimeToMinutes, getEventUTCRange } =
   await import("../src/utils/conflictDetection.js");
 
 assert.equal(parseTimeToMinutes("10:00 AM"), 600);
@@ -50,5 +50,66 @@ const selfConflictCheck = findConflictingEvents(
   "UTC"
 );
 assert.equal(selfConflictCheck.length, 0);
+
+// --- Issue 12458: same-day events with ISO eventDate timestamps ---
+// Real API events carry only a full ISO timestamp (eventDate); they must NOT
+// fall into the legacy minutes-from-midnight branch (00:00-01:00) which made
+// every same-day pair overlap.
+
+const baseEventIso = {
+  eventDate: "2026-06-01T10:00:00",
+  timezone: "UTC",
+  durationMinutes: 60,
+};
+
+const overlapIso = {
+  eventDate: "2026-06-01T10:30:00",
+  timezone: "UTC",
+  durationMinutes: 60,
+};
+
+const separateIso = {
+  eventDate: "2026-06-01T12:00:00",
+  timezone: "UTC",
+  durationMinutes: 60,
+};
+
+assert.equal(doEventsOverlap(baseEventIso, overlapIso, 60, "UTC"), true);
+assert.equal(doEventsOverlap(baseEventIso, separateIso, 60, "UTC"), false);
+
+// Explicit-offset timestamps (Z suffix) parse directly to the instant
+assert.equal(
+  doEventsOverlap(
+    { eventDate: "2026-06-01T10:00:00Z", durationMinutes: 60 },
+    { eventDate: "2026-06-01T12:00:00Z", durationMinutes: 60 },
+    60,
+    "UTC"
+  ),
+  false
+);
+
+// getEventUTCRange resolves the ISO timestamp into a real ms range
+const isoRange = getEventUTCRange({
+  eventDate: "2026-06-01T10:00:00",
+  timezone: "UTC",
+  durationMinutes: 60,
+});
+assert.equal(isoRange.startMs, Date.UTC(2026, 5, 1, 10, 0, 0));
+assert.equal(isoRange.endMs, Date.UTC(2026, 5, 1, 11, 0, 0));
+
+// Restored MyEvents records expose only eventSummary (date = ISO timestamp);
+// conflict detection must still resolve them against the new event.
+const restoredSummary = {
+  id: 7,
+  title: "Restored",
+  date: "2026-06-01T10:00:00",
+};
+const conflictsWithRestored = findConflictingEvents(
+  { ...baseEventIso, id: 1 },
+  [{ event: null, eventSummary: restoredSummary }, { event: separateIso }],
+  60,
+  "UTC"
+);
+assert.equal(conflictsWithRestored.length, 1);
 
 console.log("conflictDetection tests passed ✓");


### PR DESCRIPTION
## Problem

Conflict detection (`src/utils/conflictDetection.js`) reports a scheduling conflict for any two events that fall on the same calendar date, regardless of their actual start times, whenever the events come from the real API.

`parseEventToUTC(dateStr, timeStr, timezone)` requires both a date and a time string, but real API events carry the full `LocalDateTime` inside `eventDate` (with no separate `event.time`). `getEventUTCRange` therefore returned `null` for API events, and `doEventsOverlap` fell back to the legacy minutes-from-midnight branch where both events collapse to `00:00-01:00` and any same-day pair looks like a conflict. After a page reload this worsens because `MyEventsContext` restores only the PII-free `eventSummary`, which previously carried no date/time at all.

## Fix

- `getEventUTCRange` now falls back to parsing a full ISO timestamp from `event.eventDate` / `event.startDate` / `event.date` (offset-aware, or naive wall-clock interpreted in the event timezone) before the legacy branch is ever reached.
- `findConflictingEvents` unwraps `reg.eventSummary` for restored MyEvents records so they are resolved against the new event using their real timestamp.
- `toEventSummary` (`src/context/MyEventsContext.js`) now carries the ISO timestamp in its `date` field, so restored records remain parseable after a page reload.

The `EventRegistration.js` normalization of the fetched event is handled separately in the fix for #12459 (same lines, avoids merge conflicts).

## Files changed

- `src/utils/conflictDetection.js` — ISO timestamp parsing in `getEventUTCRange`; `eventSummary` unwrap in `findConflictingEvents`.
- `src/context/MyEventsContext.js` — `toEventSummary` includes `event.eventDate` fallback.
- `tests/conflictDetection.test.mjs` — regression tests.

## Testing

- `node tests/conflictDetection.test.mjs` — all pass, including new cases: two same-day events at non-overlapping ISO times → `doEventsOverlap` is `false`; overlapping ISO times → `true`; `Z`-suffixed timestamps; `getEventUTCRange` returns the correct ms range; restored `eventSummary` records resolve correctly.
- `npx eslint src/utils/conflictDetection.js src/context/MyEventsContext.js tests/conflictDetection.test.mjs` — clean.

Closes #12458
