### PR TITLE
fix: normalize fetched event so success screen shows real date/time

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -29,7 +29,7 @@ import {
 } from "utils/eventAvailabilityUtils.mjs";
 import { useFormValidation } from "hooks/useFormValidation";
 import SpatialSeatSelector from "components/events/SpatialSeatSelector";
-import { getEventStatus, isEventRegistrationClosed } from "utils/eventUtils";
+import { getEventStatus, isEventRegistrationClosed, normalizeEvent } from "utils/eventUtils";
 import { checkRegistrationConflict, suggestAlternativeEvents } from "utils/conflictDetection";
 import { useAuth } from "context/AuthContext";
 import { useMyEvents } from "context/MyEventsContext";
@@ -189,10 +189,10 @@ const EventRegistration = () => {
         if (response.status === 200 && response.data) {
           if (isCancelled) return;
 
-          const fetchedEvent = {
+          const fetchedEvent = normalizeEvent({
             ...response.data,
             status: getEventStatus(response.data),
-          };
+          });
           applyLoadedEvent(fetchedEvent);
           saveCachedEventDetail(fetchedEvent);
 
@@ -203,14 +203,16 @@ const EventRegistration = () => {
         console.error("Failed to load event details:", error);
         const cached = getCachedEventDetail(eventId);
         if (cached?.event) {
-          applyLoadedEvent({
-            ...cached.event,
-            status: getEventStatus(cached.event),
-            cacheInfo: {
-              cachedAt: cached.cachedAt,
-              label: getCacheAgeLabel(cached.cachedAt),
-            },
-          });
+          applyLoadedEvent(
+            normalizeEvent({
+              ...cached.event,
+              status: getEventStatus(cached.event),
+              cacheInfo: {
+                cachedAt: cached.cachedAt,
+                label: getCacheAgeLabel(cached.cachedAt),
+              },
+            })
+          );
 
           toast.warning(t("eventRegistration.toastShowingCached", { label: getCacheAgeLabel(cached.cachedAt) }));
           return;
@@ -592,6 +594,15 @@ const EventRegistration = () => {
     const shareText = `I'm attending ${event.title} on Eventra! Join me there!`;
     const shareUrl = `${window.location.origin}/events/${event.id}`;
 
+    const successStartTime =
+      event.time ||
+      (event.date && !Number.isNaN(new Date(event.date).getTime())
+        ? new Date(event.date).toLocaleTimeString("en-US", {
+            hour: "numeric",
+            minute: "2-digit",
+          })
+        : "");
+
     const handleNativeShare = () => {
       if (navigator.share) {
         navigator
@@ -671,7 +682,7 @@ const EventRegistration = () => {
 
               <div className="flex items-center gap-2">
                 <Clock className="w-4 h-4 text-pink-500" />
-                <span>{event.time}</span>
+                <span>{successStartTime}</span>
               </div>
 
               <div className="flex items-center gap-2">

--- a/src/utils/calendarUrlUtils.js
+++ b/src/utils/calendarUrlUtils.js
@@ -50,12 +50,44 @@ const formatUTCtoCalendarString = (utcMs, mode = 'compact') => {
 };
 
 /**
+ * Parse a full ISO timestamp to UTC epoch ms.
+ *
+ * Handles both explicit-offset timestamps (e.g. "2026-06-01T10:00:00Z" or
+ * "2026-06-01T10:00:00+05:30", which are self-describing) and naive local
+ * wall-clock timestamps ("2026-06-01T10:00:00"), which are interpreted in the
+ * event's timezone via parseEventToUTC.
+ *
+ * @param {string} iso  - Full ISO timestamp, not a bare "YYYY-MM-DD" date
+ * @param {string} tz   - IANA timezone used for naive timestamps
+ * @returns {number|null}
+ */
+const parseIsoTimestampUTC = (iso, tz) => {
+  if (!iso || typeof iso !== 'string') return null;
+
+  // Explicit offset or Z suffix → the instant is self-describing
+  if (/[zZ]|[+-]\d{2}:?\d{2}$/.test(iso)) {
+    const ms = new Date(iso).getTime();
+    return Number.isNaN(ms) ? null : ms;
+  }
+
+  // Naive "YYYY-MM-DDTHH:MM[:ss]" → treat wall-clock as local in `tz`
+  const match = iso.match(/^(\d{4}-\d{2}-\d{2})T(\d{1,2}):(\d{2})/);
+  if (!match) return null;
+
+  return parseEventToUTC(match[1], `${match[2]}:${match[3]}`, tz);
+};
+
+/**
  * Convert a local event time to { startMs, endMs } in UTC epoch ms.
+ *
+ * Prefers the explicit { date, time } pair used by mock/hackathon events, then
+ * falls back to the single full ISO timestamp returned by the real API
+ * (event.eventDate / event.startDate / event.date).
  *
  * Falls back gracefully to a naive UTC interpretation (assumes UTC) when
  * timezone detection fails — better than producing a wildly wrong timestamp.
  *
- * @param {object} event  - Event object with .date, .time, .durationMinutes
+ * @param {object} event  - Event object with a .date/.time pair or an ISO timestamp
  * @param {string} [timezone]  - IANA timezone string; defaults to getUserTimezone()
  * @returns {{ startMs: number, endMs: number } | null}
  *   Returns null when date/time are unparseable.
@@ -65,20 +97,22 @@ const getEventUTCRange = (event, timezone) => {
     logger.error("[getEventUTCRange] Invalid event argument: must be an object.");
     return null;
   }
-  
-  if (!event.date || !event.time) {
-    logger.warn("[getEventUTCRange] Missing required event fields: 'date' and 'time' are mandatory.");
-    return null;
-  }
 
   // Fallback to detected browser timezone if none provided
   const tz = timezone || getUserTimezone();
 
   // parseEventToUTC handles all date formats (ISO, YYYY-MM-DD, Month DD YYYY)
   // and 12h/24h time strings, with DST-correct conversion via Intl.DateTimeFormat.
-  const startMs = parseEventToUTC(event.date, event.time, tz);
+  let startMs = parseEventToUTC(event.date, event.time, tz);
+
+  // Real API events carry only a full ISO timestamp (event.eventDate), with no
+  // separate event.time field. Parse it directly so calendar links stay valid.
   if (startMs === null || isNaN(startMs)) {
-    logger.warn(`[getEventUTCRange] Date '${event.date}' or time '${event.time}' could not be parsed.`);
+    startMs = parseIsoTimestampUTC(event.eventDate || event.startDate || event.date, tz);
+  }
+
+  if (startMs === null || isNaN(startMs)) {
+    logger.warn(`[getEventUTCRange] Date '${event.date || event.eventDate}' or time '${event.time}' could not be parsed.`);
     return null;
   }
 

--- a/src/utils/calendarUrlUtils.test.js
+++ b/src/utils/calendarUrlUtils.test.js
@@ -352,7 +352,75 @@ describe('extractMeetingLink', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 8. Edge cases
+// 9. ISO eventDate fallback (issue 12459)
+// ---------------------------------------------------------------------------
+// Real API events carry only a full ISO timestamp (eventDate) with no separate
+// event.time. Calendar URLs must still be generated from it instead of the
+// broken date-only fallback ("...undefinedT000000Z/...").
+describe('calendarUrlUtils — ISO eventDate fallback', () => {
+  const parseStartMs = (url) => {
+    const match = url.match(/dates=([^&]+)/);
+    if (!match) return null;
+    const startStr = decodeURIComponent(match[1]).split('/')[0];
+    const iso = `${startStr.substring(0, 4)}-${startStr.substring(4, 6)}-${startStr.substring(6, 8)}T${startStr.substring(9, 11)}:${startStr.substring(11, 13)}:${startStr.substring(13, 15)}Z`;
+    return new Date(iso).getTime();
+  };
+
+  const isoEvent = () =>
+    mkEvent({ date: undefined, time: undefined, eventDate: '2026-06-15T10:00:00' });
+
+  test('google URL derives a valid start from eventDate (not "undefined")', () => {
+    const url = getGoogleCalendarUrl(isoEvent(), 'UTC');
+    expect(url).toContain('dates=');
+    expect(url).not.toContain('undefined');
+    const startDate = new Date(parseStartMs(url));
+    expect(startDate.getUTCHours()).toBe(10);
+    expect(startDate.getUTCMinutes()).toBe(0);
+  });
+
+  test('google URL duration honours durationMinutes with ISO-only event', () => {
+    const event = isoEvent();
+    event.durationMinutes = 180;
+    const url = getGoogleCalendarUrl(event, 'UTC');
+    const startMs = parseStartMs(url);
+    const endMatch = decodeURIComponent(url.match(/dates=([^&]+)/)[1]).split('/')[1];
+    const endIso = `${endMatch.substring(0, 4)}-${endMatch.substring(4, 6)}-${endMatch.substring(6, 8)}T${endMatch.substring(9, 11)}:${endMatch.substring(11, 13)}:${endMatch.substring(13, 15)}Z`;
+    expect(new Date(endIso).getTime() - startMs).toBe(180 * 60 * 1000);
+  });
+
+  test('outlook URL derives valid start/end from eventDate', () => {
+    const url = getOutlookCalendarUrl(isoEvent(), 'UTC');
+    expect(url).toContain('startdt=');
+    expect(url).not.toContain('undefined');
+    const startdt = decodeURIComponent(url.match(/startdt=([^&]+)/)[1]);
+    expect(startdt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+    expect(startdt.startsWith('2026-06-15T10:')).toBe(true);
+  });
+
+  test('yahoo URL derives valid start from eventDate', () => {
+    const url = getYahooCalendarUrl(isoEvent(), 'UTC');
+    expect(url).toContain('ST=');
+    expect(url).not.toContain('undefined');
+    expect(decodeURIComponent(url.match(/ST=([^&]+)/)[1])).toMatch(/^\d{8}T\d{6}Z$/);
+  });
+
+  test('explicit offset timestamp (Z) is respected directly', () => {
+    const event = mkEvent({ date: undefined, time: undefined, eventDate: '2026-06-15T10:00:00Z' });
+    const startDate = new Date(parseStartMs(getGoogleCalendarUrl(event, 'UTC')));
+    expect(startDate.getUTCHours()).toBe(10);
+  });
+
+  test('no date and no timestamp → legacy fallback (no crash, no undefined leak)', () => {
+    const event = mkEvent({ date: undefined, time: undefined });
+    const url = getGoogleCalendarUrl(event);
+    expect(typeof url).toBe('string');
+    expect(url).not.toContain('undefined');
+    expect(url).toContain(encodeURIComponent(event.title));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Edge cases
 // ---------------------------------------------------------------------------
 describe('calendarUrlUtils — edge cases', () => {
   test('event with missing date returns a fallback URL string (not empty)', () => {


### PR DESCRIPTION
## Problem

After a successful registration, the success screen (`src/Pages/Events/EventRegistration.js`) renders the event date/time from fields that are never populated for real API events. The event is loaded raw (`eventDate` only, no `event.date` / `event.time`), so:

- The success card renders `new Date(event.date)` → **"Invalid Date"** and `{event.time}` → blank row.
- The "Add to Calendar" links reject events without `date` + `time` and fall back to `dates=undefinedT000000Z/undefinedT010000Z` — broken calendar exports.

The bug was invisible with mocks because the hackathon branch explicitly sets `date: foundMock.startDate, time: "10:00 AM"`.

## Fix

- `loadEvent` now applies `normalizeEvent` to the fetched (and cached) event so `event.date` is populated from `eventDate`.
- The success card renders the start time from the timestamp when `event.time` is absent (keeps the explicit `event.time` for mock/hackathon events).
- `calendarUrlUtils.getEventUTCRange` now falls back to parsing a full ISO timestamp (`event.eventDate` / `event.startDate` / `event.date`) when no separate `time` field exists, so Google/Outlook/Yahoo/ICS links carry valid start/end timestamps.

## Files changed

- `src/Pages/Events/EventRegistration.js` — `normalizeEvent` on the loaded event (fetch + cache), success-card time rendering.
- `src/utils/calendarUrlUtils.js` — ISO-timestamp fallback in `getEventUTCRange`.
- `src/utils/calendarUrlUtils.test.js` — regression tests.

## Testing

- `npx vitest run src/utils/calendarUrlUtils.test.js src/utils/calendarUrlUtils.timezone.test.js` — 49 tests pass (6 new ISO-eventDate fallback tests).
- `npx eslint src/utils/calendarUrlUtils.js src/utils/calendarUrlUtils.test.js src/Pages/Events/EventRegistration.js` — no errors (one pre-existing unused-var warning at `EventRegistration.js:430`, untouched).
- `normalizeEvent({ eventDate: "2026-08-20T18:00:00", ... })` verified to produce a parseable `event.date`.

Closes #12459
