### PR TITLE
fix: unwrap paged events payload before suggesting alternative events

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -275,7 +275,15 @@ const EventRegistration = () => {
     if (conflictCheck.hasConflict) {
       try {
         const res = await apiUtils.get(API_ENDPOINTS.EVENTS.LIST);
-        const realEvents = res.status === 200 ? res.data : [];
+        // GET /api/events returns a PagedResponse ({ content: [...] }), not a
+        // plain array. Unwrap it so suggestAlternativeEvents receives a real
+        // array instead of returning [] on { content: [...] }.length === undefined.
+        const data = res.status === 200 ? res.data : [];
+        const realEvents = Array.isArray(data?.content)
+          ? data.content
+          : Array.isArray(data)
+            ? data
+            : [];
         const suggestions = suggestAlternativeEvents(event, realEvents, myEvents);
         setConflictData({
           conflicts: conflictCheck.conflicts,

--- a/tests/conflictDetection.test.mjs
+++ b/tests/conflictDetection.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-const { doEventsOverlap, findConflictingEvents, checkRegistrationConflict, parseTimeToMinutes } =
+const { doEventsOverlap, findConflictingEvents, checkRegistrationConflict, parseTimeToMinutes, suggestAlternativeEvents } =
   await import("../src/utils/conflictDetection.js");
 
 assert.equal(parseTimeToMinutes("10:00 AM"), 600);
@@ -50,5 +50,75 @@ const selfConflictCheck = findConflictingEvents(
   "UTC"
 );
 assert.equal(selfConflictCheck.length, 0);
+
+// --- Issue 12463: suggestAlternativeEvents with a real (unwrapped) array ---
+// The conflict modal must show alternative events. EventRegistration.js unwraps
+// the paged API payload ({ content: [...] }) into a plain array before calling
+// this function; given a real array it must return same-category,
+// non-conflicting suggestions (excluding the target and registered events).
+
+const targetEvent = {
+  id: 1,
+  title: "React Workshop",
+  date: "2026-06-01",
+  time: "10:00 AM",
+  timezone: "UTC",
+  durationMinutes: 60,
+  category: "Workshop",
+};
+
+const alreadyRegistered = {
+  id: 2,
+  title: "Registered Event",
+  date: "2026-06-01",
+  time: "12:00 PM",
+  timezone: "UTC",
+  durationMinutes: 60,
+  category: "Workshop",
+};
+
+const altSameCategory = {
+  id: 3,
+  title: "Advanced React",
+  date: "2026-06-02",
+  time: "10:00 AM",
+  timezone: "UTC",
+  durationMinutes: 60,
+  category: "Workshop",
+};
+
+const altOtherCategory = {
+  id: 4,
+  title: "Cloud Conf",
+  date: "2026-06-03",
+  time: "10:00 AM",
+  timezone: "UTC",
+  durationMinutes: 60,
+  category: "Conference",
+};
+
+const altConflicting = {
+  id: 5,
+  title: "Overlapping Registered Workshop",
+  date: "2026-06-01",
+  time: "12:30 PM",
+  timezone: "UTC",
+  durationMinutes: 60,
+  category: "Workshop",
+};
+
+const suggestions = suggestAlternativeEvents(
+  targetEvent,
+  [alreadyRegistered, altSameCategory, altOtherCategory, altConflicting],
+  [{ event: alreadyRegistered }],
+  60,
+  3,
+  "UTC"
+);
+
+// Excludes the already-registered event (2) and the one that conflicts with it
+// (5, 12:30 PM overlaps the 12:00 PM registration); prioritises the
+// same-category event (3) over the other category (4).
+assert.deepEqual(suggestions.map((s) => s.id), [3, 4]);
 
 console.log("conflictDetection tests passed ✓");


### PR DESCRIPTION
## Problem

When a registration conflict is detected, the "Suggested Alternative Events" list in the conflict modal is always empty. `GET /api/events` returns a `PagedResponse` (`{ content: [...] }`), and that paged object was passed straight into `suggestAlternativeEvents`. The paged object has no array methods (`length`/`filter`), so the call threw inside the try/catch and the modal silently fell back to `suggestions: []`.

## Fix

- In `EventRegistration.js` `checkAndHandleConflicts`, unwrap the paged payload before building suggestions: prefer `res.data.content` when it is an array, fall back to `res.data` if it is already an array, otherwise `[]`.
- Add a regression test to `tests/conflictDetection.test.mjs` asserting `suggestAlternativeEvents` returns same-category, non-conflicting suggestions (excluding the target and already-registered events) when given a real array.

## Files changed

- `src/Pages/Events/EventRegistration.js`
- `tests/conflictDetection.test.mjs`

## Testing

- `node tests/conflictDetection.test.mjs` — all assertions pass (incl. the new `suggestAlternativeEvents` regression case).
- `npx eslint src/Pages/Events/EventRegistration.js tests/conflictDetection.test.mjs` — no errors (only the pre-existing `existingRegId` unused-variable warning in `EventRegistration.js:436`).

Closes #12463
