### PR TITLE
fix(events): use attendees endpoint for cancel notifications

### DIFF
--- a/src/utils/eventCancellationNotifications.js
+++ b/src/utils/eventCancellationNotifications.js
@@ -203,7 +203,7 @@ This is an automated message. Please do not reply to this email.
    */
   async fetchEventRegistrations(eventId) {
     try {
-      const response = await this.apiClient.get(`/events/${eventId}/registrations`);
+      const response = await this.apiClient.get(`/events/${eventId}/attendees`);
       return response.data || [];
     } catch (error) {
       console.error(`Failed to fetch registrations for event ${eventId}:`, error);


### PR DESCRIPTION
## Description

`eventCancellationNotifications` called `GET /events/{id}/registrations`, which does not exist. Switch to `/events/{id}/attendees` so cancel emails can resolve recipients.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12786

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)