### PR TITLE
fix(security): block ADMIN lateral takeover of peer ADMIN accounts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -93,15 +93,8 @@ public class AdminService {
                 .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
 
         Role callerRole = getAuthenticatedRole();
-
-        if (callerRole != Role.SUPER_ADMIN) {
-            if (requestedRole == Role.SUPER_ADMIN) {
-                throw new AccessDeniedException("Only SUPER_ADMIN users can assign the SUPER_ADMIN role");
-            }
-            if (targetUser.getRole() == Role.SUPER_ADMIN) {
-                throw new AccessDeniedException("Only SUPER_ADMIN users can modify SUPER_ADMIN accounts");
-            }
-        }
+        assertCanModifyTarget(callerRole, targetUser);
+        assertCanAssignRole(callerRole, requestedRole);
 
         targetUser.setRole(requestedRole);
         return toAdminUserResponse(userRepository.save(targetUser));
@@ -113,9 +106,7 @@ public class AdminService {
                 .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
 
         Role callerRole = getAuthenticatedRole();
-        if (callerRole != Role.SUPER_ADMIN && targetUser.getRole() == Role.SUPER_ADMIN) {
-            throw new AccessDeniedException("Only SUPER_ADMIN users can modify SUPER_ADMIN accounts");
-        }
+        assertCanModifyTarget(callerRole, targetUser);
 
         if (request.getFirstName() != null) {
             targetUser.setFirstName(request.getFirstName().trim());
@@ -139,11 +130,7 @@ public class AdminService {
         }
         if (request.getRole() != null && !request.getRole().isBlank()) {
             Role requestedRole = parseRole(request.getRole());
-            if (callerRole != Role.SUPER_ADMIN) {
-                if (requestedRole == Role.SUPER_ADMIN) {
-                    throw new AccessDeniedException("Only SUPER_ADMIN users can assign the SUPER_ADMIN role");
-                }
-            }
+            assertCanAssignRole(callerRole, requestedRole);
             targetUser.setRole(requestedRole);
         }
 
@@ -164,9 +151,7 @@ public class AdminService {
         }
 
         Role callerRole = getAuthenticatedRole();
-        if (callerRole != Role.SUPER_ADMIN && targetUser.getRole() == Role.SUPER_ADMIN) {
-            throw new AccessDeniedException("Only SUPER_ADMIN users can delete SUPER_ADMIN accounts");
-        }
+        assertCanModifyTarget(callerRole, targetUser);
 
         List<Long> affectedEventIds = eventRegistrationRepository.findEventIdsByUser_Id(id);
 
@@ -483,5 +468,31 @@ public class AdminService {
             throw new AccessDeniedException("Unable to determine the authenticated user's role");
         }
         return Role.valueOf(authentication.getAuthorities().iterator().next().getAuthority());
+    }
+
+    /**
+     * Non–SUPER_ADMIN callers may not modify ADMIN or SUPER_ADMIN accounts
+     * (email/role/delete would otherwise enable peer admin takeover).
+     */
+    private void assertCanModifyTarget(Role callerRole, User targetUser) {
+        if (callerRole == Role.SUPER_ADMIN) {
+            return;
+        }
+        Role targetRole = targetUser.getRole();
+        if (targetRole == Role.SUPER_ADMIN) {
+            throw new AccessDeniedException("Only SUPER_ADMIN users can modify SUPER_ADMIN accounts");
+        }
+        if (targetRole == Role.ADMIN) {
+            throw new AccessDeniedException("Only SUPER_ADMIN users can modify ADMIN accounts");
+        }
+    }
+
+    private void assertCanAssignRole(Role callerRole, Role requestedRole) {
+        if (callerRole == Role.SUPER_ADMIN) {
+            return;
+        }
+        if (requestedRole == Role.SUPER_ADMIN || requestedRole == Role.ADMIN) {
+            throw new AccessDeniedException("Only SUPER_ADMIN users can assign ADMIN or SUPER_ADMIN roles");
+        }
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AdminPeerAdminGuardTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AdminPeerAdminGuardTests.java
@@ -1,0 +1,168 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.AdminUpdateRoleRequest;
+import com.sandeep.eventrabackend.dto.request.AdminUpdateUserRequest;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
+import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
+import com.sandeep.eventrabackend.repository.NotificationRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminPeerAdminGuardTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private EventWaitlistRepository eventWaitlistRepository;
+
+    @Autowired
+    private HackathonRegistrationRepository hackathonRegistrationRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User adminA;
+    private User adminB;
+    private User organizer;
+    private User superAdmin;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventWaitlistRepository.deleteAll();
+        hackathonRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        adminA = userRepository.save(User.builder()
+                .firstName("Admin")
+                .lastName("A")
+                .email("admin-a@example.com")
+                .username("admina")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+
+        adminB = userRepository.save(User.builder()
+                .firstName("Admin")
+                .lastName("B")
+                .email("admin-b@example.com")
+                .username("adminb")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+
+        organizer = userRepository.save(User.builder()
+                .firstName("Org")
+                .lastName("User")
+                .email("organizer@example.com")
+                .username("organizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ORGANIZER)
+                .build());
+
+        superAdmin = userRepository.save(User.builder()
+                .firstName("Super")
+                .lastName("Admin")
+                .email("superadmin@example.com")
+                .username("superadmin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.SUPER_ADMIN)
+                .build());
+    }
+
+    @Test
+    @DisplayName("ADMIN cannot change peer ADMIN email (#13584)")
+    void adminCannotChangePeerAdminEmail() throws Exception {
+        AdminUpdateUserRequest request = new AdminUpdateUserRequest();
+        request.setEmail("attacker@evil.com");
+
+        mockMvc.perform(put("/api/admin/users/" + adminB.getId())
+                        .with(user(adminA.getEmail()).authorities(() -> "ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+
+        assertEquals("admin-b@example.com", userRepository.findById(adminB.getId()).orElseThrow().getEmail());
+    }
+
+    @Test
+    @DisplayName("ADMIN cannot assign ADMIN role (#13584)")
+    void adminCannotAssignAdminRole() throws Exception {
+        AdminUpdateRoleRequest request = new AdminUpdateRoleRequest();
+        request.setRole("ADMIN");
+
+        mockMvc.perform(put("/api/admin/users/" + organizer.getId() + "/role")
+                        .with(user(adminA.getEmail()).authorities(() -> "ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+
+        assertEquals(Role.ORGANIZER, userRepository.findById(organizer.getId()).orElseThrow().getRole());
+    }
+
+    @Test
+    @DisplayName("ADMIN cannot delete peer ADMIN (#13584)")
+    void adminCannotDeletePeerAdmin() throws Exception {
+        mockMvc.perform(delete("/api/admin/users/" + adminB.getId())
+                        .with(user(adminA.getEmail()).authorities(() -> "ADMIN")))
+                .andExpect(status().isForbidden());
+
+        assertEquals(true, userRepository.existsById(adminB.getId()));
+    }
+
+    @Test
+    @DisplayName("SUPER_ADMIN can update peer ADMIN email")
+    void superAdminCanUpdateAdminEmail() throws Exception {
+        AdminUpdateUserRequest request = new AdminUpdateUserRequest();
+        request.setEmail("admin-b-new@example.com");
+
+        mockMvc.perform(put("/api/admin/users/" + adminB.getId())
+                        .with(user(superAdmin.getEmail()).authorities(() -> "SUPER_ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        assertEquals("admin-b-new@example.com", userRepository.findById(adminB.getId()).orElseThrow().getEmail());
+    }
+}


### PR DESCRIPTION
## Description

Non–`SUPER_ADMIN` callers could change a peer `ADMIN`'s email/role or delete them. That enables lateral admin account takeover (email swap) and admin minting.

Only `SUPER_ADMIN` may modify/delete `ADMIN` accounts or assign `ADMIN`/`SUPER_ADMIN` roles.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13584

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] New functionality includes tests where applicable.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Adds `AdminPeerAdminGuardTests` for email change, role assign, and delete denial paths.

Made with [Cursor](https://cursor.com)