### PR TITLE
fix: preserve capacity and imageUrl on partial event update

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -407,11 +407,15 @@ public class EventService {
                 event.setDescription(request.getDescription());
                 event.setLocation(request.getLocation());
                 event.setEventDate(request.getEventDate());
-                event.setCapacity(request.getCapacity());
+                if (request.getCapacity() != null) {
+                        event.setCapacity(request.getCapacity());
+                }
                 if (request.getIsPublic() != null) {
                         event.setPublic(request.getIsPublic());
                 }
-                event.setImageUrl(request.getImageUrl());
+                if (request.getImageUrl() != null) {
+                        event.setImageUrl(request.getImageUrl());
+                }
                 if (request.getCategory() != null) {
                         event.setCategory(request.getCategory());
                 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
@@ -231,6 +231,29 @@ public class EventUpdateTests {
     }
 
     @Test
+    @DisplayName("Partial update preserves existing capacity and imageUrl (#12456)")
+    void testUpdateWithoutCapacityOrImageUrlPreservesExistingValues() throws Exception {
+        existingEvent.setImageUrl("https://example.com/images/banner.jpg");
+        eventRepository.save(existingEvent);
+
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Partial Update Title")
+                .description("Description")
+                .location("Location")
+                .eventDate(LocalDateTime.now().plusDays(10))
+                .build();
+
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
+                        .with(user("admin@example.com").authorities(() -> "ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Partial Update Title"))
+                .andExpect(jsonPath("$.capacity").value(100))
+                .andExpect(jsonPath("$.imageUrl").value("https://example.com/images/banner.jpg"));
+    }
+
+    @Test
     @DisplayName("Capacity lower than registeredCount returns 409 (Conflict)")
     void testUpdateCapacityLowerThanRegisteredCount() throws Exception {
         // Manually set registeredCount for the event


### PR DESCRIPTION
## Problem

`EventService.updateEvent` unconditionally applied `event.setCapacity(updatedEvent.getCapacity())` and `event.setImageUrl(updatedEvent.getImageUrl())`. When an update request omitted those fields (PATCH semantics — e.g. updating only the title), the null values overwrote the stored capacity/image, corrupting the event. A regression test asserting that behavior was reported.

## Fix

- Guard `event.setCapacity(...)` and `event.setImageUrl(...)` with null checks so omitted fields preserve the existing stored values.
- Add regression test `testUpdateWithoutCapacityOrImageUrlPreservesExistingValues` to `EventUpdateTests` covering this case.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java`

## Testing

- New regression test passes — capacity/imageUrl preserved when the update omits them.
- 8 tests ran in the suite; the only failure is the pre-existing `testOrganizerCanUpdateEvent` (403, predates this change and is unrelated to #12456).

Closes #12456
