### PR TITLE
fix: persist capacity increase via API before promote

### DIFF
--- a/src/components/OrganizerWaitlistManagement.jsx
+++ b/src/components/OrganizerWaitlistManagement.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'react-toastify';
 import { useAuth } from 'context/AuthContext';
+import { API_ENDPOINTS, apiUtils } from '../config/api';
 import {
   syncWaitlistFromServer,
   organizerRemoveUser,
@@ -80,13 +81,36 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
 
     setIsProcessing(true);
     try {
+      // Persist capacity via organizer update endpoint before promoting.
+      const detailResponse = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
+      const current = detailResponse.data || {};
+      const eventDate = current.eventDate;
+      const normalizedEventDate =
+        typeof eventDate === 'string'
+          ? eventDate.replace(/\.\d{3}Z$/, '').replace(/Z$/, '').slice(0, 19)
+          : eventDate;
+
+      await apiUtils.put(API_ENDPOINTS.EVENTS.DETAIL(eventId), {
+        title: current.title || eventName,
+        description: current.description || '',
+        location: current.location || '',
+        eventDate: normalizedEventDate,
+        capacity: Number(newCapacity),
+        isPublic: current.public ?? current.isPublic,
+        category: current.category,
+        ...(current.imageUrl ? { imageUrl: current.imageUrl } : {}),
+        ...(current.tags ? { tags: current.tags } : {}),
+      });
+
       const event = {
         id: eventId,
         title: eventName,
         attendees: currentAttendees,
+        maxAttendees: Number(newCapacity),
+        capacity: Number(newCapacity),
       };
 
-      const promotedCount = await handleCapacityIncrease(event, newCapacity, user?.id);
+      const promotedCount = await handleCapacityIncrease(event, Number(newCapacity), user?.id);
 
       if (promotedCount > 0) {
         toast.success(`${promotedCount} user(s) promoted from waitlist!`);
@@ -99,7 +123,7 @@ const OrganizerWaitlistManagement = ({ eventId, eventName, currentAttendees = 0,
       setNewCapacity(maxAttendees);
     } catch (error) {
       console.error('Capacity change error:', error);
-      toast.error('Failed to update capacity and promote users');
+      toast.error(error?.response?.data?.message || error.message || 'Failed to update capacity and promote users');
     } finally {
       setIsProcessing(false);
     }

--- a/src/components/admin/AdminDashboard.js
+++ b/src/components/admin/AdminDashboard.js
@@ -44,6 +44,7 @@ import {
   deleteAdminEvent,
   fetchAdminStats,
   updateAdminUserRole,
+  updateAdminEvent,
 } from "services/adminService";
 import { safeJsonParse } from "utils/safeJsonParse";
 
@@ -299,24 +300,50 @@ const AdminDashboard = () => {
 
   const handleIncreaseCapacity = async () => {
     if (!selectedWaitlistEvent) return;
+    const currentCapacity =
+      Number(selectedWaitlistEvent.maxAttendees ?? selectedWaitlistEvent.capacity) || 0;
+    const currentAttendees =
+      Number(selectedWaitlistEvent.attendees ?? selectedWaitlistEvent.registeredCount) || 0;
     const newCapStr = window.prompt(
       "Enter new capacity for this event:",
-      (Number(selectedWaitlistEvent.maxAttendees) || 0) + 10
+      currentCapacity + 10
     );
     if (!newCapStr) return;
     const newCap = parseInt(newCapStr, 10);
-    if (isNaN(newCap) || newCap <= (selectedWaitlistEvent.maxAttendees || 0)) {
+    if (isNaN(newCap) || newCap <= currentCapacity) {
       toast.error("Please enter a valid capacity greater than current capacity.");
       return;
     }
 
     try {
+      const eventDate = selectedWaitlistEvent.eventDate;
+      const normalizedEventDate =
+        typeof eventDate === "string"
+          ? eventDate.replace(/\.\d{3}Z$/, "").replace(/Z$/, "").slice(0, 19)
+          : eventDate;
+
+      // Persist capacity on the server before promoting waitlisted users.
+      await updateAdminEvent(selectedWaitlistEvent.id, {
+        title: selectedWaitlistEvent.title,
+        description: selectedWaitlistEvent.description,
+        location: selectedWaitlistEvent.location,
+        eventDate: normalizedEventDate,
+        capacity: newCap,
+        isPublic: selectedWaitlistEvent.public ?? selectedWaitlistEvent.isPublic,
+        category: selectedWaitlistEvent.category,
+        ...(selectedWaitlistEvent.imageUrl
+          ? { imageUrl: selectedWaitlistEvent.imageUrl }
+          : {}),
+        ...(selectedWaitlistEvent.tags ? { tags: selectedWaitlistEvent.tags } : {}),
+      });
+
       const { handleCapacityIncrease } = await import("utils/waitlistUtils.js");
 
       const updatedEvent = {
         ...selectedWaitlistEvent,
         maxAttendees: newCap,
-        attendees: selectedWaitlistEvent.attendees,
+        capacity: newCap,
+        attendees: currentAttendees,
       };
 
       const promotedCount = await handleCapacityIncrease(updatedEvent, newCap, user?.id);
@@ -327,7 +354,8 @@ const AdminDashboard = () => {
         const parsed = safeJsonParse(raw, null);
         if (parsed?.event) {
           parsed.event.maxAttendees = newCap;
-          parsed.event.attendees = (Number(parsed.event.attendees) || 0) + promotedCount;
+          parsed.event.capacity = newCap;
+          parsed.event.attendees = currentAttendees + promotedCount;
           localStorage.setItem(cacheKey, JSON.stringify(parsed));
         }
       }
@@ -335,7 +363,9 @@ const AdminDashboard = () => {
       setSelectedWaitlistEvent((prev) => ({
         ...prev,
         maxAttendees: newCap,
-        attendees: (Number(prev.attendees) || 0) + promotedCount,
+        capacity: newCap,
+        attendees: currentAttendees + promotedCount,
+        registeredCount: currentAttendees + promotedCount,
       }));
 
       loadEvents(eventsPage, searchEvent);
@@ -1223,7 +1253,8 @@ const AdminDashboard = () => {
 
             <div className="mb-4 flex items-center justify-between bg-slate-50 dark:bg-slate-800/40 p-3 rounded-xl">
               <span className="text-xs font-semibold text-slate-650 dark:text-slate-400">
-                Capacity: {selectedWaitlistEvent.attendees} / {selectedWaitlistEvent.maxAttendees}{" "}
+                Capacity: {selectedWaitlistEvent.attendees ?? selectedWaitlistEvent.registeredCount} /{" "}
+                {selectedWaitlistEvent.maxAttendees ?? selectedWaitlistEvent.capacity}{" "}
                 registered
               </span>
               <button


### PR DESCRIPTION
## Description

Admin and organizer waitlist capacity increases now PUT the new capacity through the admin/organizer event update endpoints before promoting waitlisted users, so the higher capacity actually persists.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13382

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)