### PR TITLE
feat(projects): add fork endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -187,4 +187,19 @@ public class ProjectController {
             Authentication authentication) {
         return ResponseEntity.ok(projectService.upvoteProject(id, authentication.getName()));
     }
+
+    @PostMapping("/{id}/fork")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "Fork a project",
+            description = "Creates a copy of an existing project owned by the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<ProjectResponse> forkProject(
+            @Parameter(description = "ID of the project to fork")
+            @PathVariable Long id,
+            Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(projectService.forkProject(id, authentication.getName()));
+    }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -99,6 +99,26 @@ public class ProjectService {
         return getProjectById(id);
     }
 
+    @Transactional
+    public ProjectResponse forkProject(Long id, String userEmail) {
+        Project source = projectRepository.findById(id)
+                .orElseThrow(() -> new ProjectNotFoundException("Project not found with id: " + id));
+
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
+
+        Project fork = Project.builder()
+                .title(source.getTitle())
+                .description(source.getDescription())
+                .category(source.getCategory())
+                .thumbnailUrl(source.getThumbnailUrl())
+                .githubUrl(source.getGithubUrl())
+                .ownerId(user.getId())
+                .build();
+
+        return toProjectResponse(projectRepository.save(fork));
+    }
+
     private ProjectResponse toProjectResponse(Project project) {
         return ProjectResponse.builder()
                 .id(project.getId())

--- a/tests/projectForkEndpointContract.test.mjs
+++ b/tests/projectForkEndpointContract.test.mjs
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const controller = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java",
+  "utf8",
+);
+const service = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java",
+  "utf8",
+);
+
+assert.match(controller, /@PostMapping\("\/\{id}\/fork"\)/);
+assert.equal(controller.includes("projectService.forkProject(id, authentication.getName())"), true);
+assert.equal(service.includes("ProjectResponse forkProject(Long id, String userEmail)"), true);
+assert.equal(service.includes(".ownerId(user.getId())"), true);
+
+console.log("project fork endpoint contract checks passed");


### PR DESCRIPTION
Fixes #12662.

## What changed
- Added `POST /api/projects/{id}/fork` for authenticated users.
- Forks copy the visible project fields, assign the current user as owner, and start with fresh upvotes.
- Added a small route/service contract check.

## Validation
- `node tests/projectForkEndpointContract.test.mjs`

Backend compile was not run locally because this checkout does not include `mvnw` and `mvn` is not installed in the environment.
