### PR TITLE
fix(feedback): add event feedback endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -149,6 +149,7 @@ public class SecurityConfig {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/hackathons/{id}").permitAll()
                         // ── Public: Project categories endpoint ──────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/feedback").permitAll()
                         // ── Admin Panel — ADMIN / SUPER_ADMIN only ────────
                         .requestMatchers("/api/admin/**").hasAnyAuthority("ADMIN", "SUPER_ADMIN")
                         // ── Public: Swagger / OpenAPI ────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,6 +59,12 @@ public class FeedbackController {
         
         FeedbackResponse response = feedbackService.submitFeedback(authentication.getName(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get feedback for an event", description = "Returns feedback submitted for a specific event.")
+    public ResponseEntity<List<FeedbackResponse>> getEventFeedback(@RequestParam Long eventId) {
+        return ResponseEntity.ok(feedbackService.getEventFeedback(eventId));
     }
 
     @GetMapping("/organizers/{organizerId}/score")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
@@ -44,6 +44,8 @@ public interface FeedbackAnalyticsRepository extends JpaRepository<Feedback, Lon
 
     boolean existsByEvent_IdAndUser_Email(Long eventId, String email);
 
+    List<Feedback> findByEvent_IdOrderBySubmittedAtDesc(Long eventId);
+
     void deleteByUser_Id(Long userId);
 
     void deleteByEvent_Id(Long eventId);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -87,6 +87,17 @@ public class FeedbackService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public List<FeedbackResponse> getEventFeedback(Long eventId) {
+        if (!eventRepository.existsById(eventId)) {
+            throw new EventNotFoundException("Event not found with ID: " + eventId);
+        }
+
+        return feedbackRepository.findByEvent_IdOrderBySubmittedAtDesc(eventId).stream()
+                .map(this::mapToResponse)
+                .toList();
+    }
+
     private FeedbackResponse mapToResponse(Feedback feedback) {
         return FeedbackResponse.builder()
                 .id(feedback.getId())

--- a/tests/eventFeedbackEndpointContract.test.mjs
+++ b/tests/eventFeedbackEndpointContract.test.mjs
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const controller = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java",
+  "utf8",
+);
+const service = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java",
+  "utf8",
+);
+const repository = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java",
+  "utf8",
+);
+const security = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java",
+  "utf8",
+);
+
+assert.match(controller, /@GetMapping\s+[\s\S]*@RequestParam Long eventId/);
+assert.equal(service.includes("getEventFeedback(Long eventId)"), true);
+assert.equal(repository.includes("findByEvent_IdOrderBySubmittedAtDesc"), true);
+assert.equal(security.includes('org.springframework.http.HttpMethod.GET, "/api/feedback"'), true);
+
+console.log("event feedback endpoint contract checks passed");


### PR DESCRIPTION
Fixes #12661.

## What changed
- Added `GET /api/feedback?eventId=...` for event feedback reads.
- Added a service method and repository query ordered by newest feedback first.
- Permitted only GET `/api/feedback` publicly; feedback submission still falls through authenticated rules.
- Added a small endpoint contract check.

## Validation
- `node tests/eventFeedbackEndpointContract.test.mjs`

Backend compile was not run locally because this checkout does not include `mvnw` and `mvn` is not installed in the environment.
