### PR TITLE
fix(security): prevent session-recovery IDOR overwrite by foreign sessionId

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/SessionRecoveryService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/SessionRecoveryService.java
@@ -7,6 +7,7 @@ import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.RecoverySessionRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -29,9 +31,20 @@ public class SessionRecoveryService {
     public Map<String, Object> save(String userEmail, Map<String, Object> payload) {
         User user = requireUser(userEmail);
         String sessionId = stringOr(payload.get("sessionId"), UUID.randomUUID().toString());
-        RecoverySession session = recoverySessionRepository.findByIdAndUser_Id(sessionId, user.getId())
-                .orElseGet(RecoverySession::new);
-        session.setId(sessionId);
+
+        // findByIdAndUser_Id alone is not enough: a miss + assigned @Id causes JPA merge()
+        // to overwrite another user's row. Own it, create it, or deny — never steal.
+        Optional<RecoverySession> owned = recoverySessionRepository.findByIdAndUser_Id(sessionId, user.getId());
+        RecoverySession session;
+        if (owned.isPresent()) {
+            session = owned.get();
+        } else if (recoverySessionRepository.existsById(sessionId)) {
+            throw new AccessDeniedException("Recovery session belongs to another user");
+        } else {
+            session = new RecoverySession();
+            session.setId(sessionId);
+        }
+
         session.setUser(user);
         session.setName(stringOr(payload.get("name"), "Recovery Session"));
         session.setType(stringOr(payload.get("type"), "generic"));

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/SessionRecoveryServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/SessionRecoveryServiceTest.java
@@ -1,0 +1,110 @@
+package com.sandeep.eventrabackend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.model.RecoverySession;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.RecoverySessionRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class SessionRecoveryServiceTest {
+
+    @Autowired
+    private SessionRecoveryService sessionRecoveryService;
+
+    @Autowired
+    private RecoverySessionRepository recoverySessionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User userA;
+    private User userB;
+
+    @BeforeEach
+    void setUp() {
+        recoverySessionRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userA = userRepository.save(User.builder()
+                .firstName("Alice")
+                .lastName("Owner")
+                .email("alice@example.com")
+                .username("alice")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        userB = userRepository.save(User.builder()
+                .firstName("Bob")
+                .lastName("Attacker")
+                .email("bob@example.com")
+                .username("bob")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Owner can create and update their own recovery session")
+    void ownerCanSaveOwnSession() {
+        Map<String, Object> created = sessionRecoveryService.save(userA.getEmail(), Map.of(
+                "sessionId", "owned-session",
+                "draftData", Map.of("step", 1)
+        ));
+        assertEquals("owned-session", created.get("sessionId"));
+
+        Map<String, Object> updated = sessionRecoveryService.save(userA.getEmail(), Map.of(
+                "sessionId", "owned-session",
+                "draftData", Map.of("step", 2)
+        ));
+        assertEquals("owned-session", updated.get("sessionId"));
+        assertEquals(1, recoverySessionRepository.count());
+    }
+
+    @Test
+    @DisplayName("Attacker cannot overwrite another user's recovery session by ID (#13583)")
+    void attackerCannotOverwriteForeignSession() throws Exception {
+        sessionRecoveryService.save(userA.getEmail(), Map.of(
+                "sessionId", "steal-me",
+                "draftData", Map.of("secret", true)
+        ));
+
+        AccessDeniedException denied = assertThrows(AccessDeniedException.class, () ->
+                sessionRecoveryService.save(userB.getEmail(), Map.of(
+                        "sessionId", "steal-me",
+                        "draftData", Map.of("pwned", true)
+                )));
+        assertTrue(denied.getMessage().toLowerCase().contains("another user"));
+
+        RecoverySession remaining = recoverySessionRepository.findById("steal-me").orElseThrow();
+        assertEquals(userA.getId(), remaining.getUser().getId());
+        assertEquals(Map.of("secret", true), objectMapper.readValue(remaining.getDraftData(), Map.class));
+        assertTrue(remaining.getExpiresAt().isAfter(LocalDateTime.now()));
+    }
+}


### PR DESCRIPTION
## Description

`SessionRecoveryService.save` looked up sessions with `findByIdAndUser_Id` and, on a miss, created a new entity with the **client-supplied** ID. Because `RecoverySession` uses an assigned `@Id`, Spring Data JPA `merge()`d over the existing foreign row — allowing user B to overwrite/steal user A's recovery draft.

This change owns-or-creates-or-denies: update only owned rows, create only when the ID is globally unused, otherwise `403`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13583

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Backend-only security fix. Adds `SessionRecoveryServiceTest` covering own-session update and foreign IDOR denial.

Made with [Cursor](https://cursor.com)