### PR TITLE
fix(security): restrict project thumbnail/github URLs to http(s)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/ProjectCreateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/ProjectCreateRequest.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,9 +27,19 @@ public class ProjectCreateRequest {
     @Schema(description = "Project category", example = "Web Development")
     private String category;
 
+    @Pattern(
+            regexp = "^(https?://).+",
+            flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "thumbnailUrl must be an http(s) URL"
+    )
     @Schema(description = "URL to the project's thumbnail image", example = "https://example.com/thumb.png")
     private String thumbnailUrl;
 
+    @Pattern(
+            regexp = "^(https?://).+",
+            flags = Pattern.Flag.CASE_INSENSITIVE,
+            message = "githubUrl must be an http(s) URL"
+    )
     @Schema(description = "URL to the project's GitHub repository", example = "https://github.com/user/repo")
     private String githubUrl;
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -97,6 +97,40 @@ public class ProjectControllerTests {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
+    void testCreateProject_RejectsNonHttpThumbnailUrl_Returns400() throws Exception {
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("Unsafe Project")
+                .description("Description")
+                .category("Web Development")
+                .thumbnailUrl("javascript:alert(1)")
+                .githubUrl("https://github.com/user/repo")
+                .build();
+
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void testCreateProject_RejectsDataGithubUrl_Returns400() throws Exception {
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("Unsafe Project")
+                .description("Description")
+                .category("Web Development")
+                .thumbnailUrl("https://example.com/thumb.png")
+                .githubUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")
+                .build();
+
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void testCreateProject_Unauthenticated_Returns401() throws Exception {
         ProjectCreateRequest request = ProjectCreateRequest.builder()
                 .title("New Project")


### PR DESCRIPTION
## Description

`ProjectCreateRequest` accepted arbitrary URL schemes for `thumbnailUrl`/`githubUrl` (`javascript:`, `data:`, etc.), which can later render in project cards.

Both fields now require `http://` or `https://` when present.

## Type of Change

- [x] Bug fix
- [x] Test additions or fixes

## Related Issue

Closes #13602

## Checklist

- [x] Single-purpose change
- [x] Tests added
- [x] Conventional commits

## Additional Notes

@SandeepVashishtha please merge when convenient — stored malicious URL scheme prevention.

Made with [Cursor](https://cursor.com)