### PR TITLE
fix(hackathons): wire Register CTA to backend endpoint

### DIFF
--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -2,8 +2,11 @@ import { CalendarIcon, MapPinIcon, ClockIcon, UserGroupIcon, TrophyIcon, Buildin
 import { motion } from "framer-motion";
 import { useState, useEffect, useCallback, useMemo, memo } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 import useReducedMotion from "hooks/useReducedMotion.js";
 import { getServerTime } from "utils/timeSync";
+import { useAuth } from "context/AuthContext";
+import { registerHackathon } from "services/hackathonService";
 
 import ShareMenu from "components/common/ShareMenu";
 import { addHackathonToGoogleCalendar } from "utils/calendarUtils";
@@ -143,6 +146,8 @@ const formatDateRange = (startDate, endDate) => {
 const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
   const prefersReducedMotion = useReducedMotion();
   const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+  const [isRegistering, setIsRegistering] = useState(false);
   const normalizedHackathon = {
     ...hackathon,
     title: hackathon?.title || "Untitled Hackathon",
@@ -171,6 +176,37 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
     ...normalizedHackathon,
     date: normalizedHackathon.startDate,
   });
+
+  const handleRegister = useCallback(async () => {
+    if (!isAuthenticated()) {
+      toast.info("Please log in to register for this hackathon.");
+      navigate("/login", {
+        state: { from: `/hackathons` },
+      });
+      return;
+    }
+
+    if (isRegistering) return;
+
+    setIsRegistering(true);
+    try {
+      await registerHackathon(normalizedHackathon.id);
+      toast.success(`Registered for ${normalizedHackathon.title}!`);
+    } catch (error) {
+      const status = error?.response?.status;
+      const message = error?.response?.data?.message;
+      if (status === 409) {
+        toast.info(message || "You are already registered for this hackathon.");
+      } else if (status === 401) {
+        toast.info("Please log in to register for this hackathon.");
+        navigate("/login", { state: { from: `/hackathons` } });
+      } else {
+        toast.error(message || "Failed to register. Please try again.");
+      }
+    } finally {
+      setIsRegistering(false);
+    }
+  }, [isAuthenticated, isRegistering, navigate, normalizedHackathon.id, normalizedHackathon.title]);
 
   return (
     <motion.div
@@ -310,10 +346,11 @@ const HackathonCard = ({ hackathon, isFeatured = false, ...props }) => {
             <>
               <button
                 type="button"
-                onClick={() => navigate(`/register/${normalizedHackathon.id}`)}
-                className="rounded-xl bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg"
+                onClick={handleRegister}
+                disabled={isRegistering}
+                className="rounded-xl bg-linear-to-r from-blue-600 via-indigo-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Register
+                {isRegistering ? "Registering..." : "Register"}
               </button>
               <a
                 href={addHackathonToGoogleCalendar(normalizedHackathon)}

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -233,6 +233,7 @@ export const API_ENDPOINTS = {
     LIST: buildApiUrl("/hackathons"),
     DETAIL: (id) => buildApiUrl(`/hackathons/${id}`),
     HOST: buildApiUrl("/hackathons"),
+    REGISTER: (id) => buildApiUrl(`/hackathons/${id}/register`),
   },
   NOTIFICATIONS: {
     BASE: buildApiUrl("/notifications"),

--- a/src/services/hackathonService.js
+++ b/src/services/hackathonService.js
@@ -45,3 +45,8 @@ export const fetchHackathons = async () => {
 export const hostHackathon = async (hackathonData, config) => {
   return apiUtils.post(API_ENDPOINTS.HACKATHONS.HOST, hackathonData, config);
 };
+
+export const registerHackathon = async (id) => {
+  return apiUtils.post(API_ENDPOINTS.HACKATHONS.REGISTER(id));
+};
+


### PR DESCRIPTION
## Description

Hackathon cards navigated to `/register/${id}`, which is not a hackathon registration route. Call `POST /api/hackathons/{id}/register` via `registerHackathon` and surface 409/401 correctly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12792

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)