### PR TITLE
fix: ignore spoofed X-Forwarded-For prefix in rate limiting

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -150,8 +150,12 @@ public class RateLimitingFilter extends OncePerRequestFilter {
         String forwarded = request.getHeader("X-Forwarded-For");
         if (StringUtils.hasText(forwarded)) {
             String[] parts = forwarded.split(",");
-            // XFF is client, proxy1, proxy2 — strip trustedProxyHops from the right.
-            int clientIndex = Math.max(0, parts.length - 1 - trustedProxyHops);
+            // Proxies append the connecting peer on the right. Trust the rightmost
+            // N entries as infrastructure; the client is the leftmost of that
+            // trusted suffix (ignoring any client-supplied left-hand spoof).
+            // hops=1 on "spoof, real" → index length-1 = real.
+            int clientIndex = Math.min(parts.length - 1,
+                    Math.max(0, parts.length - trustedProxyHops));
             String candidate = parts[clientIndex].trim();
             if (StringUtils.hasText(candidate) && !"unknown".equalsIgnoreCase(candidate)) {
                 return candidate;

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/RateLimitingFilterTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/RateLimitingFilterTests.java
@@ -20,7 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @TestPropertySource(properties = {
         "app.rate-limit.login.capacity=1",
-        "app.rate-limit.login.window=1m"
+        "app.rate-limit.login.window=1m",
+        "app.rate-limit.trusted-proxy-hops=1"
 })
 class RateLimitingFilterTests {
 
@@ -47,6 +48,25 @@ class RateLimitingFilterTests {
                 .andExpect(header().string("X-RateLimit-Remaining", "0"))
                 .andExpect(jsonPath("$.status", is(429)))
                 .andExpect(jsonPath("$.error", is("Too Many Requests")))
+                .andExpect(jsonPath("$.path", is("/api/auth/login")));
+    }
+
+    @Test
+    void ignoresClientSpoofedLeftmostXffWithTrustedProxyHops() throws Exception {
+        // Attacker varies the left-hand spoof; LB appends the real client on the right.
+        // With trustedProxyHops=1 both requests must share the same rate-limit bucket.
+        mockMvc.perform(post("/api/auth/login")
+                        .header("X-Forwarded-For", "198.51.100.1, 203.0.113.50")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/auth/login")
+                        .header("X-Forwarded-For", "198.51.100.99, 203.0.113.50")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.status", is(429)))
                 .andExpect(jsonPath("$.path", is("/api/auth/login")));
     }
 }


### PR DESCRIPTION
## Summary
- With `trustedProxyHops=N`, resolve the client as the leftmost entry of the trusted right-hand suffix (`parts.length - N`), so a spoofed left-hand XFF value cannot bypass rate limits.
- Adds a regression test for `spoof, real` with hops=1 sharing one bucket on the real IP.

Closes #13384

Made with [Cursor](https://cursor.com)