### PR TITLE
fix(security): single user fetch in JwtAuthenticationFilter

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetails.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetails.java
@@ -1,0 +1,68 @@
+package com.sandeep.eventrabackend.security;
+
+import com.sandeep.eventrabackend.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * UserDetails backed by the persisted User entity so callers can access
+ * fields like passwordChangedAt without a second database lookup.
+ */
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+        this.authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    public LocalDateTime getPasswordChangedAt() {
+        return user.getPasswordChangedAt();
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetailsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/CustomUserDetailsService.java
@@ -2,14 +2,11 @@ package com.sandeep.eventrabackend.security;
 
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.UserRepository;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -31,10 +28,6 @@ public class CustomUserDetailsService implements UserDetailsService {
                         new UsernameNotFoundException(
                                 "User not found with username or email: " + identifier));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getEmail())   // use email as principal
-                .password(user.getPassword())
-                .authorities(List.of(new SimpleGrantedAuthority(user.getRole().name())))
-                .build();
+        return new CustomUserDetails(user);
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -1,7 +1,5 @@
 package com.sandeep.eventrabackend.security;
 
-import com.sandeep.eventrabackend.model.User;
-import com.sandeep.eventrabackend.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,9 +16,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
-import java.util.Optional;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -30,20 +28,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
     private final TokenBlacklistService tokenBlacklistService;
-    private final UserRepository userRepository;
     private final AuthCookieHelper authCookieHelper;
     private final TokenRefreshQueueHandler tokenRefreshQueueHandler;
 
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
                                    UserDetailsService userDetailsService,
                                    TokenBlacklistService tokenBlacklistService,
-                                   UserRepository userRepository,
                                    AuthCookieHelper authCookieHelper,
                                    TokenRefreshQueueHandler tokenRefreshQueueHandler) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.userDetailsService = userDetailsService;
         this.tokenBlacklistService = tokenBlacklistService;
-        this.userRepository = userRepository;
         this.authCookieHelper = authCookieHelper;
         this.tokenRefreshQueueHandler = tokenRefreshQueueHandler;
     }
@@ -74,13 +69,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
                 String username = jwtTokenProvider.getUsernameFromToken(token);
+                // Single DB load: CustomUserDetails carries passwordChangedAt
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
                 Date tokenIssuedAt = jwtTokenProvider.getIssuedAtDateFromToken(token);
-                Optional<User> userOpt = userRepository.findByEmail(username);
-                if (userOpt.isPresent() && userOpt.get().getPasswordChangedAt() != null) {
+                LocalDateTime passwordChangedAt = null;
+                if (userDetails instanceof CustomUserDetails customUserDetails) {
+                    passwordChangedAt = customUserDetails.getPasswordChangedAt();
+                }
+                if (passwordChangedAt != null) {
                     long tokenIssuedSec = tokenIssuedAt.getTime() / 1000;
-                    long passwordChangedSec = userOpt.get().getPasswordChangedAt()
+                    long passwordChangedSec = passwordChangedAt
                             .atZone(ZoneId.systemDefault())
                             .toEpochSecond();
                     if (tokenIssuedSec < passwordChangedSec) {


### PR DESCRIPTION
## Description

JwtAuthenticationFilter was loading UserDetails and then querying the user again for `passwordChangedAt`. Introduced `CustomUserDetails` so one load supplies both authorities and password-change invalidation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13390

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes

Password-change token invalidation behavior is unchanged.

Made with [Cursor](https://cursor.com)