### PR TITLE
fix: delay session backup blob cleanup

### DIFF
--- a/src/utils/sessionExportImport.js
+++ b/src/utils/sessionExportImport.js
@@ -61,12 +61,14 @@ export const downloadSessionBackup = ({
   link.style.visibility = "hidden";
   document.body.appendChild(link);
 
-  try {
-    link.click();
-  } finally {
-    document.body.removeChild(link);
+  link.click();
+
+  setTimeout(() => {
+    if (link.parentNode) {
+      document.body.removeChild(link);
+    }
     urlApi.revokeObjectURL(url);
-  }
+  }, 1000);
 
   return { filename, count: normalizeMultiSessions(sessions).length };
 };


### PR DESCRIPTION
## Related Issue

Closes #12506

## Description

This PR fixes session backup downloads by delaying Blob URL cleanup until after the browser has had time to initiate the download.

Previously, the generated Blob URL was revoked immediately after `link.click()`. Since browser downloads may be processed asynchronously, the URL could be revoked before the download was fully initialized, causing downloads to fail or behave inconsistently.

The cleanup is now performed asynchronously after a short delay.

## Changes Made

- Delayed `URL.revokeObjectURL()` after triggering the download.
- Delayed removal of the temporary download link.
- Ensured the Blob URL remains available while the browser initializes the download.
- Preserved the existing session backup export behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified the download link is clicked before cleanup.
2. Verified Blob URL revocation is delayed.
3. Verified the temporary link is removed asynchronously.
4. Ran `git diff --check` successfully.
5. Confirmed no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.