### PR TITLE
fix(build): resolve frontend bundle blockers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,10 +92,6 @@ function App() {
   });
   const [showKeyboardModal, setShowKeyboardModal] = useState(false);
   const [showChatbot, setShowChatbot] = useState(false);
-  const [isDesktop, setIsDesktop] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.innerWidth >= 1024;
-  });
 
   useLenis();
   useRoutePrefetch(); // Predictive route pre-loading

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -2,7 +2,6 @@ import React, { memo, useCallback, useId, useState } from "react";
 import { logger } from "utils/logger";
 import LazyImage from "components/common/LazyImage";
 import { formatLocalDateTime } from "utils/localDateTime";
-import { formatLocalDateTime } from "utils/localDateTime";
 import ShareModal from "components/common/ShareModal";
 import StatusBadge from "components/common/StatusBadge";
 import { getEventStatus } from "utils/eventUtils";

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -8,7 +8,8 @@ import { sanitizeMarkdown } from "utils/sanitizeHtml";
 import { toast } from "react-toastify";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import useKeyboardShortcuts from "hooks/useKeyboardShortcuts";
-import { Calendar, MapPin, Clock, Tag, CalendarPlus, Link2, Check, Archive, ExternalLink, Github, Linkedin, Users } from "lucide-react";
+import { Calendar, MapPin, Clock, Tag, CalendarPlus, Link2, Check, Archive, ExternalLink, Users, ArrowLeft } from "lucide-react";
+import { FaGithub as Github, FaLinkedin as Linkedin } from "react-icons/fa";
 import { getEventStatus, isEventRegistrationClosed } from "utils/eventUtils";
 import { useAuth } from "context/AuthContext";
 import useBookmarks from "hooks/useBookmarks";
@@ -374,14 +375,6 @@ ${window.location.href}
   const registrationEnd = event.registrationEnd
   ? new Date(event.registrationEnd)
   : null;
-
-  const eventDate =
-  event.date ||
-  event.eventDate ||
-  event.startDate ||
-  null;
-
-const dateInfo = formatLocalDateTime(eventDate);
 
   const eventDate = event.date || event.eventDate || event.startDate || null;
   const dateInfo = formatEventDate(eventDate);

--- a/src/Pages/HelpCenter.js
+++ b/src/Pages/HelpCenter.js
@@ -1,4 +1,5 @@
-import { ChevronDown, ChevronUp, MessageCircle, Github, Twitter, Youtube, Linkedin, Send } from "lucide-react";
+import { ChevronDown, ChevronUp, MessageCircle, Send } from "lucide-react";
+import { FaGithub as Github, FaTwitter as Twitter, FaYoutube as Youtube, FaLinkedin as Linkedin } from "react-icons/fa";
 import { useState, useEffect } from "react";
 import { motion, useAnimation } from "framer-motion";
 import useDocumentTitle from "../hooks/useDocumentTitle";

--- a/src/Pages/Leaderboard/ContributorGuide.js
+++ b/src/Pages/Leaderboard/ContributorGuide.js
@@ -13,7 +13,6 @@ import {
   Server,
   Clipboard,
   GitBranch,
-  Github,
   ArrowRightCircle,
   HelpCircle,
   GitPullRequest,
@@ -25,6 +24,7 @@ import {
   Target,
   Rocket,
 } from "lucide-react";
+import { FaGithub as Github } from "react-icons/fa";
 import useReducedMotion from "hooks/useReducedMotion.js";
 import useDocumentTitle from "hooks/useDocumentTitle";
 

--- a/src/Pages/Projects/ProjectCard.js
+++ b/src/Pages/Projects/ProjectCard.js
@@ -1,4 +1,5 @@
-import { Star, Github, ExternalLink, AlertCircle, GitPullRequest, Cpu, Code2, Bookmark } from "lucide-react";
+import { Star, ExternalLink, AlertCircle, GitPullRequest, Cpu, Code2, Bookmark } from "lucide-react";
+import { FaGithub as Github } from "react-icons/fa";
 import { useState, useEffect, useRef, memo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import useReducedMotion from "hooks/useReducedMotion.js";

--- a/src/Pages/Projects/ProjectHero.js
+++ b/src/Pages/Projects/ProjectHero.js
@@ -1,4 +1,5 @@
-import { Github, Twitter, Linkedin, MessageCircle, Code, Laptop, Brain, Code2, Plus, ArrowRight } from "lucide-react";
+import { MessageCircle, Code, Laptop, Brain, Code2, Plus, ArrowRight } from "lucide-react";
+import { FaGithub as Github, FaTwitter as Twitter, FaLinkedin as Linkedin } from "react-icons/fa";
 import React from "react";
 import { motion } from "framer-motion";
 import useReducedMotion from "hooks/useReducedMotion.js";

--- a/src/Pages/UserAchievements.jsx
+++ b/src/Pages/UserAchievements.jsx
@@ -17,11 +17,10 @@ import {
   ChevronDown,
   Sparkles,
   Trophy,
-  Linkedin,
-  Twitter,
   Share2,
   X,
 } from 'lucide-react';
+import { FaLinkedin as Linkedin, FaTwitter as Twitter } from 'react-icons/fa';
 
 // Escape XML special characters before embedding user-controlled values
 // into the generated SVG, preventing XML structure injection.

--- a/src/components/Contributors.js
+++ b/src/components/Contributors.js
@@ -1,4 +1,5 @@
-import { Github, ExternalLink, GitBranch, MapPin, Building, Users, Medal } from "lucide-react";
+import { ExternalLink, GitBranch, MapPin, Building, Users, Medal } from "lucide-react";
+import { FaGithub as Github } from "react-icons/fa";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { motion } from "framer-motion";
 import { useReducedMotion } from '../hooks/useReducedMotion';

--- a/src/components/common/ProjectSubmission.js
+++ b/src/components/common/ProjectSubmission.js
@@ -1,4 +1,5 @@
-import { Github, ExternalLink, Plus, X } from "lucide-react";
+import { ExternalLink, Plus, X } from "lucide-react";
+import { FaGithub as Github } from "react-icons/fa";
 import { getPublicErrorMessage, FORM_ERRORS } from "utils/errorMessages";
 import { useState } from "react";
 import { motion } from "framer-motion";

--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 // Consolidated lucide-react imports for code cleanliness
-import { Facebook, Linkedin, MessageCircle, Send, Share2, Copy, Mail, Check } from 'lucide-react';
+import { MessageCircle, Send, Share2, Copy, Mail, Check } from 'lucide-react';
+import { FaFacebook as Facebook, FaLinkedin as Linkedin } from 'react-icons/fa';
 import { generateSharingUrl, copyToClipboard } from '@utils/shareUtils';
 import { toast } from 'react-toastify';
 import './ShareMenu.css';

--- a/src/components/common/ShareModal.jsx
+++ b/src/components/common/ShareModal.jsx
@@ -3,15 +3,13 @@ import useModalManager from "hooks/useModalManager";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   Copy,
-  Facebook,
-  Linkedin,
   Mail,
   MessageCircle,
   Send,
   Share2,
-  Twitter,
   X,
 } from "lucide-react";
+import { FaFacebook as Facebook, FaLinkedin as Linkedin, FaTwitter as Twitter } from "react-icons/fa";
 import useEventShare from "hooks/useEventShare";
 import { createShareModalData } from "utils/shareModalUtils.js";
 const ModalCloseButton = memo(({ onClick }) => (
@@ -44,19 +42,6 @@ const ShareModal = ({ isOpen, onClose, event }) => {
     if (!shareData?.shareUrl) return;
     await copyInviteLink(shareData.shareUrl);
   }, [copyInviteLink, shareData]);
-
-  useEffect(() => {
-    if (!isOpen) return undefined;
-
-    const handleEsc = (eventKey) => {
-      if (eventKey.key === "Escape") {
-        onClose();
-      }
-    };
-
-    window.addEventListener("keydown", handleEsc);
-    useScrollLock(isOpen);
-  }, [isOpen, onClose]);
 
   return (
     <AnimatePresence>

--- a/src/components/common/SocialShareButtons.jsx
+++ b/src/components/common/SocialShareButtons.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useCallback } from "react";
-import { Copy, Facebook, Linkedin, Mail, MessageCircle, Send, Twitter } from "lucide-react";
+import { Copy, Mail, MessageCircle, Send } from "lucide-react";
+import { FaFacebook as Facebook, FaLinkedin as Linkedin, FaTwitter as Twitter } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { isValidShareUrl } from "utils/shareUtils";
 import useClipboard from "hooks/useClipboard";

--- a/src/components/common/VirtualizedEventGrid.jsx
+++ b/src/components/common/VirtualizedEventGrid.jsx
@@ -1,15 +1,13 @@
 import { memo } from "react";
-import { FixedSizeGrid as Grid } from "react-window";
+import { Grid } from "react-window";
 import EventCard from "../../Pages/Events/EventCard";
-import AutoSizer from "react-virtualized-auto-sizer";
+import { AutoSizer } from "react-virtualized-auto-sizer";
 
-const COLUMN_COUNT = 3;
 const CARD_WIDTH = 380;
 const CARD_HEIGHT = 420;
 
-const Cell = memo(({ columnIndex, rowIndex, style, data }) => {
-  const { items } = data;
-  const index = rowIndex * COLUMN_COUNT + columnIndex;
+const Cell = memo(({ columnIndex, rowIndex, style, items, columnCount }) => {
+  const index = rowIndex * columnCount + columnIndex;
   const event = items[index];
 
   if (!event) return null;
@@ -28,8 +26,6 @@ Cell.displayName = "Cell";
 // contributing to layout thrash and memory growth.
 
 const VirtualizedEventGrid = ({ events }) => {
-  const rowCount = Math.ceil(events.length / COLUMN_COUNT);
-
   return (
     <div style={{ width: "100%", height: "80vh" }}>
       <AutoSizer>
@@ -44,10 +40,9 @@ const VirtualizedEventGrid = ({ events }) => {
               rowCount={Math.ceil(events.length / colCount)}
               rowHeight={CARD_HEIGHT}
               width={width}
-              itemData={{ items: events }}
-            >
-              {Cell}
-            </Grid>
+              cellComponent={Cell}
+              cellProps={{ items: events, columnCount: colCount }}
+            />
           );
         }}
       </AutoSizer>

--- a/src/components/events/EventShareButtons.jsx
+++ b/src/components/events/EventShareButtons.jsx
@@ -26,7 +26,8 @@
 
 import { useCallback, useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Share2, Twitter, Linkedin, MessageCircle, Link2, Check, Eye, X, Calendar, MapPin, Mail } from "lucide-react";
+import { Share2, MessageCircle, Link2, Check, Eye, X, Calendar, MapPin, Mail } from "lucide-react";
+import { FaTwitter as Twitter, FaLinkedin as Linkedin } from "react-icons/fa";
 import useEventShare from "../../hooks/useEventShare";
 
 // ---------------------------------------------------------------------------

--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import {
-  X, Briefcase, Globe, Linkedin, Twitter, Github,
+  X, Briefcase, Globe,
   Send, MessageSquare, ArrowLeft
 } from "lucide-react";
+import { FaLinkedin as Linkedin, FaTwitter as Twitter, FaGithub as Github } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { safeJsonParse } from "utils/safeJsonParse";
 import { useAuth } from "context/AuthContext";

--- a/src/components/hackathons/WorkspaceBootstrapModal.jsx
+++ b/src/components/hackathons/WorkspaceBootstrapModal.jsx
@@ -2,11 +2,12 @@ import { useState, useEffect, useCallback } from "react";
 import useClipboard from "hooks/useClipboard";
 import { motion, AnimatePresence } from "framer-motion";
 import {
-  X, Github, Rocket, ChevronRight, ChevronLeft,
+  X, Rocket, ChevronRight, ChevronLeft,
   Check, AlertCircle, Loader2, Plus, Trash2,
   Lock, Globe, ExternalLink, Copy, Users,
   KeyRound, FolderGit2, BookOpen,
 } from "lucide-react";
+import { FaGithub as Github } from "react-icons/fa";
 import {
   validateGitHubToken,
   slugifyRepoName,

--- a/src/components/notifications/NotificationItem.jsx
+++ b/src/components/notifications/NotificationItem.jsx
@@ -12,7 +12,6 @@ import {
   Trash2,
 } from "lucide-react";
 import { NOTIFICATION_CATEGORIES } from "utils/notificationPreferences";
-import { getRelativeTime } from "utils/relativeTime";
 
 const CATEGORY_ICONS = {
   registrations: Calendar,
@@ -25,14 +24,13 @@ const CATEGORY_ICONS = {
 };
 
 const NotificationItem = ({
-  // Fix: useDateFormatter replaces raw toLocaleDateString
-  const { formatDate, getRelativeTime } = useDateFormatter();
   notification,
   onMarkRead,
   onDelete,
   compact = false,
   showActions = true,
 }) => {
+  const { formatDate, getRelativeTime } = useDateFormatter();
   const category = notification.category || "system";
   const Icon = CATEGORY_ICONS[category] || Bell;
   const isUnread = !notification.isRead;

--- a/src/components/user/AiProfileGeneratorModal.jsx
+++ b/src/components/user/AiProfileGeneratorModal.jsx
@@ -2,9 +2,10 @@ import { useState, useRef, useEffect } from "react";
 import ReactDOM from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
-  X, Sparkles, FileText, Github,
+  X, Sparkles, FileText,
   CheckCircle2, AlertTriangle, ArrowRight, Copy
 } from "lucide-react";
+import { FaGithub as Github } from "react-icons/fa";
 import { parseGithubProfile, parseResumePDF } from "utils/aiProfileParser";
 import { toast } from "react-toastify";
 

--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -11,13 +11,12 @@ import {
   AtSign,
   Phone as PhoneIcon,
   FileText,
-  Github,
-  Linkedin,
   Link as LinkIcon,
   Image as ImageIcon,
   X as XIcon,
   Sparkles,
 } from "lucide-react";
+import { FaGithub as Github, FaLinkedin as Linkedin } from "react-icons/fa";
 
 import AiProfileGeneratorModal from "./AiProfileGeneratorModal";
 

--- a/src/components/user/EventsTab.js
+++ b/src/components/user/EventsTab.js
@@ -1,4 +1,3 @@
-import useDateFormatter from "hooks/useDateFormatter";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
@@ -15,6 +14,9 @@ import {
   Activity,
   Copy,
   Star,
+  BarChart3,
+  TrendingUp,
+  ListChecks,
 } from "lucide-react";
 import CountUp from "react-countup";
 import { Link } from "react-router-dom";
@@ -505,9 +507,7 @@ const EventsEmptyState = () => (
 );
 
 /* ---------------- Main EventsTab Component ---------------- */
-const EventsTab = ({
-  const { formatDate, formatShort } = useDateFormatter();
- hostedEvents = [], onViewTicket }) => {
+const EventsTab = ({ hostedEvents = [], onViewTicket }) => {
   const prefersReducedMotion = useReducedMotion();
   const staggerVariants = stagger(prefersReducedMotion);
   const { myEvents, removeRegistration, restoreRegistration, loading: myEventsLoading } = useMyEvents();

--- a/src/components/user/UserProfile.js
+++ b/src/components/user/UserProfile.js
@@ -8,8 +8,6 @@ import {
   Mail,
   Phone,
   FileText,
-  Github,
-  Linkedin,
   Globe,
   Edit3,
   Calendar,
@@ -20,6 +18,7 @@ import {
   Star,
   Zap,
 } from "lucide-react";
+import { FaGithub as Github, FaLinkedin as Linkedin } from "react-icons/fa";
 import { useAuth } from "context/AuthContext";
 import { syncSecureStorage } from "utils/secureStorage";
 import LazyImage from "../common/LazyImage";

--- a/src/utils/routePrefetch.js
+++ b/src/utils/routePrefetch.js
@@ -21,7 +21,7 @@ const loadRouteModule = (importFn) => {
 };
 
 const ROUTE_REGISTRY = {
-  home: () => import("../Pages/Home/HomePage.js"),
+  home: () => import("../Pages/Home/HomePage.jsx"),
   events: () => import("../Pages/Events/EventsPage.js"),
   dashboard: () => import("../components/Dashboard.js"),
   hackathons: () => import("../Pages/Hackathons/HackathonPage.js"),

--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -247,7 +247,7 @@ const initializeKeyMetadata = () => {
 let _keyMetadata = null;
 let _keyPromise = null;
 
-const getKeyMetadata = () => {
+export const getKeyMetadata = () => {
   if (_keyMetadata) return _keyMetadata;
   if (typeof localStorage === "undefined") {
     _keyMetadata = {
@@ -617,10 +617,6 @@ export const rotateKey = async () => {
 
     throw new Error(`Key rotation failed: ${error.message}`);
   }
-};
-
-export const getKeyMetadata = () => {
-  return _keyMetadata;
 };
 
 export const getCryptoConfig = () => {

--- a/src/utils/security/securityConfigValidator.js
+++ b/src/utils/security/securityConfigValidator.js
@@ -4,6 +4,16 @@ const SECURITY_CONFIG_KEYS = {
   CSP_CONFIGURATION: "REACT_APP_CSP_REPORT_URI",
 };
 
+const getRuntimeEnv = () => {
+  if (typeof import.meta !== "undefined" && import.meta.env) {
+    return import.meta.env;
+  }
+  if (typeof process !== "undefined" && process.env) {
+    return process.env;
+  }
+  return {};
+};
+
 export function getSecurityConfigurationWarnings(
   config = {},
   environment = "development"
@@ -37,8 +47,8 @@ export function getSecurityConfigurationWarnings(
 }
 
 export function validateSecurityConfiguration(
-  config = process.env,
-  environment = process.env.NODE_ENV
+  config = getRuntimeEnv(),
+  environment = getRuntimeEnv().NODE_ENV || getRuntimeEnv().MODE || "development"
 ) {
   const warnings = getSecurityConfigurationWarnings(
     config,
@@ -49,27 +59,18 @@ export function validateSecurityConfiguration(
     console.warn(`[Security Configuration] ${warning}`);
   });
 
-  return {
-    valid: warnings.length === 0,
-    warnings,
-    checkedKeys: Object.values(SECURITY_CONFIG_KEYS),
-  };
-}
-export const validateSecurityConfiguration = () => {
-  const isDev = import.meta.env.DEV || process.env.NODE_ENV === "development";
-  const isProd = import.meta.env.PROD || process.env.NODE_ENV === "production";
-
-  const backendUrl = import.meta.env.VITE_API_URL || "";
+  const runtimeEnv = getRuntimeEnv();
+  const isDev = runtimeEnv.DEV || environment === "development";
+  const isProd = runtimeEnv.PROD || environment === "production";
+  const backendUrl = runtimeEnv.VITE_API_URL || config.VITE_API_URL || "";
   const hasSecureProtocol = backendUrl.startsWith("https://") || backendUrl.startsWith("/");
 
-  // Check 1: HTTPS API endpoint configuration in production
   if (isProd && backendUrl && !hasSecureProtocol) {
     console.warn(
       `[Security Warning] Backend API URL is configured to use insecure protocol: "${backendUrl}". In production, HTTPS must be used.`
     );
   }
 
-  // Check 2: Content Security Policy (CSP) presence
   if (typeof document !== "undefined") {
     const hasCspMeta = document.querySelector('meta[http-equiv="Content-Security-Policy"]');
     if (!hasCspMeta && isDev) {
@@ -79,11 +80,16 @@ export const validateSecurityConfiguration = () => {
     }
   }
 
-  // Check 3: Authentication configuration warnings if Google Client ID is placeholder
-  const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID || "";
+  const googleClientId = runtimeEnv.VITE_GOOGLE_CLIENT_ID || config.VITE_GOOGLE_CLIENT_ID || "";
   if (googleClientId && googleClientId.includes("your_google_client_id")) {
     console.warn(
       "[Security Warning] Google Client ID is using a placeholder value. Social login might not work."
     );
   }
-};
+
+  return {
+    valid: warnings.length === 0,
+    warnings,
+    checkedKeys: Object.values(SECURITY_CONFIG_KEYS),
+  };
+}


### PR DESCRIPTION
Fixes #12653

## Changes
- removes duplicate declarations/imports that stopped Vite parsing
- switches brand icons to `react-icons/fa` where the installed lucide package has no matching exports
- updates `VirtualizedEventGrid` to the installed `react-window` v2 API
- removes the redundant manual Escape/scroll-lock effect from `ShareModal`; `useModalManager` already handles it

## Validation
- `node tests/securityConfigValidator.test.mjs`
- `node --test tests/secureStorage.test.mjs`
- `npx eslint <changed files> --max-warnings=200`
- `BACKEND_URL=http://localhost:8080 npm run build`

Full `npm run lint` still fails on unrelated existing repo-wide errors outside this change.
