### PR TITLE
feat(organizer): add participant search and filters

### DIFF
--- a/src/components/organizer/ParticipantFilterResults.js
+++ b/src/components/organizer/ParticipantFilterResults.js
@@ -1,0 +1,492 @@
+import {
+  CalendarDays,
+  CheckCircle2,
+  Mail,
+  SearchX,
+  Users,
+  XCircle,
+} from "lucide-react";
+
+import { useMemo } from "react";
+
+import {
+  filterParticipants,
+  getParticipantDisplayName,
+} from "../../utils/participantSearchUtils";
+
+const ParticipantFilterResults = ({
+  participants = [],
+  filters = {},
+  onParticipantClick,
+  className = "",
+}) => {
+  const filteredParticipants =
+    useMemo(() => {
+      return filterParticipants(
+        participants,
+        filters
+      );
+    }, [
+      participants,
+      filters,
+    ]);
+
+  return (
+    <section
+      className={`w-full rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {/* Header */}
+      <div className="flex flex-col gap-2 border-b border-slate-200 p-4 sm:flex-row sm:items-center sm:justify-between dark:border-slate-700">
+        <div>
+          <h2 className="text-sm font-bold text-slate-800 dark:text-white">
+            Participants
+          </h2>
+
+          <p className="mt-1 text-[11px] text-slate-400">
+            {filteredParticipants.length}{" "}
+            {filteredParticipants.length ===
+            1
+              ? "participant"
+              : "participants"}{" "}
+            found
+          </p>
+        </div>
+
+        {filters.search && (
+          <div className="rounded-full bg-indigo-50 px-3 py-1.5 text-[10px] font-semibold text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-400">
+            Search: "{filters.search}"
+          </div>
+        )}
+      </div>
+
+      {/* Results */}
+      {filteredParticipants.length >
+      0 ? (
+        <div className="divide-y divide-slate-100 dark:divide-slate-800">
+          {filteredParticipants.map(
+            (participant, index) => (
+              <ParticipantRow
+                key={
+                  participant.id ||
+                  participant.userId ||
+                  participant.email ||
+                  index
+                }
+                participant={
+                  participant
+                }
+                onClick={
+                  onParticipantClick
+                }
+              />
+            )
+          )}
+        </div>
+      ) : (
+        <EmptyResults />
+      )}
+    </section>
+  );
+};
+
+/**
+ * Individual participant row.
+ */
+const ParticipantRow = ({
+  participant,
+  onClick,
+}) => {
+  const name =
+    getParticipantDisplayName(
+      participant
+    );
+
+  const email =
+    participant.email ||
+    participant.emailAddress ||
+    "No email available";
+
+  const team =
+    participant.teamName ||
+    participant.team?.name ||
+    participant.team ||
+    "No team";
+
+  const category =
+    participant.participantCategory ||
+    participant.category ||
+    "Uncategorized";
+
+  const registrationStatus =
+    normalizeStatus(
+      participant.registrationStatus ||
+        participant.status ||
+        "unknown"
+    );
+
+  const attendanceStatus =
+    normalizeStatus(
+      participant.attendanceStatus ||
+        participant.attendance ||
+        "not-marked"
+    );
+
+  const registrationDate =
+    formatDate(
+      participant.registrationDate ||
+        participant.registeredAt ||
+        participant.createdAt
+    );
+
+  return (
+    <div
+      role={
+        onClick
+          ? "button"
+          : undefined
+      }
+      tabIndex={
+        onClick ? 0 : undefined
+      }
+      onClick={() =>
+        onClick?.(
+          participant
+        )
+      }
+      onKeyDown={(event) => {
+        if (
+          onClick &&
+          (event.key ===
+            "Enter" ||
+            event.key ===
+              " ")
+        ) {
+          event.preventDefault();
+          onClick(
+            participant
+          );
+        }
+      }}
+      className={`p-4 transition ${
+        onClick
+          ? "cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/60"
+          : ""
+      }`}
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
+        {/* Participant identity */}
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <Avatar
+            participant={
+              participant
+            }
+            name={name}
+          />
+
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-bold text-slate-800 dark:text-white">
+              {name}
+            </h3>
+
+            <p className="mt-1 flex items-center gap-1.5 truncate text-[11px] text-slate-400">
+              <Mail
+                size={12}
+                className="shrink-0"
+              />
+              {email}
+            </p>
+
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              <StatusBadge
+                label={registrationStatus}
+                type="registration"
+              />
+
+              <StatusBadge
+                label={attendanceStatus}
+                type="attendance"
+              />
+
+              <span className="rounded-full bg-slate-100 px-2 py-1 text-[9px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                {category}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Participant metadata */}
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:w-[390px] lg:grid-cols-3">
+          <InfoItem
+            icon={Users}
+            label="Team"
+            value={team}
+          />
+
+          <InfoItem
+            icon={CalendarDays}
+            label="Registered"
+            value={
+              registrationDate ||
+              "Not available"
+            }
+          />
+
+          <StatusIndicator
+            status={
+              registrationStatus
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Avatar.
+ */
+const Avatar = ({
+  participant,
+  name,
+}) => {
+  const image =
+    participant.avatar ||
+    participant.avatarUrl ||
+    participant.profileImage ||
+    participant.photo;
+
+  const initials =
+    getInitials(name);
+
+  if (image) {
+    return (
+      <img
+        src={image}
+        alt={name}
+        className="h-10 w-10 shrink-0 rounded-xl object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-100 text-xs font-bold text-indigo-600 dark:bg-indigo-900/30 dark:text-indigo-400">
+      {initials}
+    </div>
+  );
+};
+
+/**
+ * Small metadata item.
+ */
+const InfoItem = ({
+  icon: Icon,
+  label,
+  value,
+}) => {
+  return (
+    <div className="min-w-0">
+      <p className="flex items-center gap-1 text-[9px] font-semibold uppercase tracking-wide text-slate-400">
+        <Icon size={11} />
+        {label}
+      </p>
+
+      <p className="mt-1 truncate text-[11px] font-medium text-slate-700 dark:text-slate-300">
+        {value}
+      </p>
+    </div>
+  );
+};
+
+/**
+ * Registration status indicator.
+ */
+const StatusIndicator = ({
+  status,
+}) => {
+  const registered =
+    status === "registered";
+
+  return (
+    <div className="min-w-0">
+      <p className="text-[9px] font-semibold uppercase tracking-wide text-slate-400">
+        Registration
+      </p>
+
+      <div
+        className={`mt-1 flex items-center gap-1.5 text-[11px] font-semibold ${
+          registered
+            ? "text-green-600 dark:text-green-400"
+            : "text-amber-600 dark:text-amber-400"
+        }`}
+      >
+        {registered ? (
+          <CheckCircle2 size={13} />
+        ) : (
+          <XCircle size={13} />
+        )}
+
+        {formatStatus(
+          status
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Status badge.
+ */
+const StatusBadge = ({
+  label,
+  type,
+}) => {
+  const isPositive =
+    type === "registration"
+      ? label === "registered"
+      : label === "attended";
+
+  const isNegative =
+    label ===
+      "cancelled" ||
+    label === "absent";
+
+  let classes =
+    "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300";
+
+  if (isPositive) {
+    classes =
+      "bg-green-50 text-green-600 dark:bg-green-900/20 dark:text-green-400";
+  }
+
+  if (isNegative) {
+    classes =
+      "bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-400";
+  }
+
+  return (
+    <span
+      className={`rounded-full px-2 py-1 text-[9px] font-semibold ${classes}`}
+    >
+      {formatStatus(label)}
+    </span>
+  );
+};
+
+/**
+ * Empty results state.
+ */
+const EmptyResults = () => {
+  return (
+    <div className="px-5 py-12 text-center">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-100 dark:bg-slate-800">
+        <SearchX
+          size={22}
+          className="text-slate-400"
+        />
+      </div>
+
+      <h3 className="mt-4 text-sm font-bold text-slate-700 dark:text-slate-200">
+        No participants found
+      </h3>
+
+      <p className="mx-auto mt-1 max-w-sm text-xs leading-5 text-slate-400">
+        Try changing your search or removing
+        some filters to find more participants.
+      </p>
+    </div>
+  );
+};
+
+/**
+ * Normalize status strings.
+ */
+const normalizeStatus = (
+  value
+) => {
+  if (
+    value === null ||
+    value === undefined
+  ) {
+    return "unknown";
+  }
+
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-");
+};
+
+/**
+ * Format status for display.
+ */
+const formatStatus = (
+  value
+) => {
+  if (!value) {
+    return "Unknown";
+  }
+
+  return String(value)
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (letter) =>
+      letter.toUpperCase()
+    );
+};
+
+/**
+ * Format registration date.
+ */
+const formatDate = (
+  value
+) => {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(
+    value
+  );
+
+  if (
+    Number.isNaN(
+      date.getTime()
+    )
+  ) {
+    return String(value);
+  }
+
+  return new Intl.DateTimeFormat(
+    undefined,
+    {
+      dateStyle: "medium",
+    }
+  ).format(date);
+};
+
+/**
+ * Generate initials.
+ */
+const getInitials = (
+  name
+) => {
+  const words = String(name)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (words.length === 0) {
+    return "?";
+  }
+
+  if (words.length === 1) {
+    return words[0]
+      .slice(0, 2)
+      .toUpperCase();
+  }
+
+  return `${words[0][0]}${words[
+    words.length - 1
+  ][0]}`.toUpperCase();
+};
+
+export default ParticipantFilterResults;

--- a/src/components/organizer/ParticipantSearchFilters.js
+++ b/src/components/organizer/ParticipantSearchFilters.js
@@ -1,0 +1,370 @@
+import {
+  CalendarDays,
+  ChevronDown,
+  Filter,
+  Mail,
+  RotateCcw,
+  Search,
+  Users,
+} from "lucide-react";
+import { useMemo } from "react";
+
+const ParticipantSearchFilters = ({
+  filters = {},
+  onFiltersChange,
+  onClear,
+  teams = [],
+  categories = [],
+  className = "",
+}) => {
+  const currentFilters = useMemo(
+    () => ({
+      search: "",
+      registrationStatus: "",
+      team: "",
+      attendanceStatus: "",
+      registrationDate: "",
+      participantCategory: "",
+      ...filters,
+    }),
+    [filters]
+  );
+
+  const updateFilter = (
+    field,
+    value
+  ) => {
+    onFiltersChange?.({
+      ...currentFilters,
+      [field]: value,
+    });
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    onFiltersChange?.(currentFilters);
+  };
+
+  const handleClear = () => {
+    onClear?.();
+
+    if (!onClear) {
+      onFiltersChange?.({
+        search: "",
+        registrationStatus: "",
+        team: "",
+        attendanceStatus: "",
+        registrationDate: "",
+        participantCategory: "",
+      });
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={`rounded-2xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {/* Header */}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+            <Filter
+              size={18}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div>
+            <h2 className="text-sm font-bold text-slate-800 dark:text-white">
+              Participant Search & Filters
+            </h2>
+
+            <p className="text-[11px] text-slate-400">
+              Find participants quickly.
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleClear}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 dark:border-slate-700 dark:text-slate-300 dark:hover:border-red-900/40 dark:hover:bg-red-900/10 dark:hover:text-red-400"
+        >
+          <RotateCcw size={13} />
+          Clear Filters
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className="mb-4">
+        <label
+          htmlFor="participant-search"
+          className="mb-1.5 block text-xs font-semibold text-slate-700 dark:text-slate-300"
+        >
+          Search participant
+        </label>
+
+        <div className="relative">
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+          />
+
+          <input
+            id="participant-search"
+            type="search"
+            value={
+              currentFilters.search
+            }
+            onChange={(event) =>
+              updateFilter(
+                "search",
+                event.target.value
+              )
+            }
+            placeholder="Search by name or email..."
+            className="w-full rounded-xl border border-slate-200 bg-white py-2.5 pl-9 pr-10 text-xs text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-indigo-400 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-800 dark:text-white dark:focus:border-indigo-500 dark:focus:ring-indigo-900/30"
+          />
+
+          {currentFilters.search && (
+            <button
+              type="button"
+              onClick={() =>
+                updateFilter(
+                  "search",
+                  ""
+                )
+              }
+              aria-label="Clear participant search"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-400 hover:text-red-500"
+            >
+              ×
+            </button>
+          )}
+        </div>
+
+        <p className="mt-1.5 flex items-center gap-1 text-[10px] text-slate-400">
+          <Mail size={11} />
+          Search using participant name or email.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <FilterSelect
+          label="Registration Status"
+          value={
+            currentFilters.registrationStatus
+          }
+          onChange={(value) =>
+            updateFilter(
+              "registrationStatus",
+              value
+            )
+          }
+          options={[
+            {
+              value: "registered",
+              label: "Registered",
+            },
+            {
+              value: "pending",
+              label: "Pending",
+            },
+            {
+              value: "cancelled",
+              label: "Cancelled",
+            },
+            {
+              value: "waitlisted",
+              label: "Waitlisted",
+            },
+          ]}
+        />
+
+        <FilterSelect
+          label="Team"
+          value={currentFilters.team}
+          onChange={(value) =>
+            updateFilter(
+              "team",
+              value
+            )
+          }
+          options={teams.map(
+            (team) => ({
+              value:
+                typeof team ===
+                "object"
+                  ? team.id ||
+                    team.name
+                  : team,
+              label:
+                typeof team ===
+                "object"
+                  ? team.name ||
+                    team.label ||
+                    team.id
+                  : team,
+            })
+          )}
+          icon={Users}
+        />
+
+        <FilterSelect
+          label="Attendance Status"
+          value={
+            currentFilters.attendanceStatus
+          }
+          onChange={(value) =>
+            updateFilter(
+              "attendanceStatus",
+              value
+            )
+          }
+          options={[
+            {
+              value: "attended",
+              label: "Attended",
+            },
+            {
+              value: "absent",
+              label: "Absent",
+            },
+            {
+              value: "not-marked",
+              label: "Not Marked",
+            },
+          ]}
+        />
+
+        <FilterSelect
+          label="Registration Date"
+          value={
+            currentFilters.registrationDate
+          }
+          onChange={(value) =>
+            updateFilter(
+              "registrationDate",
+              value
+            )
+          }
+          options={[
+            {
+              value: "today",
+              label: "Today",
+            },
+            {
+              value: "last-7-days",
+              label: "Last 7 Days",
+            },
+            {
+              value: "last-30-days",
+              label: "Last 30 Days",
+            },
+            {
+              value: "last-90-days",
+              label: "Last 90 Days",
+            },
+          ]}
+          icon={CalendarDays}
+        />
+
+        <FilterSelect
+          label="Participant Category"
+          value={
+            currentFilters.participantCategory
+          }
+          onChange={(value) =>
+            updateFilter(
+              "participantCategory",
+              value
+            )
+          }
+          options={categories.map(
+            (category) => ({
+              value:
+                typeof category ===
+                "object"
+                  ? category.id ||
+                    category.name
+                  : category,
+              label:
+                typeof category ===
+                "object"
+                  ? category.name ||
+                    category.label ||
+                    category.id
+                  : category,
+            })
+          )}
+        />
+      </div>
+
+      {/* Apply */}
+      <div className="mt-4 flex justify-end">
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-indigo-600 px-5 py-2.5 text-xs font-semibold text-white transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+        >
+          <Search size={14} />
+          Apply Filters
+        </button>
+      </div>
+    </form>
+  );
+};
+
+/**
+ * Reusable select control.
+ */
+const FilterSelect = ({
+  label,
+  value,
+  onChange,
+  options = [],
+  icon: Icon = ChevronDown,
+}) => {
+  return (
+    <div>
+      <label className="mb-1.5 block text-xs font-semibold text-slate-700 dark:text-slate-300">
+        {label}
+      </label>
+
+      <div className="relative">
+        <select
+          value={value || ""}
+          onChange={(event) =>
+            onChange(
+              event.target.value
+            )
+          }
+          className="w-full appearance-none rounded-xl border border-slate-200 bg-white px-3 py-2.5 pr-9 text-xs text-slate-700 outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:focus:border-indigo-500 dark:focus:ring-indigo-900/30"
+        >
+          <option value="">
+            All {label}
+          </option>
+
+          {options.map(
+            (option) => (
+              <option
+                key={option.value}
+                value={option.value}
+              >
+                {option.label}
+              </option>
+            )
+          )}
+        </select>
+
+        <Icon
+          size={14}
+          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-slate-400"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ParticipantSearchFilters;

--- a/src/utils/participantSearchUtils.js
+++ b/src/utils/participantSearchUtils.js
@@ -1,0 +1,955 @@
+/**
+ * Participant Search & Filter utilities.
+ *
+ * Supports:
+ * - Name search
+ * - Email search
+ * - Registration status
+ * - Team filtering
+ * - Attendance status
+ * - Registration date filtering
+ * - Participant category filtering
+ * - Combined filters
+ * - Sorting
+ */
+
+export const DEFAULT_PARTICIPANT_FILTERS = {
+  search: "",
+  registrationStatus: "",
+  team: "",
+  attendanceStatus: "",
+  registrationDate: "",
+  participantCategory: "",
+};
+
+/**
+ * Normalize text for comparisons.
+ */
+export const normalizeParticipantValue = (
+  value
+) => {
+  if (
+    value === null ||
+    value === undefined
+  ) {
+    return "";
+  }
+
+  return String(value)
+    .trim()
+    .toLowerCase();
+};
+
+/**
+ * Normalize participant filters.
+ */
+export const normalizeParticipantFilters = (
+  filters = {}
+) => {
+  return {
+    ...DEFAULT_PARTICIPANT_FILTERS,
+    ...filters,
+  };
+};
+
+/**
+ * Get participant display name.
+ */
+export const getParticipantDisplayName = (
+  participant = {}
+) => {
+  if (participant.name) {
+    return participant.name;
+  }
+
+  const fullName = [
+    participant.firstName,
+    participant.lastName,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return (
+    fullName ||
+    participant.fullName ||
+    participant.username ||
+    "Unknown Participant"
+  );
+};
+
+/**
+ * Get participant email.
+ */
+export const getParticipantEmail = (
+  participant = {}
+) => {
+  return (
+    participant.email ||
+    participant.emailAddress ||
+    participant.user?.email ||
+    ""
+  );
+};
+
+/**
+ * Get registration status.
+ */
+export const getParticipantRegistrationStatus =
+  (participant = {}) => {
+    return normalizeParticipantValue(
+      participant.registrationStatus ||
+        participant.status ||
+        participant.registration?.status
+    );
+  };
+
+/**
+ * Get participant team.
+ */
+export const getParticipantTeam = (
+  participant = {}
+) => {
+  const team =
+    participant.team ||
+    participant.teamName ||
+    participant.teamId ||
+    participant.registration?.team;
+
+  if (
+    team &&
+    typeof team === "object"
+  ) {
+    return (
+      team.id ||
+      team.name ||
+      team.title ||
+      ""
+    );
+  }
+
+  return team || "";
+};
+
+/**
+ * Get participant team name.
+ */
+export const getParticipantTeamName = (
+  participant = {}
+) => {
+  const team =
+    participant.team;
+
+  if (
+    team &&
+    typeof team === "object"
+  ) {
+    return (
+      team.name ||
+      team.title ||
+      team.id ||
+      "No team"
+    );
+  }
+
+  return (
+    participant.teamName ||
+    team ||
+    "No team"
+  );
+};
+
+/**
+ * Get attendance status.
+ */
+export const getParticipantAttendanceStatus =
+  (participant = {}) => {
+    const value =
+      participant.attendanceStatus ||
+      participant.attendance ||
+      participant.attendance?.status;
+
+    if (
+      value === true
+    ) {
+      return "attended";
+    }
+
+    if (
+      value === false
+    ) {
+      return "absent";
+    }
+
+    return normalizeParticipantValue(
+      value || "not-marked"
+    );
+  };
+
+/**
+ * Get registration date.
+ */
+export const getParticipantRegistrationDate =
+  (participant = {}) => {
+    return (
+      participant.registrationDate ||
+      participant.registeredAt ||
+      participant.registration?.createdAt ||
+      participant.createdAt ||
+      null
+    );
+  };
+
+/**
+ * Get participant category.
+ */
+export const getParticipantCategory =
+  (participant = {}) => {
+    return (
+      participant.participantCategory ||
+      participant.category ||
+      participant.registrationCategory ||
+      participant.type ||
+      ""
+    );
+  };
+
+/**
+ * Search by participant name or email.
+ */
+export const searchParticipants = (
+  participants = [],
+  search = ""
+) => {
+  if (
+    !Array.isArray(participants)
+  ) {
+    return [];
+  }
+
+  const query =
+    normalizeParticipantValue(
+      search
+    );
+
+  if (!query) {
+    return [...participants];
+  }
+
+  return participants.filter(
+    (participant) => {
+      const name =
+        normalizeParticipantValue(
+          getParticipantDisplayName(
+            participant
+          )
+        );
+
+      const email =
+        normalizeParticipantValue(
+          getParticipantEmail(
+            participant
+          )
+        );
+
+      return (
+        name.includes(query) ||
+        email.includes(query)
+      );
+    }
+  );
+};
+
+/**
+ * Match registration status.
+ */
+export const matchesRegistrationStatus =
+  (
+    participant,
+    status
+  ) => {
+    if (!status) {
+      return true;
+    }
+
+    return (
+      getParticipantRegistrationStatus(
+        participant
+      ) ===
+      normalizeParticipantValue(
+        status
+      )
+    );
+  };
+
+/**
+ * Match team.
+ */
+export const matchesTeam = (
+  participant,
+  team
+) => {
+  if (!team) {
+    return true;
+  }
+
+  const participantTeam =
+    normalizeParticipantValue(
+      getParticipantTeam(
+        participant
+      )
+    );
+
+  const requestedTeam =
+    normalizeParticipantValue(
+      team
+    );
+
+  return (
+    participantTeam ===
+      requestedTeam ||
+    participantTeam.includes(
+      requestedTeam
+    ) ||
+    requestedTeam.includes(
+      participantTeam
+    )
+  );
+};
+
+/**
+ * Match attendance status.
+ */
+export const matchesAttendanceStatus =
+  (
+    participant,
+    status
+  ) => {
+    if (!status) {
+      return true;
+    }
+
+    return (
+      getParticipantAttendanceStatus(
+        participant
+      ) ===
+      normalizeParticipantValue(
+        status
+      )
+    );
+  };
+
+/**
+ * Match participant category.
+ */
+export const matchesParticipantCategory =
+  (
+    participant,
+    category
+  ) => {
+    if (!category) {
+      return true;
+    }
+
+    const participantCategory =
+      normalizeParticipantValue(
+        getParticipantCategory(
+          participant
+        )
+      );
+
+    const requestedCategory =
+      normalizeParticipantValue(
+        category
+      );
+
+    return (
+      participantCategory ===
+        requestedCategory ||
+      participantCategory.includes(
+        requestedCategory
+      ) ||
+      requestedCategory.includes(
+        participantCategory
+      )
+    );
+  };
+
+/**
+ * Convert date to a valid Date.
+ */
+export const parseParticipantDate = (
+  value
+) => {
+  if (!value) {
+    return null;
+  }
+
+  const date =
+    value instanceof Date
+      ? new Date(value)
+      : new Date(value);
+
+  if (
+    Number.isNaN(
+      date.getTime()
+    )
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+/**
+ * Get the beginning of today.
+ */
+export const getStartOfDay = (
+  date = new Date()
+) => {
+  const result =
+    new Date(date);
+
+  result.setHours(
+    0,
+    0,
+    0,
+    0
+  );
+
+  return result;
+};
+
+/**
+ * Get the beginning of a date
+ * offset by a number of days.
+ */
+export const getDaysAgo = (
+  days,
+  fromDate = new Date()
+) => {
+  const result =
+    getStartOfDay(
+      fromDate
+    );
+
+  result.setDate(
+    result.getDate() -
+      Number(days)
+  );
+
+  return result;
+};
+
+/**
+ * Match registration date filters.
+ *
+ * Supported:
+ * - today
+ * - last-7-days
+ * - last-30-days
+ * - last-90-days
+ */
+export const matchesRegistrationDate = (
+  participant,
+  dateFilter,
+  now = new Date()
+) => {
+  if (!dateFilter) {
+    return true;
+  }
+
+  const registrationDate =
+    parseParticipantDate(
+      getParticipantRegistrationDate(
+        participant
+      )
+    );
+
+  if (!registrationDate) {
+    return false;
+  }
+
+  const today =
+    getStartOfDay(now);
+
+  if (
+    dateFilter === "today"
+  ) {
+    const nextDay =
+      new Date(today);
+
+    nextDay.setDate(
+      nextDay.getDate() + 1
+    );
+
+    return (
+      registrationDate >=
+        today &&
+      registrationDate <
+        nextDay
+    );
+  }
+
+  const daysMap = {
+    "last-7-days": 7,
+    "last-30-days": 30,
+    "last-90-days": 90,
+  };
+
+  const days =
+    daysMap[dateFilter];
+
+  if (!days) {
+    return true;
+  }
+
+  const startDate =
+    getDaysAgo(
+      days,
+      now
+    );
+
+  return (
+    registrationDate >=
+    startDate
+  );
+};
+
+/**
+ * Check whether one participant matches
+ * all supplied filters.
+ */
+export const participantMatchesFilters = (
+  participant,
+  filters = {},
+  options = {}
+) => {
+  const normalized =
+    normalizeParticipantFilters(
+      filters
+    );
+
+  const now =
+    options.now || new Date();
+
+  const searchMatches =
+    !normalized.search ||
+    searchParticipants(
+      [participant],
+      normalized.search
+    ).length > 0;
+
+  if (!searchMatches) {
+    return false;
+  }
+
+  if (
+    !matchesRegistrationStatus(
+      participant,
+      normalized.registrationStatus
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    !matchesTeam(
+      participant,
+      normalized.team
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    !matchesAttendanceStatus(
+      participant,
+      normalized.attendanceStatus
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    !matchesRegistrationDate(
+      participant,
+      normalized.registrationDate,
+      now
+    )
+  ) {
+    return false;
+  }
+
+  if (
+    !matchesParticipantCategory(
+      participant,
+      normalized.participantCategory
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Filter participants using all filters.
+ */
+export const filterParticipants = (
+  participants = [],
+  filters = {},
+  options = {}
+) => {
+  if (
+    !Array.isArray(
+      participants
+    )
+  ) {
+    return [];
+  }
+
+  return participants.filter(
+    (participant) =>
+      participantMatchesFilters(
+        participant,
+        filters,
+        options
+      )
+  );
+};
+
+/**
+ * Get count after filtering.
+ */
+export const getFilteredParticipantCount =
+  (
+    participants = [],
+    filters = {},
+    options = {}
+  ) => {
+    return filterParticipants(
+      participants,
+      filters,
+      options
+    ).length;
+  };
+
+/**
+ * Check if any filters are active.
+ */
+export const hasActiveParticipantFilters = (
+  filters = {}
+) => {
+  const normalized =
+    normalizeParticipantFilters(
+      filters
+    );
+
+  return Object.values(
+    normalized
+  ).some(
+    (value) =>
+      value !== null &&
+      value !== undefined &&
+      String(value).trim() !== ""
+  );
+};
+
+/**
+ * Clear all filters.
+ */
+export const clearParticipantFilters =
+  () => ({
+    ...DEFAULT_PARTICIPANT_FILTERS,
+  });
+
+/**
+ * Sort participants by name.
+ */
+export const sortParticipantsByName = (
+  participants = [],
+  direction = "asc"
+) => {
+  return [
+    ...(Array.isArray(
+      participants
+    )
+      ? participants
+      : []),
+  ].sort(
+    (first, second) => {
+      const firstName =
+        getParticipantDisplayName(
+          first
+        ).toLowerCase();
+
+      const secondName =
+        getParticipantDisplayName(
+          second
+        ).toLowerCase();
+
+      const result =
+        firstName.localeCompare(
+          secondName
+        );
+
+      return direction ===
+        "desc"
+        ? -result
+        : result;
+    }
+  );
+};
+
+/**
+ * Sort participants by registration date.
+ */
+export const sortParticipantsByRegistrationDate =
+  (
+    participants = [],
+    direction = "desc"
+  ) => {
+    return [
+      ...(Array.isArray(
+        participants
+      )
+        ? participants
+        : []),
+    ].sort(
+      (first, second) => {
+        const firstDate =
+          parseParticipantDate(
+            getParticipantRegistrationDate(
+              first
+            )
+          );
+
+        const secondDate =
+          parseParticipantDate(
+            getParticipantRegistrationDate(
+              second
+            )
+          );
+
+        if (!firstDate) {
+          return 1;
+        }
+
+        if (!secondDate) {
+          return -1;
+        }
+
+        const result =
+          firstDate.getTime() -
+          secondDate.getTime();
+
+        return direction ===
+          "desc"
+          ? -result
+          : result;
+      }
+    );
+  };
+
+/**
+ * Get unique teams from participants.
+ */
+export const getUniqueParticipantTeams = (
+  participants = []
+) => {
+  if (
+    !Array.isArray(
+      participants
+    )
+  ) {
+    return [];
+  }
+
+  const teams = new Map();
+
+  participants.forEach(
+    (participant) => {
+      const team =
+        getParticipantTeam(
+          participant
+        );
+
+      if (!team) {
+        return;
+      }
+
+      const key =
+        normalizeParticipantValue(
+          team
+        );
+
+      if (!teams.has(key)) {
+        teams.set(
+          key,
+          {
+            id: team,
+            name: getParticipantTeamName(
+              participant
+            ),
+          }
+        );
+      }
+    }
+  );
+
+  return Array.from(
+    teams.values()
+  );
+};
+
+/**
+ * Get unique participant categories.
+ */
+export const getUniqueParticipantCategories =
+  (
+    participants = []
+  ) => {
+    if (
+      !Array.isArray(
+        participants
+      )
+    ) {
+      return [];
+    }
+
+    const categories =
+      new Map();
+
+    participants.forEach(
+      (participant) => {
+        const category =
+          getParticipantCategory(
+            participant
+          );
+
+        if (!category) {
+          return;
+        }
+
+        const key =
+          normalizeParticipantValue(
+            category
+          );
+
+        if (
+          !categories.has(key)
+        ) {
+          categories.set(
+            key,
+            category
+          );
+        }
+      }
+    );
+
+    return Array.from(
+      categories.values()
+    );
+  };
+
+/**
+ * Get participant statistics.
+ */
+export const getParticipantFilterStats = (
+  participants = [],
+  filters = {}
+) => {
+  const filtered =
+    filterParticipants(
+      participants,
+      filters
+    );
+
+  return {
+    total: Array.isArray(
+      participants
+    )
+      ? participants.length
+      : 0,
+
+    filtered:
+      filtered.length,
+
+    registered:
+      filtered.filter(
+        (participant) =>
+          getParticipantRegistrationStatus(
+            participant
+          ) === "registered"
+      ).length,
+
+    pending:
+      filtered.filter(
+        (participant) =>
+          getParticipantRegistrationStatus(
+            participant
+          ) === "pending"
+      ).length,
+
+    attended:
+      filtered.filter(
+        (participant) =>
+          getParticipantAttendanceStatus(
+            participant
+          ) === "attended"
+      ).length,
+
+    absent:
+      filtered.filter(
+        (participant) =>
+          getParticipantAttendanceStatus(
+            participant
+          ) === "absent"
+      ).length,
+  };
+};
+
+/**
+ * Search and filter participants in one call.
+ */
+export const searchAndFilterParticipants = (
+  participants = [],
+  filters = {},
+  options = {}
+) => {
+  const filtered =
+    filterParticipants(
+      participants,
+      filters,
+      options
+    );
+
+  const sortBy =
+    options.sortBy || "";
+
+  const sortDirection =
+    options.sortDirection ||
+    "asc";
+
+  if (
+    sortBy === "name"
+  ) {
+    return sortParticipantsByName(
+      filtered,
+      sortDirection
+    );
+  }
+
+  if (
+    sortBy ===
+    "registrationDate"
+  ) {
+    return sortParticipantsByRegistrationDate(
+      filtered,
+      sortDirection
+    );
+  }
+
+  return filtered;
+};


### PR DESCRIPTION
## Description

Implemented advanced participant search and filtering tools for the
organizer dashboard.

### Added

- Search participants by name
- Search participants by email
- Filter by registration status
- Filter by team
- Filter by attendance status
- Filter by registration date
- Filter by participant category
- Combine multiple filters
- Clear filters
- Participant result count
- Participant status badges
- Team and registration information
- Empty search results state
- Participant sorting utilities
- Participant filter statistics
- Unique team and category helpers

Closes #12963