### PR TITLE
feat(profile): add event participation statistics

### DIFF
--- a/src/components/events/profile/EventParticipationStatistics.js
+++ b/src/components/events/profile/EventParticipationStatistics.js
@@ -1,0 +1,320 @@
+import {
+  Award,
+  CalendarCheck2,
+  ChevronDown,
+  Code2,
+  GraduationCap,
+  Users,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+
+import ParticipationStatCard from "./ParticipationStatCard";
+
+import {
+  getEventParticipationStatistics,
+  getParticipationActivityLabel,
+  getParticipationStatCards,
+} from "../../utils/eventParticipationStatsUtils";
+
+const EventParticipationStatistics = ({
+  user = {},
+  statistics: providedStatistics = null,
+  showProgress = true,
+  showActivitySummary = true,
+  collapsible = false,
+  defaultExpanded = true,
+  className = "",
+}) => {
+  const [isExpanded, setIsExpanded] =
+    useState(defaultExpanded);
+
+  const statistics = useMemo(() => {
+    if (providedStatistics) {
+      return providedStatistics;
+    }
+
+    return getEventParticipationStatistics(
+      user
+    );
+  }, [user, providedStatistics]);
+
+  const statCards = useMemo(() => {
+    return getParticipationStatCards({
+      ...user,
+      ...statistics,
+    });
+  }, [user, statistics]);
+
+  const activityLabel =
+    getParticipationActivityLabel({
+      ...user,
+      ...statistics,
+    });
+
+  const iconMap = {
+    eventsRegistered: CalendarCheck2,
+    eventsAttended: CalendarCheck2,
+    hackathonsJoined: Code2,
+    workshopsAttended: GraduationCap,
+    certificatesEarned: Award,
+    teamsJoined: Users,
+  };
+
+  const progressMap = {
+    eventsRegistered: null,
+
+    eventsAttended:
+      statistics.eventsRegistered > 0
+        ? Math.round(
+            (statistics.eventsAttended /
+              statistics.eventsRegistered) *
+              100
+          )
+        : 0,
+
+    hackathonsJoined: null,
+
+    workshopsAttended: null,
+
+    certificatesEarned: null,
+
+    teamsJoined: null,
+  };
+
+  return (
+    <section
+      className={`w-full overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {/* Header */}
+      <div className="border-b border-slate-200 p-5 dark:border-slate-700">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+              <CalendarCheck2
+                size={21}
+                className="text-indigo-600 dark:text-indigo-400"
+              />
+            </div>
+
+            <div className="min-w-0">
+              <h2 className="text-lg font-bold text-slate-800 dark:text-white">
+                Participation Statistics
+              </h2>
+
+              <p className="mt-1 text-sm leading-6 text-slate-500 dark:text-slate-400">
+                Overview of your activity and participation
+                across Eventra.
+              </p>
+            </div>
+          </div>
+
+          {collapsible && (
+            <button
+              type="button"
+              onClick={() =>
+                setIsExpanded(
+                  (current) => !current
+                )
+              }
+              aria-expanded={isExpanded}
+              aria-label={
+                isExpanded
+                  ? "Collapse participation statistics"
+                  : "Expand participation statistics"
+              }
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition hover:bg-slate-50 hover:text-indigo-600 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-indigo-400"
+            >
+              <ChevronDown
+                size={17}
+                className={`transition-transform ${
+                  isExpanded
+                    ? "rotate-180"
+                    : ""
+                }`}
+              />
+            </button>
+          )}
+        </div>
+
+        {showActivitySummary && (
+          <ActivitySummary
+            statistics={statistics}
+            activityLabel={activityLabel}
+          />
+        )}
+      </div>
+
+      {/* Statistics */}
+      {(!collapsible || isExpanded) && (
+        <div className="p-5">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {statCards.map((stat) => {
+              const Icon =
+                iconMap[stat.id] ||
+                CalendarCheck2;
+
+              const progress =
+                progressMap[stat.id];
+
+              return (
+                <ParticipationStatCard
+                  key={stat.id}
+                  {...stat}
+                  icon={Icon}
+                  progress={
+                    showProgress
+                      ? progress
+                      : null
+                  }
+                />
+              );
+            })}
+          </div>
+
+          {/* Attendance progress */}
+          {showProgress &&
+            statistics.eventsRegistered >
+              0 && (
+              <AttendanceProgress
+                registered={
+                  statistics.eventsRegistered
+                }
+                attended={
+                  statistics.eventsAttended
+                }
+                percentage={
+                  statistics.attendancePercentage
+                }
+              />
+            )}
+        </div>
+      )}
+    </section>
+  );
+};
+
+/**
+ * Activity summary shown below the header.
+ */
+const ActivitySummary = ({
+  statistics,
+  activityLabel,
+}) => {
+  const hasActivity =
+    Object.values(
+      statistics || {}
+    ).some(
+      (value) =>
+        typeof value ===
+          "number" &&
+        value > 0
+    );
+
+  return (
+    <div className="mt-5 rounded-xl bg-slate-50 p-4 dark:bg-slate-800">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+            Activity level
+          </p>
+
+          <p className="mt-1 text-sm font-bold text-slate-800 dark:text-white">
+            {activityLabel}
+          </p>
+        </div>
+
+        <div className="text-left sm:text-right">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+            Total activities
+          </p>
+
+          <p className="mt-1 text-sm font-bold text-slate-800 dark:text-white">
+            {hasActivity
+              ? getTotalActivities(
+                  statistics
+                )
+              : 0}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Attendance progress section.
+ */
+const AttendanceProgress = ({
+  registered,
+  attended,
+  percentage,
+}) => {
+  const safePercentage =
+    Math.min(
+      100,
+      Math.max(
+        0,
+        Number(percentage) || 0
+      )
+    );
+
+  return (
+    <div className="mt-5 rounded-xl border border-slate-200 p-4 dark:border-slate-700">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+            Event Attendance
+          </h3>
+
+          <p className="mt-1 text-xs text-slate-400">
+            {attended} of {registered} registered events
+            attended
+          </p>
+        </div>
+
+        <span className="text-lg font-bold text-indigo-600 dark:text-indigo-400">
+          {safePercentage}%
+        </span>
+      </div>
+
+      <div
+        className="mt-3 h-2.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={safePercentage}
+        aria-label="Event attendance percentage"
+      >
+        <div
+          className="h-full rounded-full bg-indigo-600 transition-all duration-500"
+          style={{
+            width: `${safePercentage}%`,
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Calculate a simple total activity count.
+ */
+const getTotalActivities = (
+  statistics = {}
+) => {
+  return [
+    statistics.eventsRegistered,
+    statistics.eventsAttended,
+    statistics.hackathonsJoined,
+    statistics.workshopsAttended,
+    statistics.certificatesEarned,
+    statistics.teamsJoined,
+  ].reduce(
+    (total, value) =>
+      total +
+      (Number(value) || 0),
+    0
+  );
+};
+
+export default EventParticipationStatistics;

--- a/src/components/events/profile/ParticipationStatCard.js
+++ b/src/components/events/profile/ParticipationStatCard.js
@@ -1,0 +1,148 @@
+import {
+  Award,
+  CalendarCheck2,
+  Code2,
+  GraduationCap,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+
+const DEFAULT_ICON_MAP = {
+  eventsRegistered: CalendarCheck2,
+  eventsAttended: CalendarCheck2,
+  hackathonsJoined: Code2,
+  workshopsAttended: GraduationCap,
+  certificatesEarned: Award,
+  teamsJoined: Users,
+};
+
+const ParticipationStatCard = ({
+  id,
+  label,
+  description = "",
+  value = 0,
+  icon: Icon,
+  progress = null,
+  target = null,
+  className = "",
+  onClick,
+}) => {
+  const StatIcon =
+    Icon ||
+    DEFAULT_ICON_MAP[id] ||
+    TrendingUp;
+
+  const numericValue =
+    Number.isFinite(Number(value))
+      ? Number(value)
+      : 0;
+
+  const hasProgress =
+    progress !== null &&
+    progress !== undefined &&
+    Number.isFinite(Number(progress));
+
+  const safeProgress = hasProgress
+    ? Math.min(
+        100,
+        Math.max(
+          0,
+          Number(progress)
+        )
+      )
+    : null;
+
+  const isClickable =
+    typeof onClick === "function";
+
+  const content = (
+    <>
+      {/* Top section */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+          <StatIcon
+            size={19}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        </div>
+
+        {hasProgress && (
+          <span className="rounded-full bg-indigo-50 px-2.5 py-1 text-[10px] font-semibold text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-400">
+            {Math.round(safeProgress)}%
+          </span>
+        )}
+      </div>
+
+      {/* Value */}
+      <div className="mt-5">
+        <p className="text-2xl font-bold tracking-tight text-slate-800 dark:text-white">
+          {numericValue.toLocaleString()}
+        </p>
+
+        <h3 className="mt-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
+          {label}
+        </h3>
+
+        {description && (
+          <p className="mt-1.5 text-xs leading-5 text-slate-400">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {/* Progress */}
+      {hasProgress && (
+        <div className="mt-4">
+          <div
+            className="h-1.5 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={safeProgress}
+            aria-label={`${label} progress`}
+          >
+            <div
+              className="h-full rounded-full bg-indigo-600 transition-all duration-500"
+              style={{
+                width: `${safeProgress}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Optional target */}
+      {target !== null &&
+        target !== undefined && (
+          <p className="mt-3 text-[11px] text-slate-400">
+            Target:{" "}
+            <span className="font-semibold text-slate-500 dark:text-slate-300">
+              {Number(target).toLocaleString()}
+            </span>
+          </p>
+        )}
+    </>
+  );
+
+  if (isClickable) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`w-full rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-indigo-800 dark:focus:ring-offset-slate-900 ${className}`}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className={`rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {content}
+    </div>
+  );
+};
+
+export default ParticipationStatCard;

--- a/src/utils/eventParticipationStatsUtils.js
+++ b/src/utils/eventParticipationStatsUtils.js
@@ -1,0 +1,1056 @@
+/**
+ * Event Participation Statistics utilities.
+ *
+ * Supports:
+ * - Events registered
+ * - Events attended
+ * - Hackathons joined
+ * - Workshops attended
+ * - Certificates earned
+ * - Teams joined
+ * - Participation percentages
+ * - Activity normalization
+ * - Statistics summaries
+ */
+
+export const PARTICIPATION_STAT_TYPES = {
+  EVENTS_REGISTERED: "eventsRegistered",
+  EVENTS_ATTENDED: "eventsAttended",
+  HACKATHONS_JOINED: "hackathonsJoined",
+  WORKSHOPS_ATTENDED: "workshopsAttended",
+  CERTIFICATES_EARNED: "certificatesEarned",
+  TEAMS_JOINED: "teamsJoined",
+};
+
+export const PARTICIPATION_STAT_CONFIG = [
+  {
+    id: PARTICIPATION_STAT_TYPES.EVENTS_REGISTERED,
+    label: "Events Registered",
+    description:
+      "Total events the user has registered for.",
+  },
+  {
+    id: PARTICIPATION_STAT_TYPES.EVENTS_ATTENDED,
+    label: "Events Attended",
+    description:
+      "Total registered events the user attended.",
+  },
+  {
+    id: PARTICIPATION_STAT_TYPES.HACKATHONS_JOINED,
+    label: "Hackathons Joined",
+    description:
+      "Total hackathons the user participated in.",
+  },
+  {
+    id: PARTICIPATION_STAT_TYPES.WORKSHOPS_ATTENDED,
+    label: "Workshops Attended",
+    description:
+      "Total workshops the user attended.",
+  },
+  {
+    id: PARTICIPATION_STAT_TYPES.CERTIFICATES_EARNED,
+    label: "Certificates Earned",
+    description:
+      "Total certificates earned by the user.",
+  },
+  {
+    id: PARTICIPATION_STAT_TYPES.TEAMS_JOINED,
+    label: "Teams Joined",
+    description:
+      "Total event or hackathon teams joined.",
+  },
+];
+
+/**
+ * Safely convert a value to an array.
+ */
+export const toArray = (
+  value
+) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return [];
+};
+
+/**
+ * Safely convert a value to a number.
+ */
+export const toNumber = (
+  value,
+  fallback = 0
+) => {
+  const number = Number(value);
+
+  if (
+    Number.isFinite(number)
+  ) {
+    return number;
+  }
+
+  return fallback;
+};
+
+/**
+ * Normalize an identifier.
+ */
+export const normalizeParticipationId = (
+  value
+) => {
+  if (
+    value === null ||
+    value === undefined
+  ) {
+    return "";
+  }
+
+  return String(value).trim();
+};
+
+/**
+ * Get an ID from an object.
+ */
+export const getParticipationId = (
+  item
+) => {
+  if (
+    item === null ||
+    item === undefined
+  ) {
+    return "";
+  }
+
+  if (
+    typeof item !==
+    "object"
+  ) {
+    return normalizeParticipationId(
+      item
+    );
+  }
+
+  return normalizeParticipationId(
+    item.id ??
+      item.eventId ??
+      item.event_id ??
+      item.registrationId ??
+      item.registration_id
+  );
+};
+
+/**
+ * Get a user's event registrations.
+ */
+export const getEventRegistrations = (
+  user = {}
+) => {
+  return toArray(
+    user.eventRegistrations ??
+      user.eventRegistrationsList ??
+      user.registrations ??
+      user.registeredEvents
+  );
+};
+
+/**
+ * Get attended events.
+ */
+export const getAttendedEvents = (
+  user = {}
+) => {
+  return toArray(
+    user.attendedEvents ??
+      user.eventsAttended ??
+      user.attendance
+  );
+};
+
+/**
+ * Get joined hackathons.
+ */
+export const getJoinedHackathons = (
+  user = {}
+) => {
+  return toArray(
+    user.hackathonsJoined ??
+      user.joinedHackathons ??
+      user.hackathons
+  );
+};
+
+/**
+ * Get attended workshops.
+ */
+export const getAttendedWorkshops = (
+  user = {}
+) => {
+  return toArray(
+    user.workshopsAttended ??
+      user.attendedWorkshops ??
+      user.workshops
+  );
+};
+
+/**
+ * Get earned certificates.
+ */
+export const getEarnedCertificates = (
+  user = {}
+) => {
+  return toArray(
+    user.certificatesEarned ??
+      user.certificates ??
+      user.earnedCertificates
+  );
+};
+
+/**
+ * Get joined teams.
+ */
+export const getJoinedTeams = (
+  user = {}
+) => {
+  return toArray(
+    user.teamsJoined ??
+      user.joinedTeams ??
+      user.teams
+  );
+};
+
+/**
+ * Remove duplicate items by ID.
+ */
+export const uniqueParticipationItems = (
+  items = []
+) => {
+  const seen = new Set();
+
+  return toArray(items).filter(
+    (item) => {
+      const id =
+        getParticipationId(
+          item
+        );
+
+      if (!id) {
+        return true;
+      }
+
+      if (seen.has(id)) {
+        return false;
+      }
+
+      seen.add(id);
+
+      return true;
+    }
+  );
+};
+
+/**
+ * Count unique participation items.
+ */
+export const countUniqueParticipationItems = (
+  items = []
+) => {
+  return uniqueParticipationItems(
+    items
+  ).length;
+};
+
+/**
+ * Calculate attendance percentage.
+ */
+export const calculateAttendancePercentage = ({
+  registered = 0,
+  attended = 0,
+} = {}) => {
+  const registeredCount =
+    toNumber(
+      registered
+    );
+
+  const attendedCount =
+    toNumber(
+      attended
+    );
+
+  if (
+    registeredCount <= 0
+  ) {
+    return 0;
+  }
+
+  const percentage =
+    (attendedCount /
+      registeredCount) *
+    100;
+
+  return Math.min(
+    100,
+    Math.max(
+      0,
+      Math.round(
+        percentage
+      )
+    )
+  );
+};
+
+/**
+ * Calculate participation percentage.
+ */
+export const calculateParticipationPercentage =
+  ({
+    completed = 0,
+    total = 0,
+  } = {}) => {
+    const completedCount =
+      toNumber(
+        completed
+      );
+
+    const totalCount =
+      toNumber(total);
+
+    if (totalCount <= 0) {
+      return 0;
+    }
+
+    return Math.min(
+      100,
+      Math.max(
+        0,
+        Math.round(
+          (completedCount /
+            totalCount) *
+            100
+        )
+      )
+    );
+  };
+
+/**
+ * Get events registered count.
+ */
+export const getEventsRegisteredCount = (
+  user = {}
+) => {
+  if (
+    user.eventsRegistered !==
+    undefined
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.eventsRegistered
+      )
+    );
+  }
+
+  return countUniqueParticipationItems(
+    getEventRegistrations(
+      user
+    )
+  );
+};
+
+/**
+ * Get events attended count.
+ */
+export const getEventsAttendedCount = (
+  user = {}
+) => {
+  if (
+    user.eventsAttended !==
+    undefined &&
+    typeof user.eventsAttended !==
+      "object"
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.eventsAttended
+      )
+    );
+  }
+
+  return countUniqueParticipationItems(
+    getAttendedEvents(
+      user
+    )
+  );
+};
+
+/**
+ * Get hackathons joined count.
+ */
+export const getHackathonsJoinedCount = (
+  user = {}
+) => {
+  if (
+    user.hackathonsJoinedCount !==
+    undefined
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.hackathonsJoinedCount
+      )
+    );
+  }
+
+  if (
+    user.hackathonsJoined !==
+      undefined &&
+    typeof user.hackathonsJoined !==
+      "object"
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.hackathonsJoined
+      )
+    );
+  }
+
+  return countUniqueParticipationItems(
+    getJoinedHackathons(
+      user
+    )
+  );
+};
+
+/**
+ * Get workshops attended count.
+ */
+export const getWorkshopsAttendedCount = (
+  user = {}
+) => {
+  if (
+    user.workshopsAttendedCount !==
+    undefined
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.workshopsAttendedCount
+      )
+    );
+  }
+
+  if (
+    user.workshopsAttended !==
+      undefined &&
+    typeof user.workshopsAttended !==
+      "object"
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.workshopsAttended
+      )
+    );
+  }
+
+  return countUniqueParticipationItems(
+    getAttendedWorkshops(
+      user
+    )
+  );
+};
+
+/**
+ * Get certificates earned count.
+ */
+export const getCertificatesEarnedCount = (
+  user = {}
+) => {
+  if (
+    user.certificatesEarnedCount !==
+    undefined
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.certificatesEarnedCount
+      )
+    );
+  }
+
+  if (
+    user.certificatesEarned !==
+      undefined &&
+    typeof user.certificatesEarned !==
+      "object"
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.certificatesEarned
+      )
+    );
+  }
+
+  return countUniqueParticipationItems(
+    getEarnedCertificates(
+      user
+    )
+  );
+};
+
+/**
+ * Get teams joined count.
+ */
+export const getTeamsJoinedCount = (
+  user = {}
+) => {
+  if (
+    user.teamsJoinedCount !==
+    undefined
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.teamsJoinedCount
+      )
+    );
+  }
+
+  if (
+    user.teamsJoined !==
+      undefined &&
+    typeof user.teamsJoined !==
+      "object"
+  ) {
+    return Math.max(
+      0,
+      toNumber(
+        user.teamsJoined
+      )
+    );
+  }
+
+  return countUniqueParticipationItems(
+    getJoinedTeams(
+      user
+    )
+  );
+};
+
+/**
+ * Build the complete participation
+ * statistics object.
+ */
+export const getEventParticipationStatistics = (
+  user = {}
+) => {
+  const eventsRegistered =
+    getEventsRegisteredCount(
+      user
+    );
+
+  const eventsAttended =
+    getEventsAttendedCount(
+      user
+    );
+
+  const hackathonsJoined =
+    getHackathonsJoinedCount(
+      user
+    );
+
+  const workshopsAttended =
+    getWorkshopsAttendedCount(
+      user
+    );
+
+  const certificatesEarned =
+    getCertificatesEarnedCount(
+      user
+    );
+
+  const teamsJoined =
+    getTeamsJoinedCount(
+      user
+    );
+
+  return {
+    eventsRegistered,
+    eventsAttended,
+    hackathonsJoined,
+    workshopsAttended,
+    certificatesEarned,
+    teamsJoined,
+
+    attendancePercentage:
+      calculateAttendancePercentage({
+        registered:
+          eventsRegistered,
+        attended:
+          eventsAttended,
+      }),
+  };
+};
+
+/**
+ * Convert statistics into UI cards.
+ */
+export const getParticipationStatCards = (
+  user = {}
+) => {
+  const statistics =
+    getEventParticipationStatistics(
+      user
+    );
+
+  return PARTICIPATION_STAT_CONFIG.map(
+    (config) => ({
+      ...config,
+      value:
+        statistics[
+          config.id
+        ] ?? 0,
+    })
+  );
+};
+
+/**
+ * Get one statistic by type.
+ */
+export const getParticipationStat = (
+  user = {},
+  statType
+) => {
+  const statistics =
+    getEventParticipationStatistics(
+      user
+    );
+
+  return toNumber(
+    statistics[
+      statType
+    ]
+  );
+};
+
+/**
+ * Check whether a statistic type
+ * is supported.
+ */
+export const isValidParticipationStatType =
+  (statType) => {
+    return Object.values(
+      PARTICIPATION_STAT_TYPES
+    ).includes(statType);
+  };
+
+/**
+ * Get configuration for a statistic.
+ */
+export const getParticipationStatConfig = (
+  statType
+) => {
+  return (
+    PARTICIPATION_STAT_CONFIG.find(
+      (config) =>
+        config.id === statType
+    ) || null
+  );
+};
+
+/**
+ * Calculate overall participation score.
+ *
+ * This is an activity indicator, not a
+ * percentage of all Eventra users.
+ */
+export const calculateParticipationScore = (
+  user = {}
+) => {
+  const statistics =
+    getEventParticipationStatistics(
+      user
+    );
+
+  const score =
+    statistics.eventsRegistered +
+    statistics.eventsAttended * 2 +
+    statistics.hackathonsJoined * 3 +
+    statistics.workshopsAttended * 2 +
+    statistics.certificatesEarned * 3 +
+    statistics.teamsJoined;
+
+  return Math.max(
+    0,
+    score
+  );
+};
+
+/**
+ * Get a simple activity level based
+ * on participation score.
+ */
+export const getParticipationActivityLevel = (
+  user = {}
+) => {
+  const score =
+    calculateParticipationScore(
+      user
+    );
+
+  if (score >= 50) {
+    return "high";
+  }
+
+  if (score >= 20) {
+    return "medium";
+  }
+
+  if (score > 0) {
+    return "low";
+  }
+
+  return "none";
+};
+
+/**
+ * Get a human-readable activity label.
+ */
+export const getParticipationActivityLabel = (
+  user = {}
+) => {
+  const level =
+    getParticipationActivityLevel(
+      user
+    );
+
+  const labels = {
+    high: "Highly Active",
+    medium: "Active",
+    low: "Getting Started",
+    none: "No Activity Yet",
+  };
+
+  return (
+    labels[level] ||
+    "No Activity Yet"
+  );
+};
+
+/**
+ * Get a complete profile activity
+ * summary.
+ */
+export const getParticipationSummary = (
+  user = {}
+) => {
+  const statistics =
+    getEventParticipationStatistics(
+      user
+    );
+
+  return {
+    ...statistics,
+
+    score:
+      calculateParticipationScore(
+        user
+      ),
+
+    activityLevel:
+      getParticipationActivityLevel(
+        user
+      ),
+
+    activityLabel:
+      getParticipationActivityLabel(
+        user
+      ),
+  };
+};
+
+/**
+ * Normalize profile statistics.
+ */
+export const normalizeParticipationStatistics =
+  (
+    statistics = {}
+  ) => {
+    return {
+      eventsRegistered:
+        Math.max(
+          0,
+          toNumber(
+            statistics.eventsRegistered
+          )
+        ),
+
+      eventsAttended:
+        Math.max(
+          0,
+          toNumber(
+            statistics.eventsAttended
+          )
+        ),
+
+      hackathonsJoined:
+        Math.max(
+          0,
+          toNumber(
+            statistics.hackathonsJoined
+          )
+        ),
+
+      workshopsAttended:
+        Math.max(
+          0,
+          toNumber(
+            statistics.workshopsAttended
+          )
+        ),
+
+      certificatesEarned:
+        Math.max(
+          0,
+          toNumber(
+            statistics.certificatesEarned
+          )
+        ),
+
+      teamsJoined:
+        Math.max(
+          0,
+          toNumber(
+            statistics.teamsJoined
+          )
+        ),
+    };
+  };
+
+/**
+ * Merge calculated statistics with
+ * externally supplied values.
+ */
+export const mergeParticipationStatistics =
+  (
+    calculated = {},
+    overrides = {}
+  ) => {
+    return {
+      ...normalizeParticipationStatistics(
+        calculated
+      ),
+      ...normalizeParticipationStatistics(
+        overrides
+      ),
+    };
+  };
+
+/**
+ * Get attendance status.
+ */
+export const getAttendanceStatus = (
+  registered,
+  attended
+) => {
+  const percentage =
+    calculateAttendancePercentage({
+      registered,
+      attended,
+    });
+
+  if (registered <= 0) {
+    return "not-started";
+  }
+
+  if (percentage >= 80) {
+    return "excellent";
+  }
+
+  if (percentage >= 60) {
+    return "good";
+  }
+
+  if (percentage > 0) {
+    return "needs-improvement";
+  }
+
+  return "not-attended";
+};
+
+/**
+ * Get attendance status label.
+ */
+export const getAttendanceStatusLabel = (
+  registered,
+  attended
+) => {
+  const status =
+    getAttendanceStatus(
+      registered,
+      attended
+    );
+
+  const labels = {
+    "not-started":
+      "No registrations",
+    excellent:
+      "Excellent attendance",
+    good:
+      "Good attendance",
+    "needs-improvement":
+      "Needs improvement",
+    "not-attended":
+      "No attendance recorded",
+  };
+
+  return (
+    labels[status] ||
+    "No attendance recorded"
+  );
+};
+
+/**
+ * Calculate progress toward a target.
+ */
+export const calculateStatProgress = (
+  value,
+  target
+) => {
+  const current =
+    toNumber(value);
+
+  const targetValue =
+    toNumber(target);
+
+  if (
+    targetValue <= 0
+  ) {
+    return 0;
+  }
+
+  return Math.min(
+    100,
+    Math.max(
+      0,
+      Math.round(
+        (current /
+          targetValue) *
+          100
+      )
+    )
+  );
+};
+
+/**
+ * Get event registration to attendance
+ * conversion percentage.
+ */
+export const getAttendanceConversionRate = (
+  user = {}
+) => {
+  return calculateAttendancePercentage(
+    {
+      registered:
+        getEventsRegisteredCount(
+          user
+        ),
+      attended:
+        getEventsAttendedCount(
+          user
+        ),
+    }
+  );
+};
+
+/**
+ * Check if the user has any
+ * participation activity.
+ */
+export const hasParticipationActivity = (
+  user = {}
+) => {
+  const statistics =
+    getEventParticipationStatistics(
+      user
+    );
+
+  return Object.values(
+    statistics
+  ).some(
+    (value) =>
+      typeof value ===
+        "number" &&
+      value > 0
+  );
+};
+
+/**
+ * Get statistics that have a
+ * non-zero value.
+ */
+export const getActiveParticipationStats = (
+  user = {}
+) => {
+  return getParticipationStatCards(
+    user
+  ).filter(
+    (stat) =>
+      toNumber(
+        stat.value
+      ) > 0
+  );
+};
+
+/**
+ * Get statistics with zero values.
+ */
+export const getEmptyParticipationStats = (
+  user = {}
+) => {
+  return getParticipationStatCards(
+    user
+  ).filter(
+    (stat) =>
+      toNumber(
+        stat.value
+      ) === 0
+  );
+};
+
+/**
+ * Get a concise participation overview.
+ */
+export const getParticipationOverview = (
+  user = {}
+) => {
+  const statistics =
+    getEventParticipationStatistics(
+      user
+    );
+
+  return {
+    registered:
+      statistics.eventsRegistered,
+
+    attended:
+      statistics.eventsAttended,
+
+    hackathons:
+      statistics.hackathonsJoined,
+
+    workshops:
+      statistics.workshopsAttended,
+
+    certificates:
+      statistics.certificatesEarned,
+
+    teams:
+      statistics.teamsJoined,
+
+    attendanceRate:
+      statistics.attendancePercentage,
+  };
+};


### PR DESCRIPTION
## Description

Implemented participation statistics for user profiles.

### Added

- Events registered statistic
- Events attended statistic
- Hackathons joined statistic
- Workshops attended statistic
- Certificates earned statistic
- Teams joined statistic
- Attendance percentage
- Activity level summary
- Responsive statistic cards
- Progress indicators
- Accessible progress bars
- Statistics normalization and validation utilities

Closes #12650