### PR TITLE
fix(waitlist): clean up state after confirmed leave

### DIFF
--- a/src/hooks/useWaitlist.js
+++ b/src/hooks/useWaitlist.js
@@ -56,8 +56,8 @@ function persistWaitlist(map, storageKey) {
       try {
         const mapToPersist = {};
         for (const [key, value] of Object.entries(map)) {
-          const { pendingRemoval, ...rest } = value;
-          mapToPersist[key] = rest;
+          if (value.pendingRemoval) continue;
+          mapToPersist[key] = value;
         }
         safeLocalStorage.setItem(storageKey, JSON.stringify(mapToPersist));
       } catch (err) {
@@ -212,6 +212,11 @@ export default function useWaitlist(eventId, {
           if (!res.ok) {
             throw new Error(res.data?.message || "Failed to leave waitlist.");
           }
+          setWaitlistMap((prev) => {
+            const next = { ...prev };
+            delete next[id];
+            return next;
+          });
         } catch (err) {
           setWaitlistMap((prev) => ({ ...prev, [id]: prevEntry }));
           const msg = err.message || "Unable to leave waitlist right now.";


### PR DESCRIPTION
## Description

Do not persist waitlist entries marked `pendingRemoval`, and remove the event from local state after a confirmed leave so reloads do not restore stale positions.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #13344

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).

Made with [Cursor](https://cursor.com)