### PR TITLE
perf: add read-only transaction to notification retrieval

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
@@ -19,7 +19,11 @@ public class NotificationService {
         this.notificationRepository = notificationRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<NotificationResponse> getNotificationsForUser(String email) {
+        if (email == null || email.isBlank()) {
+            return List.of();
+        }
         List<Notification> notifications = notificationRepository.findByUserEmailOrderByCreatedAtDesc(email);
         return notifications.stream()
                 .map(this::mapToResponse)


### PR DESCRIPTION
# Related Issue

Closes #12511

# Description

This PR adds an explicit read-only transaction to the `getNotificationsForUser` service method.

Previously, notification retrieval executed the repository query and mapped the returned entities without an explicit transaction boundary. If notification entities contain lazily loaded relationships accessed during response mapping, this could lead to `LazyInitializationException` errors when no persistence context is available.

# Changes Made

- Added `@Transactional(readOnly = true)` to `getNotificationsForUser`.
- Added validation for null or blank email values.
- Returns an empty list when the email is missing or blank.
- Ensures notification retrieval and response mapping execute within a consistent read-only persistence context.

# Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring
- [ ] Documentation update

# Verification & Testing

1. Verified that `getNotificationsForUser` uses a read-only transaction.
2. Verified that null or blank email values return an empty list.
3. Confirmed that notification retrieval and response mapping execute within the transaction boundary.
4. Reviewed the changes to ensure no unrelated files or code changes are included.

# Checklist

- [x] My code follows the style guidelines of this project.
- [x] My changes generate no new warnings or console errors.
- [x] I have performed a self-review of my own code.
- [x] No unrelated files or code changes are included.