### PR TITLE
fix: recognize assigned owner team members

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
@@ -73,7 +73,7 @@ public class EventRoleService {
         }
 
         EventRole newRole = EventRole.from(request.getRole());
-        if (newRole == EventRole.OWNER && !isPlatformAdmin(actor) && !isLegacyOwner(eventId, actor.getId())) {
+        if (newRole == EventRole.OWNER && !isPlatformAdmin(actor) && !hasOwnerRole(eventId, actor.getId())) {
             throw new AccessDeniedException("Only the event owner can transfer ownership.");
         }
 
@@ -162,6 +162,15 @@ public class EventRoleService {
     private boolean isLegacyOwner(Long eventId, Long userId) {
         return eventRepository.findById(eventId)
                 .map(event -> userId != null && userId.equals(event.getOwnerId()))
+                .orElse(false);
+    }
+
+    private boolean hasOwnerRole(Long eventId, Long userId) {
+        if (isLegacyOwner(eventId, userId)) {
+            return true;
+        }
+        return eventTeamMemberRepository.findByEvent_IdAndUser_Id(eventId, userId)
+                .map(member -> member.getRole() == EventRole.OWNER)
                 .orElse(false);
     }
 


### PR DESCRIPTION
## Related Issue

Closes #12505

## Description

This PR fixes ownership authorization in `EventRoleService`.

Previously, `assignRole` relied on the legacy event owner relationship when checking whether an actor was allowed to perform ownership operations. This could reject users who were already assigned the `OWNER` role through the event team membership system.

The authorization check now recognizes users who have the `OWNER` role in the event team membership.

## Changes Made

- Updated the ownership authorization check in `assignRole`.
- Added an `hasOwnerRole` check based on event team membership.
- Recognized users assigned the `OWNER` role through the team membership system.
- Preserved platform administrator authorization.
- Prevented valid event owners from being incorrectly rejected with `AccessDeniedException`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified platform administrators continue to be authorized.
2. Verified legacy event owners continue to be recognized.
3. Verified users assigned the `OWNER` role through event team membership are recognized.
4. Verified unauthorized users remain rejected.
5. Ran `git diff --check` successfully.
6. Confirmed no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.