### PR TITLE
fix(sse): resolve absolute EventSource base URL

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -1,5 +1,6 @@
 import { logger } from "./logger.js";
 import { ENV } from "../config/env.js";
+import { SSE_BASE_URL } from "../config/backendConfig.js";
 
 const MULTIPLEX_CHANNEL_NAME = "eventra_sse_multiplexer";
 const LOCK_NAME = "eventra_sse_leader_lock";
@@ -536,7 +537,11 @@ class SseMultiplexer {
   }
 
   openEventSource(path) {
-    const sseBaseUrl = ENV.API_URL || (typeof window !== "undefined" ? window.location.origin : "http://localhost:8080");
+    let sseBaseUrl = SSE_BASE_URL || ENV.API_URL || "";
+    if (!sseBaseUrl || sseBaseUrl.startsWith("/")) {
+      const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost:8080";
+      sseBaseUrl = sseBaseUrl ? `${origin}${sseBaseUrl}` : origin;
+    }
 
     logger.log(`[SSE Multiplexer] Leader tab opening physical EventSource: ${sseBaseUrl}${path}`);
     this.updatePathStatus(path, "connecting");

--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -392,7 +392,31 @@ const runTests = async () => {
 
   await testReconnectRequestUsesPerPathReconnect();
 
+  await testRelativeApiBaseUrl();
+
   console.log("🟢 All SSE Multiplexer unit tests completed successfully!");
+};
+
+const testRelativeApiBaseUrl = async () => {
+  process.env.REACT_APP_API_URL = "/api";
+  const { SSE_BASE_URL } = await import(`../src/config/backendConfig.js?relative=${Date.now()}`);
+
+  assert.equal(SSE_BASE_URL, "/", "Relative /api config should yield relative SSE base");
+
+  let sseBaseUrl = SSE_BASE_URL || "";
+  if (!sseBaseUrl || sseBaseUrl.startsWith("/")) {
+    const origin = globalThis.window.location.origin;
+    sseBaseUrl = sseBaseUrl ? `${origin}${sseBaseUrl}` : origin;
+  }
+
+  const sseUrl = new URL("/stream/relative-base", sseBaseUrl).href;
+  assert.equal(
+    sseUrl,
+    "https://api.example.test/stream/relative-base",
+    "Relative SSE base must resolve against window.location.origin"
+  );
+
+  process.env.REACT_APP_API_URL = "https://api.example.test";
 };
 
 // Run the suite


### PR DESCRIPTION
## Description

Use `SSE_BASE_URL` from backend config when opening EventSource connections. Relative bases like `/api` are resolved against `window.location.origin` so SSE URLs are always absolute.

## Type of Change

- [x] Bug fix
- [x] Test additions or fixes

## Related Issue

Closes #13338

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).

Made with [Cursor](https://cursor.com)