### PR TITLE
fix(security): allow api cors headers

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(origins));
 
         configuration.setAllowedMethods(
-                List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
         );
 
         configuration.setAllowedHeaders(
@@ -69,7 +69,13 @@ public class SecurityConfig {
                         "Content-Type",
                         "Accept",
                         "Origin",
-                        "X-Requested-With"
+                        "X-Requested-With",
+                        "X-CSRF-Token",
+                        "Idempotency-Key",
+                        "X-Request-Integrity",
+                        "X-Timestamp",
+                        "X-Nonce",
+                        "X-Signature"
                 )
         );
 

--- a/tests/corsSecurityConfigContract.test.mjs
+++ b/tests/corsSecurityConfigContract.test.mjs
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const source = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java",
+  "utf8",
+);
+
+for (const token of [
+  '"PATCH"',
+  '"X-CSRF-Token"',
+  '"Idempotency-Key"',
+  '"X-Request-Integrity"',
+  '"X-Timestamp"',
+  '"X-Nonce"',
+  '"X-Signature"',
+]) {
+  assert.equal(source.includes(token), true, `SecurityConfig CORS allowlist should include ${token}`);
+}
+
+console.log("CORS security config contract checks passed");


### PR DESCRIPTION
Fixes #12657.

## What changed
- Added PATCH to the backend CORS method allowlist.
- Added the custom headers already emitted by the frontend API client: CSRF token, idempotency key, request integrity, and request signature headers.
- Added a small contract check so these entries do not get dropped silently.

## Validation
- `node tests/corsSecurityConfigContract.test.mjs`

Backend compile was not run locally because this checkout does not include `mvnw` and `mvn` is not installed in the environment.
