### PR TITLE
fix(security): authenticate sensitive SSE stream topics

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -148,7 +148,8 @@ public class SecurityConfig {
                                 "/api/events/{id}/seats",
                                 "/api/events/stream"
                         ).permitAll()
-                        .requestMatchers("/stream", "/stream/**").permitAll()
+                        .requestMatchers("/stream/events", "/stream/leaderboard", "/stream/live-audience").permitAll()
+                        .requestMatchers("/stream/notifications", "/stream/analytics").authenticated()
                         // ── Public: Projects endpoint ────────────────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/{id}").permitAll()

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java
@@ -6,11 +6,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Set;
 
 /**
  * SSE endpoints matching the frontend RealTime paths under {@code /stream/*}.
@@ -26,9 +29,18 @@ public class StreamController {
         this.eventStreamService = eventStreamService;
     }
 
+    private static final Set<String> AUTH_REQUIRED_TOPICS = Set.of("notifications", "analytics");
+
     @GetMapping(value = "/{topic}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "Subscribe to a realtime SSE topic")
-    public ResponseEntity<SseEmitter> subscribe(@PathVariable String topic) {
+    public ResponseEntity<SseEmitter> subscribe(
+            @PathVariable String topic,
+            Authentication authentication) {
+        String normalized = topic == null ? "" : topic.trim().toLowerCase();
+        if (AUTH_REQUIRED_TOPICS.contains(normalized)
+                && (authentication == null || !authentication.isAuthenticated())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         try {
             return ResponseEntity.ok(eventStreamService.createEmitter(topic));
         } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
## Description

`/stream/**` was fully public, so anonymous clients could exhaust the 200-emitter cap on notifications/analytics. Keep public topics open; require authentication for notifications and analytics.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12800

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)