### PR TITLE
fix: validate event pagination parameters

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -202,7 +202,9 @@ public class EventService {
                         String search,
                         List<String> statuses,
                         String sort) {
-                Pageable pageable = PageRequest.of(page, size, resolveSort(sort));
+                int safePage = Math.max(0, page);
+                int safeSize = (size <= 0) ? 20 : Math.min(size, 100);
+                Pageable pageable = PageRequest.of(safePage, safeSize, resolveSort(sort));
                 Specification<Event> spec = EventSpecifications.publicListing(search, statuses);
                 Page<EventResponse> result = eventRepository.findAll(spec, pageable).map(this::toEventResponse);
                 return PagedResponse.from(result);


### PR DESCRIPTION
## Related Issue

Closes #12501

## Description

This PR fixes invalid pagination parameters in `EventService` that could cause `PageRequest.of()` to throw an `IllegalArgumentException` and result in HTTP 500 responses.

Previously, negative page values and non-positive page sizes were passed directly to `PageRequest.of()` without validation.

The pagination parameters are now normalized before creating the `Pageable`.

## Changes Made

- Prevented negative page numbers by clamping `page` to `0`.
- Added a default page size of `20` when the requested size is non-positive.
- Limited the maximum page size to `100`.
- Preserved the existing sorting and event filtering behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified negative page values are normalized to `0`.
2. Verified `size=0` uses the default page size of `20`.
3. Verified negative page sizes use the default page size.
4. Verified excessively large page sizes are capped at `100`.
5. Verified valid pagination values continue to work normally.
6. Verified no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.