### PR TITLE
fix(hackathons): return 409 on concurrent duplicate register

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -13,6 +13,7 @@ import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
 import com.sandeep.eventrabackend.repository.HackathonRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.security.access.AccessDeniedException;
 import com.sandeep.eventrabackend.model.Role;
@@ -129,7 +130,11 @@ public class HackathonService {
                 .status("CONFIRMED")
                 .build();
 
-        registration = hackathonRegistrationRepository.save(registration);
+        try {
+            registration = hackathonRegistrationRepository.saveAndFlush(registration);
+        } catch (DataIntegrityViolationException ex) {
+            throw new RegistrationConflictException("You are already registered for this hackathon.");
+        }
 
         return HackathonRegistrationResponse.builder()
                 .registrationId(registration.getId())


### PR DESCRIPTION
## Description

Concurrent `registerUserForHackathon` calls can pass `existsBy` and hit the unique constraint as a 500. Catch `DataIntegrityViolationException` and throw `RegistrationConflictException`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12793

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)