### PR TITLE
fix(scanner): validate tickets before treating re-scans as duplicates

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -349,6 +349,24 @@ export default function TicketScanner() {
         ticketData.ticketId = result.registrationId || ticketId;
       }
 
+      if (!result.valid) {
+        setScanResult({
+          status: "flagged",
+          data: ticketData,
+          message: result.message || "This ticket is not valid for entry.",
+        });
+        toast.error(`Invalid Ticket: ${ticketData.userName}`);
+        addToHistory({
+          id: `invalid-${Date.now()}`,
+          ticketId: ticketData.ticketId,
+          name: ticketData.userName,
+          event: eventName,
+          status: "Flagged",
+          time: new Date().toISOString(),
+        });
+        return;
+      }
+
       if (result.alreadyCheckedIn) {
         setScanResult({
           status: "duplicate",
@@ -365,24 +383,6 @@ export default function TicketScanner() {
           time: new Date().toISOString(),
         });
         if (selectedEventId) fetchStats(selectedEventId);
-        return;
-      }
-
-      if (!result.valid) {
-        setScanResult({
-          status: "flagged",
-          data: ticketData,
-          message: result.message || "This ticket is not valid for entry.",
-        });
-        toast.error(`Invalid Ticket: ${ticketData.userName}`);
-        addToHistory({
-          id: `invalid-${Date.now()}`,
-          ticketId: ticketData.ticketId,
-          name: ticketData.userName,
-          event: eventName,
-          status: "Flagged",
-          time: new Date().toISOString(),
-        });
         return;
       }
 


### PR DESCRIPTION
## Problem

In `src/components/admin/TicketScanner.jsx`, `processTicket` checks `result.alreadyCheckedIn` before `result.valid`, so a ticket that is both `alreadyCheckedIn` and `valid: false` (e.g. checked in and then cancelled/revoked, or a previously scanned token now out of event scope) is reported as a harmless "duplicate" and never rejected. The function exits before `!result.valid` is evaluated, so the attendee is admitted even though the ticket is invalid.

## Fix

Re-order the checks so validity wins: `!result.valid` is evaluated first (flag + reject), and duplicate handling applies only to valid tickets.

## Files changed

- `src/components/admin/TicketScanner.jsx` — `processTicket`: swap the `!result.valid` and `result.alreadyCheckedIn` branches

## Testing

- `npx eslint src/components/admin/TicketScanner.jsx` — clean
- Note: `vitest run src/components/admin/TicketScanner.test.jsx` cannot start in this environment due to a pre-existing parse error in `src/utils/secureStorage.js`, unrelated to this change

Closes #12578
