### PR TITLE
feat(users): add achievements endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -6,6 +6,7 @@ import com.sandeep.eventrabackend.dto.request.UserProfileUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.UserProfileResponse;
+import com.sandeep.eventrabackend.dto.response.UserAchievementsResponse;
 import com.sandeep.eventrabackend.exception.UserAlreadyExistsException;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.UserRepository;
@@ -238,6 +239,16 @@ public class UserController {
             Authentication authentication) {
 
         return ResponseEntity.ok(eventService.getRegisteredEventsForUser(authentication.getName()));
+    }
+
+    @GetMapping("/achievements")
+    @Operation(
+            summary = "Get authenticated user achievements",
+            description = "Returns achievement progress for the currently authenticated JWT user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ResponseEntity<UserAchievementsResponse> getUserAchievements(Authentication authentication) {
+        return ResponseEntity.ok(eventService.getAchievementsForUser(authentication.getName()));
     }
 
     @PutMapping("/change-password")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/AchievementBadgeResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/AchievementBadgeResponse.java
@@ -1,0 +1,15 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AchievementBadgeResponse {
+    private String id;
+    private String name;
+    private String description;
+    private boolean earned;
+    private long currentProgress;
+    private long targetProgress;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/UserAchievementsResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/UserAchievementsResponse.java
@@ -1,0 +1,14 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserAchievementsResponse {
+    private long totalEvents;
+    private long gssocEvents;
+    private int currentStreak;
+    private List<AchievementBadgeResponse> badges;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -9,6 +9,8 @@ import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.PagedResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
+import com.sandeep.eventrabackend.dto.response.AchievementBadgeResponse;
+import com.sandeep.eventrabackend.dto.response.UserAchievementsResponse;
 import com.sandeep.eventrabackend.dto.response.WaitlistResponse;
 import com.sandeep.eventrabackend.exception.EventFullException;
 import com.sandeep.eventrabackend.exception.EventNotFoundException;
@@ -46,9 +48,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -304,6 +308,91 @@ public class EventService {
                                 .stream()
                                 .map(this::toMyRegisteredEventResponse)
                                 .toList();
+        }
+
+        @Transactional(readOnly = true)
+        public UserAchievementsResponse getAchievementsForUser(String userEmail) {
+                userRepository.findByEmail(userEmail)
+                                .orElseThrow(() -> new UsernameNotFoundException(
+                                                "User not found with email: " + userEmail));
+
+                List<EventRegistration> registrations =
+                                eventRegistrationRepository.findByUser_EmailOrderByRegisteredAtDesc(userEmail);
+                long totalEvents = registrations.stream()
+                                .filter(registration -> "CONFIRMED".equals(registration.getStatus()))
+                                .count();
+                long gssocEvents = registrations.stream()
+                                .filter(registration -> "CONFIRMED".equals(registration.getStatus()))
+                                .filter(registration -> isGssocEvent(registration.getEvent()))
+                                .count();
+                int currentStreak = calculateCurrentStreak(registrations);
+
+                return UserAchievementsResponse.builder()
+                                .totalEvents(totalEvents)
+                                .gssocEvents(gssocEvents)
+                                .currentStreak(currentStreak)
+                                .badges(List.of(
+                                                buildBadge("first-step", "First Step",
+                                                                "Registered for your first event.", totalEvents, 1),
+                                                buildBadge("active-attendee", "Active Attendee",
+                                                                "Registered for five events.", totalEvents, 5),
+                                                buildBadge("streak-builder", "Streak Builder",
+                                                                "Attended events on three consecutive days.",
+                                                                currentStreak, 3),
+                                                buildBadge("gssoc-explorer", "GSSoC Explorer",
+                                                                "Joined two GSSoC-tagged events.", gssocEvents, 2)))
+                                .build();
+        }
+
+        private AchievementBadgeResponse buildBadge(
+                        String id,
+                        String name,
+                        String description,
+                        long currentProgress,
+                        long targetProgress) {
+                return AchievementBadgeResponse.builder()
+                                .id(id)
+                                .name(name)
+                                .description(description)
+                                .currentProgress(currentProgress)
+                                .targetProgress(targetProgress)
+                                .earned(currentProgress >= targetProgress)
+                                .build();
+        }
+
+        private boolean isGssocEvent(Event event) {
+                if (event == null) {
+                        return false;
+                }
+                String haystack = String.join(" ",
+                                String.valueOf(event.getTitle()),
+                                String.valueOf(event.getDescription()),
+                                String.valueOf(event.getCategory()),
+                                String.join(" ", event.getTags()))
+                                .toLowerCase(Locale.ROOT);
+                return haystack.contains("gssoc") || haystack.contains("girlscript");
+        }
+
+        private int calculateCurrentStreak(List<EventRegistration> registrations) {
+                LinkedHashSet<LocalDate> dates = registrations.stream()
+                                .filter(registration -> "CONFIRMED".equals(registration.getStatus()))
+                                .map(EventRegistration::getEvent)
+                                .filter(event -> event != null && event.getEventDate() != null)
+                                .map(event -> event.getEventDate().toLocalDate())
+                                .sorted(java.util.Comparator.reverseOrder())
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+                int streak = 0;
+                LocalDate expected = null;
+                for (LocalDate date : dates) {
+                        if (expected == null || date.equals(expected)) {
+                                streak++;
+                                expected = date.minusDays(1);
+                        } else if (date.isBefore(expected)) {
+                                break;
+                        }
+                }
+                return streak;
         }
 
         /**

--- a/tests/userAchievementsEndpointContract.test.mjs
+++ b/tests/userAchievementsEndpointContract.test.mjs
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const controller = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java",
+  "utf8",
+);
+const service = fs.readFileSync(
+  "Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java",
+  "utf8",
+);
+
+assert.match(controller, /@GetMapping\("\/achievements"\)/);
+assert.equal(controller.includes("eventService.getAchievementsForUser(authentication.getName())"), true);
+assert.equal(service.includes("UserAchievementsResponse getAchievementsForUser(String userEmail)"), true);
+assert.equal(service.includes("calculateCurrentStreak"), true);
+
+console.log("user achievements endpoint contract checks passed");


### PR DESCRIPTION
Fixes #12667.

## What changed
- Added `GET /api/users/achievements` for authenticated users.
- Computes total registered events, GSSoC-tagged registrations, a registration-day streak, and badge progress from existing registrations.
- Added DTOs for the frontend achievement shape and a small endpoint contract check.

## Validation
- `node tests/userAchievementsEndpointContract.test.mjs`

Backend compile was not run locally because this checkout does not include `mvnw` and `mvn` is not installed in the environment.
