### PR TITLE
feat(events): add contact and support center

### DIFF
--- a/src/components/events/EventSupportCenter.js
+++ b/src/components/events/EventSupportCenter.js
@@ -1,0 +1,277 @@
+import {
+  ExternalLink,
+  FileQuestion,
+  Flag,
+  HelpCircle,
+  Mail,
+  MessageCircle,
+  ShieldQuestion,
+  UserRound,
+} from "lucide-react";
+
+import {
+  getEventSupportInfo,
+  hasSupportInformation,
+} from "../../utils/eventSupportUtils";
+
+const EventSupportCenter = ({
+  event = {},
+  onReportIssue,
+  onContactOrganizer,
+}) => {
+  const support =
+    getEventSupportInfo(event);
+
+  if (!hasSupportInformation(event)) {
+    return (
+      <section className="w-full rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+        <div className="flex items-start gap-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-slate-100 dark:bg-slate-800">
+            <HelpCircle
+              size={21}
+              className="text-slate-500"
+            />
+          </div>
+
+          <div>
+            <h2 className="text-lg font-bold text-slate-800 dark:text-white">
+              Event Support
+            </h2>
+
+            <p className="mt-2 text-sm leading-6 text-slate-500 dark:text-slate-400">
+              Support information for this event has
+              not been provided yet.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const handleReport = () => {
+    if (onReportIssue) {
+      onReportIssue(event);
+      return;
+    }
+
+    if (support.reportIssueUrl) {
+      window.open(
+        support.reportIssueUrl,
+        "_blank",
+        "noopener,noreferrer"
+      );
+    }
+  };
+
+  const handleContact = () => {
+    if (onContactOrganizer) {
+      onContactOrganizer(event);
+    }
+  };
+
+  return (
+    <section className="w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+      {/* Header */}
+      <div className="border-b border-slate-200 p-5 dark:border-slate-700">
+        <div className="flex items-start gap-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+            <ShieldQuestion
+              size={21}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div>
+            <h2 className="text-lg font-bold text-slate-800 dark:text-white">
+              Event Contact &amp; Support
+            </h2>
+
+            <p className="mt-1 text-sm leading-6 text-slate-500 dark:text-slate-400">
+              Need help with this event? Contact the
+              organizer or use one of the support options
+              below.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-5">
+        {/* Organizer */}
+        {support.organizer && (
+          <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-700">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
+                <UserRound
+                  size={18}
+                  className="text-slate-500 dark:text-slate-400"
+                />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Event Organizer
+                </p>
+
+                <p className="mt-1 font-semibold text-slate-800 dark:text-white">
+                  {support.organizer.name ||
+                    "Event Organizer"}
+                </p>
+
+                {support.organizer.description && (
+                  <p className="mt-1 text-sm leading-5 text-slate-500 dark:text-slate-400">
+                    {support.organizer.description}
+                  </p>
+                )}
+
+                {support.organizer.email && (
+                  <a
+                    href={`mailto:${support.organizer.email}`}
+                    className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300"
+                  >
+                    <Mail size={15} />
+                    {support.organizer.email}
+                  </a>
+                )}
+              </div>
+            </div>
+
+            {onContactOrganizer && (
+              <button
+                type="button"
+                onClick={handleContact}
+                className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+              >
+                <MessageCircle size={16} />
+                Contact Organizer
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Support email */}
+        {support.supportEmail && (
+          <div className="mt-4 rounded-xl bg-slate-50 p-4 dark:bg-slate-800">
+            <div className="flex items-start gap-3">
+              <Mail
+                size={19}
+                className="mt-0.5 shrink-0 text-indigo-600 dark:text-indigo-400"
+              />
+
+              <div className="min-w-0">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Support Email
+                </p>
+
+                <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                  Contact the event support team for
+                  event-specific assistance.
+                </p>
+
+                <a
+                  href={`mailto:${support.supportEmail}`}
+                  className="mt-2 inline-flex items-center gap-2 break-all text-sm font-semibold text-indigo-600 hover:text-indigo-700 dark:text-indigo-400"
+                >
+                  <Mail size={14} />
+                  {support.supportEmail}
+                </a>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Event-specific support information */}
+        {support.supportInformation && (
+          <div className="mt-4 rounded-xl border border-indigo-100 bg-indigo-50/60 p-4 dark:border-indigo-900/40 dark:bg-indigo-900/10">
+            <div className="flex items-start gap-3">
+              <MessageCircle
+                size={19}
+                className="mt-0.5 shrink-0 text-indigo-600 dark:text-indigo-400"
+              />
+
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-400">
+                  Event-Specific Support
+                </p>
+
+                <p className="mt-1 text-sm leading-6 text-slate-700 dark:text-slate-300">
+                  {support.supportInformation}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Action links */}
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          {/* FAQ */}
+          {support.faqUrl && (
+            <a
+              href={support.faqUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-center gap-3 rounded-xl border border-slate-200 p-4 transition hover:border-indigo-300 hover:bg-slate-50 dark:border-slate-700 dark:hover:border-indigo-700 dark:hover:bg-slate-800"
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+                <FileQuestion
+                  size={18}
+                  className="text-indigo-600 dark:text-indigo-400"
+                />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-slate-800 dark:text-white">
+                  Event FAQ
+                </p>
+
+                <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                  Find answers to common questions
+                </p>
+              </div>
+
+              <ExternalLink
+                size={15}
+                className="shrink-0 text-slate-400 transition group-hover:text-indigo-500"
+              />
+            </a>
+          )}
+
+          {/* Report issue */}
+          {(support.reportIssueUrl ||
+            onReportIssue) && (
+            <button
+              type="button"
+              onClick={handleReport}
+              className="group flex items-center gap-3 rounded-xl border border-slate-200 p-4 text-left transition hover:border-red-300 hover:bg-red-50 dark:border-slate-700 dark:hover:border-red-800 dark:hover:bg-red-900/10"
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-red-100 dark:bg-red-900/30">
+                <Flag
+                  size={18}
+                  className="text-red-600 dark:text-red-400"
+                />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-slate-800 dark:text-white">
+                  Report an Issue
+                </p>
+
+                <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                  Report an event-related problem
+                </p>
+              </div>
+
+              {support.reportIssueUrl && (
+                <ExternalLink
+                  size={15}
+                  className="shrink-0 text-slate-400"
+                />
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default EventSupportCenter;

--- a/src/components/events/SupportContactCard.js
+++ b/src/components/events/SupportContactCard.js
@@ -1,0 +1,187 @@
+import {
+  ExternalLink,
+  Mail,
+  MessageCircle,
+  Phone,
+  UserRound,
+} from "lucide-react";
+
+const SupportContactCard = ({
+  contact = {},
+  title = "Contact Support",
+  description = "Need help with this event? Contact the organizer or support team.",
+  onContact,
+}) => {
+  const {
+    name = "Event Organizer",
+    role = "",
+    email = "",
+    phone = "",
+    description: contactDescription = "",
+    website = "",
+  } = contact;
+
+  const handleContact = () => {
+    onContact?.(contact);
+  };
+
+  return (
+    <section className="w-full rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+          <MessageCircle
+            size={21}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <h2 className="text-lg font-bold text-slate-800 dark:text-white">
+            {title}
+          </h2>
+
+          <p className="mt-1 text-sm leading-6 text-slate-500 dark:text-slate-400">
+            {description}
+          </p>
+        </div>
+      </div>
+
+      {/* Contact information */}
+      <div className="mt-5 rounded-xl bg-slate-50 p-4 dark:bg-slate-800">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white dark:bg-slate-900">
+            <UserRound
+              size={18}
+              className="text-slate-500 dark:text-slate-400"
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-slate-800 dark:text-white">
+              {name}
+            </p>
+
+            {role && (
+              <p className="mt-0.5 text-xs font-medium text-slate-400">
+                {role}
+              </p>
+            )}
+
+            {contactDescription && (
+              <p className="mt-2 text-sm leading-5 text-slate-500 dark:text-slate-400">
+                {contactDescription}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Email */}
+      {email && (
+        <a
+          href={`mailto:${email}`}
+          className="mt-3 flex items-center gap-3 rounded-xl border border-slate-200 p-3 transition hover:border-indigo-300 hover:bg-indigo-50/50 dark:border-slate-700 dark:hover:border-indigo-700 dark:hover:bg-indigo-900/10"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+            <Mail
+              size={17}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Email
+            </p>
+
+            <p className="mt-0.5 break-all text-sm font-medium text-slate-700 dark:text-slate-300">
+              {email}
+            </p>
+          </div>
+
+          <ExternalLink
+            size={15}
+            className="shrink-0 text-slate-400"
+          />
+        </a>
+      )}
+
+      {/* Phone */}
+      {phone && (
+        <a
+          href={`tel:${phone}`}
+          className="mt-3 flex items-center gap-3 rounded-xl border border-slate-200 p-3 transition hover:border-green-300 hover:bg-green-50/50 dark:border-slate-700 dark:hover:border-green-700 dark:hover:bg-green-900/10"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green-100 dark:bg-green-900/30">
+            <Phone
+              size={17}
+              className="text-green-600 dark:text-green-400"
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Phone
+            </p>
+
+            <p className="mt-0.5 text-sm font-medium text-slate-700 dark:text-slate-300">
+              {phone}
+            </p>
+          </div>
+
+          <ExternalLink
+            size={15}
+            className="shrink-0 text-slate-400"
+          />
+        </a>
+      )}
+
+      {/* Website */}
+      {website && (
+        <a
+          href={website}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 flex items-center gap-3 rounded-xl border border-slate-200 p-3 transition hover:border-indigo-300 hover:bg-indigo-50/50 dark:border-slate-700 dark:hover:border-indigo-700 dark:hover:bg-indigo-900/10"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
+            <ExternalLink
+              size={17}
+              className="text-slate-500 dark:text-slate-400"
+            />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Website
+            </p>
+
+            <p className="mt-0.5 truncate text-sm font-medium text-slate-700 dark:text-slate-300">
+              {website}
+            </p>
+          </div>
+
+          <ExternalLink
+            size={15}
+            className="shrink-0 text-slate-400"
+          />
+        </a>
+      )}
+
+      {/* Contact button */}
+      {onContact && (
+        <button
+          type="button"
+          onClick={handleContact}
+          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+        >
+          <MessageCircle size={16} />
+          Contact Organizer
+        </button>
+      )}
+    </section>
+  );
+};
+
+export default SupportContactCard;

--- a/src/utils/eventSupportUtils.js
+++ b/src/utils/eventSupportUtils.js
@@ -1,0 +1,695 @@
+/**
+ * Event Contact & Support utilities.
+ */
+
+/**
+ * Support types available for an event.
+ */
+export const SUPPORT_TYPES = {
+  ORGANIZER: "organizer",
+  EMAIL: "email",
+  FAQ: "faq",
+  REPORT: "report",
+};
+
+/**
+ * Extract organizer information from an event.
+ */
+export const getOrganizerContact = (
+  event = {}
+) => {
+  const organizer =
+    event.organizer ||
+    event.organizerDetails ||
+    event.organizerInfo ||
+    {};
+
+  const name =
+    organizer.name ||
+    organizer.organizerName ||
+    event.organizerName ||
+    event.organizer ||
+    "";
+
+  const email =
+    organizer.email ||
+    organizer.contactEmail ||
+    event.organizerEmail ||
+    event.contactEmail ||
+    "";
+
+  const phone =
+    organizer.phone ||
+    organizer.phoneNumber ||
+    event.organizerPhone ||
+    event.contactPhone ||
+    "";
+
+  const description =
+    organizer.description ||
+    organizer.bio ||
+    event.organizerDescription ||
+    "";
+
+  const website =
+    organizer.website ||
+    organizer.websiteUrl ||
+    event.organizerWebsite ||
+    "";
+
+  const role =
+    organizer.role ||
+    event.organizerRole ||
+    "Event Organizer";
+
+  if (
+    !name &&
+    !email &&
+    !phone &&
+    !description &&
+    !website
+  ) {
+    return null;
+  }
+
+  return {
+    name:
+      name || "Event Organizer",
+    email,
+    phone,
+    description,
+    website,
+    role,
+  };
+};
+
+/**
+ * Get the event support email.
+ */
+export const getSupportEmail = (
+  event = {}
+) => {
+  return (
+    event.supportEmail ||
+    event.support?.email ||
+    event.eventSupportEmail ||
+    event.helpEmail ||
+    event.contactEmail ||
+    getOrganizerContact(event)
+      ?.email ||
+    ""
+  );
+};
+
+/**
+ * Get the FAQ URL for an event.
+ */
+export const getFAQUrl = (
+  event = {}
+) => {
+  return (
+    event.faqUrl ||
+    event.faqLink ||
+    event.faq ||
+    event.support?.faqUrl ||
+    event.support?.faqLink ||
+    null
+  );
+};
+
+/**
+ * Get the report-issue URL.
+ */
+export const getReportIssueUrl = (
+  event = {}
+) => {
+  return (
+    event.reportIssueUrl ||
+    event.reportUrl ||
+    event.issueUrl ||
+    event.support?.reportIssueUrl ||
+    event.support?.reportUrl ||
+    null
+  );
+};
+
+/**
+ * Get event-specific support information.
+ */
+export const getSupportInformation = (
+  event = {}
+) => {
+  return (
+    event.supportInformation ||
+    event.supportInfo ||
+    event.support?.information ||
+    event.support?.description ||
+    event.eventSupport ||
+    ""
+  );
+};
+
+/**
+ * Get all support information for an event.
+ */
+export const getEventSupportInfo = (
+  event = {}
+) => {
+  const organizer =
+    getOrganizerContact(event);
+
+  const supportEmail =
+    getSupportEmail(event);
+
+  const faqUrl =
+    getFAQUrl(event);
+
+  const reportIssueUrl =
+    getReportIssueUrl(event);
+
+  const supportInformation =
+    getSupportInformation(event);
+
+  return {
+    organizer,
+    supportEmail,
+    faqUrl,
+    reportIssueUrl,
+    supportInformation,
+
+    hasOrganizer:
+      Boolean(organizer),
+
+    hasSupportEmail:
+      Boolean(supportEmail),
+
+    hasFAQ:
+      Boolean(faqUrl),
+
+    hasReportIssue:
+      Boolean(reportIssueUrl),
+
+    hasSupportInformation:
+      Boolean(
+        supportInformation
+      ),
+  };
+};
+
+/**
+ * Check whether any support information
+ * exists for the event.
+ */
+export const hasSupportInformation = (
+  event = {}
+) => {
+  const support =
+    getEventSupportInfo(event);
+
+  return (
+    support.hasOrganizer ||
+    support.hasSupportEmail ||
+    support.hasFAQ ||
+    support.hasReportIssue ||
+    support.hasSupportInformation
+  );
+};
+
+/**
+ * Check whether organizer contact
+ * information exists.
+ */
+export const hasOrganizerContact = (
+  event = {}
+) => {
+  return Boolean(
+    getOrganizerContact(event)
+  );
+};
+
+/**
+ * Check whether an event has a support email.
+ */
+export const hasSupportEmail = (
+  event = {}
+) => {
+  return Boolean(
+    getSupportEmail(event)
+  );
+};
+
+/**
+ * Check whether an FAQ is available.
+ */
+export const hasFAQ = (
+  event = {}
+) => {
+  return Boolean(
+    getFAQUrl(event)
+  );
+};
+
+/**
+ * Check whether reporting an issue
+ * is supported.
+ */
+export const hasReportIssue = (
+  event = {}
+) => {
+  return Boolean(
+    getReportIssueUrl(event)
+  );
+};
+
+/**
+ * Build a mailto URL for support.
+ */
+export const getSupportMailtoUrl = (
+  event = {},
+  subject = ""
+) => {
+  const email =
+    getSupportEmail(event);
+
+  if (!email) {
+    return null;
+  }
+
+  const eventName =
+    event.name ||
+    event.title ||
+    "Event";
+
+  const finalSubject =
+    subject ||
+    `Support request for ${eventName}`;
+
+  return `mailto:${email}?subject=${encodeURIComponent(
+    finalSubject
+  )}`;
+};
+
+/**
+ * Build a mailto URL for the organizer.
+ */
+export const getOrganizerMailtoUrl = (
+  event = {},
+  subject = ""
+) => {
+  const organizer =
+    getOrganizerContact(event);
+
+  if (!organizer?.email) {
+    return null;
+  }
+
+  const eventName =
+    event.name ||
+    event.title ||
+    "Event";
+
+  const finalSubject =
+    subject ||
+    `Question about ${eventName}`;
+
+  return `mailto:${organizer.email}?subject=${encodeURIComponent(
+    finalSubject
+  )}`;
+};
+
+/**
+ * Validate an email address.
+ */
+export const isValidEmail = (
+  email
+) => {
+  if (
+    typeof email !==
+    "string"
+  ) {
+    return false;
+  }
+
+  const value = email.trim();
+
+  if (!value) {
+    return false;
+  }
+
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+    value
+  );
+};
+
+/**
+ * Validate a support URL.
+ */
+export const isValidSupportUrl = (
+  url
+) => {
+  if (
+    typeof url !==
+    "string"
+  ) {
+    return false;
+  }
+
+  try {
+    const parsed =
+      new URL(url);
+
+    return (
+      parsed.protocol ===
+        "http:" ||
+      parsed.protocol ===
+        "https:"
+    );
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Validate support configuration.
+ */
+export const validateEventSupport = (
+  event = {}
+) => {
+  const support =
+    getEventSupportInfo(event);
+
+  const errors = [];
+
+  if (
+    support.supportEmail &&
+    !isValidEmail(
+      support.supportEmail
+    )
+  ) {
+    errors.push(
+      "Support email is invalid."
+    );
+  }
+
+  if (
+    support.faqUrl &&
+    !isValidSupportUrl(
+      support.faqUrl
+    )
+  ) {
+    errors.push(
+      "FAQ URL is invalid."
+    );
+  }
+
+  if (
+    support.reportIssueUrl &&
+    !isValidSupportUrl(
+      support.reportIssueUrl
+    )
+  ) {
+    errors.push(
+      "Report issue URL is invalid."
+    );
+  }
+
+  if (
+    support.organizer?.email &&
+    !isValidEmail(
+      support.organizer.email
+    )
+  ) {
+    errors.push(
+      "Organizer email is invalid."
+    );
+  }
+
+  if (
+    support.organizer?.website &&
+    !isValidSupportUrl(
+      support.organizer.website
+    )
+  ) {
+    errors.push(
+      "Organizer website URL is invalid."
+    );
+  }
+
+  return {
+    valid:
+      errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * Create a normalized support configuration.
+ */
+export const createEventSupportConfig = ({
+  organizer = {},
+  supportEmail = "",
+  faqUrl = "",
+  reportIssueUrl = "",
+  supportInformation = "",
+} = {}) => {
+  return {
+    organizer: {
+      name:
+        organizer.name ||
+        "Event Organizer",
+      role:
+        organizer.role ||
+        "Event Organizer",
+      email:
+        organizer.email || "",
+      phone:
+        organizer.phone || "",
+      description:
+        organizer.description ||
+        "",
+      website:
+        organizer.website || "",
+    },
+    supportEmail,
+    faqUrl,
+    reportIssueUrl,
+    supportInformation,
+  };
+};
+
+/**
+ * Merge existing support information
+ * with updates.
+ */
+export const updateEventSupportConfig = (
+  event = {},
+  updates = {}
+) => {
+  const current =
+    getEventSupportInfo(event);
+
+  const updatedOrganizer = {
+    ...(current.organizer || {}),
+    ...(updates.organizer || {}),
+  };
+
+  return {
+    ...event,
+
+    organizer:
+      updatedOrganizer,
+
+    supportEmail:
+      updates.supportEmail !==
+      undefined
+        ? updates.supportEmail
+        : current.supportEmail,
+
+    faqUrl:
+      updates.faqUrl !==
+      undefined
+        ? updates.faqUrl
+        : current.faqUrl,
+
+    reportIssueUrl:
+      updates.reportIssueUrl !==
+      undefined
+        ? updates.reportIssueUrl
+        : current.reportIssueUrl,
+
+    supportInformation:
+      updates.supportInformation !==
+      undefined
+        ? updates.supportInformation
+        : current.supportInformation,
+  };
+};
+
+/**
+ * Remove empty support fields.
+ */
+export const cleanSupportConfig = (
+  support = {}
+) => {
+  const cleaned = {
+    ...support,
+  };
+
+  Object.keys(cleaned).forEach(
+    (key) => {
+      const value =
+        cleaned[key];
+
+      if (
+        value === "" ||
+        value === null ||
+        value === undefined
+      ) {
+        delete cleaned[key];
+      }
+    }
+  );
+
+  if (
+    cleaned.organizer &&
+    typeof cleaned.organizer ===
+      "object"
+  ) {
+    Object.keys(
+      cleaned.organizer
+    ).forEach((key) => {
+      const value =
+        cleaned.organizer[key];
+
+      if (
+        value === "" ||
+        value === null ||
+        value === undefined
+      ) {
+        delete cleaned.organizer[
+          key
+        ];
+      }
+    });
+  }
+
+  return cleaned;
+};
+
+/**
+ * Get available support actions.
+ */
+export const getAvailableSupportActions = (
+  event = {}
+) => {
+  const support =
+    getEventSupportInfo(event);
+
+  const actions = [];
+
+  if (
+    support.organizer
+      ?.email
+  ) {
+    actions.push({
+      type:
+        SUPPORT_TYPES.ORGANIZER,
+      label:
+        "Contact Organizer",
+      href:
+        getOrganizerMailtoUrl(
+          event
+        ),
+    });
+  }
+
+  if (
+    support.supportEmail
+  ) {
+    actions.push({
+      type:
+        SUPPORT_TYPES.EMAIL,
+      label:
+        "Email Support",
+      href:
+        getSupportMailtoUrl(
+          event
+        ),
+    });
+  }
+
+  if (support.faqUrl) {
+    actions.push({
+      type:
+        SUPPORT_TYPES.FAQ,
+      label: "View FAQ",
+      href:
+        support.faqUrl,
+    });
+  }
+
+  if (
+    support.reportIssueUrl
+  ) {
+    actions.push({
+      type:
+        SUPPORT_TYPES.REPORT,
+      label:
+        "Report an Issue",
+      href:
+        support.reportIssueUrl,
+    });
+  }
+
+  return actions;
+};
+
+/**
+ * Get a short support summary.
+ */
+export const getSupportSummary = (
+  event = {}
+) => {
+  const support =
+    getEventSupportInfo(event);
+
+  const options = [];
+
+  if (support.organizer) {
+    options.push(
+      "organizer contact"
+    );
+  }
+
+  if (support.supportEmail) {
+    options.push(
+      "support email"
+    );
+  }
+
+  if (support.faqUrl) {
+    options.push("FAQ");
+  }
+
+  if (support.reportIssueUrl) {
+    options.push(
+      "issue reporting"
+    );
+  }
+
+  if (
+    support.supportInformation
+  ) {
+    options.push(
+      "event-specific support"
+    );
+  }
+
+  if (options.length === 0) {
+    return "No support information available.";
+  }
+
+  return `Support available: ${options.join(
+    ", "
+  )}.`;
+};


### PR DESCRIPTION
## Description

Implemented a dedicated contact and support center for event participants.

### Added

- Organizer contact information
- Support email
- FAQ link
- Report an issue action
- Event-specific support information
- Contact organizer action
- Email and phone contact options
- Organizer website link
- Support URL validation
- Email validation
- Available support action detection
- Responsive support UI

Closes #12643