### PR TITLE
fix: cap session recovery draftData size

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/SessionRecoveryService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/SessionRecoveryService.java
@@ -21,6 +21,9 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class SessionRecoveryService {
 
+    /** Maximum serialized draft JSON size accepted from clients. */
+    public static final int MAX_DRAFT_BYTES = 64 * 1024;
+
     private final RecoverySessionRepository recoverySessionRepository;
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
@@ -35,7 +38,13 @@ public class SessionRecoveryService {
         session.setUser(user);
         session.setName(stringOr(payload.get("name"), "Recovery Session"));
         session.setType(stringOr(payload.get("type"), "generic"));
-        session.setDraftData(writeJson(payload.getOrDefault("draftData", payload)));
+        String draftJson = writeJson(payload.getOrDefault("draftData", payload));
+        if (draftJson.length() > MAX_DRAFT_BYTES) {
+            throw new IllegalArgumentException(
+                    "draftData exceeds the maximum allowed size of " + MAX_DRAFT_BYTES
+                            + " bytes (got " + draftJson.length() + ").");
+        }
+        session.setDraftData(draftJson);
         session.setExpiresAt(LocalDateTime.now().plusDays(14));
         return toResponse(recoverySessionRepository.save(session));
     }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/SessionRecoveryServiceTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/SessionRecoveryServiceTests.java
@@ -1,0 +1,70 @@
+package com.sandeep.eventrabackend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.RecoverySessionRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SessionRecoveryServiceTests {
+
+    @Mock
+    private RecoverySessionRepository recoverySessionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private SessionRecoveryService sessionRecoveryService;
+
+    @BeforeEach
+    void setUp() {
+        sessionRecoveryService = new SessionRecoveryService(
+                recoverySessionRepository,
+                userRepository,
+                new ObjectMapper());
+    }
+
+    @Test
+    void save_rejectsDraftDataOverMaxBytes() {
+        User user = User.builder()
+                .id(1L)
+                .firstName("A")
+                .lastName("B")
+                .email("user@example.com")
+                .username("user")
+                .password("x")
+                .role(Role.ATTENDEE)
+                .build();
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        when(recoverySessionRepository.findByIdAndUser_Id(anyString(), anyLong()))
+                .thenReturn(Optional.empty());
+
+        String oversized = "x".repeat(SessionRecoveryService.MAX_DRAFT_BYTES + 1);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> sessionRecoveryService.save("user@example.com", Map.of(
+                        "name", "Big Draft",
+                        "type", "generic",
+                        "draftData", Map.of("blob", oversized))));
+
+        assertTrue(ex.getMessage().contains("draftData exceeds the maximum allowed size"));
+        verify(recoverySessionRepository, never()).save(any());
+    }
+}

--- a/src/services/sessionRecoveryService.js
+++ b/src/services/sessionRecoveryService.js
@@ -5,7 +5,7 @@ import { safeJsonParse } from "../utils/safeJsonParse.js";
 export const CLOUD_RECOVERY_PENDING_KEY = "eventra:cloud-session-recovery:pending:v1";
 export const CLOUD_RECOVERY_CACHE_KEY = "eventra:cloud-session-recovery:cache:v1";
 export const DEFAULT_RECOVERY_RETENTION_DAYS = 7;
-export const MAX_DRAFT_BYTES = 512 * 1024;
+export const MAX_DRAFT_BYTES = 64 * 1024;
 
 const RECOVERY_TYPES = new Set([
   "event-creation",


### PR DESCRIPTION
## Summary
- Reject session-recovery saves when serialized `draftData` exceeds 64KB with a clear error.
- Align the frontend `MAX_DRAFT_BYTES` cap with the server limit.

Closes #13389

Made with [Cursor](https://cursor.com)