### PR TITLE
fix(auth): prevent Google takeover of unverified password accounts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
@@ -68,6 +68,13 @@ public class User {
     @Column(name = "password_changed_at")
     private LocalDateTime passwordChangedAt;
 
+    @Builder.Default
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified = false;
+
+    @Column(name = "auth_provider", length = 30)
+    private String authProvider;
+
     @Convert(converter = JsonMapAttributeConverter.class)
     @Column(name = "preferences", columnDefinition = "TEXT")
     private Map<String, Object> preferences = new HashMap<>();

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -75,6 +75,8 @@ public class AuthService {
                 .username(username)
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(Role.ATTENDEE)
+                .emailVerified(false)
+                .authProvider("LOCAL")
                 .build();
 
         user = userRepository.save(user);
@@ -160,8 +162,21 @@ public class AuthService {
                         .username(username)
                         .password(passwordEncoder.encode(securePassword))
                         .role(Role.ATTENDEE)
+                        .emailVerified(true)
+                        .authProvider("GOOGLE")
                         .build();
 
+                user = userRepository.save(user);
+            } else if (!user.isEmailVerified()
+                    && (user.getAuthProvider() == null || "LOCAL".equalsIgnoreCase(user.getAuthProvider()))) {
+                throw new InvalidGoogleTokenException(
+                        "An unverified password account already exists for this email. "
+                                + "Sign in with your password and verify the email before linking Google.");
+            } else if (!user.isEmailVerified()) {
+                user.setEmailVerified(true);
+                if (user.getAuthProvider() == null || user.getAuthProvider().isBlank()) {
+                    user.setAuthProvider("GOOGLE");
+                }
                 user = userRepository.save(user);
             }
 


### PR DESCRIPTION
## Description

Password signup created accounts with no email verification, and Google login adopted any matching email. Track emailVerified/authProvider and refuse Google login into unverified LOCAL accounts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12791

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)