### PR TITLE
fix: align event create payload and success check with API

### DIFF
--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -69,9 +69,12 @@ const EventCreation = () => {
     const response = await apiUtils.post(API_ENDPOINTS.EVENTS.CREATE, eventData);
     const result = response.data;
 
-    if (!(response.status === 200 && result.success)) {
+    // Backend returns 201 Created with EventResponse (id/title), not { success: true }.
+    const isSuccessStatus = response.status >= 200 && response.status < 300;
+    const hasEventData = Boolean(result && (result.id || result.title));
+    if (!(isSuccessStatus && hasEventData)) {
       const errorMessage =
-        result.message || result.error || `Server error: ${response.status}`;
+        result?.message || result?.error || `Server error: ${response.status}`;
       throw new Error(errorMessage);
     }
   });

--- a/src/utils/eventCreationUtils.js
+++ b/src/utils/eventCreationUtils.js
@@ -52,15 +52,21 @@ export const validateCoordinates = (latitude, longitude) => {
   return null;
 };
 
-export const buildEventPayload = (formData) => {
-  let coordinates = null;
-  if (formData.location?.coordinates?.latitude && formData.location?.coordinates?.longitude) {
-    coordinates = validateCoordinates(
-      formData.location?.coordinates?.latitude,
-      formData.location?.coordinates?.longitude
-    );
+const formatLocalDateTime = (date) => date.toISOString().slice(0, 19);
+
+const buildLocationString = (formData) => {
+  if (formData.isVirtual) {
+    const link = formData.virtualLink?.trim();
+    return link || "Virtual";
   }
 
+  const name = formData.location?.name?.trim() || "";
+  const address = formData.location?.address?.trim() || "";
+  if (name && address) return `${name}, ${address}`;
+  return name || address || "";
+};
+
+export const buildEventPayload = (formData) => {
   const eventStartDate = resolveEventInstant(
     formData.isMultiDay ? formData.startDate : formData.date,
     formData.startTime,
@@ -76,43 +82,21 @@ export const buildEventPayload = (formData) => {
     throw new Error("Invalid date or time format");
   }
 
-  const registrationStart = formData.registrationStart
-    ? resolveEventInstant(formData.registrationStart, "12:00 AM", formData.timezone)
-    : null;
-  const registrationEnd = formData.registrationEnd
-    ? resolveEventInstant(formData.registrationEnd, "11:59 PM", formData.timezone)
-    : null;
-
-  return {
+  const payload = {
     title: formData.title.trim(),
     description: formData.description.trim(),
-    startDate: eventStartDate.toISOString(),
-    endDate: eventEndDate.toISOString(),
-    timezone: formData.timezone,
-    location: formData.isVirtual
-      ? null
-      : {
-          name: formData.location.name.trim(),
-          address: formData.location.address?.trim() || "",
-          coordinates: coordinates,
-        },
-    isVirtual: formData.isVirtual,
-    virtualLink: formData.isVirtual ? formData.virtualLink.trim() : null,
+    location: buildLocationString(formData),
+    eventDate: formatLocalDateTime(eventStartDate),
     capacity: formData.capacity ? Number(formData.capacity) : null,
     isPublic: formData.isPublic,
-    requiresApproval: formData.requiresApproval,
-    registrationStart: registrationStart ? registrationStart.toISOString() : null,
-    registrationEnd: registrationEnd ? registrationEnd.toISOString() : null,
     category: formData.category,
     tags: formData.tags.filter((tag) => tag.trim()),
-    ticketTiers: formData.ticketTiers
-      .filter((tier) => tier.name.trim())
-      .map((tier) => ({
-        name: tier.name.trim(),
-        price: Number(tier.price) || 0,
-        capacity: tier.capacity ? Number(tier.capacity) : null,
-        description: tier.description?.trim() || "",
-      })),
-    venueMap: formData.venueMap || [],
   };
+
+  const imageUrl = formData.imageUrl?.trim();
+  if (imageUrl) {
+    payload.imageUrl = imageUrl;
+  }
+
+  return payload;
 };

--- a/tests/eventCreationUtils.test.mjs
+++ b/tests/eventCreationUtils.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 const {
   parseTimeToMinutes,
   validateCoordinates,
+  buildEventPayload,
 } = await import("../src/utils/eventCreationUtils.js");
 
 assert.equal(parseTimeToMinutes("09:30"), 570);
@@ -14,5 +15,34 @@ assert.deepEqual(validateCoordinates("40.7128", "-74.0060"), {
 });
 assert.equal(validateCoordinates("95", "10"), null);
 assert.equal(validateCoordinates("10", "200"), null);
+
+const payload = buildEventPayload({
+  title: " Tech Meetup ",
+  description: " Deep dive ",
+  category: "MEETUP",
+  isMultiDay: false,
+  date: "2099-06-15",
+  startTime: "10:00 AM",
+  endTime: "11:00 AM",
+  timezone: "UTC",
+  location: { name: "Hall A", address: "1 Main St", coordinates: {} },
+  isVirtual: false,
+  virtualLink: "",
+  capacity: "50",
+  isPublic: true,
+  tags: ["ai", ""],
+  imageUrl: "https://example.com/banner.jpg",
+});
+
+assert.equal(payload.title, "Tech Meetup");
+assert.equal(payload.description, "Deep dive");
+assert.equal(payload.location, "Hall A, 1 Main St");
+assert.equal(payload.eventDate, "2099-06-15T10:00:00");
+assert.equal(payload.capacity, 50);
+assert.equal(payload.isPublic, true);
+assert.equal(payload.category, "MEETUP");
+assert.deepEqual(payload.tags, ["ai"]);
+assert.equal(payload.imageUrl, "https://example.com/banner.jpg");
+assert.equal(payload.startDate, undefined);
 
 console.log("eventCreationUtils tests passed ✓");


### PR DESCRIPTION
## Description

Maps `buildEventPayload` to `EventCreateRequest` fields (`title`, `description`, `location` string, `eventDate`, `capacity`, `isPublic`, `category`, `tags`, optional `imageUrl`). Treats HTTP 2xx responses that include event `id` or `title` as success, matching the 201 `EventResponse` from create.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13379

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)