### PR TITLE
fix: hide private events from public ICS feed

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1220,8 +1220,7 @@ public class EventService {
         }
 
         public String buildIcsFeed(Long eventId) {
-                Event event = eventRepository.findById(eventId)
-                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+                Event event = requirePublicEvent(eventId);
 
                 java.time.LocalDateTime start = event.getEventDate() != null
                                 ? event.getEventDate()


### PR DESCRIPTION
## Description

`buildIcsFeed` now uses `requirePublicEvent` (same check as seats/availability) so private events are not leaked via the ICS endpoint.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13381

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)