### PR TITLE
fix: validate feedback rating range

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -52,6 +52,11 @@ public class FeedbackService {
             throw new FeedbackAlreadyExistsException("You have already submitted feedback for this event.");
         }
 
+        // Validate rating is within valid range
+        if (request.getRating() == null || request.getRating() < 1 || request.getRating() > 5) {
+            throw new IllegalArgumentException("Rating must be an integer between 1 and 5.");
+        }
+
         Feedback feedback = new Feedback();
         feedback.setUser(user);
         feedback.setEvent(event);


### PR DESCRIPTION
## Related Issue

Closes #12508

## Description

This PR fixes feedback submission by validating that submitted ratings are within the supported 1–5 range.

Previously, `submitFeedback` stored the requested rating without checking its value. This allowed clients to submit invalid ratings such as `0`, negative values, or values greater than `5`, which could result in incorrect organizer rating calculations.

The service now validates the rating before creating the `Feedback` entity.

## Changes Made

- Added validation for missing feedback ratings.
- Added a minimum rating boundary of `1`.
- Added a maximum rating boundary of `5`.
- Rejected invalid ratings before persisting feedback.
- Preserved the existing feedback submission flow.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

## Verification & Testing

1. Verified ratings below `1` are rejected.
2. Verified ratings above `5` are rejected.
3. Verified a missing rating is rejected.
4. Verified valid ratings from `1` to `5` continue through the existing submission flow.
5. Ran `git diff --check` successfully.
6. Confirmed no unrelated files or changes are included.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] No unrelated files or code changes are included.