### PR TITLE
fix(auth): clear cookie on logout with expired JWT

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -213,16 +213,17 @@ public ResponseEntity<AuthResponse> googleLogin(
 
         String refreshToken = body != null ? body.getRefreshToken() : null;
 
-        if (!StringUtils.hasText(token) && !StringUtils.hasText(refreshToken)) {
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.SET_COOKIE, authCookieHelper.clearAuthCookie().toString())
-                    .body("Logged out successfully");
+        ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.ok();
+        try {
+            if (StringUtils.hasText(token) || StringUtils.hasText(refreshToken)) {
+                authService.logout(token, refreshToken);
+            }
+        } catch (RuntimeException ignored) {
+            // Best-effort blacklist; cookie clear must still proceed.
+        } finally {
+            responseBuilder.header(HttpHeaders.SET_COOKIE, authCookieHelper.clearAuthCookie().toString());
         }
-
-        authService.logout(token, refreshToken);
-        return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, authCookieHelper.clearAuthCookie().toString())
-                .body("Logged out successfully");
+        return responseBuilder.body("Logged out successfully");
     }
 
     private ResponseEntity<AuthResponse> withAuthCookie(

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
@@ -118,6 +118,21 @@ public class JwtTokenProvider {
         return parseClaims(token).getExpiration();
     }
 
+    /**
+     * Returns the JWT expiration even when the token is expired (for best-effort
+     * blacklisting during logout). Returns null if the token cannot be parsed.
+     */
+    public Date getExpirationDateFromTokenAllowExpired(String token) {
+        try {
+            return parseClaims(token).getExpiration();
+        } catch (ExpiredJwtException ex) {
+            return ex.getClaims().getExpiration();
+        } catch (RuntimeException ex) {
+            logger.debug("Unable to read expiration from token: {}", ex.getMessage());
+            return null;
+        }
+    }
+
     public Date getIssuedAtDateFromToken(String token) {
         return parseClaims(token).getIssuedAt();
     }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -211,15 +211,24 @@ public class AuthService {
 
     public void logout(String accessToken, String refreshToken) {
         if (accessToken != null && !accessToken.isBlank()) {
-            java.util.Date expiration = jwtTokenProvider.getExpirationDateFromToken(accessToken);
-            tokenBlacklistService.addToBlacklist(accessToken, expiration);
+            try {
+                java.util.Date expiration = jwtTokenProvider.getExpirationDateFromTokenAllowExpired(accessToken);
+                tokenBlacklistService.addToBlacklist(accessToken, expiration);
+            } catch (RuntimeException ex) {
+                // Best-effort blacklist: expired or malformed tokens must not block logout.
+            }
         }
 
-        if (refreshToken != null && !refreshToken.isBlank()
-                && jwtTokenProvider.validateToken(refreshToken)
-                && jwtTokenProvider.isRefreshToken(refreshToken)) {
-            java.util.Date refreshExpiration = jwtTokenProvider.getExpirationDateFromToken(refreshToken);
-            tokenBlacklistService.addToBlacklist(refreshToken, refreshExpiration);
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            try {
+                if (jwtTokenProvider.isRefreshToken(refreshToken)) {
+                    java.util.Date refreshExpiration =
+                            jwtTokenProvider.getExpirationDateFromTokenAllowExpired(refreshToken);
+                    tokenBlacklistService.addToBlacklist(refreshToken, refreshExpiration);
+                }
+            } catch (RuntimeException ex) {
+                // Best-effort blacklist for refresh token as well.
+            }
         }
     }
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLogoutTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthLogoutTests.java
@@ -8,6 +8,10 @@ import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
+import com.sandeep.eventrabackend.security.JwtTokenProvider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +23,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -127,17 +136,51 @@ public class AuthLogoutTests {
     }
 
     @Test
-    @DisplayName("POST /api/auth/logout without token returns 401")
+    @DisplayName("POST /api/auth/logout without token still clears cookie")
     void testLogoutWithoutToken() throws Exception {
         mockMvc.perform(post("/api/auth/logout"))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("token", 0));
     }
 
     @Test
-    @DisplayName("POST /api/auth/logout with malformed token returns 401")
+    @DisplayName("POST /api/auth/logout with malformed token still clears cookie")
     void testLogoutWithMalformedToken() throws Exception {
         mockMvc.perform(post("/api/auth/logout")
-                        .header("Authorization", "InvalidFormat " + jwtToken))
-                .andExpect(status().isUnauthorized());
+                        .header("Authorization", "Bearer not-a-valid-jwt"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("token", 0));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/logout with expired token clears cookie (#13339)")
+    void testLogoutWithExpiredToken() throws Exception {
+        String expiredToken = buildExpiredAccessToken("test@example.com");
+
+        mockMvc.perform(post("/api/auth/logout")
+                        .cookie(new jakarta.servlet.http.Cookie("token", expiredToken)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("token", 0));
+    }
+
+    private String buildExpiredAccessToken(String email) {
+        String secret = "test-secret-key-that-is-at-least-256-bits-long-for-hs256-algorithm-ok";
+        byte[] keyBytes;
+        try {
+            keyBytes = Decoders.BASE64.decode(secret);
+        } catch (Exception ex) {
+            keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        }
+        SecretKey key = Keys.hmacShaKeyFor(keyBytes);
+        Date issuedAt = Date.from(Instant.now().minusSeconds(7200));
+        Date expiresAt = Date.from(Instant.now().minusSeconds(3600));
+
+        return Jwts.builder()
+                .subject(email)
+                .claim(JwtTokenProvider.CLAIM_TOKEN_TYPE, JwtTokenProvider.TYPE_ACCESS)
+                .issuedAt(issuedAt)
+                .expiration(expiresAt)
+                .signWith(key)
+                .compact();
     }
 }


### PR DESCRIPTION
## Description

Logout now blacklists tokens on a best-effort basis and always clears the HttpOnly auth cookie, even when the JWT is expired or malformed. Adds `getExpirationDateFromTokenAllowExpired` to read expiration from expired tokens without aborting logout.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13339

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — backend-only change.

## Additional Notes

`AuthService.logout` and `AuthController.logout` both treat blacklisting as best-effort so `Set-Cookie` clear is always returned.

Made with [Cursor](https://cursor.com)