### PR TITLE
fix(security): sanitize AuthPage post-login redirect path

### DIFF
--- a/src/components/auth/AuthPage.js
+++ b/src/components/auth/AuthPage.js
@@ -9,6 +9,37 @@ import useReducedMotion from "hooks/useReducedMotion";
 const LoginForm = lazy(() => import("./LoginForm"));
 const SignupForm = lazy(() => import("./SignupForm"));
 
+const AUTH_ROUTES = new Set([
+  "/login",
+  "/register",
+  "/signup",
+  "/unauthorized",
+  "/password-reset",
+]);
+
+/**
+ * Only allow same-origin relative paths. Reject schemes, protocol-relative
+ * URLs, and anything that is not a single path starting with "/".
+ */
+export function sanitizeRedirectPath(candidate, fallback = "/dashboard") {
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    return fallback;
+  }
+  const trimmed = candidate.trim();
+  if (
+    !trimmed.startsWith("/") ||
+    trimmed.startsWith("//") ||
+    trimmed.includes("\\") ||
+    /^\/[a-z][a-z0-9+.-]*:/i.test(trimmed)
+  ) {
+    return fallback;
+  }
+  if (AUTH_ROUTES.has(trimmed.split(/[?#]/, 1)[0])) {
+    return fallback;
+  }
+  return trimmed;
+}
+
 const AuthPage = () => {
   const prefersReducedMotion = useReducedMotion();
   const location = useLocation();
@@ -19,7 +50,6 @@ const AuthPage = () => {
   const sessionExpired = location.state?.sessionExpired === true;
   const from = location.state?.from;
 
-  // 🔥 FIX 1A: Derived the raw path
   const rawRedirectPath =
     typeof from === "string"
       ? from
@@ -33,14 +63,7 @@ const AuthPage = () => {
 
   useEffect(() => {
     if (isAuthenticated()) {
-      // 🔥 FIX 1B: The Infinite Redirect Guard
-      // Prevents redirecting authenticated users back into an auth-loop.
-      // Only redirect to dashboard for actual auth routes, not event registration pages
-      const authRoutes = ["/login", "/register", "/signup", "/unauthorized", "/password-reset"];
-      const isAuthRoute = authRoutes.includes(rawRedirectPath);
-      const safeRedirectPath = isAuthRoute ? "/dashboard" : rawRedirectPath;
-
-      navigate(safeRedirectPath, { replace: true });
+      navigate(sanitizeRedirectPath(rawRedirectPath), { replace: true });
     }
   }, [navigate, isAuthenticated, rawRedirectPath]);
 

--- a/src/components/auth/__tests__/AuthPage.redirect.test.js
+++ b/src/components/auth/__tests__/AuthPage.redirect.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeRedirectPath } from "../AuthPage";
+
+describe("sanitizeRedirectPath (#13601)", () => {
+  it("allows relative same-origin paths", () => {
+    expect(sanitizeRedirectPath("/dashboard")).toBe("/dashboard");
+    expect(sanitizeRedirectPath("/events/12/register?x=1#top")).toBe(
+      "/events/12/register?x=1#top",
+    );
+  });
+
+  it("rejects absolute and protocol-relative URLs", () => {
+    expect(sanitizeRedirectPath("https://phish.example/login")).toBe(
+      "/dashboard",
+    );
+    expect(sanitizeRedirectPath("//phish.example/login")).toBe("/dashboard");
+    expect(sanitizeRedirectPath("http://evil.test")).toBe("/dashboard");
+  });
+
+  it("rejects auth routes and empty values", () => {
+    expect(sanitizeRedirectPath("/login")).toBe("/dashboard");
+    expect(sanitizeRedirectPath("/signup")).toBe("/dashboard");
+    expect(sanitizeRedirectPath("")).toBe("/dashboard");
+    expect(sanitizeRedirectPath(null)).toBe("/dashboard");
+  });
+});


### PR DESCRIPTION
## Description

`AuthPage` trusted `location.state.from` with only an auth-route deny list, so absolute/`//` URLs could open-redirect authenticated users to phishing sites.

`sanitizeRedirectPath` now allows only same-origin relative paths.

## Type of Change

- [x] Bug fix
- [x] Test additions or fixes

## Related Issue

Closes #13601

## Checklist

- [x] Changes scoped to a single purpose
- [x] Tests added where applicable
- [x] Conventional commit format

## Additional Notes

@SandeepVashishtha please merge when convenient — security open-redirect fix with unit tests.

Made with [Cursor](https://cursor.com)