### PR TITLE
fix: set owner when creating project

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -82,8 +82,10 @@ public class ProjectController {
             )
     })
     public ResponseEntity<ProjectResponse> createProject(
-            @Valid @RequestBody ProjectCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(projectService.createProject(request));
+            @Valid @RequestBody ProjectCreateRequest request,
+            Authentication authentication) {
+        String userEmail = authentication.getName();
+        return ResponseEntity.status(HttpStatus.CREATED).body(projectService.createProject(request, userEmail));
     }
 
     @GetMapping

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Project.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Project.java
@@ -33,4 +33,6 @@ public class Project {
 
     @Builder.Default
     private long upvotes = 0;
+
+    private Long ownerId;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -34,13 +34,17 @@ public class ProjectService {
     }
 
     @Transactional
-    public ProjectResponse createProject(ProjectCreateRequest request) {
+    public ProjectResponse createProject(ProjectCreateRequest request, String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
+
         Project project = Project.builder()
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .category(request.getCategory())
                 .thumbnailUrl(request.getThumbnailUrl())
                 .githubUrl(request.getGithubUrl())
+                .createdBy(user)
                 .build();
 
         Project savedProject = projectRepository.save(project);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -44,7 +44,7 @@ public class ProjectService {
                 .category(request.getCategory())
                 .thumbnailUrl(request.getThumbnailUrl())
                 .githubUrl(request.getGithubUrl())
-                .createdBy(user)
+                .ownerId(user.getId())
                 .build();
 
         Project savedProject = projectRepository.save(project);


### PR DESCRIPTION
## Related Issue

Closes #12504

## Description

This PR fixes project creation so that newly created projects are assigned to their authenticated creator.

Previously, the `Project` entity did not have an `ownerId` populated during project creation. As a result, newly created projects were persisted without an owner, preventing the application from reliably identifying the project creator.

The project creation flow now resolves the authenticated user and assigns their user ID to the project's `ownerId` before saving the entity.

## Changes Made

- Added `ownerId` to the `Project` entity.
- Resolved the authenticated creator using their email.
- Assigned the creator's user ID to the project's `ownerId`.
- Ensured the owner information is persisted when creating a project.
- Preserved the existing project creation flow.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified the authenticated user is resolved before project creation.
2. Verified the creator's user ID is assigned to `ownerId`.
3. Verified the project is saved with the owner information.
4. Ran `git diff --check` successfully.
5. Confirmed no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.