### PR TITLE
fix(events): wire event role management endpoints

### DIFF
--- a/src/Pages/Events/EventRoleManagement.jsx
+++ b/src/Pages/Events/EventRoleManagement.jsx
@@ -43,15 +43,10 @@ export default function EventRoleManagement() {
     event.preventDefault();
     setSaving(true);
     try {
-      const response = await apiUtils.put(API_ENDPOINTS.EVENTS.ROLES(eventId), {
+      await apiUtils.put(API_ENDPOINTS.EVENTS.ROLES(eventId), {
         userEmail,
         role,
       });
-      const updatedMember = await response.json();
-      setMembers((current) => [
-        updatedMember,
-        ...current.filter((member) => member.userId !== updatedMember.userId),
-      ]);
       setUserEmail("");
       toast.success("Event role updated.");
       loadRoles();

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -204,6 +204,9 @@ export const API_ENDPOINTS = {
     AVAILABILITY: (id) => buildApiUrl(`/events/${id}/availability`),
     ATTENDEES: (id) => buildApiUrl(`/events/${id}/attendees`),
 
+    ROLES: (id) => buildApiUrl(`/events/${id}/roles`),
+    ROLE_AUDIT: (id) => buildApiUrl(`/events/${id}/roles/audit`),
+
     REGISTRANTS: (id) => buildApiUrl(`/events/${id}/registrants`),
     WAITLIST: (id) => buildApiUrl(`/events/${id}/waitlist`),
     SCHEDULE: (id) => buildApiUrl(`/events/${id}/schedule`),


### PR DESCRIPTION
## Description

Add `EVENTS.ROLES` and `EVENTS.ROLE_AUDIT` API endpoints. After assigning a role, show a toast and reload the list instead of calling undefined `setMembers`.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #13342

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).

Made with [Cursor](https://cursor.com)