### PR TITLE
fix: omit cancelledAt from cancel payload

### DIFF
--- a/src/hooks/useEventCancellation.js
+++ b/src/hooks/useEventCancellation.js
@@ -111,7 +111,6 @@ const useEventCancellation = (eventId, onSuccess, ownerId) => {
           ...(refundPolicy === REFUND_POLICIES.PARTIAL && {
             refundPercent: Number(refundPercent),
           }),
-          cancelledAt: new Date().toISOString(),
         };
 
         const res = await apiUtils.post(


### PR DESCRIPTION
## Description

Stops sending `cancelledAt` as an Instant-style ISO string with `Z`, which fails `LocalDateTime` deserialization. The server already defaults `cancelledAt` to now when omitted.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13383

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

Made with [Cursor](https://cursor.com)