### PR TITLE
fix(events): allow EventUpdateRequest dates in the past

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
@@ -31,7 +31,6 @@ public class EventUpdateRequest {
     private String location;
 
     @NotNull(message = "Event date is required")
-    @Future(message = "Event date must be in the future")
     @Schema(description = "Date and time when the event starts")
     private LocalDateTime eventDate;
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
@@ -219,7 +219,7 @@ public class EventUpdateTests {
                 .title("") // Blank title
                 .description("Description")
                 .location("Location")
-                .eventDate(LocalDateTime.now().minusDays(1)) // Past date
+                .eventDate(LocalDateTime.now().plusDays(1))
                 .capacity(-10) // Negative capacity
                 .build();
 
@@ -228,6 +228,30 @@ public class EventUpdateTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Update with past eventDate is allowed (#13587)")
+    void testUpdateWithPastEventDateAllowed() throws Exception {
+        existingEvent.setEventDate(LocalDateTime.now().minusDays(2));
+        eventRepository.save(existingEvent);
+
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Live Event Title")
+                .description("Updated Description")
+                .location("Updated Location")
+                .eventDate(LocalDateTime.now().minusDays(2))
+                .capacity(120)
+                .isPublic(true)
+                .build();
+
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
+                        .with(user("admin@example.com").authorities(() -> "ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Live Event Title"))
+                .andExpect(jsonPath("$.capacity").value(120));
     }
 
     @Test


### PR DESCRIPTION
## Description

`EventUpdateRequest.eventDate` used `@Future`, so organizers/admins could not update live or past events (title/capacity/visibility) without forging a future date.

`@Future` remains appropriate on create; updates now accept the event's real (possibly past) date.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #13587

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] New functionality includes tests where applicable.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Adds `EventUpdateTests` coverage for past `eventDate` updates.

Made with [Cursor](https://cursor.com)