### PR TITLE
fix(scanner): decode JWT payloads as base64url before atob

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -221,7 +221,14 @@ export default function TicketScanner() {
     } catch {
       if (decodedText.startsWith("eyJ") && decodedText.split(".").length === 3) {
         try {
-          const payload = JSON.parse(atob(decodedText.split(".")[1]));
+          // JWT payloads are base64url (RFC 4648): '-'/'_' instead of '+'/'/'
+          // and no padding. Convert to standard base64 before atob.
+          const encodedPayload = decodedText.split(".")[1];
+          const b64 = encodedPayload
+            .replace(/-/g, "+")
+            .replace(/_/g, "/")
+            .padEnd(Math.ceil(encodedPayload.length / 4) * 4, "=");
+          const payload = JSON.parse(atob(b64));
           const activeEvent = events.find(e => String(e.id) === String(selectedEventId));
           const ticketEventId = payload.eventId || payload.event_id;
           if (ticketEventId && String(ticketEventId) !== String(selectedEventId)) {


### PR DESCRIPTION
## Problem

The JWT fallback for scanned QR tokens in `src/components/admin/TicketScanner.jsx` decodes the payload with `atob(decodedText.split(".")[1])`. JWT payload segments are base64url (RFC 4648): they use `-` and `_` in place of `+` and `/` and are not padded. `atob` throws `InvalidCharacterError` on `-`/`_` characters and on missing padding, so any legitimate JWT ticket whose payload contains base64url-specific bytes is flagged as "Invalid Ticket QR Code scanned!" and the attendee cannot be checked in.

## Fix

Convert the base64url payload segment to standard base64 before calling `atob`:

- replace `-` → `+` and `_` → `/`
- pad to a multiple of 4 with `=`

## Files changed

- `src/components/admin/TicketScanner.jsx` — JWT fallback: base64url-to-base64 conversion before `atob`

## Testing

- Verified in Node: a base64url payload containing `_` (e.g. `eyJlbWFpbCI6IsO_w75AeC5jb20ifQ`) previously threw `InvalidCharacterError` from `atob`; with the fix it decodes to the correct JSON payload
- `npx eslint src/components/admin/TicketScanner.jsx` — clean
- Note: `vitest run src/components/admin/TicketScanner.test.jsx` cannot start in this environment due to a pre-existing parse error in `src/utils/secureStorage.js`, unrelated to this change

Closes #12579
