### PR TITLE
fix(scanner): record check-ins under the canonical registrationId from validation

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -322,7 +322,7 @@ export default function TicketScanner() {
       await pushToQueue(
         {
           actionType: "TICKET_CHECK_IN",
-          ticketId,
+          ticketId: ticketData.ticketId,
           eventId: eventId || "unknown",
           endpoint: API_ENDPOINTS.TICKETS.CHECK_IN,
           payload: ticketData,
@@ -386,7 +386,7 @@ export default function TicketScanner() {
         return;
       }
 
-      await recordCheckIn(ticketId, eventId, { validatedAt: new Date().toISOString() });
+      await recordCheckIn(ticketData.ticketId, eventId, { validatedAt: new Date().toISOString() });
 
       triggerScanFeedback("verified");
       setScanResult({


### PR DESCRIPTION
## Problem

In `src/components/admin/TicketScanner.jsx`, `processTicket` records the check-in under the raw scanned QR token (`ticketId` local variable) instead of the canonical `registrationId` returned by server validation. When the QR token differs from the server-side `registrationId` (e.g. JWT tickets, or tokens rewritten by the server), the check-in is stored under the raw token, so re-scans are not detected as duplicates, the history log contradicts what was recorded, and per-event check-in counts drift. The offline queue path enqueues the raw token the same way.

## Fix

Use the canonical id everywhere the check-in is recorded:

- Online path: `recordCheckIn(ticketData.ticketId, ...)` — after validation, `ticketData.ticketId` holds `result.registrationId` (falling back to the raw token when the server returns none).
- Offline queue: enqueue `ticketData.ticketId` so the queued check-in is later verified under the same identifier.

## Files changed

- `src/components/admin/TicketScanner.jsx` — `processTicket`: use `ticketData.ticketId` for the offline queue entry and the `recordCheckIn` call

## Testing

- `npx eslint src/components/admin/TicketScanner.jsx` — clean
- `node --test tests/checkInUtils.test.mjs` — passes
- Note: `vitest run src/components/admin/TicketScanner.test.jsx` cannot start in this environment due to a pre-existing parse error in `src/utils/secureStorage.js` (`getKeyMetadata` redeclared), which is unrelated to this change

Closes #12572
