### PR TITLE
[Fix] Parse string prize values in Highest Prize hackathon sort

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -416,9 +416,13 @@ const HackathonHub = () => {
     } else if (sortBy === "oldest") {
       sorted.sort((a, b) => new Date(a.startDate || a.date || a.createdAt || 0) - new Date(b.startDate || b.date || b.createdAt || 0));
     } else if (sortBy === "prize_desc") {
+      const toNum = (value) => {
+        if (typeof value === "number") return value;
+        return Number(String(value || "").replace(/[^0-9.]/g, "")) || 0;
+      };
       sorted.sort((a, b) => {
-        const prizeA = typeof a.prizePool === 'number' ? a.prizePool : (a.prize || 0);
-        const prizeB = typeof b.prizePool === 'number' ? b.prizePool : (b.prize || 0);
+        const prizeA = toNum(a.prize ?? a.prizePool);
+        const prizeB = toNum(b.prize ?? b.prizePool);
         return prizeB - prizeA;
       });
     }


### PR DESCRIPTION
## Problem

The Hackathon "Highest Prize" sort compared raw string values (e.g. `"$2,000"` or `"₹5000"`), producing `NaN` and a broken/erratic ordering.

## Fix

Added a `toNum` helper that strips non-numeric characters (`/[^0-9.]/g`) and parses the value; the `prize_desc` sort now compares `toNum(a.prize ?? a.prizePool)` so string currency values are ordered correctly.

## Files changed

- `src/Pages/Hackathons/HackathonPage.js`

## Testing

- Sorting hackathons by "Highest Prize" yields a descending, numerically-correct order for mixed currency/string prize values.

Closes #12621
