### PR TITLE
fix(auth): rate limit google login and token refresh

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
@@ -15,6 +15,8 @@ public class RateLimitProperties {
     private EndpointLimit forgotPassword = new EndpointLimit(3, Duration.ofMinutes(15));
     private EndpointLimit contact = new EndpointLimit(5, Duration.ofMinutes(10));
     private EndpointLimit githubProxy = new EndpointLimit(30, Duration.ofMinutes(1));
+    private EndpointLimit google = new EndpointLimit(10, Duration.ofMinutes(1));
+    private EndpointLimit refresh = new EndpointLimit(30, Duration.ofMinutes(1));
 
     public boolean isEnabled() {
         return enabled;
@@ -62,6 +64,22 @@ public class RateLimitProperties {
 
     public void setGithubProxy(EndpointLimit githubProxy) {
         this.githubProxy = githubProxy;
+    }
+
+    public EndpointLimit getGoogle() {
+        return google;
+    }
+
+    public void setGoogle(EndpointLimit google) {
+        this.google = google;
+    }
+
+    public EndpointLimit getRefresh() {
+        return refresh;
+    }
+
+    public void setRefresh(EndpointLimit refresh) {
+        this.refresh = refresh;
     }
 
     public static class EndpointLimit {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -30,6 +30,8 @@ public class RateLimitingFilter extends OncePerRequestFilter {
     private static final List<EndpointRule> ENDPOINT_RULES = List.of(
             new EndpointRule("login", POST, "/api/auth/login"),
             new EndpointRule("signup", POST, "/api/auth/signup"),
+            new EndpointRule("google", POST, "/api/auth/google"),
+            new EndpointRule("refresh", POST, "/api/auth/refresh"),
             new EndpointRule("forgotPassword", POST, "/api/auth/forgot-password"),
             new EndpointRule("forgotPassword", POST, "/api/auth/forgot-password/"),
             new EndpointRule("contact", POST, "/api/contact"),
@@ -114,6 +116,8 @@ public class RateLimitingFilter extends OncePerRequestFilter {
         return switch (endpointName) {
             case "login" -> properties.getLogin();
             case "signup" -> properties.getSignup();
+            case "google" -> properties.getGoogle();
+            case "refresh" -> properties.getRefresh();
             case "forgotPassword" -> properties.getForgotPassword();
             case "contact" -> properties.getContact();
             case "githubProxy" -> properties.getGithubProxy();

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -27,6 +27,12 @@ app:
     github-proxy:
       capacity: ${RATE_LIMIT_GITHUB_PROXY_CAPACITY:30}
       window: ${RATE_LIMIT_GITHUB_PROXY_WINDOW:1m}
+    google:
+      capacity: ${RATE_LIMIT_GOOGLE_CAPACITY:10}
+      window: ${RATE_LIMIT_GOOGLE_WINDOW:1m}
+    refresh:
+      capacity: ${RATE_LIMIT_REFRESH_CAPACITY:30}
+      window: ${RATE_LIMIT_REFRESH_WINDOW:1m}
 
 google:
   client:

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/RateLimitingFilterTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/RateLimitingFilterTests.java
@@ -21,6 +21,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "app.rate-limit.login.capacity=1",
         "app.rate-limit.login.window=1m",
+        "app.rate-limit.google.capacity=1",
+        "app.rate-limit.google.window=1m",
         "app.rate-limit.trusted-proxy-hops=1"
 })
 class RateLimitingFilterTests {
@@ -68,5 +70,23 @@ class RateLimitingFilterTests {
                 .andExpect(status().isTooManyRequests())
                 .andExpect(jsonPath("$.status", is(429)))
                 .andExpect(jsonPath("$.path", is("/api/auth/login")));
+    }
+
+    @Test
+    void returnsTooManyRequestsWhenGoogleLimitIsExceeded() throws Exception {
+        String clientIp = "203.0.113.20";
+
+        mockMvc.perform(post("/api/auth/google")
+                        .header("X-Forwarded-For", clientIp)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/auth/google")
+                        .header("X-Forwarded-For", clientIp)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.path", is("/api/auth/google")));
     }
 }


### PR DESCRIPTION
## Description

Adds rate limiting for `POST /api/auth/google` (10/min) and `POST /api/auth/refresh` (30/min) via `RateLimitingFilter` and `RateLimitProperties`, with defaults documented in `application.yml`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13343

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — backend-only change.

## Additional Notes

Google and refresh endpoints were previously `permitAll` without backend rate caps unlike login/signup.

Made with [Cursor](https://cursor.com)