### PR TITLE
fix(session): implement /api/session-recovery endpoints

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/SessionRecoveryController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/SessionRecoveryController.java
@@ -1,0 +1,56 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.service.SessionRecoveryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/session-recovery")
+@PreAuthorize("isAuthenticated()")
+@Tag(name = "Session Recovery")
+public class SessionRecoveryController {
+
+    private final SessionRecoveryService sessionRecoveryService;
+
+    public SessionRecoveryController(SessionRecoveryService sessionRecoveryService) {
+        this.sessionRecoveryService = sessionRecoveryService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> save(@RequestBody Map<String, Object> body, Authentication authentication) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(sessionRecoveryService.save(authentication.getName(), body));
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> list(Authentication authentication) {
+        return ResponseEntity.ok(sessionRecoveryService.list(authentication.getName()));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> update(@PathVariable String id, @RequestBody Map<String, Object> body, Authentication authentication) {
+        body.put("sessionId", id);
+        return ResponseEntity.ok(sessionRecoveryService.save(authentication.getName(), body));
+    }
+
+    @PostMapping("/{id}/restore")
+    public ResponseEntity<Map<String, Object>> restore(@PathVariable String id, Authentication authentication) {
+        return ResponseEntity.ok(sessionRecoveryService.restore(authentication.getName(), id));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id, Authentication authentication) {
+        sessionRecoveryService.delete(authentication.getName(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/cleanup")
+    public ResponseEntity<Map<String, Object>> cleanup(Authentication authentication) {
+        return ResponseEntity.ok(sessionRecoveryService.cleanup(authentication.getName()));
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/RecoverySession.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/RecoverySession.java
@@ -1,0 +1,58 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recovery_sessions", indexes = {
+        @Index(name = "idx_recovery_user", columnList = "user_id")
+})
+public class RecoverySession {
+
+    @Id
+    @Column(length = 100)
+    private String id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(length = 120)
+    private String name;
+
+    @Column(length = 60)
+    private String type;
+
+    @Lob
+    @Column(nullable = false)
+    private String draftData;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public String getDraftData() { return draftData; }
+    public void setDraftData(String draftData) { this.draftData = draftData; }
+    public LocalDateTime getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/RecoverySessionRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/RecoverySessionRepository.java
@@ -1,0 +1,15 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.RecoverySession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface RecoverySessionRepository extends JpaRepository<RecoverySession, String> {
+    List<RecoverySession> findByUser_IdAndExpiresAtAfterOrderByUpdatedAtDesc(Long userId, LocalDateTime now);
+    Optional<RecoverySession> findByIdAndUser_Id(String id, Long userId);
+    long deleteByUser_IdAndExpiresAtBefore(Long userId, LocalDateTime now);
+    void deleteByIdAndUser_Id(String id, Long userId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/SessionRecoveryService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/SessionRecoveryService.java
@@ -1,0 +1,114 @@
+package com.sandeep.eventrabackend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.model.RecoverySession;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.RecoverySessionRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SessionRecoveryService {
+
+    private final RecoverySessionRepository recoverySessionRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public Map<String, Object> save(String userEmail, Map<String, Object> payload) {
+        User user = requireUser(userEmail);
+        String sessionId = stringOr(payload.get("sessionId"), UUID.randomUUID().toString());
+        RecoverySession session = recoverySessionRepository.findByIdAndUser_Id(sessionId, user.getId())
+                .orElseGet(RecoverySession::new);
+        session.setId(sessionId);
+        session.setUser(user);
+        session.setName(stringOr(payload.get("name"), "Recovery Session"));
+        session.setType(stringOr(payload.get("type"), "generic"));
+        session.setDraftData(writeJson(payload.getOrDefault("draftData", payload)));
+        session.setExpiresAt(LocalDateTime.now().plusDays(14));
+        return toResponse(recoverySessionRepository.save(session));
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> list(String userEmail) {
+        User user = requireUser(userEmail);
+        List<Map<String, Object>> sessions = recoverySessionRepository
+                .findByUser_IdAndExpiresAtAfterOrderByUpdatedAtDesc(user.getId(), LocalDateTime.now())
+                .stream()
+                .map(this::toResponse)
+                .toList();
+        return Map.of("sessions", sessions);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> restore(String userEmail, String sessionId) {
+        User user = requireUser(userEmail);
+        RecoverySession session = recoverySessionRepository.findByIdAndUser_Id(sessionId, user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Recovery session not found"));
+        if (session.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Recovery session expired");
+        }
+        return Map.of("session", toResponse(session));
+    }
+
+    @Transactional
+    public void delete(String userEmail, String sessionId) {
+        User user = requireUser(userEmail);
+        recoverySessionRepository.deleteByIdAndUser_Id(sessionId, user.getId());
+    }
+
+    @Transactional
+    public Map<String, Object> cleanup(String userEmail) {
+        User user = requireUser(userEmail);
+        long deleted = recoverySessionRepository.deleteByUser_IdAndExpiresAtBefore(user.getId(), LocalDateTime.now());
+        return Map.of("deleted", deleted);
+    }
+
+    private User requireUser(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    private Map<String, Object> toResponse(RecoverySession session) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("sessionId", session.getId());
+        response.put("userId", session.getUser().getId());
+        response.put("name", session.getName());
+        response.put("type", session.getType());
+        response.put("draftData", readJson(session.getDraftData()));
+        response.put("lastUpdated", session.getUpdatedAt());
+        response.put("expiresAt", session.getExpiresAt());
+        return response;
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Invalid draft data");
+        }
+    }
+
+    private Object readJson(String value) {
+        try {
+            return objectMapper.readValue(value, Object.class);
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    private static String stringOr(Object value, String fallback) {
+        return value == null ? fallback : String.valueOf(value);
+    }
+}


### PR DESCRIPTION
## Description

Cloud session recovery client already calls `/session-recovery` CRUD routes. Add authenticated user-scoped persistence so sync/restore/cleanup stop 404ing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #12799

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run relevant local checks for the touched files.
- [x] My commit messages follow the conventional commit format.

## Additional Notes


Made with [Cursor](https://cursor.com)