### PR TITLE
fix: drop stale SSE emitters without aborting publish loop

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
@@ -77,9 +77,13 @@ public class EventStreamService {
         for (SseEmitter emitter : emitters) {
             try {
                 emitter.send(SseEmitter.event().name(eventName).data(payload));
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 removeEmitter(normalized, emitter);
-                emitter.completeWithError(ex);
+                try {
+                    emitter.completeWithError(ex);
+                } catch (IllegalStateException ignored) {
+                    // Emitter already completed or closed; nothing left to clean up.
+                }
             }
         }
     }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/EventStreamServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/EventStreamServiceTest.java
@@ -1,0 +1,97 @@
+package com.sandeep.eventrabackend.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EventStreamServiceTest {
+
+    @Test
+    @DisplayName("publish removes a stale emitter without propagating the send failure (#12464)")
+    void publishDoesNotPropagateStaleEmitterFailure() throws Exception {
+        EventStreamService service = new EventStreamService();
+
+        Field emittersField = EventStreamService.class.getDeclaredField("emittersByTopic");
+        emittersField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, CopyOnWriteArrayList<SseEmitter>> emittersByTopic =
+                (Map<String, CopyOnWriteArrayList<SseEmitter>>) emittersField.get(service);
+
+        Field countsField = EventStreamService.class.getDeclaredField("emitterCounts");
+        countsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, AtomicInteger> emitterCounts =
+                (Map<String, AtomicInteger>) countsField.get(service);
+
+        CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+        AtomicInteger count = new AtomicInteger(1);
+        emittersByTopic.put("events", emitters);
+        emitterCounts.put("events", count);
+
+        SseEmitter stale = new SseEmitter() {
+            @Override
+            public void send(SseEventBuilder builder) throws IOException {
+                throw new IllegalStateException("ResponseBodyEmitter has already completed");
+            }
+        };
+        emitters.add(stale);
+
+        assertDoesNotThrow(() -> service.publish("events", "update", "{}"));
+        assertFalse(emitters.contains(stale));
+        assertEquals(0, count.get());
+    }
+
+    @Test
+    @DisplayName("publish keeps delivering to healthy emitters when one is stale (#12464)")
+    void publishKeepsDeliveringToHealthyEmitters() throws Exception {
+        EventStreamService service = new EventStreamService();
+
+        Field emittersField = EventStreamService.class.getDeclaredField("emittersByTopic");
+        emittersField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, CopyOnWriteArrayList<SseEmitter>> emittersByTopic =
+                (Map<String, CopyOnWriteArrayList<SseEmitter>>) emittersField.get(service);
+
+        Field countsField = EventStreamService.class.getDeclaredField("emitterCounts");
+        countsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, AtomicInteger> emitterCounts =
+                (Map<String, AtomicInteger>) countsField.get(service);
+
+        CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+        AtomicInteger count = new AtomicInteger(2);
+        emittersByTopic.put("events", emitters);
+        emitterCounts.put("events", count);
+
+        SseEmitter stale = new SseEmitter() {
+            @Override
+            public void send(SseEventBuilder builder) throws IOException {
+                throw new IllegalStateException("ResponseBodyEmitter has already completed");
+            }
+        };
+        SseEmitter healthy = new SseEmitter() {
+            @Override
+            public void send(SseEventBuilder builder) throws IOException {
+                // no-op: simulate a successful send
+            }
+        };
+        emitters.add(stale);
+        emitters.add(healthy);
+
+        assertDoesNotThrow(() -> service.publish("events", "update", "{}"));
+        assertFalse(emitters.contains(stale));
+        assertTrue(emitters.contains(healthy));
+        assertEquals(1, count.get());
+    }
+}


### PR DESCRIPTION
## Problem

SSE clients can disconnect while `EventStreamService.publish` is mid-loop. The old code only caught `IOException`; a disconnect could surface as another runtime exception, and the removed/stale emitter was never dropped from the `emitters` set, so publish kept pushing to (and accumulating) dead connections. `completeWithError` could also throw `IllegalStateException` if the emitter had already completed.

## Fix

- In `EventStreamService.publish`, catch `Exception` (not just `IOException`) and remove the failed emitter from the set before completing with error.
- Wrap `completeWithError` in a try/catch for `IllegalStateException` so a concurrently completed emitter cannot abort the publish loop.
- Add `EventStreamServiceTest` with 2 tests: stale/errored emitter is removed from the set, and healthy emitters continue to receive events after one fails.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/EventStreamServiceTest.java`

## Testing

- New `EventStreamServiceTest` (2 tests) passes — verifies stale emitter removal and that healthy emitters are still served.
- Existing `EventStreamTests` suite passes.
- Verified against the pre-existing backend compile-error workaround (stubs reverted; not part of this PR).

Closes #12464
