### PR TITLE
feat(events): add private participant notes

### DIFF
--- a/src/components/events/EventNoteEditor.js
+++ b/src/components/events/EventNoteEditor.js
@@ -1,0 +1,294 @@
+import { useEffect, useState } from "react";
+import {
+  Check,
+  FileText,
+  Link as LinkIcon,
+  X,
+} from "lucide-react";
+
+import {
+  createEventNote,
+  updateEventNote,
+  validateEventNote,
+  getEventNotes,
+} from "../../utils/eventNotesUtils";
+
+const MAX_TITLE_LENGTH = 100;
+const MAX_CONTENT_LENGTH = 2000;
+
+const EventNoteEditor = ({
+  event = {},
+  user = {},
+  notes = [],
+  note = null,
+  onSave,
+  onCancel,
+}) => {
+  const isEditing = Boolean(note);
+
+  const [title, setTitle] = useState(
+    note?.title || ""
+  );
+
+  const [content, setContent] = useState(
+    note?.content || ""
+  );
+
+  const [error, setError] = useState("");
+
+  const [isSaving, setIsSaving] =
+    useState(false);
+
+  useEffect(() => {
+    setTitle(note?.title || "");
+    setContent(note?.content || "");
+    setError("");
+  }, [note]);
+
+  const eventId =
+    event.id ??
+    event.eventId ??
+    event.event_id;
+
+  const userId =
+    user.id ??
+    user.userId ??
+    user.user_id;
+
+  const handleSubmit = (eventObject) => {
+    eventObject.preventDefault();
+
+    if (isSaving) {
+      return;
+    }
+
+    setError("");
+
+    const validation =
+      validateEventNote({
+        title,
+        content,
+      });
+
+    if (!validation.valid) {
+      setError(
+        validation.errors.join(" ")
+      );
+      return;
+    }
+
+    if (!eventId || !userId) {
+      setError(
+        "Unable to identify the event or user."
+      );
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      let updatedNotes;
+
+      if (isEditing) {
+        updatedNotes =
+          updateEventNote(
+            notes,
+            note.id,
+            {
+              title: title.trim(),
+              content: content.trim(),
+            }
+          );
+      } else {
+        const newNote =
+          createEventNote({
+            eventId,
+            userId,
+            title: title.trim(),
+            content: content.trim(),
+          });
+
+        updatedNotes = [
+          ...getEventNotes({
+            notes,
+            eventId: null,
+            userId: null,
+            includeAll: true,
+          }),
+          newNote,
+        ];
+      }
+
+      onSave?.(updatedNotes);
+    } catch (saveError) {
+      setError(
+        saveError?.message ||
+          "Unable to save your note."
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const remainingTitle =
+    MAX_TITLE_LENGTH -
+    title.length;
+
+  const remainingContent =
+    MAX_CONTENT_LENGTH -
+    content.length;
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-5"
+    >
+      {/* Editor header */}
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+          <FileText
+            size={18}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        </div>
+
+        <div>
+          <h3 className="text-sm font-bold text-slate-800 dark:text-white">
+            {isEditing
+              ? "Edit Personal Note"
+              : "Add Personal Note"}
+          </h3>
+
+          <p className="mt-1 text-xs leading-5 text-slate-500 dark:text-slate-400">
+            This note is private and visible only to
+            you.
+          </p>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-xs leading-5 text-red-700 dark:border-red-900/50 dark:bg-red-900/10 dark:text-red-400"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Title */}
+      <div>
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor="event-note-title"
+            className="text-sm font-semibold text-slate-700 dark:text-slate-200"
+          >
+            Note title
+          </label>
+
+          <span
+            className={`text-[11px] ${
+              remainingTitle < 0
+                ? "text-red-500"
+                : "text-slate-400"
+            }`}
+          >
+            {title.length}/
+            {MAX_TITLE_LENGTH}
+          </span>
+        </div>
+
+        <input
+          id="event-note-title"
+          type="text"
+          value={title}
+          onChange={(eventObject) =>
+            setTitle(
+              eventObject.target.value
+            )
+          }
+          maxLength={MAX_TITLE_LENGTH}
+          placeholder="e.g. Things to bring"
+          className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-indigo-400 dark:focus:ring-indigo-900/30"
+        />
+      </div>
+
+      {/* Content */}
+      <div>
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor="event-note-content"
+            className="text-sm font-semibold text-slate-700 dark:text-slate-200"
+          >
+            Note
+          </label>
+
+          <span
+            className={`text-[11px] ${
+              remainingContent < 0
+                ? "text-red-500"
+                : "text-slate-400"
+            }`}
+          >
+            {content.length}/
+            {MAX_CONTENT_LENGTH}
+          </span>
+        </div>
+
+        <textarea
+          id="event-note-content"
+          value={content}
+          onChange={(eventObject) =>
+            setContent(
+              eventObject.target.value
+            )
+          }
+          maxLength={MAX_CONTENT_LENGTH}
+          rows={7}
+          placeholder={
+            "Write your preparation tasks, questions, important links, things to bring, or personal reminders..."
+          }
+          className="mt-2 w-full resize-y rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-indigo-400 dark:focus:ring-indigo-900/30"
+        />
+
+        <p className="mt-2 flex items-center gap-1.5 text-[11px] text-slate-400">
+          <LinkIcon size={12} />
+          You can include important links directly in your
+          note.
+        </p>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-600 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          <X size={16} />
+          Cancel
+        </button>
+
+        <button
+          type="submit"
+          disabled={
+            isSaving ||
+            !content.trim()
+          }
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+        >
+          <Check size={16} />
+
+          {isSaving
+            ? "Saving..."
+            : isEditing
+              ? "Save Changes"
+              : "Save Note"}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default EventNoteEditor;

--- a/src/components/events/EventNotes.js
+++ b/src/components/events/EventNotes.js
@@ -1,0 +1,301 @@
+import {
+  BookOpen,
+  Lock,
+  Pencil,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+import {
+  deleteEventNote,
+  getEventNotes,
+} from "../../utils/eventNotesUtils";
+
+import EventNoteEditor from "./EventNoteEditor";
+
+const EventNotes = ({
+  event = {},
+  user = {},
+  notes = [],
+  onChange,
+}) => {
+  const [isEditorOpen, setIsEditorOpen] =
+    useState(false);
+
+  const [editingNote, setEditingNote] =
+    useState(null);
+
+  const eventId =
+    event.id ??
+    event.eventId ??
+    event.event_id;
+
+  const userId =
+    user.id ??
+    user.userId ??
+    user.user_id;
+
+  const eventNotes =
+    getEventNotes({
+      notes,
+      eventId,
+      userId,
+    });
+
+  const handleAddNote = () => {
+    setEditingNote(null);
+    setIsEditorOpen(true);
+  };
+
+  const handleEditNote = (note) => {
+    setEditingNote(note);
+    setIsEditorOpen(true);
+  };
+
+  const handleDeleteNote = (noteId) => {
+    const confirmed =
+      window.confirm(
+        "Are you sure you want to delete this note?"
+      );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const updatedNotes =
+      deleteEventNote(
+        notes,
+        noteId
+      );
+
+    onChange?.(updatedNotes);
+  };
+
+  const handleSave = (updatedNotes) => {
+    onChange?.(updatedNotes);
+    setIsEditorOpen(false);
+    setEditingNote(null);
+  };
+
+  const handleCancel = () => {
+    setIsEditorOpen(false);
+    setEditingNote(null);
+  };
+
+  return (
+    <section className="w-full rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">
+      {/* Header */}
+      <div className="flex flex-col gap-4 border-b border-slate-200 p-5 sm:flex-row sm:items-center sm:justify-between dark:border-slate-700">
+        <div className="flex items-start gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+            <BookOpen
+              size={21}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-lg font-bold text-slate-800 dark:text-white">
+                My Event Notes
+              </h2>
+
+              <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                <Lock size={11} />
+                Private
+              </span>
+            </div>
+
+            <p className="mt-1 text-sm leading-6 text-slate-500 dark:text-slate-400">
+              Save personal preparation tasks, questions,
+              links, and reminders for this event.
+            </p>
+          </div>
+        </div>
+
+        {!isEditorOpen && (
+          <button
+            type="button"
+            onClick={handleAddNote}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            <Plus size={16} />
+            Add Note
+          </button>
+        )}
+      </div>
+
+      {/* Editor */}
+      {isEditorOpen && (
+        <div className="border-b border-slate-200 p-5 dark:border-slate-700">
+          <EventNoteEditor
+            event={event}
+            user={user}
+            notes={notes}
+            note={editingNote}
+            onSave={handleSave}
+            onCancel={handleCancel}
+          />
+        </div>
+      )}
+
+      {/* Notes */}
+      <div className="p-5">
+        {eventNotes.length > 0 ? (
+          <div className="space-y-3">
+            {eventNotes.map((note) => (
+              <NoteCard
+                key={note.id}
+                note={note}
+                onEdit={() =>
+                  handleEditNote(note)
+                }
+                onDelete={() =>
+                  handleDeleteNote(note.id)
+                }
+              />
+            ))}
+          </div>
+        ) : (
+          <EmptyNotesState
+            onAddNote={handleAddNote}
+          />
+        )}
+      </div>
+    </section>
+  );
+};
+
+/**
+ * Individual note card.
+ */
+const NoteCard = ({
+  note,
+  onEdit,
+  onDelete,
+}) => {
+  return (
+    <article className="group rounded-xl border border-slate-200 bg-slate-50 p-4 transition hover:border-indigo-200 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-indigo-800">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {note.title && (
+              <h3 className="text-sm font-semibold text-slate-800 dark:text-white">
+                {note.title}
+              </h3>
+            )}
+
+            <span className="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-slate-400 dark:bg-slate-900">
+              <Lock size={10} />
+              Private
+            </span>
+          </div>
+
+          <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-slate-600 dark:text-slate-300">
+            {note.content}
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-slate-400">
+            {note.createdAt && (
+              <span>
+                Created{" "}
+                {formatNoteDate(
+                  note.createdAt
+                )}
+              </span>
+            )}
+
+            {note.updatedAt &&
+              note.updatedAt !==
+                note.createdAt && (
+                <span>
+                  Updated{" "}
+                  {formatNoteDate(
+                    note.updatedAt
+                  )}
+                </span>
+              )}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onEdit}
+            aria-label="Edit note"
+            className="rounded-lg p-2 text-slate-400 transition hover:bg-white hover:text-indigo-600 dark:hover:bg-slate-900 dark:hover:text-indigo-400"
+          >
+            <Pencil size={15} />
+          </button>
+
+          <button
+            type="button"
+            onClick={onDelete}
+            aria-label="Delete note"
+            className="rounded-lg p-2 text-slate-400 transition hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+          >
+            <Trash2 size={15} />
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+/**
+ * Empty state.
+ */
+const EmptyNotesState = ({
+  onAddNote,
+}) => {
+  return (
+    <div className="rounded-xl border border-dashed border-slate-300 p-8 text-center dark:border-slate-700">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800">
+        <BookOpen
+          size={22}
+          className="text-slate-400"
+        />
+      </div>
+
+      <h3 className="mt-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
+        No personal notes yet
+      </h3>
+
+      <p className="mx-auto mt-1 max-w-md text-xs leading-5 text-slate-400">
+        Add preparation tasks, questions, important links,
+        things to bring, or personal reminders.
+      </p>
+
+      <button
+        type="button"
+        onClick={onAddNote}
+        className="mt-4 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-xs font-semibold text-slate-700 transition hover:border-indigo-300 hover:text-indigo-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-indigo-700 dark:hover:text-indigo-400"
+      >
+        <Plus size={14} />
+        Add Your First Note
+      </button>
+    </div>
+  );
+};
+
+/**
+ * Format note dates safely.
+ */
+const formatNoteDate = (value) => {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat(
+    undefined,
+    {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }
+  ).format(date);
+};
+
+export default EventNotes;

--- a/src/utils/eventNotesUtils.js
+++ b/src/utils/eventNotesUtils.js
@@ -1,0 +1,824 @@
+/**
+ * Event Notes utilities.
+ *
+ * Notes are private to the user and associated
+ * with a specific event.
+ */
+
+export const MAX_NOTE_TITLE_LENGTH = 100;
+export const MAX_NOTE_CONTENT_LENGTH = 2000;
+
+/**
+ * Generate a unique note ID.
+ */
+export const generateEventNoteId = () => {
+  return `event-note-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
+};
+
+/**
+ * Normalize an ID for reliable comparisons.
+ */
+export const normalizeNoteId = (value) => {
+  if (
+    value === null ||
+    value === undefined
+  ) {
+    return "";
+  }
+
+  return String(value).trim();
+};
+
+/**
+ * Extract an event ID.
+ */
+export const getNoteEventId = (
+  event = {}
+) => {
+  if (
+    typeof event !== "object" ||
+    event === null
+  ) {
+    return normalizeNoteId(event);
+  }
+
+  return normalizeNoteId(
+    event.id ??
+      event.eventId ??
+      event.event_id
+  );
+};
+
+/**
+ * Extract a user ID.
+ */
+export const getNoteUserId = (
+  user = {}
+) => {
+  if (
+    typeof user !== "object" ||
+    user === null
+  ) {
+    return normalizeNoteId(user);
+  }
+
+  return normalizeNoteId(
+    user.id ??
+      user.userId ??
+      user.user_id ??
+      user.participantId
+  );
+};
+
+/**
+ * Create a new private event note.
+ */
+export const createEventNote = ({
+  eventId,
+  userId,
+  title = "",
+  content = "",
+} = {}) => {
+  const now =
+    new Date().toISOString();
+
+  return {
+    id: generateEventNoteId(),
+    eventId: normalizeNoteId(
+      eventId
+    ),
+    userId: normalizeNoteId(
+      userId
+    ),
+    title: String(title).trim(),
+    content: String(content).trim(),
+    createdAt: now,
+    updatedAt: now,
+    private: true,
+  };
+};
+
+/**
+ * Validate note title and content.
+ */
+export const validateEventNote = ({
+  title = "",
+  content = "",
+} = {}) => {
+  const errors = [];
+
+  const normalizedTitle =
+    String(title).trim();
+
+  const normalizedContent =
+    String(content).trim();
+
+  if (!normalizedContent) {
+    errors.push(
+      "Note content cannot be empty."
+    );
+  }
+
+  if (
+    normalizedTitle.length >
+    MAX_NOTE_TITLE_LENGTH
+  ) {
+    errors.push(
+      `Note title cannot exceed ${MAX_NOTE_TITLE_LENGTH} characters.`
+    );
+  }
+
+  if (
+    normalizedContent.length >
+    MAX_NOTE_CONTENT_LENGTH
+  ) {
+    errors.push(
+      `Note content cannot exceed ${MAX_NOTE_CONTENT_LENGTH} characters.`
+    );
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+};
+
+/**
+ * Check whether a note belongs to
+ * a specific event and user.
+ */
+export const noteBelongsToUserEvent = (
+  note,
+  eventId,
+  userId
+) => {
+  if (!note) {
+    return false;
+  }
+
+  return (
+    normalizeNoteId(
+      note.eventId
+    ) === normalizeNoteId(eventId) &&
+    normalizeNoteId(
+      note.userId
+    ) === normalizeNoteId(userId)
+  );
+};
+
+/**
+ * Get notes belonging to a specific
+ * event and user.
+ *
+ * includeAll is useful internally when
+ * updating the complete notes collection.
+ */
+export const getEventNotes = ({
+  notes = [],
+  eventId,
+  userId,
+  includeAll = false,
+} = {}) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  if (includeAll) {
+    return [...notes];
+  }
+
+  const normalizedEventId =
+    normalizeNoteId(eventId);
+
+  const normalizedUserId =
+    normalizeNoteId(userId);
+
+  if (
+    !normalizedEventId ||
+    !normalizedUserId
+  ) {
+    return [];
+  }
+
+  return notes.filter((note) =>
+    noteBelongsToUserEvent(
+      note,
+      normalizedEventId,
+      normalizedUserId
+    )
+  );
+};
+
+/**
+ * Find one note by ID.
+ */
+export const findEventNote = (
+  notes = [],
+  noteId
+) => {
+  if (!Array.isArray(notes)) {
+    return null;
+  }
+
+  const normalizedId =
+    normalizeNoteId(noteId);
+
+  return (
+    notes.find(
+      (note) =>
+        normalizeNoteId(
+          note.id
+        ) === normalizedId
+    ) || null
+  );
+};
+
+/**
+ * Add a note to a notes collection.
+ */
+export const addEventNote = (
+  notes = [],
+  note
+) => {
+  if (!note) {
+    return Array.isArray(notes)
+      ? [...notes]
+      : [];
+  }
+
+  return [
+    ...(Array.isArray(notes)
+      ? notes
+      : []),
+    note,
+  ];
+};
+
+/**
+ * Update an existing note.
+ */
+export const updateEventNote = (
+  notes = [],
+  noteId,
+  updates = {}
+) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  const normalizedId =
+    normalizeNoteId(noteId);
+
+  const title =
+    updates.title !== undefined
+      ? String(
+          updates.title
+        ).trim()
+      : undefined;
+
+  const content =
+    updates.content !==
+    undefined
+      ? String(
+          updates.content
+        ).trim()
+      : undefined;
+
+  const validation =
+    validateEventNote({
+      title:
+        title !== undefined
+          ? title
+          : findEventNote(
+              notes,
+              noteId
+            )?.title || "",
+      content:
+        content !== undefined
+          ? content
+          : findEventNote(
+              notes,
+              noteId
+            )?.content || "",
+    });
+
+  if (!validation.valid) {
+    return [...notes];
+  }
+
+  return notes.map((note) => {
+    if (
+      normalizeNoteId(
+        note.id
+      ) !== normalizedId
+    ) {
+      return note;
+    }
+
+    return {
+      ...note,
+      ...(title !== undefined
+        ? { title }
+        : {}),
+      ...(content !== undefined
+        ? { content }
+        : {}),
+      updatedAt:
+        new Date().toISOString(),
+      private: true,
+    };
+  });
+};
+
+/**
+ * Delete a note by ID.
+ */
+export const deleteEventNote = (
+  notes = [],
+  noteId
+) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  const normalizedId =
+    normalizeNoteId(noteId);
+
+  return notes.filter(
+    (note) =>
+      normalizeNoteId(
+        note.id
+      ) !== normalizedId
+  );
+};
+
+/**
+ * Delete all notes belonging to
+ * a specific event and user.
+ */
+export const deleteEventNotesForEvent = (
+  notes = [],
+  eventId,
+  userId
+) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  return notes.filter(
+    (note) =>
+      !noteBelongsToUserEvent(
+        note,
+        eventId,
+        userId
+      )
+  );
+};
+
+/**
+ * Sort notes by most recently updated.
+ */
+export const sortEventNotes = (
+  notes = [],
+  order = "desc"
+) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  return [...notes].sort(
+    (first, second) => {
+      const firstDate =
+        new Date(
+          first.updatedAt ||
+            first.createdAt ||
+            0
+        ).getTime();
+
+      const secondDate =
+        new Date(
+          second.updatedAt ||
+            second.createdAt ||
+            0
+        ).getTime();
+
+      return order === "asc"
+        ? firstDate - secondDate
+        : secondDate - firstDate;
+    }
+  );
+};
+
+/**
+ * Get the most recently updated notes.
+ */
+export const getRecentEventNotes = (
+  notes = [],
+  limit = 5
+) => {
+  const sorted =
+    sortEventNotes(
+      notes,
+      "desc"
+    );
+
+  return sorted.slice(
+    0,
+    Math.max(0, limit)
+  );
+};
+
+/**
+ * Get notes for a particular event,
+ * sorted by latest update.
+ */
+export const getSortedEventNotes = ({
+  notes = [],
+  eventId,
+  userId,
+  order = "desc",
+} = {}) => {
+  return sortEventNotes(
+    getEventNotes({
+      notes,
+      eventId,
+      userId,
+    }),
+    order
+  );
+};
+
+/**
+ * Count notes belonging to an event.
+ */
+export const getEventNoteCount = ({
+  notes = [],
+  eventId,
+  userId,
+} = {}) => {
+  return getEventNotes({
+    notes,
+    eventId,
+    userId,
+  }).length;
+};
+
+/**
+ * Check whether a user has notes for
+ * a particular event.
+ */
+export const hasEventNotes = ({
+  notes = [],
+  eventId,
+  userId,
+} = {}) => {
+  return (
+    getEventNoteCount({
+      notes,
+      eventId,
+      userId,
+    }) > 0
+  );
+};
+
+/**
+ * Get note completion-style metadata.
+ */
+export const getEventNotesSummary = ({
+  notes = [],
+  eventId,
+  userId,
+} = {}) => {
+  const eventNotes =
+    getEventNotes({
+      notes,
+      eventId,
+      userId,
+    });
+
+  return {
+    total:
+      eventNotes.length,
+    hasNotes:
+      eventNotes.length > 0,
+    latestNote:
+      sortEventNotes(
+        eventNotes,
+        "desc"
+      )[0] || null,
+  };
+};
+
+/**
+ * Sanitize note text.
+ *
+ * Removes control characters while preserving
+ * normal whitespace and line breaks.
+ */
+export const sanitizeNoteText = (
+  value = ""
+) => {
+  return String(value)
+    .replace(
+      /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g,
+      ""
+    )
+    .trim();
+};
+
+/**
+ * Normalize a note before persistence.
+ */
+export const normalizeEventNote = (
+  note = {}
+) => {
+  const normalized = {
+    ...note,
+    id:
+      normalizeNoteId(
+        note.id
+      ) ||
+      generateEventNoteId(),
+    eventId:
+      normalizeNoteId(
+        note.eventId
+      ),
+    userId:
+      normalizeNoteId(
+        note.userId
+      ),
+    title:
+      sanitizeNoteText(
+        note.title || ""
+      ).slice(
+        0,
+        MAX_NOTE_TITLE_LENGTH
+      ),
+    content:
+      sanitizeNoteText(
+        note.content || ""
+      ).slice(
+        0,
+        MAX_NOTE_CONTENT_LENGTH
+      ),
+    private: true,
+  };
+
+  if (!normalized.createdAt) {
+    normalized.createdAt =
+      new Date().toISOString();
+  }
+
+  normalized.updatedAt =
+    normalized.updatedAt ||
+    normalized.createdAt;
+
+  return normalized;
+};
+
+/**
+ * Normalize an entire notes collection.
+ */
+export const normalizeEventNotes = (
+  notes = []
+) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  return notes
+    .map(normalizeEventNote)
+    .filter(
+      (note) =>
+        Boolean(
+          note.eventId &&
+            note.userId &&
+            note.content
+        )
+    );
+};
+
+/**
+ * Remove duplicate note IDs.
+ */
+export const removeDuplicateNotes = (
+  notes = []
+) => {
+  if (!Array.isArray(notes)) {
+    return [];
+  }
+
+  const seen = new Set();
+
+  return notes.filter((note) => {
+    const id =
+      normalizeNoteId(note.id);
+
+    if (!id) {
+      return true;
+    }
+
+    if (seen.has(id)) {
+      return false;
+    }
+
+    seen.add(id);
+
+    return true;
+  });
+};
+
+/**
+ * Prepare notes for localStorage/API
+ * persistence.
+ */
+export const serializeEventNotes = (
+  notes = []
+) => {
+  return JSON.stringify(
+    normalizeEventNotes(
+      notes
+    )
+  );
+};
+
+/**
+ * Restore notes from serialized data.
+ */
+export const deserializeEventNotes = (
+  value
+) => {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed =
+      typeof value === "string"
+        ? JSON.parse(value)
+        : value;
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return normalizeEventNotes(
+      parsed
+    );
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Save notes to localStorage.
+ *
+ * Returns false when localStorage is
+ * unavailable.
+ */
+export const saveEventNotesToStorage = (
+  storageKey,
+  notes = []
+) => {
+  if (
+    typeof window === "undefined" ||
+    !window.localStorage ||
+    !storageKey
+  ) {
+    return false;
+  }
+
+  try {
+    window.localStorage.setItem(
+      storageKey,
+      serializeEventNotes(
+        notes
+      )
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Load notes from localStorage.
+ */
+export const loadEventNotesFromStorage = (
+  storageKey
+) => {
+  if (
+    typeof window === "undefined" ||
+    !window.localStorage ||
+    !storageKey
+  ) {
+    return [];
+  }
+
+  try {
+    const stored =
+      window.localStorage.getItem(
+        storageKey
+      );
+
+    return deserializeEventNotes(
+      stored
+    );
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Create a storage key for a user's
+ * event notes.
+ */
+export const getEventNotesStorageKey = (
+  userId
+) => {
+  const normalizedUserId =
+    normalizeNoteId(
+      userId
+    );
+
+  if (!normalizedUserId) {
+    return null;
+  }
+
+  return `eventra:event-notes:${normalizedUserId}`;
+};
+
+/**
+ * Create a filtered storage key for
+ * one event.
+ */
+export const getSingleEventNotesStorageKey = (
+  userId,
+  eventId
+) => {
+  const normalizedUserId =
+    normalizeNoteId(
+      userId
+    );
+
+  const normalizedEventId =
+    normalizeNoteId(
+      eventId
+    );
+
+  if (
+    !normalizedUserId ||
+    !normalizedEventId
+  ) {
+    return null;
+  }
+
+  return `eventra:event-notes:${normalizedUserId}:${normalizedEventId}`;
+};
+
+/**
+ * Get note statistics.
+ */
+export const getNoteStatistics = (
+  notes = []
+) => {
+  const normalized =
+    normalizeEventNotes(
+      notes
+    );
+
+  const total =
+    normalized.length;
+
+  const withTitles =
+    normalized.filter(
+      (note) =>
+        Boolean(note.title)
+    ).length;
+
+  const totalCharacters =
+    normalized.reduce(
+      (totalLength, note) =>
+        totalLength +
+        note.content.length,
+      0
+    );
+
+  return {
+    total,
+    withTitles,
+    withoutTitles:
+      total - withTitles,
+    totalCharacters,
+    averageCharacters:
+      total > 0
+        ? Math.round(
+            totalCharacters /
+              total
+          )
+        : 0,
+  };
+};


### PR DESCRIPTION
## Description

Implemented private event notes for participants.

### Added

- Add private event notes
- Edit existing notes
- Delete notes
- Personal note titles
- Preparation tasks and reminders
- Important links and questions
- Character limits
- Note validation
- Created and updated timestamps
- Private note indicators
- Empty state
- Note sorting and filtering
- Optional localStorage persistence
- Note sanitization

Closes #12645