### PR TITLE
fix(reminders): persist event timezone in stored reminder snapshot

### DIFF
--- a/src/utils/reminderUtils.js
+++ b/src/utils/reminderUtils.js
@@ -124,6 +124,7 @@ export const addReminder = (event, timing) => {
       title: event.title ?? "",
       date: event.date ?? "",
       time: event.time ?? "",
+      timezone: event.timezone || event.timeZone || null,
       location: event.location ?? "",
       type: event.type ?? event.category ?? "",
       image: event.image ?? event.imageUrl ?? "",

--- a/tests/reminderUtils.test.mjs
+++ b/tests/reminderUtils.test.mjs
@@ -275,4 +275,48 @@ assert.equal(
   "getReminderTriggerTime calculates correct timezone-aware trigger time"
 );
 
+// ── timezone persistence in stored reminder snapshots ─────────────────────────
+resetStorage();
+const tzSnapshotEvt = {
+  id: "evt-tz-snapshot",
+  title: "NY Event",
+  date: "2099-01-01",
+  time: "10:00",
+  timezone: "America/New_York",
+};
+const tzSnapshotResult = addReminder(tzSnapshotEvt, "1h");
+assert.equal(tzSnapshotResult.ok, true, "addReminder succeeds for a timezone event");
+assert.equal(
+  tzSnapshotResult.reminder.event.timezone,
+  "America/New_York",
+  "stored reminder snapshot retains the event timezone"
+);
+
+const liveInstant = getEventDateTime(tzSnapshotEvt).getTime();
+const snapshotInstant = getEventDateTime(tzSnapshotResult.reminder.event).getTime();
+assert.equal(
+  snapshotInstant,
+  liveInstant,
+  "getEventDateTime returns the same instant for the live event and the stored snapshot"
+);
+
+// Reminders stored before the timezone field existed must fall back to the
+// browser timezone without crashing.
+resetStorage();
+const legacySnapshot = {
+  id: "evt-legacy::1h",
+  eventId: "evt-legacy",
+  timing: "1h",
+  triggerAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+  event: { id: "evt-legacy", date: "2099-01-01", time: "10:00", title: "Legacy" },
+};
+window.localStorage.setItem(
+  "eventra_event_reminders",
+  JSON.stringify([legacySnapshot])
+);
+assert.ok(
+  getEventDateTime(getReminders()[0].event) instanceof Date,
+  "getEventDateTime resolves legacy snapshots without a timezone field"
+);
+
 console.log("All reminderUtils tests passed ✓");


### PR DESCRIPTION
## Problem

`addReminder` in `src/utils/reminderUtils.js` persists a snapshot of the event that omits the timezone fields. When `popDueReminders`/`getActiveReminders` later re-derive the event start from the stored snapshot, the timezone is gone and the browser's local timezone is used instead. Out-of-timezone reminders therefore fire at the wrong time or are silently skipped (and hidden from the active-reminders UI list).

## Fix

Persist the event timezone (`event.timezone` / `event.timeZone`) in the stored reminder snapshot, so `getEventDateTime` resolves the same instant whether called with the live event or with the stored snapshot. Snapshots stored without the field fall back to the browser timezone exactly as before, matching the existing `getEventDateTime` behaviour.

## Files changed

- `src/utils/reminderUtils.js` — persist `timezone` in the `addReminder` event snapshot
- `tests/reminderUtils.test.mjs` — add coverage for timezone persistence in the snapshot, identical instants for live vs stored snapshots, and legacy snapshots without the field

## Testing

- `node --test tests/reminderUtils.test.mjs` — all assertions pass
- `npx eslint src/utils/reminderUtils.js tests/reminderUtils.test.mjs` — clean

Closes #12569
