### PR TITLE
fix: notify waitlist on event cancellation

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -637,18 +637,39 @@ public class EventService {
                         return List.of();
                 }
 
-                return eventRegistrationRepository.findByEvent_IdAndStatus(eventId, "CONFIRMED").stream()
+                java.util.LinkedHashSet<String> emails = new java.util.LinkedHashSet<>();
+                eventRegistrationRepository.findByEvent_IdAndStatus(eventId, "CONFIRMED").stream()
                                 .map(registration -> registration.getUser().getEmail())
-                                .toList();
+                                .forEach(emails::add);
+                eventWaitlistRepository
+                                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId, "CANCELLED")
+                                .stream()
+                                .map(entry -> entry.getUser().getEmail())
+                                .forEach(emails::add);
+                return List.copyOf(emails);
         }
 
         private void notifyCancellation(Event event, String reason) {
+                String message = event.getTitle() + " has been cancelled. Reason: " + reason;
+
                 eventRegistrationRepository.findByEvent_IdAndStatus(event.getId(), "CONFIRMED")
                                 .forEach(registration -> notificationRepository.save(Notification.builder()
                                                 .user(registration.getUser())
                                                 .title("Event cancelled")
-                                                .message(event.getTitle() + " has been cancelled. Reason: " + reason)
+                                                .message(message)
                                                 .build()));
+
+                eventWaitlistRepository
+                                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(event.getId(), "WAITING")
+                                .forEach(entry -> {
+                                        notificationRepository.save(Notification.builder()
+                                                        .user(entry.getUser())
+                                                        .title("Event cancelled")
+                                                        .message(message)
+                                                        .build());
+                                        entry.setStatus("CANCELLED");
+                                        eventWaitlistRepository.save(entry);
+                                });
         }
 
         /**

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/CancelEventRequestTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/CancelEventRequestTests.java
@@ -2,9 +2,11 @@ package com.sandeep.eventrabackend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventWaitlist;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +24,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -55,11 +60,15 @@ class CancelEventRequestTests {
     @Autowired
     private NotificationRepository notificationRepository;
 
+    @Autowired
+    private EventWaitlistRepository eventWaitlistRepository;
+
     private Event existingEvent;
 
     @BeforeEach
     void setUp() {
         notificationRepository.deleteAll();
+        eventWaitlistRepository.deleteAll();
         eventRepository.deleteAll();
         userRepository.deleteAll();
 
@@ -104,5 +113,44 @@ class CancelEventRequestTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("reason", "Venue unavailable"))))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Cancel notifies WAITING waitlist users and clears their entries")
+    void cancelEvent_NotifiesWaitlistedUsers() throws Exception {
+        User waitlisted = userRepository.save(User.builder()
+                .firstName("Wait")
+                .lastName("Lister")
+                .email("waitlist@example.com")
+                .username("waitlist")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ATTENDEE)
+                .build());
+
+        EventWaitlist entry = new EventWaitlist();
+        entry.setEvent(existingEvent);
+        entry.setUser(waitlisted);
+        entry.setPosition(1);
+        entry.setStatus("WAITING");
+        eventWaitlistRepository.save(entry);
+
+        mockMvc.perform(post("/api/events/" + existingEvent.getId() + "/cancel")
+                        .with(user("admin@example.com").authorities(new SimpleGrantedAuthority("ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("reason", "Venue unavailable", "refundPolicy", "NONE", "notifyAttendees", true))))
+                .andExpect(status().isOk());
+
+        assertEquals("CANCELLED",
+                eventWaitlistRepository.findById(entry.getId()).orElseThrow().getStatus());
+        assertEquals(1, notificationRepository.findAll().stream()
+                .filter(n -> n.getUser().getEmail().equals("waitlist@example.com"))
+                .filter(n -> "Event cancelled".equals(n.getTitle()))
+                .count());
+
+        mockMvc.perform(get("/api/events/" + existingEvent.getId() + "/notified-attendees")
+                        .with(user("admin@example.com").authorities(new SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasItem("waitlist@example.com")));
     }
 }


### PR DESCRIPTION
## Summary
- `notifyCancellation` notifies WAITING waitlist users and marks those entries CANCELLED.
- `getNotifiedAttendees` includes cancelled waitlist emails alongside confirmed attendees.

Closes #13387

Made with [Cursor](https://cursor.com)