### PR TITLE
fix: apply listing/advanced filters to Best Match sort

### DIFF
--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -315,7 +315,19 @@ const useEventListing = () => {
   }, [scoredEvents]);
 
   const sortedEvents = useMemo(() => {
-    const base = sortType === "Best Match" ? scoredEvents : filteredEvents;
+    // Best Match must only re-order the already-filtered set (#12461).
+    // filteredEvents does not carry recommendation scores (useRecommendations
+    // returns a separate array), so enrich it from matchScoreMap first —
+    // otherwise the sort would compare all-zero scores and lose the ranking.
+    const base =
+      sortType === "Best Match"
+        ? filteredEvents.map((event) => ({
+            ...event,
+            recommendationScore: matchScoreMap.get(String(event.id))?.score ?? 0,
+            recommendationReasons: matchScoreMap.get(String(event.id))?.reasons ?? [],
+          }))
+        : filteredEvents;
+
     return [...base].sort((a, b) => {
       // Best Match: sort by AI recommendation score descending
       if (sortType === "Best Match") {
@@ -331,7 +343,7 @@ const useEventListing = () => {
       // Default / Newest
       return dateB - dateA;
     });
-  }, [filteredEvents, scoredEvents, sortType]);
+  }, [filteredEvents, matchScoreMap, sortType]);
 
   const paginatedEvents = useMemo(() => {
     // Server already returned one page — do not re-slice client-side.

--- a/src/Pages/Events/useEventListing.test.js
+++ b/src/Pages/Events/useEventListing.test.js
@@ -1,0 +1,88 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import useEventListing from "./useEventListing";
+import { apiUtils } from "config/api";
+
+vi.mock("config/api", () => ({
+  API_ENDPOINTS: { EVENTS: { LIST: "/api/events" } },
+  apiUtils: { get: vi.fn() },
+}));
+
+vi.mock("hooks/useDebounce", () => ({
+  default: (value) => value,
+}));
+
+vi.mock("hooks/useRecommendations", () => ({
+  default: (events) =>
+    (events || []).map((event) => ({
+      ...event,
+      recommendationScore: (event.id % 10) * 10,
+      recommendationReasons: [],
+    })),
+}));
+
+const mkEvent = (id, price) => ({
+  id,
+  title: `Event ${id}`,
+  date: `2026-07-0${id}T10:00:00`,
+  price,
+});
+
+const mockEvents = [mkEvent(1, 0), mkEvent(2, 100), mkEvent(3, 20), mkEvent(4, 300)];
+
+const mockPagedResponse = {
+  status: 200,
+  data: {
+    content: mockEvents,
+    totalPages: 1,
+    totalElements: mockEvents.length,
+    first: true,
+    last: true,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiUtils.get.mockResolvedValue(mockPagedResponse);
+});
+
+describe("Best Match sort (#12461)", () => {
+  test("with an active price range, out-of-range events are excluded and the rest are score-ordered", async () => {
+    const { result } = renderHook(() => useEventListing());
+
+    await waitFor(() => {
+      expect(result.current.paginatedEvents.length).toBe(mockEvents.length);
+    });
+
+    act(() => {
+      result.current.setSortType("Best Match");
+    });
+
+    act(() => {
+      result.current.setAdvancedFilters({ priceRange: { min: 0, max: 50 } });
+    });
+
+    await waitFor(() => {
+      // Only events priced ≤ 50 (ids 1 and 3) survive the filter, and the
+      // Best Match sort must order them by recommendation score descending
+      // (id 3 → 30 > id 1 → 10), NOT resurrect the paid events (ids 2, 4).
+      expect(result.current.paginatedEvents.map((e) => e.id)).toEqual([3, 1]);
+    });
+  });
+
+  test("with no filters, Best Match keeps all events ordered by score descending", async () => {
+    const { result } = renderHook(() => useEventListing());
+
+    await waitFor(() => {
+      expect(result.current.paginatedEvents.length).toBe(mockEvents.length);
+    });
+
+    act(() => {
+      result.current.setSortType("Best Match");
+    });
+
+    await waitFor(() => {
+      expect(result.current.paginatedEvents.map((e) => e.id)).toEqual([4, 3, 2, 1]);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

With `"Best Match"` sort selected, `useEventListing` re-ordered the raw `scoredEvents` list (from `useRecommendations`) instead of the filtered set:

```js
const base = sortType === "Best Match" ? scoredEvents : filteredEvents;
```

`scoredEvents` is computed from the raw `events` array and skips the entire `filteredEvents` pipeline (fuzzy search re-match, status/live/upcoming/past filter, bookmarked, category, and `applyAdvancedFilters` — price range, date range, mode, location, skill level, tags). So selecting Best Match silently resurrected events that violated active filters (e.g. a paid event after setting a low price range, or a past event on the "Upcoming" tab).

## Fix

`sortedEvents` now sorts the **already-filtered** set. Because `filteredEvents` does not carry `recommendationScore` (note: `useRecommendations` returns a separate enriched array and does not mutate `events`), the score is merged back in from `matchScoreMap` (which is derived from the scored events) before sorting — so Best Match still ranks by recommendation score, but only within the filtered results. The `useMemo` deps now use `matchScoreMap` instead of `scoredEvents`.

## Files changed

- `src/Pages/Events/useEventListing.js` — `sortedEvents` uses `filteredEvents` (+ score enrichment from `matchScoreMap`).
- `src/Pages/Events/useEventListing.test.js` — new vitest regression tests.

## Testing

- `npx vitest run src/Pages/Events/useEventListing.test.js` — 2 tests pass:
  - Best Match + active price range (`{min: 0, max: 50}`) → only events priced ≤ 50 are returned, score-ordered (`[3, 1]`); the paid events (100, 300) are excluded.
  - Best Match with no filters → all events, score-ordered (`[4, 3, 2, 1]`).
- Negative verification: temporarily reverting to `scoredEvents` makes the price-range test fail, confirming it guards the regression.
- `npx eslint src/Pages/Events/useEventListing.js src/Pages/Events/useEventListing.test.js` — clean.

Closes #12461
