### PR TITLE
fix(users): allowlist preference keys and cap payload size

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -26,6 +26,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import com.sandeep.eventrabackend.dto.request.UpdateUserProfileRequest;
 import com.sandeep.eventrabackend.dto.response.UserProfileResponse;
 import com.sandeep.eventrabackend.service.UserService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,6 +40,10 @@ import java.util.Set;
 @RequestMapping("/api/users")
 @Tag(name = "Users", description = "Endpoints for authenticated user data")
 public class UserController {
+
+    private static final Set<String> ALLOWED_PREFERENCE_KEYS = Set.of("theme", "notifications");
+    private static final int MAX_PREFERENCES_BYTES = 4096;
+    private static final ObjectMapper PREFERENCES_MAPPER = new ObjectMapper();
 
     private final EventService eventService;
     private final UserService userService;
@@ -329,17 +335,43 @@ public class UserController {
             return ResponseEntity.ok(user.getPreferences() != null ? user.getPreferences() : Map.of());
         }
 
+        for (String key : incoming.keySet()) {
+            if (!ALLOWED_PREFERENCE_KEYS.contains(key)) {
+                throw new IllegalArgumentException(
+                        "Unknown preference key: " + key + ". Allowed keys: theme, notifications");
+            }
+        }
+
         String theme = (String) incoming.get("theme");
         if (theme != null && !Set.of("light", "dark", "system").contains(theme)) {
             throw new IllegalArgumentException("Invalid theme value: " + theme + ". Allowed values are light, dark, system.");
         }
 
+        Object notifications = incoming.get("notifications");
+        if (notifications != null && !(notifications instanceof Map)) {
+            throw new IllegalArgumentException("notifications preference must be an object");
+        }
+
         Map<String, Object> merged = new HashMap<>(user.getPreferences() != null ? user.getPreferences() : Map.of());
         merged.putAll(incoming);
+        enforcePreferencesSizeLimit(merged);
+
         user.setPreferences(merged);
 
         User updatedUser = userRepository.save(user);
         return ResponseEntity.ok(updatedUser.getPreferences());
+    }
+
+    private static void enforcePreferencesSizeLimit(Map<String, Object> preferences) {
+        try {
+            int size = PREFERENCES_MAPPER.writeValueAsBytes(preferences).length;
+            if (size > MAX_PREFERENCES_BYTES) {
+                throw new IllegalArgumentException(
+                        "Preferences payload exceeds maximum size of " + MAX_PREFERENCES_BYTES + " bytes");
+            }
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Invalid preferences payload");
+        }
     }
 
     private UserProfileResponse mapToUserProfileResponse(User user) {

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/UserPreferencesTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/UserPreferencesTests.java
@@ -117,4 +117,45 @@ public class UserPreferencesTests {
                                 """))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("PUT /api/users/preferences - rejects unknown keys")
+    void testUpdatePreferences_RejectsUnknownKeys() throws Exception {
+        mockMvc.perform(put("/api/users/preferences")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "preferences": { "evilKey": "payload" } }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Unknown preference key: evilKey. Allowed keys: theme, notifications"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/preferences - accepts notifications object")
+    void testUpdatePreferences_AcceptsNotifications() throws Exception {
+        mockMvc.perform(put("/api/users/preferences")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "preferences": { "notifications": { "inApp": true, "push": false } } }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.notifications.inApp").value(true))
+                .andExpect(jsonPath("$.notifications.push").value(false));
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/preferences - rejects oversized payload")
+    void testUpdatePreferences_RejectsOversizedPayload() throws Exception {
+        String padding = "x".repeat(5000);
+        mockMvc.perform(put("/api/users/preferences")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "preferences": { "notifications": { "blob": "%s" } } }
+                                """.formatted(padding)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Preferences payload exceeds maximum size of 4096 bytes"));
+    }
 }


### PR DESCRIPTION
## Description

Restricts `PUT /api/users/preferences` to allowlisted keys (`theme`, `notifications`), validates the notifications value is an object, enforces a 4KB serialized size cap, and keeps existing theme validation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13351

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — backend-only change.

## Additional Notes

The `notifications` key matches the shape sent by the frontend notification preferences hook.

Made with [Cursor](https://cursor.com)