### PR TITLE
fix(events): add ICS subscription feed endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -146,6 +146,7 @@ public class SecurityConfig {
                                 "/api/events/{id}",
                                 "/api/events/{id}/availability",
                                 "/api/events/{id}/seats",
+                                "/api/events/{id}/feed.ics",
                                 "/api/events/stream"
                         ).permitAll()
                         .requestMatchers("/stream", "/stream/**").permitAll()

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -357,6 +358,16 @@ public class EventController {
                         @PathVariable Long id,
                         Authentication authentication) {
                 return ResponseEntity.ok(eventService.getNotifiedAttendees(id, authentication.getName()));
+        }
+
+
+        @GetMapping(value = "/{id}/feed.ics", produces = "text/calendar")
+        @Operation(summary = "ICS calendar feed for an event")
+        public ResponseEntity<String> getEventIcsFeed(@PathVariable Long id) {
+                String ics = eventService.buildIcsFeed(id);
+                return ResponseEntity.ok()
+                                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"event-" + id + ".ics\"")
+                                .body(ics);
         }
 
         // ── Issue #2100 — DELETE /api/events/{id} ───────────────────────────────

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1148,4 +1148,46 @@ public class EventService {
                 return new RegistrationConflictException(
                                 "Registration could not be completed due to a conflict. Please try again.");
         }
+
+        public String buildIcsFeed(Long eventId) {
+                Event event = eventRepository.findById(eventId)
+                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+
+                java.time.LocalDateTime start = event.getEventDate() != null
+                                ? event.getEventDate()
+                                : java.time.LocalDateTime.now();
+                java.time.LocalDateTime end = start.plusHours(2);
+                java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+
+                String summary = escapeIcs(event.getTitle() != null ? event.getTitle() : "Eventra Event");
+                String description = escapeIcs(event.getDescription() != null ? event.getDescription() : "");
+                String location = escapeIcs(event.getLocation() != null ? event.getLocation() : "");
+                String uid = "event-" + event.getId() + "@eventra";
+
+                return "BEGIN:VCALENDAR\r\n"
+                                + "VERSION:2.0\r\n"
+                                + "PRODID:-//Eventra//EN\r\n"
+                                + "CALSCALE:GREGORIAN\r\n"
+                                + "METHOD:PUBLISH\r\n"
+                                + "BEGIN:VEVENT\r\n"
+                                + "UID:" + uid + "\r\n"
+                                + "DTSTAMP:" + java.time.LocalDateTime.now().format(fmt) + "\r\n"
+                                + "DTSTART:" + start.format(fmt) + "\r\n"
+                                + "DTEND:" + end.format(fmt) + "\r\n"
+                                + "SUMMARY:" + summary + "\r\n"
+                                + "DESCRIPTION:" + description + "\r\n"
+                                + "LOCATION:" + location + "\r\n"
+                                + "END:VEVENT\r\n"
+                                + "END:VCALENDAR\r\n";
+        }
+
+        private static String escapeIcs(String value) {
+                return value
+                                .replace("\\", "\\\\")
+                                .replace(",", "\\,")
+                                .replace(";", "\\;")
+                                .replace("\n", "\\n")
+                                .replace("\r", "");
+        }
+
 }


### PR DESCRIPTION
## Description

Post-registration Apple/ICS subscribe URLs hit `/api/events/{id}/feed.ics`, which did not exist. Add a public text/calendar feed built from the event details.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12788

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)