### PR TITLE
[Fix] Persist published survey before clearing the draft in SurveyEngine

### DIFF
--- a/src/Pages/Feedback/SurveyEngine.jsx
+++ b/src/Pages/Feedback/SurveyEngine.jsx
@@ -211,7 +211,13 @@ const SurveyEngine = () => {
       return;
     }
 
-
+    const publishedSurvey = {
+      title: surveyTitle,
+      description: surveyDescription,
+      questions,
+      publishedAt: new Date().toISOString(),
+    };
+    localStorage.setItem("eventra_survey_active", JSON.stringify(publishedSurvey));
     localStorage.removeItem("eventra_survey_builder_draft");
     toast.success("Survey published and active for attendees!");
   };


### PR DESCRIPTION
## Problem

The "Publish Survey" button in `SurveyEngine` deleted the only stored copy of the survey (`eventra_survey_builder_draft`) and saved nothing — no API call, no storage write. After any refresh the survey was gone completely, a full data-loss path on the only save/publish affordance.

No surveys API endpoint exists in the codebase (`api.js` / Backend), so a server-side publish is not currently available.

## Fix

`handleSaveSurvey` now persists the survey before clearing the draft: it writes a `publishedSurvey` payload (`title`, `description`, `questions`, `publishedAt`) to a separate `eventra_survey_active` localStorage key, then removes the draft. The user's work survives a refresh instead of being destroyed.

## Files changed

- `src/Pages/Feedback/SurveyEngine.jsx`

## Testing

- Build a survey, click "Publish Survey", refresh the page — the published survey is retained under `eventra_survey_active`; the draft key is cleared as before.

Closes #12625
