### PR TITLE
fix(feedback): map unique constraint races to already-exists conflict

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -15,6 +15,7 @@ import com.sandeep.eventrabackend.repository.FeedbackAnalyticsRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,9 +65,12 @@ public class FeedbackService {
         feedback.setRating(request.getRating());
         feedback.setComment(request.getComment());
 
-        Feedback savedFeedback = feedbackRepository.save(feedback);
-
-        return mapToResponse(savedFeedback);
+        try {
+            Feedback savedFeedback = feedbackRepository.saveAndFlush(feedback);
+            return mapToResponse(savedFeedback);
+        } catch (DataIntegrityViolationException ex) {
+            throw new FeedbackAlreadyExistsException("You have already submitted feedback for this event.");
+        }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Description

Concurrent feedback posts could pass existsBy then hit uk_feedback_event_user and 500. saveAndFlush now maps DataIntegrityViolationException to FeedbackAlreadyExistsException.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13353

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes

Made with [Cursor](https://cursor.com)