### PR TITLE
fix: reset rate limit attempts after lockout expiry

### DIFF
--- a/src/utils/rateLimitUtils.js
+++ b/src/utils/rateLimitUtils.js
@@ -31,6 +31,12 @@ export function readPersistedRateLimit() {
 
     if (!Number.isFinite(attempts) || attempts < 0) return { attempts: 0, lockoutUntil: 0 };
 
+    // If lockout has expired, reset both attempts and lockout
+    if (Number.isFinite(lockoutUntil) && lockoutUntil > 0 && lockoutUntil <= Date.now()) {
+      clearPersistedRateLimit();
+      return { attempts: 0, lockoutUntil: 0 };
+    }
+
     // Discard expired lockouts — don't start with a stale "locked" state
     const validLockout = Number.isFinite(lockoutUntil) && lockoutUntil > Date.now()
       ? lockoutUntil


### PR DESCRIPTION
## Related Issue

Closes #12498

## Description

This PR fixes stale failed-attempt counters in the persisted rate-limit state after a lockout period expires.

Previously, `readPersistedRateLimit()` reset the expired `lockoutUntil` value but retained the previous failed-attempt count. This caused the next failed login attempt to reuse the stale counter and potentially trigger another lockout immediately.

The persisted rate-limit state is now cleared when the lockout period has expired.

## Changes Made

- Detect expired lockout timestamps.
- Clear persisted rate-limit state when the lockout expires.
- Reset both `attempts` and `lockoutUntil` after expiry.
- Preserve active lockout state while the lockout is still valid.
- Handle invalid persisted values safely.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified that an active lockout preserves the existing attempt count.
2. Verified that an expired lockout resets the attempt count.
3. Verified that the expired lockout timestamp is cleared.
4. Verified that invalid persisted values return a clean rate-limit state.
5. Verified that no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.