### PR TITLE
feat(events): add paginated registrants export endpoint (closes #12615)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -9,6 +9,7 @@ import com.sandeep.eventrabackend.dto.response.AttendeeDirectoryResponse;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.PagedResponse;
+import com.sandeep.eventrabackend.dto.response.RegistrantsPageResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
 import com.sandeep.eventrabackend.dto.response.WaitlistResponse;
 import com.sandeep.eventrabackend.service.EventService;
@@ -208,6 +209,20 @@ public class EventController {
                         Authentication authentication) {
 
                 return ResponseEntity.ok(eventService.getEventWaitlist(id, authentication.getName()));
+        }
+
+        @GetMapping("/{id}/registrants")
+        @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+        @Operation(summary = "List event registrants for export", description = "Paginated list of registrations for an event, restricted to organizers and admins. Pages are 1-based.", security = @SecurityRequirement(name = "bearerAuth"))
+        public ResponseEntity<RegistrantsPageResponse> getEventRegistrants(
+                        @Parameter(description = "ID of the event") @PathVariable Long id,
+                        @Parameter(description = "Page number (1-based)", example = "1")
+                        @RequestParam(defaultValue = "1") int page,
+                        @Parameter(description = "Registrants per page", example = "500")
+                        @RequestParam(defaultValue = "500") int limit,
+                        Authentication authentication) {
+
+                return ResponseEntity.ok(eventService.getEventRegistrants(id, authentication.getName(), page, limit));
         }
 
         @GetMapping("/{id}/attendees")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventRegistrantResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventRegistrantResponse.java
@@ -1,0 +1,40 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * A single event registration row returned by
+ * {@code GET /api/events/{id}/registrants} for organizer/admin CSV & JSON export.
+ */
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Event registrant row used for organizer/admin export")
+public class EventRegistrantResponse {
+
+    @Schema(description = "Registrant user ID", example = "7")
+    private Long userId;
+
+    @Schema(description = "Registrant display name", example = "Jane Doe")
+    private String name;
+
+    @Schema(description = "Registrant email", example = "jane@example.com")
+    private String email;
+
+    @Schema(description = "Registrant username", example = "janedoe")
+    private String username;
+
+    @Schema(description = "Registration timestamp", example = "2026-08-04T10:30:00")
+    private LocalDateTime registeredAt;
+
+    @Schema(description = "Registration status (CONFIRMED, CANCELLED, ...)", example = "CONFIRMED")
+    private String status;
+
+    @Schema(description = "Selected seat identifier, when the event offers seat selection")
+    private String seatId;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrantsPageResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrantsPageResponse.java
@@ -1,0 +1,29 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Paginated registrant page for {@code GET /api/events/{id}/registrants}.
+ *
+ * <p>Shape matches the contract consumed by {@code EventDetails.js}, which reads
+ * {@code response.data.data} and {@code response.data.totalPages}.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Paginated event registrants for organizer/admin export")
+public class RegistrantsPageResponse {
+
+    @Schema(description = "Registrant rows for the requested page")
+    private List<EventRegistrantResponse> data;
+
+    @Schema(description = "Total number of pages (1-based page numbering)", example = "3")
+    private int totalPages;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -1,6 +1,8 @@
 package com.sandeep.eventrabackend.repository;
 
 import com.sandeep.eventrabackend.model.EventRegistration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,6 +25,8 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
     Optional<EventRegistration> findByEvent_IdAndUser_Email(Long eventId, String userEmail);
 
     List<EventRegistration> findByEvent_Id(Long eventId);
+
+    Page<EventRegistration> findByEvent_Id(Long eventId, Pageable pageable);
 
     List<EventRegistration> findByEvent_IdAndStatus(Long eventId, String status);
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -6,8 +6,10 @@ import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.AttendeeDirectoryResponse;
 import com.sandeep.eventrabackend.dto.response.EventResponse;
+import com.sandeep.eventrabackend.dto.response.EventRegistrantResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.PagedResponse;
+import com.sandeep.eventrabackend.dto.response.RegistrantsPageResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
 import com.sandeep.eventrabackend.dto.response.WaitlistResponse;
 import com.sandeep.eventrabackend.exception.EventFullException;
@@ -663,6 +665,34 @@ public class EventService {
                                 .toList();
         }
 
+        /**
+         * Returns a paginated list of event registrants for organizer/admin export.
+         *
+         * <p>Pages are 1-based to match the frontend export contract
+         * ({@code src/Pages/Events/EventDetails.js} uses {@code page} starting at 1).
+         */
+        @Transactional(readOnly = true)
+        public RegistrantsPageResponse getEventRegistrants(Long eventId, String userEmail, int page, int limit) {
+                eventRepository.findById(eventId)
+                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+
+                eventRoleService.requireRole(eventId, userEmail, EventRole.ORGANIZER);
+
+                int safePage = Math.max(page, 1);
+                int safeLimit = Math.min(Math.max(limit, 1), 1000);
+                Pageable pageable = PageRequest.of(safePage - 1, safeLimit);
+
+                Page<EventRegistration> result = eventRegistrationRepository
+                                .findByEvent_Id(eventId, pageable);
+
+                return RegistrantsPageResponse.builder()
+                                .data(result.getContent().stream()
+                                                .map(this::toRegistrantResponse)
+                                                .toList())
+                                .totalPages(result.getTotalPages())
+                                .build();
+        }
+
         @Transactional
         public void leaveWaitlist(Long eventId, String userEmail) {
                 EventWaitlist entry = eventWaitlistRepository
@@ -1020,6 +1050,21 @@ public class EventService {
                                 .position(entry.getPosition())
                                 .status(entry.getStatus())
                                 .joinedAt(entry.getJoinedAt())
+                                .build();
+        }
+
+        private EventRegistrantResponse toRegistrantResponse(EventRegistration registration) {
+                User user = registration.getUser();
+                String displayName = (user.getFirstName() + " " + user.getLastName()).trim();
+
+                return EventRegistrantResponse.builder()
+                                .userId(user.getId())
+                                .name(displayName.isBlank() ? user.getUsername() : displayName)
+                                .email(user.getEmail())
+                                .username(user.getUsername())
+                                .registeredAt(registration.getRegisteredAt())
+                                .status(registration.getStatus())
+                                .seatId(registration.getSeatId())
                                 .build();
         }
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrantsTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrantsTests.java
@@ -1,0 +1,210 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.EventRoleAuditLogRepository;
+import com.sandeep.eventrabackend.repository.EventTeamMemberRepository;
+import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
+import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #12615 — {@code GET /api/events/{id}/registrants} must serve the
+ * paginated {@code { data, totalPages }} contract consumed by the CSV/JSON
+ * export in {@code src/Pages/Events/EventDetails.js}, restricted to the event's
+ * organizers and platform admins.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class EventRegistrantsTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private EventWaitlistRepository eventWaitlistRepository;
+
+    @Autowired
+    private EventTeamMemberRepository eventTeamMemberRepository;
+
+    @Autowired
+    private EventRoleAuditLogRepository eventRoleAuditLogRepository;
+
+    @Autowired
+    private HackathonRegistrationRepository hackathonRegistrationRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User organizer;
+    private Event event;
+
+    @BeforeEach
+    void setUp() {
+        hackathonRegistrationRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventWaitlistRepository.deleteAll();
+        eventTeamMemberRepository.deleteAll();
+        eventRoleAuditLogRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        organizer = userRepository.save(User.builder()
+                .firstName("Org")
+                .lastName("Nizer")
+                .email("organizer@example.com")
+                .username("organizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ORGANIZER)
+                .build());
+
+        event = new Event();
+        event.setTitle("Registrants Test Event");
+        event.setDescription("Description");
+        event.setLocation("Location");
+        event.setEventDate(LocalDateTime.now().plusDays(7));
+        event.setCapacity(100);
+        event.setPublic(true);
+        event.setOwnerId(organizer.getId());
+        event = eventRepository.save(event);
+    }
+
+    private User createClient(String email) {
+        return userRepository.save(User.builder()
+                .firstName("Test")
+                .lastName("User")
+                .email(email)
+                .username(email.split("@")[0])
+                .password(passwordEncoder.encode("secret"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    private EventRegistration register(User attendee) {
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(event);
+        registration.setUser(attendee);
+        return eventRegistrationRepository.save(registration);
+    }
+
+    @Test
+    @DisplayName("Organizer can export all registrants with data and totalPages")
+    void getRegistrants_OrganizerSeesAll() throws Exception {
+        register(createClient("alice@example.com"));
+        register(createClient("bob@example.com"));
+
+        mockMvc.perform(get("/api/events/{id}/registrants", event.getId())
+                        .with(user(organizer.getEmail())
+                                .authorities(new SimpleGrantedAuthority("ORGANIZER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.data[0].email").exists())
+                .andExpect(jsonPath("$.data[0].status").value("CONFIRMED"));
+    }
+
+    @Test
+    @DisplayName("Paginates registrants (page is 1-based) and respects limit")
+    void getRegistrants_Pagination() throws Exception {
+        register(createClient("alice@example.com"));
+        register(createClient("bob@example.com"));
+        register(createClient("carol@example.com"));
+
+        mockMvc.perform(get("/api/events/{id}/registrants", event.getId())
+                        .param("page", "1")
+                        .param("limit", "2")
+                        .with(user(organizer.getEmail())
+                                .authorities(new SimpleGrantedAuthority("ORGANIZER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.totalPages").value(2));
+
+        mockMvc.perform(get("/api/events/{id}/registrants", event.getId())
+                        .param("page", "2")
+                        .param("limit", "2")
+                        .with(user(organizer.getEmail())
+                                .authorities(new SimpleGrantedAuthority("ORGANIZER"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.totalPages").value(2));
+    }
+
+    @Test
+    @DisplayName("Platform admin can fetch registrants")
+    void getRegistrants_AdminAllowed() throws Exception {
+        User admin = userRepository.save(User.builder()
+                .firstName("Admin")
+                .lastName("User")
+                .email("admin@example.com")
+                .username("admin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+
+        mockMvc.perform(get("/api/events/{id}/registrants", event.getId())
+                        .with(user(admin.getEmail())
+                                .authorities(new SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(0)))
+                .andExpect(jsonPath("$.totalPages").value(0));
+    }
+
+    @Test
+    @DisplayName("Non-organizer attendee gets 403")
+    void getRegistrants_ForbiddenForClient() throws Exception {
+        User client = createClient("client@example.com");
+
+        mockMvc.perform(get("/api/events/{id}/registrants", event.getId())
+                        .with(user(client.getEmail())
+                                .authorities(new SimpleGrantedAuthority("CLIENT"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Unauthenticated request gets 401")
+    void getRegistrants_Unauthenticated() throws Exception {
+        mockMvc.perform(get("/api/events/{id}/registrants", event.getId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Unknown event gets 404")
+    void getRegistrants_UnknownEvent() throws Exception {
+        mockMvc.perform(get("/api/events/999999/registrants")
+                        .with(user(organizer.getEmail())
+                                .authorities(new SimpleGrantedAuthority("ORGANIZER"))))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Problem

The organizer-facing registrant export UI in `src/Pages/Events/EventDetails.js` (lines ~600–665) calls `GET /api/events/{id}/registrants?page=…&limit=…` and expects a `{ data, totalPages }` response, but that endpoint does not exist yet — the backend returns 404. Issue #12615 asks for a registrants export endpoint so organizers can download who signed up.

## Fix

Add a paginated `GET /api/events/{id}/registrants` endpoint:

- `dto/response/EventRegistrantResponse.java` — one registrant row: `userId`, `name`, `email`, `username`, `registeredAt`, `status`, `seatId` (name falls back to the username when first/last name is blank).
- `dto/response/RegistrantsPageResponse.java` — `{ data: List<EventRegistrantResponse>, totalPages: int }`, matching the frontend contract.
- `EventRegistrationRepository#findByEvent_Id(eventId, pageable)` — paginated query over all registration statuses (export shows cancellations too).
- `EventService#getEventRegistrants(eventId, userEmail, page, limit)` — 404 if the event is unknown, organizer-only authorization via `eventRoleService.requireRole(...ORGANIZER)` (accepts admins and legacy owners), 1-based `page`, `limit` clamped to 1..1000.
- `EventController#GET /api/events/{id}/registrants` — `@PreAuthorize` on `ORGANIZER`/`ADMIN`/`SUPER_ADMIN`, `@RequestParam` `page` (default 1) and `limit` (default 500).
- `EventRegistrantsTests` — 6 tests (organizer export, 1-based pagination, admin allowed, client 403, anonymous 401, unknown event 404).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventRegistrantResponse.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrantsPageResponse.java` (new)
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrantsTests.java` (new)

## Testing

`mvn test -Dtest=EventRegistrantsTests -DfailIfNoTests=false` — 6/6 pass. The response shape `{ data, totalPages }` matches what `EventDetails.js` reads (`response.data?.data`, `response.data?.totalPages || 1`).

Closes #12615
