### PR TITLE
fix(security): restrict anonymous actuator access to health only

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -128,8 +128,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(
-                                "/actuator",
-                                "/actuator/**",
                                 "/actuator/health",
                                 "/actuator/health/**"
                         ).permitAll()


### PR DESCRIPTION
## Description

`SecurityConfig` previously `permitAll`'d `/actuator/**`. Only `health` is exposed today, but widening `management.endpoints.web.exposure.include` would make sensitive actuator endpoints anonymously reachable.

Public matchers are now limited to `/actuator/health` and `/actuator/health/**`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13586

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)