### PR TITLE
fix(calendar): honor selected reminder time in exported .ics files

### DIFF
--- a/src/components/common/AddToCalendar.jsx
+++ b/src/components/common/AddToCalendar.jsx
@@ -1,20 +1,33 @@
 import { useState, useRef, useEffect } from 'react';
-import { Calendar, ChevronDown, X } from 'lucide-react';
+import { Calendar, ChevronDown, Download, ExternalLink, X } from 'lucide-react';
 import {
+    generateIcsFileBlobUrl,
     getGoogleCalendarUrl,
     getOutlookCalendarUrl,
     getYahooCalendarUrl,
     getWebcalSubscriptionUrl
 } from "utils/calendarUrlUtils";
-const generateICalContent = (event) => {
+const to24HourTime = (timeStr) => {
+  if (!timeStr) return '00:00';
+  const match = String(timeStr).match(/^(\d{1,2}):(\d{2})\s*([APap][Mm])?/);
+  if (!match) return timeStr;
+  let hours = parseInt(match[1], 10);
+  const minutes = match[2];
+  const period = match[3] ? match[3].toUpperCase() : '';
+  if (period === 'PM' && hours < 12) hours += 12;
+  if (period === 'AM' && hours === 12) hours = 0;
+  return `${String(hours).padStart(2, '0')}:${minutes}`;
+};
+
+const generateICalContent = (event, reminderMinutes = 30) => {
   const formatICalDate = (dateStr, timeStr) => {
     if (!dateStr) return '';
-    const dt = new Date(`${dateStr}T${timeStr || '00:00'}:00`);
+    const dt = new Date(`${dateStr}T${to24HourTime(timeStr)}:00`);
     return dt.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
   };
   const start = formatICalDate(event.date, event.time);
   const durationMs = (event.durationMinutes || 60) * 60 * 1000;
-  const endDate = new Date(new Date(`${event.date}T${event.time || '00:00'}:00`).getTime() + durationMs);
+  const endDate = new Date(new Date(`${event.date}T${to24HourTime(event.time)}:00`).getTime() + durationMs);
   const end = endDate.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
   return [
     'BEGIN:VCALENDAR',
@@ -29,7 +42,7 @@ const generateICalContent = (event) => {
     `URL:${event.joiningLink || window.location.href}`,
     `UID:${event.id || Date.now()}@eventra`,
     'BEGIN:VALARM',
-    'TRIGGER:-PT30M',
+    `TRIGGER:-PT${reminderMinutes}M`,
     'ACTION:DISPLAY',
     'DESCRIPTION:Reminder',
     'END:VALARM',
@@ -37,8 +50,6 @@ const generateICalContent = (event) => {
     'END:VCALENDAR',
   ].join('\r\n');
 };
-import { Calendar, ChevronDown, Download, ExternalLink, X } from 'lucide-react';
-import { generateIcsFileBlobUrl, getGoogleCalendarUrl, getOutlookCalendarUrl } from 'utils/calendarUrlUtils';
 
 const toSafeFilename = (value) =>
   (value || 'event')
@@ -46,8 +57,8 @@ const toSafeFilename = (value) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '') || 'event';
 
-const downloadIcal = (event) => {
-  const url = generateIcsFileBlobUrl(event);
+const downloadIcal = (event, reminderMinutes) => {
+  const url = generateIcsFileBlobUrl(event, undefined, reminderMinutes);
   if (!url) return false;
 
   const a = document.createElement('a');
@@ -99,7 +110,7 @@ const [reminder, setReminder] = useState("30");
 };
 
   const handleIcal = () => {
-    if (downloadIcal(event)) {
+    if (downloadIcal(event, reminder)) {
       setAdded('iCal file');
       timeoutRef.current = setTimeout(() => setOpen(false), 800);
     }

--- a/src/utils/calendarUrlUtils.js
+++ b/src/utils/calendarUrlUtils.js
@@ -264,9 +264,11 @@ export const getYahooCalendarUrl = (event, timezone) => {
  *
  * @param {object} event  - Event object
  * @param {string} [timezone]  - IANA tz string; defaults to browser timezone
+ * @param {number|string} [reminderMinutes]  - Minutes before the event for a
+ *   VALARM reminder (e.g. 10, 30, 60). Omitted when falsy.
  * @returns {string|null}  A Blob URL that can be used in an <a href> tag with download attribute. Returns null on error.
  */
-export const generateIcsFileBlobUrl = (event, timezone) => {
+export const generateIcsFileBlobUrl = (event, timezone, reminderMinutes) => {
   if (!event) return null;
 
   const range = getEventUTCRange(event, timezone);
@@ -282,7 +284,9 @@ export const generateIcsFileBlobUrl = (event, timezone) => {
   }
 
   const now = new Date().toISOString().replace(/-|:|\.\d+/g, '');
-  
+
+  const reminderMinutesNum = parseInt(reminderMinutes, 10);
+
   const icsContent = [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
@@ -297,6 +301,15 @@ export const generateIcsFileBlobUrl = (event, timezone) => {
     `SUMMARY:${(event.title || '').replace(/,/g, '\\,')}`,
     `DESCRIPTION:${(event.description || '').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/,/g, '\\,')}`,
     `LOCATION:${(event.location || '').replace(/,/g, '\\,')}`,
+    ...(reminderMinutesNum > 0
+      ? [
+          'BEGIN:VALARM',
+          `TRIGGER:-PT${reminderMinutesNum}M`,
+          'ACTION:DISPLAY',
+          'DESCRIPTION:Reminder',
+          'END:VALARM',
+        ]
+      : []),
     'END:VEVENT',
     'END:VCALENDAR'
   ].join('\r\n');

--- a/src/utils/calendarUrlUtils.test.js
+++ b/src/utils/calendarUrlUtils.test.js
@@ -323,6 +323,43 @@ describe('generateIcsFileBlobUrl', () => {
   test('returns null on null event', () => {
     expect(generateIcsFileBlobUrl(null)).toBeNull();
   });
+
+  test('emits a VALARM reflecting the requested reminder minutes', async () => {
+    const originalCreate = URL.createObjectURL;
+    const captured = [];
+    URL.createObjectURL = (blob) => {
+      captured.push(blob);
+      return 'blob:mock';
+    };
+    try {
+      const url = generateIcsFileBlobUrl(mkEvent(), undefined, 10);
+      expect(url).toBe('blob:mock');
+      expect(captured.length).toBe(1);
+      const content = await captured[0].text();
+      expect(content).toContain('BEGIN:VALARM');
+      expect(content).toContain('TRIGGER:-PT10M');
+      expect(content).toContain('ACTION:DISPLAY');
+      expect(content).toContain('END:VALARM');
+    } finally {
+      URL.createObjectURL = originalCreate;
+    }
+  });
+
+  test('omits VALARM when no reminder minutes are requested', async () => {
+    const originalCreate = URL.createObjectURL;
+    const captured = [];
+    URL.createObjectURL = (blob) => {
+      captured.push(blob);
+      return 'blob:mock';
+    };
+    try {
+      generateIcsFileBlobUrl(mkEvent(), undefined, 0);
+      const content = await captured[0].text();
+      expect(content).not.toContain('VALARM');
+    } finally {
+      URL.createObjectURL = originalCreate;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The "Reminder Time" dropdown in `AddToCalendar` is dead UI. Its value is stored in the `reminder` state but no handler reads it, and the exported `.ics` file contains no alarm at all (`generateIcsFileBlobUrl` emits no `VALARM`). The dead `generateICalContent` helper would also crash on 12-hour time strings such as `"10:00 AM"` (`new Date("2026-06-15T10:00 AM:00")` → `RangeError`).

## Fix

- `generateIcsFileBlobUrl` accepts an optional `reminderMinutes` argument and emits a `BEGIN:VALARM` / `TRIGGER:-PT{reminderMinutes}M` block in the ICS payload when a positive value is provided (omitted otherwise).
- `AddToCalendar` passes the selected `reminder` value through `downloadIcal` into `generateIcsFileBlobUrl`, so the exported `.ics` file reflects the user's selection (e.g. `TRIGGER:-PT60M` for "1 hour before").
- `generateICalContent` now converts 12-hour time strings to 24-hour before building the `Date`, and its `TRIGGER` is configurable instead of hardcoded to `-PT30M`.
- Consolidated duplicate `import` statements in `AddToCalendar.jsx` (the same module was imported twice with overlapping names, which is a compile error in strict ESM and blocks the app from building).

## Files changed

- `src/utils/calendarUrlUtils.js` — `generateIcsFileBlobUrl`: optional `reminderMinutes` param + `VALARM` emission
- `src/components/common/AddToCalendar.jsx` — pass `reminder` to `downloadIcal`, fix 12-hour parsing and configurable trigger in `generateICalContent`, merge duplicate imports
- `src/utils/calendarUrlUtils.test.js` — add tests verifying the VALARM block is emitted for the requested minutes and omitted when not requested

## Testing

- `npx vitest run src/utils/calendarUrlUtils.test.js` — 44 tests pass
- `npx eslint` on all three changed files — 0 errors (only pre-existing unused-variable warnings)
- `npx esbuild` confirms `AddToCalendar.jsx` now compiles (it previously failed on duplicate `Calendar`/`ChevronDown`/`X`/`getGoogleCalendarUrl` declarations)

Closes #12573
