### PR TITLE
fix: normalize waitlist user IDs for position notifications

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -128,7 +128,9 @@ const getWaitlistEventTitle = (eventId, eventOrTitle, records = []) => {
 
 const getPositionMap = (waitlist) =>
   waitlist.reduce((positions, record, index) => {
-    positions.set(record.userId, index + 1);
+    if (record && record.userId != null) {
+      positions.set(String(record.userId), index + 1);
+    }
     return positions;
   }, new Map());
 
@@ -141,7 +143,9 @@ const notifyWaitlistPositionChanges = async (eventId, beforeWaitlist, eventOrTit
 
   await Promise.all(
     afterWaitlist.map(async (record, index) => {
-      const previousPosition = previousPositions.get(record.userId);
+      if (!record || record.userId == null) return;
+
+      const previousPosition = previousPositions.get(String(record.userId));
       const currentPosition = index + 1;
       if (!previousPosition || currentPosition >= previousPosition) return;
 


### PR DESCRIPTION
## Related Issue

Closes #12500

## Description

This PR fixes waitlist position change notifications when `userId` values have different types between the previous and current waitlist data.

Previously, the position map could store a user ID as a string while the current waitlist provided the same ID as a number. Because JavaScript `Map` keys are type-sensitive, the lookup failed and valid position changes were treated as missing.

## Changes Made

- Normalize `userId` values to strings when building the position map.
- Normalize `userId` values during position lookup.
- Ignore malformed waitlist records without a valid `userId`.
- Preserve existing waitlist position notification behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified string and numeric `userId` values resolve to the same position-map key.
2. Verified position-change notifications are generated when a user's position improves.
3. Verified records without a valid `userId` are safely ignored.
4. Verified existing waitlist behavior remains unchanged.
5. Verified no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.