### PR TITLE
[Fix] Normalize circle dimensions in InteractiveWhiteboard

### DIFF
--- a/src/components/hackathons/InteractiveWhiteboard.jsx
+++ b/src/components/hackathons/InteractiveWhiteboard.jsx
@@ -231,8 +231,8 @@ const InteractiveWhiteboard = () => {
       // shape
       return {
         ...prev,
-        width: coords.x - prev.x,
-        height: coords.y - prev.y,
+        width: Math.abs(coords.x - prev.x),
+        height: Math.abs(coords.y - prev.y),
       };
     });
   }, [tool, isDrawing]);


### PR DESCRIPTION
## Problem

Drawing a circle on the InteractiveWhiteboard could produce negative width/height when the pointer moved backwards, causing an `IndexSizeError: The provided double value is non-finite` (negative radius) when the shape was rendered/measured.

## Fix

Circle dimensions are now normalized with `Math.abs(coords.x - prev.x)` and `Math.abs(coords.y - prev.y)`, so dragging in any direction always produces a valid non-negative radius.

## Files changed

- `src/components/hackathons/InteractiveWhiteboard.jsx`

## Testing

- Drawing circles while dragging up/left (previously negative deltas) renders correctly with no console error.

Closes #12623
