### PR TITLE
fix(events): persist registration cancellation via API

### DIFF
--- a/src/components/events/RegistrationCancellation.js
+++ b/src/components/events/RegistrationCancellation.js
@@ -50,9 +50,9 @@ const RegistrationCancellation = ({
     setShowConfirmation(false);
   };
 
-  const handleConfirmCancellation = () => {
+  const handleConfirmCancellation = async () => {
     const result =
-      cancelRegistration(updatedRegistration);
+      await cancelRegistration(updatedRegistration);
 
     if (!result?.success) {
       setMessage(

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -198,6 +198,7 @@ export const API_ENDPOINTS = {
     LIST: buildApiUrl("/events"),
     DETAIL: (id) => buildApiUrl(`/events/${id}`),
     REGISTER: (id) => buildApiUrl(`/events/${id}/register`),
+    CANCEL_REGISTRATION: (id) => buildApiUrl(`/events/${id}/registration`),
     CANCEL: (id) => buildApiUrl(`/events/${id}/cancel`),
     AVAILABILITY: (id) => buildApiUrl(`/events/${id}/availability`),
     ATTENDEES: (id) => buildApiUrl(`/events/${id}/attendees`),

--- a/src/utils/registrationCancellationUtils.js
+++ b/src/utils/registrationCancellationUtils.js
@@ -1,3 +1,5 @@
+import { apiUtils, API_ENDPOINTS } from '../config/api';
+
 export const CANCELLATION_STATUS = "Cancelled";
 
 /**
@@ -32,7 +34,7 @@ export const canCancelRegistration = (
  * The utility updates the registration status and
  * records the cancellation timestamp.
  */
-export const cancelRegistration = (
+export const cancelRegistration = async (
   registration
 ) => {
   if (!registration) {
@@ -50,6 +52,46 @@ export const cancelRegistration = (
       success: false,
       message:
         "This registration cannot be cancelled.",
+      registration,
+      seatReleased: false,
+      waitlistEligible: false,
+    };
+  }
+
+  const eventId =
+    registration.eventId ||
+    registration.event?.id ||
+    registration.eventID;
+
+  if (!eventId) {
+    return {
+      success: false,
+      message: "Event id is required to cancel this registration.",
+      registration,
+      seatReleased: false,
+      waitlistEligible: false,
+    };
+  }
+
+  try {
+    const response = await apiUtils.delete(
+      API_ENDPOINTS.EVENTS.CANCEL_REGISTRATION(eventId)
+    );
+    if (!response.ok) {
+      return {
+        success: false,
+        message: "Unable to cancel registration on the server.",
+        registration,
+        seatReleased: false,
+        waitlistEligible: false,
+      };
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message:
+        error?.message ||
+        "Unable to cancel registration on the server.",
       registration,
       seatReleased: false,
       waitlistEligible: false,


### PR DESCRIPTION
## Description

Cancel registration only flipped local status and never called the backend. Call `DELETE /api/events/{id}/registration` before updating UI state so seats and waitlist promotion stay correct.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12785

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)