### PR TITLE
[Fix] Remove undefined setMembers call in EventRoleManagement

### DIFF
--- a/src/Pages/Events/EventRoleManagement.jsx
+++ b/src/Pages/Events/EventRoleManagement.jsx
@@ -43,15 +43,10 @@ export default function EventRoleManagement() {
     event.preventDefault();
     setSaving(true);
     try {
-      const response = await apiUtils.put(API_ENDPOINTS.EVENTS.ROLES(eventId), {
+      await apiUtils.put(API_ENDPOINTS.EVENTS.ROLES(eventId), {
         userEmail,
         role,
       });
-      const updatedMember = await response.json();
-      setMembers((current) => [
-        updatedMember,
-        ...current.filter((member) => member.userId !== updatedMember.userId),
-      ]);
       setUserEmail("");
       toast.success("Event role updated.");
       loadRoles();


### PR DESCRIPTION
## Problem

`EventRoleManagement` called an undefined `setMembers(...)` in `handleSubmit`, throwing a `ReferenceError` on every role assignment and preventing the submit flow from completing.

`members` is derived from the fetched roles data (`rolesData?.members ?? []`), not component state, so there was no `setMembers` to call.

## Fix

- Removed the `setMembers((current) => [...])` block from `handleSubmit`.
- Kept `setUserEmail("")`, the success toast, and the `loadRoles()` refetch, which is the source of truth for the members list.

## Files changed

- `src/Pages/Events/EventRoleManagement.jsx`

## Testing

- Assigning a role to a user no longer throws; the members list refreshes from the server after the successful API call.

Closes #12622
