### PR TITLE
Implement live audience Q&A and polls API (closes #12608)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java
@@ -1,0 +1,184 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.dto.request.CreatePollRequest;
+import com.sandeep.eventrabackend.dto.request.CreateQuestionRequest;
+import com.sandeep.eventrabackend.dto.request.SubmitVoteRequest;
+import com.sandeep.eventrabackend.dto.request.UpdatePollStatusRequest;
+import com.sandeep.eventrabackend.dto.response.ErrorResponse;
+import com.sandeep.eventrabackend.dto.response.LiveAudienceDataResponse;
+import com.sandeep.eventrabackend.dto.response.LiveAudiencePollResponse;
+import com.sandeep.eventrabackend.dto.response.LiveAudienceQuestionResponse;
+import com.sandeep.eventrabackend.service.LiveAudienceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/events/{eventId}/live-audience")
+@RequiredArgsConstructor
+@Tag(name = "Live Audience", description = "Endpoints for the live Q&A board and polls during an event")
+public class LiveAudienceController {
+
+    private final LiveAudienceService liveAudienceService;
+
+    @GetMapping
+    @Operation(summary = "Get initial live audience data",
+            description = "Returns the Q&A questions and the latest poll for an event. Requires authentication.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Live audience data fetched successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudienceDataResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Event not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudienceDataResponse> getInitialData(@PathVariable Long eventId) {
+        return ResponseEntity.ok(liveAudienceService.getInitialData(eventId));
+    }
+
+    @PostMapping("/questions")
+    @Operation(summary = "Submit a Q&A question",
+            description = "Posts a question to the live audience board. Requires authentication.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Question submitted successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudienceQuestionResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid payload (validation failed)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudienceQuestionResponse> createQuestion(
+            @PathVariable Long eventId,
+            @Valid @RequestBody CreateQuestionRequest request,
+            Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(liveAudienceService.createQuestion(eventId, request.getText(), authentication.getName()));
+    }
+
+    @PostMapping("/questions/{questionId}/upvote")
+    @Operation(summary = "Upvote a Q&A question",
+            description = "Upvotes a question. Each user can upvote a question at most once. Requires authentication.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Question upvoted successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudienceQuestionResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Question not found or already upvoted",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudienceQuestionResponse> upvoteQuestion(
+            @PathVariable Long eventId,
+            @PathVariable Long questionId,
+            Authentication authentication) {
+        return ResponseEntity.ok(
+                liveAudienceService.upvoteQuestion(eventId, questionId, authentication.getName()));
+    }
+
+    @PostMapping("/questions/{questionId}/flag")
+    @Operation(summary = "Flag a Q&A question",
+            description = "Flags a question for moderation. Requires organizer, admin or owner access.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Question flagged successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudienceQuestionResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient event role",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudienceQuestionResponse> flagQuestion(
+            @PathVariable Long eventId,
+            @PathVariable Long questionId,
+            Authentication authentication) {
+        return ResponseEntity.ok(
+                liveAudienceService.flagQuestion(eventId, questionId, authentication.getName()));
+    }
+
+    @DeleteMapping("/questions/{questionId}")
+    @Operation(summary = "Delete a Q&A question",
+            description = "Deletes a question. Requires organizer, admin or owner access.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Question deleted successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient event role",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteQuestion(
+            @PathVariable Long eventId,
+            @PathVariable Long questionId,
+            Authentication authentication) {
+        liveAudienceService.deleteQuestion(eventId, questionId, authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/polls")
+    @Operation(summary = "Create a live poll",
+            description = "Creates a new poll for the event. Requires organizer, admin or owner access.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Poll created successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudiencePollResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid payload (validation failed)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient event role",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudiencePollResponse> createPoll(
+            @PathVariable Long eventId,
+            @Valid @RequestBody CreatePollRequest request,
+            Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(liveAudienceService.createPoll(eventId, request, authentication.getName()));
+    }
+
+    @PostMapping("/polls/{pollId}/status")
+    @Operation(summary = "Update poll status",
+            description = "Sets a poll status to 'active', 'paused' or 'closed'. Requires organizer, admin or owner access.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Poll status updated successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudiencePollResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid payload (validation failed)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - insufficient event role",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudiencePollResponse> updatePollStatus(
+            @PathVariable Long eventId,
+            @PathVariable Long pollId,
+            @Valid @RequestBody UpdatePollStatusRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(
+                liveAudienceService.updatePollStatus(eventId, pollId, request.getStatus(), authentication.getName()));
+    }
+
+    @PostMapping("/polls/{pollId}/vote")
+    @Operation(summary = "Submit a poll vote",
+            description = "Records a vote for a poll option. Each user can vote once per poll. Requires authentication.",
+            security = @SecurityRequirement(name = "bearerAuth"))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Vote submitted successfully",
+                    content = @Content(schema = @Schema(implementation = LiveAudiencePollResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Poll not found, voting closed or already voted",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LiveAudiencePollResponse> submitVote(
+            @PathVariable Long eventId,
+            @PathVariable Long pollId,
+            @Valid @RequestBody SubmitVoteRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(
+                liveAudienceService.submitVote(eventId, pollId, request.getOption(), authentication.getName()));
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreatePollRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreatePollRequest.java
@@ -1,0 +1,35 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to create a live-audience poll")
+public class CreatePollRequest {
+
+    @NotBlank(message = "Poll question is required")
+    @Size(max = 300, message = "Poll question must not exceed 300 characters")
+    @Schema(description = "Poll question", example = "How did you find today's keynote?")
+    private String question;
+
+    @Pattern(regexp = "single|multiple", message = "Poll type must be 'single' or 'multiple'")
+    @Schema(description = "Poll type: single or multiple", example = "single")
+    private String type;
+
+    @NotEmpty(message = "Poll options are required")
+    @Size(max = 10, message = "A poll can have at most 10 options")
+    @Schema(description = "Poll options", example = "[\"Excellent\", \"Good\", \"Average\", \"Poor\"]")
+    private List<String> options;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreateQuestionRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreateQuestionRequest.java
@@ -1,0 +1,22 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to submit a live-audience Q&A question")
+public class CreateQuestionRequest {
+
+    @NotBlank(message = "Question text is required")
+    @Size(max = 500, message = "Question text must not exceed 500 characters")
+    @Schema(description = "Question text", example = "Will there be a networking session?")
+    private String text;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/SubmitVoteRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/SubmitVoteRequest.java
@@ -1,0 +1,22 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to submit a live-audience poll vote")
+public class SubmitVoteRequest {
+
+    @NotBlank(message = "Option is required")
+    @Size(max = 200, message = "Option must not exceed 200 characters")
+    @Schema(description = "Selected poll option", example = "Excellent")
+    private String option;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/UpdatePollStatusRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/UpdatePollStatusRequest.java
@@ -1,0 +1,22 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request to update a live-audience poll status")
+public class UpdatePollStatusRequest {
+
+    @NotBlank(message = "Poll status is required")
+    @Pattern(regexp = "active|paused|closed", message = "Poll status must be 'active', 'paused' or 'closed'")
+    @Schema(description = "New poll status", example = "closed")
+    private String status;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudienceDataResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudienceDataResponse.java
@@ -1,0 +1,19 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@Schema(description = "Initial snapshot of the live audience board for an event")
+public class LiveAudienceDataResponse {
+
+    @Schema(description = "All Q&A questions for the event")
+    private List<LiveAudienceQuestionResponse> questions;
+
+    @Schema(description = "Most recently created poll for the event (may be null)")
+    private LiveAudiencePollResponse activePoll;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudiencePollResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudiencePollResponse.java
@@ -1,0 +1,38 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Live-audience poll")
+public class LiveAudiencePollResponse {
+
+    @Schema(description = "Poll ID", example = "3")
+    private Long id;
+
+    @Schema(description = "Poll question", example = "How did you find today's keynote?")
+    private String question;
+
+    @Schema(description = "Poll type: single or multiple", example = "single")
+    private String type;
+
+    @Schema(description = "Poll status: active, paused or closed", example = "active")
+    private String status;
+
+    @Schema(description = "Poll options", example = "[\"Excellent\", \"Good\", \"Average\"]")
+    private List<String> options;
+
+    @Schema(description = "Running vote tally per option", example = "{\"Excellent\": 12, \"Good\": 8}")
+    private Map<String, Object> results;
+
+    @Schema(description = "Poll creation time", example = "2026-08-09T13:00:00")
+    private LocalDateTime createdAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudienceQuestionResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudienceQuestionResponse.java
@@ -1,0 +1,36 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Live-audience Q&A question")
+public class LiveAudienceQuestionResponse {
+
+    @Schema(description = "Question ID", example = "12")
+    private Long id;
+
+    @Schema(description = "Question text", example = "Will there be a networking session?")
+    private String text;
+
+    @Schema(description = "Number of upvotes", example = "7")
+    private Integer upvotes;
+
+    @Schema(description = "Whether the question was flagged for moderation")
+    private Boolean flagged;
+
+    @Schema(description = "Whether the author is a speaker / organizer")
+    private Boolean isSpeaker;
+
+    @Schema(description = "Author display name")
+    private String userName;
+
+    @Schema(description = "Question creation time", example = "2026-08-09T12:30:00")
+    private LocalDateTime createdAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudiencePoll.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudiencePoll.java
@@ -1,0 +1,64 @@
+package com.sandeep.eventrabackend.model;
+
+import com.sandeep.eventrabackend.config.JsonMapAttributeConverter;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A live poll run by the event organizer. Option labels are stored in a join
+ * table and running vote tallies in a JSON text column ({@code option -> count}).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "live_audience_polls",
+        indexes = @Index(name = "idx_lap_event", columnList = "event_id"))
+public class LiveAudiencePoll {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(nullable = false, length = 300)
+    private String question;
+
+    /** single | multiple */
+    @Column(nullable = false, length = 20)
+    private String type = "single";
+
+    /** active | paused | closed */
+    @Column(nullable = false, length = 20)
+    private String status = "active";
+
+    @ElementCollection
+    @CollectionTable(name = "live_audience_poll_options",
+            joinColumns = @JoinColumn(name = "poll_id"))
+    @Column(name = "option_text", length = 200)
+    private List<String> options = new ArrayList<>();
+
+    @Convert(converter = JsonMapAttributeConverter.class)
+    @Column(name = "results", columnDefinition = "TEXT")
+    private Map<String, Object> results = new HashMap<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudiencePollVote.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudiencePollVote.java
@@ -1,0 +1,43 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Records one attendee's vote on a live poll so each attendee can vote at
+ * most once per poll (unique {@code poll_id + user_id}).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "live_audience_poll_votes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_lapv_poll_user",
+                columnNames = {"poll_id", "user_id"}))
+public class LiveAudiencePollVote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "poll_id", nullable = false)
+    private Long pollId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "option_text", nullable = false, length = 200)
+    private String optionText;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudienceQuestion.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudienceQuestion.java
@@ -1,0 +1,55 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * A question posted by an attendee on the live audience Q&A board.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "live_audience_questions",
+        indexes = {
+                @Index(name = "idx_laq_event", columnList = "event_id"),
+                @Index(name = "idx_laq_event_created", columnList = "event_id, created_at")
+        })
+public class LiveAudienceQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "user_name", length = 100)
+    private String userName;
+
+    @Column(nullable = false, length = 500)
+    private String text;
+
+    @Column(nullable = false)
+    private int upvotes = 0;
+
+    @Column(nullable = false)
+    private boolean flagged = false;
+
+    @Column(name = "is_speaker", nullable = false)
+    private boolean isSpeaker = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudienceQuestionUpvote.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudienceQuestionUpvote.java
@@ -1,0 +1,40 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Tracks which user upvoted which live-audience question so each attendee can
+ * upvote a question at most once.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "live_audience_question_upvotes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_laqu_question_user",
+                columnNames = {"question_id", "user_id"}))
+public class LiveAudienceQuestionUpvote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "question_id", nullable = false)
+    private Long questionId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java
@@ -1,0 +1,16 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.LiveAudiencePoll;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveAudiencePollRepository extends JpaRepository<LiveAudiencePoll, Long> {
+
+    List<LiveAudiencePoll> findByEventIdOrderByCreatedAtDesc(Long eventId);
+
+    Optional<LiveAudiencePoll> findByIdAndEventId(Long id, Long eventId);
+
+    void deleteByEventId(Long eventId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollVoteRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollVoteRepository.java
@@ -1,0 +1,9 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.LiveAudiencePollVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LiveAudiencePollVoteRepository extends JpaRepository<LiveAudiencePollVote, Long> {
+
+    boolean existsByPollIdAndUserId(Long pollId, Long userId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudienceQuestionRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudienceQuestionRepository.java
@@ -1,0 +1,16 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.LiveAudienceQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LiveAudienceQuestionRepository extends JpaRepository<LiveAudienceQuestion, Long> {
+
+    List<LiveAudienceQuestion> findByEventIdOrderByUpvotesDescCreatedAtDesc(Long eventId);
+
+    Optional<LiveAudienceQuestion> findByIdAndEventId(Long id, Long eventId);
+
+    void deleteByEventId(Long eventId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudienceQuestionUpvoteRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudienceQuestionUpvoteRepository.java
@@ -1,0 +1,10 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.LiveAudienceQuestionUpvote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LiveAudienceQuestionUpvoteRepository
+        extends JpaRepository<LiveAudienceQuestionUpvote, Long> {
+
+    boolean existsByQuestionIdAndUserId(Long questionId, Long userId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
@@ -1,0 +1,281 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.request.CreatePollRequest;
+import com.sandeep.eventrabackend.dto.response.LiveAudienceDataResponse;
+import com.sandeep.eventrabackend.dto.response.LiveAudiencePollResponse;
+import com.sandeep.eventrabackend.dto.response.LiveAudienceQuestionResponse;
+import com.sandeep.eventrabackend.exception.EventNotFoundException;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRole;
+import com.sandeep.eventrabackend.model.LiveAudiencePoll;
+import com.sandeep.eventrabackend.model.LiveAudiencePollVote;
+import com.sandeep.eventrabackend.model.LiveAudienceQuestion;
+import com.sandeep.eventrabackend.model.LiveAudienceQuestionUpvote;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.LiveAudiencePollRepository;
+import com.sandeep.eventrabackend.repository.LiveAudiencePollVoteRepository;
+import com.sandeep.eventrabackend.repository.LiveAudienceQuestionRepository;
+import com.sandeep.eventrabackend.repository.LiveAudienceQuestionUpvoteRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class LiveAudienceService {
+
+    private static final String TOPIC = "live-audience";
+    private static final List<String> POLL_STATUSES = List.of("active", "paused", "closed");
+    private static final List<String> POLL_TYPES = List.of("single", "multiple");
+
+    private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+    private final EventRoleService eventRoleService;
+    private final LiveAudienceQuestionRepository questionRepository;
+    private final LiveAudienceQuestionUpvoteRepository questionUpvoteRepository;
+    private final LiveAudiencePollRepository pollRepository;
+    private final LiveAudiencePollVoteRepository pollVoteRepository;
+    private final EventStreamService eventStreamService;
+
+    @Transactional(readOnly = true)
+    public LiveAudienceDataResponse getInitialData(Long eventId) {
+        requireEvent(eventId);
+        List<LiveAudienceQuestionResponse> questions = questionRepository
+                .findByEventIdOrderByUpvotesDescCreatedAtDesc(eventId)
+                .stream()
+                .map(this::toQuestionResponse)
+                .toList();
+        LiveAudiencePollResponse activePoll = pollRepository
+                .findByEventIdOrderByCreatedAtDesc(eventId)
+                .stream()
+                .findFirst()
+                .map(this::toPollResponse)
+                .orElse(null);
+        return LiveAudienceDataResponse.builder()
+                .questions(questions)
+                .activePoll(activePoll)
+                .build();
+    }
+
+    @Transactional
+    public LiveAudienceQuestionResponse createQuestion(Long eventId, String text, String email) {
+        requireEvent(eventId);
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Question text is required");
+        }
+        String trimmed = text.trim();
+        if (trimmed.length() > 500) {
+            throw new IllegalArgumentException("Question text must not exceed 500 characters");
+        }
+        User user = getUser(email);
+        LiveAudienceQuestion question = LiveAudienceQuestion.builder()
+                .eventId(eventId)
+                .userId(user.getId())
+                .userName(displayName(user))
+                .text(trimmed)
+                .upvotes(0)
+                .flagged(false)
+                .isSpeaker(eventRoleService.hasRole(eventId, email, EventRole.ORGANIZER))
+                .build();
+        question = questionRepository.save(question);
+        LiveAudienceQuestionResponse response = toQuestionResponse(question);
+        publish(eventId, "NEW_QUESTION", response);
+        return response;
+    }
+
+    @Transactional
+    public LiveAudienceQuestionResponse upvoteQuestion(Long eventId, Long questionId, String email) {
+        requireEvent(eventId);
+        LiveAudienceQuestion question = requireQuestion(eventId, questionId);
+        User user = getUser(email);
+        if (questionUpvoteRepository.existsByQuestionIdAndUserId(questionId, user.getId())) {
+            throw new IllegalArgumentException("You have already upvoted this question");
+        }
+        questionUpvoteRepository.save(LiveAudienceQuestionUpvote.builder()
+                .questionId(questionId)
+                .userId(user.getId())
+                .build());
+        question.setUpvotes(question.getUpvotes() + 1);
+        question = questionRepository.save(question);
+        LiveAudienceQuestionResponse response = toQuestionResponse(question);
+        publish(eventId, "UPDATE_QUESTION", response);
+        return response;
+    }
+
+    @Transactional
+    public LiveAudienceQuestionResponse flagQuestion(Long eventId, Long questionId, String email) {
+        requireEvent(eventId);
+        requireModerator(eventId, email);
+        LiveAudienceQuestion question = requireQuestion(eventId, questionId);
+        question.setFlagged(true);
+        question = questionRepository.save(question);
+        LiveAudienceQuestionResponse response = toQuestionResponse(question);
+        publish(eventId, "UPDATE_QUESTION", response);
+        return response;
+    }
+
+    @Transactional
+    public void deleteQuestion(Long eventId, Long questionId, String email) {
+        requireEvent(eventId);
+        requireModerator(eventId, email);
+        requireQuestion(eventId, questionId);
+        questionRepository.deleteById(questionId);
+        publish(eventId, "DELETE_QUESTION", questionId);
+    }
+
+    @Transactional
+    public LiveAudiencePollResponse createPoll(Long eventId, CreatePollRequest request, String email) {
+        requireEvent(eventId);
+        requireModerator(eventId, email);
+        String type = request.getType() == null || request.getType().isBlank() ? "single" : request.getType().trim();
+        if (!POLL_TYPES.contains(type)) {
+            throw new IllegalArgumentException("Poll type must be 'single' or 'multiple'");
+        }
+        if (request.getOptions() == null || request.getOptions().size() < 2) {
+            throw new IllegalArgumentException("A poll needs at least 2 options");
+        }
+        if (request.getOptions().size() > 10) {
+            throw new IllegalArgumentException("A poll can have at most 10 options");
+        }
+        List<String> options = new ArrayList<>();
+        for (String option : request.getOptions()) {
+            if (option == null || option.isBlank()) {
+                throw new IllegalArgumentException("Poll options cannot be blank");
+            }
+            options.add(option.trim());
+        }
+        Map<String, Object> results = new HashMap<>();
+        options.forEach(opt -> results.put(opt, 0));
+
+        LiveAudiencePoll poll = LiveAudiencePoll.builder()
+                .eventId(eventId)
+                .question(request.getQuestion().trim())
+                .type(type)
+                .status("active")
+                .options(options)
+                .results(results)
+                .build();
+        poll = pollRepository.save(poll);
+        LiveAudiencePollResponse response = toPollResponse(poll);
+        publish(eventId, "SET_POLL", response);
+        return response;
+    }
+
+    @Transactional
+    public LiveAudiencePollResponse updatePollStatus(Long eventId, Long pollId, String status, String email) {
+        requireEvent(eventId);
+        requireModerator(eventId, email);
+        if (!POLL_STATUSES.contains(status)) {
+            throw new IllegalArgumentException("Poll status must be 'active', 'paused' or 'closed'");
+        }
+        LiveAudiencePoll poll = requirePoll(eventId, pollId);
+        poll.setStatus(status);
+        poll.setUpdatedAt(LocalDateTime.now());
+        poll = pollRepository.save(poll);
+        LiveAudiencePollResponse response = toPollResponse(poll);
+        publish(eventId, "UPDATE_POLL", response);
+        return response;
+    }
+
+    @Transactional
+    public LiveAudiencePollResponse submitVote(Long eventId, Long pollId, String option, String email) {
+        requireEvent(eventId);
+        LiveAudiencePoll poll = requirePoll(eventId, pollId);
+        if ("closed".equals(poll.getStatus())) {
+            throw new IllegalArgumentException("Voting is closed for this poll");
+        }
+        if ("paused".equals(poll.getStatus())) {
+            throw new IllegalArgumentException("Voting is paused for this poll");
+        }
+        User user = getUser(email);
+        if (pollVoteRepository.existsByPollIdAndUserId(pollId, user.getId())) {
+            throw new IllegalArgumentException("You have already voted in this poll");
+        }
+        String trimmed = option == null ? "" : option.trim();
+        if (!poll.getOptions().contains(trimmed)) {
+            throw new IllegalArgumentException("Selected option is not part of this poll");
+        }
+        pollVoteRepository.save(LiveAudiencePollVote.builder()
+                .pollId(pollId)
+                .userId(user.getId())
+                .optionText(trimmed)
+                .build());
+        Map<String, Object> results = poll.getResults() == null
+                ? new HashMap<>()
+                : new HashMap<>(poll.getResults());
+        int current = results.get(trimmed) instanceof Number number ? number.intValue() : 0;
+        results.put(trimmed, current + 1);
+        poll.setResults(results);
+        poll = pollRepository.save(poll);
+        LiveAudiencePollResponse response = toPollResponse(poll);
+        publish(eventId, "UPDATE_POLL", response);
+        return response;
+    }
+
+    private void publish(Long eventId, String type, Object payload) {
+        eventStreamService.publish(TOPIC, type,
+                Map.of("eventId", eventId, "type", type, "payload", payload));
+    }
+
+    private Event requireEvent(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+    }
+
+    private LiveAudienceQuestion requireQuestion(Long eventId, Long questionId) {
+        return questionRepository.findByIdAndEventId(questionId, eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Question not found with id: " + questionId));
+    }
+
+    private LiveAudiencePoll requirePoll(Long eventId, Long pollId) {
+        return pollRepository.findByIdAndEventId(pollId, eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Poll not found with id: " + pollId));
+    }
+
+    private User getUser(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+    }
+
+    private void requireModerator(Long eventId, String email) {
+        eventRoleService.requireRole(eventId, email, EventRole.ORGANIZER);
+    }
+
+    private String displayName(User user) {
+        String full = (user.getFirstName() + " " + user.getLastName()).trim();
+        return full.isBlank() ? user.getUsername() : full;
+    }
+
+    private LiveAudienceQuestionResponse toQuestionResponse(LiveAudienceQuestion question) {
+        return LiveAudienceQuestionResponse.builder()
+                .id(question.getId())
+                .text(question.getText())
+                .upvotes(question.getUpvotes())
+                .flagged(question.isFlagged())
+                .isSpeaker(question.isSpeaker())
+                .userName(question.getUserName())
+                .createdAt(question.getCreatedAt())
+                .build();
+    }
+
+    private LiveAudiencePollResponse toPollResponse(LiveAudiencePoll poll) {
+        return LiveAudiencePollResponse.builder()
+                .id(poll.getId())
+                .question(poll.getQuestion())
+                .type(poll.getType())
+                .status(poll.getStatus())
+                .options(poll.getOptions())
+                .results(poll.getResults())
+                .createdAt(poll.getCreatedAt())
+                .build();
+    }
+}

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
@@ -1,0 +1,369 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.LiveAudiencePollRepository;
+import com.sandeep.eventrabackend.repository.LiveAudiencePollVoteRepository;
+import com.sandeep.eventrabackend.repository.LiveAudienceQuestionRepository;
+import com.sandeep.eventrabackend.repository.LiveAudienceQuestionUpvoteRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class LiveAudienceControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LiveAudienceQuestionRepository questionRepository;
+
+    @Autowired
+    private LiveAudienceQuestionUpvoteRepository questionUpvoteRepository;
+
+    @Autowired
+    private LiveAudiencePollRepository pollRepository;
+
+    @Autowired
+    private LiveAudiencePollVoteRepository pollVoteRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Long eventId;
+    private final String organizerEmail = "liveorganizer@example.com";
+    private final String attendeeEmail = "liveattendee@example.com";
+
+    @BeforeEach
+    void setUp() {
+        pollVoteRepository.deleteAll();
+        pollRepository.deleteAll();
+        questionUpvoteRepository.deleteAll();
+        questionRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User organizer = User.builder()
+                .firstName("Live")
+                .lastName("Organizer")
+                .email(organizerEmail)
+                .username("liveorganizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(organizer);
+
+        User attendee = User.builder()
+                .firstName("Live")
+                .lastName("Attendee")
+                .email(attendeeEmail)
+                .username("liveattendee")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(attendee);
+
+        Event event = new Event();
+        event.setTitle("Live Audience Test Event");
+        event.setCapacity(50);
+        event.setEventDate(LocalDateTime.now().plusDays(1));
+        event.setOwnerId(organizer.getId());
+        event.setPublic(true);
+        event = eventRepository.save(event);
+        eventId = event.getId();
+    }
+
+    @Test
+    @DisplayName("GET /api/events/{id}/live-audience — empty board")
+    void testGetInitialDataEmpty() throws Exception {
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.questions", hasSize(0)))
+                .andExpect(jsonPath("$.activePoll").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/events/{id}/live-audience — 404 event not found")
+    void testGetInitialDataEventNotFound() throws Exception {
+        mockMvc.perform(get("/api/events/99999/live-audience")
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/events/{id}/live-audience — 401 unauthenticated")
+    void testGetInitialDataUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/events/{id}/live-audience/questions — success")
+    void testCreateQuestionSuccess() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("text", "Will there be a networking session?"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.text").value("Will there be a networking session?"))
+                .andExpect(jsonPath("$.upvotes").value(0))
+                .andExpect(jsonPath("$.flagged").value(false))
+                .andExpect(jsonPath("$.isSpeaker").value(false))
+                .andExpect(jsonPath("$.userName").value("Live Attendee"));
+    }
+
+    @Test
+    @DisplayName("POST /api/events/{id}/live-audience/questions — 400 blank text")
+    void testCreateQuestionBlankText() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("text", "   "))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/events/{id}/live-audience/questions — 401 unauthenticated")
+    void testCreateQuestionUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("text", "Hello?"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST upvote — success then duplicate rejected")
+    void testUpvoteQuestion() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("text", "When is lunch?"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long questionId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions/{qid}/upvote", eventId, questionId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.upvotes").value(1));
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions/{qid}/upvote", eventId, questionId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST flag — owner can flag, plain attendee cannot")
+    void testFlagQuestionAuthorization() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("text", "Spam question"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long questionId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions/{qid}/flag", eventId, questionId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions/{qid}/flag", eventId, questionId)
+                        .with(user(organizerEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flagged").value(true));
+    }
+
+    @Test
+    @DisplayName("DELETE question — owner deletes, board empty")
+    void testDeleteQuestion() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("text", "Remove me"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long questionId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(delete("/api/events/{id}/live-audience/questions/{qid}", eventId, questionId)
+                        .with(user(organizerEmail)))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.questions", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("POST /polls — organizer creates poll")
+    void testCreatePoll() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "How was the keynote?",
+                                        "type", "single",
+                                        "options", List.of("Excellent", "Good", "Poor")))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.question").value("How was the keynote?"))
+                .andExpect(jsonPath("$.status").value("active"))
+                .andExpect(jsonPath("$.options", hasSize(3)))
+                .andExpect(jsonPath("$.results.Excellent").value(0));
+    }
+
+    @Test
+    @DisplayName("POST /polls — attendee forbidden, too-few options rejected")
+    void testCreatePollValidation() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "Any questions?",
+                                        "options", List.of("Yes", "No")))))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "One option only",
+                                        "options", List.of("Only")))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /polls/{id}/vote — success, duplicate rejected, closed rejected")
+    void testSubmitVote() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "How was the keynote?",
+                                        "options", List.of("Excellent", "Good")))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long pollId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/vote", eventId, pollId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("option", "Excellent"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results.Excellent").value(1));
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/vote", eventId, pollId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("option", "Excellent"))))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/vote", eventId, pollId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("option", "Unknown"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /polls/{id}/status — owner closes poll, votes then rejected")
+    void testClosePollBlocksVotes() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "Vote please",
+                                        "options", List.of("A", "B")))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long pollId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/status", eventId, pollId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("status", "closed"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("closed"));
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/vote", eventId, pollId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("option", "A"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET initial data — reflects persisted questions and latest poll")
+    void testGetInitialDataPopulated() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("text", "Question one"))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("question", "Poll question", "options", List.of("Yes", "No")))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.questions", hasSize(1)))
+                .andExpect(jsonPath("$.questions[0].text").value("Question one"))
+                .andExpect(jsonPath("$.activePoll.question").value("Poll question"));
+    }
+}


### PR DESCRIPTION
## Problem

All live-audience REST endpoints (`/api/events/{eventId}/live-audience/**` used by `useLiveAudience.js`) return 404 because no backend controller exists. The frontend live Q&A board and live polls only have a static mock flow, and the `/stream/live-audience` SSE stream has nothing to push real events into.

## Fix

Adds the missing backend for the live audience board:

- `LiveAudienceQuestion` / `LiveAudienceQuestionUpvote` / `LiveAudiencePoll` / `LiveAudiencePollVote` entities with repositories (`LiveAudienceQuestionRepository`, `LiveAudienceQuestionUpvoteRepository`, `LiveAudiencePollRepository`, `LiveAudiencePollVoteRepository`).
- `LiveAudienceService` implementing Q&A (create/upvote/flag/delete) and polls (create/status/vote) with persistence, dedupe (unique question+user upvotes, poll+user votes), poll status gating (active/paused/closed), and SSE pushes into the existing `live-audience` topic via `EventStreamService` (`NEW_QUESTION`, `UPDATE_QUESTION`, `DELETE_QUESTION`, `SET_POLL`, `UPDATE_POLL`).
- `LiveAudienceController` exposing the exact endpoint contract the frontend expects:
  - `GET /api/events/{eventId}/live-audience` — initial board snapshot (`{ questions, activePoll }`)
  - `POST /api/events/{eventId}/live-audience/questions`
  - `POST /api/events/{eventId}/live-audience/questions/{questionId}/upvote`
  - `POST /api/events/{eventId}/live-audience/questions/{questionId}/flag`
  - `DELETE /api/events/{eventId}/live-audience/questions/{questionId}`
  - `POST /api/events/{eventId}/live-audience/polls`
  - `POST /api/events/{eventId}/live-audience/polls/{pollId}/status`
  - `POST /api/events/{eventId}/live-audience/polls/{pollId}/vote`
- Organizer-only actions (flag/delete question, create poll, update poll status) are protected via `EventRoleService.requireRole(..., ORGANIZER)` (which also accepts platform admins and legacy owners); attendee actions require authentication only.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/model/LiveAudienceQuestion.java`, `LiveAudienceQuestionUpvote.java`, `LiveAudiencePoll.java`, `LiveAudiencePollVote.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudienceQuestionRepository.java`, `LiveAudienceQuestionUpvoteRepository.java`, `LiveAudiencePollRepository.java`, `LiveAudiencePollVoteRepository.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreateQuestionRequest.java`, `CreatePollRequest.java`, `UpdatePollStatusRequest.java`, `SubmitVoteRequest.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/dto/response/LiveAudienceQuestionResponse.java`, `LiveAudiencePollResponse.java`, `LiveAudienceDataResponse.java` (new)
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java` (new)

## Testing

- Added `LiveAudienceControllerTests` (14 tests): initial data load (empty and populated), 404 for unknown event, 401 unauthenticated, question create + validation, upvote success + duplicate rejection, flag authorization (owner ok / attendee 403), delete question, poll create + validation (attendee 403, too-few options 400), vote success + duplicate + invalid option rejection, and close-poll-blocks-votes.
- Ran `mvn test -Dtest=LiveAudienceControllerTests -DfailIfNoTests=false`: **14 passed, 0 failed**.
- All response shapes match what the frontend consumes (`useLiveAudience.js`, `RealTimeContext.js` live-audience reducer, `LiveQABoard.jsx`, `LivePollController.jsx`).

Closes #12608
