### PR TITLE
fix(admin): guard capacity reduction and promote waitlist on increase

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.dto.AdminDashboardStatsDTO;
 import com.sandeep.eventrabackend.dto.AdminStatsResponse;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
 import com.sandeep.eventrabackend.dto.response.*;
+import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Feedback;
 import com.sandeep.eventrabackend.model.Hackathon;
 import com.sandeep.eventrabackend.model.Role;
@@ -221,10 +222,17 @@ public class AdminService {
      * Force-deletes an event (admin override, bypasses organizer ownership).
      */
     @Transactional
-    @Transactional
     public EventResponse updateEvent(Long id, com.sandeep.eventrabackend.dto.request.EventUpdateRequest request) {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Event not found with id: " + id));
+
+        Integer previousCapacity = event.getCapacity();
+
+        if (request.getCapacity() != null && request.getCapacity() < event.getRegisteredCount()) {
+            throw new RegistrationConflictException(
+                    "Capacity cannot be reduced below the current number of registered users ("
+                            + event.getRegisteredCount() + ")");
+        }
 
         event.setTitle(request.getTitle());
         event.setDescription(request.getDescription());
@@ -247,6 +255,12 @@ public class AdminService {
         }
 
         Event saved = eventRepository.save(event);
+
+        if (request.getCapacity() != null && previousCapacity != null
+                && request.getCapacity() > previousCapacity) {
+            eventService.promoteWaitlistAfterVacancy(id);
+        }
+
         return toEventResponse(saved);
     }
 


### PR DESCRIPTION
## Description

Admin event updates could set capacity below registered count and did not promote waitlist when capacity increased. This PR rejects invalid capacity reductions (matching EventService) and calls `promoteWaitlistAfterVacancy` when capacity is raised.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #13346

## Checklist

- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.

## Test plan

- [ ] Admin update with capacity < registeredCount returns conflict error
- [ ] Admin increase capacity promotes eligible waitlisted users
- [ ] Capacity unchanged or decreased (but valid) does not trigger extra promotions

Made with [Cursor](https://cursor.com)