### PR TITLE
[Fix] Derive leaderboard ranks from bonus-adjusted final points

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -53,7 +53,9 @@ const formatLastUpdated = (timestamp, t) => {
 };
 
 const prepareLeaderboardEntries = (entries = []) =>
-  entries.map((entry) => applyAchievementBonus({ ...entry }));
+  entries
+    .map((entry) => applyAchievementBonus({ ...entry }))
+    .sort((a, b) => b.points - a.points);
 
 const useDebouncedValue = (value, delay) => {
   const [debouncedValue, setDebouncedValue] = useState(value);


### PR DESCRIPTION
## Problem

The Leaderboard ranked contributors by `totalPRs` (or raw points order) even though `applyAchievementBonus` later added bonus points per difficulty/quality label. The "final points" column therefore did not match the displayed rank order, so rankings were inconsistent with the points shown.

## Fix

`prepareLeaderboardEntries` now sorts by the final, bonus-adjusted `points` (`b.points - a.points`) after `applyAchievementBonus` is applied, so displayed rank matches the displayed points.

## Files changed

- `src/Pages/Leaderboard/Leaderboard.jsx`

## Testing

- Multiple contributors with different bonus levels produce a leaderboard where rank order equals descending final points.

Closes #12618
