### PR TITLE
fix(security): tighten github-proxy allowlist and rate limit

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
@@ -14,6 +14,7 @@ public class RateLimitProperties {
     private EndpointLimit signup = new EndpointLimit(3, Duration.ofMinutes(10));
     private EndpointLimit forgotPassword = new EndpointLimit(3, Duration.ofMinutes(15));
     private EndpointLimit contact = new EndpointLimit(5, Duration.ofMinutes(10));
+    private EndpointLimit githubProxy = new EndpointLimit(30, Duration.ofMinutes(1));
 
     public boolean isEnabled() {
         return enabled;
@@ -53,6 +54,14 @@ public class RateLimitProperties {
 
     public void setContact(EndpointLimit contact) {
         this.contact = contact;
+    }
+
+    public EndpointLimit getGithubProxy() {
+        return githubProxy;
+    }
+
+    public void setGithubProxy(EndpointLimit githubProxy) {
+        this.githubProxy = githubProxy;
     }
 
     public static class EndpointLimit {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class RateLimitingFilter extends OncePerRequestFilter {
 
     private static final String POST = "POST";
+    private static final String GET = "GET";
     private static final List<EndpointRule> ENDPOINT_RULES = List.of(
             new EndpointRule("login", POST, "/api/auth/login"),
             new EndpointRule("signup", POST, "/api/auth/signup"),
@@ -34,7 +35,8 @@ public class RateLimitingFilter extends OncePerRequestFilter {
             new EndpointRule("contact", POST, "/api/contact"),
             new EndpointRule("contact", POST, "/api/contact/"),
             new EndpointRule("contact", POST, "/api/contacts"),
-            new EndpointRule("contact", POST, "/api/contacts/")
+            new EndpointRule("contact", POST, "/api/contacts/"),
+            new EndpointRule("githubProxy", GET, "/api/github-proxy")
     );
 
     private final RateLimitProperties properties;
@@ -114,6 +116,7 @@ public class RateLimitingFilter extends OncePerRequestFilter {
             case "signup" -> properties.getSignup();
             case "forgotPassword" -> properties.getForgotPassword();
             case "contact" -> properties.getContact();
+            case "githubProxy" -> properties.getGithubProxy();
             default -> throw new IllegalArgumentException("Unknown rate limit endpoint: " + endpointName);
         };
     }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/GitHubProxyService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/GitHubProxyService.java
@@ -14,6 +14,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -21,13 +22,20 @@ import java.util.regex.Pattern;
 @Service
 public class GitHubProxyService {
 
-    private static final Set<String> ALLOWED_PREFIXES = Set.of(
-            "repos/",
-            "orgs/",
-            "users/"
+    /**
+     * Public Eventra surfaces only need this repo (contributors/stats) plus
+     * public user profile lookups. Broad {@code repos|orgs|users} prefixes let
+     * an unauthenticated caller abuse a shared {@code GITHUB_TOKEN}.
+     */
+    private static final Set<String> ALLOWED_REPOS = Set.of(
+            "repos/sandeepvashishtha/eventra"
     );
 
     private static final Pattern SAFE_PATH = Pattern.compile("^[A-Za-z0-9_./\\-]+$");
+    private static final Pattern USERS_PATH = Pattern.compile(
+            "^users/[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}(/[A-Za-z0-9_./\\-]*)?$",
+            Pattern.CASE_INSENSITIVE
+    );
 
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
@@ -47,8 +55,7 @@ public class GitHubProxyService {
             return ResponseEntity.badRequest().body("{\"error\":\"invalid path\"}");
         }
 
-        boolean allowed = ALLOWED_PREFIXES.stream().anyMatch(normalized::startsWith);
-        if (!allowed) {
+        if (!isAllowlisted(normalized)) {
             return ResponseEntity.status(403).body("{\"error\":\"path not allowlisted\"}");
         }
 
@@ -90,5 +97,17 @@ public class GitHubProxyService {
             Thread.currentThread().interrupt();
             return ResponseEntity.status(502).body("{\"error\":\"github upstream failed\"}");
         }
+    }
+
+    static boolean isAllowlisted(String normalizedPath) {
+        String lower = normalizedPath.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("repos/")) {
+            return ALLOWED_REPOS.stream().anyMatch(repo ->
+                    lower.equals(repo) || lower.startsWith(repo + "/"));
+        }
+        if (lower.startsWith("users/")) {
+            return USERS_PATH.matcher(normalizedPath).matches();
+        }
+        return false;
     }
 }

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -24,6 +24,9 @@ app:
     contact:
       capacity: ${RATE_LIMIT_CONTACT_CAPACITY:5}
       window: ${RATE_LIMIT_CONTACT_WINDOW:10m}
+    github-proxy:
+      capacity: ${RATE_LIMIT_GITHUB_PROXY_CAPACITY:30}
+      window: ${RATE_LIMIT_GITHUB_PROXY_WINDOW:1m}
 
 google:
   client:

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/GitHubProxyServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/GitHubProxyServiceTest.java
@@ -1,0 +1,29 @@
+package com.sandeep.eventrabackend.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GitHubProxyServiceTest {
+
+    @Test
+    @DisplayName("Allowlists Eventra repo paths and public user lookups (#13585)")
+    void allowlistsExpectedPaths() {
+        assertTrue(GitHubProxyService.isAllowlisted("repos/sandeepvashishtha/Eventra"));
+        assertTrue(GitHubProxyService.isAllowlisted("repos/SandeepVashishtha/eventra/contributors"));
+        assertTrue(GitHubProxyService.isAllowlisted("users/octocat"));
+        assertTrue(GitHubProxyService.isAllowlisted("users/octocat/repos"));
+    }
+
+    @Test
+    @DisplayName("Rejects arbitrary repos/orgs and unsafe user paths (#13585)")
+    void rejectsNonAllowlistedPaths() {
+        assertFalse(GitHubProxyService.isAllowlisted("repos/other-org/private-repo"));
+        assertFalse(GitHubProxyService.isAllowlisted("orgs/sandeepvashishtha"));
+        assertFalse(GitHubProxyService.isAllowlisted("users/../admins"));
+        assertFalse(GitHubProxyService.isAllowlisted("user/octocat"));
+        assertFalse(GitHubProxyService.isAllowlisted("gists/1"));
+    }
+}


### PR DESCRIPTION
## Description

Unauthenticated `GET /api/github-proxy` accepted any `repos|orgs|users` path and attached the shared `GITHUB_TOKEN`, enabling private-repo disclosure (scoped tokens) and quota drain.

This PR:
- Restricts `repos/` to `sandeepvashishtha/Eventra` (+ subpaths)
- Keeps public `users/{login}` lookups for the contributors UI
- Drops broad `orgs/` access
- Adds a dedicated IP rate limit for the proxy

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13585

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] New functionality includes tests where applicable.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Frontend contributor/stats paths remain supported.

Made with [Cursor](https://cursor.com)