### PR TITLE
fix(config): use file-based H2 in dev profile so data persists across restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,15 @@ REACT_APP_GOOGLE_CLIENT_ID=your_google_client_id_here
 # Note: src/setupProxy.js runs in a Node.js context and uses its own inline resolution
 # logic to avoid ESM/CommonJS compatibility issues, but follows the same resolution order.
 
+# Local backend (dev profile) database
+# ====================================
+# The Spring Boot backend's default (dev) profile uses a FILE-based H2 database
+# (jdbc:h2:file:./data/eventradb) so data persists across restarts.
+# Override the datasource for local development if needed:
+# DB_URL=jdbc:h2:file:./data/eventradb;DB_CLOSE_ON_EXIT=FALSE
+# DB_USERNAME=sa
+# DB_PASSWORD=
+
 # Optional: Public repository metadata
 REACT_APP_GITHUB_REPO=SandeepVashishtha/Eventra
 

--- a/Backend/README.md
+++ b/Backend/README.md
@@ -85,11 +85,14 @@ The backend implements a comprehensive set of modules to handle various platform
 | `CORS_ALLOWED_ORIGINS`| No | Comma-separated list of allowed origins |
 | `RATE_LIMIT_ENABLED`| No | Toggle for API rate limiting (Default: true) |
 | `GOOGLE_CLIENT_ID` | No | Client ID for Google OAuth integration |
+| `DB_URL` | No | Dev datasource JDBC URL (Default: `jdbc:h2:file:./data/eventradb`) |
+| `DB_USERNAME` | No | Dev datasource username (Default: `sa`) |
+| `DB_PASSWORD` | No | Dev datasource password (Default: empty) |
 
 ## Database Configuration
 
-*   **Development**: By default, the application uses an in-memory **H2 Database** (`jdbc:h2:mem:testdb`) for easy local development without external dependencies.
-*   **Production**: The project is configured to support **PostgreSQL**. Database connection details should be provided via environment variables in a production environment.
+*   **Development**: By default, the application uses a **file-based H2 Database** (`jdbc:h2:file:./data/eventradb`) so that data — including the persisted JWT blacklist — survives application restarts. The database file is written under `Backend/data/`. Override the datasource with `DB_URL`, `DB_USERNAME`, and `DB_PASSWORD` (e.g. to point at a local PostgreSQL instance).
+*   **Production**: The project is configured to support **PostgreSQL**. Database connection details are provided via `DATABASE_URL`, `DATABASE_USERNAME`, and `DATABASE_PASSWORD` environment variables (see `application-prod.yml`).
 *   **JPA Strategy**: Hibernate is set to `update` mode in development, automatically managing schema changes based on entities.
 
 ## Running Tests

--- a/Backend/src/main/resources/application-dev.yml
+++ b/Backend/src/main/resources/application-dev.yml
@@ -1,10 +1,12 @@
-# Local / default profile — in-memory H2 only.
+# Local / default profile — file-based H2 so data (users, events, and the
+# persisted JWT blacklist) survives restarts. Override with DB_URL /
+# DB_USERNAME / DB_PASSWORD to point at any other JDBC datasource.
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: ${DB_URL:jdbc:h2:file:./data/eventradb;DB_CLOSE_ON_EXIT=FALSE}
     driverClassName: org.h2.Driver
-    username: sa
-    password:
+    username: ${DB_USERNAME:sa}
+    password: ${DB_PASSWORD:}
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Problem

The default (dev) profile configures an in-memory H2 database (`jdbc:h2:mem:testdb`), so every restart wipes all data — including the DB-persisted JWT blacklist (`token_blacklist`). Logged-out / rotated tokens become valid again after a restart, which is a real security regression during local development.

## Fix

Switched the dev profile's datasource to a file-based H2 database:

- `application-dev.yml` now uses `jdbc:h2:file:./data/eventradb` (file written under `Backend/data/`), with `DB_URL`, `DB_USERNAME`, and `DB_PASSWORD` overrides so it can be pointed at any JDBC datasource.
- Documented the new defaults in `Backend/README.md` (Database Configuration + environment-variable table).
- Added a local-backend database section to the root `.env.example`.

The test profile (`application-test.properties`) is untouched and continues to use in-memory H2.

## Files changed

- `Backend/src/main/resources/application-dev.yml`
- `Backend/README.md`
- `.env.example`

## Testing

- Booted the packaged jar with the dev profile: creates `Backend/data/eventradb.mv.db` and starts cleanly (`Started EventraBackendApplication`).
- Re-booted a second time to confirm the file DB reopens without errors (data persists).
- Full backend main sources compile clean; test profile unaffected.

Closes #12613
