### PR TITLE
fix(notifications): add push subscription API endpoints

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -10,12 +10,19 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import com.sandeep.eventrabackend.dto.request.PushSubscriptionRequest;
+import com.sandeep.eventrabackend.service.PushSubscriptionService;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 import java.util.List;
 
@@ -26,9 +33,12 @@ import java.util.List;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final PushSubscriptionService pushSubscriptionService;
 
-    public NotificationController(NotificationService notificationService) {
+    public NotificationController(NotificationService notificationService,
+                                  PushSubscriptionService pushSubscriptionService) {
         this.notificationService = notificationService;
+        this.pushSubscriptionService = pushSubscriptionService;
     }
 
     @GetMapping
@@ -138,5 +148,24 @@ public class NotificationController {
         String email = authentication.getName();
         notificationService.deleteNotification(id, email);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/push-subscriptions")
+    @Operation(summary = "Register a browser push subscription")
+    public ResponseEntity<Map<String, Object>> subscribePush(
+            @Valid @RequestBody PushSubscriptionRequest request,
+            Authentication authentication) {
+        pushSubscriptionService.subscribe(authentication.getName(), request);
+        return ResponseEntity.ok(Map.of("ok", true));
+    }
+
+    @PostMapping("/push-subscriptions/unsubscribe")
+    @Operation(summary = "Remove the current user's push subscription")
+    public ResponseEntity<Map<String, Object>> unsubscribePush(
+            @RequestBody(required = false) PushSubscriptionRequest request,
+            Authentication authentication) {
+        String endpoint = request != null ? request.getEndpoint() : null;
+        pushSubscriptionService.unsubscribe(authentication.getName(), endpoint);
+        return ResponseEntity.ok(Map.of("ok", true));
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/PushSubscriptionRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/PushSubscriptionRequest.java
@@ -1,0 +1,13 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class PushSubscriptionRequest {
+    @NotBlank
+    private String endpoint;
+    private Map<String, String> keys;
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/PushSubscription.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/PushSubscription.java
@@ -1,0 +1,45 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "push_subscriptions", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "endpoint"})
+})
+public class PushSubscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 2048)
+    private String endpoint;
+
+    @Column(name = "p256dh", nullable = false, length = 512)
+    private String p256dh;
+
+    @Column(name = "auth", nullable = false, length = 512)
+    private String auth;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public Long getId() { return id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getEndpoint() { return endpoint; }
+    public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+    public String getP256dh() { return p256dh; }
+    public void setP256dh(String p256dh) { this.p256dh = p256dh; }
+    public String getAuth() { return auth; }
+    public void setAuth(String auth) { this.auth = auth; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/PushSubscriptionRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/PushSubscriptionRepository.java
@@ -1,0 +1,12 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.PushSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription, Long> {
+    Optional<PushSubscription> findByUser_IdAndEndpoint(Long userId, String endpoint);
+    void deleteByUser_IdAndEndpoint(Long userId, String endpoint);
+    void deleteByUser_Id(Long userId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
@@ -1,0 +1,55 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.request.PushSubscriptionRequest;
+import com.sandeep.eventrabackend.model.PushSubscription;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.PushSubscriptionRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PushSubscriptionService {
+
+    private final PushSubscriptionRepository pushSubscriptionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void subscribe(String userEmail, PushSubscriptionRequest request) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        Map<String, String> keys = request.getKeys();
+        String p256dh = keys != null ? keys.get("p256dh") : null;
+        String auth = keys != null ? keys.get("auth") : null;
+        if (p256dh == null || p256dh.isBlank() || auth == null || auth.isBlank()) {
+            throw new IllegalArgumentException("Push subscription keys.p256dh and keys.auth are required");
+        }
+
+        PushSubscription subscription = pushSubscriptionRepository
+                .findByUser_IdAndEndpoint(user.getId(), request.getEndpoint())
+                .orElseGet(PushSubscription::new);
+
+        subscription.setUser(user);
+        subscription.setEndpoint(request.getEndpoint());
+        subscription.setP256dh(p256dh);
+        subscription.setAuth(auth);
+        pushSubscriptionRepository.save(subscription);
+    }
+
+    @Transactional
+    public void unsubscribe(String userEmail, String endpoint) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        if (endpoint != null && !endpoint.isBlank()) {
+            pushSubscriptionRepository.deleteByUser_IdAndEndpoint(user.getId(), endpoint);
+            return;
+        }
+        pushSubscriptionRepository.deleteByUser_Id(user.getId());
+    }
+}


### PR DESCRIPTION
## Description

Push subscribe/unsubscribe called `/notifications/push-subscriptions*` with no backend. Add authenticated persistence for endpoint + keys so registration no longer 404s.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12796

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)