### PR TITLE
fix(team-workspace): scope sync state and SSE by room key

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -27,15 +28,24 @@ public class TeamWorkspaceSyncController {
     }
 
     @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream() {
-        return teamWorkspaceSyncService.subscribe();
+    public SseEmitter stream(
+            @RequestParam(required = false) String roomKey,
+            @RequestParam(required = false) String hackathonId,
+            @RequestParam(required = false) String teamId) {
+        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
+        return teamWorkspaceSyncService.subscribe(resolved);
     }
 
     @PostMapping
-    public ResponseEntity<Map<String, Object>> pollOrUpdate(@RequestBody(required = false) Map<String, Object> body) {
+    public ResponseEntity<Map<String, Object>> pollOrUpdate(
+            @RequestParam(required = false) String roomKey,
+            @RequestParam(required = false) String hackathonId,
+            @RequestParam(required = false) String teamId,
+            @RequestBody(required = false) Map<String, Object> body) {
+        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
         if (body == null || body.isEmpty()) {
-            return ResponseEntity.ok(teamWorkspaceSyncService.snapshot());
+            return ResponseEntity.ok(teamWorkspaceSyncService.snapshot(resolved));
         }
-        return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(body));
+        return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
@@ -1,67 +1,78 @@
 package com.sandeep.eventrabackend.service;
 
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 public class TeamWorkspaceSyncService {
 
-    private final Object lock = new Object();
-    private List<Map<String, Object>> tasks = new ArrayList<>();
-    private List<Map<String, Object>> pins = new ArrayList<>();
-    private List<Map<String, Object>> chat = new ArrayList<>();
-    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+    private static final class WorkspaceState {
+        private final Object lock = new Object();
+        private List<Map<String, Object>> tasks = new ArrayList<>();
+        private List<Map<String, Object>> pins = new ArrayList<>();
+        private List<Map<String, Object>> chat = new ArrayList<>();
+        private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+    }
 
-    public Map<String, Object> snapshot() {
-        synchronized (lock) {
+    private final ConcurrentHashMap<String, WorkspaceState> rooms = new ConcurrentHashMap<>();
+
+    public Map<String, Object> snapshot(String roomKey) {
+        WorkspaceState room = roomFor(roomKey);
+        synchronized (room.lock) {
             return Map.of(
-                    "tasks", List.copyOf(tasks),
-                    "pins", List.copyOf(pins),
-                    "chat", List.copyOf(chat)
+                    "tasks", List.copyOf(room.tasks),
+                    "pins", List.copyOf(room.pins),
+                    "chat", List.copyOf(room.chat)
             );
         }
     }
 
-    public Map<String, Object> applyUpdate(Map<String, Object> body) {
-        synchronized (lock) {
+    public Map<String, Object> applyUpdate(String roomKey, Map<String, Object> body) {
+        WorkspaceState room = roomFor(roomKey);
+        synchronized (room.lock) {
             if (body != null) {
                 if (body.get("tasks") instanceof List<?> list) {
-                    tasks = castList(list);
+                    room.tasks = castList(list);
                 }
                 if (body.get("pins") instanceof List<?> list) {
-                    pins = castList(list);
+                    room.pins = castList(list);
                 }
                 if (body.get("chat") instanceof List<?> list) {
-                    chat = castList(list);
+                    room.chat = castList(list);
                 }
             }
             Map<String, Object> snap = Map.of(
-                    "tasks", List.copyOf(tasks),
-                    "pins", List.copyOf(pins),
-                    "chat", List.copyOf(chat)
+                    "tasks", List.copyOf(room.tasks),
+                    "pins", List.copyOf(room.pins),
+                    "chat", List.copyOf(room.chat)
             );
-            broadcast("init", snap);
+            broadcast(room, "init", snap);
             return snap;
         }
     }
 
-    public SseEmitter subscribe() {
+    public SseEmitter subscribe(String roomKey) {
+        WorkspaceState room = roomFor(roomKey);
         SseEmitter emitter = new SseEmitter(300_000L);
-        emitters.add(emitter);
-        Runnable cleanup = () -> emitters.remove(emitter);
+        room.emitters.add(emitter);
+        Runnable cleanup = () -> room.emitters.remove(emitter);
         emitter.onCompletion(cleanup);
         emitter.onTimeout(cleanup);
         emitter.onError(ex -> cleanup.run());
 
         try {
-            Map<String, Object> payload = new java.util.HashMap<>(snapshot());
+            Map<String, Object> payload = new java.util.HashMap<>(snapshot(roomKey));
             payload.put("type", "init");
             emitter.send(SseEmitter.event().name("message").data(payload, MediaType.APPLICATION_JSON));
         } catch (IOException ex) {
@@ -71,14 +82,35 @@ public class TeamWorkspaceSyncService {
         return emitter;
     }
 
-    private void broadcast(String type, Map<String, Object> snap) {
+    public String resolveRoomKey(String roomKey, String hackathonId, String teamId) {
+        if (StringUtils.hasText(roomKey)) {
+            return roomKey.trim();
+        }
+        if (StringUtils.hasText(hackathonId) && StringUtils.hasText(teamId)) {
+            return "hackathon:" + hackathonId.trim() + ":team:" + teamId.trim();
+        }
+        if (StringUtils.hasText(hackathonId)) {
+            return "hackathon:" + hackathonId.trim();
+        }
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && StringUtils.hasText(auth.getName())) {
+            return "user:" + auth.getName().trim().toLowerCase();
+        }
+        return "default";
+    }
+
+    private WorkspaceState roomFor(String roomKey) {
+        return rooms.computeIfAbsent(roomKey, key -> new WorkspaceState());
+    }
+
+    private void broadcast(WorkspaceState room, String type, Map<String, Object> snap) {
         Map<String, Object> payload = new java.util.HashMap<>(snap);
         payload.put("type", type);
-        for (SseEmitter emitter : emitters) {
+        for (SseEmitter emitter : room.emitters) {
             try {
                 emitter.send(SseEmitter.event().name("message").data(payload, MediaType.APPLICATION_JSON));
             } catch (IOException ex) {
-                emitters.remove(emitter);
+                room.emitters.remove(emitter);
             }
         }
     }

--- a/src/components/hackathons/TeamWorkspace.jsx
+++ b/src/components/hackathons/TeamWorkspace.jsx
@@ -1,4 +1,6 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useAuth } from "context/AuthContext";
 import {
   Users,
   CheckCircle2,
@@ -27,6 +29,26 @@ const INITIAL_TEAM_MEMBERS = [
 ];
 
 const TeamWorkspace = () => {
+  const { id: hackathonId } = useParams();
+  const [searchParams] = useSearchParams();
+  const { user } = useAuth();
+  const teamId = searchParams.get("teamId");
+  const roomKeyParam = searchParams.get("roomKey");
+
+  const syncQuery = useMemo(() => {
+    const params = new URLSearchParams();
+    if (hackathonId) params.set("hackathonId", hackathonId);
+    if (teamId) params.set("teamId", teamId);
+    if (roomKeyParam) params.set("roomKey", roomKeyParam);
+    if (!hackathonId && !teamId && !roomKeyParam && user?.email) {
+      params.set("roomKey", `user:${user.email}`);
+    }
+    const qs = params.toString();
+    return qs ? `?${qs}` : "";
+  }, [hackathonId, teamId, roomKeyParam, user?.email]);
+
+  const syncBaseUrl = `/api/hackathons/team/sync${syncQuery}`;
+
   const [activeTab, setActiveTab] = useState("dashboard"); // 'dashboard' | 'whiteboard'
 
   // Team recruitment slots state
@@ -74,7 +96,7 @@ const TeamWorkspace = () => {
       const fetchState = async () => {
         if (!isMounted) return;
         try {
-          const response = await fetch("/api/hackathons/team/sync", {
+          const response = await fetch(syncBaseUrl, {
             method: "POST",
           });
           if (response.ok) {
@@ -105,7 +127,7 @@ const TeamWorkspace = () => {
       setConnectionStatus("connecting");
       try {
         logger.info(`${logPrefix} Establishing real-time Server-Sent Events stream...`);
-        sseSource = new EventSource("/api/hackathons/team/sync");
+        sseSource = new EventSource(syncBaseUrl);
 
         sseSource.onopen = () => {
           setConnectionStatus("sse");
@@ -185,7 +207,7 @@ const TeamWorkspace = () => {
       if (idleTimeout) clearTimeout(idleTimeout);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, []);
+  }, [syncBaseUrl]);
 
   // Auto-scroll chat
   useEffect(() => {


### PR DESCRIPTION
## Description

Team workspace sync used a single global in-memory store shared by all users. This PR scopes state and SSE subscriptions by `roomKey` or `hackathonId`+`teamId`, with authenticated `user:{email}` fallback. Frontend passes scoping query params from route and auth context.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #13347

## Checklist

- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.

## Test plan

- [ ] Two users on different hackathon/team rooms do not see each other's tasks/chat
- [ ] SSE updates only reach subscribers in the same room
- [ ] `/hackathons/:id/lifecycle` passes hackathonId to sync endpoints
- [ ] Users without route params fall back to `user:{email}` isolation

Made with [Cursor](https://cursor.com)