### PR TITLE
feat(teams): add hackathon team formation

### DIFF
--- a/src/components/events/TeamFormation.js
+++ b/src/components/events/TeamFormation.js
@@ -1,0 +1,767 @@
+import { useMemo, useState } from "react";
+import {
+  Check,
+  Plus,
+  Search,
+  Send,
+  Users,
+  X,
+} from "lucide-react";
+import TeamMemberCard from "./TeamMemberCard";
+import {
+  createTeam,
+  getTeamRoles,
+  searchParticipantsBySkills,
+  addTeamMember,
+  removeTeamMember,
+  createTeamRequest,
+  updateTeamRequestStatus,
+  validateTeam,
+} from "../../utils/teamFormationUtils";
+
+const TeamFormation = ({
+  participants = [],
+  currentUser = null,
+  initialTeam = null,
+  maxTeamSize = 4,
+  onTeamChange,
+  onRequestChange,
+}) => {
+  const [team, setTeam] = useState(
+    initialTeam || null
+  );
+
+  const [teamName, setTeamName] =
+    useState(
+      initialTeam?.name || ""
+    );
+
+  const [requiredRoles, setRequiredRoles] =
+    useState(
+      initialTeam?.requiredRoles || []
+    );
+
+  const [roleInput, setRoleInput] =
+    useState("");
+
+  const [skillSearch, setSkillSearch] =
+    useState("");
+
+  const [requests, setRequests] =
+    useState(
+      initialTeam?.requests || []
+    );
+
+  const [error, setError] =
+    useState("");
+
+  const [success, setSuccess] =
+    useState("");
+
+  const roles = useMemo(
+    () => getTeamRoles(team),
+    [team]
+  );
+
+  const members =
+    team?.members || [];
+
+  const filteredParticipants =
+    useMemo(() => {
+      return searchParticipantsBySkills(
+        participants,
+        skillSearch
+      ).filter(
+        (participant) =>
+          !members.some(
+            (member) =>
+              member.id ===
+              participant.id
+          )
+      );
+    }, [
+      participants,
+      skillSearch,
+      members,
+    ]);
+
+  const handleCreateTeam = () => {
+    setError("");
+    setSuccess("");
+
+    if (!teamName.trim()) {
+      setError(
+        "Please enter a team name."
+      );
+      return;
+    }
+
+    const newTeam = createTeam({
+      name: teamName.trim(),
+      requiredRoles,
+      createdBy:
+        currentUser?.id || null,
+      maxTeamSize,
+    });
+
+    setTeam(newTeam);
+    onTeamChange?.(newTeam);
+
+    setSuccess(
+      "Team created successfully."
+    );
+  };
+
+  const handleAddRole = () => {
+    const role = roleInput.trim();
+
+    if (!role) {
+      return;
+    }
+
+    const alreadyExists =
+      requiredRoles.some(
+        (item) =>
+          item.toLowerCase() ===
+          role.toLowerCase()
+      );
+
+    if (alreadyExists) {
+      setRoleInput("");
+      return;
+    }
+
+    setRequiredRoles([
+      ...requiredRoles,
+      role,
+    ]);
+
+    setRoleInput("");
+  };
+
+  const handleRemoveRole = (role) => {
+    setRequiredRoles(
+      requiredRoles.filter(
+        (item) => item !== role
+      )
+    );
+  };
+
+  const handleInvite = (
+    participant
+  ) => {
+    if (!team) {
+      setError(
+        "Create a team before inviting participants."
+      );
+      return;
+    }
+
+    if (
+      members.length >= maxTeamSize
+    ) {
+      setError(
+        "The team has reached its maximum size."
+      );
+      return;
+    }
+
+    const alreadyRequested =
+      requests.some(
+        (request) =>
+          request.participantId ===
+            participant.id &&
+          request.status ===
+            "pending"
+      );
+
+    if (alreadyRequested) {
+      return;
+    }
+
+    const request =
+      createTeamRequest({
+        teamId: team.id,
+        participantId:
+          participant.id,
+        participantName:
+          participant.name,
+        role:
+          participant.role ||
+          "",
+        invitedBy:
+          currentUser?.id || null,
+      });
+
+    const updatedRequests = [
+      ...requests,
+      request,
+    ];
+
+    setRequests(
+      updatedRequests
+    );
+
+    onRequestChange?.(
+      updatedRequests
+    );
+
+    setSuccess(
+      `Invitation sent to ${
+        participant.name ||
+        "participant"
+      }.`
+    );
+  };
+
+  const handleRequestStatus = (
+    request,
+    status
+  ) => {
+    const updatedRequests =
+      requests.map((item) =>
+        item.id === request.id
+          ? updateTeamRequestStatus(
+              item,
+              status
+            )
+          : item
+      );
+
+    setRequests(
+      updatedRequests
+    );
+
+    onRequestChange?.(
+      updatedRequests
+    );
+
+    if (
+      status === "accepted"
+    ) {
+      const participant =
+        participants.find(
+          (item) =>
+            item.id ===
+            request.participantId
+        );
+
+      if (participant) {
+        handleAddMember(
+          participant,
+          request.role
+        );
+      }
+    }
+  };
+
+  const handleAddMember = (
+    participant,
+    role = ""
+  ) => {
+    if (!team) {
+      return;
+    }
+
+    if (
+      members.length >= maxTeamSize
+    ) {
+      setError(
+        "The team has reached its maximum size."
+      );
+      return;
+    }
+
+    if (
+      members.some(
+        (member) =>
+          member.id ===
+          participant.id
+      )
+    ) {
+      return;
+    }
+
+    const updatedTeam =
+      addTeamMember(
+        team,
+        {
+          ...participant,
+          role:
+            role ||
+            participant.role ||
+            "",
+        }
+      );
+
+    setTeam(updatedTeam);
+    onTeamChange?.(
+      updatedTeam
+    );
+
+    setSuccess(
+      `${
+        participant.name ||
+        "Participant"
+      } joined the team.`
+    );
+  };
+
+  const handleRemoveMember = (
+    memberId
+  ) => {
+    if (!team) {
+      return;
+    }
+
+    const updatedTeam =
+      removeTeamMember(
+        team,
+        memberId
+      );
+
+    setTeam(updatedTeam);
+    onTeamChange?.(
+      updatedTeam
+    );
+  };
+
+  const handleValidateTeam = () => {
+    if (!team) {
+      setError(
+        "Create a team first."
+      );
+      return;
+    }
+
+    const result =
+      validateTeam(team);
+
+    if (!result.valid) {
+      setError(
+        result.errors.join(" ")
+      );
+      setSuccess("");
+      return;
+    }
+
+    setError("");
+    setSuccess(
+      "Team is ready for participation."
+    );
+  };
+
+  return (
+    <section className="mx-auto w-full max-w-6xl space-y-6">
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+          <Users
+            size={23}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        </div>
+
+        <div>
+          <h2 className="text-2xl font-bold text-slate-800 dark:text-white">
+            Team Formation
+          </h2>
+
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Create a team, define required roles,
+            and find participants with matching
+            skills.
+          </p>
+        </div>
+      </div>
+
+      {/* Alerts */}
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-300">
+          {success}
+        </div>
+      )}
+
+      {/* Team creation */}
+      {!team && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <h3 className="text-lg font-bold text-slate-800 dark:text-white">
+            Create Your Team
+          </h3>
+
+          <div className="mt-5">
+            <label
+              htmlFor="team-name"
+              className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300"
+            >
+              Team Name
+            </label>
+
+            <input
+              id="team-name"
+              value={teamName}
+              onChange={(event) =>
+                setTeamName(
+                  event.target.value
+                )
+              }
+              placeholder="Enter team name"
+              className={inputClass}
+            />
+          </div>
+
+          <RoleEditor
+            roles={requiredRoles}
+            roleInput={roleInput}
+            setRoleInput={setRoleInput}
+            onAddRole={handleAddRole}
+            onRemoveRole={
+              handleRemoveRole
+            }
+          />
+
+          <button
+            type="button"
+            onClick={handleCreateTeam}
+            className="mt-6 inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-3 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            <Plus size={17} />
+            Create Team
+          </button>
+        </div>
+      )}
+
+      {/* Existing team */}
+      {team && (
+        <>
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <span className="text-xs font-medium uppercase tracking-wide text-indigo-600 dark:text-indigo-400">
+                  Hackathon Team
+                </span>
+
+                <h3 className="mt-1 text-xl font-bold text-slate-800 dark:text-white">
+                  {team.name}
+                </h3>
+              </div>
+
+              <div className="rounded-xl bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                {members.length} /{" "}
+                {maxTeamSize} members
+              </div>
+            </div>
+
+            <RoleEditor
+              roles={requiredRoles}
+              roleInput={roleInput}
+              setRoleInput={setRoleInput}
+              onAddRole={handleAddRole}
+              onRemoveRole={
+                handleRemoveRole
+              }
+            />
+
+            <button
+              type="button"
+              onClick={handleValidateTeam}
+              className="mt-5 inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              <Check size={16} />
+              Validate Team
+            </button>
+          </div>
+
+          {/* Members */}
+          <div>
+            <div className="mb-4">
+              <h3 className="text-lg font-bold text-slate-800 dark:text-white">
+                Team Members
+              </h3>
+
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Current members of your team.
+              </p>
+            </div>
+
+            {members.length > 0 ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                {members.map(
+                  (member) => (
+                    <TeamMemberCard
+                      key={member.id}
+                      member={member}
+                      isTeamMember
+                      onRemove={() =>
+                        handleRemoveMember(
+                          member.id
+                        )
+                      }
+                    />
+                  )
+                )}
+              </div>
+            ) : (
+              <EmptyState text="No team members yet." />
+            )}
+          </div>
+
+          {/* Participant search */}
+          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <div>
+              <h3 className="text-lg font-bold text-slate-800 dark:text-white">
+                Find Teammates
+              </h3>
+
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Search participants by their skills.
+              </p>
+            </div>
+
+            <div className="relative mt-5">
+              <Search
+                size={18}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+              />
+
+              <input
+                value={skillSearch}
+                onChange={(event) =>
+                  setSkillSearch(
+                    event.target.value
+                  )
+                }
+                placeholder="Search skills, e.g. React, Python, UI/UX"
+                className={`${inputClass} pl-10`}
+              />
+            </div>
+
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              {filteredParticipants.map(
+                (participant) => (
+                  <TeamMemberCard
+                    key={
+                      participant.id
+                    }
+                    member={
+                      participant
+                    }
+                    actionLabel="Invite"
+                    actionIcon={Send}
+                    onAction={() =>
+                      handleInvite(
+                        participant
+                      )
+                    }
+                  />
+                )
+              ))}
+            </div>
+
+            {filteredParticipants.length ===
+              0 && (
+              <EmptyState
+                text={
+                  skillSearch
+                    ? "No participants found with matching skills."
+                    : "No available participants found."
+                }
+              />
+            )}
+          </div>
+
+          {/* Requests */}
+          <div>
+            <div className="mb-4">
+              <h3 className="text-lg font-bold text-slate-800 dark:text-white">
+                Team Requests
+              </h3>
+
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Manage invitations and team requests.
+              </p>
+            </div>
+
+            {requests.length > 0 ? (
+              <div className="space-y-3">
+                {requests.map(
+                  (request) => (
+                    <RequestCard
+                      key={request.id}
+                      request={request}
+                      onAccept={() =>
+                        handleRequestStatus(
+                          request,
+                          "accepted"
+                        )
+                      }
+                      onReject={() =>
+                        handleRequestStatus(
+                          request,
+                          "rejected"
+                        )
+                      }
+                    />
+                  )
+                )}
+              </div>
+            ) : (
+              <EmptyState text="No team requests yet." />
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+const RoleEditor = ({
+  roles,
+  roleInput,
+  setRoleInput,
+  onAddRole,
+  onRemoveRole,
+}) => (
+  <div className="mt-6">
+    <label
+      htmlFor="required-role"
+      className="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-300"
+    >
+      Required Roles
+    </label>
+
+    <div className="flex gap-2">
+      <input
+        id="required-role"
+        value={roleInput}
+        onChange={(event) =>
+          setRoleInput(
+            event.target.value
+          )
+        }
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onAddRole();
+          }
+        }}
+        placeholder="e.g. Frontend Developer"
+        className={inputClass}
+      />
+
+      <button
+        type="button"
+        onClick={onAddRole}
+        className="shrink-0 rounded-xl border border-slate-200 px-4 text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+        aria-label="Add required role"
+      >
+        <Plus size={18} />
+      </button>
+    </div>
+
+    {roles.length > 0 && (
+      <div className="mt-3 flex flex-wrap gap-2">
+        {roles.map((role) => (
+          <span
+            key={role}
+            className="inline-flex items-center gap-2 rounded-full bg-indigo-100 px-3 py-1.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+          >
+            {role}
+
+            <button
+              type="button"
+              onClick={() =>
+                onRemoveRole(role)
+              }
+              aria-label={`Remove ${role}`}
+              className="rounded-full hover:bg-indigo-200 dark:hover:bg-indigo-900"
+            >
+              <X size={13} />
+            </button>
+          </span>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+const RequestCard = ({
+  request,
+  onAccept,
+  onReject,
+}) => {
+  const status =
+    String(
+      request.status || "pending"
+    ).toLowerCase();
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h4 className="font-semibold text-slate-800 dark:text-white">
+          {request.participantName ||
+            "Participant"}
+        </h4>
+
+        {request.role && (
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Requested role:{" "}
+            {request.role}
+          </p>
+        )}
+
+        <span className="mt-2 inline-flex rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium capitalize text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+          {status}
+        </span>
+      </div>
+
+      {status === "pending" && (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onAccept}
+            className="inline-flex items-center gap-1.5 rounded-xl bg-green-600 px-3 py-2 text-sm font-semibold text-white hover:bg-green-700"
+          >
+            <Check size={15} />
+            Accept
+          </button>
+
+          <button
+            type="button"
+            onClick={onReject}
+            className="inline-flex items-center gap-1.5 rounded-xl bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-700"
+          >
+            <X size={15} />
+            Reject
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const EmptyState = ({
+  text,
+}) => (
+  <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center dark:border-slate-700 dark:bg-slate-900">
+    <Users
+      size={32}
+      className="mx-auto text-slate-400"
+    />
+
+    <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+      {text}
+    </p>
+  </div>
+);
+
+const inputClass =
+  "w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-white";
+
+export default TeamFormation;

--- a/src/components/events/TeamMemberCard.js
+++ b/src/components/events/TeamMemberCard.js
@@ -1,0 +1,147 @@
+import {
+  Mail,
+  User,
+  X,
+} from "lucide-react";
+
+const TeamMemberCard = ({
+  member = {},
+  isTeamMember = false,
+  actionLabel = "Invite",
+  actionIcon: ActionIcon,
+  onAction,
+  onRemove,
+}) => {
+  const name =
+    member.name ||
+    member.displayName ||
+    member.username ||
+    "Participant";
+
+  const role =
+    member.role ||
+    member.position ||
+    "Team Member";
+
+  const skills = getSkills(member);
+
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:shadow-md dark:border-slate-700 dark:bg-slate-900">
+      <div className="flex items-start gap-4">
+        {/* Avatar */}
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+          {member.avatar ||
+          member.profileImage ? (
+            <img
+              src={
+                member.avatar ||
+                member.profileImage
+              }
+              alt={`${name} profile`}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <User
+              size={23}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          )}
+        </div>
+
+        {/* Member information */}
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate font-semibold text-slate-800 dark:text-white">
+            {name}
+          </h3>
+
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {role}
+          </p>
+
+          {member.email && (
+            <div className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+              <Mail size={13} />
+              <span className="truncate">
+                {member.email}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Remove button */}
+        {isTeamMember &&
+          onRemove && (
+            <button
+              type="button"
+              onClick={onRemove}
+              aria-label={`Remove ${name} from team`}
+              className="rounded-lg p-2 text-slate-400 transition hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            >
+              <X size={17} />
+            </button>
+          )}
+      </div>
+
+      {/* Skills */}
+      {skills.length > 0 && (
+        <div className="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">
+          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+            Skills
+          </p>
+
+          <div className="flex flex-wrap gap-2">
+            {skills.map(
+              (skill, index) => (
+                <span
+                  key={`${skill}-${index}`}
+                  className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                >
+                  {skill}
+                </span>
+              )
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Action */}
+      {!isTeamMember &&
+        onAction && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            {ActionIcon ? (
+              <ActionIcon size={16} />
+            ) : null}
+
+            {actionLabel}
+          </button>
+        )}
+    </article>
+  );
+};
+
+const getSkills = (member) => {
+  const value =
+    member.skills ||
+    member.skillSet ||
+    member.technologies ||
+    [];
+
+  if (Array.isArray(value)) {
+    return value.filter(Boolean);
+  }
+
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((skill) => skill.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+export default TeamMemberCard;

--- a/src/utils/teamFormationUtils.js
+++ b/src/utils/teamFormationUtils.js
@@ -1,0 +1,680 @@
+export const DEFAULT_MAX_TEAM_SIZE = 4;
+
+/**
+ * Create a new team.
+ */
+export const createTeam = ({
+  name = "",
+  requiredRoles = [],
+  createdBy = null,
+  maxTeamSize = DEFAULT_MAX_TEAM_SIZE,
+} = {}) => {
+  return {
+    id: generateTeamId(),
+    name: name.trim(),
+    createdBy,
+    maxTeamSize,
+    requiredRoles: normalizeRoles(
+      requiredRoles
+    ),
+    members: [],
+    requests: [],
+    createdAt: new Date().toISOString(),
+  };
+};
+
+/**
+ * Normalize team roles.
+ */
+export const normalizeRoles = (
+  roles = []
+) => {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+
+  const normalized = new Map();
+
+  roles
+    .map((role) => String(role).trim())
+    .filter(Boolean)
+    .forEach((role) => {
+      const key = role.toLowerCase();
+
+      if (!normalized.has(key)) {
+        normalized.set(key, role);
+      }
+    });
+
+  return Array.from(
+    normalized.values()
+  );
+};
+
+/**
+ * Get roles required by a team.
+ */
+export const getTeamRoles = (
+  team
+) => {
+  if (!team) {
+    return [];
+  }
+
+  return normalizeRoles(
+    team.requiredRoles || []
+  );
+};
+
+/**
+ * Normalize participant skills.
+ */
+export const getParticipantSkills = (
+  participant = {}
+) => {
+  const skills =
+    participant.skills ||
+    participant.skillSet ||
+    participant.technologies ||
+    [];
+
+  if (Array.isArray(skills)) {
+    return skills
+      .map((skill) =>
+        String(skill).trim()
+      )
+      .filter(Boolean);
+  }
+
+  if (typeof skills === "string") {
+    return skills
+      .split(",")
+      .map((skill) => skill.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+/**
+ * Search participants by one or more skills.
+ *
+ * A participant is returned when at least one
+ * requested skill matches.
+ */
+export const searchParticipantsBySkills = (
+  participants = [],
+  searchTerm = ""
+) => {
+  if (!Array.isArray(participants)) {
+    return [];
+  }
+
+  const query = String(searchTerm)
+    .trim()
+    .toLowerCase();
+
+  if (!query) {
+    return participants;
+  }
+
+  const queries = query
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  return participants.filter(
+    (participant) => {
+      const skills =
+        getParticipantSkills(
+          participant
+        ).map((skill) =>
+          skill.toLowerCase()
+        );
+
+      return queries.some((querySkill) =>
+        skills.some(
+          (skill) =>
+            skill.includes(querySkill) ||
+            querySkill.includes(skill)
+        )
+      );
+    }
+  );
+};
+
+/**
+ * Find participants with a specific skill.
+ */
+export const findParticipantsBySkill = (
+  participants = [],
+  skill = ""
+) => {
+  const query = String(skill)
+    .trim()
+    .toLowerCase();
+
+  if (!query) {
+    return [];
+  }
+
+  return participants.filter(
+    (participant) =>
+      getParticipantSkills(
+        participant
+      ).some((item) =>
+        item
+          .toLowerCase()
+          .includes(query)
+      )
+  );
+};
+
+/**
+ * Add a participant to a team.
+ */
+export const addTeamMember = (
+  team,
+  participant
+) => {
+  if (!team || !participant) {
+    return team;
+  }
+
+  const members = Array.isArray(
+    team.members
+  )
+    ? team.members
+    : [];
+
+  const maxSize =
+    Number(team.maxTeamSize) ||
+    DEFAULT_MAX_TEAM_SIZE;
+
+  if (members.length >= maxSize) {
+    return team;
+  }
+
+  const alreadyMember =
+    members.some(
+      (member) =>
+        member.id === participant.id
+    );
+
+  if (alreadyMember) {
+    return team;
+  }
+
+  return {
+    ...team,
+    members: [
+      ...members,
+      {
+        ...participant,
+        joinedAt:
+          participant.joinedAt ||
+          new Date().toISOString(),
+      },
+    ],
+  };
+};
+
+/**
+ * Remove a participant from a team.
+ */
+export const removeTeamMember = (
+  team,
+  memberId
+) => {
+  if (!team) {
+    return team;
+  }
+
+  return {
+    ...team,
+    members: (
+      team.members || []
+    ).filter(
+      (member) =>
+        member.id !== memberId
+    ),
+  };
+};
+
+/**
+ * Get the number of available team slots.
+ */
+export const getAvailableTeamSlots = (
+  team
+) => {
+  if (!team) {
+    return 0;
+  }
+
+  const maxSize =
+    Number(team.maxTeamSize) ||
+    DEFAULT_MAX_TEAM_SIZE;
+
+  const memberCount =
+    Array.isArray(team.members)
+      ? team.members.length
+      : 0;
+
+  return Math.max(
+    0,
+    maxSize - memberCount
+  );
+};
+
+/**
+ * Check whether a team is full.
+ */
+export const isTeamFull = (
+  team
+) => {
+  return (
+    getAvailableTeamSlots(team) === 0
+  );
+};
+
+/**
+ * Create a team invitation/request.
+ */
+export const createTeamRequest = ({
+  teamId,
+  participantId,
+  participantName = "",
+  role = "",
+  invitedBy = null,
+} = {}) => {
+  return {
+    id: generateRequestId(),
+    teamId,
+    participantId,
+    participantName,
+    role,
+    invitedBy,
+    status: "pending",
+    createdAt:
+      new Date().toISOString(),
+    respondedAt: null,
+  };
+};
+
+/**
+ * Update a request status.
+ */
+export const updateTeamRequestStatus = (
+  request,
+  status
+) => {
+  if (!request) {
+    return request;
+  }
+
+  const allowedStatuses = [
+    "pending",
+    "accepted",
+    "rejected",
+  ];
+
+  if (!allowedStatuses.includes(status)) {
+    return request;
+  }
+
+  return {
+    ...request,
+    status,
+    respondedAt:
+      status === "pending"
+        ? null
+        : new Date().toISOString(),
+  };
+};
+
+/**
+ * Get pending team requests.
+ */
+export const getPendingTeamRequests = (
+  requests = []
+) => {
+  if (!Array.isArray(requests)) {
+    return [];
+  }
+
+  return requests.filter(
+    (request) =>
+      request.status === "pending"
+  );
+};
+
+/**
+ * Get accepted team requests.
+ */
+export const getAcceptedTeamRequests = (
+  requests = []
+) => {
+  if (!Array.isArray(requests)) {
+    return [];
+  }
+
+  return requests.filter(
+    (request) =>
+      request.status === "accepted"
+  );
+};
+
+/**
+ * Check whether a participant has already
+ * received a pending request.
+ */
+export const hasPendingTeamRequest = (
+  requests = [],
+  participantId
+) => {
+  return requests.some(
+    (request) =>
+      request.participantId ===
+        participantId &&
+      request.status === "pending"
+  );
+};
+
+/**
+ * Validate a team before submission.
+ */
+export const validateTeam = (
+  team
+) => {
+  const errors = [];
+
+  if (!team) {
+    return {
+      valid: false,
+      errors: ["Team is required."],
+    };
+  }
+
+  if (!team.name?.trim()) {
+    errors.push(
+      "Team name is required."
+    );
+  }
+
+  const members = Array.isArray(
+    team.members
+  )
+    ? team.members
+    : [];
+
+  if (members.length === 0) {
+    errors.push(
+      "At least one team member is required."
+    );
+  }
+
+  const maxSize =
+    Number(team.maxTeamSize) ||
+    DEFAULT_MAX_TEAM_SIZE;
+
+  if (members.length > maxSize) {
+    errors.push(
+      `Team cannot have more than ${maxSize} members.`
+    );
+  }
+
+  const roles = getTeamRoles(team);
+
+  if (roles.length > 0) {
+    const memberRoles =
+      members
+        .map(
+          (member) =>
+            member.role
+              ?.trim()
+              .toLowerCase()
+        )
+        .filter(Boolean);
+
+    const missingRoles =
+      roles.filter(
+        (role) =>
+          !memberRoles.includes(
+            role.toLowerCase()
+          )
+      );
+
+    if (missingRoles.length > 0) {
+      errors.push(
+        `Missing required roles: ${missingRoles.join(
+          ", "
+        )}.`
+      );
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * Find missing roles in a team.
+ */
+export const getMissingTeamRoles = (
+  team
+) => {
+  const requiredRoles =
+    getTeamRoles(team);
+
+  const members = Array.isArray(
+    team?.members
+  )
+    ? team.members
+    : [];
+
+  const memberRoles = members
+    .map(
+      (member) =>
+        member.role
+          ?.trim()
+          .toLowerCase()
+    )
+    .filter(Boolean);
+
+  return requiredRoles.filter(
+    (role) =>
+      !memberRoles.includes(
+        role.toLowerCase()
+      )
+  );
+};
+
+/**
+ * Calculate how well a participant's
+ * skills match required team roles.
+ */
+export const calculateSkillMatch = (
+  participant,
+  requiredSkills = []
+) => {
+  const participantSkills =
+    getParticipantSkills(
+      participant
+    ).map((skill) =>
+      skill.toLowerCase()
+    );
+
+  const skills = Array.isArray(
+    requiredSkills
+  )
+    ? requiredSkills
+    : [requiredSkills];
+
+  const normalizedRequired =
+    skills
+      .map((skill) =>
+        String(skill)
+          .trim()
+          .toLowerCase()
+      )
+      .filter(Boolean);
+
+  if (
+    normalizedRequired.length === 0
+  ) {
+    return {
+      matchedSkills: [],
+      missingSkills: [],
+      score: 0,
+    };
+  }
+
+  const matchedSkills =
+    normalizedRequired.filter(
+      (requiredSkill) =>
+        participantSkills.some(
+          (skill) =>
+            skill.includes(
+              requiredSkill
+            ) ||
+            requiredSkill.includes(
+              skill
+            )
+        )
+    );
+
+  const missingSkills =
+    normalizedRequired.filter(
+      (requiredSkill) =>
+        !matchedSkills.includes(
+          requiredSkill
+        )
+    );
+
+  return {
+    matchedSkills,
+    missingSkills,
+    score: Math.round(
+      (matchedSkills.length /
+        normalizedRequired.length) *
+        100
+    ),
+  };
+};
+
+/**
+ * Rank participants according to their
+ * skill match with required skills.
+ */
+export const rankParticipantsBySkills = (
+  participants = [],
+  requiredSkills = []
+) => {
+  if (!Array.isArray(participants)) {
+    return [];
+  }
+
+  return participants
+    .map((participant) => ({
+      ...participant,
+      skillMatch:
+        calculateSkillMatch(
+          participant,
+          requiredSkills
+        ),
+    }))
+    .sort(
+      (a, b) =>
+        b.skillMatch.score -
+        a.skillMatch.score
+    );
+};
+
+/**
+ * Get a team's current status.
+ */
+export const getTeamStatus = (
+  team
+) => {
+  if (!team) {
+    return "Unavailable";
+  }
+
+  if (isTeamFull(team)) {
+    return "Full";
+  }
+
+  const validation =
+    validateTeam(team);
+
+  if (
+    validation.valid
+  ) {
+    return "Ready";
+  }
+
+  return "Incomplete";
+};
+
+/**
+ * Get a simple team summary.
+ */
+export const getTeamSummary = (
+  team
+) => {
+  if (!team) {
+    return {
+      memberCount: 0,
+      maxTeamSize:
+        DEFAULT_MAX_TEAM_SIZE,
+      availableSlots: 0,
+      status: "Unavailable",
+      requiredRoles: [],
+      missingRoles: [],
+    };
+  }
+
+  return {
+    memberCount: Array.isArray(
+      team.members
+    )
+      ? team.members.length
+      : 0,
+
+    maxTeamSize:
+      Number(team.maxTeamSize) ||
+      DEFAULT_MAX_TEAM_SIZE,
+
+    availableSlots:
+      getAvailableTeamSlots(team),
+
+    status:
+      getTeamStatus(team),
+
+    requiredRoles:
+      getTeamRoles(team),
+
+    missingRoles:
+      getMissingTeamRoles(team),
+  };
+};
+
+/**
+ * Generate a simple unique team ID.
+ */
+const generateTeamId = () => {
+  return `team-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+};
+
+/**
+ * Generate a simple unique request ID.
+ */
+const generateRequestId = () => {
+  return `request-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+};


### PR DESCRIPTION
## Description

Implemented an in-platform team formation system for hackathons.

### Added

- Create a team
- Set required team roles
- Search participants by skills
- Invite participants
- Accept/reject team requests
- Add and remove team members
- Team capacity management
- Required-role validation
- Skill matching and participant ranking
- Team status and summary
- Responsive team formation UI

Closes #12550