### PR TITLE
fix(scanner): keep active-event and manual-event selectors in sync

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -451,6 +451,7 @@ export default function TicketScanner() {
     const option = e.target.options[idx];
     setManualEventId(option.value);
     setManualEventName(option.text);
+    setSelectedEventId(option.value);
   };
 
   return (
@@ -517,7 +518,13 @@ export default function TicketScanner() {
             <select
               id="active-event-select"
               value={selectedEventId}
-              onChange={(e) => setSelectedEventId(e.target.value)}
+              onChange={(e) => {
+                const idx = e.target.selectedIndex;
+                const option = e.target.options[idx];
+                setSelectedEventId(e.target.value);
+                setManualEventId(e.target.value);
+                setManualEventName(option?.text || "");
+              }}
               className="w-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl px-3 py-2 text-xs font-semibold text-slate-700 dark:text-slate-350 focus:outline-none focus:border-indigo-500"
             >
               {events.length === 0 ? (


### PR DESCRIPTION
## Problem

The top "Select Active Event for Checking In" dropdown and the manual check-in form's "Event Destination" dropdown are backed by two independent pieces of state (`selectedEventId` vs `manualEventId`/`manualEventName`) that are never kept in sync. An admin can change the top dropdown to event B (for stats/history) and then check someone in manually against event A, silently recording the check-in under the wrong event — while the stats panel shows the other event. The reverse case (manual dropdown change) leaves stats/history showing a stale event.

## Fix

Keep both selectors on a single "active event" by syncing them in both directions:

- The manual "Event Destination" `handleEventSelect` now also updates `selectedEventId`, so manual check-ins, camera scans, stats, and history all target the same event.
- The top "Select Active Event" dropdown now also updates `manualEventId`/`manualEventName`.

## Files changed

- `src/components/admin/TicketScanner.jsx` — sync `selectedEventId` and `manualEventId`/`manualEventName` on both selector changes

## Testing

- `npx eslint src/components/admin/TicketScanner.jsx` — clean
- Note: `vitest run src/components/admin/TicketScanner.test.jsx` cannot start in this environment due to a pre-existing parse error in `src/utils/secureStorage.js`, unrelated to this change

Closes #12576
