### PR TITLE
fix(notifications): save preferences to /users/preferences

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -240,7 +240,7 @@ export const API_ENDPOINTS = {
     READ: (id) => (id ? buildApiUrl(`/notifications/${id}/read`) : ""),
     DELETE: (id) => (id ? buildApiUrl(`/notifications/${id}`) : ""),
     READ_ALL: buildApiUrl("/notifications/read-all"),
-    PREFERENCES: buildApiUrl("/notifications/preferences"),
+    PREFERENCES: buildApiUrl("/users/preferences"),
     PUSH_SUBSCRIBE: buildApiUrl("/notifications/push-subscriptions"),
     PUSH_UNSUBSCRIBE: buildApiUrl("/notifications/push-subscriptions/unsubscribe"),
   },

--- a/src/hooks/useNotificationPreferences.js
+++ b/src/hooks/useNotificationPreferences.js
@@ -40,7 +40,8 @@ export function useNotificationPreferences() {
       const endpoint = API_ENDPOINTS?.NOTIFICATIONS?.PREFERENCES;
       if (!token || !endpoint) return { savedRemotely: false, preferences: normalized };
       try {
-        await apiUtils.put(endpoint, normalized);
+        // UserController expects PreferencesUpdateRequest: { preferences: {...} }
+        await apiUtils.put(endpoint, { preferences: { notifications: normalized } });
         return { savedRemotely: true, preferences: normalized };
       } catch (error) {
         console.error("[useNotificationPreferences] Error saving:", error);


### PR DESCRIPTION
## Description

FE was PUTting `/notifications/preferences`, which does not exist. Point at `/users/preferences` and wrap the payload as `{ preferences: { notifications } }` to match PreferencesUpdateRequest.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12795

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)