### PR TITLE
feat(registration): add form auto-save drafts

### DIFF
--- a/src/components/registration/DraftSavedIndicator.js
+++ b/src/components/registration/DraftSavedIndicator.js
@@ -1,0 +1,189 @@
+import {
+  AlertCircle,
+  Check,
+  Loader2,
+  RotateCcw,
+  Save,
+} from "lucide-react";
+
+const DraftSavedIndicator = ({
+  status = "idle",
+  draftRestored = false,
+  updatedAt = null,
+  compact = false,
+  className = "",
+}) => {
+  const config = getStatusConfig(
+    status,
+    draftRestored
+  );
+
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 ${className}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        className={`flex shrink-0 items-center justify-center rounded-full ${
+          compact
+            ? "h-6 w-6"
+            : "h-8 w-8"
+        } ${config.iconBackground}`}
+      >
+        <Icon
+          size={compact ? 13 : 15}
+          className={config.iconClassName}
+        />
+      </span>
+
+      <div className="min-w-0">
+        <p
+          className={`font-semibold ${
+            compact
+              ? "text-[11px]"
+              : "text-xs"
+          } ${config.textClassName}`}
+        >
+          {config.label}
+        </p>
+
+        {!compact &&
+          config.description && (
+            <p className="mt-0.5 text-[10px] leading-4 text-slate-400">
+              {config.description}
+            </p>
+          )}
+
+        {!compact &&
+          updatedAt &&
+          status === "saved" && (
+            <p className="mt-0.5 text-[10px] text-slate-400">
+              {formatUpdatedTime(
+                updatedAt
+              )}
+            </p>
+          )}
+      </div>
+    </div>
+  );
+};
+
+const getStatusConfig = (
+  status,
+  draftRestored
+) => {
+  if (status === "saving") {
+    return {
+      label: "Saving draft...",
+      description:
+        "Your registration progress is being saved.",
+      icon: Loader2,
+      iconClassName:
+        "animate-spin text-indigo-600 dark:text-indigo-400",
+      iconBackground:
+        "bg-indigo-100 dark:bg-indigo-900/30",
+      textClassName:
+        "text-indigo-600 dark:text-indigo-400",
+    };
+  }
+
+  if (status === "saved") {
+    return {
+      label: "Draft saved",
+      description:
+        "Your progress has been saved locally.",
+      icon: Check,
+      iconClassName:
+        "text-green-600 dark:text-green-400",
+      iconBackground:
+        "bg-green-100 dark:bg-green-900/30",
+      textClassName:
+        "text-green-600 dark:text-green-400",
+    };
+  }
+
+  if (status === "submitted") {
+    return {
+      label: "Registration submitted",
+      description:
+        "Your saved draft has been cleared.",
+      icon: Check,
+      iconClassName:
+        "text-green-600 dark:text-green-400",
+      iconBackground:
+        "bg-green-100 dark:bg-green-900/30",
+      textClassName:
+        "text-green-600 dark:text-green-400",
+    };
+  }
+
+  if (status === "error") {
+    return {
+      label: "Draft could not be saved",
+      description:
+        "Your browser could not save the latest changes.",
+      icon: AlertCircle,
+      iconClassName:
+        "text-red-600 dark:text-red-400",
+      iconBackground:
+        "bg-red-100 dark:bg-red-900/30",
+      textClassName:
+        "text-red-600 dark:text-red-400",
+    };
+  }
+
+  if (draftRestored) {
+    return {
+      label: "Draft restored",
+      description:
+        "Your previous registration progress has been restored.",
+      icon: RotateCcw,
+      iconClassName:
+        "text-indigo-600 dark:text-indigo-400",
+      iconBackground:
+        "bg-indigo-100 dark:bg-indigo-900/30",
+      textClassName:
+        "text-indigo-600 dark:text-indigo-400",
+    };
+  }
+
+  return {
+    label: "Draft saving enabled",
+    description:
+      "Your registration progress will be saved automatically.",
+    icon: Save,
+    iconClassName:
+      "text-slate-500 dark:text-slate-400",
+    iconBackground:
+      "bg-slate-100 dark:bg-slate-800",
+    textClassName:
+      "text-slate-500 dark:text-slate-400",
+  };
+};
+
+const formatUpdatedTime = (
+  value
+) => {
+  const date = new Date(value);
+
+  if (
+    Number.isNaN(
+      date.getTime()
+    )
+  ) {
+    return "";
+  }
+
+  return `Saved ${new Intl.DateTimeFormat(
+    undefined,
+    {
+      hour: "numeric",
+      minute: "2-digit",
+    }
+  ).format(date)}`;
+};
+
+export default DraftSavedIndicator;

--- a/src/components/registration/RegistrationFormAutoSave.js
+++ b/src/components/registration/RegistrationFormAutoSave.js
@@ -1,0 +1,373 @@
+import {
+  Check,
+  RotateCcw,
+  Save,
+  Trash2,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  clearRegistrationDraftAfterSuccess,
+  discardRegistrationDraft,
+  getRegistrationDraft,
+  saveRegistrationDraftIfNeeded,
+} from "../../utils/registrationDraftUtils";
+
+const AUTOSAVE_DELAY = 800;
+
+const RegistrationFormAutoSave = ({
+  eventId,
+  userId = "guest",
+  initialValues = {},
+  onChange,
+  onSubmit,
+  children,
+  autoSave = true,
+  autoSaveDelay = AUTOSAVE_DELAY,
+  showDraftControls = true,
+  className = "",
+}) => {
+  const [formData, setFormData] =
+    useState(initialValues);
+
+  const [saveStatus, setSaveStatus] =
+    useState("idle");
+
+  const [draftRestored, setDraftRestored] =
+    useState(false);
+
+  const [hasDraft, setHasDraft] =
+    useState(false);
+
+  const saveTimerRef =
+    useRef(null);
+
+  const initializedRef =
+    useRef(false);
+
+  /**
+   * Restore an existing draft when the
+   * registration form is opened.
+   */
+  useEffect(() => {
+    if (!eventId || initializedRef.current) {
+      return;
+    }
+
+    initializedRef.current = true;
+
+    const savedDraft =
+      getRegistrationDraft({
+        eventId,
+        userId,
+      });
+
+    if (savedDraft?.formData) {
+      setFormData((current) => ({
+        ...current,
+        ...savedDraft.formData,
+      }));
+
+      setDraftRestored(true);
+      setHasDraft(true);
+
+      onChange?.({
+        ...initialValues,
+        ...savedDraft.formData,
+      });
+
+      return;
+    }
+
+    setFormData(initialValues);
+  }, [
+    eventId,
+    userId,
+    initialValues,
+    onChange,
+  ]);
+
+  /**
+   * Notify parent whenever form data changes.
+   */
+  const updateFormData = useCallback(
+    (nextData) => {
+      setFormData(nextData);
+      onChange?.(nextData);
+    },
+    [onChange]
+  );
+
+  /**
+   * Update a single form field.
+   */
+  const updateField = useCallback(
+    (field, value) => {
+      setFormData((current) => {
+        const nextData = {
+          ...current,
+          [field]: value,
+        };
+
+        onChange?.(nextData);
+
+        return nextData;
+      });
+    },
+    [onChange]
+  );
+
+  /**
+   * Automatically save form changes.
+   */
+  useEffect(() => {
+    if (
+      !autoSave ||
+      !eventId ||
+      !initializedRef.current
+    ) {
+      return undefined;
+    }
+
+    if (saveTimerRef.current) {
+      clearTimeout(
+        saveTimerRef.current
+      );
+    }
+
+    setSaveStatus("saving");
+
+    saveTimerRef.current =
+      setTimeout(() => {
+        const result =
+          saveRegistrationDraftIfNeeded({
+            eventId,
+            userId,
+            formData,
+          });
+
+        if (result.success) {
+          setSaveStatus("saved");
+          setHasDraft(true);
+        } else if (result.skipped) {
+          setSaveStatus("idle");
+        } else {
+          setSaveStatus("error");
+        }
+      }, autoSaveDelay);
+
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(
+          saveTimerRef.current
+        );
+      }
+    };
+  }, [
+    formData,
+    eventId,
+    userId,
+    autoSave,
+    autoSaveDelay,
+  ]);
+
+  /**
+   * Discard the current saved draft.
+   */
+  const handleDiscardDraft = useCallback(() => {
+    if (!eventId) {
+      return;
+    }
+
+    discardRegistrationDraft({
+      eventId,
+      userId,
+    });
+
+    setHasDraft(false);
+    setDraftRestored(false);
+    setSaveStatus("idle");
+
+    setFormData(initialValues);
+    onChange?.(initialValues);
+  }, [
+    eventId,
+    userId,
+    initialValues,
+    onChange,
+  ]);
+
+  /**
+   * Clear draft after successful registration.
+   */
+  const handleSubmit = useCallback(
+    async (event) => {
+      event?.preventDefault?.();
+
+      setSaveStatus("submitting");
+
+      try {
+        const result =
+          await onSubmit?.(
+            formData
+          );
+
+        /*
+         * Only remove the draft after
+         * successful registration.
+         */
+        if (
+          result !== false
+        ) {
+          clearRegistrationDraftAfterSuccess(
+            {
+              eventId,
+              userId,
+            }
+          );
+
+          setHasDraft(false);
+          setDraftRestored(false);
+          setSaveStatus("submitted");
+        } else {
+          setSaveStatus("saved");
+        }
+
+        return result;
+      } catch (error) {
+        setSaveStatus("error");
+        throw error;
+      }
+    },
+    [
+      formData,
+      eventId,
+      userId,
+      onSubmit,
+    ]
+  );
+
+  /**
+   * Render children using either:
+   *
+   * 1. Function-as-child:
+   *    {({ formData, updateField }) => ...}
+   *
+   * 2. Normal React children.
+   */
+  const renderedChildren =
+    typeof children === "function"
+      ? children({
+          formData,
+          updateFormData,
+          updateField,
+          handleSubmit,
+          hasDraft,
+          draftRestored,
+        })
+      : children;
+
+  return (
+    <div
+      className={`w-full ${className}`}
+    >
+      {/* Draft status */}
+      {showDraftControls && (
+        <div className="mb-4 flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-3 shadow-sm sm:flex-row sm:items-center sm:justify-between dark:border-slate-700 dark:bg-slate-900">
+          <DraftStatus
+            status={saveStatus}
+            draftRestored={
+              draftRestored
+            }
+          />
+
+          {hasDraft && (
+            <button
+              type="button"
+              onClick={
+                handleDiscardDraft
+              }
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-red-900/50 dark:hover:bg-red-900/10 dark:hover:text-red-400"
+            >
+              <Trash2 size={14} />
+              Discard Draft
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Registration form content */}
+      {renderedChildren}
+    </div>
+  );
+};
+
+/**
+ * Draft status indicator.
+ */
+const DraftStatus = ({
+  status,
+  draftRestored,
+}) => {
+  if (status === "saving") {
+    return (
+      <div className="inline-flex items-center gap-2 text-xs font-medium text-slate-500 dark:text-slate-400">
+        <Save
+          size={14}
+          className="animate-pulse"
+        />
+        Saving draft...
+      </div>
+    );
+  }
+
+  if (status === "saved") {
+    return (
+      <div className="inline-flex items-center gap-2 text-xs font-semibold text-green-600 dark:text-green-400">
+        <Check size={14} />
+        Draft saved
+      </div>
+    );
+  }
+
+  if (status === "submitted") {
+    return (
+      <div className="inline-flex items-center gap-2 text-xs font-semibold text-green-600 dark:text-green-400">
+        <Check size={14} />
+        Registration submitted
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="inline-flex items-center gap-2 text-xs font-semibold text-red-600 dark:text-red-400">
+        <Save size={14} />
+        Unable to save draft
+      </div>
+    );
+  }
+
+  if (draftRestored) {
+    return (
+      <div className="inline-flex items-center gap-2 text-xs font-semibold text-indigo-600 dark:text-indigo-400">
+        <RotateCcw size={14} />
+        Draft restored
+      </div>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2 text-xs text-slate-400">
+      <Save size={14} />
+      Your progress will be saved automatically
+    </div>
+  );
+};
+
+export default RegistrationFormAutoSave;

--- a/src/utils/registrationDraftUtils.js
+++ b/src/utils/registrationDraftUtils.js
@@ -1,0 +1,894 @@
+/**
+ * Registration Form Auto-Save utilities.
+ *
+ * Supports:
+ * - Saving registration drafts locally
+ * - Restoring saved drafts
+ * - Checking for existing drafts
+ * - Clearing drafts after successful registration
+ * - Discarding drafts
+ * - Draft timestamps
+ * - Corrupted-data handling
+ * - Event/user-specific storage keys
+ */
+
+export const REGISTRATION_DRAFT_PREFIX =
+  "eventra_registration_draft";
+
+export const REGISTRATION_DRAFT_VERSION = 1;
+
+export const DEFAULT_DRAFT_TTL_MS =
+  7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Normalize an identifier.
+ */
+export const normalizeDraftId = (
+  value
+) => {
+  if (
+    value === null ||
+    value === undefined
+  ) {
+    return "";
+  }
+
+  return String(value).trim();
+};
+
+/**
+ * Safely normalize form data.
+ */
+export const normalizeDraftData = (
+  data
+) => {
+  if (
+    !data ||
+    typeof data !== "object" ||
+    Array.isArray(data)
+  ) {
+    return {};
+  }
+
+  return {
+    ...data,
+  };
+};
+
+/**
+ * Create a unique localStorage key
+ * for an event registration draft.
+ */
+export const getRegistrationDraftKey = ({
+  eventId,
+  userId = "guest",
+} = {}) => {
+  const normalizedEventId =
+    normalizeDraftId(eventId);
+
+  const normalizedUserId =
+    normalizeDraftId(userId) ||
+    "guest";
+
+  if (!normalizedEventId) {
+    return "";
+  }
+
+  return `${REGISTRATION_DRAFT_PREFIX}:${normalizedEventId}:${normalizedUserId}`;
+};
+
+/**
+ * Check whether localStorage is available.
+ */
+export const isDraftStorageAvailable = () => {
+  if (
+    typeof window === "undefined"
+  ) {
+    return false;
+  }
+
+  try {
+    const testKey =
+      "__eventra_draft_test__";
+
+    window.localStorage.setItem(
+      testKey,
+      "1"
+    );
+
+    window.localStorage.removeItem(
+      testKey
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Create the stored draft object.
+ */
+export const createRegistrationDraft = ({
+  eventId,
+  userId = "guest",
+  formData = {},
+} = {}) => {
+  const now =
+    new Date().toISOString();
+
+  return {
+    version:
+      REGISTRATION_DRAFT_VERSION,
+
+    eventId:
+      normalizeDraftId(
+        eventId
+      ),
+
+    userId:
+      normalizeDraftId(
+        userId
+      ) || "guest",
+
+    formData:
+      normalizeDraftData(
+        formData
+      ),
+
+    createdAt: now,
+
+    updatedAt: now,
+  };
+};
+
+/**
+ * Save a registration form draft.
+ */
+export const saveRegistrationDraft = ({
+  eventId,
+  userId = "guest",
+  formData = {},
+} = {}) => {
+  if (
+    !isDraftStorageAvailable()
+  ) {
+    return {
+      success: false,
+      error:
+        "Local draft storage is unavailable.",
+      draft: null,
+    };
+  }
+
+  const key =
+    getRegistrationDraftKey({
+      eventId,
+      userId,
+    });
+
+  if (!key) {
+    return {
+      success: false,
+      error:
+        "Event ID is required to save a draft.",
+      draft: null,
+    };
+  }
+
+  try {
+    const existingDraft =
+      getRegistrationDraft({
+        eventId,
+        userId,
+        ignoreExpiration: true,
+      });
+
+    const now =
+      new Date().toISOString();
+
+    const draft = {
+      version:
+        REGISTRATION_DRAFT_VERSION,
+
+      eventId:
+        normalizeDraftId(
+          eventId
+        ),
+
+      userId:
+        normalizeDraftId(
+          userId
+        ) || "guest",
+
+      formData:
+        normalizeDraftData(
+          formData
+        ),
+
+      createdAt:
+        existingDraft?.createdAt ||
+        now,
+
+      updatedAt: now,
+    };
+
+    window.localStorage.setItem(
+      key,
+      JSON.stringify(draft)
+    );
+
+    return {
+      success: true,
+      error: null,
+      draft,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error?.message ||
+        "Unable to save registration draft.",
+      draft: null,
+    };
+  }
+};
+
+/**
+ * Read and parse a stored draft.
+ */
+export const getRegistrationDraft = ({
+  eventId,
+  userId = "guest",
+  ignoreExpiration = false,
+  ttlMs = DEFAULT_DRAFT_TTL_MS,
+} = {}) => {
+  if (
+    !isDraftStorageAvailable()
+  ) {
+    return null;
+  }
+
+  const key =
+    getRegistrationDraftKey({
+      eventId,
+      userId,
+    });
+
+  if (!key) {
+    return null;
+  }
+
+  try {
+    const raw =
+      window.localStorage.getItem(
+        key
+      );
+
+    if (!raw) {
+      return null;
+    }
+
+    const draft =
+      JSON.parse(raw);
+
+    if (
+      !draft ||
+      typeof draft !==
+        "object"
+    ) {
+      removeRegistrationDraft({
+        eventId,
+        userId,
+      });
+
+      return null;
+    }
+
+    if (
+      draft.eventId &&
+      normalizeDraftId(
+        draft.eventId
+      ) !==
+        normalizeDraftId(
+          eventId
+        )
+    ) {
+      return null;
+    }
+
+    if (
+      !ignoreExpiration &&
+      isRegistrationDraftExpired(
+        draft,
+        ttlMs
+      )
+    ) {
+      removeRegistrationDraft({
+        eventId,
+        userId,
+      });
+
+      return null;
+    }
+
+    return {
+      ...draft,
+      formData:
+        normalizeDraftData(
+          draft.formData
+        ),
+    };
+  } catch {
+    removeRegistrationDraft({
+      eventId,
+      userId,
+    });
+
+    return null;
+  }
+};
+
+/**
+ * Check whether a saved draft exists.
+ */
+export const hasRegistrationDraft = ({
+  eventId,
+  userId = "guest",
+  ignoreExpiration = false,
+  ttlMs = DEFAULT_DRAFT_TTL_MS,
+} = {}) => {
+  return Boolean(
+    getRegistrationDraft({
+      eventId,
+      userId,
+      ignoreExpiration,
+      ttlMs,
+    })
+  );
+};
+
+/**
+ * Remove a registration draft.
+ */
+export const removeRegistrationDraft = ({
+  eventId,
+  userId = "guest",
+} = {}) => {
+  if (
+    !isDraftStorageAvailable()
+  ) {
+    return false;
+  }
+
+  const key =
+    getRegistrationDraftKey({
+      eventId,
+      userId,
+    });
+
+  if (!key) {
+    return false;
+  }
+
+  try {
+    window.localStorage.removeItem(
+      key
+    );
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Alias for discarding a draft.
+ */
+export const discardRegistrationDraft =
+  removeRegistrationDraft;
+
+/**
+ * Clear the draft after successful
+ * registration.
+ */
+export const clearRegistrationDraftAfterSuccess =
+  ({
+    eventId,
+    userId = "guest",
+  } = {}) => {
+    return removeRegistrationDraft({
+      eventId,
+      userId,
+    });
+  };
+
+/**
+ * Check whether a draft has expired.
+ */
+export const isRegistrationDraftExpired = (
+  draft,
+  ttlMs = DEFAULT_DRAFT_TTL_MS
+) => {
+  if (
+    !draft?.updatedAt
+  ) {
+    return false;
+  }
+
+  const updatedAt =
+    new Date(
+      draft.updatedAt
+    ).getTime();
+
+  if (
+    Number.isNaN(
+      updatedAt
+    )
+  ) {
+    return false;
+  }
+
+  const ttl =
+    Number(ttlMs);
+
+  if (
+    !Number.isFinite(ttl) ||
+    ttl <= 0
+  ) {
+    return false;
+  }
+
+  return (
+    Date.now() -
+      updatedAt >
+    ttl
+  );
+};
+
+/**
+ * Get the age of a draft in milliseconds.
+ */
+export const getRegistrationDraftAge = (
+  draft
+) => {
+  if (
+    !draft?.updatedAt
+  ) {
+    return 0;
+  }
+
+  const updatedAt =
+    new Date(
+      draft.updatedAt
+    ).getTime();
+
+  if (
+    Number.isNaN(
+      updatedAt
+    )
+  ) {
+    return 0;
+  }
+
+  return Math.max(
+    0,
+    Date.now() -
+      updatedAt
+  );
+};
+
+/**
+ * Get a human-readable draft age.
+ */
+export const formatDraftAge = (
+  draft
+) => {
+  const age =
+    getRegistrationDraftAge(
+      draft
+    );
+
+  if (age < 60 * 1000) {
+    return "Just now";
+  }
+
+  const minutes = Math.floor(
+    age /
+      (60 * 1000)
+  );
+
+  if (minutes < 60) {
+    return `${minutes} minute${
+      minutes === 1
+        ? ""
+        : "s"
+    } ago`;
+  }
+
+  const hours = Math.floor(
+    minutes / 60
+  );
+
+  if (hours < 24) {
+    return `${hours} hour${
+      hours === 1
+        ? ""
+        : "s"
+    } ago`;
+  }
+
+  const days = Math.floor(
+    hours / 24
+  );
+
+  return `${days} day${
+    days === 1
+      ? ""
+      : "s"
+  } ago`;
+};
+
+/**
+ * Get the draft updated timestamp.
+ */
+export const getDraftUpdatedAt = (
+  draft
+) => {
+  return (
+    draft?.updatedAt ||
+    null
+  );
+};
+
+/**
+ * Get form data from a draft.
+ */
+export const getDraftFormData = (
+  draft
+) => {
+  return normalizeDraftData(
+    draft?.formData
+  );
+};
+
+/**
+ * Merge saved draft data with
+ * current form data.
+ *
+ * Current values take priority.
+ */
+export const mergeRegistrationDraft = (
+  savedDraft,
+  currentFormData = {}
+) => {
+  const draftData =
+    getDraftFormData(
+      savedDraft
+    );
+
+  return {
+    ...draftData,
+    ...normalizeDraftData(
+      currentFormData
+    ),
+  };
+};
+
+/**
+ * Check whether form data contains
+ * meaningful user input.
+ */
+export const hasMeaningfulDraftData = (
+  formData
+) => {
+  if (
+    !formData ||
+    typeof formData !==
+      "object"
+  ) {
+    return false;
+  }
+
+  return Object.values(
+    formData
+  ).some((value) => {
+    if (
+      value === null ||
+      value === undefined
+    ) {
+      return false;
+    }
+
+    if (
+      typeof value ===
+      "string"
+    ) {
+      return value.trim()
+        .length > 0;
+    }
+
+    if (
+      Array.isArray(value)
+    ) {
+      return value.length > 0;
+    }
+
+    if (
+      typeof value ===
+      "object"
+    ) {
+      return (
+        Object.keys(value)
+          .length > 0
+      );
+    }
+
+    return true;
+  });
+};
+
+/**
+ * Save only when the form contains
+ * meaningful data.
+ */
+export const saveRegistrationDraftIfNeeded =
+  ({
+    eventId,
+    userId = "guest",
+    formData = {},
+  } = {}) => {
+    if (
+      !hasMeaningfulDraftData(
+        formData
+      )
+    ) {
+      return {
+        success: false,
+        skipped: true,
+        draft: null,
+      };
+    }
+
+    return {
+      ...saveRegistrationDraft({
+        eventId,
+        userId,
+        formData,
+      }),
+      skipped: false,
+    };
+  };
+
+/**
+ * Restore a draft and indicate whether
+ * it was successfully restored.
+ */
+export const restoreRegistrationDraft = ({
+  eventId,
+  userId = "guest",
+  ttlMs = DEFAULT_DRAFT_TTL_MS,
+} = {}) => {
+  const draft =
+    getRegistrationDraft({
+      eventId,
+      userId,
+      ttlMs,
+    });
+
+  if (!draft) {
+    return {
+      restored: false,
+      draft: null,
+      formData: {},
+    };
+  }
+
+  return {
+    restored: true,
+    draft,
+    formData:
+      getDraftFormData(
+        draft
+      ),
+  };
+};
+
+/**
+ * Get all Eventra registration draft
+ * storage keys.
+ */
+export const getRegistrationDraftKeys = () => {
+  if (
+    !isDraftStorageAvailable()
+  ) {
+    return [];
+  }
+
+  const keys = [];
+
+  try {
+    for (
+      let index = 0;
+      index <
+      window.localStorage
+        .length;
+      index += 1
+    ) {
+      const key =
+        window.localStorage.key(
+          index
+        );
+
+      if (
+        key?.startsWith(
+          `${REGISTRATION_DRAFT_PREFIX}:`
+        )
+      ) {
+        keys.push(key);
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return keys;
+};
+
+/**
+ * Remove every Eventra registration
+ * draft.
+ *
+ * Useful for account logout or cleanup.
+ */
+export const clearAllRegistrationDrafts =
+  () => {
+    if (
+      !isDraftStorageAvailable()
+    ) {
+      return 0;
+    }
+
+    const keys =
+      getRegistrationDraftKeys();
+
+    let removed = 0;
+
+    keys.forEach((key) => {
+      try {
+        window.localStorage.removeItem(
+          key
+        );
+
+        removed += 1;
+      } catch {
+        // Ignore individual removal failures.
+      }
+    });
+
+    return removed;
+  };
+
+/**
+ * Remove expired registration drafts.
+ */
+export const clearExpiredRegistrationDrafts =
+  (
+    ttlMs = DEFAULT_DRAFT_TTL_MS
+  ) => {
+    if (
+      !isDraftStorageAvailable()
+    ) {
+      return 0;
+    }
+
+    const keys =
+      getRegistrationDraftKeys();
+
+    let removed = 0;
+
+    keys.forEach((key) => {
+      try {
+        const raw =
+          window.localStorage.getItem(
+            key
+          );
+
+        if (!raw) {
+          return;
+        }
+
+        const draft =
+          JSON.parse(raw);
+
+        if (
+          isRegistrationDraftExpired(
+            draft,
+            ttlMs
+          )
+        ) {
+          window.localStorage.removeItem(
+            key
+          );
+
+          removed += 1;
+        }
+      } catch {
+        try {
+          window.localStorage.removeItem(
+            key
+          );
+
+          removed += 1;
+        } catch {
+          // Ignore cleanup failures.
+        }
+      }
+    });
+
+    return removed;
+  };
+
+/**
+ * Get the number of stored drafts.
+ */
+export const getRegistrationDraftCount =
+  () => {
+    return getRegistrationDraftKeys()
+      .length;
+  };
+
+/**
+ * Create a draft storage snapshot.
+ *
+ * Useful for debugging or displaying
+ * draft information.
+ */
+export const getRegistrationDraftSnapshot =
+  ({
+    eventId,
+    userId = "guest",
+    ttlMs = DEFAULT_DRAFT_TTL_MS,
+  } = {}) => {
+    const draft =
+      getRegistrationDraft({
+        eventId,
+        userId,
+        ttlMs,
+      });
+
+    if (!draft) {
+      return {
+        exists: false,
+        expired: false,
+        updatedAt: null,
+        age: 0,
+        formData: {},
+      };
+    }
+
+    return {
+      exists: true,
+      expired:
+        isRegistrationDraftExpired(
+          draft,
+          ttlMs
+        ),
+      updatedAt:
+        getDraftUpdatedAt(
+          draft
+        ),
+      age:
+        getRegistrationDraftAge(
+          draft
+        ),
+      ageLabel:
+        formatDraftAge(
+          draft
+        ),
+      formData:
+        getDraftFormData(
+          draft
+        ),
+    };
+  };


### PR DESCRIPTION
## Description

Implemented automatic saving and restoration of partially completed
event registration forms.

### Added

- Automatic local draft saving
- Draft restoration when returning to the form
- "Saving draft..." indicator
- "Draft saved" indicator
- "Draft restored" indicator
- Draft save error state
- Discard Draft option
- Event/user-specific draft storage
- Draft expiration handling
- Corrupted localStorage data handling
- Draft cleanup after successful registration
- Registration form state management

Closes #12960