### PR TITLE
fix: remove bogus lat/lng check in parseTimeToMinutes

### DIFF
--- a/src/utils/eventCreationUtils.js
+++ b/src/utils/eventCreationUtils.js
@@ -6,10 +6,6 @@ export const parseTimeToMinutes = (timeStr) => {
   const parsed = parseTimeString(timeStr);
   if (!parsed) return 0;
 
-  if (isNaN(lat) || isNaN(lng)) {
-    return null;
-  }
-
   return parsed.hours * 60 + parsed.minutes;
 };
 

--- a/tests/eventCreationUtils.test.mjs
+++ b/tests/eventCreationUtils.test.mjs
@@ -6,7 +6,10 @@ const {
 } = await import("../src/utils/eventCreationUtils.js");
 
 assert.equal(parseTimeToMinutes("09:30"), 570);
+assert.equal(parseTimeToMinutes("00:00"), 0);
+assert.equal(parseTimeToMinutes("12:45"), 765);
 assert.equal(parseTimeToMinutes(""), 0);
+assert.equal(parseTimeToMinutes(null), 0);
 
 assert.deepEqual(validateCoordinates("40.7128", "-74.0060"), {
   latitude: 40.7128,


### PR DESCRIPTION
## Description

`parseTimeToMinutes` referenced undefined `lat`/`lng` variables, causing a ReferenceError. Removed that check and return `parsed.hours * 60 + parsed.minutes`. Expanded unit coverage for common time inputs.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13378

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)