### PR TITLE
feat: add fomo badges for low ticket inventory

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -4,7 +4,7 @@ import LazyImage from "components/common/LazyImage";
 import { formatLocalDateTime } from "utils/localDateTime";
 import ShareModal from "components/common/ShareModal";
 import StatusBadge from "components/common/StatusBadge";
-import { getEventStatus } from "utils/eventUtils";
+import { getEventStatus, getFomoStatus } from "utils/eventUtils";
 import SocialShareButtons from "components/common/SocialShareButtons";
 import AddToCalendar from "components/common/AddToCalendar";
 import { useMyEvents } from "context/MyEventsContext";
@@ -15,6 +15,7 @@ import { BookmarkCheck, Bookmark, MapPin, Calendar, Clock, ArrowRight } from "lu
 
 import { isEventBookmarked, addBookmarkedEvent, removeBookmarkedEvent } from "utils/bookmarkUtils";
 import SeatsRemaining from "components/common/SeatsRemaining";
+import SellingFastBadge from "components/common/SellingFastBadge";
 import useEventAvailability from "hooks/useEventAvailability";
 
 const EventCard = ({ event, position }) => {
@@ -32,6 +33,11 @@ const EventCard = ({ event, position }) => {
 
   const isUserRegistered = isRegistered(event.id);
   const computedStatus = getEventStatus(event);
+
+  // Calculate FOMO status for low inventory
+  const capacity = availability?.capacity ?? event.capacity;
+  const registeredCount = availability?.registeredCount ?? event.registeredCount ?? event.attendees?.length ?? 0;
+  const { isLowInventory, message: fomoMessage } = getFomoStatus(capacity, registeredCount);
 
   const eventImage = event.image || event.imageUrl || null;
   const eventDate = event.date || event.eventDate || event.startDate || null;
@@ -94,6 +100,9 @@ const EventCard = ({ event, position }) => {
             <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider bg-emerald-500/90 text-white shadow-md">
               Registered
             </span>
+          )}
+          {isLowInventory && fomoMessage && (
+            <SellingFastBadge message={fomoMessage} />
           )}
         </div>
 

--- a/src/Pages/Events/EventCard.test.js
+++ b/src/Pages/Events/EventCard.test.js
@@ -36,6 +36,7 @@ jest.mock('utils/conflictDetection', () => ({
 
 jest.mock('utils/eventUtils', () => ({
   getEventStatus: jest.fn().mockReturnValue('upcoming'),
+  getFomoStatus: jest.fn().mockReturnValue({ isLowInventory: false, message: null }),
 }));
 
 jest.mock('context/MyEventsContext', () => ({
@@ -47,6 +48,7 @@ jest.mock('components/common/ShareMenu', () =>
 );
 
 jest.mock('components/common/StatusBadge', () => () => null);
+jest.mock('components/common/SellingFastBadge', () => () => null);
 
 jest.mock('components/reminders/ReminderControls', () => () => null);
 
@@ -208,6 +210,37 @@ describe('EventCard', () => {
       expect(
         screen.getByRole('button', { name: /copy link for GSSoC Hackathon 2027/i })
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('FOMO badge', () => {
+    const SellingFastBadge = require('components/common/SellingFastBadge').default;
+
+    beforeEach(() => {
+      // Mock the SellingFastBadge to render its message
+      SellingFastBadge.mockImplementation(({ message }) => (
+        <span data-testid="fomo-badge">{message}</span>
+      ));
+    });
+
+    it('shows "Selling Fast!" badge when inventory is low', () => {
+      getFomoStatus.mockReturnValue({ isLowInventory: true, message: "Selling Fast!" });
+      renderCard({ capacity: 100, registeredCount: 85 }); // 15 remaining (< 10% of 100 = 10, so should be low)
+      expect(screen.getByTestId('fomo-badge')).toBeInTheDocument();
+      expect(screen.getByText('Selling Fast!')).toBeInTheDocument();
+    });
+
+    it('shows "Only X Tickets Left!" badge when very few tickets remain', () => {
+      getFomoStatus.mockReturnValue({ isLowInventory: true, message: "Only 3 Tickets Left!" });
+      renderCard({ capacity: 50, registeredCount: 47 }); // 3 remaining
+      expect(screen.getByTestId('fomo-badge')).toBeInTheDocument();
+      expect(screen.getByText('Only 3 Tickets Left!')).toBeInTheDocument();
+    });
+
+    it('does not show FOMO badge when inventory is sufficient', () => {
+      getFomoStatus.mockReturnValue({ isLowInventory: false, message: null });
+      renderCard({ capacity: 100, registeredCount: 50 }); // 50 remaining (> 10% of 100)
+      expect(screen.queryByTestId('fomo-badge')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/common/SeatsRemaining.jsx
+++ b/src/components/common/SeatsRemaining.jsx
@@ -28,7 +28,8 @@ export function toneFor(capacity, registeredCount) {
   if (capacity == null) return "available";
   const remaining = capacity - registeredCount;
   if (remaining <= 0) return "full";
-  if (remaining <= Math.max(5, Math.ceil(capacity * 0.1))) return "low";
+  // Use 20 tickets threshold to match FOMO badge logic (10% of capacity OR < 20 tickets)
+  if (remaining <= Math.max(20, Math.ceil(capacity * 0.1))) return "low";
   return "available";
 }
 

--- a/src/components/common/SellingFastBadge.jsx
+++ b/src/components/common/SellingFastBadge.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+/**
+ * SellingFastBadge - A pulsing red badge that displays FOMO messages
+ * for events with low ticket inventory.
+ * 
+ * @param {Object} props
+ * @param {string} props.message - The FOMO message to display (e.g., "Selling Fast!" or "Only 5 Tickets Left!")
+ * @param {string} [props.className] - Additional CSS classes
+ * @returns {JSX.Element}
+ */
+const SellingFastBadge = ({ message, className = "" }) => {
+  return (
+    <motion.span
+      className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-bold uppercase tracking-wider text-white shadow-lg ${className}`}
+      initial={{ scale: 1 }}
+      animate={{ 
+        scale: [1, 1.05, 1],
+        boxShadow: [
+          "0 0 0 0 rgba(248, 113, 113, 0.4)",
+          "0 0 0 8px rgba(248, 113, 113, 0)",
+          "0 0 0 0 rgba(248, 113, 113, 0.4)"
+        ]
+      }}
+      transition={{ 
+        duration: 2,
+        repeat: Infinity,
+        ease: "easeInOut"
+      }}
+      style={{
+        background: "linear-gradient(45deg, #ef4444, #dc2626)",
+        backgroundSize: "200% 200%"
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      <motion.span
+        className="mr-1"
+        animate={{ opacity: [0.7, 1, 0.7] }}
+        transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
+      >
+        ⚡
+      </motion.span>
+      {message}
+    </motion.span>
+  );
+};
+
+export default React.memo(SellingFastBadge);

--- a/src/components/common/SellingFastBadge.test.jsx
+++ b/src/components/common/SellingFastBadge.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SellingFastBadge from './SellingFastBadge';
+
+describe('SellingFastBadge', () => {
+  it('renders with the provided message', () => {
+    render(<SellingFastBadge message="Selling Fast!" />);
+    expect(screen.getByText('Selling Fast!')).toBeInTheDocument();
+  });
+
+  it('renders with custom message', () => {
+    render(<SellingFastBadge message="Only 5 Tickets Left!" />);
+    expect(screen.getByText('Only 5 Tickets Left!')).toBeInTheDocument();
+  });
+
+  it('includes lightning emoji', () => {
+    render(<SellingFastBadge message="Selling Fast!" />);
+    expect(screen.getByText('⚡')).toBeInTheDocument();
+  });
+
+  it('applies additional className', () => {
+    render(<SellingFastBadge message="Test" className="custom-class" />);
+    const badge = screen.getByText('Test');
+    expect(badge).toHaveClass('custom-class');
+  });
+
+  it('has appropriate accessibility attributes', () => {
+    render(<SellingFastBadge message="Selling Fast!" />);
+    const badge = screen.getByText('Selling Fast!');
+    expect(badge.parentElement).toHaveAttribute('role', 'status');
+    expect(badge.parentElement).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -92,6 +92,34 @@ export const isEventRegistrationClosed = (eventOrStatus) => {
   return status === "past" || status === "ended" || status === "cancelled";
 };
 
+/**
+ * Check if an event has low inventory and should show FOMO badge.
+ * FOMO (Fear Of Missing Out) is triggered when remaining tickets drop below 10% 
+ * of capacity OR below 20 absolute tickets.
+ * 
+ * @param {number} capacity - Total event capacity
+ * @param {number} registeredCount - Number of registered participants
+ * @returns {Object} Object containing isLowInventory boolean and message string
+ */
+export const getFomoStatus = (capacity, registeredCount) => {
+  if (capacity == null || capacity <= 0) return { isLowInventory: false, message: null };
+  
+  const remaining = capacity - (registeredCount ?? 0);
+  if (remaining <= 0) return { isLowInventory: false, message: null }; // Event is full, not "selling fast"
+  
+  const lowThreshold = Math.max(20, Math.ceil(capacity * 0.1));
+  const isLowInventory = remaining <= lowThreshold;
+  
+  if (!isLowInventory) return { isLowInventory: false, message: null };
+  
+  // Generate appropriate FOMO message
+  if (remaining <= 5) {
+    return { isLowInventory: true, message: `Only ${remaining} Tickets Left!` };
+  } else {
+    return { isLowInventory: true, message: "Selling Fast!" };
+  }
+};
+
 export const normalizeEvent = (event) => {
   if (!event) return event;
   const mapped = {

--- a/src/utils/eventUtils.test.js
+++ b/src/utils/eventUtils.test.js
@@ -2,7 +2,7 @@ jest.mock("./timeSync", () => ({
   getServerTime: jest.fn(),
 }));
 
-import { getEventStatus, isEventRegistrationClosed } from "./eventUtils";
+import { getEventStatus, isEventRegistrationClosed, getFomoStatus } from "./eventUtils";
 import { getServerTime } from "./timeSync";
 
 describe("event status utilities", () => {
@@ -41,5 +41,75 @@ describe("event status utilities", () => {
   it("keeps registration open for upcoming and live events", () => {
     expect(isEventRegistrationClosed("upcoming")).toBe(false);
     expect(isEventRegistrationClosed("live")).toBe(false);
+  });
+});
+
+describe("getFomoStatus", () => {
+  describe("low inventory detection", () => {
+    it("returns false for null capacity", () => {
+      const result = getFomoStatus(null, 10);
+      expect(result.isLowInventory).toBe(false);
+      expect(result.message).toBeNull();
+    });
+
+    it("returns false for zero capacity", () => {
+      const result = getFomoStatus(0, 0);
+      expect(result.isLowInventory).toBe(false);
+      expect(result.message).toBeNull();
+    });
+
+    it("returns false when event is full", () => {
+      const result = getFomoStatus(50, 50);
+      expect(result.isLowInventory).toBe(false);
+      expect(result.message).toBeNull();
+    });
+
+    it("returns false when more than 10% capacity remains and more than 20 tickets", () => {
+      const result = getFomoStatus(100, 50); // 50 remaining
+      expect(result.isLowInventory).toBe(false);
+      expect(result.message).toBeNull();
+    });
+
+    it("returns true with 'Selling Fast!' when at 10% threshold for large events", () => {
+      const result = getFomoStatus(200, 180); // 20 remaining (exactly 10%)
+      expect(result.isLowInventory).toBe(true);
+      expect(result.message).toBe("Selling Fast!");
+    });
+
+    it("returns true with 'Selling Fast!' when below 20 tickets threshold", () => {
+      const result = getFomoStatus(1000, 985); // 15 remaining (< 20)
+      expect(result.isLowInventory).toBe(true);
+      expect(result.message).toBe("Selling Fast!");
+    });
+
+    it("returns true with 'Only X Tickets Left!' when 5 or fewer tickets remain", () => {
+      const result = getFomoStatus(50, 47); // 3 remaining
+      expect(result.isLowInventory).toBe(true);
+      expect(result.message).toBe("Only 3 Tickets Left!");
+    });
+
+    it("returns true with 'Only 1 Tickets Left!' when 1 ticket remains", () => {
+      const result = getFomoStatus(25, 24); // 1 remaining
+      expect(result.isLowInventory).toBe(true);
+      expect(result.message).toBe("Only 1 Tickets Left!");
+    });
+
+    it("handles small events with < 20 capacity correctly", () => {
+      const result = getFomoStatus(15, 10); // 5 remaining
+      expect(result.isLowInventory).toBe(true);
+      expect(result.message).toBe("Only 5 Tickets Left!");
+    });
+
+    it("uses 20 tickets as minimum threshold for larger events", () => {
+      // For 300 capacity, 10% would be 30, but we use max(20, 30) = 30
+      const result1 = getFomoStatus(300, 275); // 25 remaining (< 30)
+      expect(result1.isLowInventory).toBe(true);
+      expect(result1.message).toBe("Selling Fast!");
+
+      // For 150 capacity, 10% would be 15, but we use max(20, 15) = 20
+      const result2 = getFomoStatus(150, 135); // 15 remaining (< 20)
+      expect(result2.isLowInventory).toBe(true);
+      expect(result2.message).toBe("Selling Fast!");
+    });
   });
 });


### PR DESCRIPTION
Closes #12156

## Summary

Implemented automatic **"Selling Fast!" FOMO badges** for events with low ticket inventory. The badge uses real-time availability data to surface urgency to users and dynamically updates as inventory changes.

## What Changed

* Added a reusable `SellingFastBadge` component with:

  * Pulsing scale animation and glow effect using Framer Motion
  * Red gradient styling with lightning icon
  * Accessibility support via `role="status"` and `aria-live="polite"`
* Added `getFomoStatus()` utility to centralize low-inventory detection:

  * Triggers when remaining tickets are **<10% of capacity OR <20 tickets**
  * Shows **"Selling Fast!"** when 6–20 tickets remain
  * Shows **"Only X Tickets Left!"** when ≤5 tickets remain
* Integrated the badge into `EventCard` using existing real-time SSE availability updates.
* Updated `SeatsRemaining` to use the same **20-ticket threshold** for consistent inventory messaging.
* Added and updated unit tests covering:

  * FOMO status calculation and thresholds
  * Badge rendering and messaging
  * Event card FOMO badge integration

## Feature Behavior

* **Automatic:** No manual configuration or toggle is required.
* **Real-time:** Badge visibility and messaging respond to live ticket availability updates.
* **Dynamic messaging:** Urgency increases as inventory gets lower.
* **Consistent:** FOMO badge and seat availability indicator use the same low-inventory thresholds.
* **Accessible:** Status updates are exposed to assistive technologies.

## Testing

Added comprehensive unit test coverage for the new FOMO utility and badge, and updated `EventCard` tests to cover the new integration.
