### PR TITLE
feat(events): add attendance history dashboard

### DIFF
--- a/src/components/events/AttendanceHistoryCard.js
+++ b/src/components/events/AttendanceHistoryCard.js
@@ -1,0 +1,198 @@
+import {
+  Award,
+  CalendarDays,
+  CheckCircle,
+  Clock,
+  MapPin,
+  XCircle,
+} from "lucide-react";
+import {
+  getAttendanceEventDetails,
+} from "../../utils/attendanceHistoryUtils";
+
+const AttendanceHistoryCard = ({ event }) => {
+  if (!event) return null;
+
+  const details =
+    getAttendanceEventDetails(event);
+
+  const isAttended = details.attended;
+  const isUpcoming =
+    details.attendanceStatus === "Upcoming";
+
+  const certificateIssued =
+    details.certificate.status === "Issued";
+
+  const certificatePending =
+    details.certificate.status === "Pending";
+
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-700 dark:bg-slate-900">
+      {/* Event header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <span className="inline-flex rounded-full bg-indigo-100 px-2.5 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+            {details.type}
+          </span>
+
+          <h3 className="mt-3 line-clamp-2 text-lg font-bold text-slate-800 dark:text-white">
+            {details.name}
+          </h3>
+        </div>
+
+        <AttendanceStatusBadge
+          status={details.attendanceStatus}
+        />
+      </div>
+
+      {/* Event details */}
+      <div className="mt-5 space-y-3">
+        <DetailRow
+          icon={CalendarDays}
+          value={details.date}
+        />
+
+        {details.venue && (
+          <DetailRow
+            icon={MapPin}
+            value={details.venue}
+          />
+        )}
+
+        <DetailRow
+          icon={
+            isUpcoming
+              ? Clock
+              : isAttended
+                ? CheckCircle
+                : XCircle
+          }
+          value={
+            isUpcoming
+              ? "Upcoming event"
+              : isAttended
+                ? "Attendance recorded"
+                : details.attendanceStatus
+          }
+        />
+      </div>
+
+      {/* Certificate */}
+      <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <Award
+              size={18}
+              className={
+                certificateIssued
+                  ? "text-green-600 dark:text-green-400"
+                  : "text-slate-400"
+              }
+            />
+
+            <div>
+              <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+                Certificate
+              </p>
+
+              <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                {details.certificate.status}
+              </p>
+            </div>
+          </div>
+
+          {certificateIssued &&
+            details.certificate
+              .certificateUrl && (
+              <a
+                href={
+                  details.certificate
+                    .certificateUrl
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-lg bg-indigo-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-indigo-700"
+              >
+                View Certificate
+              </a>
+            )}
+        </div>
+
+        {certificatePending && (
+          <p className="mt-3 text-xs text-amber-600 dark:text-amber-400">
+            Your certificate is being prepared.
+          </p>
+        )}
+
+        {!certificateIssued &&
+          !certificatePending && (
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+              No certificate is currently available
+              for this event.
+            </p>
+          )}
+      </div>
+    </article>
+  );
+};
+
+const DetailRow = ({
+  icon: Icon,
+  value,
+}) => (
+  <div className="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
+    <Icon
+      size={17}
+      className="shrink-0 text-slate-400 dark:text-slate-500"
+    />
+
+    <span>{value}</span>
+  </div>
+);
+
+const AttendanceStatusBadge = ({
+  status,
+}) => {
+  const normalizedStatus = String(
+    status || ""
+  )
+    .trim()
+    .toLowerCase();
+
+  const isAttended =
+    normalizedStatus === "attended" ||
+    normalizedStatus === "present" ||
+    normalizedStatus === "checked in" ||
+    normalizedStatus === "checked-in";
+
+  const isUpcoming =
+    normalizedStatus === "upcoming";
+
+  const isCancelled =
+    normalizedStatus === "cancelled" ||
+    normalizedStatus === "canceled";
+
+  let className =
+    "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300";
+
+  if (isAttended) {
+    className =
+      "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300";
+  } else if (isUpcoming) {
+    className =
+      "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300";
+  } else if (isCancelled) {
+    className =
+      "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
+  }
+
+  return (
+    <span
+      className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold ${className}`}
+    >
+      {status || "Unknown"}
+    </span>
+  );
+};
+
+export default AttendanceHistoryCard;

--- a/src/components/events/AttendanceHistoryDashboard.js
+++ b/src/components/events/AttendanceHistoryDashboard.js
@@ -1,0 +1,338 @@
+import { useMemo, useState } from "react";
+import {
+  CalendarDays,
+  Award,
+  CheckCircle,
+  Clock,
+  Filter,
+  History,
+} from "lucide-react";
+import AttendanceHistoryCard from "./AttendanceHistoryCard";
+import {
+  filterAttendanceHistory,
+  getAttendanceSummary,
+  getAvailableEventTypes,
+  getAvailableYears,
+  sortAttendanceHistory,
+} from "../../utils/attendanceHistoryUtils";
+
+const AttendanceHistoryDashboard = ({
+  events = [],
+}) => {
+  const [selectedYear, setSelectedYear] =
+    useState("All");
+
+  const [selectedType, setSelectedType] =
+    useState("All");
+
+  const [sortDirection, setSortDirection] =
+    useState("desc");
+
+  const years = useMemo(
+    () => getAvailableYears(events),
+    [events]
+  );
+
+  const eventTypes = useMemo(
+    () => getAvailableEventTypes(events),
+    [events]
+  );
+
+  const summary = useMemo(
+    () =>
+      getAttendanceSummary(events),
+    [events]
+  );
+
+  const filteredEvents = useMemo(() => {
+    const filtered =
+      filterAttendanceHistory(events, {
+        year: selectedYear,
+        eventType: selectedType,
+      });
+
+    return sortAttendanceHistory(
+      filtered,
+      sortDirection
+    );
+  }, [
+    events,
+    selectedYear,
+    selectedType,
+    sortDirection,
+  ]);
+
+  return (
+    <section className="mx-auto w-full max-w-6xl space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+            <History
+              size={25}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-bold text-slate-800 dark:text-white">
+              Attendance History
+            </h2>
+
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              View your event participation and
+              attendance history.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <SummaryCard
+          icon={CheckCircle}
+          label="Events Attended"
+          value={
+            summary.totalEventsAttended
+          }
+          description="Total events attended"
+        />
+
+        <SummaryCard
+          icon={CalendarDays}
+          label="Upcoming Events"
+          value={
+            summary.upcomingEvents
+          }
+          description="Events still to attend"
+        />
+
+        <SummaryCard
+          icon={Clock}
+          label="Past Events"
+          value={summary.pastEvents}
+          description="Events already completed"
+        />
+
+        <SummaryCard
+          icon={Award}
+          label="Certificates"
+          value={
+            summary.certificatesIssued
+          }
+          description="Certificates issued"
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="mb-4 flex items-center gap-2">
+          <Filter
+            size={18}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+
+          <h3 className="font-semibold text-slate-800 dark:text-white">
+            Filter Attendance History
+          </h3>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {/* Year */}
+          <div>
+            <label
+              htmlFor="attendance-year"
+              className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300"
+            >
+              Year
+            </label>
+
+            <select
+              id="attendance-year"
+              value={selectedYear}
+              onChange={(event) =>
+                setSelectedYear(
+                  event.target.value ===
+                    "All"
+                    ? "All"
+                    : Number(
+                        event.target.value
+                      )
+                )
+              }
+              className={selectClass}
+            >
+              <option value="All">
+                All Years
+              </option>
+
+              {years.map((year) => (
+                <option
+                  key={year}
+                  value={year}
+                >
+                  {year}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Event type */}
+          <div>
+            <label
+              htmlFor="attendance-type"
+              className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300"
+            >
+              Event Type
+            </label>
+
+            <select
+              id="attendance-type"
+              value={selectedType}
+              onChange={(event) =>
+                setSelectedType(
+                  event.target.value
+                )
+              }
+              className={selectClass}
+            >
+              <option value="All">
+                All Event Types
+              </option>
+
+              {eventTypes.map((type) => (
+                <option
+                  key={type}
+                  value={type}
+                >
+                  {type}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Sort */}
+          <div>
+            <label
+              htmlFor="attendance-sort"
+              className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300"
+            >
+              Sort By
+            </label>
+
+            <select
+              id="attendance-sort"
+              value={sortDirection}
+              onChange={(event) =>
+                setSortDirection(
+                  event.target.value
+                )
+              }
+              className={selectClass}
+            >
+              <option value="desc">
+                Newest First
+              </option>
+
+              <option value="asc">
+                Oldest First
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Results */}
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-bold text-slate-800 dark:text-white">
+              Participation History
+            </h3>
+
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {filteredEvents.length}{" "}
+              {filteredEvents.length === 1
+                ? "event"
+                : "events"}{" "}
+              found
+            </p>
+          </div>
+        </div>
+
+        {filteredEvents.length > 0 ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {filteredEvents.map(
+              (event, index) => (
+                <AttendanceHistoryCard
+                  key={
+                    event.id ||
+                    event.eventId ||
+                    `${event.eventName || event.name}-${index}`
+                  }
+                  event={event}
+                />
+              )
+            )}
+          </div>
+        ) : (
+          <EmptyState />
+        )}
+      </div>
+    </section>
+  );
+};
+
+const SummaryCard = ({
+  icon: Icon,
+  label,
+  value,
+  description,
+}) => (
+  <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+    <div className="flex items-center justify-between">
+      <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+        <Icon
+          size={20}
+          className="text-indigo-600 dark:text-indigo-400"
+        />
+      </div>
+
+      <span className="text-2xl font-bold text-slate-800 dark:text-white">
+        {value}
+      </span>
+    </div>
+
+    <h4 className="mt-4 font-semibold text-slate-700 dark:text-slate-200">
+      {label}
+    </h4>
+
+    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+      {description}
+    </p>
+  </div>
+);
+
+const EmptyState = () => (
+  <div className="rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-12 text-center dark:border-slate-700 dark:bg-slate-900">
+    <History
+      size={42}
+      className="mx-auto mb-4 text-slate-400"
+    />
+
+    <h3 className="font-semibold text-slate-700 dark:text-white">
+      No attendance records found
+    </h3>
+
+    <p className="mx-auto mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+      Try changing the year or event type filter,
+      or attend an event to build your participation
+      history.
+    </p>
+  </div>
+);
+
+const selectClass =
+  "w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white";
+
+export default AttendanceHistoryDashboard;

--- a/src/components/events/CancellationConfirmation.js
+++ b/src/components/events/CancellationConfirmation.js
@@ -1,0 +1,102 @@
+import { AlertTriangle, X } from "lucide-react";
+
+const CancellationConfirmation = ({
+  registration,
+  onConfirm,
+  onCancel,
+}) => {
+  if (!registration) return null;
+
+  const eventName =
+    registration.eventName ||
+    registration.event?.name ||
+    "this event";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="cancellation-title"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl dark:bg-slate-900">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+              <AlertTriangle
+                size={23}
+                className="text-red-600 dark:text-red-400"
+              />
+            </div>
+
+            <h2
+              id="cancellation-title"
+              className="text-xl font-bold text-slate-800 dark:text-white"
+            >
+              Cancel Registration?
+            </h2>
+          </div>
+
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close confirmation dialog"
+            className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <X size={19} />
+          </button>
+        </div>
+
+        {/* Warning */}
+        <div className="mt-6 rounded-xl bg-red-50 p-4 dark:bg-red-900/20">
+          <p className="text-sm leading-6 text-red-700 dark:text-red-300">
+            Are you sure you want to cancel your
+            registration for{" "}
+            <strong>{eventName}</strong>?
+          </p>
+
+          <p className="mt-2 text-xs leading-5 text-red-600 dark:text-red-400">
+            Your registration slot will be released and
+            may be offered to a participant on the
+            waitlist.
+          </p>
+        </div>
+
+        {/* Registration ID */}
+        {registration.registrationId && (
+          <div className="mt-5 rounded-xl border border-slate-200 p-4 dark:border-slate-700">
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Registration ID
+            </p>
+
+            <p className="mt-1 break-all text-sm font-semibold text-slate-800 dark:text-white">
+              {registration.registrationId}
+            </p>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-xl border border-slate-200 px-5 py-3 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            Keep Registration
+          </button>
+
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-xl bg-red-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-red-700"
+          >
+            Yes, Cancel Registration
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CancellationConfirmation;

--- a/src/components/events/EligibilityResult.js
+++ b/src/components/events/EligibilityResult.js
@@ -1,0 +1,196 @@
+import {
+  AlertCircle,
+  CheckCircle,
+  XCircle,
+} from "lucide-react";
+import {
+  getEligibilityMessage,
+} from "../../utils/eventEligibilityUtils";
+
+const EligibilityResult = ({ result }) => {
+  if (!result) return null;
+
+  const isEligible = result.eligible;
+
+  return (
+    <div
+      className={`rounded-2xl border p-5 ${
+        isEligible
+          ? "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/20"
+          : "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20"
+      }`}
+      role="status"
+      aria-live="polite"
+    >
+      {/* Result header */}
+      <div className="flex items-start gap-3">
+        <div
+          className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full ${
+            isEligible
+              ? "bg-green-100 dark:bg-green-900/40"
+              : "bg-red-100 dark:bg-red-900/40"
+          }`}
+        >
+          {isEligible ? (
+            <CheckCircle
+              size={25}
+              className="text-green-600 dark:text-green-400"
+            />
+          ) : (
+            <XCircle
+              size={25}
+              className="text-red-600 dark:text-red-400"
+            />
+          )}
+        </div>
+
+        <div>
+          <h3
+            className={`text-lg font-bold ${
+              isEligible
+                ? "text-green-800 dark:text-green-300"
+                : "text-red-800 dark:text-red-300"
+            }`}
+          >
+            {isEligible
+              ? "Eligible"
+              : "Not Eligible"}
+          </h3>
+
+          <p
+            className={`mt-1 text-sm ${
+              isEligible
+                ? "text-green-700 dark:text-green-400"
+                : "text-red-700 dark:text-red-400"
+            }`}
+          >
+            {getEligibilityMessage(result)}
+          </p>
+        </div>
+      </div>
+
+      {/* Requirement results */}
+      {result.results &&
+        Object.keys(result.results).length > 0 && (
+          <div className="mt-5 space-y-2">
+            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              Requirement Check
+            </h4>
+
+            {Object.entries(
+              result.results
+            ).map(
+              ([requirement, check]) => (
+                <RequirementRow
+                  key={requirement}
+                  requirement={requirement}
+                  check={check}
+                />
+              )
+            )}
+          </div>
+        )}
+
+      {/* Failed requirements */}
+      {!isEligible &&
+        result.failedRequirements?.length >
+          0 && (
+          <div className="mt-5 rounded-xl border border-red-200 bg-white/70 p-4 dark:border-red-800 dark:bg-slate-900/40">
+            <div className="flex items-center gap-2">
+              <AlertCircle
+                size={18}
+                className="text-red-600 dark:text-red-400"
+              />
+
+              <h4 className="text-sm font-semibold text-red-800 dark:text-red-300">
+                Requirements Not Met
+              </h4>
+            </div>
+
+            <ul className="mt-3 space-y-2">
+              {result.failedRequirements.map(
+                (item) => (
+                  <li
+                    key={item.requirement}
+                    className="text-sm text-red-700 dark:text-red-400"
+                  >
+                    <span className="font-semibold capitalize">
+                      {formatRequirementName(
+                        item.requirement
+                      )}
+                      :
+                    </span>{" "}
+                    {item.reason}
+                  </li>
+                )
+              )}
+            </ul>
+          </div>
+        )}
+    </div>
+  );
+};
+
+const RequirementRow = ({
+  requirement,
+  check,
+}) => {
+  const passed = check?.eligible;
+
+  return (
+    <div className="flex items-start gap-3 rounded-xl bg-white/70 px-4 py-3 dark:bg-slate-900/40">
+      {passed ? (
+        <CheckCircle
+          size={18}
+          className="mt-0.5 shrink-0 text-green-600 dark:text-green-400"
+        />
+      ) : (
+        <XCircle
+          size={18}
+          className="mt-0.5 shrink-0 text-red-600 dark:text-red-400"
+        />
+      )}
+
+      <div className="min-w-0">
+        <p className="text-sm font-semibold capitalize text-slate-800 dark:text-white">
+          {formatRequirementName(
+            requirement
+          )}
+        </p>
+
+        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+          {check?.reason ||
+            "No additional information available."}
+        </p>
+
+        {check?.missingSkills?.length >
+          0 && (
+          <p className="mt-1 text-xs font-medium text-red-600 dark:text-red-400">
+            Missing:{" "}
+            {check.missingSkills.join(", ")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const formatRequirementName = (
+  requirement
+) => {
+  const names = {
+    age: "Age",
+    education: "Education",
+    location: "Location",
+    skills: "Required Skills",
+    team: "Team Requirement",
+    category: "Participant Category",
+  };
+
+  return (
+    names[requirement] ||
+    requirement
+  );
+};
+
+export default EligibilityResult;

--- a/src/components/events/EventEligibilityChecker.js
+++ b/src/components/events/EventEligibilityChecker.js
@@ -1,0 +1,320 @@
+import { useMemo, useState } from "react";
+import {
+  CheckCircle,
+  ClipboardCheck,
+  UserCheck,
+} from "lucide-react";
+import EligibilityResult from "./EligibilityResult";
+import {
+  checkEventEligibility,
+} from "../../utils/eventEligibilityUtils";
+
+const EventEligibilityChecker = ({
+  eventRequirements = {},
+  initialProfile = {},
+  onEligibilityChange,
+}) => {
+  const [profile, setProfile] =
+    useState({
+      age: initialProfile.age || "",
+      education:
+        initialProfile.education || "",
+      location:
+        initialProfile.location || "",
+      skills:
+        initialProfile.skills || [],
+      teamSize:
+        initialProfile.teamSize || "",
+      category:
+        initialProfile.category || "",
+    });
+
+  const [skillInput, setSkillInput] =
+    useState("");
+
+  const [hasChecked, setHasChecked] =
+    useState(false);
+
+  const eligibilityResult = useMemo(
+    () =>
+      checkEventEligibility(
+        profile,
+        eventRequirements
+      ),
+    [profile, eventRequirements]
+  );
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+
+    setProfile((previous) => ({
+      ...previous,
+      [name]: value,
+    }));
+
+    setHasChecked(false);
+  };
+
+  const handleAddSkill = () => {
+    const skill = skillInput.trim();
+
+    if (!skill) return;
+
+    const exists = profile.skills.some(
+      (item) =>
+        item.toLowerCase() ===
+        skill.toLowerCase()
+    );
+
+    if (!exists) {
+      setProfile((previous) => ({
+        ...previous,
+        skills: [
+          ...previous.skills,
+          skill,
+        ],
+      }));
+    }
+
+    setSkillInput("");
+    setHasChecked(false);
+  };
+
+  const handleRemoveSkill = (skillToRemove) => {
+    setProfile((previous) => ({
+      ...previous,
+      skills: previous.skills.filter(
+        (skill) =>
+          skill !== skillToRemove
+      ),
+    }));
+
+    setHasChecked(false);
+  };
+
+  const handleSkillKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleAddSkill();
+    }
+  };
+
+  const handleCheckEligibility = () => {
+    setHasChecked(true);
+
+    onEligibilityChange?.(
+      eligibilityResult
+    );
+  };
+
+  return (
+    <section className="mx-auto w-full max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+          <ClipboardCheck
+            size={25}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        </div>
+
+        <div>
+          <h2 className="text-2xl font-bold text-slate-800 dark:text-white">
+            Event Eligibility Checker
+          </h2>
+
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Check whether you meet the participation
+            requirements before registering.
+          </p>
+        </div>
+      </div>
+
+      {/* Form */}
+      <div className="mt-8 space-y-5">
+        {/* Age */}
+        <FormField label="Age">
+          <input
+            type="number"
+            name="age"
+            min="1"
+            value={profile.age}
+            onChange={handleChange}
+            placeholder="Enter your age"
+            className={inputClass}
+          />
+        </FormField>
+
+        {/* Education */}
+        <FormField label="Education Level">
+          <select
+            name="education"
+            value={profile.education}
+            onChange={handleChange}
+            className={inputClass}
+          >
+            <option value="">
+              Select education level
+            </option>
+            <option value="School">
+              School
+            </option>
+            <option value="Student">
+              Student
+            </option>
+            <option value="Graduate">
+              Graduate
+            </option>
+            <option value="Postgraduate">
+              Postgraduate
+            </option>
+            <option value="Professional">
+              Professional
+            </option>
+          </select>
+        </FormField>
+
+        {/* Location */}
+        <FormField label="Location">
+          <input
+            type="text"
+            name="location"
+            value={profile.location}
+            onChange={handleChange}
+            placeholder="Enter your country or location"
+            className={inputClass}
+          />
+        </FormField>
+
+        {/* Skills */}
+        <FormField label="Skills">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={skillInput}
+              onChange={(event) =>
+                setSkillInput(
+                  event.target.value
+                )
+              }
+              onKeyDown={
+                handleSkillKeyDown
+              }
+              placeholder="Enter a skill"
+              className={inputClass}
+            />
+
+            <button
+              type="button"
+              onClick={handleAddSkill}
+              className="shrink-0 rounded-xl bg-slate-800 px-4 py-3 text-sm font-semibold text-white transition hover:bg-slate-700 dark:bg-slate-700 dark:hover:bg-slate-600"
+            >
+              Add
+            </button>
+          </div>
+
+          {profile.skills.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {profile.skills.map(
+                (skill) => (
+                  <button
+                    key={skill}
+                    type="button"
+                    onClick={() =>
+                      handleRemoveSkill(
+                        skill
+                      )
+                    }
+                    className="rounded-full bg-indigo-100 px-3 py-1.5 text-xs font-medium text-indigo-700 transition hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-300"
+                    title={`Remove ${skill}`}
+                  >
+                    {skill} ×
+                  </button>
+                )
+              )}
+            </div>
+          )}
+        </FormField>
+
+        {/* Team Size */}
+        <FormField label="Team Size">
+          <input
+            type="number"
+            name="teamSize"
+            min="1"
+            value={profile.teamSize}
+            onChange={handleChange}
+            placeholder="Number of team members"
+            className={inputClass}
+          />
+        </FormField>
+
+        {/* Participant Category */}
+        <FormField label="Participant Category">
+          <select
+            name="category"
+            value={profile.category}
+            onChange={handleChange}
+            className={inputClass}
+          >
+            <option value="">
+              Select participant category
+            </option>
+            <option value="Student">
+              Student
+            </option>
+            <option value="Professional">
+              Professional
+            </option>
+            <option value="Researcher">
+              Researcher
+            </option>
+            <option value="Educator">
+              Educator
+            </option>
+            <option value="Other">
+              Other
+            </option>
+          </select>
+        </FormField>
+      </div>
+
+      {/* Check button */}
+      <button
+        type="button"
+        onClick={handleCheckEligibility}
+        className="mt-8 flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-5 py-3.5 font-semibold text-white transition hover:bg-indigo-700"
+      >
+        <UserCheck size={19} />
+        Check Eligibility
+      </button>
+
+      {/* Result */}
+      {hasChecked && (
+        <div className="mt-6">
+          <EligibilityResult
+            result={eligibilityResult}
+          />
+        </div>
+      )}
+    </section>
+  );
+};
+
+const FormField = ({
+  label,
+  children,
+}) => (
+  <div>
+    <label className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300">
+      {label}
+    </label>
+
+    {children}
+  </div>
+);
+
+const inputClass =
+  "w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white";
+
+export default EventEligibilityChecker;

--- a/src/components/events/RegistrationCancellation.js
+++ b/src/components/events/RegistrationCancellation.js
@@ -1,0 +1,252 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle,
+  XCircle,
+} from "lucide-react";
+import CancellationConfirmation from "./CancellationConfirmation";
+import {
+  canCancelRegistration,
+  cancelRegistration,
+} from "../../utils/registrationCancellationUtils";
+
+const RegistrationCancellation = ({
+  registration,
+  onCancellation,
+}) => {
+  const [showConfirmation, setShowConfirmation] =
+    useState(false);
+  const [updatedRegistration, setUpdatedRegistration] =
+    useState(registration);
+  const [message, setMessage] = useState("");
+
+  if (!updatedRegistration) {
+    return null;
+  }
+
+  const status =
+    updatedRegistration.status || "Registered";
+
+  const isCancelled =
+    status.toLowerCase() === "cancelled";
+
+  const cancellationAllowed =
+    canCancelRegistration(updatedRegistration);
+
+  const handleCancelClick = () => {
+    setMessage("");
+
+    if (!cancellationAllowed) {
+      setMessage(
+        "This registration cannot be cancelled."
+      );
+      return;
+    }
+
+    setShowConfirmation(true);
+  };
+
+  const handleCloseConfirmation = () => {
+    setShowConfirmation(false);
+  };
+
+  const handleConfirmCancellation = () => {
+    const result =
+      cancelRegistration(updatedRegistration);
+
+    if (!result?.success) {
+      setMessage(
+        result?.message ||
+          "Unable to cancel registration."
+      );
+      setShowConfirmation(false);
+      return;
+    }
+
+    setUpdatedRegistration(
+      result.registration
+    );
+
+    setMessage(
+      "Registration cancelled successfully."
+    );
+
+    setShowConfirmation(false);
+
+    onCancellation?.(
+      result.registration,
+      result
+    );
+  };
+
+  return (
+    <>
+      <section className="w-full max-w-2xl rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div
+            className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl ${
+              isCancelled
+                ? "bg-red-100 dark:bg-red-900/30"
+                : "bg-indigo-100 dark:bg-indigo-900/30"
+            }`}
+          >
+            {isCancelled ? (
+              <XCircle
+                size={24}
+                className="text-red-600 dark:text-red-400"
+              />
+            ) : (
+              <AlertTriangle
+                size={24}
+                className="text-indigo-600 dark:text-indigo-400"
+              />
+            )}
+          </div>
+
+          <div>
+            <h2 className="text-xl font-bold text-slate-800 dark:text-white">
+              Registration Cancellation
+            </h2>
+
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Manage your registration for this event.
+            </p>
+          </div>
+        </div>
+
+        {/* Event details */}
+        <div className="mt-6 rounded-xl bg-slate-50 p-4 dark:bg-slate-800">
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Event
+          </p>
+
+          <h3 className="mt-1 font-semibold text-slate-800 dark:text-white">
+            {updatedRegistration.eventName ||
+              updatedRegistration.event?.name ||
+              "Event"}
+          </h3>
+
+          {updatedRegistration.registrationId && (
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Registration ID:{" "}
+              <span className="font-medium">
+                {updatedRegistration.registrationId}
+              </span>
+            </p>
+          )}
+        </div>
+
+        {/* Current status */}
+        <div className="mt-5 flex items-center justify-between rounded-xl border border-slate-200 p-4 dark:border-slate-700">
+          <div>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Registration Status
+            </p>
+
+            <p
+              className={`mt-1 text-sm font-semibold ${
+                isCancelled
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-green-600 dark:text-green-400"
+              }`}
+            >
+              {status}
+            </p>
+          </div>
+
+          {isCancelled && (
+            <CheckCircle
+              size={21}
+              className="text-red-600 dark:text-red-400"
+            />
+          )}
+        </div>
+
+        {/* Cancellation information */}
+        {isCancelled &&
+          updatedRegistration.cancelledAt && (
+            <div className="mt-4 rounded-xl bg-red-50 p-4 dark:bg-red-900/20">
+              <p className="text-xs font-medium text-red-600 dark:text-red-400">
+                Cancellation Timestamp
+              </p>
+
+              <p className="mt-1 text-sm font-semibold text-red-700 dark:text-red-300">
+                {formatTimestamp(
+                  updatedRegistration.cancelledAt
+                )}
+              </p>
+            </div>
+          )}
+
+        {/* Message */}
+        {message && (
+          <div
+            className={`mt-5 rounded-xl px-4 py-3 text-sm font-medium ${
+              isCancelled
+                ? "bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300"
+                : "bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300"
+            }`}
+            role="status"
+            aria-live="polite"
+          >
+            {message}
+          </div>
+        )}
+
+        {/* Cancel action */}
+        {!isCancelled && (
+          <button
+            type="button"
+            onClick={handleCancelClick}
+            disabled={!cancellationAllowed}
+            className="mt-6 w-full rounded-xl bg-red-600 px-5 py-3 font-semibold text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Cancel Registration
+          </button>
+        )}
+
+        {isCancelled && (
+          <div className="mt-6 rounded-xl bg-slate-50 p-4 text-center text-sm text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+            Your registration slot has been released.
+          </div>
+        )}
+
+        {!cancellationAllowed &&
+          !isCancelled && (
+            <p className="mt-3 text-center text-xs text-slate-500 dark:text-slate-400">
+              This registration is no longer eligible for
+              cancellation.
+            </p>
+          )}
+      </section>
+
+      {/* Confirmation dialog */}
+      {showConfirmation && (
+        <CancellationConfirmation
+          registration={updatedRegistration}
+          onConfirm={handleConfirmCancellation}
+          onCancel={handleCloseConfirmation}
+        />
+      )}
+    </>
+  );
+};
+
+const formatTimestamp = (timestamp) => {
+  const date = new Date(timestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    return String(timestamp);
+  }
+
+  return date.toLocaleString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+export default RegistrationCancellation;

--- a/src/utils/attendanceHistoryUtils.js
+++ b/src/utils/attendanceHistoryUtils.js
@@ -1,0 +1,477 @@
+export const ATTENDANCE_STATUSES = [
+  "Registered",
+  "Confirmed",
+  "Checked In",
+  "Attended",
+  "Absent",
+  "Cancelled",
+];
+
+export const CERTIFICATE_STATUSES = [
+  "Not Available",
+  "Pending",
+  "Issued",
+];
+
+/**
+ * Safely convert a value to a Date.
+ */
+export const parseEventDate = (date) => {
+  if (!date) {
+    return null;
+  }
+
+  const parsedDate = new Date(date);
+
+  return Number.isNaN(parsedDate.getTime())
+    ? null
+    : parsedDate;
+};
+
+/**
+ * Check whether an event has already happened.
+ */
+export const isPastEvent = (
+  event,
+  referenceDate = new Date()
+) => {
+  const eventDate = parseEventDate(
+    event?.date || event?.eventDate
+  );
+
+  if (!eventDate) {
+    return false;
+  }
+
+  return eventDate < referenceDate;
+};
+
+/**
+ * Check whether an event is upcoming.
+ */
+export const isUpcomingEvent = (
+  event,
+  referenceDate = new Date()
+) => {
+  const eventDate = parseEventDate(
+    event?.date || event?.eventDate
+  );
+
+  if (!eventDate) {
+    return false;
+  }
+
+  return eventDate >= referenceDate;
+};
+
+/**
+ * Determine whether the user attended an event.
+ */
+export const hasAttendedEvent = (event) => {
+  const status = String(
+    event?.attendanceStatus ||
+      event?.status ||
+      ""
+  )
+    .trim()
+    .toLowerCase();
+
+  return [
+    "attended",
+    "present",
+    "checked in",
+    "checked-in",
+  ].includes(status);
+};
+
+/**
+ * Get the attendance status of an event.
+ */
+export const getAttendanceStatus = (event) => {
+  if (!event) {
+    return "Unknown";
+  }
+
+  if (event.attendanceStatus) {
+    return event.attendanceStatus;
+  }
+
+  if (event.status) {
+    return event.status;
+  }
+
+  return isPastEvent(event)
+    ? "Not Recorded"
+    : "Upcoming";
+};
+
+/**
+ * Get certificate status.
+ */
+export const getCertificateStatus = (event) => {
+  if (!event) {
+    return "Not Available";
+  }
+
+  if (event.certificateStatus) {
+    return event.certificateStatus;
+  }
+
+  if (
+    event.certificateIssued === true ||
+    event.hasCertificate === true
+  ) {
+    return "Issued";
+  }
+
+  if (event.certificatePending === true) {
+    return "Pending";
+  }
+
+  return "Not Available";
+};
+
+/**
+ * Get certificate information.
+ */
+export const getCertificateInfo = (event) => {
+  const status =
+    getCertificateStatus(event);
+
+  return {
+    status,
+    available: status === "Issued",
+    certificateId:
+      event?.certificateId || null,
+    certificateUrl:
+      event?.certificateUrl || null,
+  };
+};
+
+/**
+ * Get the year of an event.
+ */
+export const getEventYear = (event) => {
+  const eventDate = parseEventDate(
+    event?.date || event?.eventDate
+  );
+
+  return eventDate
+    ? eventDate.getFullYear()
+    : null;
+};
+
+/**
+ * Get the event type.
+ */
+export const getEventType = (event) => {
+  return (
+    event?.eventType ||
+    event?.type ||
+    event?.category ||
+    "Other"
+  );
+};
+
+/**
+ * Filter attendance history by year.
+ */
+export const filterAttendanceByYear = (
+  events = [],
+  year = "All"
+) => {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  if (
+    year === "All" ||
+    year === "" ||
+    year === null
+  ) {
+    return events;
+  }
+
+  const selectedYear = Number(year);
+
+  return events.filter(
+    (event) =>
+      getEventYear(event) === selectedYear
+  );
+};
+
+/**
+ * Filter attendance history by event type.
+ */
+export const filterAttendanceByType = (
+  events = [],
+  eventType = "All"
+) => {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  if (
+    eventType === "All" ||
+    eventType === "" ||
+    eventType === null
+  ) {
+    return events;
+  }
+
+  const selectedType = String(
+    eventType
+  )
+    .trim()
+    .toLowerCase();
+
+  return events.filter(
+    (event) =>
+      getEventType(event)
+        .trim()
+        .toLowerCase() === selectedType
+  );
+};
+
+/**
+ * Apply both year and event-type filters.
+ */
+export const filterAttendanceHistory = (
+  events = [],
+  {
+    year = "All",
+    eventType = "All",
+  } = {}
+) => {
+  const yearFiltered =
+    filterAttendanceByYear(
+      events,
+      year
+    );
+
+  return filterAttendanceByType(
+    yearFiltered,
+    eventType
+  );
+};
+
+/**
+ * Sort events by date.
+ *
+ * Default: newest first.
+ */
+export const sortAttendanceHistory = (
+  events = [],
+  direction = "desc"
+) => {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+
+  return [...events].sort((a, b) => {
+    const dateA = parseEventDate(
+      a?.date || a?.eventDate
+    );
+
+    const dateB = parseEventDate(
+      b?.date || b?.eventDate
+    );
+
+    if (!dateA && !dateB) {
+      return 0;
+    }
+
+    if (!dateA) {
+      return 1;
+    }
+
+    if (!dateB) {
+      return -1;
+    }
+
+    return direction === "asc"
+      ? dateA - dateB
+      : dateB - dateA;
+  });
+};
+
+/**
+ * Get past events.
+ */
+export const getPastEvents = (
+  events = [],
+  referenceDate = new Date()
+) => {
+  return events.filter((event) =>
+    isPastEvent(event, referenceDate)
+  );
+};
+
+/**
+ * Get upcoming events.
+ */
+export const getUpcomingEvents = (
+  events = [],
+  referenceDate = new Date()
+) => {
+  return events.filter((event) =>
+    isUpcomingEvent(
+      event,
+      referenceDate
+    )
+  );
+};
+
+/**
+ * Get only events that the user attended.
+ */
+export const getAttendedEvents = (
+  events = []
+) => {
+  return events.filter(hasAttendedEvent);
+};
+
+/**
+ * Calculate dashboard summary statistics.
+ */
+export const getAttendanceSummary = (
+  events = [],
+  referenceDate = new Date()
+) => {
+  const pastEvents = getPastEvents(
+    events,
+    referenceDate
+  );
+
+  const upcomingEvents =
+    getUpcomingEvents(
+      events,
+      referenceDate
+    );
+
+  const attendedEvents =
+    getAttendedEvents(events);
+
+  return {
+    totalEvents: events.length,
+    totalEventsAttended:
+      attendedEvents.length,
+    upcomingEvents:
+      upcomingEvents.length,
+    pastEvents: pastEvents.length,
+    certificatesIssued:
+      events.filter(
+        (event) =>
+          getCertificateStatus(event) ===
+          "Issued"
+      ).length,
+    certificatesPending:
+      events.filter(
+        (event) =>
+          getCertificateStatus(event) ===
+          "Pending"
+      ).length,
+  };
+};
+
+/**
+ * Get unique years available in the history.
+ */
+export const getAvailableYears = (
+  events = []
+) => {
+  const years = events
+    .map(getEventYear)
+    .filter(Boolean);
+
+  return [
+    ...new Set(years),
+  ].sort((a, b) => b - a);
+};
+
+/**
+ * Get unique event types available
+ * in the attendance history.
+ */
+export const getAvailableEventTypes = (
+  events = []
+) => {
+  const types = events
+    .map(getEventType)
+    .filter(Boolean);
+
+  return [
+    ...new Set(types),
+  ].sort((a, b) =>
+    a.localeCompare(b)
+  );
+};
+
+/**
+ * Format an event date for display.
+ */
+export const formatEventDate = (
+  date
+) => {
+  const parsedDate =
+    parseEventDate(date);
+
+  if (!parsedDate) {
+    return "Date not available";
+  }
+
+  return parsedDate.toLocaleDateString(
+    "en-IN",
+    {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }
+  );
+};
+
+/**
+ * Get a complete display model for an event.
+ */
+export const getAttendanceEventDetails = (
+  event
+) => {
+  return {
+    id:
+      event?.id ||
+      event?.eventId ||
+      null,
+
+    name:
+      event?.eventName ||
+      event?.name ||
+      event?.title ||
+      "Untitled Event",
+
+    date: formatEventDate(
+      event?.date ||
+        event?.eventDate
+    ),
+
+    rawDate:
+      event?.date ||
+      event?.eventDate ||
+      null,
+
+    type: getEventType(event),
+
+    attendanceStatus:
+      getAttendanceStatus(event),
+
+    attended:
+      hasAttendedEvent(event),
+
+    certificate:
+      getCertificateInfo(event),
+
+    venue:
+      event?.venue ||
+      event?.location ||
+      null,
+  };
+};

--- a/src/utils/eventEligibilityUtils.js
+++ b/src/utils/eventEligibilityUtils.js
@@ -1,0 +1,410 @@
+export const ELIGIBILITY_REQUIREMENTS = [
+  "age",
+  "education",
+  "location",
+  "skills",
+  "team",
+  "category",
+];
+
+/**
+ * Check whether the user's age is within
+ * the event's allowed age range.
+ */
+export const checkAgeEligibility = (
+  userAge,
+  requirement = {}
+) => {
+  if (
+    userAge === undefined ||
+    userAge === null ||
+    userAge === ""
+  ) {
+    return {
+      eligible: false,
+      reason: "Age information is required.",
+    };
+  }
+
+  const age = Number(userAge);
+
+  if (Number.isNaN(age)) {
+    return {
+      eligible: false,
+      reason: "Invalid age.",
+    };
+  }
+
+  const minAge =
+    requirement.minAge ?? null;
+  const maxAge =
+    requirement.maxAge ?? null;
+
+  if (
+    minAge !== null &&
+    age < Number(minAge)
+  ) {
+    return {
+      eligible: false,
+      reason: `Minimum age is ${minAge}.`,
+    };
+  }
+
+  if (
+    maxAge !== null &&
+    age > Number(maxAge)
+  ) {
+    return {
+      eligible: false,
+      reason: `Maximum age is ${maxAge}.`,
+    };
+  }
+
+  return {
+    eligible: true,
+    reason: "Age requirement satisfied.",
+  };
+};
+
+/**
+ * Check education eligibility.
+ *
+ * `allowedLevels` should contain the education
+ * levels accepted by the event.
+ */
+export const checkEducationEligibility = (
+  userEducation,
+  allowedLevels = []
+) => {
+  if (!allowedLevels.length) {
+    return {
+      eligible: true,
+      reason: "No education restriction.",
+    };
+  }
+
+  if (!userEducation) {
+    return {
+      eligible: false,
+      reason: "Education level is required.",
+    };
+  }
+
+  const normalizedEducation =
+    String(userEducation)
+      .trim()
+      .toLowerCase();
+
+  const eligible = allowedLevels.some(
+    (level) =>
+      String(level)
+        .trim()
+        .toLowerCase() ===
+      normalizedEducation
+  );
+
+  return {
+    eligible,
+    reason: eligible
+      ? "Education requirement satisfied."
+      : "Education level does not meet the event requirement.",
+  };
+};
+
+/**
+ * Check location eligibility.
+ */
+export const checkLocationEligibility = (
+  userLocation,
+  allowedLocations = []
+) => {
+  if (!allowedLocations.length) {
+    return {
+      eligible: true,
+      reason: "No location restriction.",
+    };
+  }
+
+  if (!userLocation) {
+    return {
+      eligible: false,
+      reason: "Location is required.",
+    };
+  }
+
+  const normalizedLocation =
+    String(userLocation)
+      .trim()
+      .toLowerCase();
+
+  const eligible = allowedLocations.some(
+    (location) =>
+      String(location)
+        .trim()
+        .toLowerCase() ===
+      normalizedLocation
+  );
+
+  return {
+    eligible,
+    reason: eligible
+      ? "Location requirement satisfied."
+      : "Your location is not eligible for this event.",
+  };
+};
+
+/**
+ * Check required skills.
+ *
+ * Every required event skill must be
+ * present in the user's skill list.
+ */
+export const checkSkillsEligibility = (
+  userSkills = [],
+  requiredSkills = []
+) => {
+  if (!requiredSkills.length) {
+    return {
+      eligible: true,
+      reason: "No required skills.",
+      missingSkills: [],
+    };
+  }
+
+  const normalizedUserSkills =
+    userSkills.map((skill) =>
+      String(skill).trim().toLowerCase()
+    );
+
+  const missingSkills =
+    requiredSkills.filter(
+      (skill) =>
+        !normalizedUserSkills.includes(
+          String(skill)
+            .trim()
+            .toLowerCase()
+        )
+    );
+
+  return {
+    eligible: missingSkills.length === 0,
+    reason:
+      missingSkills.length === 0
+        ? "Required skills satisfied."
+        : `Missing required skills: ${missingSkills.join(
+            ", "
+          )}.`,
+    missingSkills,
+  };
+};
+
+/**
+ * Check team-size requirements.
+ */
+export const checkTeamEligibility = (
+  teamSize,
+  requirement = {}
+) => {
+  if (
+    requirement.minSize === undefined &&
+    requirement.maxSize === undefined
+  ) {
+    return {
+      eligible: true,
+      reason: "No team-size restriction.",
+    };
+  }
+
+  if (
+    teamSize === undefined ||
+    teamSize === null ||
+    teamSize === ""
+  ) {
+    return {
+      eligible: false,
+      reason: "Team size is required.",
+    };
+  }
+
+  const size = Number(teamSize);
+
+  if (Number.isNaN(size)) {
+    return {
+      eligible: false,
+      reason: "Invalid team size.",
+    };
+  }
+
+  if (
+    requirement.minSize !== undefined &&
+    size < Number(requirement.minSize)
+  ) {
+    return {
+      eligible: false,
+      reason: `Minimum team size is ${requirement.minSize}.`,
+    };
+  }
+
+  if (
+    requirement.maxSize !== undefined &&
+    size > Number(requirement.maxSize)
+  ) {
+    return {
+      eligible: false,
+      reason: `Maximum team size is ${requirement.maxSize}.`,
+    };
+  }
+
+  return {
+    eligible: true,
+    reason: "Team requirement satisfied.",
+  };
+};
+
+/**
+ * Check participant category.
+ */
+export const checkCategoryEligibility = (
+  userCategory,
+  allowedCategories = []
+) => {
+  if (!allowedCategories.length) {
+    return {
+      eligible: true,
+      reason: "No participant category restriction.",
+    };
+  }
+
+  if (!userCategory) {
+    return {
+      eligible: false,
+      reason: "Participant category is required.",
+    };
+  }
+
+  const normalizedCategory =
+    String(userCategory)
+      .trim()
+      .toLowerCase();
+
+  const eligible = allowedCategories.some(
+    (category) =>
+      String(category)
+        .trim()
+        .toLowerCase() ===
+      normalizedCategory
+  );
+
+  return {
+    eligible,
+    reason: eligible
+      ? "Participant category accepted."
+      : "Your participant category is not eligible for this event.",
+  };
+};
+
+/**
+ * Run all event eligibility checks.
+ *
+ * Expected structure:
+ *
+ * eventRequirements = {
+ *   age: { minAge: 18, maxAge: 30 },
+ *   education: { allowedLevels: ["Student", "Graduate"] },
+ *   location: { allowedLocations: ["India"] },
+ *   skills: { requiredSkills: ["JavaScript", "React"] },
+ *   team: { minSize: 1, maxSize: 4 },
+ *   category: { allowedCategories: ["Student"] }
+ * }
+ *
+ * userProfile = {
+ *   age: 21,
+ *   education: "Student",
+ *   location: "India",
+ *   skills: ["JavaScript", "React"],
+ *   teamSize: 2,
+ *   category: "Student"
+ * }
+ */
+export const checkEventEligibility = (
+  userProfile = {},
+  eventRequirements = {}
+) => {
+  const results = {
+    age: checkAgeEligibility(
+      userProfile.age,
+      eventRequirements.age
+    ),
+
+    education:
+      checkEducationEligibility(
+        userProfile.education,
+        eventRequirements.education
+          ?.allowedLevels || []
+      ),
+
+    location:
+      checkLocationEligibility(
+        userProfile.location,
+        eventRequirements.location
+          ?.allowedLocations || []
+      ),
+
+    skills: checkSkillsEligibility(
+      userProfile.skills || [],
+      eventRequirements.skills
+        ?.requiredSkills || []
+    ),
+
+    team: checkTeamEligibility(
+      userProfile.teamSize,
+      eventRequirements.team
+    ),
+
+    category:
+      checkCategoryEligibility(
+        userProfile.category,
+        eventRequirements.category
+          ?.allowedCategories || []
+      ),
+  };
+
+  const eligible = Object.values(
+    results
+  ).every((result) => result.eligible);
+
+  const failedRequirements =
+    Object.entries(results)
+      .filter(
+        ([, result]) => !result.eligible
+      )
+      .map(([requirement, result]) => ({
+        requirement,
+        reason: result.reason,
+      }));
+
+  return {
+    eligible,
+    results,
+    failedRequirements,
+    checkedRequirements:
+      Object.keys(results).length,
+  };
+};
+
+/**
+ * Get a simple eligibility message.
+ */
+export const getEligibilityMessage = (
+  eligibilityResult
+) => {
+  if (!eligibilityResult) {
+    return "Eligibility could not be determined.";
+  }
+
+  if (eligibilityResult.eligible) {
+    return "You are eligible to participate in this event.";
+  }
+
+  return "You are not eligible to participate in this event.";
+};

--- a/src/utils/registrationCancellationUtils.js
+++ b/src/utils/registrationCancellationUtils.js
@@ -1,0 +1,185 @@
+export const CANCELLATION_STATUS = "Cancelled";
+
+/**
+ * Check whether a registration can be cancelled.
+ */
+export const canCancelRegistration = (
+  registration
+) => {
+  if (!registration) {
+    return false;
+  }
+
+  const status = String(
+    registration.status || "Registered"
+  )
+    .trim()
+    .toLowerCase();
+
+  const nonCancellableStatuses = [
+    "cancelled",
+    "canceled",
+    "attended",
+    "certificate issued",
+  ];
+
+  return !nonCancellableStatuses.includes(status);
+};
+
+/**
+ * Cancel a registration.
+ *
+ * The utility updates the registration status and
+ * records the cancellation timestamp.
+ */
+export const cancelRegistration = (
+  registration
+) => {
+  if (!registration) {
+    return {
+      success: false,
+      message: "Registration not found.",
+      registration: null,
+      seatReleased: false,
+      waitlistEligible: false,
+    };
+  }
+
+  if (!canCancelRegistration(registration)) {
+    return {
+      success: false,
+      message:
+        "This registration cannot be cancelled.",
+      registration,
+      seatReleased: false,
+      waitlistEligible: false,
+    };
+  }
+
+  const cancelledAt =
+    new Date().toISOString();
+
+  const updatedRegistration = {
+    ...registration,
+    status: CANCELLATION_STATUS,
+    cancellationStatus: CANCELLATION_STATUS,
+    cancelledAt,
+    seatReleased: true,
+    waitlistEligible: true,
+  };
+
+  return {
+    success: true,
+    message:
+      "Registration cancelled successfully.",
+    registration: updatedRegistration,
+    seatReleased: true,
+    waitlistEligible: true,
+    cancelledAt,
+  };
+};
+
+/**
+ * Check whether a registration has been cancelled.
+ */
+export const isRegistrationCancelled = (
+  registration
+) => {
+  if (!registration) {
+    return false;
+  }
+
+  const status = String(
+    registration.status || ""
+  )
+    .trim()
+    .toLowerCase();
+
+  return (
+    status === "cancelled" ||
+    status === "canceled"
+  );
+};
+
+/**
+ * Get the cancellation timestamp.
+ */
+export const getCancellationTimestamp = (
+  registration
+) => {
+  return (
+    registration?.cancelledAt ||
+    registration?.cancellationTimestamp ||
+    null
+  );
+};
+
+/**
+ * Format the cancellation timestamp.
+ */
+export const formatCancellationTimestamp = (
+  timestamp
+) => {
+  if (!timestamp) {
+    return "";
+  }
+
+  const date = new Date(timestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    return String(timestamp);
+  }
+
+  return date.toLocaleString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+/**
+ * Calculate the updated available seats after
+ * a registration is cancelled.
+ */
+export const calculateReleasedSeats = (
+  registeredParticipants,
+  capacity
+) => {
+  const registered = Number(
+    registeredParticipants
+  );
+
+  const totalCapacity = Number(capacity);
+
+  if (
+    Number.isNaN(registered) ||
+    Number.isNaN(totalCapacity)
+  ) {
+    return null;
+  }
+
+  return Math.max(
+    0,
+    totalCapacity - Math.max(0, registered - 1)
+  );
+};
+
+/**
+ * Determine whether a released seat can be
+ * offered to a waitlisted participant.
+ */
+export const shouldPromoteWaitlist = (
+  registration,
+  waitlistedCount = 0
+) => {
+  if (
+    !registration ||
+    !isRegistrationCancelled(registration)
+  ) {
+    return false;
+  }
+
+  return Number(waitlistedCount) > 0;
+};


### PR DESCRIPTION
## Description

Implemented an attendance history dashboard that gives users a centralized overview of their event participation.

### Added

- Total events attended summary
- Upcoming events count
- Past events count
- Certificate count
- Attendance status indicators
- Event date and type
- Venue information
- Certificate status and certificate link
- Filter by year
- Filter by event type
- Newest/oldest sorting
- Responsive attendance history cards
- Empty-state handling

Closes #12543