### PR TITLE
fix: discard malformed notification queue items

### DIFF
--- a/src/utils/notificationQueue.js
+++ b/src/utils/notificationQueue.js
@@ -45,8 +45,25 @@ export const pushToNotificationQueue = (action, payload) => {
 // 🔥 CodeScene refactor: extracted to keep syncNotificationQueue below the
 // "Complex Method" and "Bumpy Road" thresholds.
 const dispatchOne = async (item, apiUtils) => {
-  if (item.action === 'read') return apiUtils.put(item.payload.endpoint, {});
-  if (item.action === 'delete') return apiUtils.delete(item.payload.endpoint);
+  if (
+    !item ||
+    typeof item !== "object" ||
+    !item.payload ||
+    typeof item.payload.endpoint !== "string"
+  ) {
+    return false;
+  }
+
+  if (item.action === 'read') {
+    await apiUtils.put(item.payload.endpoint, {});
+    return true;
+  }
+  if (item.action === 'delete') {
+    await apiUtils.delete(item.payload.endpoint);
+    return true;
+  }
+
+  return false;
 };
 
 
@@ -59,10 +76,13 @@ export const syncNotificationQueue = async (apiUtils) => {
   // a single failed item caused the entire queue to be wiped at the end of
   // the function, silently losing every subsequent item that had not yet been
   // attempted.
-  let remaining = [];
+  const remaining = [];
   for (const item of queue) {
     try {
-      await dispatchOne(item, apiUtils);
+      const success = await dispatchOne(item, apiUtils);
+      if (!success) {
+        console.warn("Discarding malformed notification queue item:", item);
+      }
     } catch (e) {
       console.error('Failed to sync queued notification action', e);
       remaining.push(item);


### PR DESCRIPTION
## Related Issue

Closes #12499

## Description

This PR fixes a permanent retry loop in the notification queue when a queued item contains a missing or invalid `payload.endpoint`.

Previously, malformed queue items could cause `dispatchOne()` to throw an error during synchronization. The failed item was then retained and persisted back into the queue, causing it to be retried on every subsequent synchronization.

The queue now validates items before dispatching them and discards malformed items instead of retrying them indefinitely.

## Changes Made

- Added validation for notification queue items before dispatch.
- Added validation for `payload.endpoint`.
- Prevented malformed queue items from causing dispatch errors.
- Discarded invalid queue items instead of retaining them for retry.
- Preserved retry behavior for valid items that fail during API execution.
- Added a warning when malformed items are discarded.


## Verification & Testing

1. Verified malformed items without `payload.endpoint` are rejected.
2. Verified invalid queue items are discarded instead of being retried.
3. Verified valid `read` actions continue to use the notification API.
4. Verified valid `delete` actions continue to use the notification API.
5. Verified API failures for valid items can still be retained for retry.
6. Verified no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.