### PR TITLE
fix(auth): use google token exchange

### DIFF
--- a/src/components/auth/SocialLogin.js
+++ b/src/components/auth/SocialLogin.js
@@ -1,15 +1,70 @@
-import React from 'react';
-import { API_ENDPOINTS } from '../../config/api';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 import './Auth.css';
 
-export default function SocialLogin() {
-  const handleSocialLogin = (provider) => {
-    // Redirect to backend OAuth endpoint which handles the flow
-    if (provider === 'google') {
-      window.location.href = API_ENDPOINTS.AUTH.GOOGLE;
-    } else if (provider === 'github') {
-      window.location.href = API_ENDPOINTS.AUTH.GITHUB;
+const GOOGLE_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+const GOOGLE_CLIENT_ID = process.env.VITE_GOOGLE_CLIENT_ID || process.env.REACT_APP_GOOGLE_CLIENT_ID || '';
+
+const loadGoogleScript = () => {
+  if (typeof window === 'undefined') return Promise.reject(new Error('Browser required'));
+  if (window.google?.accounts?.id) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${GOOGLE_SCRIPT_SRC}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error('Google login unavailable')), { once: true });
+      return;
     }
+
+    const script = document.createElement('script');
+    script.src = GOOGLE_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Google login unavailable'));
+    document.head.appendChild(script);
+  });
+};
+
+export default function SocialLogin() {
+  const navigate = useNavigate();
+  const { googleLogin } = useAuth();
+  const [googleReady, setGoogleReady] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!GOOGLE_CLIENT_ID) return undefined;
+
+    loadGoogleScript()
+      .then(() => {
+        if (cancelled) return;
+        window.google.accounts.id.initialize({
+          client_id: GOOGLE_CLIENT_ID,
+          callback: async ({ credential }) => {
+            if (!credential) return;
+            setLoading(true);
+            const success = await googleLogin(credential);
+            setLoading(false);
+            if (success) navigate('/dashboard', { replace: true });
+          },
+        });
+        setGoogleReady(true);
+      })
+      .catch(() => {
+        if (!cancelled) setGoogleReady(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [googleLogin, navigate]);
+
+  const handleGoogleLogin = () => {
+    if (!googleReady || loading) return;
+    window.google.accounts.id.prompt();
   };
 
   return (
@@ -26,8 +81,9 @@ export default function SocialLogin() {
       <div className="grid grid-cols-2 gap-4">
         <button
           type="button"
-          onClick={() => handleSocialLogin('google')}
-          className="flex items-center justify-center gap-2 px-4 py-3 border border-slate-300/20 rounded-xl hover:bg-white/5 transition-all duration-300"
+          onClick={handleGoogleLogin}
+          disabled={!googleReady || loading}
+          className="flex items-center justify-center gap-2 px-4 py-3 border border-slate-300/20 rounded-xl hover:bg-white/5 transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <svg className="w-5 h-5" viewBox="0 0 24 24">
             <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
@@ -35,13 +91,13 @@ export default function SocialLogin() {
             <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
             <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
           </svg>
-          <span className="text-gray-300 font-medium">Google</span>
+          <span className="text-gray-300 font-medium">{loading ? 'Google...' : 'Google'}</span>
         </button>
         
         <button
           type="button"
-          onClick={() => handleSocialLogin('github')}
-          className="flex items-center justify-center gap-2 px-4 py-3 border border-slate-300/20 rounded-xl hover:bg-white/5 transition-all duration-300"
+          disabled
+          className="flex items-center justify-center gap-2 px-4 py-3 border border-slate-300/20 rounded-xl opacity-50 cursor-not-allowed"
         >
           <svg className="w-5 h-5 text-gray-300" fill="currentColor" viewBox="0 0 24 24">
             <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -404,6 +404,35 @@ export const AuthProvider = ({ children }) => {
     [persistSession]
   );
 
+  const googleLogin = useCallback(
+    async (idToken) => {
+      setAuthRequest({ loading: true, error: null });
+
+      try {
+        const res = await authService.googleLogin(idToken);
+        const data = res.data;
+        const { refreshToken, sessionUser } = extractSession(data, data?.email || null);
+        const persisted = await persistSession("cookie-managed", sessionUser, refreshToken);
+        if (!persisted) return false;
+
+        setAuthRequest({ loading: false, error: null });
+        return true;
+      } catch (error) {
+        if (!isMountedRef.current) return false;
+        deleteCookie("token", {
+          path: "/",
+          secureVariants: true,
+        });
+        setAuthRequest({
+          loading: false,
+          error: getAuthErrorMessage(error, "Google login failed. Please try again."),
+        });
+        return false;
+      }
+    },
+    [persistSession]
+  );
+
   /**
    * Logs out the user.
    */
@@ -447,6 +476,7 @@ export const AuthProvider = ({ children }) => {
     requiresReauth,
     setRequiresReauth,
     login,
+    googleLogin,
     logout,
     setAuthSession,
     setUser,
@@ -460,6 +490,7 @@ export const AuthProvider = ({ children }) => {
     requiresReauth,
     setRequiresReauth,
     login,
+    googleLogin,
     logout,
     setAuthSession,
     setUser,

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -17,5 +17,9 @@ export const authService = {
   
   logout: async () => {
     return apiUtils.post(API_ENDPOINTS.AUTH.LOGOUT);
-  }
+  },
+
+  googleLogin: withRateLimit(async (token) => {
+    return apiUtils.post(API_ENDPOINTS.AUTH.GOOGLE, { token });
+  }, { maxTokens: 5, refillRate: 0.1 }),
 };

--- a/tests/socialLoginContract.test.mjs
+++ b/tests/socialLoginContract.test.mjs
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import assert from "node:assert/strict";
+
+const socialLogin = fs.readFileSync("src/components/auth/SocialLogin.js", "utf8");
+const authService = fs.readFileSync("src/services/authService.js", "utf8");
+const authContext = fs.readFileSync("src/context/AuthContext.js", "utf8");
+
+assert.equal(socialLogin.includes("window.location.href"), false);
+assert.equal(socialLogin.includes("API_ENDPOINTS.AUTH.GITHUB"), false);
+assert.equal(socialLogin.includes("window.google.accounts.id.initialize"), true);
+assert.equal(authService.includes("googleLogin"), true);
+assert.equal(authContext.includes("googleLogin,"), true);
+
+console.log("social login contract checks passed");


### PR DESCRIPTION
Fixes #12660.

## What changed
- Removed broken `window.location.href` redirects to backend auth routes.
- Added a Google ID-token exchange path that posts to the existing `POST /auth/google` backend contract.
- Reuses the normal cookie-managed session persistence path after Google login succeeds.
- Leaves GitHub disabled until there is a backend GitHub verifier instead of sending users to a missing route.
- Added a small contract check for the social-login behavior.

## Validation
- `node tests/socialLoginContract.test.mjs`
- `npx eslint src/components/auth/SocialLogin.js src/services/authService.js src/context/AuthContext.js tests/socialLoginContract.test.mjs`
