### PR TITLE
[Fix] Reconcile pomodoro countdown on visibilitychange/focus

### DIFF
--- a/src/components/hackathons/PomodoroTimer.jsx
+++ b/src/components/hackathons/PomodoroTimer.jsx
@@ -68,11 +68,18 @@ const usePomodoroStorage = ({ mode, timeLeft, isActive, setMode, setTimeLeft, se
 
 const usePomodoroInterval = ({ isActive, timeLeft, setTimeLeft, setIsActive }) => {
   const timerRef = useRef(null);
+  const lastTickRef = useRef(Date.now());
 
   useEffect(() => {
     if (isActive && timeLeft > 0) {
+      lastTickRef.current = Date.now();
       timerRef.current = setInterval(() => {
-        setTimeLeft((prev) => prev - 1);
+        const now = Date.now();
+        const elapsedSeconds = Math.floor((now - lastTickRef.current) / 1000);
+        if (elapsedSeconds > 0) {
+          lastTickRef.current = now;
+          setTimeLeft((prev) => Math.max(0, prev - elapsedSeconds));
+        }
       }, 1000);
     } else if (timeLeft === 0 && isActive) {
       setIsActive(false);
@@ -81,6 +88,26 @@ const usePomodoroInterval = ({ isActive, timeLeft, setTimeLeft, setIsActive }) =
 
     return () => clearInterval(timerRef.current);
   }, [isActive, timeLeft, setTimeLeft, setIsActive]);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const reconcile = () => {
+      const now = Date.now();
+      const elapsedSeconds = Math.floor((now - lastTickRef.current) / 1000);
+      if (elapsedSeconds > 0) {
+        lastTickRef.current = now;
+        setTimeLeft((prev) => Math.max(0, prev - elapsedSeconds));
+      }
+    };
+
+    document.addEventListener("visibilitychange", reconcile);
+    window.addEventListener("focus", reconcile);
+    return () => {
+      document.removeEventListener("visibilitychange", reconcile);
+      window.removeEventListener("focus", reconcile);
+    };
+  }, [isActive, setTimeLeft]);
 };
 
 const ModeSelectors = ({ mode, switchMode }) => (


### PR DESCRIPTION
## Problem

The Pomodoro timer counted down with a plain `setInterval(... , 1000)` that browsers throttle to ~1 tick/minute in background tabs. A running focus session effectively froze while hidden, and the wall-clock correction that exists in the mount-time storage loader was never applied on tab return — so sessions ran far beyond the intended length.

## Fix

- `usePomodoroInterval` now tracks `lastTickRef` and computes each interval step from real elapsed wall-clock time (`Math.floor((Date.now() - lastTickRef.current) / 1000)`), so throttled ticks still decrement the correct amount.
- Added a `visibilitychange`/`focus` reconciliation effect that recomputes `timeLeft` from elapsed time when the tab becomes visible/focused again.

## Files changed

- `src/components/hackathons/PomodoroTimer.jsx`

## Testing

- Start a Focus session, switch to another tab for several minutes, return — the timer reflects real elapsed wall-clock time instead of being frozen.

Closes #12626
