### PR TITLE
fix(waitlist): include soft-deleted rows when allocating positions

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventWaitlistRepository.java
@@ -28,7 +28,7 @@ public interface EventWaitlistRepository extends JpaRepository<EventWaitlist, Lo
             """)
     List<EventWaitlist> findWaitingByEventIdWithLock(@Param("eventId") Long eventId);
 
-    @Query("SELECT COALESCE(MAX(w.position), 0) FROM EventWaitlist w WHERE w.event.id = :eventId AND w.status = 'WAITING'")
+    @Query("SELECT COALESCE(MAX(w.position), 0) FROM EventWaitlist w WHERE w.event.id = :eventId")
     int findMaxPositionByEventId(@Param("eventId") Long eventId);
 
     void deleteByEvent_Id(Long eventId);


### PR DESCRIPTION
## Description

Allocator used MAX(position) WHERE WAITING only while the unique key covers all rows. After leave/promote, rejoins could reuse REMOVED positions and hit the unique constraint.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13340

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes