### PR TITLE
fix(users): restrict social profile URLs to http/https

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -139,14 +139,21 @@ public class UserController {
         user.setLastName(request.getLastName());
         user.setUsername(request.getUsername());
         user.setProfileHeadline(request.getProfileHeadline());
-        user.setLinkedinUrl(request.getLinkedinUrl());
-        user.setGithubUrl(request.getGithubUrl());
+        user.setLinkedinUrl(normalizeBlankToNull(request.getLinkedinUrl()));
+        user.setGithubUrl(normalizeBlankToNull(request.getGithubUrl()));
 
         User updatedUser = userRepository.save(user);
         return ResponseEntity.ok(mapToUserProfileResponse(updatedUser));
     }
 
-/*
+    private static String normalizeBlankToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    /*
     @PutMapping("/profile")
     @Operation(
             summary = "Update authenticated user profile",

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/UserProfileUpdateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/UserProfileUpdateRequest.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,10 +36,12 @@ public class UserProfileUpdateRequest {
     private String profileHeadline;
 
     @Size(max = 255, message = "LinkedIn URL must be 255 characters or fewer")
+    @Pattern(regexp = "^(|(?i)https?://\\S+)$", message = "LinkedIn URL must use http or https scheme")
     @Schema(description = "LinkedIn profile URL", example = "https://www.linkedin.com/in/johndoe")
     private String linkedinUrl;
 
     @Size(max = 255, message = "GitHub URL must be 255 characters or fewer")
+    @Pattern(regexp = "^(|(?i)https?://\\S+)$", message = "GitHub URL must use http or https scheme")
     @Schema(description = "GitHub profile URL", example = "https://github.com/johndoe")
     private String githubUrl;
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/UserProfileUpdateTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/UserProfileUpdateTests.java
@@ -185,4 +185,42 @@ public class UserProfileUpdateTests {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("Validation Error"));
     }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - rejects javascript: LinkedIn URL")
+    void testUpdateUserProfile_RejectsJavascriptLinkedinUrl() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("John")
+                .lastName("Doe")
+                .username("johndoe")
+                .linkedinUrl("javascript:alert(1)")
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Validation Error"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - accepts https social URLs")
+    void testUpdateUserProfile_AcceptsHttpsSocialUrls() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("John")
+                .lastName("Doe")
+                .username("johndoe")
+                .linkedinUrl("https://www.linkedin.com/in/johndoe")
+                .githubUrl("https://github.com/johndoe")
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.linkedinUrl").value("https://www.linkedin.com/in/johndoe"))
+                .andExpect(jsonPath("$.githubUrl").value("https://github.com/johndoe"));
+    }
 }


### PR DESCRIPTION
## Description

Adds `@Pattern` validation on `linkedinUrl` and `githubUrl` to allow only http/https schemes (or blank). Rejects dangerous schemes such as `javascript:` and `data:` before persistence.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13352

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — backend-only change.

## Additional Notes

Blank social URLs are normalized to null on save.

Made with [Cursor](https://cursor.com)