### PR TITLE
fix(events): do not block admins in useEventCancellation

### DIFF
--- a/src/hooks/useEventCancellation.js
+++ b/src/hooks/useEventCancellation.js
@@ -67,8 +67,13 @@ const useEventCancellation = (eventId, onSuccess, ownerId) => {
 
       // Guard (Issue #11021): role alone is not enough — only the event's own
       // organizer may cancel it. Prevents cross-tenant cancellation by swapping
-      // the event id in the URL.
-      if (ownerId != null && user?.id != null && String(ownerId) !== String(user.id)) {
+      // the event id in the URL. Admins may cancel any event.
+      if (
+        !isAdmin() &&
+        ownerId != null &&
+        user?.id != null &&
+        String(ownerId) !== String(user.id)
+      ) {
         setCancellationError("Only the event's own organizer can cancel this event.");
         return false;
       }


### PR DESCRIPTION
## Description

The ownerId check in `useEventCancellation` was blocking admins from cancelling events they do not own. Admins can now cancel any event; non-admin organizers still must own the event.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13393

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes


Made with [Cursor](https://cursor.com)