### PR TITLE
feat(admin): implement GET /api/admin/stats dashboard endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.AdminDashboardStatsDTO;
+import com.sandeep.eventrabackend.dto.AdminStatsResponse;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
 import com.sandeep.eventrabackend.dto.request.AdminUpdateRoleRequest;
 import com.sandeep.eventrabackend.dto.response.*;
@@ -244,6 +245,22 @@ public class AdminController {
     // ══════════════════════════════════════════════════════════════════════
     // 4. ANALYTICS  —  /api/admin/analytics
     // ══════════════════════════════════════════════════════════════════════
+
+    @GetMapping("/stats")
+    @Operation(
+            summary = "Admin dashboard stats (home page)",
+            description = "Returns the compact stats card data rendered on the admin home page: " +
+                          "total users, active users, total and upcoming events, and total participants."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Dashboard stats fetched successfully",
+                    content = @Content(schema = @Schema(implementation = AdminStatsResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AdminStatsResponse> getStats() {
+        return ResponseEntity.ok(adminService.getDashboardStats());
+    }
 
     @GetMapping("/analytics/dashboard")
     @Operation(

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/AdminStatsResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/AdminStatsResponse.java
@@ -1,0 +1,35 @@
+package com.sandeep.eventrabackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Compact dashboard stats consumed by the admin panel home page.
+ *
+ * <p>Shape matches what {@code AdminDashboard.js} renders:
+ * {@code totalUsers}, {@code activeUsers}, {@code totalEvents},
+ * {@code upcoming} and {@code totalParticipants}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminStatsResponse {
+
+    /** Total number of registered user accounts. */
+    private long totalUsers;
+
+    /** Distinct users with at least one confirmed event registration. */
+    private long activeUsers;
+
+    /** Total number of events. */
+    private long totalEvents;
+
+    /** Number of events scheduled in the future. */
+    private long upcoming;
+
+    /** Total confirmed registrations across all events. */
+    private long totalParticipants;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.AdminDashboardStatsDTO;
+import com.sandeep.eventrabackend.dto.AdminStatsResponse;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
 import com.sandeep.eventrabackend.dto.response.*;
 import com.sandeep.eventrabackend.model.Feedback;
@@ -246,6 +247,23 @@ public class AdminService {
                 .totalFeedbackSubmissions(feedbackRepository.countTotalFeedback())
                 .overallAverageRating(
                         Optional.ofNullable(feedbackRepository.findOverallAverageRating()).orElse(0.0))
+                .build();
+    }
+
+    /**
+     * Returns the compact dashboard stats consumed by the admin home page.
+     *
+     * <p>Mirrors {@code GET /api/admin/stats}: total users, active (participating)
+     * users, total and upcoming events, and total confirmed registrations.
+     */
+    public AdminStatsResponse getDashboardStats() {
+        LocalDateTime now = LocalDateTime.now();
+        return AdminStatsResponse.builder()
+                .totalUsers(userRepository.count())
+                .activeUsers(eventAnalyticsRepo.countUniqueParticipants())
+                .totalEvents(eventAnalyticsRepo.count())
+                .upcoming(eventAnalyticsRepo.countActiveEvents(now))
+                .totalParticipants(regRepo.countConfirmedRegistrations())
                 .build();
     }
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AdminStatsTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AdminStatsTests.java
@@ -1,0 +1,159 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #12610 — {@code GET /api/admin/stats} must return the compact dashboard
+ * stats rendered by {@code AdminDashboard.js}: totalUsers, activeUsers,
+ * totalEvents, upcoming, and totalParticipants.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminStatsTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private HackathonRegistrationRepository hackathonRegistrationRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        hackathonRegistrationRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userRepository.save(User.builder()
+                .firstName("Admin")
+                .lastName("User")
+                .email("admin@example.com")
+                .username("admin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+    }
+
+    private User createClient(String email) {
+        return userRepository.save(User.builder()
+                .firstName("Test")
+                .lastName("User")
+                .email(email)
+                .username(email.split("@")[0])
+                .password(passwordEncoder.encode("secret"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    private Event createEvent(LocalDateTime eventDate) {
+        Event event = new Event();
+        event.setTitle("Stats Test Event");
+        event.setDescription("Description");
+        event.setLocation("Location");
+        event.setEventDate(eventDate);
+        event.setCapacity(100);
+        event.setPublic(true);
+        return eventRepository.save(event);
+    }
+
+    private void register(User attendee, Event event) {
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(event);
+        registration.setUser(attendee);
+        eventRegistrationRepository.save(registration);
+    }
+
+    @Test
+    @DisplayName("Returns total users, events, upcoming events, and participant counts")
+    void getStats_ReturnsDashboardCounts() throws Exception {
+        User alice = createClient("alice@example.com");
+        User bob = createClient("bob@example.com");
+        createClient("carol@example.com");
+
+        Event upcomingEvent = createEvent(LocalDateTime.now().plusDays(7));
+        Event pastEvent = createEvent(LocalDateTime.now().minusDays(7));
+
+        register(alice, upcomingEvent);
+        register(bob, upcomingEvent);
+        register(alice, pastEvent);
+
+        mockMvc.perform(get("/api/admin/stats")
+                        .with(user("admin@example.com")
+                                .authorities(new SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalUsers").value(4))
+                .andExpect(jsonPath("$.activeUsers").value(2))
+                .andExpect(jsonPath("$.totalEvents").value(2))
+                .andExpect(jsonPath("$.upcoming").value(1))
+                .andExpect(jsonPath("$.totalParticipants").value(3));
+    }
+
+    @Test
+    @DisplayName("Returns zeroed stats when the database is empty")
+    void getStats_EmptyDatabase() throws Exception {
+        mockMvc.perform(get("/api/admin/stats")
+                        .with(user("admin@example.com")
+                                .authorities(new SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalUsers").value(1))
+                .andExpect(jsonPath("$.activeUsers").value(0))
+                .andExpect(jsonPath("$.totalEvents").value(0))
+                .andExpect(jsonPath("$.upcoming").value(0))
+                .andExpect(jsonPath("$.totalParticipants").value(0));
+    }
+
+    @Test
+    @DisplayName("Rejects non-admin users with 403")
+    void getStats_ForbiddenForNonAdmin() throws Exception {
+        createClient("client@example.com");
+
+        mockMvc.perform(get("/api/admin/stats")
+                        .with(user("client@example.com")
+                                .authorities(new SimpleGrantedAuthority("CLIENT"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Rejects unauthenticated requests with 401")
+    void getStats_Unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/admin/stats"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Problem

The admin dashboard home page (`AdminDashboard.js`) calls `GET /api/admin/stats` via `fetchAdminStats()` to render its stats cards, but no such endpoint exists on the backend. `AdminController` only exposes `/api/admin/analytics/dashboard`, which returns a different DTO shape, so the dashboard fails to load its stats.

## Fix

Implemented `GET /api/admin/stats` behind the existing `ADMIN`/`SUPER_ADMIN` `@PreAuthorize` guard, returning exactly the shape the frontend parses:

- `totalUsers` — total registered accounts
- `activeUsers` — distinct users with at least one confirmed event registration
- `totalEvents` — total events
- `upcoming` — events scheduled in the future
- `totalParticipants` — total confirmed registrations across all events

Added `AdminStatsResponse` DTO and `AdminService.getDashboardStats()`, reusing existing analytics repositories (`EventAnalyticsRepository`, `RegistrationAnalyticsRepository`, `UserRepository`). No frontend changes required.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/dto/AdminStatsResponse.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/AdminStatsTests.java` (new)

## Testing

- Added `AdminStatsTests` (4 tests): correct dashboard counts, zeroed stats on empty DB, 403 for non-admin, 401 for unauthenticated.
- `mvn test -Dtest=AdminStatsTests -DfailIfNoTests=false` → 4/4 pass.
- Full backend main sources compile clean.

Closes #12610
