### PR TITLE
fix: handle unauthenticated notification requests

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/notifications")
+@PreAuthorize("isAuthenticated()")
 @Tag(name = "Notifications", description = "Endpoints for user notifications")
 public class NotificationController {
 
@@ -46,6 +48,9 @@ public class NotificationController {
             )
     })
     public ResponseEntity<List<NotificationResponse>> getNotifications(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).build();
+        }
         String email = authentication.getName();
         return ResponseEntity.ok(notificationService.getNotificationsForUser(email));
     }
@@ -73,6 +78,9 @@ public class NotificationController {
     public ResponseEntity<NotificationResponse> markAsRead(
             @PathVariable Long id,
             Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).build();
+        }
         String email = authentication.getName();
         return ResponseEntity.ok(notificationService.markAsRead(id, email));
     }
@@ -94,6 +102,9 @@ public class NotificationController {
             )
     })
     public ResponseEntity<List<NotificationResponse>> markAllAsRead(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).build();
+        }
         String email = authentication.getName();
         return ResponseEntity.ok(notificationService.markAllAsRead(email));
     }
@@ -121,6 +132,9 @@ public class NotificationController {
     public ResponseEntity<Void> deleteNotification(
             @PathVariable Long id,
             Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).build();
+        }
         String email = authentication.getName();
         notificationService.deleteNotification(id, email);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
# Related Issue

Closes #12510

# Description

This PR fixes an authentication handling issue in the notification controller where unauthenticated requests could cause a `NullPointerException`.

Previously, the controller accessed `authentication.getName()` without first ensuring that an authenticated principal was available. If an unauthenticated request reached the controller with `authentication == null`, the request could result in an HTTP 500 response instead of a proper HTTP 401 Unauthorized response.

# Changes Made

- Added `@PreAuthorize("isAuthenticated()")` to the notification controller.
- Added null and authentication-state checks before accessing `authentication.getName()`.
- Return HTTP 401 Unauthorized for unauthenticated requests.
- Applied the authentication guard consistently across notification endpoints.
- Prevented `NullPointerException` caused by missing authentication.

# Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update

# Verification & Testing

1. Verified that authenticated requests can still access notification endpoints.
2. Verified that unauthenticated requests are rejected with HTTP 401.
3. Verified that `authentication.getName()` is only accessed after authentication validation.
4. Confirmed that missing authentication no longer causes a `NullPointerException`.
5. Reviewed the diff to ensure no unrelated files or changes are included.

# Checklist

- [x] My code follows the style guidelines of this project.
- [x] My changes generate no new warnings or console errors.
- [x] I have performed a self-review of my own code.
- [x] No unrelated files or code changes are included.