### PR TITLE
fix(waitlist): stop inflating positions after leave/promote

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
@@ -28,7 +28,7 @@ public interface EventWaitlistRepository extends JpaRepository<EventWaitlist, Lo
             """)
     List<EventWaitlist> findWaitingByEventIdWithLock(@Param("eventId") Long eventId);
 
-    @Query("SELECT COALESCE(MAX(w.position), 0) FROM EventWaitlist w WHERE w.event.id = :eventId")
+    @Query("SELECT COALESCE(MAX(w.position), 0) FROM EventWaitlist w WHERE w.event.id = :eventId AND w.status = 'WAITING'")
     int findMaxPositionByEventId(@Param("eventId") Long eventId);
 
     void deleteByEvent_Id(Long eventId);


### PR DESCRIPTION
## Description

`findMaxPositionByEventId` used MAX(position) across all statuses, so REMOVED/PROMOTED rows permanently inflated new join positions. Restrict the query to `WAITING`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12802

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)