### PR TITLE
fix(registration): validate seatId format and reject occupied seats

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -16,6 +16,8 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
 
     boolean existsByEvent_IdAndUser_Email(Long eventId, String userEmail);
 
+    boolean existsByEvent_IdAndSeatId(Long eventId, String seatId);
+
     long countByEvent_IdAndStatus(Long eventId, String status);
 
     List<EventRegistration> findByUser_EmailOrderByRegisteredAtDesc(String userEmail);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -940,6 +940,16 @@ public class EventService {
                                         "You are already registered for this event.");
                 }
 
+                if (seatId != null && !seatId.isBlank()) {
+                        if (!seatId.matches("^[^:\\s]+:\\d+$")) {
+                                throw new IllegalArgumentException(
+                                                "Invalid seatId format. Expected elementId:seatIndex");
+                        }
+                        if (eventRegistrationRepository.existsByEvent_IdAndSeatId(eventId, seatId)) {
+                                throw new RegistrationConflictException("Seat " + seatId + " is already taken.");
+                        }
+                }
+
                 if (event.getCapacity() != null
                                 && event.getRegisteredCount() >= event.getCapacity()) {
 


### PR DESCRIPTION
## Description

Registration accepted arbitrary seatId strings until DB constraints failed. This PR validates `elementId:seatIndex` format and rejects already-occupied seats before insert.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #13348

## Checklist

- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.

## Test plan

- [ ] Invalid seatId (bad format) returns 400
- [ ] Occupied seatId returns registration conflict
- [ ] Valid unoccupied seatId registers successfully
- [ ] Null/blank seatId still allowed (general admission)

Made with [Cursor](https://cursor.com)