### PR TITLE
fix: validate JWT issued-at and expiration clock skew

### DIFF
--- a/src/utils/tokenUtils.js
+++ b/src/utils/tokenUtils.js
@@ -7,12 +7,28 @@
  * avoid duplicate implementations.
  */
 
-export function isTokenSkewValid(payload) {
+export function isTokenSkewValid(payload, maxSkewSeconds = 30) {
   if (!payload || typeof payload !== "object") return false;
   const now = Math.floor(Date.now() / 1000);
-  if (payload.nbf && payload.nbf > now + 30) {
-    return false; // Token not yet active (nbf clock skew)
+
+  if (payload.nbf && typeof payload.nbf === "number") {
+    if (payload.nbf > now + maxSkewSeconds) {
+      return false;
+    }
   }
+
+  if (payload.iat && typeof payload.iat === "number") {
+    if (payload.iat > now + maxSkewSeconds) {
+      return false;
+    }
+  }
+
+  if (payload.exp && typeof payload.exp === "number") {
+    if (payload.exp < now - maxSkewSeconds) {
+      return false;
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Related Issue

Closes #12497

## Description

This PR fixes `isTokenSkewValid` so that JWT clock-skew validation checks the `nbf`, `iat`, and `exp` claims using a consistent configurable tolerance.

Previously, the function only validated the `nbf` claim. As a result, tokens with future `iat` timestamps or expired `exp` timestamps could incorrectly pass the clock-skew validation.

## Changes Made

- Added validation for the JWT `nbf` claim.
- Added validation for the JWT `iat` claim.
- Added validation for the JWT `exp` claim.
- Added a configurable `maxSkewSeconds` parameter with a default tolerance of 30 seconds.
- Added numeric type checks before validating timestamp claims.
- Preserved the existing behavior for valid tokens.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified tokens with `nbf` values too far in the future are rejected.
2. Verified tokens with `iat` values too far in the future are rejected.
3. Verified tokens with expired `exp` values outside the allowed skew are rejected.
4. Verified valid tokens within the configured clock-skew tolerance continue to pass.
5. Verified the changes introduce no unrelated modifications.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.