### PR TITLE
feat(organizers): add event co-organizer management

### DIFF
--- a/src/components/events/CoOrganizerCard.js
+++ b/src/components/events/CoOrganizerCard.js
@@ -1,0 +1,469 @@
+import {
+  Check,
+  ChevronDown,
+  Clock3,
+  Mail,
+  ShieldCheck,
+  Trash2,
+  UserRound,
+  X,
+} from "lucide-react";
+import { useState } from "react";
+
+import {
+  CO_ORGANIZER_PERMISSION_CONFIG,
+  CO_ORGANIZER_STATUSES,
+  getCoOrganizerPermissionLabels,
+  getCoOrganizerStatusLabel,
+  normalizePermissions,
+} from "../../utils/eventCoOrganizerUtils";
+
+const CoOrganizerCard = ({
+  coOrganizer = {},
+  onPermissionsChange,
+  onRemove,
+}) => {
+  const [isPermissionsOpen, setIsPermissionsOpen] =
+    useState(false);
+
+  const permissions = normalizePermissions(
+    coOrganizer.permissions
+  );
+
+  const status =
+    coOrganizer.status ||
+    CO_ORGANIZER_STATUSES.PENDING;
+
+  const statusLabel =
+    getCoOrganizerStatusLabel(status);
+
+  const permissionLabels =
+    getCoOrganizerPermissionLabels(
+      permissions
+    );
+
+  const displayName =
+    coOrganizer.name ||
+    coOrganizer.email ||
+    "Co-Organizer";
+
+  const initials = getInitials(
+    coOrganizer.name ||
+      coOrganizer.email ||
+      "CO"
+  );
+
+  const handlePermissionToggle = (
+    permissionId
+  ) => {
+    const nextPermissions =
+      permissions.includes(permissionId)
+        ? permissions.filter(
+            (permission) =>
+              permission !== permissionId
+          )
+        : [
+            ...permissions,
+            permissionId,
+          ];
+
+    onPermissionsChange?.(
+      coOrganizer,
+      nextPermissions
+    );
+  };
+
+  const isActive =
+    status ===
+    CO_ORGANIZER_STATUSES.ACCEPTED;
+
+  const isPending =
+    status ===
+    CO_ORGANIZER_STATUSES.PENDING;
+
+  const isRemoved =
+    status ===
+    CO_ORGANIZER_STATUSES.REMOVED;
+
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-4 transition hover:border-indigo-200 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-indigo-800">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+        {/* Avatar */}
+        <div
+          className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-xl text-sm font-bold ${
+            isActive
+              ? "bg-indigo-100 text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400"
+              : "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+          }`}
+        >
+          {initials}
+        </div>
+
+        {/* Main content */}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="truncate text-sm font-bold text-slate-800 dark:text-white">
+              {displayName}
+            </h3>
+
+            <StatusBadge status={status} />
+          </div>
+
+          {coOrganizer.email && (
+            <a
+              href={`mailto:${coOrganizer.email}`}
+              className="mt-1 inline-flex max-w-full items-center gap-1.5 break-all text-xs text-slate-500 hover:text-indigo-600 dark:text-slate-400 dark:hover:text-indigo-400"
+            >
+              <Mail size={12} />
+              {coOrganizer.email}
+            </a>
+          )}
+
+          {/* Invitation information */}
+          <div className="mt-3 flex flex-wrap gap-3 text-[11px] text-slate-400">
+            {coOrganizer.invitedAt && (
+              <span className="inline-flex items-center gap-1">
+                <Clock3 size={11} />
+                Invited{" "}
+                {formatDate(
+                  coOrganizer.invitedAt
+                )}
+              </span>
+            )}
+
+            {coOrganizer.acceptedAt && (
+              <span className="inline-flex items-center gap-1 text-green-600 dark:text-green-400">
+                <Check size={11} />
+                Accepted{" "}
+                {formatDate(
+                  coOrganizer.acceptedAt
+                )}
+              </span>
+            )}
+
+            {coOrganizer.declinedAt && (
+              <span className="inline-flex items-center gap-1 text-red-500">
+                <X size={11} />
+                Declined{" "}
+                {formatDate(
+                  coOrganizer.declinedAt
+                )}
+              </span>
+            )}
+
+            {coOrganizer.removedAt && (
+              <span className="inline-flex items-center gap-1">
+                <Trash2 size={11} />
+                Removed{" "}
+                {formatDate(
+                  coOrganizer.removedAt
+                )}
+              </span>
+            )}
+          </div>
+
+          {/* Permissions summary */}
+          <div className="mt-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-1.5 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                <ShieldCheck
+                  size={14}
+                  className="text-indigo-500"
+                />
+                Permissions
+              </div>
+
+              {permissionLabels.length > 0 ? (
+                permissionLabels.map(
+                  (label) => (
+                    <span
+                      key={label}
+                      className="rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                    >
+                      {label}
+                    </span>
+                  )
+                )
+              ) : (
+                <span className="text-[11px] text-slate-400">
+                  No permissions assigned
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Permission editor */}
+          {isPermissionsOpen && (
+            <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/50">
+              <p className="text-xs font-semibold text-slate-700 dark:text-slate-200">
+                Manage Permissions
+              </p>
+
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {CO_ORGANIZER_PERMISSION_CONFIG.map(
+                  (permission) => {
+                    const selected =
+                      permissions.includes(
+                        permission.id
+                      );
+
+                    return (
+                      <button
+                        key={
+                          permission.id
+                        }
+                        type="button"
+                        disabled={
+                          isRemoved
+                        }
+                        onClick={() =>
+                          handlePermissionToggle(
+                            permission.id
+                          )
+                        }
+                        className={`flex items-start gap-3 rounded-xl border p-3 text-left transition ${
+                          selected
+                            ? "border-indigo-300 bg-indigo-50 dark:border-indigo-700 dark:bg-indigo-900/20"
+                            : "border-slate-200 bg-white hover:border-indigo-200 dark:border-slate-700 dark:bg-slate-900"
+                        } ${
+                          isRemoved
+                            ? "cursor-not-allowed opacity-50"
+                            : ""
+                        }`}
+                      >
+                        <span
+                          className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border ${
+                            selected
+                              ? "border-indigo-600 bg-indigo-600 text-white"
+                              : "border-slate-300 dark:border-slate-600"
+                          }`}
+                        >
+                          {selected && (
+                            <Check size={13} />
+                          )}
+                        </span>
+
+                        <span className="min-w-0">
+                          <span className="block text-xs font-semibold text-slate-800 dark:text-white">
+                            {
+                              permission.label
+                            }
+                          </span>
+
+                          <span className="mt-1 block text-[11px] leading-5 text-slate-400">
+                            {
+                              permission.description
+                            }
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  }
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex shrink-0 items-center gap-2 sm:flex-col">
+          {!isRemoved && (
+            <button
+              type="button"
+              onClick={() =>
+                setIsPermissionsOpen(
+                  (current) =>
+                    !current
+                )
+              }
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:border-indigo-300 hover:text-indigo-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-indigo-700 dark:hover:text-indigo-400"
+              aria-expanded={
+                isPermissionsOpen
+              }
+            >
+              <ShieldCheck
+                size={14}
+              />
+
+              <span className="hidden md:inline">
+                Permissions
+              </span>
+
+              <ChevronDown
+                size={13}
+                className={`transition-transform ${
+                  isPermissionsOpen
+                    ? "rotate-180"
+                    : ""
+                }`}
+              />
+            </button>
+          )}
+
+          {!isRemoved && (
+            <button
+              type="button"
+              onClick={() =>
+                onRemove?.(
+                  coOrganizer
+                )
+              }
+              className="inline-flex items-center gap-1.5 rounded-lg border border-red-200 px-3 py-2 text-xs font-semibold text-red-600 transition hover:bg-red-50 dark:border-red-900/50 dark:text-red-400 dark:hover:bg-red-900/20"
+              aria-label={`Remove ${displayName}`}
+            >
+              <Trash2 size={14} />
+
+              <span className="hidden md:inline">
+                Remove
+              </span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Pending notice */}
+      {isPending && (
+        <div className="mt-4 flex items-start gap-2 rounded-xl bg-amber-50 p-3 text-xs text-amber-700 dark:bg-amber-900/10 dark:text-amber-300">
+          <Clock3
+            size={14}
+            className="mt-0.5 shrink-0"
+          />
+
+          <p>
+            This invitation is waiting for the
+            participant to accept.
+          </p>
+        </div>
+      )}
+
+      {/* Removed notice */}
+      {isRemoved && (
+        <div className="mt-4 flex items-start gap-2 rounded-xl bg-slate-50 p-3 text-xs text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+          <X
+            size={14}
+            className="mt-0.5 shrink-0"
+          />
+
+          <p>
+            This co-organizer has been removed and no
+            longer has access to the event.
+          </p>
+        </div>
+      )}
+    </article>
+  );
+};
+
+/**
+ * Status badge.
+ */
+const StatusBadge = ({
+  status,
+}) => {
+  const config = {
+    [CO_ORGANIZER_STATUSES.PENDING]: {
+      label: "Pending",
+      className:
+        "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+      icon: Clock3,
+    },
+
+    [CO_ORGANIZER_STATUSES.ACCEPTED]: {
+      label: "Active",
+      className:
+        "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300",
+      icon: Check,
+    },
+
+    [CO_ORGANIZER_STATUSES.DECLINED]: {
+      label: "Declined",
+      className:
+        "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+      icon: X,
+    },
+
+    [CO_ORGANIZER_STATUSES.REMOVED]: {
+      label: "Removed",
+      className:
+        "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+      icon: Trash2,
+    },
+  };
+
+  const current =
+    config[status] ||
+    {
+      label: "Unknown",
+      className:
+        "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+      icon: UserRound,
+    };
+
+  const Icon = current.icon;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-semibold ${current.className}`}
+    >
+      <Icon size={10} />
+      {current.label}
+    </span>
+  );
+};
+
+/**
+ * Generate initials from a name/email.
+ */
+const getInitials = (
+  value
+) => {
+  const text = String(
+    value || ""
+  ).trim();
+
+  if (!text) {
+    return "CO";
+  }
+
+  const parts = text
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (parts.length >= 2) {
+    return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+  }
+
+  return text
+    .replace(
+      /[^a-zA-Z0-9]/g,
+      ""
+    )
+    .slice(0, 2)
+    .toUpperCase();
+};
+
+/**
+ * Format an ISO timestamp.
+ */
+const formatDate = (
+  value
+) => {
+  const date = new Date(value);
+
+  if (
+    Number.isNaN(
+      date.getTime()
+    )
+  ) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat(
+    undefined,
+    {
+      dateStyle: "medium",
+    }
+  ).format(date);
+};
+
+export default CoOrganizerCard;

--- a/src/components/events/EventCoOrganizers.js
+++ b/src/components/events/EventCoOrganizers.js
@@ -1,0 +1,650 @@
+import {
+  Check,
+  ChevronDown,
+  Mail,
+  Plus,
+  ShieldCheck,
+  Trash2,
+  Users,
+  X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  CO_ORGANIZER_PERMISSION_CONFIG,
+  CO_ORGANIZER_STATUSES,
+  addCoOrganizer,
+  createCoOrganizerActivity,
+  createCoOrganizerInvitation,
+  getActiveCoOrganizerCount,
+  getActiveCoOrganizers,
+  getCoOrganizerSummary,
+  normalizePermissions,
+  removeCoOrganizer,
+  updateCoOrganizerPermissions,
+  validateCoOrganizerInvitation,
+} from "../../utils/eventCoOrganizerUtils";
+
+import CoOrganizerCard from "./CoOrganizerCard";
+
+const EventCoOrganizers = ({
+  event = {},
+  user = {},
+  coOrganizers = [],
+  activities = [],
+  onChange,
+  onActivitiesChange,
+  className = "",
+}) => {
+  const [isInviteOpen, setIsInviteOpen] =
+    useState(false);
+
+  const [email, setEmail] =
+    useState("");
+
+  const [name, setName] =
+    useState("");
+
+  const [selectedPermissions, setSelectedPermissions] =
+    useState([]);
+
+  const [message, setMessage] =
+    useState("");
+
+  const [error, setError] =
+    useState("");
+
+  const [isSaving, setIsSaving] =
+    useState(false);
+
+  const eventId =
+    event.id ??
+    event.eventId ??
+    event.event_id;
+
+  const organizerId =
+    user.id ??
+    user.userId ??
+    user.user_id;
+
+  const summary = useMemo(
+    () =>
+      getCoOrganizerSummary(
+        coOrganizers
+      ),
+    [coOrganizers]
+  );
+
+  const activeCoOrganizers =
+    useMemo(
+      () =>
+        getActiveCoOrganizers(
+          coOrganizers
+        ),
+      [coOrganizers]
+    );
+
+  const togglePermission = (
+    permission
+  ) => {
+    setSelectedPermissions(
+      (current) => {
+        if (
+          current.includes(
+            permission
+          )
+        ) {
+          return current.filter(
+            (item) =>
+              item !== permission
+          );
+        }
+
+        return [
+          ...current,
+          permission,
+        ];
+      }
+    );
+  };
+
+  const resetInviteForm = () => {
+    setEmail("");
+    setName("");
+    setSelectedPermissions([]);
+    setMessage("");
+    setError("");
+  };
+
+  const handleInvite = async (
+    eventObject
+  ) => {
+    eventObject.preventDefault();
+
+    if (isSaving) {
+      return;
+    }
+
+    setError("");
+
+    const validation =
+      validateCoOrganizerInvitation({
+        eventId,
+        organizerId,
+        email,
+        permissions:
+          selectedPermissions,
+      });
+
+    if (!validation.valid) {
+      setError(
+        validation.errors.join(" ")
+      );
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const invitation =
+        createCoOrganizerInvitation({
+          eventId,
+          organizerId,
+          email,
+          name,
+          permissions:
+            selectedPermissions,
+          message,
+        });
+
+      const updatedCoOrganizers =
+        addCoOrganizer(
+          coOrganizers,
+          invitation
+        );
+
+      onChange?.(
+        updatedCoOrganizers
+      );
+
+      const activity =
+        createCoOrganizerActivity({
+          eventId,
+          actorId:
+            organizerId,
+          coOrganizerId:
+            invitation.id,
+          action:
+            "co-organizer-invited",
+          details: `Invited ${email} as a co-organizer.`,
+        });
+
+      onActivitiesChange?.([
+        ...activities,
+        activity,
+      ]);
+
+      resetInviteForm();
+      setIsInviteOpen(false);
+    } catch (inviteError) {
+      setError(
+        inviteError?.message ||
+          "Unable to create the co-organizer invitation."
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handlePermissionsChange = (
+    coOrganizer,
+    permissions
+  ) => {
+    const normalized =
+      normalizePermissions(
+        permissions
+      );
+
+    const updated =
+      updateCoOrganizerPermissions(
+        coOrganizers,
+        coOrganizer.id,
+        normalized
+      );
+
+    onChange?.(updated);
+
+    const activity =
+      createCoOrganizerActivity({
+        eventId,
+        actorId:
+          organizerId,
+        coOrganizerId:
+          coOrganizer.id,
+        action:
+          "permissions-updated",
+        details:
+          "Co-organizer permissions were updated.",
+      });
+
+    onActivitiesChange?.([
+      ...activities,
+      activity,
+    ]);
+  };
+
+  const handleRemove = (
+    coOrganizer
+  ) => {
+    const confirmed =
+      window.confirm(
+        `Remove ${
+          coOrganizer.name ||
+          coOrganizer.email ||
+          "this co-organizer"
+        } from the event?`
+      );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const updated =
+      removeCoOrganizer(
+        coOrganizers,
+        coOrganizer.id
+      );
+
+    onChange?.(updated);
+
+    const activity =
+      createCoOrganizerActivity({
+        eventId,
+        actorId:
+          organizerId,
+        coOrganizerId:
+          coOrganizer.id,
+        action:
+          "co-organizer-removed",
+        details:
+          "Co-organizer was removed from the event.",
+      });
+
+    onActivitiesChange?.([
+      ...activities,
+      activity,
+    ]);
+  };
+
+  return (
+    <section
+      className={`w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {/* Header */}
+      <div className="border-b border-slate-200 p-5 dark:border-slate-700">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+              <Users
+                size={21}
+                className="text-indigo-600 dark:text-indigo-400"
+              />
+            </div>
+
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-bold text-slate-800 dark:text-white">
+                  Co-Organizers
+                </h2>
+
+                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-semibold text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+                  {getActiveCoOrganizerCount(
+                    coOrganizers
+                  )}{" "}
+                  active
+                </span>
+              </div>
+
+              <p className="mt-1 text-sm leading-6 text-slate-500 dark:text-slate-400">
+                Invite trusted collaborators and assign
+                permissions for managing this event.
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => {
+              setError("");
+              setIsInviteOpen(
+                (current) => !current
+              );
+            }}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700"
+          >
+            {isInviteOpen ? (
+              <X size={16} />
+            ) : (
+              <Plus size={16} />
+            )}
+
+            {isInviteOpen
+              ? "Cancel"
+              : "Invite Co-Organizer"}
+          </button>
+        </div>
+
+        {/* Summary */}
+        <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <SummaryItem
+            label="Total"
+            value={summary.total}
+          />
+
+          <SummaryItem
+            label="Active"
+            value={summary.active}
+          />
+
+          <SummaryItem
+            label="Pending"
+            value={summary.pending}
+          />
+
+          <SummaryItem
+            label="Removed"
+            value={summary.removed}
+          />
+        </div>
+      </div>
+
+      {/* Invitation form */}
+      {isInviteOpen && (
+        <form
+          onSubmit={handleInvite}
+          className="border-b border-slate-200 bg-slate-50/70 p-5 dark:border-slate-700 dark:bg-slate-800/40"
+        >
+          <div className="mb-5">
+            <h3 className="text-sm font-bold text-slate-800 dark:text-white">
+              Invite a Co-Organizer
+            </h3>
+
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              The invitation will start with pending
+              status until the participant accepts it.
+            </p>
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="mb-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-xs leading-5 text-red-700 dark:border-red-900/50 dark:bg-red-900/10 dark:text-red-400"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            {/* Email */}
+            <div>
+              <label
+                htmlFor="co-organizer-email"
+                className="text-xs font-semibold text-slate-700 dark:text-slate-200"
+              >
+                Email address *
+              </label>
+
+              <div className="relative mt-2">
+                <Mail
+                  size={16}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+                />
+
+                <input
+                  id="co-organizer-email"
+                  type="email"
+                  value={email}
+                  onChange={(eventObject) =>
+                    setEmail(
+                      eventObject.target.value
+                    )
+                  }
+                  placeholder="organizer@example.com"
+                  autoComplete="email"
+                  className="w-full rounded-xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-indigo-400"
+                />
+              </div>
+            </div>
+
+            {/* Name */}
+            <div>
+              <label
+                htmlFor="co-organizer-name"
+                className="text-xs font-semibold text-slate-700 dark:text-slate-200"
+              >
+                Name
+              </label>
+
+              <input
+                id="co-organizer-name"
+                type="text"
+                value={name}
+                onChange={(eventObject) =>
+                  setName(
+                    eventObject.target.value
+                  )
+                }
+                placeholder="Co-organizer name"
+                className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-indigo-400"
+              />
+            </div>
+          </div>
+
+          {/* Permissions */}
+          <div className="mt-5">
+            <div className="flex items-center gap-2">
+              <ShieldCheck
+                size={16}
+                className="text-indigo-500"
+              />
+
+              <p className="text-xs font-semibold text-slate-700 dark:text-slate-200">
+                Assign permissions
+              </p>
+            </div>
+
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              {CO_ORGANIZER_PERMISSION_CONFIG.map(
+                (permission) => {
+                  const selected =
+                    selectedPermissions.includes(
+                      permission.id
+                    );
+
+                  return (
+                    <button
+                      key={permission.id}
+                      type="button"
+                      onClick={() =>
+                        togglePermission(
+                          permission.id
+                        )
+                      }
+                      className={`flex items-start gap-3 rounded-xl border p-3 text-left transition ${
+                        selected
+                          ? "border-indigo-300 bg-indigo-50 dark:border-indigo-700 dark:bg-indigo-900/20"
+                          : "border-slate-200 bg-white hover:border-indigo-200 dark:border-slate-700 dark:bg-slate-900"
+                      }`}
+                    >
+                      <span
+                        className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border ${
+                          selected
+                            ? "border-indigo-600 bg-indigo-600 text-white"
+                            : "border-slate-300 dark:border-slate-600"
+                        }`}
+                      >
+                        {selected && (
+                          <Check size={13} />
+                        )}
+                      </span>
+
+                      <span className="min-w-0">
+                        <span className="block text-xs font-semibold text-slate-800 dark:text-white">
+                          {permission.label}
+                        </span>
+
+                        <span className="mt-1 block text-[11px] leading-5 text-slate-400">
+                          {permission.description}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                }
+              )}
+            </div>
+          </div>
+
+          {/* Message */}
+          <div className="mt-5">
+            <label
+              htmlFor="co-organizer-message"
+              className="text-xs font-semibold text-slate-700 dark:text-slate-200"
+            >
+              Invitation message
+            </label>
+
+            <textarea
+              id="co-organizer-message"
+              value={message}
+              onChange={(eventObject) =>
+                setMessage(
+                  eventObject.target.value
+                )
+              }
+              rows={3}
+              maxLength={500}
+              placeholder="Add a short message for the co-organizer..."
+              className="mt-2 w-full resize-y rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-indigo-400"
+            />
+          </div>
+
+          {/* Form actions */}
+          <div className="mt-5 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={() => {
+                resetInviteForm();
+                setIsInviteOpen(false);
+              }}
+              disabled={isSaving}
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-semibold text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+            >
+              <X size={16} />
+              Cancel
+            </button>
+
+            <button
+              type="submit"
+              disabled={
+                isSaving ||
+                !email.trim()
+              }
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              <Mail size={16} />
+
+              {isSaving
+                ? "Sending..."
+                : "Send Invitation"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Co-organizer list */}
+      <div className="p-5">
+        {coOrganizers.length > 0 ? (
+          <div className="space-y-3">
+            {coOrganizers.map(
+              (coOrganizer) => (
+                <CoOrganizerCard
+                  key={
+                    coOrganizer.id
+                  }
+                  coOrganizer={
+                    coOrganizer
+                  }
+                  onPermissionsChange={
+                    handlePermissionsChange
+                  }
+                  onRemove={
+                    handleRemove
+                  }
+                />
+              )
+            )}
+          </div>
+        ) : (
+          <EmptyCoOrganizerState
+            onInvite={() => {
+              setError("");
+              setIsInviteOpen(true);
+            }}
+          />
+        )}
+      </div>
+    </section>
+  );
+};
+
+const SummaryItem = ({
+  label,
+  value,
+}) => {
+  return (
+    <div className="rounded-xl bg-slate-50 p-3 dark:bg-slate-800">
+      <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+        {label}
+      </p>
+
+      <p className="mt-1 text-lg font-bold text-slate-800 dark:text-white">
+        {value}
+      </p>
+    </div>
+  );
+};
+
+const EmptyCoOrganizerState = ({
+  onInvite,
+}) => {
+  return (
+    <div className="rounded-xl border border-dashed border-slate-300 p-8 text-center dark:border-slate-700">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800">
+        <Users
+          size={21}
+          className="text-slate-400"
+        />
+      </div>
+
+      <h3 className="mt-4 text-sm font-semibold text-slate-700 dark:text-slate-200">
+        No co-organizers yet
+      </h3>
+
+      <p className="mx-auto mt-1 max-w-md text-xs leading-5 text-slate-400">
+        Invite collaborators to help manage participants,
+        announcements, event details, and feedback.
+      </p>
+
+      <button
+        type="button"
+        onClick={onInvite}
+        className="mt-4 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-xs font-semibold text-slate-700 transition hover:border-indigo-300 hover:text-indigo-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-indigo-700 dark:hover:text-indigo-400"
+      >
+        <Plus size={14} />
+        Invite Co-Organizer
+      </button>
+    </div>
+  );
+};
+
+export default EventCoOrganizers;

--- a/src/utils/eventCoOrganizerUtils.js
+++ b/src/utils/eventCoOrganizerUtils.js
@@ -1,0 +1,1306 @@
+/**
+ * Event Co-Organizer utilities.
+ *
+ * Supports:
+ * - Inviting co-organizers
+ * - Assigning permissions
+ * - Removing co-organizers
+ * - Invitation status management
+ * - Permission checks
+ * - Activity tracking
+ */
+
+export const CO_ORGANIZER_PERMISSIONS = {
+  MANAGE_PARTICIPANTS:
+    "manageParticipants",
+  PUBLISH_ANNOUNCEMENTS:
+    "publishAnnouncements",
+  EDIT_EVENT_DETAILS:
+    "editEventDetails",
+  MANAGE_FEEDBACK:
+    "manageFeedback",
+};
+
+export const CO_ORGANIZER_PERMISSION_CONFIG = [
+  {
+    id: CO_ORGANIZER_PERMISSIONS.MANAGE_PARTICIPANTS,
+    label: "Manage Participants",
+    description:
+      "View, manage, and remove event participants.",
+  },
+  {
+    id: CO_ORGANIZER_PERMISSIONS.PUBLISH_ANNOUNCEMENTS,
+    label: "Publish Announcements",
+    description:
+      "Create and publish announcements for the event.",
+  },
+  {
+    id: CO_ORGANIZER_PERMISSIONS.EDIT_EVENT_DETAILS,
+    label: "Edit Event Details",
+    description:
+      "Update event information, schedule, and venue details.",
+  },
+  {
+    id: CO_ORGANIZER_PERMISSIONS.MANAGE_FEEDBACK,
+    label: "Manage Feedback",
+    description:
+      "Review and manage participant feedback.",
+  },
+];
+
+export const CO_ORGANIZER_STATUSES = {
+  PENDING: "pending",
+  ACCEPTED: "accepted",
+  DECLINED: "declined",
+  REMOVED: "removed",
+};
+
+/**
+ * Normalize an ID.
+ */
+export const normalizeOrganizerId = (
+  value
+) => {
+  if (
+    value === null ||
+    value === undefined
+  ) {
+    return "";
+  }
+
+  return String(value).trim();
+};
+
+/**
+ * Extract a user ID from a user object.
+ */
+export const getOrganizerUserId = (
+  user = {}
+) => {
+  if (
+    typeof user !== "object" ||
+    user === null
+  ) {
+    return normalizeOrganizerId(
+      user
+    );
+  }
+
+  return normalizeOrganizerId(
+    user.id ??
+      user.userId ??
+      user.user_id ??
+      user.organizerId
+  );
+};
+
+/**
+ * Extract an event ID.
+ */
+export const getOrganizerEventId = (
+  event = {}
+) => {
+  if (
+    typeof event !== "object" ||
+    event === null
+  ) {
+    return normalizeOrganizerId(
+      event
+    );
+  }
+
+  return normalizeOrganizerId(
+    event.id ??
+      event.eventId ??
+      event.event_id
+  );
+};
+
+/**
+ * Generate a unique co-organizer ID.
+ */
+export const generateCoOrganizerId = () => {
+  return `co-organizer-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 9)}`;
+};
+
+/**
+ * Generate a unique activity ID.
+ */
+export const generateCoOrganizerActivityId =
+  () => {
+    return `co-organizer-activity-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 9)}`;
+  };
+
+/**
+ * Normalize an email address.
+ */
+export const normalizeOrganizerEmail = (
+  email
+) => {
+  if (
+    email === null ||
+    email === undefined
+  ) {
+    return "";
+  }
+
+  return String(email)
+    .trim()
+    .toLowerCase();
+};
+
+/**
+ * Validate an email address.
+ */
+export const isValidOrganizerEmail = (
+  email
+) => {
+  const normalized =
+    normalizeOrganizerEmail(
+      email
+    );
+
+  if (!normalized) {
+    return false;
+  }
+
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(
+    normalized
+  );
+};
+
+/**
+ * Normalize a permission list.
+ */
+export const normalizePermissions = (
+  permissions = []
+) => {
+  if (!Array.isArray(permissions)) {
+    return [];
+  }
+
+  const validPermissions =
+    new Set(
+      Object.values(
+        CO_ORGANIZER_PERMISSIONS
+      )
+    );
+
+  return [
+    ...new Set(
+      permissions.filter(
+        (permission) =>
+          validPermissions.has(
+            permission
+          )
+      )
+    ),
+  ];
+};
+
+/**
+ * Get permission metadata.
+ */
+export const getPermissionConfig = (
+  permissionId
+) => {
+  return (
+    CO_ORGANIZER_PERMISSION_CONFIG.find(
+      (permission) =>
+        permission.id ===
+        permissionId
+    ) || null
+  );
+};
+
+/**
+ * Get all available permissions.
+ */
+export const getAvailablePermissions = () => {
+  return CO_ORGANIZER_PERMISSION_CONFIG.map(
+    (permission) => ({
+      ...permission,
+    })
+  );
+};
+
+/**
+ * Check whether a permission exists.
+ */
+export const isValidPermission = (
+  permissionId
+) => {
+  return Object.values(
+    CO_ORGANIZER_PERMISSIONS
+  ).includes(permissionId);
+};
+
+/**
+ * Check whether a co-organizer has
+ * a specific permission.
+ */
+export const hasCoOrganizerPermission = (
+  coOrganizer,
+  permission
+) => {
+  if (!coOrganizer) {
+    return false;
+  }
+
+  const permissions =
+    normalizePermissions(
+      coOrganizer.permissions
+    );
+
+  return permissions.includes(
+    permission
+  );
+};
+
+/**
+ * Check whether a co-organizer has
+ * at least one permission.
+ */
+export const hasAnyCoOrganizerPermission = (
+  coOrganizer,
+  permissions = []
+) => {
+  if (!coOrganizer) {
+    return false;
+  }
+
+  return normalizePermissions(
+    permissions
+  ).some((permission) =>
+    hasCoOrganizerPermission(
+      coOrganizer,
+      permission
+    )
+  );
+};
+
+/**
+ * Check whether a co-organizer has
+ * every requested permission.
+ */
+export const hasAllCoOrganizerPermissions = (
+  coOrganizer,
+  permissions = []
+) => {
+  if (!coOrganizer) {
+    return false;
+  }
+
+  return normalizePermissions(
+    permissions
+  ).every((permission) =>
+    hasCoOrganizerPermission(
+      coOrganizer,
+      permission
+    )
+  );
+};
+
+/**
+ * Create a new co-organizer invitation.
+ */
+export const createCoOrganizerInvitation = ({
+  eventId,
+  organizerId,
+  userId = "",
+  email = "",
+  name = "",
+  permissions = [],
+  message = "",
+} = {}) => {
+  const normalizedEventId =
+    normalizeOrganizerId(
+      eventId
+    );
+
+  const normalizedOrganizerId =
+    normalizeOrganizerId(
+      organizerId
+    );
+
+  const normalizedUserId =
+    normalizeOrganizerId(
+      userId
+    );
+
+  const normalizedEmail =
+    normalizeOrganizerEmail(
+      email
+    );
+
+  const normalizedPermissions =
+    normalizePermissions(
+      permissions
+    );
+
+  const now =
+    new Date().toISOString();
+
+  return {
+    id: generateCoOrganizerId(),
+    eventId:
+      normalizedEventId,
+    organizerId:
+      normalizedOrganizerId,
+    userId:
+      normalizedUserId,
+    email:
+      normalizedEmail,
+    name:
+      String(name || "").trim(),
+    permissions:
+      normalizedPermissions,
+    status:
+      CO_ORGANIZER_STATUSES.PENDING,
+    message:
+      String(message || "").trim(),
+    invitedAt: now,
+    acceptedAt: null,
+    declinedAt: null,
+    removedAt: null,
+  };
+};
+
+/**
+ * Validate a co-organizer invitation.
+ */
+export const validateCoOrganizerInvitation =
+  ({
+    eventId,
+    organizerId,
+    userId = "",
+    email = "",
+    permissions = [],
+  } = {}) => {
+    const errors = [];
+
+    if (
+      !normalizeOrganizerId(
+        eventId
+      )
+    ) {
+      errors.push(
+        "Event ID is required."
+      );
+    }
+
+    if (
+      !normalizeOrganizerId(
+        organizerId
+      )
+    ) {
+      errors.push(
+        "Primary organizer ID is required."
+      );
+    }
+
+    if (
+      !normalizeOrganizerId(
+        userId
+      ) &&
+      !normalizeOrganizerEmail(
+        email
+      )
+    ) {
+      errors.push(
+        "A participant user ID or email is required."
+      );
+    }
+
+    if (
+      email &&
+      !isValidOrganizerEmail(
+        email
+      )
+    ) {
+      errors.push(
+        "The co-organizer email address is invalid."
+      );
+    }
+
+    if (
+      !Array.isArray(permissions)
+    ) {
+      errors.push(
+        "Permissions must be provided as an array."
+      );
+    }
+
+    return {
+      valid:
+        errors.length === 0,
+      errors,
+    };
+  };
+
+/**
+ * Check whether a user is already
+ * a co-organizer.
+ */
+export const isExistingCoOrganizer = (
+  coOrganizers = [],
+  {
+    userId = "",
+    email = "",
+  } = {}
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return false;
+  }
+
+  const normalizedUserId =
+    normalizeOrganizerId(
+      userId
+    );
+
+  const normalizedEmail =
+    normalizeOrganizerEmail(
+      email
+    );
+
+  return coOrganizers.some(
+    (coOrganizer) => {
+      const sameUser =
+        normalizedUserId &&
+        normalizeOrganizerId(
+          coOrganizer.userId
+        ) === normalizedUserId;
+
+      const sameEmail =
+        normalizedEmail &&
+        normalizeOrganizerEmail(
+          coOrganizer.email
+        ) === normalizedEmail;
+
+      return (
+        sameUser || sameEmail
+      );
+    }
+  );
+};
+
+/**
+ * Find a co-organizer by ID.
+ */
+export const findCoOrganizer = (
+  coOrganizers = [],
+  coOrganizerId
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return null;
+  }
+
+  const normalizedId =
+    normalizeOrganizerId(
+      coOrganizerId
+    );
+
+  return (
+    coOrganizers.find(
+      (coOrganizer) =>
+        normalizeOrganizerId(
+          coOrganizer.id
+        ) === normalizedId
+    ) || null
+  );
+};
+
+/**
+ * Find a co-organizer by user ID.
+ */
+export const findCoOrganizerByUserId = (
+  coOrganizers = [],
+  userId
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return null;
+  }
+
+  const normalizedUserId =
+    normalizeOrganizerId(
+      userId
+    );
+
+  return (
+    coOrganizers.find(
+      (coOrganizer) =>
+        normalizeOrganizerId(
+          coOrganizer.userId
+        ) === normalizedUserId
+    ) || null
+  );
+};
+
+/**
+ * Find a co-organizer by email.
+ */
+export const findCoOrganizerByEmail = (
+  coOrganizers = [],
+  email
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return null;
+  }
+
+  const normalizedEmail =
+    normalizeOrganizerEmail(
+      email
+    );
+
+  return (
+    coOrganizers.find(
+      (coOrganizer) =>
+        normalizeOrganizerEmail(
+          coOrganizer.email
+        ) === normalizedEmail
+    ) || null
+  );
+};
+
+/**
+ * Add a co-organizer invitation.
+ */
+export const addCoOrganizer = (
+  coOrganizers = [],
+  invitation
+) => {
+  if (!invitation) {
+    return Array.isArray(
+      coOrganizers
+    )
+      ? [...coOrganizers]
+      : [];
+  }
+
+  if (
+    isExistingCoOrganizer(
+      coOrganizers,
+      {
+        userId:
+          invitation.userId,
+        email:
+          invitation.email,
+      }
+    )
+  ) {
+    return Array.isArray(
+      coOrganizers
+    )
+      ? [...coOrganizers]
+      : [];
+  }
+
+  return [
+    ...(Array.isArray(
+      coOrganizers
+    )
+      ? coOrganizers
+      : []),
+    invitation,
+  ];
+};
+
+/**
+ * Update co-organizer permissions.
+ */
+export const updateCoOrganizerPermissions =
+  (
+    coOrganizers = [],
+    coOrganizerId,
+    permissions = []
+  ) => {
+    if (
+      !Array.isArray(
+        coOrganizers
+      )
+    ) {
+      return [];
+    }
+
+    const normalizedPermissions =
+      normalizePermissions(
+        permissions
+      );
+
+    const normalizedId =
+      normalizeOrganizerId(
+        coOrganizerId
+      );
+
+    return coOrganizers.map(
+      (coOrganizer) => {
+        if (
+          normalizeOrganizerId(
+            coOrganizer.id
+          ) !== normalizedId
+        ) {
+          return coOrganizer;
+        }
+
+        return {
+          ...coOrganizer,
+          permissions:
+            normalizedPermissions,
+          updatedAt:
+            new Date().toISOString(),
+        };
+      }
+    );
+  };
+
+/**
+ * Add one permission to a
+ * co-organizer.
+ */
+export const grantCoOrganizerPermission =
+  (
+    coOrganizers = [],
+    coOrganizerId,
+    permission
+  ) => {
+    if (
+      !isValidPermission(
+        permission
+      )
+    ) {
+      return Array.isArray(
+        coOrganizers
+      )
+        ? [...coOrganizers]
+        : [];
+    }
+
+    const coOrganizer =
+      findCoOrganizer(
+        coOrganizers,
+        coOrganizerId
+      );
+
+    if (!coOrganizer) {
+      return [...coOrganizers];
+    }
+
+    const permissions =
+      normalizePermissions([
+        ...(coOrganizer.permissions ||
+          []),
+        permission,
+      ]);
+
+    return updateCoOrganizerPermissions(
+      coOrganizers,
+      coOrganizerId,
+      permissions
+    );
+  };
+
+/**
+ * Remove one permission from a
+ * co-organizer.
+ */
+export const revokeCoOrganizerPermission =
+  (
+    coOrganizers = [],
+    coOrganizerId,
+    permission
+  ) => {
+    if (
+      !Array.isArray(
+        coOrganizers
+      )
+    ) {
+      return [];
+    }
+
+    const coOrganizer =
+      findCoOrganizer(
+        coOrganizers,
+        coOrganizerId
+      );
+
+    if (!coOrganizer) {
+      return [...coOrganizers];
+    }
+
+    const permissions =
+      normalizePermissions(
+        coOrganizer.permissions
+      ).filter(
+        (item) =>
+          item !== permission
+      );
+
+    return updateCoOrganizerPermissions(
+      coOrganizers,
+      coOrganizerId,
+      permissions
+    );
+  };
+
+/**
+ * Accept a co-organizer invitation.
+ */
+export const acceptCoOrganizerInvitation =
+  (
+    coOrganizers = [],
+    coOrganizerId
+  ) => {
+    if (
+      !Array.isArray(
+        coOrganizers
+      )
+    ) {
+      return [];
+    }
+
+    const normalizedId =
+      normalizeOrganizerId(
+        coOrganizerId
+      );
+
+    const now =
+      new Date().toISOString();
+
+    return coOrganizers.map(
+      (coOrganizer) => {
+        if (
+          normalizeOrganizerId(
+            coOrganizer.id
+          ) !== normalizedId
+        ) {
+          return coOrganizer;
+        }
+
+        return {
+          ...coOrganizer,
+          status:
+            CO_ORGANIZER_STATUSES.ACCEPTED,
+          acceptedAt: now,
+          updatedAt: now,
+        };
+      }
+    );
+  };
+
+/**
+ * Decline a co-organizer invitation.
+ */
+export const declineCoOrganizerInvitation =
+  (
+    coOrganizers = [],
+    coOrganizerId
+  ) => {
+    if (
+      !Array.isArray(
+        coOrganizers
+      )
+    ) {
+      return [];
+    }
+
+    const normalizedId =
+      normalizeOrganizerId(
+        coOrganizerId
+      );
+
+    const now =
+      new Date().toISOString();
+
+    return coOrganizers.map(
+      (coOrganizer) => {
+        if (
+          normalizeOrganizerId(
+            coOrganizer.id
+          ) !== normalizedId
+        ) {
+          return coOrganizer;
+        }
+
+        return {
+          ...coOrganizer,
+          status:
+            CO_ORGANIZER_STATUSES.DECLINED,
+          declinedAt: now,
+          updatedAt: now,
+        };
+      }
+    );
+  };
+
+/**
+ * Remove a co-organizer.
+ */
+export const removeCoOrganizer = (
+  coOrganizers = [],
+  coOrganizerId
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return [];
+  }
+
+  const normalizedId =
+    normalizeOrganizerId(
+      coOrganizerId
+    );
+
+  const now =
+    new Date().toISOString();
+
+  return coOrganizers.map(
+    (coOrganizer) => {
+      if (
+        normalizeOrganizerId(
+          coOrganizer.id
+        ) !== normalizedId
+      ) {
+        return coOrganizer;
+      }
+
+      return {
+        ...coOrganizer,
+        status:
+          CO_ORGANIZER_STATUSES.REMOVED,
+        removedAt: now,
+        updatedAt: now,
+      };
+    }
+  );
+};
+
+/**
+ * Get active co-organizers.
+ */
+export const getActiveCoOrganizers = (
+  coOrganizers = []
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return [];
+  }
+
+  return coOrganizers.filter(
+    (coOrganizer) =>
+      coOrganizer.status ===
+      CO_ORGANIZER_STATUSES.ACCEPTED
+  );
+};
+
+/**
+ * Get pending invitations.
+ */
+export const getPendingCoOrganizerInvitations =
+  (
+    coOrganizers = []
+  ) => {
+    if (
+      !Array.isArray(
+        coOrganizers
+      )
+    ) {
+      return [];
+    }
+
+    return coOrganizers.filter(
+      (coOrganizer) =>
+        coOrganizer.status ===
+        CO_ORGANIZER_STATUSES.PENDING
+    );
+  };
+
+/**
+ * Get declined invitations.
+ */
+export const getDeclinedCoOrganizerInvitations =
+  (
+    coOrganizers = []
+  ) => {
+    if (
+      !Array.isArray(
+        coOrganizers
+      )
+    ) {
+      return [];
+    }
+
+    return coOrganizers.filter(
+      (coOrganizer) =>
+        coOrganizer.status ===
+        CO_ORGANIZER_STATUSES.DECLINED
+    );
+  };
+
+/**
+ * Get removed co-organizers.
+ */
+export const getRemovedCoOrganizers = (
+  coOrganizers = []
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return [];
+  }
+
+  return coOrganizers.filter(
+    (coOrganizer) =>
+      coOrganizer.status ===
+      CO_ORGANIZER_STATUSES.REMOVED
+  );
+};
+
+/**
+ * Create a co-organizer activity
+ * record.
+ */
+export const createCoOrganizerActivity = ({
+  eventId,
+  actorId,
+  coOrganizerId,
+  action,
+  details = "",
+} = {}) => {
+  return {
+    id:
+      generateCoOrganizerActivityId(),
+    eventId:
+      normalizeOrganizerId(
+        eventId
+      ),
+    actorId:
+      normalizeOrganizerId(
+        actorId
+      ),
+    coOrganizerId:
+      normalizeOrganizerId(
+        coOrganizerId
+      ),
+    action:
+      String(action || "").trim(),
+    details:
+      String(details || "").trim(),
+    timestamp:
+      new Date().toISOString(),
+  };
+};
+
+/**
+ * Add an activity record.
+ */
+export const addCoOrganizerActivity = (
+  activities = [],
+  activity
+) => {
+  if (!activity) {
+    return Array.isArray(
+      activities
+    )
+      ? [...activities]
+      : [];
+  }
+
+  return [
+    ...(Array.isArray(
+      activities
+    )
+      ? activities
+      : []),
+    activity,
+  ];
+};
+
+/**
+ * Get activity for a specific
+ * co-organizer.
+ */
+export const getCoOrganizerActivity = (
+  activities = [],
+  coOrganizerId
+) => {
+  if (
+    !Array.isArray(
+      activities
+    )
+  ) {
+    return [];
+  }
+
+  const normalizedId =
+    normalizeOrganizerId(
+      coOrganizerId
+    );
+
+  return activities.filter(
+    (activity) =>
+      normalizeOrganizerId(
+        activity.coOrganizerId
+      ) === normalizedId
+  );
+};
+
+/**
+ * Get permission labels for display.
+ */
+export const getCoOrganizerPermissionLabels =
+  (
+    permissions = []
+  ) => {
+    return normalizePermissions(
+      permissions
+    ).map(
+      (permission) =>
+        getPermissionConfig(
+          permission
+        )?.label ||
+        permission
+    );
+  };
+
+/**
+ * Get a readable status label.
+ */
+export const getCoOrganizerStatusLabel =
+  (status) => {
+    const labels = {
+      [CO_ORGANIZER_STATUSES.PENDING]:
+        "Pending",
+      [CO_ORGANIZER_STATUSES.ACCEPTED]:
+        "Accepted",
+      [CO_ORGANIZER_STATUSES.DECLINED]:
+        "Declined",
+      [CO_ORGANIZER_STATUSES.REMOVED]:
+        "Removed",
+    };
+
+    return (
+      labels[status] ||
+      "Unknown"
+    );
+  };
+
+/**
+ * Count active co-organizers.
+ */
+export const getActiveCoOrganizerCount = (
+  coOrganizers = []
+) => {
+  return getActiveCoOrganizers(
+    coOrganizers
+  ).length;
+};
+
+/**
+ * Check whether a user is the
+ * primary organizer.
+ */
+export const isPrimaryOrganizer = (
+  organizerId,
+  userId
+) => {
+  return (
+    normalizeOrganizerId(
+      organizerId
+    ) ===
+    normalizeOrganizerId(
+      userId
+    )
+  );
+};
+
+/**
+ * Check whether a user can perform
+ * an action for an event.
+ */
+export const canCoOrganizerPerformAction =
+  ({
+    organizerId,
+    userId,
+    coOrganizers = [],
+    permission,
+  } = {}) => {
+    // Primary organizer has full access.
+    if (
+      isPrimaryOrganizer(
+        organizerId,
+        userId
+      )
+    ) {
+      return true;
+    }
+
+    const coOrganizer =
+      findCoOrganizerByUserId(
+        coOrganizers,
+        userId
+      );
+
+    if (
+      !coOrganizer ||
+      coOrganizer.status !==
+        CO_ORGANIZER_STATUSES.ACCEPTED
+    ) {
+      return false;
+    }
+
+    return hasCoOrganizerPermission(
+      coOrganizer,
+      permission
+    );
+  };
+
+/**
+ * Get a co-organizer's role summary.
+ */
+export const getCoOrganizerRoleSummary = (
+  coOrganizer
+) => {
+  if (!coOrganizer) {
+    return {
+      status: "Unknown",
+      permissions: [],
+      permissionLabels: [],
+    };
+  }
+
+  const permissions =
+    normalizePermissions(
+      coOrganizer.permissions
+    );
+
+  return {
+    status:
+      getCoOrganizerStatusLabel(
+        coOrganizer.status
+      ),
+    permissions,
+    permissionLabels:
+      getCoOrganizerPermissionLabels(
+        permissions
+      ),
+  };
+};
+
+/**
+ * Normalize a complete co-organizer
+ * collection.
+ */
+export const normalizeCoOrganizers = (
+  coOrganizers = []
+) => {
+  if (
+    !Array.isArray(
+      coOrganizers
+    )
+  ) {
+    return [];
+  }
+
+  return coOrganizers.map(
+    (coOrganizer) => ({
+      ...coOrganizer,
+      id:
+        normalizeOrganizerId(
+          coOrganizer.id
+        ) ||
+        generateCoOrganizerId(),
+      eventId:
+        normalizeOrganizerId(
+          coOrganizer.eventId
+        ),
+      organizerId:
+        normalizeOrganizerId(
+          coOrganizer.organizerId
+        ),
+      userId:
+        normalizeOrganizerId(
+          coOrganizer.userId
+        ),
+      email:
+        normalizeOrganizerEmail(
+          coOrganizer.email
+        ),
+      name:
+        String(
+          coOrganizer.name ||
+            ""
+        ).trim(),
+      permissions:
+        normalizePermissions(
+          coOrganizer.permissions
+        ),
+      status:
+        coOrganizer.status ||
+        CO_ORGANIZER_STATUSES.PENDING,
+      invitedAt:
+        coOrganizer.invitedAt ||
+        new Date().toISOString(),
+    })
+  );
+};
+
+/**
+ * Get a compact summary of co-organizer
+ * management.
+ */
+export const getCoOrganizerSummary = (
+  coOrganizers = []
+) => {
+  const normalized =
+    normalizeCoOrganizers(
+      coOrganizers
+    );
+
+  return {
+    total:
+      normalized.length,
+    active:
+      getActiveCoOrganizers(
+        normalized
+      ).length,
+    pending:
+      getPendingCoOrganizerInvitations(
+        normalized
+      ).length,
+    declined:
+      getDeclinedCoOrganizerInvitations(
+        normalized
+      ).length,
+    removed:
+      getRemovedCoOrganizers(
+        normalized
+      ).length,
+  };
+};


### PR DESCRIPTION
## Description

Implemented co-organizer management for events.

### Added

- Invite co-organizers
- Assign co-organizer permissions
- Edit permissions
- Remove co-organizers
- Pending, active, declined, and removed states
- Co-organizer email and profile information
- Invitation messages
- Permission validation
- Co-organizer activity tracking
- Permission-based action checks
- Responsive management UI

Closes #12648