### PR TITLE
fix(events): promote waitlist on updateEvent capacity increase

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -530,6 +530,8 @@ public class EventService {
                                                         + event.getRegisteredCount() + ")");
                 }
 
+                Integer previousCapacity = event.getCapacity();
+
                 event.setTitle(request.getTitle());
                 event.setDescription(request.getDescription());
                 event.setLocation(request.getLocation());
@@ -551,6 +553,19 @@ public class EventService {
                 }
 
                 Event saved = eventRepository.save(event);
+
+                // Capacity increase frees seats — promote waitlisted users (same helper as cancel/admin)
+                boolean capacityIncreased = request.getCapacity() != null
+                                && previousCapacity != null
+                                && request.getCapacity() > previousCapacity;
+                if (capacityIncreased) {
+                        int freedSeats = request.getCapacity() - previousCapacity;
+                        for (int i = 0; i < freedSeats; i++) {
+                                promoteWaitlistAfterVacancy(saved.getId());
+                        }
+                        saved = eventRepository.findById(saved.getId()).orElse(saved);
+                }
+
                 return toEventResponse(saved);
         }
 


### PR DESCRIPTION
## Description

When an organizer increases event capacity via `updateEvent`, newly freed seats now promote waitlisted users using the same `promoteWaitlistAfterVacancy` helper as cancel and admin paths.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13392

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes


Made with [Cursor](https://cursor.com)