### PR TITLE
fix(waitlist): use server message on joinWaitlist 409

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -405,7 +405,11 @@ export const joinWaitlist = async (eventId, user, registrationForm = {}) => {
   } catch (error) {
     const status = error?.status || error?.response?.status;
     if (status === 409) {
-      throw new Error("You are already on the waitlist for this event.");
+      const serverMessage =
+        error?.response?.data?.message ||
+        error?.message ||
+        "Unable to join waitlist due to a conflict.";
+      throw new Error(serverMessage);
     }
     if (error.isNetworkError || error.isTimeout) {
       // Fall through to offline fallback


### PR DESCRIPTION
## Description

On waitlist join conflict (409), use the server error message when present instead of always showing that the user is already on the waitlist. Falls back to a generic conflict message.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13391

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes


Made with [Cursor](https://cursor.com)