### PR TITLE
fix(check-in): clamp stats to active registrations and avoid mutating input

### DIFF
--- a/src/utils/checkInUtils.js
+++ b/src/utils/checkInUtils.js
@@ -103,20 +103,25 @@ export const recordCheckIn = (checkIn) => {
  */
 export const computeCheckInStats = (registrations = [], checkIns = []) => {
   const totalRegistrations = registrations.length;
-  const activeRegistrations = registrations.filter((r) => r.status !== 'cancelled').length;
+  const activeRegistrations = registrations.filter((r) => r.status !== 'cancelled');
+  const activeRegistrationsCount = activeRegistrations.length;
 
-  // Create a set of checked-in registration IDs for efficient lookup
-  const checkedInIds = new Set(checkIns.map((c) => c.registrationId));
-
-  const checkedIn = checkedInIds.size;
-  const notCheckedIn = activeRegistrations - checkedIn;
+  // Count only check-ins that reference an active (non-cancelled) registration,
+  // so stale offline replay, cancelled-then-rescanned tickets, or check-ins
+  // synced from another event cannot make the counts negative or exceed 100%.
+  const activeIds = new Set(activeRegistrations.map((r) => r.id));
+  const checkedIn = [...new Set(checkIns.map((c) => c.registrationId))]
+    .filter((id) => activeIds.has(id)).length;
+  const notCheckedIn = activeRegistrationsCount - checkedIn;
 
   // Calculate check-in rate
   const checkInRate =
-    activeRegistrations > 0 ? Math.round((checkedIn / activeRegistrations) * 10000) / 100 : 0;
+    activeRegistrationsCount > 0
+      ? Math.round((checkedIn / activeRegistrationsCount) * 10000) / 100
+      : 0;
 
-  // Get recent check-ins (last 10)
-  const recentCheckIns = checkIns
+  // Get recent check-ins (last 10) — sort a copy so the caller's array is not mutated
+  const recentCheckIns = [...checkIns]
     .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
     .slice(0, 10)
     .map((c) => {
@@ -130,7 +135,7 @@ export const computeCheckInStats = (registrations = [], checkIns = []) => {
 
   return {
     totalRegistrations,
-    activeRegistrations,
+    activeRegistrations: activeRegistrationsCount,
     checkedIn,
     notCheckedIn,
     checkInRate,

--- a/tests/checkInUtils.test.mjs
+++ b/tests/checkInUtils.test.mjs
@@ -169,6 +169,32 @@ const noCheckInStats = computeCheckInStats(registrations, []);
 assert.equal(noCheckInStats.checkedIn, 0, 'should handle no check-ins');
 assert.equal(noCheckInStats.notCheckedIn, 3, 'should count all as not checked in');
 
+// Test: computeCheckInStats - check-ins outside the active set must not produce
+// negative counts or a rate above 100%.
+const staleCheckIns = [
+  ...eventCheckIns,
+  { registrationId: 'reg-3', timestamp: new Date().toISOString(), scannedBy: 'scanner-1' },
+  { registrationId: 'reg-999', timestamp: new Date().toISOString(), scannedBy: 'scanner-1' },
+];
+const staleStats = computeCheckInStats(registrations, staleCheckIns);
+assert.equal(staleStats.checkedIn, 2, 'should count only check-ins for active registrations');
+assert.equal(staleStats.notCheckedIn, 1, 'should never report negative not-checked-in counts');
+assert.ok(staleStats.checkInRate <= 100, 'check-in rate should never exceed 100%');
+assert.equal(
+  staleStats.checkInRate,
+  66.67,
+  'should compute the rate against active registrations only'
+);
+
+// Test: computeCheckInStats - must not mutate the caller's checkIns array.
+const originalOrder = eventCheckIns.map((c) => c.registrationId);
+computeCheckInStats(registrations, eventCheckIns);
+assert.deepEqual(
+  eventCheckIns.map((c) => c.registrationId),
+  originalOrder,
+  'should not reorder the caller checkIns array'
+);
+
 // Test: computeSessionCheckInStats - basic session stats
 const sessions = [
   { id: 'session-1', name: 'Keynote', track: 'Main' },


### PR DESCRIPTION
## Problem

`computeCheckInStats` in `src/utils/checkInUtils.js` counts every distinct `registrationId` in `checkIns` with no filter against the active registration set. When a check-in references a cancelled registration or any id not in the active list (stale offline queue replay, cancelled-then-rescanned tickets, check-ins synced from another event), `notCheckedIn = activeRegistrations - checkedIn` goes negative and `checkInRate` exceeds 100% — the dashboard shows impossible statistics. The `.sort()` also mutates the caller's `checkIns` array in place, reordering other consumers of the same array.

## Fix

- Count only check-ins whose `registrationId` belongs to an active (non-cancelled) registration, so `notCheckedIn` can never be negative and `checkInRate` can never exceed 100%.
- Sort a copy (`[...checkIns].sort(...)`) so the caller's array is not mutated.

## Files changed

- `src/utils/checkInUtils.js` — `computeCheckInStats`: filter checked-in ids against the active registration set; sort a copy
- `tests/checkInUtils.test.mjs` — add coverage for out-of-set check-ins (no negative counts, rate ≤ 100%) and input array non-mutation

## Testing

- `node --test tests/checkInUtils.test.mjs` — all assertions pass
- `npx eslint src/utils/checkInUtils.js tests/checkInUtils.test.mjs` — 0 errors (one pre-existing unused-import warning)

Closes #12580
