### PR TITLE
fix(security): strip userId from public feedback API

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
@@ -3,6 +3,7 @@ package com.sandeep.eventrabackend.controller;
 import com.sandeep.eventrabackend.dto.request.FeedbackRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.FeedbackResponse;
+import com.sandeep.eventrabackend.dto.response.PublicFeedbackResponse;
 import com.sandeep.eventrabackend.service.FeedbackService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -63,7 +64,7 @@ public class FeedbackController {
 
     @GetMapping
     @Operation(summary = "Get feedback for an event", description = "Returns feedback submitted for a specific event.")
-    public ResponseEntity<List<FeedbackResponse>> getEventFeedback(@RequestParam Long eventId) {
+    public ResponseEntity<List<PublicFeedbackResponse>> getEventFeedback(@RequestParam Long eventId) {
         return ResponseEntity.ok(feedbackService.getEventFeedback(eventId));
     }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/PublicFeedbackResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/PublicFeedbackResponse.java
@@ -1,0 +1,20 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PublicFeedbackResponse {
+    private Long id;
+    private Long eventId;
+    private Integer rating;
+    private String comment;
+    private LocalDateTime submittedAt;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.request.FeedbackRequest;
 import com.sandeep.eventrabackend.dto.response.FeedbackResponse;
+import com.sandeep.eventrabackend.dto.response.PublicFeedbackResponse;
 import com.sandeep.eventrabackend.exception.EventNotFoundException;
 import com.sandeep.eventrabackend.exception.FeedbackAlreadyExistsException;
 import com.sandeep.eventrabackend.exception.UserNotRegisteredException;
@@ -88,13 +89,13 @@ public class FeedbackService {
     }
 
     @Transactional(readOnly = true)
-    public List<FeedbackResponse> getEventFeedback(Long eventId) {
+    public List<PublicFeedbackResponse> getEventFeedback(Long eventId) {
         if (!eventRepository.existsById(eventId)) {
             throw new EventNotFoundException("Event not found with ID: " + eventId);
         }
 
         return feedbackRepository.findByEvent_IdOrderBySubmittedAtDesc(eventId).stream()
-                .map(this::mapToResponse)
+                .map(this::mapToPublicResponse)
                 .toList();
     }
 
@@ -103,6 +104,16 @@ public class FeedbackService {
                 .id(feedback.getId())
                 .eventId(feedback.getEvent().getId())
                 .userId(feedback.getUser().getId())
+                .rating(feedback.getRating())
+                .comment(feedback.getComment())
+                .submittedAt(feedback.getSubmittedAt())
+                .build();
+    }
+
+    private PublicFeedbackResponse mapToPublicResponse(Feedback feedback) {
+        return PublicFeedbackResponse.builder()
+                .id(feedback.getId())
+                .eventId(feedback.getEvent().getId())
                 .rating(feedback.getRating())
                 .comment(feedback.getComment())
                 .submittedAt(feedback.getSubmittedAt())


### PR DESCRIPTION
## Description

Public `GET /api/feedback` returned `userId` alongside comments. Serve a public DTO without `userId` for the unauthenticated event feedback list.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12789

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)