### PR TITLE
fix(calendar): add to Google Calendar on the correct day for negative UTC offsets

### DIFF
--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -25,8 +25,8 @@ export const generateGoogleCalendarUrl = (eventData) => {
   if (eventData.startTime) {
     // If we have a start time, combine date and time
     const [hours, minutes] = eventData.startTime.split(':');
-    const startDate = new Date(eventData.startDate);
-    startDate.setHours(parseInt(hours, 10), parseInt(minutes, 10), 0);
+    const [y, m, d] = eventData.startDate.split('-').map(Number);
+    const startDate = new Date(y, m - 1, d, parseInt(hours, 10), parseInt(minutes, 10), 0);
     startDateTime = startDate.toISOString().replace(/-|:|\.\d+/g, '');
   } else {
     // If no time, use the date only (all day event)
@@ -38,8 +38,8 @@ export const generateGoogleCalendarUrl = (eventData) => {
     if (eventData.endTime) {
       // If we have an end time, combine date and time
       const [hours, minutes] = eventData.endTime.split(':');
-      const endDate = new Date(eventData.endDate);
-      endDate.setHours(parseInt(hours, 10), parseInt(minutes, 10), 0);
+      const [y, m, d] = eventData.endDate.split('-').map(Number);
+      const endDate = new Date(y, m - 1, d, parseInt(hours, 10), parseInt(minutes, 10), 0);
       endDateTime = endDate.toISOString().replace(/-|:|\.\d+/g, '');
     } else {
       // If no time, use the date only (all day event)

--- a/tests/calendarUtils.test.mjs
+++ b/tests/calendarUtils.test.mjs
@@ -29,4 +29,42 @@ const hackathon = {
 const hackUrl = addHackathonToGoogleCalendar(hackathon);
 assert.ok(hackUrl.includes("GSSoC%20Hack"));
 
+// Timed events must land on the organizer-specified date with the specified
+// wall-clock time in the local timezone, regardless of the UTC offset.
+const timeEventData = {
+  title: "Timed Event",
+  startDate: "2026-06-15",
+  endDate: "2026-06-15",
+  startTime: "10:00",
+  endTime: "12:00",
+};
+const timeUrl = generateGoogleCalendarUrl(timeEventData);
+const datesMatch = timeUrl.match(/dates=(\d{8})T(\d{6})Z\/(\d{8})T(\d{6})Z/);
+assert.ok(datesMatch, "timed Google Calendar URLs use compact UTC format");
+
+const parseCompactUtc = (datePart, timePart) =>
+  new Date(
+    `${datePart.slice(0, 4)}-${datePart.slice(4, 6)}-${datePart.slice(6, 8)}` +
+    `T${timePart.slice(0, 2)}:${timePart.slice(2, 4)}:${timePart.slice(4, 6)}Z`
+  );
+
+const startLocal = new Date(parseCompactUtc(datesMatch[1], datesMatch[2]).getTime());
+assert.equal(
+  `${startLocal.getFullYear()}-${String(startLocal.getMonth() + 1).padStart(2, "0")}-${String(startLocal.getDate()).padStart(2, "0")}`,
+  "2026-06-15",
+  "timed events land on the organizer-specified date in the local timezone"
+);
+assert.equal(
+  `${String(startLocal.getHours()).padStart(2, "0")}:${String(startLocal.getMinutes()).padStart(2, "0")}`,
+  "10:00",
+  "timed events preserve the organizer-specified wall-clock start time"
+);
+
+const endLocal = new Date(parseCompactUtc(datesMatch[3], datesMatch[4]).getTime());
+assert.equal(
+  `${String(endLocal.getHours()).padStart(2, "0")}:${String(endLocal.getMinutes()).padStart(2, "0")}`,
+  "12:00",
+  "timed events preserve the organizer-specified wall-clock end time"
+);
+
 console.log("calendarUtils tests passed ✓");


### PR DESCRIPTION
## Problem

`generateGoogleCalendarUrl` in `src/utils/calendarUtils.js` mixes UTC date parsing with local `setHours`. A date-only string like `"2026-06-15"` is parsed by `new Date("2026-06-15")` as UTC midnight, then `.setHours(...)` applies the local wall clock and `.toISOString()` serializes back to UTC. For users with a negative UTC offset (the Americas), the generated Google Calendar `dates=` parameter lands one calendar day early, shifting the time by the offset as well. Both start and end timestamps are affected.

## Fix

Build the local date from its components instead of parsing the date-only string in UTC: split `YYYY-MM-DD` and construct `new Date(y, m - 1, d, hours, minutes, 0)`, then serialize with `.toISOString()`. Date and time are now interpreted in the same (local) frame, so the event is added to Google Calendar on the day the organizer specified.

## Files changed

- `src/utils/calendarUtils.js` — `generateGoogleCalendarUrl`: construct start and end `Date`s from local date components instead of `setHours` on a UTC-parsed date-only string
- `tests/calendarUtils.test.mjs` — add round-trip coverage verifying timed events land on the organizer-specified date and wall-clock time in any local timezone

## Testing

- `node --test tests/calendarUtils.test.mjs` — all assertions pass
- `npx eslint src/utils/calendarUtils.js tests/calendarUtils.test.mjs` — clean

Closes #12570
