### PR TITLE
fix(waitlist): use event scoped endpoints

### DIFF
--- a/src/services/waitlistService.js
+++ b/src/services/waitlistService.js
@@ -7,20 +7,20 @@ import { apiUtils, API_ENDPOINTS } from "../config/api";
  */
 
 export const joinWaitlist = async (eventId) => {
-  const response = await apiUtils.post(API_ENDPOINTS.WAITLIST.JOIN(eventId));
+  const response = await apiUtils.post(API_ENDPOINTS.EVENTS.WAITLIST(eventId));
   if (!response.ok) throw new Error("Failed to join waitlist");
   return response.json();
 };
 
 export const leaveWaitlist = async (eventId) => {
-  const response = await apiUtils.delete(API_ENDPOINTS.WAITLIST.LEAVE(eventId));
+  const response = await apiUtils.delete(API_ENDPOINTS.EVENTS.WAITLIST(eventId));
   if (!response.ok) throw new Error("Failed to leave waitlist");
   return response.json();
 };
 
 export const getWaitlistStatus = async (eventId) => {
   try {
-    const response = await apiUtils.get(API_ENDPOINTS.WAITLIST.STATUS(eventId));
+    const response = await apiUtils.get(`${API_ENDPOINTS.EVENTS.WAITLIST(eventId)}/me`);
     if (!response.ok) return { onWaitlist: false, position: null };
     return response.json();
   } catch {
@@ -30,9 +30,10 @@ export const getWaitlistStatus = async (eventId) => {
 
 export const getWaitlistCount = async (eventId) => {
   try {
-    const response = await apiUtils.get(API_ENDPOINTS.WAITLIST.COUNT(eventId));
+    const response = await apiUtils.get(API_ENDPOINTS.EVENTS.WAITLIST(eventId));
     if (!response.ok) return { count: 0 };
-    return response.json();
+    const waitlist = await response.json();
+    return { count: Array.isArray(waitlist) ? waitlist.length : 0 };
   } catch {
     return { count: 0 };
   }

--- a/tests/waitlistServiceEndpointContract.test.mjs
+++ b/tests/waitlistServiceEndpointContract.test.mjs
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const source = fs.readFileSync("src/services/waitlistService.js", "utf8");
+
+assert.equal(
+  source.includes("API_ENDPOINTS.WAITLIST.JOIN(eventId)"),
+  false,
+  "joinWaitlist must not call WAITLIST.JOIN as a function",
+);
+assert.equal(
+  source.includes("API_ENDPOINTS.WAITLIST.COUNT(eventId)"),
+  false,
+  "getWaitlistCount must not reference a missing COUNT endpoint",
+);
+assert.equal(
+  source.includes("API_ENDPOINTS.EVENTS.WAITLIST(eventId)"),
+  true,
+  "waitlistService should use the backend's event-scoped waitlist route",
+);
+
+console.log("waitlist service endpoint contract checks passed");


### PR DESCRIPTION
Fixes #12666.

## What changed
- Pointed waitlist helpers at the backend's existing `/events/{id}/waitlist` routes.
- Removed the broken `WAITLIST.JOIN(eventId)` and missing `WAITLIST.COUNT(eventId)` usage.
- Added a small contract test for the endpoint helper shape.

## Validation
- `node tests/waitlistServiceEndpointContract.test.mjs`
- `npx eslint src/services/waitlistService.js tests/waitlistServiceEndpointContract.test.mjs`
