### PR TITLE
fix(api): remove double api prefixes

### DIFF
--- a/src/api/eventCancellationAPI.js
+++ b/src/api/eventCancellationAPI.js
@@ -1,4 +1,4 @@
-import { apiUtils } from "../config/api";
+import { apiUtils, API_ENDPOINTS } from "../config/api";
 
 /**
  * Event cancellation API with notification support
@@ -29,21 +29,21 @@ export const eventCancellationAPI = {
       notifyAttendees: options.notifyAttendees !== false,
     };
 
-    return apiUtils.post(`/api/events/${eventId}/cancel`, payload);
+    return apiUtils.post(API_ENDPOINTS.EVENTS.CANCEL(eventId), payload);
   },
 
   /**
    * Get cancellation details for an event
    */
   getCancellationDetails: async (eventId) => {
-    return apiUtils.get(`/api/events/${eventId}`);
+    return apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
   },
 
   /**
    * Resend cancellation notification to specific attendee
    */
   resendCancellationNotification: async (eventId, attendeeEmail) => {
-    return apiUtils.post(`/api/events/${eventId}/resend-cancellation-notice`, {
+    return apiUtils.post(`${API_ENDPOINTS.EVENTS.DETAIL(eventId)}/resend-cancellation-notice`, {
       attendeeEmail,
     });
   },
@@ -52,6 +52,6 @@ export const eventCancellationAPI = {
    * Get list of attendees who have been notified
    */
   getNotifiedAttendees: async (eventId) => {
-    return apiUtils.get(`/api/events/${eventId}/notified-attendees`);
+    return apiUtils.get(`${API_ENDPOINTS.EVENTS.DETAIL(eventId)}/notified-attendees`);
   },
 };

--- a/src/hooks/usePublicEvents.js
+++ b/src/hooks/usePublicEvents.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useAuth } from "./useAuth";
-import { apiUtils } from "../config/api";
+import { apiUtils, API_ENDPOINTS } from "../config/api";
 
 /**
  * Hook to fetch only published events (respects draft visibility rules)
@@ -9,7 +9,7 @@ import { apiUtils } from "../config/api";
  * - Admin users: all events
  */
 export function usePublicEvents(options = {}) {
-  const { user, token } = useAuth();
+  const { token } = useAuth();
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -28,10 +28,12 @@ export function usePublicEvents(options = {}) {
       // Add user context header for backend to filter appropriately
       const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
-      const response = await apiUtils.get(
-        `/api/events?page=${page}&limit=${options.limit || 20}&status=PUBLISHED`,
-        { headers }
-      );
+      const params = new URLSearchParams({
+        page: String(page),
+        size: String(options.limit || 20),
+        status: "PUBLISHED",
+      });
+      const response = await apiUtils.get(`${API_ENDPOINTS.EVENTS.LIST}?${params.toString()}`, { headers });
 
       const newEvents = response.data?.events || response.data || [];
 
@@ -88,7 +90,9 @@ export function useUserVisibleEvents(userId) {
   const fetchUserEvents = async () => {
     setLoading(true);
     try {
-      const endpoint = user?.id === userId ? "/api/user/events" : `/api/events?organiser=${userId}`;
+      const endpoint = user?.id === userId
+        ? "/users/my-events"
+        : `${API_ENDPOINTS.EVENTS.LIST}?organiser=${encodeURIComponent(userId)}`;
 
       const response = await apiUtils.get(endpoint);
       setEvents(response.data?.events || response.data || []);
@@ -119,7 +123,7 @@ export function useEventDetail(eventId) {
   const fetchEvent = async () => {
     setLoading(true);
     try {
-      const response = await apiUtils.get(`/api/events/${eventId}`);
+      const response = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
       setEvent(response.data);
     } catch (err) {
       // 404 for draft events user can't view

--- a/tests/apiPathContract.test.mjs
+++ b/tests/apiPathContract.test.mjs
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const rawApiPattern = /apiUtils\.(?:get|post|put|patch|delete)\(\s*`?['"]\/api\//;
+const files = [
+  "src/api/eventCancellationAPI.js",
+  "src/hooks/usePublicEvents.js",
+];
+
+for (const file of files) {
+  const source = fs.readFileSync(file, "utf8");
+  assert.equal(
+    rawApiPattern.test(source),
+    false,
+    `${file} must not pass /api-prefixed paths to apiUtils`,
+  );
+}
+
+console.log("apiUtils path contract checks passed");


### PR DESCRIPTION
Fixes #12665.

## What changed
- Replaced raw `/api/...` apiUtils calls in event cancellation and public event hooks with centralized endpoint helpers.
- Switched the public-events query to the backend's `size` parameter.
- Added a small contract test so these callers do not pass `/api`-prefixed paths into an Axios client already rooted at `/api`.

## Validation
- `node tests/apiPathContract.test.mjs`
- `npx eslint src/api/eventCancellationAPI.js src/hooks/usePublicEvents.js tests/apiPathContract.test.mjs` passes with existing hook dependency warnings in `usePublicEvents.js`.
