### PR TITLE
fix(security): restrict Swagger/OpenAPI outside prod

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig {
     @Value("${app.cors.allowed-origins:http://localhost:3000,https://eventra.vercel.app,https://eventra.sandeepvashishtha.tech}")
     private String allowedOrigins;
 
+    @Value("${eventra.api-docs.enabled:false}")
+    private boolean apiDocsEnabled;
+
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
             UserDetailsService userDetailsService) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
@@ -125,8 +128,8 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 // Stateless sessions — JWT handles auth
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                .authorizeHttpRequests(auth -> {
+                        auth.requestMatchers("/api/auth/**").permitAll()
                         // ── Public: pre-submit availability checks ──────────
                         // Email/username validation runs before the user has a JWT.
                         .requestMatchers("/api/validate/**").permitAll()
@@ -163,19 +166,22 @@ public class SecurityConfig {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/feedback").permitAll()
                         // ── Admin Panel — ADMIN / SUPER_ADMIN only ────────
-                        .requestMatchers("/api/admin/**").hasAnyAuthority("ADMIN", "SUPER_ADMIN")
-                        // ── Public: Swagger / OpenAPI ────────────────────
-                        .requestMatchers(
-                                "/swagger-ui.html",
-                                "/swagger-ui/**",
-                                "/api-docs",
-                                "/api-docs/**",
-                                "/api-docs.yaml",
-                                "/v3/api-docs",
-                                "/v3/api-docs/**")
-                        .permitAll()
+                        .requestMatchers("/api/admin/**").hasAnyAuthority("ADMIN", "SUPER_ADMIN");
+                        // ── Swagger / OpenAPI — only when explicitly enabled (dev)
+                        if (apiDocsEnabled) {
+                                auth.requestMatchers(
+                                                "/swagger-ui.html",
+                                                "/swagger-ui/**",
+                                                "/api-docs",
+                                                "/api-docs/**",
+                                                "/api-docs.yaml",
+                                                "/v3/api-docs",
+                                                "/v3/api-docs/**")
+                                        .permitAll();
+                        }
                         // ── Everything else requires a valid JWT ─────────
-                        .anyRequest().authenticated())
+                        auth.anyRequest().authenticated();
+                })
                 // Return 401 (not Spring Security's default 403) for missing/invalid JWT
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(unauthorizedEntryPoint()))

--- a/Backend/src/main/resources/application-dev.yml
+++ b/Backend/src/main/resources/application-dev.yml
@@ -21,3 +21,7 @@ app:
 google:
   client:
     id: ${GOOGLE_CLIENT_ID:dev-google-client-id}
+
+eventra:
+  api-docs:
+    enabled: true

--- a/Backend/src/main/resources/application-prod.yml
+++ b/Backend/src/main/resources/application-prod.yml
@@ -19,3 +19,7 @@ app:
 google:
   client:
     id: ${GOOGLE_CLIENT_ID}
+
+eventra:
+  api-docs:
+    enabled: false

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -44,3 +44,14 @@ management:
 
 server:
   forward-headers-strategy: framework
+
+# Secure default: OpenAPI/Swagger is off unless a profile enables it (dev).
+eventra:
+  api-docs:
+    enabled: ${EVENTRA_API_DOCS_ENABLED:false}
+
+springdoc:
+  api-docs:
+    enabled: ${eventra.api-docs.enabled:false}
+  swagger-ui:
+    enabled: ${eventra.api-docs.enabled:false}

--- a/Backend/src/test/resources/application-test.properties
+++ b/Backend/src/test/resources/application-test.properties
@@ -13,3 +13,6 @@ spring.jpa.show-sql=false
 app.jwt.secret=test-secret-key-that-is-at-least-256-bits-long-for-hs256-algorithm-ok
 app.jwt.expiration-ms=86400000
 app.auth.cookie.secure=false
+
+# Tests may hit OpenAPI routes; keep docs enabled under the test profile.
+eventra.api-docs.enabled=true


### PR DESCRIPTION
## Description

Swagger and OpenAPI routes are no longer unconditionally `permitAll`. They are gated by `eventra.api-docs.enabled` (true in dev/test, false in prod by default). Springdoc UI/docs follow the same flag.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13395

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

## Additional Notes

Override with `EVENTRA_API_DOCS_ENABLED=true` if docs are needed outside the default profiles.

Made with [Cursor](https://cursor.com)