### PR TITLE
feat(validation): implement public email/username availability API

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -121,6 +121,9 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        // ── Public: pre-submit availability checks ──────────
+                        // Email/username validation runs before the user has a JWT.
+                        .requestMatchers("/api/validate/**").permitAll()
                         .requestMatchers(
                                 "/actuator",
                                 "/actuator/**",

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
@@ -1,0 +1,98 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.dto.response.ErrorResponse;
+import com.sandeep.eventrabackend.dto.response.ValidationResponse;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+/**
+ * Public availability-validation endpoints used by pre-submit form checks
+ * (registration / profile screens) via {@code src/utils/validationApi.js}.
+ *
+ * <p>Both endpoints are anonymous-safe (permitted in {@link SecurityConfig})
+ * so the checks can run before a user has a JWT. They report whether a value
+ * is still available, returning {@code 400 Bad Request} for malformed input.
+ */
+@RestController
+@RequestMapping("/api/validate")
+@Tag(name = "Validation", description = "Public availability checks for email and username")
+public class ValidationController {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+    private static final Pattern USERNAME_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9_-]{3,50}$");
+
+    private final UserRepository userRepository;
+
+    public ValidationController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/email/{email}")
+    @Operation(
+            summary = "Check email availability",
+            description = "Returns whether the given email is not already registered. " +
+                          "Rejects malformed email addresses with 400 Bad Request."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Availability check succeeded",
+                    content = @Content(schema = @Schema(implementation = ValidationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid email format",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<?> validateEmail(@PathVariable String email) {
+        if (email == null || !EMAIL_PATTERN.matcher(email).matches()) {
+            return ResponseEntity.badRequest().body(buildError("Invalid email format", "/api/validate/email/" + email));
+        }
+        boolean available = !userRepository.existsByEmail(email);
+        return ResponseEntity.ok(ValidationResponse.builder()
+                .available(available)
+                .build());
+    }
+
+    @GetMapping("/username/{username}")
+    @Operation(
+            summary = "Check username availability",
+            description = "Returns whether the given username is not already taken. " +
+                          "Rejects malformed usernames with 400 Bad Request."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Availability check succeeded",
+                    content = @Content(schema = @Schema(implementation = ValidationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid username format",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<?> validateUsername(@PathVariable String username) {
+        if (username == null || !USERNAME_PATTERN.matcher(username).matches()) {
+            return ResponseEntity.badRequest().body(buildError("Invalid username format", "/api/validate/username/" + username));
+        }
+        boolean available = !userRepository.existsByUsername(username);
+        return ResponseEntity.ok(ValidationResponse.builder()
+                .available(available)
+                .build());
+    }
+
+    private ErrorResponse buildError(String message, String path) {
+        return ErrorResponse.builder()
+                .status(400)
+                .error("Bad Request")
+                .message(message)
+                .path(path)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/ValidationResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/ValidationResponse.java
@@ -1,0 +1,30 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response for the public availability-validation endpoints
+ * ({@code GET /api/validate/email/{email}} and {@code GET /api/validate/username/{username}}).
+ *
+ * <p>Matches the shape consumed by {@code src/utils/validationApi.js}, which reads
+ * the {@code available} field (its default availability field).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Availability check result for email / username validation")
+public class ValidationResponse {
+
+    @Schema(description = "Whether the value is available (not already taken)", example = "true")
+    private boolean available;
+
+    @Schema(description = "Optional human-readable message", example = "Email is available")
+    private String message;
+}

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/ValidationControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/ValidationControllerTests.java
@@ -1,0 +1,124 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #12611 — {@code /api/validate/email/{email}} and
+ * {@code /api/validate/username/{username}} must power the pre-submit
+ * availability checks in {@code src/utils/validationApi.js}, and be reachable
+ * without authentication.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ValidationControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+
+    private User createUser(String email, String username) {
+        return userRepository.save(User.builder()
+                .firstName("Test")
+                .lastName("User")
+                .email(email)
+                .username(username)
+                .password(passwordEncoder.encode("secret"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Returns available=true for a free email")
+    void validateEmail_Available() throws Exception {
+        mockMvc.perform(get("/api/validate/email/new@example.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true));
+    }
+
+    @Test
+    @DisplayName("Returns available=false for a registered email")
+    void validateEmail_Taken() throws Exception {
+        createUser("taken@example.com", "taken");
+
+        mockMvc.perform(get("/api/validate/email/taken@example.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(false));
+    }
+
+    @Test
+    @DisplayName("Rejects a malformed email with 400")
+    void validateEmail_InvalidFormat() throws Exception {
+        mockMvc.perform(get("/api/validate/email/not-an-email"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Returns available=true for a free username")
+    void validateUsername_Available() throws Exception {
+        mockMvc.perform(get("/api/validate/username/newuser"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true));
+    }
+
+    @Test
+    @DisplayName("Returns available=false for a taken username")
+    void validateUsername_Taken() throws Exception {
+        createUser("owner@example.com", "takenuser");
+
+        mockMvc.perform(get("/api/validate/username/takenuser"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(false));
+    }
+
+    @Test
+    @DisplayName("Rejects an invalid username with 400")
+    void validateUsername_InvalidFormat() throws Exception {
+        mockMvc.perform(get("/api/validate/username/ab"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Rejects a username with illegal characters with 400")
+    void validateUsername_IllegalCharacters() throws Exception {
+        mockMvc.perform(get("/api/validate/username/bad user!"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Endpoints are reachable without authentication")
+    void validate_AnonymousAccess() throws Exception {
+        mockMvc.perform(get("/api/validate/email/anon@example.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true));
+
+        mockMvc.perform(get("/api/validate/username/anonuser"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true));
+    }
+}


### PR DESCRIPTION
## Problem

Pre-submit availability checks in `src/utils/validationApi.js` call `GET /api/validate/email/{email}` and `GET /api/validate/username/{username}`, but no backend controller implements these routes. Every check fails (`skippedDueToError`), so the UI never learns that an email or username is already taken, and `SecurityConfig`'s `.anyRequest().authenticated()` would block anonymous checks anyway.

## Fix

Implemented a public `ValidationController` at `/api/validate`:

- `GET /api/validate/email/{email}` → `{ "available": !existsByEmail(email) }`, `400` for malformed emails
- `GET /api/validate/username/{username}` → `{ "available": !existsByUsername(username) }`, `400` for malformed usernames

The response uses the `available` field that `validationApi.js` reads by default (its `availabilityField`), so existing frontend logic works unchanged. Added `/api/validate/**` to `SecurityConfig` permitAll so checks run anonymously before a user has a JWT.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/dto/response/ValidationResponse.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/ValidationControllerTests.java` (new)

## Testing

- Added `ValidationControllerTests` (8 tests): available/taken email, malformed email 400, available/taken username, too-short username 400, illegal-character username 400, anonymous access works.
- `mvn test -Dtest=ValidationControllerTests -DfailIfNoTests=false` → 8/8 pass.
- Full backend main sources compile clean.

Closes #12611
