### PR TITLE
fix(admin): wire search param through users and events listing

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -73,10 +73,13 @@ public class AdminController {
             @RequestParam(defaultValue = "10") int size,
 
             @Parameter(description = "Filter by role: CLIENT | ORGANIZER | ADMIN | SUPER_ADMIN")
-            @RequestParam(required = false) String role
+            @RequestParam(required = false) String role,
+
+            @Parameter(description = "Search email, username, first name, or last name (case-insensitive)")
+            @RequestParam(required = false) String search
     ) {
         int clampedSize = Math.min(Math.max(size, 1), 100);
-        return ResponseEntity.ok(adminService.getUsers(page, clampedSize, role));
+        return ResponseEntity.ok(adminService.getUsers(page, clampedSize, role, search));
     }
 
     @GetMapping("/users/{id}")
@@ -167,10 +170,13 @@ public class AdminController {
     })
     public ResponseEntity<PagedResponse<EventResponse>> getAllEvents(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(description = "Search title, location, or description (case-insensitive)")
+            @RequestParam(required = false) String search
     ) {
         int clampedSize = Math.min(Math.max(size, 1), 100);
-        return ResponseEntity.ok(adminService.getEvents(page, clampedSize));
+        return ResponseEntity.ok(adminService.getEvents(page, clampedSize, search));
     }
 
     @GetMapping("/events/{id}/attendees")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
@@ -31,6 +31,25 @@ public interface UserRepository extends JpaRepository<User, Long> {
     /** Returns all users with a specific role, paginated. */
     Page<User> findByRole(Role role, Pageable pageable);
 
+    @Query("""
+            SELECT u FROM User u WHERE
+            LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%')) OR
+            LOWER(u.username) LIKE LOWER(CONCAT('%', :search, '%')) OR
+            LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%')) OR
+            LOWER(u.lastName) LIKE LOWER(CONCAT('%', :search, '%'))
+            """)
+    Page<User> searchUsers(@Param("search") String search, Pageable pageable);
+
+    @Query("""
+            SELECT u FROM User u WHERE u.role = :role AND (
+            LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%')) OR
+            LOWER(u.username) LIKE LOWER(CONCAT('%', :search, '%')) OR
+            LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%')) OR
+            LOWER(u.lastName) LIKE LOWER(CONCAT('%', :search, '%'))
+            )
+            """)
+    Page<User> searchUsersByRole(@Param("role") Role role, @Param("search") String search, Pageable pageable);
+
     /** Count users created after the given timestamp — used for growth stats. */
     long countByCreatedAtAfter(LocalDateTime date);
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -12,6 +12,8 @@ import com.sandeep.eventrabackend.repository.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -60,11 +62,18 @@ public class AdminService {
      * @param size page size
      * @param role optional role filter (e.g. "CLIENT") — null means all users
      */
-    public PagedResponse<AdminUserResponse> getUsers(int page, int size, String role) {
+    public PagedResponse<AdminUserResponse> getUsers(int page, int size, String role, String search) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Page<User> userPage;
+        boolean hasSearch = StringUtils.hasText(search);
+        String trimmedSearch = hasSearch ? search.trim() : null;
 
-        if (role != null && !role.isBlank()) {
+        if (hasSearch && role != null && !role.isBlank()) {
+            Role roleEnum = parseRole(role);
+            userPage = userRepository.searchUsersByRole(roleEnum, trimmedSearch, pageable);
+        } else if (hasSearch) {
+            userPage = userRepository.searchUsers(trimmedSearch, pageable);
+        } else if (role != null && !role.isBlank()) {
             Role roleEnum = parseRole(role);
             userPage = userRepository.findByRole(roleEnum, pageable);
         } else {
@@ -199,9 +208,13 @@ public class AdminService {
     /**
      * Returns all events (paginated), visible to admin regardless of isPublic.
      */
-    public PagedResponse<EventResponse> getEvents(int page, int size) {
+    public PagedResponse<EventResponse> getEvents(int page, int size, String search) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("eventDate").descending());
-        return PagedResponse.from(eventRepository.findAll(pageable).map(this::toEventResponse));
+        Specification<com.sandeep.eventrabackend.model.Event> spec = EventSpecifications.searchContains(search);
+        Page<com.sandeep.eventrabackend.model.Event> eventPage = spec == null
+                ? eventRepository.findAll(pageable)
+                : eventRepository.findAll(spec, pageable);
+        return PagedResponse.from(eventPage.map(this::toEventResponse));
     }
 
     /**


### PR DESCRIPTION
## Description

Admin dashboard search boxes send `?search=` but the backend ignored it. This PR adds optional `search` query params to `GET /api/admin/users` and `GET /api/admin/events`, filtering results case-insensitively while preserving pagination.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13341

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Test plan

- [ ] `GET /api/admin/users?search=john` filters email/username/firstName/lastName
- [ ] `GET /api/admin/users?role=CLIENT&search=john` combines role + search
- [ ] `GET /api/admin/events?search=workshop` filters title/location/description
- [ ] Pagination still works with search applied

Made with [Cursor](https://cursor.com)