### PR TITLE
feat(search): add recent event search history

### DIFF
--- a/src/components/events/RecentEventSearches.js
+++ b/src/components/events/RecentEventSearches.js
@@ -1,0 +1,253 @@
+import {
+  Clock3,
+  History,
+  Search,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+import {
+  clearRecentSearchHistory,
+  deleteRecentSearchFromStorage,
+  getRecentSearches,
+  loadRecentSearchesFromStorage,
+  saveRecentSearch,
+} from "../../utils/recentEventSearchUtils";
+
+import RecentSearchItem from "./RecentSearchItem";
+
+const RecentEventSearches = ({
+  userId,
+  onSearchSelect,
+  storageKey,
+  maxSearches = 10,
+  searchPath = "/events/search",
+  className = "",
+}) => {
+  const [searches, setSearches] =
+    useState([]);
+
+  const [isVisible, setIsVisible] =
+    useState(true);
+
+  const resolvedStorageKey =
+    storageKey ||
+    `eventra:recent-event-searches${
+      userId
+        ? `:${userId}`
+        : ""
+    }`;
+
+  useEffect(() => {
+    const stored =
+      loadRecentSearchesFromStorage({
+        storageKey:
+          resolvedStorageKey,
+        maxSearches,
+      });
+
+    setSearches(
+      getRecentSearches(
+        stored,
+        maxSearches
+      )
+    );
+  }, [
+    resolvedStorageKey,
+    maxSearches,
+  ]);
+
+  const handleSearchSelect = (
+    search
+  ) => {
+    const query =
+      search?.query || "";
+
+    if (!query) {
+      return;
+    }
+
+    // Update the selected search so it
+    // becomes the most recent query.
+    const result =
+      saveRecentSearch(
+        query,
+        {
+          storageKey:
+            resolvedStorageKey,
+          maxSearches,
+        }
+      );
+
+    setSearches(
+      getRecentSearches(
+        result.searches,
+        maxSearches
+      )
+    );
+
+    if (onSearchSelect) {
+      onSearchSelect(
+        query,
+        search
+      );
+      return;
+    }
+
+    // Fallback navigation when no callback
+    // is supplied.
+    if (
+      typeof window !==
+        "undefined"
+    ) {
+      const params =
+        new URLSearchParams();
+
+      params.set(
+        "q",
+        query
+      );
+
+      if (searchPath) {
+        window.location.href = `${searchPath}?${params.toString()}`;
+      }
+    }
+  };
+
+  const handleDelete = (
+    search
+  ) => {
+    if (!search?.id) {
+      return;
+    }
+
+    const result =
+      deleteRecentSearchFromStorage(
+        search.id,
+        {
+          storageKey:
+            resolvedStorageKey,
+          maxSearches,
+        }
+      );
+
+    setSearches(
+      getRecentSearches(
+        result.searches,
+        maxSearches
+      )
+    );
+  };
+
+  const handleClear = () => {
+    const result =
+      clearRecentSearchHistory({
+        storageKey:
+          resolvedStorageKey,
+      });
+
+    if (result.cleared) {
+      setSearches([]);
+    }
+  };
+
+  if (
+    !searches.length ||
+    !isVisible
+  ) {
+    return null;
+  }
+
+  return (
+    <section
+      className={`w-full rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+      aria-label="Recent event searches"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-slate-700">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+            <History
+              size={17}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="truncate text-sm font-bold text-slate-800 dark:text-white">
+                Recent Searches
+              </h2>
+
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                {searches.length}
+              </span>
+            </div>
+
+            <p className="mt-0.5 text-[11px] text-slate-400">
+              Reuse a previous event search
+            </p>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={handleClear}
+            className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-2 text-xs font-medium text-slate-500 transition hover:bg-red-50 hover:text-red-600 dark:text-slate-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+            aria-label="Clear search history"
+          >
+            <Trash2 size={14} />
+            <span className="hidden sm:inline">
+              Clear
+            </span>
+          </button>
+
+          <button
+            type="button"
+            onClick={() =>
+              setIsVisible(false)
+            }
+            className="rounded-lg p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            aria-label="Hide recent searches"
+          >
+            <X size={15} />
+          </button>
+        </div>
+      </div>
+
+      {/* Search history */}
+      <div className="p-3">
+        <div className="space-y-1">
+          {searches.map(
+            (search) => (
+              <RecentSearchItem
+                key={search.id}
+                search={search}
+                onSelect={
+                  handleSearchSelect
+                }
+                onDelete={
+                  handleDelete
+                }
+              />
+            )
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center gap-2 border-t border-slate-100 px-4 py-3 text-[11px] text-slate-400 dark:border-slate-800">
+        <Clock3 size={13} />
+
+        <span>
+          Your recent event searches are stored
+          locally on this device.
+        </span>
+      </div>
+    </section>
+  );
+};
+
+export default RecentEventSearches;

--- a/src/components/events/RecentSearchItem.js
+++ b/src/components/events/RecentSearchItem.js
@@ -1,0 +1,88 @@
+import {
+  Clock3,
+  Search,
+  Trash2,
+} from "lucide-react";
+
+import {
+  getSearchTimeLabel,
+} from "../../utils/recentEventSearchUtils";
+
+const RecentSearchItem = ({
+  search = {},
+  onSelect,
+  onDelete,
+}) => {
+  const query =
+    search.query || "";
+
+  const timeLabel =
+    getSearchTimeLabel(
+      search.searchedAt ||
+        search.createdAt
+    );
+
+  const handleSelect = () => {
+    if (!query) {
+      return;
+    }
+
+    onSelect?.(search);
+  };
+
+  const handleDelete = (
+    event
+  ) => {
+    event.stopPropagation();
+    onDelete?.(search);
+  };
+
+  if (!query) {
+    return null;
+  }
+
+  return (
+    <div className="group flex items-center gap-2 rounded-xl px-3 py-2.5 transition hover:bg-slate-50 dark:hover:bg-slate-800/70">
+      {/* Reuse search */}
+      <button
+        type="button"
+        onClick={handleSelect}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+        aria-label={`Reuse search: ${query}`}
+      >
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
+          <Search
+            size={16}
+            className="text-slate-500 dark:text-slate-400"
+          />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-slate-700 dark:text-slate-200">
+            {query}
+          </p>
+
+          {timeLabel && (
+            <span className="mt-0.5 inline-flex items-center gap-1 text-[11px] text-slate-400">
+              <Clock3 size={11} />
+              {timeLabel}
+            </span>
+          )}
+        </div>
+      </button>
+
+      {/* Delete */}
+      <button
+        type="button"
+        onClick={handleDelete}
+        className="shrink-0 rounded-lg p-2 text-slate-400 opacity-70 transition hover:bg-red-50 hover:text-red-600 group-hover:opacity-100 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+        aria-label={`Delete recent search: ${query}`}
+        title="Delete search"
+      >
+        <Trash2 size={15} />
+      </button>
+    </div>
+  );
+};
+
+export default RecentSearchItem;

--- a/src/utils/recentEventSearchUtils.js
+++ b/src/utils/recentEventSearchUtils.js
@@ -1,0 +1,1000 @@
+/**
+ * Utilities for managing recent event searches.
+ *
+ * Features:
+ * - Save recent search queries
+ * - Retrieve search history
+ * - Reuse previous searches
+ * - Delete individual searches
+ * - Clear search history
+ * - Remove duplicate queries
+ * - Limit history size
+ * - Optional localStorage persistence
+ */
+
+export const DEFAULT_MAX_RECENT_SEARCHES = 10;
+
+export const DEFAULT_STORAGE_KEY =
+  "eventra:recent-event-searches";
+
+/**
+ * Normalize a search query.
+ */
+export const normalizeSearchQuery = (
+  query
+) => {
+  if (
+    query === null ||
+    query === undefined
+  ) {
+    return "";
+  }
+
+  return String(query)
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+/**
+ * Check whether a query is valid.
+ */
+export const isValidSearchQuery = (
+  query
+) => {
+  return (
+    normalizeSearchQuery(query)
+      .length > 0
+  );
+};
+
+/**
+ * Create a unique ID for a search entry.
+ */
+export const generateSearchId = () => {
+  return `search-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
+};
+
+/**
+ * Create a recent search object.
+ */
+export const createRecentSearch = (
+  query,
+  metadata = {}
+) => {
+  const normalizedQuery =
+    normalizeSearchQuery(query);
+
+  if (!normalizedQuery) {
+    return null;
+  }
+
+  const now =
+    new Date().toISOString();
+
+  return {
+    id: generateSearchId(),
+    query: normalizedQuery,
+    searchedAt: now,
+    ...metadata,
+  };
+};
+
+/**
+ * Compare two queries case-insensitively.
+ */
+export const searchQueriesMatch = (
+  firstQuery,
+  secondQuery
+) => {
+  const first =
+    normalizeSearchQuery(
+      firstQuery
+    ).toLowerCase();
+
+  const second =
+    normalizeSearchQuery(
+      secondQuery
+    ).toLowerCase();
+
+  return (
+    Boolean(first) &&
+    Boolean(second) &&
+    first === second
+  );
+};
+
+/**
+ * Remove duplicate search entries.
+ *
+ * The newest occurrence is preserved.
+ */
+export const removeDuplicateSearches = (
+  searches = []
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  const seen = new Set();
+  const result = [];
+
+  for (
+    let index = searches.length - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const search =
+      searches[index];
+
+    const query =
+      normalizeSearchQuery(
+        search?.query
+      );
+
+    if (!query) {
+      continue;
+    }
+
+    const key =
+      query.toLowerCase();
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+
+    result.unshift({
+      ...search,
+      query,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Limit the number of stored searches.
+ */
+export const limitRecentSearches = (
+  searches = [],
+  maxSearches = DEFAULT_MAX_RECENT_SEARCHES
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  const limit = Math.max(
+    0,
+    Number(maxSearches) ||
+      DEFAULT_MAX_RECENT_SEARCHES
+  );
+
+  return searches.slice(
+    -limit
+  );
+};
+
+/**
+ * Sort searches from newest to oldest.
+ */
+export const sortRecentSearches = (
+  searches = []
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  return [...searches].sort(
+    (first, second) => {
+      const firstTime =
+        new Date(
+          first?.searchedAt ||
+            first?.createdAt ||
+            0
+        ).getTime();
+
+      const secondTime =
+        new Date(
+          second?.searchedAt ||
+            second?.createdAt ||
+            0
+        ).getTime();
+
+      return secondTime - firstTime;
+    }
+  );
+};
+
+/**
+ * Normalize a complete search history.
+ */
+export const normalizeRecentSearches = (
+  searches = [],
+  maxSearches = DEFAULT_MAX_RECENT_SEARCHES
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  const normalized =
+    searches
+      .map((search) => {
+        if (
+          typeof search ===
+          "string"
+        ) {
+          return createRecentSearch(
+            search
+          );
+        }
+
+        if (
+          !search ||
+          typeof search !==
+            "object"
+        ) {
+          return null;
+        }
+
+        const query =
+          normalizeSearchQuery(
+            search.query
+          );
+
+        if (!query) {
+          return null;
+        }
+
+        return {
+          ...search,
+          id:
+            search.id ||
+            generateSearchId(),
+          query,
+          searchedAt:
+            search.searchedAt ||
+            search.createdAt ||
+            new Date().toISOString(),
+        };
+      })
+      .filter(Boolean);
+
+  const unique =
+    removeDuplicateSearches(
+      normalized
+    );
+
+  return limitRecentSearches(
+    sortRecentSearches(
+      unique
+    ),
+    maxSearches
+  );
+};
+
+/**
+ * Add a query to recent searches.
+ *
+ * If the query already exists, it is moved
+ * to the top rather than duplicated.
+ */
+export const addRecentSearch = (
+  searches = [],
+  query,
+  options = {}
+) => {
+  const {
+    maxSearches =
+      DEFAULT_MAX_RECENT_SEARCHES,
+    metadata = {},
+  } = options;
+
+  const normalizedQuery =
+    normalizeSearchQuery(query);
+
+  if (!normalizedQuery) {
+    return normalizeRecentSearches(
+      searches,
+      maxSearches
+    );
+  }
+
+  const existing =
+    Array.isArray(searches)
+      ? searches.find((search) =>
+          searchQueriesMatch(
+            search?.query,
+            normalizedQuery
+          )
+        )
+      : null;
+
+  const newSearch =
+    createRecentSearch(
+      normalizedQuery,
+      {
+        ...metadata,
+        ...(existing || {}),
+        id:
+          existing?.id ||
+          generateSearchId(),
+        searchedAt:
+          new Date().toISOString(),
+      }
+    );
+
+  const remaining =
+    Array.isArray(searches)
+      ? searches.filter(
+          (search) =>
+            !searchQueriesMatch(
+              search?.query,
+              normalizedQuery
+            )
+        )
+      : [];
+
+  return limitRecentSearches(
+    [newSearch, ...remaining],
+    maxSearches
+  );
+};
+
+/**
+ * Find a recent search by ID.
+ */
+export const findRecentSearch = (
+  searches = [],
+  searchId
+) => {
+  if (!Array.isArray(searches)) {
+    return null;
+  }
+
+  return (
+    searches.find(
+      (search) =>
+        String(search?.id) ===
+        String(searchId)
+    ) || null
+  );
+};
+
+/**
+ * Find a recent search by query.
+ */
+export const findRecentSearchByQuery = (
+  searches = [],
+  query
+) => {
+  if (!Array.isArray(searches)) {
+    return null;
+  }
+
+  return (
+    searches.find((search) =>
+      searchQueriesMatch(
+        search?.query,
+        query
+      )
+    ) || null
+  );
+};
+
+/**
+ * Delete one search by ID.
+ */
+export const deleteRecentSearch = (
+  searches = [],
+  searchId
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  return searches.filter(
+    (search) =>
+      String(search?.id) !==
+      String(searchId)
+  );
+};
+
+/**
+ * Delete a search by query.
+ */
+export const deleteRecentSearchByQuery = (
+  searches = [],
+  query
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  return searches.filter(
+    (search) =>
+      !searchQueriesMatch(
+        search?.query,
+        query
+      )
+  );
+};
+
+/**
+ * Clear all search history.
+ */
+export const clearRecentSearches = () => {
+  return [];
+};
+
+/**
+ * Check whether search history exists.
+ */
+export const hasRecentSearches = (
+  searches = []
+) => {
+  return (
+    Array.isArray(searches) &&
+    searches.length > 0
+  );
+};
+
+/**
+ * Get the number of recent searches.
+ */
+export const getRecentSearchCount = (
+  searches = []
+) => {
+  return Array.isArray(searches)
+    ? searches.length
+    : 0;
+};
+
+/**
+ * Get only the query strings.
+ */
+export const getRecentSearchQueries = (
+  searches = []
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  return searches
+    .map((search) =>
+      normalizeSearchQuery(
+        search?.query
+      )
+    )
+    .filter(Boolean);
+};
+
+/**
+ * Get recent searches matching a
+ * partial query.
+ */
+export const filterRecentSearches = (
+  searches = [],
+  query
+) => {
+  if (!Array.isArray(searches)) {
+    return [];
+  }
+
+  const normalizedQuery =
+    normalizeSearchQuery(
+      query
+    ).toLowerCase();
+
+  if (!normalizedQuery) {
+    return searches;
+  }
+
+  return searches.filter(
+    (search) =>
+      normalizeSearchQuery(
+        search?.query
+      )
+        .toLowerCase()
+        .includes(normalizedQuery)
+  );
+};
+
+/**
+ * Get the most recent searches.
+ */
+export const getRecentSearches = (
+  searches = [],
+  limit = DEFAULT_MAX_RECENT_SEARCHES
+) => {
+  return limitRecentSearches(
+    sortRecentSearches(
+      normalizeRecentSearches(
+        searches,
+        Number.MAX_SAFE_INTEGER
+      )
+    ),
+    limit
+  );
+};
+
+/**
+ * Create a storage key for a user.
+ */
+export const getUserSearchStorageKey = (
+  userId,
+  baseKey = DEFAULT_STORAGE_KEY
+) => {
+  if (
+    userId === null ||
+    userId === undefined ||
+    String(userId).trim() === ""
+  ) {
+    return baseKey;
+  }
+
+  return `${baseKey}:${String(
+    userId
+  ).trim()}`;
+};
+
+/**
+ * Save recent searches to localStorage.
+ */
+export const saveRecentSearchesToStorage = (
+  searches = [],
+  options = {}
+) => {
+  if (
+    typeof window ===
+      "undefined" ||
+    !window.localStorage
+  ) {
+    return false;
+  }
+
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+    maxSearches =
+      DEFAULT_MAX_RECENT_SEARCHES,
+  } = options;
+
+  try {
+    const normalized =
+      normalizeRecentSearches(
+        searches,
+        maxSearches
+      );
+
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify(
+        normalized
+      )
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Load recent searches from localStorage.
+ */
+export const loadRecentSearchesFromStorage = (
+  options = {}
+) => {
+  if (
+    typeof window ===
+      "undefined" ||
+    !window.localStorage
+  ) {
+    return [];
+  }
+
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+    maxSearches =
+      DEFAULT_MAX_RECENT_SEARCHES,
+  } = options;
+
+  try {
+    const stored =
+      window.localStorage.getItem(
+        storageKey
+      );
+
+    if (!stored) {
+      return [];
+    }
+
+    const parsed =
+      JSON.parse(stored);
+
+    return normalizeRecentSearches(
+      parsed,
+      maxSearches
+    );
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Remove recent search history from
+ * localStorage.
+ */
+export const clearRecentSearchesFromStorage = (
+  options = {}
+) => {
+  if (
+    typeof window ===
+      "undefined" ||
+    !window.localStorage
+  ) {
+    return false;
+  }
+
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+  } = options;
+
+  try {
+    window.localStorage.removeItem(
+      storageKey
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Save a single query directly to
+ * localStorage.
+ */
+export const saveRecentSearch = (
+  query,
+  options = {}
+) => {
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+    maxSearches =
+      DEFAULT_MAX_RECENT_SEARCHES,
+    metadata = {},
+  } = options;
+
+  const existing =
+    loadRecentSearchesFromStorage({
+      storageKey,
+      maxSearches,
+    });
+
+  const updated =
+    addRecentSearch(
+      existing,
+      query,
+      {
+        maxSearches,
+        metadata,
+      }
+    );
+
+  const saved =
+    saveRecentSearchesToStorage(
+      updated,
+      {
+        storageKey,
+        maxSearches,
+      }
+    );
+
+  return {
+    saved,
+    searches: updated,
+  };
+};
+
+/**
+ * Delete one search directly from
+ * localStorage.
+ */
+export const deleteRecentSearchFromStorage = (
+  searchId,
+  options = {}
+) => {
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+    maxSearches =
+      DEFAULT_MAX_RECENT_SEARCHES,
+  } = options;
+
+  const searches =
+    loadRecentSearchesFromStorage({
+      storageKey,
+      maxSearches,
+    });
+
+  const updated =
+    deleteRecentSearch(
+      searches,
+      searchId
+    );
+
+  const saved =
+    saveRecentSearchesToStorage(
+      updated,
+      {
+        storageKey,
+        maxSearches,
+      }
+    );
+
+  return {
+    saved,
+    searches: updated,
+  };
+};
+
+/**
+ * Delete a query directly from
+ * localStorage.
+ */
+export const deleteRecentSearchQueryFromStorage = (
+  query,
+  options = {}
+) => {
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+    maxSearches =
+      DEFAULT_MAX_RECENT_SEARCHES,
+  } = options;
+
+  const searches =
+    loadRecentSearchesFromStorage({
+      storageKey,
+      maxSearches,
+    });
+
+  const updated =
+    deleteRecentSearchByQuery(
+      searches,
+      query
+    );
+
+  const saved =
+    saveRecentSearchesToStorage(
+      updated,
+      {
+        storageKey,
+        maxSearches,
+      }
+    );
+
+  return {
+    saved,
+    searches: updated,
+  };
+};
+
+/**
+ * Clear recent searches directly from
+ * localStorage.
+ */
+export const clearRecentSearchHistory = (
+  options = {}
+) => {
+  const {
+    storageKey =
+      DEFAULT_STORAGE_KEY,
+  } = options;
+
+  const cleared =
+    clearRecentSearchesFromStorage({
+      storageKey,
+    });
+
+  return {
+    cleared,
+    searches: [],
+  };
+};
+
+/**
+ * Build a search URL from a previous query.
+ */
+export const buildSearchUrl = (
+  query,
+  options = {}
+) => {
+  const {
+    searchPath = "/events/search",
+    parameter = "q",
+    additionalParams = {},
+  } = options;
+
+  const normalizedQuery =
+    normalizeSearchQuery(query);
+
+  if (!normalizedQuery) {
+    return searchPath;
+  }
+
+  const params =
+    new URLSearchParams();
+
+  params.set(
+    parameter,
+    normalizedQuery
+  );
+
+  Object.entries(
+    additionalParams
+  ).forEach(
+    ([key, value]) => {
+      if (
+        value !== null &&
+        value !== undefined &&
+        value !== ""
+      ) {
+        params.set(
+          key,
+          String(value)
+        );
+      }
+    }
+  );
+
+  return `${searchPath}?${params.toString()}`;
+};
+
+/**
+ * Reuse a previous search by returning
+ * its query and optional navigation URL.
+ */
+export const reuseRecentSearch = (
+  search,
+  options = {}
+) => {
+  if (!search) {
+    return null;
+  }
+
+  const query =
+    normalizeSearchQuery(
+      typeof search === "string"
+        ? search
+        : search.query
+    );
+
+  if (!query) {
+    return null;
+  }
+
+  return {
+    query,
+    url: buildSearchUrl(
+      query,
+      options
+    ),
+    search:
+      typeof search === "object"
+        ? search
+        : null,
+  };
+};
+
+/**
+ * Get a display-friendly relative time.
+ */
+export const getSearchTimeLabel = (
+  searchedAt,
+  now = new Date()
+) => {
+  if (!searchedAt) {
+    return "";
+  }
+
+  const searchDate =
+    new Date(searchedAt);
+
+  if (
+    Number.isNaN(
+      searchDate.getTime()
+    )
+  ) {
+    return "";
+  }
+
+  const currentDate =
+    now instanceof Date
+      ? now
+      : new Date(now);
+
+  const difference =
+    Math.max(
+      0,
+      currentDate.getTime() -
+        searchDate.getTime()
+    );
+
+  const minutes = Math.floor(
+    difference / 60000
+  );
+
+  if (minutes < 1) {
+    return "Just now";
+  }
+
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.floor(
+    minutes / 60
+  );
+
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  const days = Math.floor(
+    hours / 24
+  );
+
+  if (days < 7) {
+    return `${days}d ago`;
+  }
+
+  return new Intl.DateTimeFormat(
+    undefined,
+    {
+      dateStyle: "medium",
+    }
+  ).format(searchDate);
+};
+
+/**
+ * Get search history statistics.
+ */
+export const getSearchHistoryStats = (
+  searches = []
+) => {
+  const normalized =
+    normalizeRecentSearches(
+      searches,
+      Number.MAX_SAFE_INTEGER
+    );
+
+  const queries =
+    getRecentSearchQueries(
+      normalized
+    );
+
+  return {
+    total:
+      normalized.length,
+    unique:
+      new Set(
+        queries.map((query) =>
+          query.toLowerCase()
+        )
+      ).size,
+    latest:
+      normalized[0] || null,
+    oldest:
+      normalized[
+        normalized.length - 1
+      ] || null,
+  };
+};


### PR DESCRIPTION
## Description

Implemented recent event search history to help users quickly reuse previous searches.

### Added

- Save recent event searches
- Display recent searches below the search bar
- Reuse previous search queries
- Delete individual searches
- Clear complete search history
- Duplicate query prevention
- Search history size limit
- Search timestamps
- LocalStorage persistence
- User-specific storage keys
- Search history statistics
- Empty-state handling

Closes #12646