### PR TITLE
fix(notifications): map API read field to isRead in poller normalize

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -31,6 +31,7 @@ const normalize = (n = {}) => ({
   ...n,
   id: n.id || n._id || `${n.timestamp || n.createdAt || Date.now()}-${Math.random().toString(36).slice(2)}`,
   timestamp: n.timestamp || n.createdAt || n.updatedAt || new Date().toISOString(),
+  isRead: Boolean(n.isRead ?? n.read),
 });
 
 const persist = (items, storageKey) => {


### PR DESCRIPTION
## Description

Backend NotificationResponse uses `read`; the poller counted unread via `isRead`, so every server notification looked unread. normalize() now maps both.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13337

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes

Made with [Cursor](https://cursor.com)