### PR TITLE
fix(hackathons): allow HackathonUpdateRequest dates in the past

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/HackathonUpdateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/HackathonUpdateRequest.java
@@ -1,7 +1,6 @@
 package com.sandeep.eventrabackend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -31,12 +30,10 @@ public class HackathonUpdateRequest {
     private String organizer;
 
     @NotNull(message = "Start date is required")
-    @Future(message = "Start date must be in the future")
     @Schema(description = "Start date and time of the hackathon")
     private LocalDateTime startDate;
 
     @NotNull(message = "End date is required")
-    @Future(message = "End date must be in the future")
     @Schema(description = "End date and time of the hackathon")
     private LocalDateTime endDate;
 
@@ -52,7 +49,6 @@ public class HackathonUpdateRequest {
     private String prizePool;
 
     @NotNull(message = "Registration deadline is required")
-    @Future(message = "Registration deadline must be in the future")
     @Schema(description = "Deadline for registration")
     private LocalDateTime registrationDeadline;
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/HackathonUpdateTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/HackathonUpdateTests.java
@@ -234,7 +234,7 @@ public class HackathonUpdateTests {
                 .title("") // Blank title
                 .description("Desc")
                 .organizer("Org")
-                .startDate(LocalDateTime.now().minusDays(1)) // Past date
+                .startDate(LocalDateTime.now().plusDays(10))
                 .endDate(LocalDateTime.now().plusDays(12))
                 .location("Loc")
                 .mode("Online")
@@ -245,5 +245,33 @@ public class HackathonUpdateTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    @DisplayName("Update with past dates is allowed (#13605)")
+    void testUpdateWithPastDatesAllowed() throws Exception {
+        existingHackathon.setStartDate(LocalDateTime.now().minusDays(3));
+        existingHackathon.setEndDate(LocalDateTime.now().minusDays(1));
+        existingHackathon.setRegistrationDeadline(LocalDateTime.now().minusDays(4));
+        hackathonRepository.save(existingHackathon);
+
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("Live Hackathon Title")
+                .description("Updated Description")
+                .organizer("Updated Organizer")
+                .startDate(LocalDateTime.now().minusDays(3))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .location("Updated Location")
+                .mode("Hybrid")
+                .registrationDeadline(LocalDateTime.now().minusDays(4))
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/" + existingHackathon.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Live Hackathon Title"))
+                .andExpect(jsonPath("$.mode").value("Hybrid"));
     }
 }


### PR DESCRIPTION
## Description

`HackathonUpdateRequest` required `@Future` on start/end/registration dates, so organizers could not update live or past hackathons without forging future timestamps.

`@Future` remains on create; updates now accept the real (possibly past) dates.

## Type of Change

- [x] Bug fix
- [x] Test additions or fixes

## Related Issue

Closes #13605

## Checklist

- [x] Single-purpose change
- [x] Tests added
- [x] Conventional commits

## Additional Notes

@SandeepVashishtha please merge when convenient — same class of fix as EventUpdateRequest `#13587`/`#13594`.

Made with [Cursor](https://cursor.com)