### PR TITLE
fix(scanner): cancel requestAnimationFrame loop on stop and unmount

### DIFF
--- a/src/components/EventCheckInScanner.jsx
+++ b/src/components/EventCheckInScanner.jsx
@@ -16,6 +16,7 @@ import {
 const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], registrations = [] }) => {
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
+  const frameRef = useRef(null);
   const [isScanning, setIsScanning] = useState(false);
   const [lastScannedId, setLastScannedId] = useState(null);
   const [scannedData, setScannedData] = useState(null);
@@ -55,6 +56,10 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
 
   // Stop camera stream
   const stopCamera = () => {
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
     if (videoRef.current?.srcObject) {
       videoRef.current.srcObject.getTracks().forEach((track) => track.stop());
     }
@@ -88,7 +93,7 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
     }
 
     if (isScanning) {
-      requestAnimationFrame(processFrame);
+      frameRef.current = requestAnimationFrame(processFrame);
     }
   };
 
@@ -176,7 +181,10 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
     }
 
     return () => {
-      // Cleanup
+      if (frameRef.current) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
     };
   }, [isScanning]);
 


### PR DESCRIPTION
## Problem

The `requestAnimationFrame` loop started by `processFrame` in `src/components/EventCheckInScanner.jsx` is never cancelled. `stopCamera` only stops the media tracks and sets `isScanning` to false; the already-scheduled rAF callback keeps re-scheduling itself against the dead `video` element at ~60fps. Clicking "Start Scanning" again stacks a second concurrent loop because the first was never cancelled.

## Fix

Track the rAF id in a `frameRef` and cancel it in `stopCamera` and in the effect cleanup (which runs both on `isScanning` changes and on unmount):

- `processFrame` stores the handle: `frameRef.current = requestAnimationFrame(processFrame)`
- `stopCamera` cancels the stored handle before stopping tracks
- the `isScanning` effect cleanup cancels the handle as well, covering unmount

## Files changed

- `src/components/EventCheckInScanner.jsx` — add `frameRef`, cancel the animation loop in `stopCamera` and in the effect cleanup

## Testing

- `npx eslint src/components/EventCheckInScanner.jsx` — same result as on master (only pre-existing warnings/errors unrelated to this change)

Closes #12575
