### PR TITLE
fix(waitlist): iterate queue and fill all open seats on promotion

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -742,7 +742,7 @@ public class EventService {
 
                 broadcastAvailability(event);
 
-                promoteFirstWaitingUser(event);
+                promoteWaitlistAfterVacancy(eventId);
         }
 
         @Transactional(readOnly = true)
@@ -1018,7 +1018,14 @@ public class EventService {
                 Event event = eventRepository.findByIdWithLock(eventId)
                                 .orElseThrow(() -> new EventNotFoundException(
                                                 "Event not found with id: " + eventId));
-                promoteFirstWaitingUser(event);
+                while (event.getCapacity() == null || event.getRegisteredCount() < event.getCapacity()) {
+                        RegistrationResponse promoted = promoteFirstWaitingUser(event);
+                        if (promoted == null) {
+                                break;
+                        }
+                        event.setRegisteredCount((int) eventRegistrationRepository
+                                        .countByEvent_IdAndStatus(eventId, "CONFIRMED"));
+                }
         }
 
         private RegistrationResponse promoteFirstWaitingUser(Event event) {
@@ -1026,21 +1033,20 @@ public class EventService {
                         return null;
                 }
 
-                return eventWaitlistRepository.findWaitingByEventIdWithLock(event.getId())
-                                .stream()
-                                .findFirst()
-                                .map(entry -> promoteEntry(event, entry))
-                                .orElse(null);
+                for (EventWaitlist entry : eventWaitlistRepository.findWaitingByEventIdWithLock(event.getId())) {
+                        if (eventRegistrationRepository.existsByEvent_IdAndUser_Email(
+                                        event.getId(), entry.getUser().getEmail())) {
+                                entry.setStatus("REMOVED");
+                                eventWaitlistRepository.save(entry);
+                                continue;
+                        }
+                        return promoteEntry(event, entry);
+                }
+                return null;
         }
 
         private RegistrationResponse promoteEntry(Event event, EventWaitlist entry) {
                 User user = entry.getUser();
-
-                if (eventRegistrationRepository.existsByEvent_IdAndUser_Email(event.getId(), user.getEmail())) {
-                        entry.setStatus("REMOVED");
-                        eventWaitlistRepository.save(entry);
-                        return null;
-                }
 
                 EventRegistration registration = new EventRegistration();
                 registration.setEvent(event);


### PR DESCRIPTION
## Description

When the head of the waitlist is already registered, promotion stopped without trying the next waiter. This PR iterates the waiting list, marks stale entries REMOVED, and keeps promoting while capacity remains after a vacancy.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #13345

## Checklist

- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.

## Test plan

- [ ] Cancel registration with ineligible head waiter → next eligible user is promoted
- [ ] Multiple vacancies filled in one `promoteWaitlistAfterVacancy` call when capacity allows
- [ ] No promotion when event is at capacity

Made with [Cursor](https://cursor.com)