### PR TITLE
fix: classify events as past once the start time passes (moment-based)

### DIFF
--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -39,21 +39,18 @@ const parseEventDate = (dateValue) => {
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 };
 
-const asEndOfDay = (date) => {
-  if (!date) return null;
-  const clone = new Date(date.valueOf());
-  clone.setHours(23, 59, 59, 999);
-  return clone;
-};
-
 export const computeDateStatus = (event) => {
   const startDate = parseEventDate(event.startDate || event.date || event.eventDate);
-  const endDate = asEndOfDay(parseEventDate(event.endDate || event.date || event.eventDate));
   const now = getServerTime();
 
   if (!startDate) return "upcoming";
   if (now < startDate) return "upcoming";
-  if (endDate && now <= endDate) return "live";
+
+  // Moment-based, matching the backend's Event.isEventPast(): once the
+  // event's start time has passed it is no longer "live" — even when it is
+  // still the same calendar day. The old day-granular "live until midnight"
+  // kept the registration form enabled for hours after the event started
+  // while the server rejected every submission. (#12462)
   return "past";
 };
 

--- a/tests/eventUtils.test.mjs
+++ b/tests/eventUtils.test.mjs
@@ -11,4 +11,22 @@ assert.equal(computeDateStatus(pastEvent), "past");
 assert.equal(getEventStatus({ status: "ended" }), "ended");
 assert.equal(isEventRegistrationClosed(pastEvent), true);
 
+// ── Issue 12462: moment-based live/past classification ──────────────────────
+// An event whose start time has passed — even earlier the SAME calendar day —
+// must be classified "past" (and registration closed), matching the backend's
+// Event.isEventPast(). Previously the day-granular "live until midnight" kept
+// the form enabled while the server rejected every submission.
+
+const sameDayPastEvent = { eventDate: new Date(now.getTime() - 2 * 3600 * 1000).toISOString() };
+assert.equal(computeDateStatus(sameDayPastEvent), "past");
+assert.equal(getEventStatus(sameDayPastEvent), "past");
+assert.equal(isEventRegistrationClosed(sameDayPastEvent), true);
+
+const sameDayUpcomingEvent = { eventDate: new Date(now.getTime() + 2 * 3600 * 1000).toISOString() };
+assert.equal(computeDateStatus(sameDayUpcomingEvent), "upcoming");
+assert.equal(isEventRegistrationClosed(sameDayUpcomingEvent), false);
+
+// Explicit backend "live" status still wins over the date-derived status.
+assert.equal(getEventStatus({ status: "live", eventDate: new Date(now.getTime() - 3600 * 1000).toISOString() }), "live");
+
 console.log("eventUtils tests passed ✓");


### PR DESCRIPTION
## Problem

There is a day-vs-moment granularity mismatch between how "live" events are classified and how past-event registration is rejected. `computeDateStatus` (`src/utils/eventUtils.js`) treated an event as `live` for the entire calendar day via `asEndOfDay`, while the backend rejects registration the moment the start time passes (`Event.isEventPast()` = `eventDate.isBefore(now)`). So for a 9:00 AM event viewed at 3:00 PM the same day: the card shows a "LIVE" badge, the registration form is fully enabled, and every submission fails with "Registration is closed for this event."

## Fix

- `computeDateStatus` now classifies by the event's start instant, matching the backend's moment-based `Event.isEventPast()`: once the start time has passed the event is `past` — even when it is still the same calendar day.
- The unused `asEndOfDay` day-granular helper is removed.
- Because `isEventRegistrationClosed` already blocks `past`/`ended`/`cancelled`, the registration page now shows the existing "this event has already ended" notice and disables the form instead of letting users fill in a form that can never submit. The explicit backend "live"/"in progress"/"ongoing" status strings are unaffected (still map to `live`).

## Files changed

- `src/utils/eventUtils.js` — `computeDateStatus` now moment-based (start instant), removed `asEndOfDay`.
- `tests/eventUtils.test.mjs` — regression tests.

## Testing

- `node tests/eventUtils.test.mjs` — pass, including new same-day cases: an event whose start passed 2 hours ago is `past` and `isEventRegistrationClosed` is `true`; an event starting in 2 hours is `upcoming`/open; explicit `live` status still wins.
- `node tests/conflictDetection.test.mjs`, `node tests/cancelledEventRegistration.test.mjs` — all pass (registration-open/closed states intact).
- `npx eslint src/utils/eventUtils.js tests/eventUtils.test.mjs` — clean.
- Note: `tests/eventDetails.test.mjs` has pre-existing failures on master (source-drift assertions about loading spinner / mock fallback) unrelated to this change.

Closes #12462
