### PR TITLE
fix(calendar): CalendarOptionsModal imports providers from the module that exports them

### DIFF
--- a/src/components/events/CalendarOptionsModal.js
+++ b/src/components/events/CalendarOptionsModal.js
@@ -2,7 +2,7 @@ import { X, Calendar, Download } from "lucide-react";
 import {
   openCalendarProvider,
   getCalendarProviders,
-} from "../../utils/calendarUtils";
+} from "../../utils/calendarUtils-jp";
 
 const CalendarOptionsModal = ({ event, onClose }) => {
   const providers = getCalendarProviders();


### PR DESCRIPTION
## Problem

`CalendarOptionsModal.js` imports `openCalendarProvider` and `getCalendarProviders` from `src/utils/calendarUtils`, but that module does not export them — they live in `src/utils/calendarUtils-jp.js`. As a result, `getCalendarProviders()` throws `TypeError: getCalendarProviders is not a function` as soon as the modal renders, and selecting a provider throws the same way, so the "Add to Calendar" modal is broken.

## Fix

Import `getCalendarProviders` and `openCalendarProvider` from `src/utils/calendarUtils-jp`, the module that actually defines them.

## Files changed

- `src/components/events/CalendarOptionsModal.js` — fix import source for `getCalendarProviders` / `openCalendarProvider`

## Testing

- `npx eslint src/components/events/CalendarOptionsModal.js` — clean
- Confirmed the imported names are exported by `src/utils/calendarUtils-jp.js`

Closes #12571
