### PR TITLE
fix: remove duplicate findAlternativeEvents method

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -274,35 +274,6 @@ public class EventService {
                                 .toList();
         }
 
-
-        /**
-         * Returns a bounded window of public events near {@code around} for conflict
-         * alternative suggestions (avoids loading the entire catalog).
-         */
-        @Transactional(readOnly = true)
-        public List<EventResponse> findAlternativeEvents(
-                        Long excludeEventId,
-                        LocalDateTime around,
-                        int windowDays,
-                        int limit) {
-
-                LocalDateTime center = around != null ? around : LocalDateTime.now();
-                int days = Math.min(Math.max(windowDays, 1), 90);
-                int size = Math.min(Math.max(limit, 1), 50);
-                LocalDateTime from = center.minusDays(days);
-                LocalDateTime to = center.plusDays(days);
-
-                return eventRepository
-                                .findPublicAlternativesInWindow(
-                                                excludeEventId,
-                                                from,
-                                                to,
-                                                org.springframework.data.domain.PageRequest.of(0, size))
-                                .stream()
-                                .map(this::toPublicEventResponse)
-                                .toList();
-        }
-
         /**
          * Retrieves events registered by the authenticated user.
          *


### PR DESCRIPTION
## Description

Removes the identical duplicate `findAlternativeEvents` method in `EventService` so the class compiles cleanly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13380

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)