### PR TITLE
feat(events): add post-event summary

### DIFF
--- a/src/components/events/EventPostEventSummary.js
+++ b/src/components/events/EventPostEventSummary.js
@@ -1,0 +1,628 @@
+import {
+  Award,
+  BarChart3,
+  BookOpen,
+  CalendarCheck,
+  CheckCircle2,
+  ExternalLink,
+  Image,
+  MessageSquare,
+  PlayCircle,
+  Trophy,
+  Users,
+} from "lucide-react";
+
+import {
+  buildPostEventSummary,
+} from "../../utils/postEventSummaryUtils";
+
+const EventPostEventSummary = ({
+  event = {},
+  className = "",
+}) => {
+  const summary =
+    buildPostEventSummary(event);
+
+  if (!summary.completed) {
+    return null;
+  }
+
+  const stats =
+    summary.statistics;
+
+  return (
+    <section
+      aria-labelledby="post-event-summary-title"
+      className={`rounded-3xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/30">
+            <BarChart3
+              size={21}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-indigo-600 dark:text-indigo-400">
+              Event Recap
+            </p>
+
+            <h2
+              id="post-event-summary-title"
+              className="mt-1 text-lg font-bold text-slate-900 dark:text-white"
+            >
+              {summary.title}
+            </h2>
+
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Post-Event Summary
+            </p>
+          </div>
+        </div>
+
+        <span className="inline-flex w-fit items-center gap-1.5 rounded-full bg-green-50 px-3 py-1.5 text-[10px] font-semibold text-green-600 dark:bg-green-900/20 dark:text-green-400">
+          <CheckCircle2 size={13} />
+          Event Completed
+        </span>
+      </div>
+
+      {summary.description && (
+        <p className="mt-5 rounded-xl bg-slate-50 p-3 text-xs leading-5 text-slate-600 dark:bg-slate-800/60 dark:text-slate-400">
+          {summary.description}
+        </p>
+      )}
+
+      {/* Statistics */}
+      <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatCard
+          icon={Users}
+          label="Registered"
+          value={
+            stats.registeredParticipants
+          }
+        />
+
+        <StatCard
+          icon={CalendarCheck}
+          label="Attendees"
+          value={stats.attendees}
+        />
+
+        <StatCard
+          icon={BarChart3}
+          label="Attendance"
+          value={`${stats.attendancePercentage}%`}
+        />
+
+        <StatCard
+          icon={Award}
+          label="Certificates"
+          value={
+            stats.certificates
+              .issued
+          }
+          secondary={`of ${stats.certificates.total}`}
+        />
+      </div>
+
+      {/* Attendance progress */}
+      <div className="mt-5 rounded-2xl border border-slate-200 p-4 dark:border-slate-700">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-bold text-slate-800 dark:text-white">
+              Attendance Overview
+            </p>
+
+            <p className="mt-1 text-[10px] text-slate-400">
+              {stats.attendees} attendees from{" "}
+              {stats.registeredParticipants}{" "}
+              registrations
+            </p>
+          </div>
+
+          <span className="text-sm font-bold text-indigo-600 dark:text-indigo-400">
+            {stats.attendancePercentage}%
+          </span>
+        </div>
+
+        <div
+          className="mt-3 h-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800"
+          role="progressbar"
+          aria-valuenow={
+            stats.attendancePercentage
+          }
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-label="Attendance percentage"
+        >
+          <div
+            className="h-full rounded-full bg-indigo-600 transition-all"
+            style={{
+              width: `${stats.attendancePercentage}%`,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Highlights */}
+      {summary.highlights.length >
+        0 && (
+        <SummaryBlock
+          icon={Trophy}
+          title="Event Highlights"
+        >
+          <ul className="space-y-2">
+            {summary.highlights.map(
+              (highlight, index) => (
+                <li
+                  key={index}
+                  className="flex items-start gap-2 text-xs leading-5 text-slate-600 dark:text-slate-400"
+                >
+                  <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-indigo-500" />
+
+                  {typeof highlight ===
+                  "object"
+                    ? highlight.text ||
+                      highlight.title ||
+                      highlight.description
+                    : highlight}
+                </li>
+              )
+            )}
+          </ul>
+        </SummaryBlock>
+      )}
+
+      {/* Winners */}
+      {summary.winners.length >
+        0 && (
+        <SummaryBlock
+          icon={Trophy}
+          title="Winners & Top Participants"
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            {summary.winners.map(
+              (winner, index) => (
+                <WinnerCard
+                  key={
+                    winner?.id ||
+                    winner?.userId ||
+                    index
+                  }
+                  winner={winner}
+                  position={
+                    index + 1
+                  }
+                />
+              )
+            )}
+          </div>
+        </SummaryBlock>
+      )}
+
+      {/* Top participants fallback */}
+      {summary.winners.length ===
+        0 &&
+        summary.topParticipants
+          .length > 0 && (
+          <SummaryBlock
+            icon={Trophy}
+            title="Top Participants"
+          >
+            <div className="grid gap-3 sm:grid-cols-2">
+              {summary.topParticipants.map(
+                (
+                  participant,
+                  index
+                ) => (
+                  <WinnerCard
+                    key={
+                      participant?.id ||
+                      participant?.userId ||
+                      index
+                    }
+                    winner={
+                      participant
+                    }
+                    position={
+                      index + 1
+                    }
+                  />
+                )
+              )}
+            </div>
+          </SummaryBlock>
+        )}
+
+      {/* Feedback */}
+      {stats.feedback.count >
+        0 && (
+        <SummaryBlock
+          icon={MessageSquare}
+          title="Feedback Summary"
+        >
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <FeedbackStat
+              label="Responses"
+              value={
+                stats.feedback.count
+              }
+            />
+
+            <FeedbackStat
+              label="Average Rating"
+              value={
+                stats.feedback
+                  .averageRating
+                  ? `${stats.feedback.averageRating}/5`
+                  : "N/A"
+              }
+            />
+
+            <FeedbackStat
+              label="Positive"
+              value={
+                stats.feedback
+                  .positiveCount
+              }
+            />
+
+            <FeedbackStat
+              label="Needs Improvement"
+              value={
+                stats.feedback
+                  .negativeCount
+              }
+            />
+          </div>
+        </SummaryBlock>
+      )}
+
+      {/* Photos */}
+      {summary.photos.length >
+        0 && (
+        <SummaryBlock
+          icon={Image}
+          title="Event Photos & Gallery"
+        >
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+            {summary.photos
+              .slice(0, 8)
+              .map(
+                (photo, index) => (
+                  <PhotoCard
+                    key={index}
+                    photo={photo}
+                  />
+                )
+              )}
+          </div>
+        </SummaryBlock>
+      )}
+
+      {/* Resources */}
+      {summary.links.length >
+        0 && (
+        <SummaryBlock
+          icon={BookOpen}
+          title="Event Resources"
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            {summary.links.map(
+              (link, index) => (
+                <ResourceLink
+                  key={
+                    link.url ||
+                    index
+                  }
+                  link={link}
+                />
+              )
+            )}
+          </div>
+        </SummaryBlock>
+      )}
+
+      {/* Certificates */}
+      {stats.certificates
+        .total > 0 && (
+        <SummaryBlock
+          icon={Award}
+          title="Certificates"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold text-slate-700 dark:text-slate-200">
+                Certificate status
+              </p>
+
+              <p className="mt-1 text-[11px] text-slate-400">
+                {
+                  stats.certificates
+                    .issued
+                }{" "}
+                issued ·{" "}
+                {
+                  stats.certificates
+                    .pending
+                }{" "}
+                pending
+              </p>
+            </div>
+
+            <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100 sm:w-40 dark:bg-slate-800">
+              <div
+                className="h-full rounded-full bg-green-500"
+                style={{
+                  width: `${stats.certificates.percentage}%`,
+                }}
+              />
+            </div>
+          </div>
+        </SummaryBlock>
+      )}
+
+      {/* Empty state */}
+      {!hasSummarySections(
+        summary
+      ) && (
+        <div className="mt-5 rounded-2xl bg-slate-50 p-6 text-center dark:bg-slate-800/60">
+          <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+            Event summary is available
+          </p>
+
+          <p className="mt-1 text-xs text-slate-400">
+            More event recap information will appear
+            here when available.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+};
+
+/**
+ * Statistics card.
+ */
+const StatCard = ({
+  icon: Icon,
+  label,
+  value,
+  secondary,
+}) => {
+  return (
+    <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-700">
+      <Icon
+        size={17}
+        className="text-indigo-500"
+      />
+
+      <p className="mt-3 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+        {label}
+      </p>
+
+      <div className="mt-1 flex items-baseline gap-1">
+        <span className="text-xl font-bold text-slate-900 dark:text-white">
+          {value}
+        </span>
+
+        {secondary && (
+          <span className="text-[10px] text-slate-400">
+            {secondary}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Reusable summary section.
+ */
+const SummaryBlock = ({
+  icon: Icon,
+  title,
+  children,
+}) => {
+  return (
+    <div className="mt-5 rounded-2xl border border-slate-200 p-4 dark:border-slate-700">
+      <div className="mb-4 flex items-center gap-2">
+        <Icon
+          size={16}
+          className="text-indigo-500"
+        />
+
+        <h3 className="text-sm font-bold text-slate-800 dark:text-white">
+          {title}
+        </h3>
+      </div>
+
+      {children}
+    </div>
+  );
+};
+
+/**
+ * Winner card.
+ */
+const WinnerCard = ({
+  winner,
+  position,
+}) => {
+  const name =
+    winner?.name ||
+    winner?.fullName ||
+    winner?.username ||
+    winner?.participantName ||
+    "Participant";
+
+  const score =
+    winner?.score ??
+    winner?.points;
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-slate-50 p-3 dark:bg-slate-800/60">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-xs font-bold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+        #{position}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-bold text-slate-800 dark:text-white">
+          {name}
+        </p>
+
+        {winner?.award && (
+          <p className="mt-0.5 text-[10px] text-slate-400">
+            {winner.award}
+          </p>
+        )}
+      </div>
+
+      {score !==
+        undefined && (
+        <span className="text-xs font-bold text-indigo-600 dark:text-indigo-400">
+          {score}
+        </span>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Feedback statistic.
+ */
+const FeedbackStat = ({
+  label,
+  value,
+}) => {
+  return (
+    <div className="rounded-xl bg-slate-50 p-3 dark:bg-slate-800/60">
+      <p className="text-[9px] font-semibold uppercase tracking-wide text-slate-400">
+        {label}
+      </p>
+
+      <p className="mt-1 text-sm font-bold text-slate-800 dark:text-white">
+        {value}
+      </p>
+    </div>
+  );
+};
+
+/**
+ * Photo card.
+ */
+const PhotoCard = ({
+  photo,
+}) => {
+  const src =
+    typeof photo ===
+    "string"
+      ? photo
+      : photo?.url ||
+        photo?.src ||
+        photo?.imageUrl;
+
+  if (!src) {
+    return (
+      <div className="flex aspect-video items-center justify-center rounded-xl bg-slate-100 text-xs text-slate-400 dark:bg-slate-800">
+        Image unavailable
+      </div>
+    );
+  }
+
+  return (
+    <a
+      href={src}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block overflow-hidden rounded-xl"
+    >
+      <img
+        src={src}
+        alt={
+          typeof photo ===
+          "object"
+            ? photo.alt ||
+              photo.title ||
+              "Event photo"
+            : "Event photo"
+        }
+        className="aspect-video w-full object-cover transition duration-300 group-hover:scale-105"
+        loading="lazy"
+      />
+    </a>
+  );
+};
+
+/**
+ * Resource link.
+ */
+const ResourceLink = ({
+  link,
+}) => {
+  const isRecording =
+    link.type ===
+    "recording";
+
+  return (
+    <a
+      href={link.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-center gap-3 rounded-xl border border-slate-200 p-3 transition hover:border-indigo-300 hover:bg-indigo-50 dark:border-slate-700 dark:hover:border-indigo-700 dark:hover:bg-indigo-900/10"
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+        {isRecording ? (
+          <PlayCircle
+            size={17}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        ) : (
+          <BookOpen
+            size={17}
+            className="text-indigo-600 dark:text-indigo-400"
+          />
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-semibold text-slate-700 dark:text-slate-200">
+          {link.label}
+        </p>
+
+        <p className="mt-0.5 text-[10px] text-slate-400">
+          Open resource
+        </p>
+      </div>
+
+      <ExternalLink
+        size={14}
+        className="shrink-0 text-slate-400 transition group-hover:text-indigo-500"
+      />
+    </a>
+  );
+};
+
+/**
+ * Determine whether additional summary
+ * sections contain content.
+ */
+const hasSummarySections = (
+  summary
+) => {
+  return Boolean(
+    summary.highlights.length ||
+      summary.winners.length ||
+      summary.topParticipants
+        .length ||
+      summary.photos.length ||
+      summary.links.length ||
+      summary.feedback.count ||
+      summary.certificates.total
+  );
+};
+
+export default EventPostEventSummary;

--- a/src/components/events/PostEventSummarySection.js
+++ b/src/components/events/PostEventSummarySection.js
@@ -1,0 +1,91 @@
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+const PostEventSummarySection = ({
+  title,
+  icon: Icon,
+  children,
+  description,
+  defaultOpen = true,
+  collapsible = false,
+  badge,
+  className = "",
+}) => {
+  const [open, setOpen] =
+    useState(defaultOpen);
+
+  const handleToggle = () => {
+    if (collapsible) {
+      setOpen((current) => !current);
+    }
+  };
+
+  return (
+    <section
+      className={`rounded-2xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900 ${className}`}
+    >
+      {/* Header */}
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={!collapsible}
+        aria-expanded={open}
+        className={`flex w-full items-center gap-3 p-4 text-left ${
+          collapsible
+            ? "cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50"
+            : "cursor-default"
+        }`}
+      >
+        {Icon && (
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-100 dark:bg-indigo-900/30">
+            <Icon
+              size={17}
+              className="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-bold text-slate-800 dark:text-white">
+              {title}
+            </h3>
+
+            {badge !== undefined &&
+              badge !== null && (
+                <span className="rounded-full bg-slate-100 px-2 py-1 text-[9px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                  {badge}
+                </span>
+              )}
+          </div>
+
+          {description && (
+            <p className="mt-1 text-[11px] leading-5 text-slate-400">
+              {description}
+            </p>
+          )}
+        </div>
+
+        {collapsible && (
+          <ChevronDown
+            size={17}
+            className={`shrink-0 text-slate-400 transition-transform duration-200 ${
+              open
+                ? "rotate-180"
+                : ""
+            }`}
+          />
+        )}
+      </button>
+
+      {/* Content */}
+      {open && (
+        <div className="border-t border-slate-100 p-4 dark:border-slate-800">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default PostEventSummarySection;

--- a/src/utils/postEventSummaryUtils.js
+++ b/src/utils/postEventSummaryUtils.js
@@ -1,0 +1,828 @@
+/**
+ * Post-Event Summary utilities.
+ *
+ * Supports:
+ * - Participant statistics
+ * - Attendance percentage
+ * - Event highlights
+ * - Winners / top participants
+ * - Photos and resources
+ * - Feedback summary
+ * - Certificate status
+ * - Recording / presentation links
+ * - Complete post-event summary
+ */
+
+/**
+ * Safely convert a value into an array.
+ */
+export const toSummaryArray = (
+  value
+) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (
+    value === null ||
+    value === undefined ||
+    value === ""
+  ) {
+    return [];
+  }
+
+  return [value];
+};
+
+/**
+ * Safely convert a value into a number.
+ */
+export const toSummaryNumber = (
+  value,
+  fallback = 0
+) => {
+  const number = Number(value);
+
+  return Number.isFinite(number)
+    ? number
+    : fallback;
+};
+
+/**
+ * Get registered participant count.
+ */
+export const getRegisteredParticipantCount =
+  (event = {}) => {
+    const directCount =
+      event.totalRegistered ??
+      event.registeredCount ??
+      event.registrationCount;
+
+    if (
+      directCount !== undefined &&
+      directCount !== null
+    ) {
+      return toSummaryNumber(
+        directCount
+      );
+    }
+
+    const participants =
+      event.registeredParticipants ||
+      event.registrations ||
+      [];
+
+    return Array.isArray(
+      participants
+    )
+      ? participants.length
+      : 0;
+  };
+
+/**
+ * Get attendee count.
+ */
+export const getAttendeeCount = (
+  event = {}
+) => {
+  const directCount =
+    event.totalAttendees ??
+    event.attendeeCount ??
+    event.attendedCount;
+
+  if (
+    directCount !== undefined &&
+    directCount !== null
+  ) {
+    return toSummaryNumber(
+      directCount
+    );
+  }
+
+  const attendees =
+    event.attendees || [];
+
+  if (
+    Array.isArray(attendees)
+  ) {
+    return attendees.length;
+  }
+
+  const participants =
+    event.participants || [];
+
+  if (
+    Array.isArray(
+      participants
+    )
+  ) {
+    return participants.filter(
+      (participant) =>
+        participant.attended ===
+          true ||
+        participant.attendanceStatus ===
+          "attended"
+    ).length;
+  }
+
+  return 0;
+};
+
+/**
+ * Calculate attendance percentage.
+ */
+export const getAttendancePercentage = (
+  event = {}
+) => {
+  const registered =
+    getRegisteredParticipantCount(
+      event
+    );
+
+  const attendees =
+    getAttendeeCount(event);
+
+  if (registered <= 0) {
+    return 0;
+  }
+
+  return Math.min(
+    100,
+    Math.round(
+      (attendees / registered) *
+        100
+    )
+  );
+};
+
+/**
+ * Get event highlights.
+ */
+export const getEventHighlights = (
+  event = {}
+) => {
+  return toSummaryArray(
+    event.highlights ||
+      event.eventHighlights ||
+      event.keyHighlights
+  ).filter(Boolean);
+};
+
+/**
+ * Get winners.
+ */
+export const getEventWinners = (
+  event = {}
+) => {
+  return toSummaryArray(
+    event.winners ||
+      event.topParticipants ||
+      event.topPerformers ||
+      event.results
+  ).filter(Boolean);
+};
+
+/**
+ * Get photos.
+ */
+export const getEventPhotos = (
+  event = {}
+) => {
+  return toSummaryArray(
+    event.photos ||
+      event.eventPhotos ||
+      event.gallery ||
+      event.images
+  ).filter(Boolean);
+};
+
+/**
+ * Get event resources.
+ */
+export const getEventResources = (
+  event = {}
+) => {
+  return toSummaryArray(
+    event.resources ||
+      event.eventResources ||
+      event.materials
+  ).filter(Boolean);
+};
+
+/**
+ * Get recording link.
+ */
+export const getEventRecordingLink = (
+  event = {}
+) => {
+  return (
+    event.recordingUrl ||
+    event.recordingLink ||
+    event.eventRecording ||
+    event.videoUrl ||
+    null
+  );
+};
+
+/**
+ * Get presentation link.
+ */
+export const getPresentationLink = (
+  event = {}
+) => {
+  return (
+    event.presentationUrl ||
+    event.presentationLink ||
+    event.slidesUrl ||
+    null
+  );
+};
+
+/**
+ * Get all media/resource links.
+ */
+export const getEventLinks = (
+  event = {}
+) => {
+  const links = [];
+
+  const recording =
+    getEventRecordingLink(
+      event
+    );
+
+  const presentation =
+    getPresentationLink(
+      event
+    );
+
+  if (recording) {
+    links.push({
+      type: "recording",
+      label: "Event Recording",
+      url: recording,
+    });
+  }
+
+  if (presentation) {
+    links.push({
+      type: "presentation",
+      label: "Presentation",
+      url: presentation,
+    });
+  }
+
+  getEventResources(
+    event
+  ).forEach(
+    (resource, index) => {
+      if (
+        typeof resource ===
+        "string"
+      ) {
+        links.push({
+          type: "resource",
+          label: `Resource ${
+            index + 1
+          }`,
+          url: resource,
+        });
+      } else if (
+        resource?.url ||
+        resource?.link
+      ) {
+        links.push({
+          type: "resource",
+          label:
+            resource.title ||
+            resource.name ||
+            `Resource ${
+              index + 1
+            }`,
+          url:
+            resource.url ||
+            resource.link,
+        });
+      }
+    }
+  );
+
+  return links;
+};
+
+/**
+ * Get feedback entries.
+ */
+export const getFeedbackEntries = (
+  event = {}
+) => {
+  return toSummaryArray(
+    event.feedback ||
+      event.feedbackEntries ||
+      event.reviews
+  ).filter(Boolean);
+};
+
+/**
+ * Calculate feedback statistics.
+ */
+export const getFeedbackSummary = (
+  event = {}
+) => {
+  const feedback =
+    getFeedbackEntries(event);
+
+  const directAverage =
+    event.averageRating ??
+    event.feedbackAverage ??
+    event.averageFeedbackRating;
+
+  const directCount =
+    event.feedbackCount;
+
+  if (
+    directAverage !==
+      undefined &&
+    directAverage !== null
+  ) {
+    return {
+      count:
+        toSummaryNumber(
+          directCount,
+          feedback.length
+        ),
+      averageRating:
+        Number(
+          Number(
+            directAverage
+          ).toFixed(1)
+        ),
+      positiveCount:
+        0,
+      negativeCount:
+        0,
+    };
+  }
+
+  const ratings =
+    feedback
+      .map(
+        (item) =>
+          typeof item ===
+          "object"
+            ? item.rating ??
+              item.score
+            : null
+      )
+      .map(Number)
+      .filter(
+        (rating) =>
+          Number.isFinite(
+            rating
+          )
+      );
+
+  const averageRating =
+    ratings.length
+      ? Number(
+          (
+            ratings.reduce(
+              (
+                total,
+                rating
+              ) =>
+                total +
+                rating,
+              0
+            ) /
+            ratings.length
+          ).toFixed(1)
+        )
+      : 0;
+
+  const positiveCount =
+    ratings.filter(
+      (rating) =>
+        rating >= 4
+    ).length;
+
+  const negativeCount =
+    ratings.filter(
+      (rating) =>
+        rating <= 2
+    ).length;
+
+  return {
+    count:
+      ratings.length ||
+      feedback.length,
+
+    averageRating,
+
+    positiveCount,
+
+    negativeCount,
+  };
+};
+
+/**
+ * Get certificate statistics.
+ */
+export const getCertificateSummary = (
+  event = {}
+) => {
+  const certificates =
+    event.certificates ||
+    event.certificateStatus ||
+    {};
+
+  if (
+    Array.isArray(
+      certificates
+    )
+  ) {
+    const total =
+      certificates.length;
+
+    const issued =
+      certificates.filter(
+        (certificate) =>
+          certificate?.issued ===
+            true ||
+          certificate?.status ===
+            "issued"
+      ).length;
+
+    return {
+      total,
+      issued,
+      pending: Math.max(
+        0,
+        total - issued
+      ),
+      percentage: total
+        ? Math.round(
+            (issued / total) *
+              100
+          )
+        : 0,
+    };
+  }
+
+  const total =
+    toSummaryNumber(
+      certificates.total ??
+        event.totalCertificates ??
+        0
+    );
+
+  const issued =
+    toSummaryNumber(
+      certificates.issued ??
+        event.certificatesIssued ??
+        0
+    );
+
+  const pending =
+    toSummaryNumber(
+      certificates.pending ??
+        Math.max(
+          0,
+          total - issued
+        )
+    );
+
+  return {
+    total,
+    issued,
+    pending,
+    percentage: total
+      ? Math.round(
+          (issued / total) *
+            100
+        )
+      : 0,
+  };
+};
+
+/**
+ * Get event title.
+ */
+export const getSummaryEventTitle = (
+  event = {}
+) => {
+  return (
+    event.title ||
+    event.name ||
+    event.eventTitle ||
+    "Event Summary"
+  );
+};
+
+/**
+ * Get event description.
+ */
+export const getSummaryDescription = (
+  event = {}
+) => {
+  return (
+    event.summary ||
+    event.eventSummary ||
+    event.description ||
+    ""
+  );
+};
+
+/**
+ * Get top participants.
+ *
+ * Supports either:
+ * - event.topParticipants
+ * - event.winners
+ * - participants sorted by score
+ */
+export const getTopParticipants = (
+  event = {},
+  limit = 5
+) => {
+  const explicit =
+    event.topParticipants ||
+    event.winners;
+
+  if (
+    Array.isArray(explicit)
+  ) {
+    return explicit.slice(
+      0,
+      limit
+    );
+  }
+
+  const participants =
+    event.participants || [];
+
+  if (
+    !Array.isArray(
+      participants
+    )
+  ) {
+    return [];
+  }
+
+  return [
+    ...participants,
+  ]
+    .filter(
+      (participant) =>
+        participant.score !==
+          undefined ||
+        participant.points !==
+          undefined ||
+        participant.rank !==
+          undefined
+    )
+    .sort(
+      (first, second) => {
+        const firstRank =
+          Number(
+            first.rank
+          );
+
+        const secondRank =
+          Number(
+            second.rank
+          );
+
+        if (
+          Number.isFinite(
+            firstRank
+          ) &&
+          Number.isFinite(
+            secondRank
+          )
+        ) {
+          return (
+            firstRank -
+            secondRank
+          );
+        }
+
+        return (
+          Number(
+            second.score ??
+              second.points ??
+              0
+          ) -
+          Number(
+            first.score ??
+              first.points ??
+              0
+          )
+        );
+      }
+    )
+    .slice(0, limit);
+};
+
+/**
+ * Check whether the event has ended.
+ */
+export const isEventCompleted = (
+  event = {},
+  now = new Date()
+) => {
+  if (
+    event.status ===
+      "completed" ||
+    event.status ===
+      "ended"
+  ) {
+    return true;
+  }
+
+  const endValue =
+    event.endDateTime ||
+    event.endDatetime ||
+    event.endTime ||
+    event.endDate ||
+    event.endsAt;
+
+  if (!endValue) {
+    return false;
+  }
+
+  const endDate =
+    new Date(endValue);
+
+  if (
+    Number.isNaN(
+      endDate.getTime()
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    endDate.getTime() <=
+    new Date(now).getTime()
+  );
+};
+
+/**
+ * Create event statistics.
+ */
+export const getPostEventStatistics = (
+  event = {}
+) => {
+  const registered =
+    getRegisteredParticipantCount(
+      event
+    );
+
+  const attendees =
+    getAttendeeCount(event);
+
+  return {
+    registeredParticipants:
+      registered,
+
+    attendees,
+
+    attendancePercentage:
+      getAttendancePercentage(
+        event
+      ),
+
+    certificates:
+      getCertificateSummary(
+        event
+      ),
+
+    feedback:
+      getFeedbackSummary(
+        event
+      ),
+  };
+};
+
+/**
+ * Create the complete post-event summary.
+ */
+export const buildPostEventSummary = (
+  event = {}
+) => {
+  return {
+    title:
+      getSummaryEventTitle(
+        event
+      ),
+
+    description:
+      getSummaryDescription(
+        event
+      ),
+
+    completed:
+      isEventCompleted(
+        event
+      ),
+
+    statistics:
+      getPostEventStatistics(
+        event
+      ),
+
+    highlights:
+      getEventHighlights(
+        event
+      ),
+
+    winners:
+      getEventWinners(
+        event
+      ),
+
+    topParticipants:
+      getTopParticipants(
+        event
+      ),
+
+    photos:
+      getEventPhotos(
+        event
+      ),
+
+    resources:
+      getEventResources(
+        event
+      ),
+
+    links:
+      getEventLinks(event),
+
+    feedback:
+      getFeedbackSummary(
+        event
+      ),
+
+    certificates:
+      getCertificateSummary(
+        event
+      ),
+  };
+};
+
+/**
+ * Check whether there is enough content
+ * to display a post-event summary.
+ */
+export const hasPostEventSummaryContent =
+  (event = {}) => {
+    const summary =
+      buildPostEventSummary(
+        event
+      );
+
+    return Boolean(
+      summary.statistics
+        .registeredParticipants ||
+        summary.statistics
+          .attendees ||
+        summary.highlights.length ||
+        summary.winners.length ||
+        summary.topParticipants
+          .length ||
+        summary.photos.length ||
+        summary.resources.length ||
+        summary.links.length ||
+        summary.feedback.count ||
+        summary.certificates.total
+    );
+  };
+
+/**
+ * Get a friendly summary message.
+ */
+export const getPostEventSummaryMessage =
+  (event = {}) => {
+    const summary =
+      buildPostEventSummary(
+        event
+      );
+
+    const {
+      registeredParticipants,
+      attendees,
+      attendancePercentage,
+    } =
+      summary.statistics;
+
+    if (
+      !registeredParticipants &&
+      !attendees
+    ) {
+      return "Event summary information is not available yet.";
+    }
+
+    return `${attendees} of ${registeredParticipants} registered participants attended this event (${attendancePercentage}% attendance).`;
+  };


### PR DESCRIPTION
## Description

Implemented a post-event summary section that gives participants and
organizers a quick overview after an event has ended.

### Added

- Total registered participant count
- Total attendee count
- Attendance percentage
- Event highlights
- Winners and top participants
- Event photos and gallery
- Event resources
- Recording and presentation links
- Feedback summary
- Certificate status
- Reusable post-event summary sections
- Responsive design
- Completed-event detection

Closes #12964