### PR TITLE
fix(events): permit public discovery routes

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -135,6 +135,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 org.springframework.http.HttpMethod.GET,
                                 "/api/events",
+                                "/api/events/search",
+                                "/api/events/alternatives",
                                 "/api/events/{id}",
                                 "/api/events/{id}/availability",
                                 "/api/events/{id}/seats",

--- a/tests/publicEventRoutesSecurityContract.test.mjs
+++ b/tests/publicEventRoutesSecurityContract.test.mjs
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const source = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java",
+  "utf8",
+);
+
+for (const route of ['"/api/events/search"', '"/api/events/alternatives"']) {
+  assert.equal(source.includes(route), true, `${route} should be permitted for public GET requests`);
+}
+
+console.log("public event route security contract checks passed");


### PR DESCRIPTION
Fixes #12658.

## What changed
- Added anonymous GET access for the existing public event search route.
- Added anonymous GET access for the existing alternative-event suggestion route.
- Added a small contract check for the security matcher entries.

## Validation
- `node tests/publicEventRoutesSecurityContract.test.mjs`

Backend compile was not run locally because this checkout does not include `mvnw` and `mvn` is not installed in the environment.
