### PR TITLE
fix(feedback): authorize organizer feedback endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
@@ -6,6 +6,7 @@ import com.sandeep.eventrabackend.dto.response.FeedbackResponse;
 import com.sandeep.eventrabackend.dto.response.PublicFeedbackResponse;
 import com.sandeep.eventrabackend.service.FeedbackService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -75,8 +76,18 @@ public class FeedbackController {
     }
 
     @GetMapping("/organizers/{organizerId}")
-    @Operation(summary = "Get organizer feedback", description = "Returns feedback submitted for past events owned by an organizer.")
-    public ResponseEntity<List<FeedbackResponse>> getOrganizerFeedback(@PathVariable Long organizerId) {
-        return ResponseEntity.ok(feedbackService.getOrganizerFeedback(organizerId));
+    @Operation(summary = "Get organizer feedback", description = "Returns feedback submitted for past events owned by an organizer. Only the organizer or an administrator may access this endpoint.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Organizer feedback fetched successfully",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = FeedbackResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - JWT required",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Caller is not the organizer or an administrator",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<FeedbackResponse>> getOrganizerFeedback(
+            @PathVariable Long organizerId,
+            Authentication authentication) {
+        return ResponseEntity.ok(feedbackService.getOrganizerFeedback(organizerId, authentication.getName()));
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -8,12 +8,14 @@ import com.sandeep.eventrabackend.exception.FeedbackAlreadyExistsException;
 import com.sandeep.eventrabackend.exception.UserNotRegisteredException;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.Feedback;
+import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
 import com.sandeep.eventrabackend.repository.FeedbackAnalyticsRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,7 +84,15 @@ public class FeedbackService {
     }
 
     @Transactional(readOnly = true)
-    public List<FeedbackResponse> getOrganizerFeedback(Long organizerId) {
+    public List<FeedbackResponse> getOrganizerFeedback(Long organizerId, String callerEmail) {
+        User caller = userRepository.findByEmail(callerEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + callerEmail));
+
+        boolean isAdmin = caller.getRole() == Role.ADMIN || caller.getRole() == Role.SUPER_ADMIN;
+        if (!isAdmin && !caller.getId().equals(organizerId)) {
+            throw new AccessDeniedException("You are not authorized to view feedback for this organizer.");
+        }
+
         return feedbackRepository.findByOrganizer(organizerId).stream()
                 .map(this::mapToResponse)
                 .toList();

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/FeedbackControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/FeedbackControllerTests.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -263,5 +264,68 @@ public class FeedbackControllerTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback/organizers/{id} — organizer can view own feedback")
+    void testOrganizerFeedbackSelfAccess() throws Exception {
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(eventRepository.findById(eventId).orElseThrow());
+        registration.setUser(userRepository.findByEmail(testUserEmail).orElseThrow());
+        eventRegistrationRepository.save(registration);
+
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(eventId)
+                .rating(5)
+                .comment("Great event")
+                .build();
+
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/feedback/organizers/{organizerId}", organizerId)
+                        .with(user(testUserEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId").value(organizerId));
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback/organizers/{id} — other user gets 403")
+    void testOrganizerFeedbackForbiddenForOtherUser() throws Exception {
+        User other = User.builder()
+                .firstName("Other")
+                .lastName("User")
+                .email("other@example.com")
+                .username("otheruser")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(other);
+
+        mockMvc.perform(get("/api/feedback/organizers/{organizerId}", organizerId)
+                        .with(user("other@example.com")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback/organizers/{id} — admin can view any organizer feedback")
+    void testOrganizerFeedbackAdminAccess() throws Exception {
+        User admin = User.builder()
+                .firstName("Admin")
+                .lastName("User")
+                .email("admin@example.com")
+                .username("adminuser")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build();
+        userRepository.save(admin);
+
+        mockMvc.perform(get("/api/feedback/organizers/{organizerId}", organizerId)
+                        .with(user("admin@example.com")
+                                .authorities(new SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Description

Restricts `GET /api/feedback/organizers/{organizerId}` to the matching organizer or users with ADMIN/SUPER_ADMIN role. Prevents authenticated callers from reading another organizer's feedback including reviewer userIds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13350

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — backend-only change.

## Additional Notes

Returns `FeedbackResponse` (with userId) only for authorized organizer/admin callers.

Made with [Cursor](https://cursor.com)