### PR TITLE
feat: add get object type helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/abs-number.test.js
+++ b/src/eventra-kit/__tests__/abs-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AbsNumber from '../abs-number.js';
+
+describe('abs-number', () => {
+  it('exports a module', () => {
+    expect(AbsNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/append-string.test.js
+++ b/src/eventra-kit/__tests__/append-string.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AppendString from '../append-string.js';
+
+describe('append-string', () => {
+  it('exports a module', () => {
+    expect(AppendString).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/array-fill.test.js
+++ b/src/eventra-kit/__tests__/array-fill.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ArrayFill from '../array-fill.js';
+
+describe('array-fill', () => {
+  it('exports a module', () => {
+    expect(ArrayFill).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/array-intersect.test.js
+++ b/src/eventra-kit/__tests__/array-intersect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ArrayIntersect from '../array-intersect.js';
+
+describe('array-intersect', () => {
+  it('exports a module', () => {
+    expect(ArrayIntersect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/array-of-size.test.js
+++ b/src/eventra-kit/__tests__/array-of-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ArrayOfSize from '../array-of-size.js';
+
+describe('array-of-size', () => {
+  it('exports a module', () => {
+    expect(ArrayOfSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/array-subtract.test.js
+++ b/src/eventra-kit/__tests__/array-subtract.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ArraySubtract from '../array-subtract.js';
+
+describe('array-subtract', () => {
+  it('exports a module', () => {
+    expect(ArraySubtract).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/array-without.test.js
+++ b/src/eventra-kit/__tests__/array-without.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ArrayWithout from '../array-without.js';
+
+describe('array-without', () => {
+  it('exports a module', () => {
+    expect(ArrayWithout).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-round.test.js
+++ b/src/eventra-kit/__tests__/average-round.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageRound from '../average-round.js';
+
+describe('average-round', () => {
+  it('exports a module', () => {
+    expect(AverageRound).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/bounded-percent.test.js
+++ b/src/eventra-kit/__tests__/bounded-percent.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BoundedPercent from '../bounded-percent.js';
+
+describe('bounded-percent', () => {
+  it('exports a module', () => {
+    expect(BoundedPercent).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/case-insensitive-compare.test.js
+++ b/src/eventra-kit/__tests__/case-insensitive-compare.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CaseInsensitiveCompare from '../case-insensitive-compare.js';
+
+describe('case-insensitive-compare', () => {
+  it('exports a module', () => {
+    expect(CaseInsensitiveCompare).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ceil-number.test.js
+++ b/src/eventra-kit/__tests__/ceil-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CeilNumber from '../ceil-number.js';
+
+describe('ceil-number', () => {
+  it('exports a module', () => {
+    expect(CeilNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/choice-weighted.test.js
+++ b/src/eventra-kit/__tests__/choice-weighted.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChoiceWeighted from '../choice-weighted.js';
+
+describe('choice-weighted', () => {
+  it('exports a module', () => {
+    expect(ChoiceWeighted).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compare-numbers.test.js
+++ b/src/eventra-kit/__tests__/compare-numbers.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CompareNumbers from '../compare-numbers.js';
+
+describe('compare-numbers', () => {
+  it('exports a module', () => {
+    expect(CompareNumbers).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compare-values.test.js
+++ b/src/eventra-kit/__tests__/compare-values.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CompareValues from '../compare-values.js';
+
+describe('compare-values', () => {
+  it('exports a module', () => {
+    expect(CompareValues).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/cos-degrees.test.js
+++ b/src/eventra-kit/__tests__/cos-degrees.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CosDegrees from '../cos-degrees.js';
+
+describe('cos-degrees', () => {
+  it('exports a module', () => {
+    expect(CosDegrees).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-object-keys.test.js
+++ b/src/eventra-kit/__tests__/count-object-keys.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountObjectKeys from '../count-object-keys.js';
+
+describe('count-object-keys', () => {
+  it('exports a module', () => {
+    expect(CountObjectKeys).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/cube-value.test.js
+++ b/src/eventra-kit/__tests__/cube-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CubeValue from '../cube-value.js';
+
+describe('cube-value', () => {
+  it('exports a module', () => {
+    expect(CubeValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deep-clone-object.test.js
+++ b/src/eventra-kit/__tests__/deep-clone-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeepCloneObject from '../deep-clone-object.js';
+
+describe('deep-clone-object', () => {
+  it('exports a module', () => {
+    expect(DeepCloneObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deep-equal.test.js
+++ b/src/eventra-kit/__tests__/deep-equal.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeepEqual from '../deep-equal.js';
+
+describe('deep-equal', () => {
+  it('exports a module', () => {
+    expect(DeepEqual).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/exp-value.test.js
+++ b/src/eventra-kit/__tests__/exp-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExpValue from '../exp-value.js';
+
+describe('exp-value', () => {
+  it('exports a module', () => {
+    expect(ExpValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/filter-object.test.js
+++ b/src/eventra-kit/__tests__/filter-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as FilterObject from '../filter-object.js';
+
+describe('filter-object', () => {
+  it('exports a module', () => {
+    expect(FilterObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/find-all-indexes.test.js
+++ b/src/eventra-kit/__tests__/find-all-indexes.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as FindAllIndexes from '../find-all-indexes.js';
+
+describe('find-all-indexes', () => {
+  it('exports a module', () => {
+    expect(FindAllIndexes).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/first-item.test.js
+++ b/src/eventra-kit/__tests__/first-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as FirstItem from '../first-item.js';
+
+describe('first-item', () => {
+  it('exports a module', () => {
+    expect(FirstItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/flatten-object.test.js
+++ b/src/eventra-kit/__tests__/flatten-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as FlattenObject from '../flatten-object.js';
+
+describe('flatten-object', () => {
+  it('exports a module', () => {
+    expect(FlattenObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/floor-number.test.js
+++ b/src/eventra-kit/__tests__/floor-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as FloorNumber from '../floor-number.js';
+
+describe('floor-number', () => {
+  it('exports a module', () => {
+    expect(FloorNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/get-object-type.test.js
+++ b/src/eventra-kit/__tests__/get-object-type.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as GetObjectType from '../get-object-type.js';
+
+describe('get-object-type', () => {
+  it('exports a module', () => {
+    expect(GetObjectType).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/abs-number.js
+++ b/src/eventra-kit/abs-number.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds an absolute helper.
+ */
+export function absNumber(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/append-string.js
+++ b/src/eventra-kit/append-string.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a string appender.
+ */
+export function appendString(text, suffix) {
+  return text + suffix;
+}
+

--- a/src/eventra-kit/array-fill.js
+++ b/src/eventra-kit/array-fill.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds an array fill helper.
+ */
+export function arrayFill(length, value) {
+  return Array.from({ length }, () => value);
+}
+

--- a/src/eventra-kit/array-intersect.js
+++ b/src/eventra-kit/array-intersect.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds an intersect helper.
+ */
+export function arrayIntersect(first, second) {
+  return first.filter((item) => second.includes(item));
+}
+

--- a/src/eventra-kit/array-of-size.js
+++ b/src/eventra-kit/array-of-size.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds an array of size helper.
+ */
+export function arrayOfSize(length, fn) {
+  return Array.from({ length }, (_, i) => (fn ? fn(i) : i));
+}
+

--- a/src/eventra-kit/array-subtract.js
+++ b/src/eventra-kit/array-subtract.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a subtract helper.
+ */
+export function arraySubtract(first, second) {
+  return first.filter((item) => !second.includes(item));
+}
+

--- a/src/eventra-kit/array-without.js
+++ b/src/eventra-kit/array-without.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a without helper.
+ */
+export function arrayWithout(array, ...excluded) {
+  return array.filter((item) => !excluded.includes(item));
+}
+

--- a/src/eventra-kit/average-round.js
+++ b/src/eventra-kit/average-round.js
@@ -1,0 +1,11 @@
+
+/**
+ * adds a rounded average helper.
+ */
+export function averageRound(array, decimals = 0) {
+  if (array.length === 0) return 0;
+  const avg = array.reduce((a, b) => a + b, 0) / array.length;
+  const factor = 10 ** decimals;
+  return Math.round(avg * factor) / factor;
+}
+

--- a/src/eventra-kit/bounded-percent.js
+++ b/src/eventra-kit/bounded-percent.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a bounded percent helper.
+ */
+export function boundedPercent(value) {
+  return Math.min(100, Math.max(0, value));
+}
+

--- a/src/eventra-kit/case-insensitive-compare.js
+++ b/src/eventra-kit/case-insensitive-compare.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a case-insensitive comparator.
+ */
+export function caseInsensitiveCompare(a, b) {
+  return String(a).toLowerCase().localeCompare(String(b).toLowerCase());
+}
+

--- a/src/eventra-kit/ceil-number.js
+++ b/src/eventra-kit/ceil-number.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a ceil helper.
+ */
+export function ceilNumber(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/choice-weighted.js
+++ b/src/eventra-kit/choice-weighted.js
@@ -1,0 +1,14 @@
+
+/**
+ * adds a weighted choice helper.
+ */
+export function choiceWeighted(items, weights) {
+  const total = weights.reduce((a, b) => a + b, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < items.length; i++) {
+    r -= weights[i];
+    if (r <= 0) return items[i];
+  }
+  return items[items.length - 1];
+}
+

--- a/src/eventra-kit/compare-numbers.js
+++ b/src/eventra-kit/compare-numbers.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a number comparator.
+ */
+export function compareNumbers(a, b) {
+  return a - b;
+}
+

--- a/src/eventra-kit/compare-values.js
+++ b/src/eventra-kit/compare-values.js
@@ -1,0 +1,10 @@
+
+/**
+ * adds a value comparator.
+ */
+export function compareValues(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+

--- a/src/eventra-kit/cos-degrees.js
+++ b/src/eventra-kit/cos-degrees.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a cosine helper.
+ */
+export function cosDegrees(degrees) {
+  return Math.cos((degrees * Math.PI) / 180);
+}
+

--- a/src/eventra-kit/count-object-keys.js
+++ b/src/eventra-kit/count-object-keys.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a key counter.
+ */
+export function countObjectKeys(object) {
+  return Object.keys(object).length;
+}
+

--- a/src/eventra-kit/cube-value.js
+++ b/src/eventra-kit/cube-value.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a cube helper.
+ */
+export function cubeValue(value) {
+  return value * value * value;
+}
+

--- a/src/eventra-kit/deep-clone-object.js
+++ b/src/eventra-kit/deep-clone-object.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a deep clone helper.
+ */
+export function deepCloneObject(object) {
+  return object === undefined ? undefined : JSON.parse(JSON.stringify(object));
+}
+

--- a/src/eventra-kit/deep-equal.js
+++ b/src/eventra-kit/deep-equal.js
@@ -1,0 +1,13 @@
+
+/**
+ * adds a deep equality helper.
+ */
+export function deepEqual(first, second) {
+  if (first === second) return true;
+  if (typeof first !== 'object' || typeof second !== 'object' || first === null || second === null) return false;
+  const aKeys = Object.keys(first);
+  const bKeys = Object.keys(second);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((key) => deepEqual(first[key], second[key]));
+}
+

--- a/src/eventra-kit/exp-value.js
+++ b/src/eventra-kit/exp-value.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds an exponential helper.
+ */
+export function expValue(value) {
+  return Math.exp(value);
+}
+

--- a/src/eventra-kit/filter-object.js
+++ b/src/eventra-kit/filter-object.js
@@ -1,0 +1,10 @@
+
+/**
+ * adds an object filter.
+ */
+export function filterObject(object, predicate) {
+  const out = {};
+  for (const key in object) if (predicate(object[key], key)) out[key] = object[key];
+  return out;
+}
+

--- a/src/eventra-kit/find-all-indexes.js
+++ b/src/eventra-kit/find-all-indexes.js
@@ -1,0 +1,10 @@
+
+/**
+ * adds an index finder helper.
+ */
+export function findAllIndexes(array, predicate) {
+  const out = [];
+  for (let i = 0; i < array.length; i++) if (predicate(array[i])) out.push(i);
+  return out;
+}
+

--- a/src/eventra-kit/first-item.js
+++ b/src/eventra-kit/first-item.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a first item helper.
+ */
+export function firstItem(array) {
+  return array[0];
+}
+

--- a/src/eventra-kit/flatten-object.js
+++ b/src/eventra-kit/flatten-object.js
@@ -1,0 +1,17 @@
+
+/**
+ * adds an object flattener.
+ */
+export function flattenObject(object, prefix = '') {
+  const out = {};
+  for (const key in object) {
+    const flatKey = prefix ? `${prefix}.${key}` : key;
+    if (object[key] && typeof object[key] === 'object' && !Array.isArray(object[key])) {
+      Object.assign(out, flattenObject(object[key], flatKey));
+    } else {
+      out[flatKey] = object[key];
+    }
+  }
+  return out;
+}
+

--- a/src/eventra-kit/floor-number.js
+++ b/src/eventra-kit/floor-number.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a floor helper.
+ */
+export function floorNumber(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/get-object-type.js
+++ b/src/eventra-kit/get-object-type.js
@@ -1,0 +1,8 @@
+
+/**
+ * adds a type helper.
+ */
+export function getObjectType(value) {
+  return Object.prototype.toString.call(value).slice(8, -1).toLowerCase();
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated src/eventra-kit/ module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New src/eventra-kit/get-object-type.js module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] 
pm run lint passes for the new file

## Checklist
- [x] Diff is contained entirely inside src/eventra-kit/
- [x] No legacy files touched
- [x] Small, focused change