### PR TITLE
fix: reject unsupported event sort instead of silent fallback

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -217,7 +217,9 @@ public class EventService {
                 String rawProperty = parts[0].trim();
                 String mapped = SORT_ALIASES.getOrDefault(rawProperty.toLowerCase(Locale.ROOT), rawProperty);
                 if (!ALLOWED_SORT_PROPERTIES.contains(mapped)) {
-                        return Sort.by(Sort.Direction.DESC, "eventDate");
+                        throw new IllegalArgumentException(
+                                        "Unsupported sort property '" + rawProperty + "'. Allowed values: "
+                                                        + String.join(", ", ALLOWED_SORT_PROPERTIES));
                 }
 
                 Sort.Direction direction = Sort.Direction.DESC;

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/ListEventsTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/ListEventsTests.java
@@ -95,6 +95,14 @@ public class ListEventsTests {
 
     @Test
     @WithMockUser
+    void testGetAllEventsUnsupportedSortRejected() throws Exception {
+        mockMvc.perform(get("/api/events").param("sort", "match,desc"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Unsupported sort property 'match'")));
+    }
+
+    @Test
+    @WithMockUser
     void testGetAllEventsSearch() throws Exception {
         mockMvc.perform(get("/api/events").param("search", "Alpha"))
                 .andExpect(status().isOk())

--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -24,8 +24,6 @@ const MAX_TAG_LENGTH = 50;
 const SORT_MAPPING = {
   Newest: "date,desc",
   Upcoming: "date,asc",
-  // FIX (#7437): sort by AI recommendation score, highest first
-  "Best Match": "match,desc",
   Oldest: "date,asc",
   "Title A-Z": "title,asc",
   "Title Z-A": "title,desc",


### PR DESCRIPTION
## Problem

The events listing accepted an unsupported sort value (the frontend was sending `sort=match,desc` for "Best Match", a client-side-only ranking) and silently fell back to a default sort, masking the wrong sort order server-side. "Best Match" must never be sent to the server as a sort parameter.

## Fix

- Backend: `EventService.resolveSort` now throws `IllegalArgumentException` for unsupported sort values, which `GlobalExceptionHandler` (line 76–81) turns into a 400 response instead of a silent fallback.
- Frontend: remove the `"Best Match": "match,desc"` entry from `SORT_MAPPING` in `useEventListing.js`; Best Match stays a purely client-side ranking via `recommendationScore`.
- Add `testGetAllEventsUnsupportedSortRejected` to `ListEventsTests` asserting a 400 for an unknown sort.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/GlobalExceptionHandler.java` (existing registration used)
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/ListEventsTests.java`
- `src/Pages/Events/useEventListing.js`

## Testing

- All 4 `ListEventsTests` pass (incl. the new unsupported-sort 400 test).
- `npx eslint src/Pages/Events/useEventListing.js` clean.
- Backend tests run against the pre-existing compile-error workaround (stubs reverted; not part of this PR).

Closes #12457
