### PR TITLE
feat: Add color-coded event category badges with multi-select support

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventCreateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventCreateRequest.java
@@ -46,9 +46,11 @@ public class EventCreateRequest {
     @Schema(description = "Optional URL to the event's banner or thumbnail image (link only)", example = "https://example.com/images/event-banner.jpg")
     private String imageUrl;
 
-    @NotBlank(message = "Category is required")
-    @Schema(description = "Event category for filtering and discovery", example = "Tech")
+    @Schema(description = "Event category for filtering and discovery (kept for backward compatibility)", example = "Tech")
     private String category;
+
+    @Schema(description = "Multiple categories for the event to enable better discovery and filtering (up to 3)", example = "Tech,Music,Food")
+    private Set<String> categories;
 
     @Schema(description = "Optional tags for the event to enable granular filtering and search", example = "AI,Conference,2026")
     private Set<String> tags;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
@@ -45,8 +45,11 @@ public class EventUpdateRequest {
     @Schema(description = "Optional URL to the event's banner or thumbnail image (link only)", example = "https://example.com/images/event-banner.jpg")
     private String imageUrl;
 
-    @Schema(description = "Event category for filtering and discovery", example = "Tech")
+    @Schema(description = "Event category for filtering and discovery (kept for backward compatibility)", example = "Tech")
     private String category;
+
+    @Schema(description = "Multiple categories for the event to enable better discovery and filtering (up to 3)", example = "Tech,Music,Food")
+    private Set<String> categories;
 
     @Schema(description = "Optional tags for the event to enable granular filtering and search", example = "AI,Conference,2026")
     private Set<String> tags;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
@@ -51,6 +51,9 @@ public class EventResponse {
     @Schema(description = "Event category for filtering and discovery", example = "Tech")
     private String category;
 
+    @Schema(description = "Multiple categories for the event to enable better discovery and filtering", example = "Tech,Music,Food")
+    private Set<String> categories;
+
     @Schema(description = "Tags for the event to enable granular filtering and search", example = "AI,Conference,2026")
     private Set<String> tags;
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -58,6 +58,15 @@ public class Event {
     private String category;
 
     /**
+     * Multiple categories for the event to enable better discovery and filtering.
+     * Organizers can select up to 3 predefined categories.
+     */
+    @ElementCollection
+    @CollectionTable(name = "event_categories", joinColumns = @JoinColumn(name = "event_id"))
+    @Column(name = "category")
+    private Set<String> categories = new HashSet<>();
+
+    /**
      * Tags for the event to enable granular filtering and search.
      */
     @ElementCollection
@@ -243,6 +252,24 @@ public class Event {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    public Set<String> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(Set<String> categories) {
+        this.categories = categories;
+    }
+
+    public void addCategory(String category) {
+        if (this.categories.size() < 3) {
+            this.categories.add(category);
+        }
+    }
+
+    public void removeCategory(String category) {
+        this.categories.remove(category);
     }
 
     public Set<String> getTags() {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -486,6 +486,9 @@ public class EventService {
                 event.setCapacity(request.getCapacity());
                 event.setImageUrl(request.getImageUrl());
                 event.setCategory(request.getCategory());
+                if (request.getCategories() != null) {
+                    event.setCategories(new HashSet<>(request.getCategories()));
+                }
                 if (request.getTags() != null) {
                         event.setTags(new HashSet<>(request.getTags()));
                 }
@@ -545,6 +548,9 @@ public class EventService {
                 }
                 if (request.getCategory() != null) {
                         event.setCategory(request.getCategory());
+                }
+                if (request.getCategories() != null) {
+                    event.setCategories(new HashSet<>(request.getCategories()));
                 }
                 if (request.getTags() != null) {
                         event.setTags(new HashSet<>(request.getTags()));
@@ -1145,6 +1151,7 @@ public class EventService {
                                 .imageUrl(event.getImageUrl())
                                 .ownerId(event.getOwnerId())
                                 .category(event.getCategory())
+                                .categories(event.getCategories())
                                 .tags(event.getTags())
                                 .status(event.getStatus())
                                 .cancellationReason(event.getCancellationReason())

--- a/src/Pages/EventRecommendation/EventRecommendation.jsx
+++ b/src/Pages/EventRecommendation/EventRecommendation.jsx
@@ -43,7 +43,7 @@ const EventRecommendation = () => {
             : event.price > 500
               ? "Advanced"
               : "Intermediate"),
-        tag: event.tags?.[0] || event.category,
+        tag: event.tags?.[0] || (event.categories && event.categories.length > 0 ? event.categories[0] : event.category),
       })),
     [],
   );
@@ -104,7 +104,7 @@ const EventRecommendation = () => {
         limit: events.length,
       }).map((event) => {
         const selectedBoost =
-          (interest && event.category === interest ? interestWeight : 0) +
+          (interest && ((event.categories && event.categories.includes(interest)) || event.category === interest) ? interestWeight : 0) +
           (level && event.level === level ? levelWeight : 0) +
           (eventType && event.type === eventType.toLowerCase() ? typeWeight : 0);
         const boost = Math.round(selectedBoost / 10);

--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -13,6 +13,7 @@ import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { toast } from "react-toastify";
 import { BookmarkCheck, Bookmark, MapPin, Calendar, Clock, ArrowRight } from "lucide-react";
+import { categories, getCategoryByValue } from "constants/eventDefaults";
 
 import { isEventBookmarked, addBookmarkedEvent, removeBookmarkedEvent } from "utils/bookmarkUtils";
 import SeatsRemaining from "components/common/SeatsRemaining";
@@ -94,9 +95,28 @@ const EventCard = ({ event, position }) => {
 
         {/* Overlay badges */}
         <div className="absolute top-4 left-4 flex flex-wrap gap-2">
-          <span className="inline-flex items-center px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider bg-black/40 backdrop-blur-md text-white border border-white/10">
-            {event.type || event.category || "Event"}
-          </span>
+          {/* Color-coded category badges */}
+          {event.categories && Array.isArray(event.categories) && event.categories.length > 0 ? (
+            event.categories.slice(0, 3).map((catValue) => {
+              const category = getCategoryByValue(catValue);
+              return category ? (
+                <span
+                  key={catValue}
+                  className={`inline-flex items-center px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider text-white shadow-md ${category.color}`}
+                  style={{ boxShadow: '0 2px 8px rgba(0,0,0,0.3)' }}
+                >
+                  {category.label}
+                </span>
+              ) : null;
+            })
+          ) : (
+            // Fallback for backward compatibility - single category
+            (event.category || event.type) && (
+              <span className="inline-flex items-center px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider bg-black/40 backdrop-blur-md text-white border border-white/10">
+                {event.category || event.type}
+              </span>
+            )
+          )}
           {isUserRegistered && (
             <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider bg-emerald-500/90 text-white shadow-md">
               Registered

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -275,7 +275,8 @@ const EventDetails = () => {
     return {
       title: sourceEvent.title ? `Copy of ${sourceEvent.title}` : "",
       description: sourceEvent.description || "",
-      category: sourceEvent.category || "",
+      categories: sourceEvent.categories && sourceEvent.categories.length > 0 ? sourceEvent.categories : [],
+      category: sourceEvent.category || sourceEvent.categories?.[0] || "",
       isMultiDay,
       date: isMultiDay ? "" : parsedStartDate,
       startDate: isMultiDay ? parsedStartDate : "",
@@ -905,7 +906,7 @@ ${window.location.href}
           </div>
 
           <div className="mt-12">
-            <EventRecommendations currentEventId={event.id} currentCategory={event.category} />
+            <EventRecommendations currentEventId={event.id} currentCategory={event.category || event.categories?.[0]} />
           </div>
 
           {/* Similar Events — multi-signal recommendation section (#7754)

--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -253,15 +253,19 @@ const useEventListing = () => {
       filtered = filtered.filter((event) => {
         const cat = event.category?.toLowerCase() || "";
         const type = event.type?.toLowerCase() || "";
+        const categories = event.categories || [];
 
         // Normalize for fuzzy matching (strip non-alphanumerics)
         const norm = (s) => s.replace(/[^a-z0-9]+/g, "");
         const nTarget = norm(target);
         const nCat = norm(cat);
         const nType = norm(type);
+        
+        // Check if any category in categories array matches
+        const nCategories = categories.map(c => norm(c.toLowerCase()));
 
         // Exact category match takes priority (backend enum values)
-        if (nCat === nTarget) return true;
+        if (nCat === nTarget || nCategories.includes(nTarget)) return true;
 
         // Legacy / fuzzy fallback for older event data
         if (target === "hackathon" || target === "hackathons") {

--- a/src/components/EventCreation.jsx
+++ b/src/components/EventCreation.jsx
@@ -270,10 +270,26 @@ const EventCreation = () => {
                       No banner uploaded
                     </div>
                   )}
-                  <div className="absolute top-4 left-4">
-                    <span className="px-4 py-1.5 bg-indigo-600 text-white text-sm font-bold rounded-full shadow-lg">
-                      {formData.category ? categories.find(c => (c.id === formData.category || c.value === formData.category))?.label : "General"}
-                    </span>
+                  <div className="absolute top-4 left-4 flex flex-wrap gap-2">
+                    {formData.categories && formData.categories.length > 0 ? (
+                      formData.categories.slice(0, 3).map((catId) => {
+                        const category = categories.find(c => c.id === catId || c.value === catId);
+                        return category ? (
+                          <span
+                            key={catId}
+                            className={`px-3 py-1 text-white text-sm font-bold rounded-full shadow-lg ${category.color}`}
+                          >
+                            {category.label}
+                          </span>
+                        ) : null;
+                      })
+                    ) : (
+                      formData.category && (
+                        <span className="px-4 py-1.5 bg-indigo-600 text-white text-sm font-bold rounded-full shadow-lg">
+                          {categories.find(c => (c.id === formData.category || c.value === formData.category))?.label || "General"}
+                        </span>
+                      )
+                    )}
                   </div>
                 </div>
 

--- a/src/components/SearchFilter.js
+++ b/src/components/SearchFilter.js
@@ -114,7 +114,9 @@ const SearchFilter = () => {
       event.description.toLowerCase().includes(term);
 
     const matchesCategory =
-      selectedCategory === "all" || event.category === selectedCategory;
+      selectedCategory === "all" ||
+      event.category === selectedCategory ||
+      (event.categories && event.categories.includes(selectedCategory));
 
     const normalizedLocation = event.location
       .toLowerCase()

--- a/src/components/common/EventCreation/EventBasicInfo.jsx
+++ b/src/components/common/EventCreation/EventBasicInfo.jsx
@@ -52,26 +52,40 @@ const EventBasicInfo = ({ formData, handleInputChange, handleFieldBlur, errors }
         </div>
       </FormField>
 
-      <FormField label="Category" icon={Tag} error={errors.category} required>
+      <FormField label="Categories" icon={Tag} error={errors.categories} required>
         <select
-          name="category"
-          value={formData.category}
-          onChange={handleInputChange}
+          name="categories"
+          value={formData.categories || []}
+          onChange={(e) => {
+            const selectedOptions = Array.from(e.target.selectedOptions, option => option.value);
+            if (selectedOptions.length <= 3) {
+              handleInputChange({
+                target: {
+                  name: "categories",
+                  value: selectedOptions
+                }
+              });
+            }
+          }}
           onBlur={handleFieldBlur}
+          multiple
+          size={4}
           className={`w-full border rounded-lg p-3 bg-white dark:bg-gray-700
                    text-gray-900 dark:text-gray-100 focus:outline-none
                    focus:ring-2 focus:ring-indigo-500 focus:border-transparent
                    transition-all duration-200 ${
-                     errors.category ? "border-red-500" : "border-gray-300 dark:border-gray-600"
+                     errors.categories ? "border-red-500" : "border-gray-300 dark:border-gray-600"
                    }`}
         >
-          <option value="">Select a category</option>
           {categories.map((cat) => (
             <option key={cat.id} value={cat.id}>
               {cat.label}
             </option>
           ))}
         </select>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+          Hold Ctrl/Cmd to select multiple categories (max 3)
+        </p>
       </FormField>
 
       <FormField label="Description" icon={FileText} error={errors.description} required>

--- a/src/components/events/OrganizerEventCard.js
+++ b/src/components/events/OrganizerEventCard.js
@@ -7,6 +7,7 @@ import {
   formatOrganizerEventDate,
   getOrganizerEventStatus,
 } from "../../utils/organizerProfileUtils";
+import { getCategoryByValue } from "constants/eventDefaults";
 
 const OrganizerEventCard = ({ event }) => {
   if (!event) return null;
@@ -22,6 +23,12 @@ const OrganizerEventCard = ({ event }) => {
     event.type ||
     event.category ||
     "Event";
+
+  const categoriesArray = event.categories && Array.isArray(event.categories) && event.categories.length > 0
+    ? event.categories
+    : eventType
+      ? [eventType]
+      : [];
 
   const eventDate =
     event.date ||
@@ -53,9 +60,30 @@ const OrganizerEventCard = ({ event }) => {
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
-          <span className="inline-flex rounded-full bg-indigo-100 px-2.5 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
-            {eventType}
-          </span>
+          <div className="flex flex-wrap gap-1.5">
+            {categoriesArray.slice(0, 3).map((catValue, index) => {
+              const category = getCategoryByValue(catValue);
+              if (category) {
+                return (
+                  <span
+                    key={catValue}
+                    className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold text-white ${category.color}`}
+                  >
+                    {category.label}
+                  </span>
+                );
+              }
+              // Fallback for non-matching categories
+              return (
+                <span
+                  key={catValue}
+                  className="inline-flex rounded-full bg-indigo-100 px-2.5 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300"
+                >
+                  {catValue}
+                </span>
+              );
+            })}
+          </div>
 
           <h3 className="mt-3 line-clamp-2 text-lg font-bold text-slate-800 dark:text-white">
             {eventName}

--- a/src/components/events/RecommendationCard.js
+++ b/src/components/events/RecommendationCard.js
@@ -1,5 +1,6 @@
 import { Calendar, MapPin, Tag, Star, ArrowRight } from "lucide-react";
 import { Link } from "react-router-dom";
+import { getCategoryByValue } from "constants/eventDefaults";
 
 const RecommendationCard = ({
   event,
@@ -59,11 +60,28 @@ const RecommendationCard = ({
             </div>
           )}
 
-          {event.category && (
-            <div className="flex items-center gap-2">
-              <Tag size={15} />
-              {event.category}
+          {event.categories && Array.isArray(event.categories) && event.categories.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {event.categories.slice(0, 3).map((catValue) => {
+                const category = getCategoryByValue(catValue);
+                return category ? (
+                  <span
+                    key={catValue}
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold text-white ${category.color}`}
+                  >
+                    <Tag size={12} />
+                    {category.label}
+                  </span>
+                ) : null;
+              })}
             </div>
+          ) : (
+            event.category && (
+              <div className="flex items-center gap-2">
+                <Tag size={15} />
+                {event.category}
+              </div>
+            )
           )}
 
         </div>

--- a/src/components/user/EventCard.jsx
+++ b/src/components/user/EventCard.jsx
@@ -17,6 +17,7 @@ import { useReducedMotion } from "hooks/useReducedMotion";
 import { useOfflineStatus } from "hooks/useOfflineStatus";
 import StatusBadge from "../common/StatusBadge";
 import LazyImage from "../common/LazyImage";
+import { getCategoryByValue } from "constants/eventDefaults";
 
 // Helper functions
 const getEventStatus = (event) => {
@@ -142,7 +143,26 @@ const EventCard = memo(({
       <div className="px-6 py-5 grid grid-cols-2 gap-4 text-sm">
         <div><MapPin size={14} /> {event?.location || "—"}</div>
         <div><Clock size={14} /> {event?.time || "—"}</div>
-        <div><Tag size={14} /> {event?.type || "—"}</div>
+        <div>
+          <Tag size={14} className="inline" /> 
+          {event?.categories && Array.isArray(event.categories) && event.categories.length > 0 ? (
+            <span className="inline-flex flex-wrap gap-1">
+              {event.categories.slice(0, 2).map((catValue) => {
+                const category = getCategoryByValue(catValue);
+                return category ? (
+                  <span
+                    key={catValue}
+                    className={`px-2 py-0.5 text-white text-xs font-semibold rounded ${category.color}`}
+                  >
+                    {category.label}
+                  </span>
+                ) : null;
+              })}
+            </span>
+          ) : (
+            event?.type || event?.category || "—"
+          )}
+        </div>
         <div><Calendar size={14} /> {shortDate}</div>
       </div>
 

--- a/src/constants/eventDefaults.js
+++ b/src/constants/eventDefaults.js
@@ -3,17 +3,31 @@ export const DUPLICATED_DRAFT_KEY = "eventra_duplicate_event_draft";
 export const CREATION_STEPS = { FORM: "form", PREVIEW: "preview" };
 
 export const categories = [
-  { label: "Conference", value: "CONFERENCE" },
-  { label: "Workshop", value: "WORKSHOP" },
-  { label: "Meetup", value: "MEETUP" },
-  { label: "Webinar", value: "WEBINAR" },
-  { label: "Social", value: "SOCIAL" },
-  { label: "Sports", value: "SPORTS" },
-  { label: "Cultural", value: "CULTURAL" },
-  { label: "Business", value: "BUSINESS" },
-  { label: "Charity", value: "CHARITY" },
-  { label: "Other", value: "OTHER" },
+  { id: "CONFERENCE", label: "Conference", value: "CONFERENCE", color: "bg-blue-500" },
+  { id: "WORKSHOP", label: "Workshop", value: "WORKSHOP", color: "bg-green-500" },
+  { id: "MEETUP", label: "Meetup", value: "MEETUP", color: "bg-purple-500" },
+  { id: "WEBINAR", label: "Webinar", value: "WEBINAR", color: "bg-indigo-500" },
+  { id: "SOCIAL", label: "Social", value: "SOCIAL", color: "bg-pink-500" },
+  { id: "SPORTS", label: "Sports", value: "SPORTS", color: "bg-orange-500" },
+  { id: "CULTURAL", label: "Cultural", value: "CULTURAL", color: "bg-teal-500" },
+  { id: "BUSINESS", label: "Business", value: "BUSINESS", color: "bg-emerald-500" },
+  { id: "CHARITY", label: "Charity", value: "CHARITY", color: "bg-rose-500" },
+  { id: "TECH", label: "Tech", value: "TECH", color: "bg-blue-600" },
+  { id: "MUSIC", label: "Music", value: "MUSIC", color: "bg-pink-600" },
+  { id: "FOOD", label: "Food", value: "FOOD", color: "bg-red-500" },
+  { id: "OTHER", label: "Other", value: "OTHER", color: "bg-gray-500" },
 ];
+
+// Helper function to get category by value
+export const getCategoryByValue = (value) => {
+  return categories.find(cat => cat.value === value || cat.id === value);
+};
+
+// Helper function to get color for a category value
+export const getCategoryColor = (categoryValue) => {
+  const category = getCategoryByValue(categoryValue);
+  return category ? category.color : "bg-gray-500";
+};
 
 export const mockAttendees = [
   {
@@ -41,7 +55,8 @@ export const mockAttendees = [
 export const getInitialFormData = () => ({
   title: "",
   description: "",
-  category: "",
+  categories: [],
+  category: "", // Backward compatibility - keep single category field
   isMultiDay: false,
   date: "",
   startDate: "",

--- a/src/hooks/useAdvancedEventSearch.js
+++ b/src/hooks/useAdvancedEventSearch.js
@@ -147,12 +147,14 @@ export default function useAdvancedEventSearch(events = [], { debounceMs = 250 }
         }
 
         // Category filter
-        if (
-          filters.categories.length > 0 &&
-          !filters.categories.includes(event.category) &&
-          !filters.categories.includes(event.type)
-        ) {
-          return false;
+        if (filters.categories.length > 0) {
+          const hasMatchingCategory = 
+            (event.category && filters.categories.includes(event.category)) ||
+            (event.type && filters.categories.includes(event.type)) ||
+            (event.categories && event.categories.some(cat => filters.categories.includes(cat)));
+          if (!hasMatchingCategory) {
+            return false;
+          }
         }
 
         // Status filter

--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -303,6 +303,16 @@ export const useEventForm = () => {
     formDataRef.current = formData;
   }, [formData]);
 
+  // Sync category field with categories for backward compatibility
+  useEffect(() => {
+    if (formData.categories && formData.categories.length > 0 && formData.category !== formData.categories[0]) {
+      setFormData(prev => ({
+        ...prev,
+        category: prev.categories[0]
+      }));
+    }
+  }, [formData.categories, formData.category, setFormData]);
+
   const resetForm = useCallback(() => {
     setFormData(getInitialFormData());
     setErrors({});
@@ -316,10 +326,18 @@ export const useEventForm = () => {
     error: submitError,
     success: submitSuccess
   } = useFormSubmit(async (eventData) => {
-    const sanitized = {
+    // Ensure backward compatibility - sync category with categories
+    const dataWithCompatibility = {
       ...eventData,
+      category: eventData.categories && eventData.categories.length > 0 
+        ? eventData.categories[0] 
+        : eventData.category || "",
+      categories: eventData.categories || [],
       description: sanitizeHtml(eventData.description || ""),
     };
+    
+    const sanitized = dataWithCompatibility;
+    
     if (!API_ENDPOINTS.EVENTS.CREATE) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
       return { id: "mock-event-id", success: true };
@@ -366,7 +384,18 @@ export const useEventForm = () => {
     }
 
     if (!data.description?.trim()) newErrors.description = "Event description is required";
-    if (!data.category) newErrors.category = "Please select a category";
+    
+    // Validate categories (new multi-select field)
+    if (!data.categories || data.categories.length === 0) {
+      newErrors.categories = "Please select at least one category";
+    } else if (data.categories.length > 3) {
+      newErrors.categories = "You can select a maximum of 3 categories";
+    }
+    
+    // Backward compatibility - keep category field in sync
+    if (data.categories && data.categories.length > 0 && !data.category) {
+      newErrors.category = "Please select a category";
+    }
 
     if (data.isMultiDay) {
       if (!data.startDate) {

--- a/src/utils/advancedFilterUtils.js
+++ b/src/utils/advancedFilterUtils.js
@@ -145,6 +145,7 @@ export const filterByCategory = (events, selectedCategories) => {
   return events.filter((event) => {
     if (!event) return false;
     const eventCategory = normalizeFilterValue(event.category);
+    const eventCategories = event.categories || [];
     return selectedCategories.some((cat) => {
       const mappedCategory = EVENT_CATEGORIES.find(
         (category) =>
@@ -153,10 +154,12 @@ export const filterByCategory = (events, selectedCategories) => {
             normalizeFilterValue(category.label) === normalizeFilterValue(cat)),
       );
 
+      const normalizedCat = normalizeFilterValue(cat);
       return (
-        eventCategory === normalizeFilterValue(cat) ||
+        eventCategory === normalizedCat ||
         eventCategory === normalizeFilterValue(mappedCategory?.id) ||
-        eventCategory === normalizeFilterValue(mappedCategory?.label)
+        eventCategory === normalizeFilterValue(mappedCategory?.label) ||
+        eventCategories.some(ec => normalizeFilterValue(ec) === normalizedCat)
       );
     });
   });
@@ -349,7 +352,13 @@ export const applyAdvancedFilters = (events, filters = {}) => {
 export const getUniqueCategories = (events) => {
   const categories = new Set();
   events.forEach((event) => {
-    // Fallback to event.type if event.category is missing
+    // Add all categories from the categories array
+    if (event.categories && Array.isArray(event.categories)) {
+      event.categories.forEach(cat => {
+        if (cat) categories.add(cat);
+      });
+    }
+    // Fallback to event.category or event.type if categories array is missing
     const categoryValue = event.category || event.type;
     if (categoryValue) {
       categories.add(categoryValue);

--- a/src/utils/eventCategoryFilterUtils.js
+++ b/src/utils/eventCategoryFilterUtils.js
@@ -15,6 +15,11 @@ export const EVENT_CATEGORIES = [
 export const getEventCategory = (event) => {
   if (!event) return "";
 
+  // Return the first category from categories array if available
+  if (event.categories && Array.isArray(event.categories) && event.categories.length > 0) {
+    return event.categories[0];
+  }
+
   return (
     event.category ||
     event.eventCategory ||
@@ -49,7 +54,12 @@ export const filterEventsByCategory = (
       .trim()
       .toLowerCase();
 
-    return eventCategory === selectedCategory;
+    // Also check if the event has the category in its categories array
+    const hasCategoryInArray = event.categories && 
+      Array.isArray(event.categories) && 
+      event.categories.some(cat => cat.trim().toLowerCase() === selectedCategory);
+
+    return eventCategory === selectedCategory || hasCategoryInArray;
   });
 };
 
@@ -68,12 +78,17 @@ export const isEventInCategory = (
     return true;
   }
 
-  return (
-    getEventCategory(event)
-      .trim()
-      .toLowerCase() ===
-    category.trim().toLowerCase()
-  );
+  const normalizedCategory = category.trim().toLowerCase();
+  const eventCategory = getEventCategory(event)
+    .trim()
+    .toLowerCase();
+
+  // Also check if the event has the category in its categories array
+  const hasCategoryInArray = event.categories && 
+    Array.isArray(event.categories) && 
+    event.categories.some(cat => cat.trim().toLowerCase() === normalizedCategory);
+
+  return eventCategory === normalizedCategory || hasCategoryInArray;
 };
 
 /**
@@ -98,6 +113,15 @@ export const getAvailableCategories = (
   const categories = events
     .map(getEventCategory)
     .filter(Boolean);
+
+  // Also add categories from the categories array
+  events.forEach(event => {
+    if (event.categories && Array.isArray(event.categories)) {
+      event.categories.forEach(cat => {
+        if (cat) categories.push(cat);
+      });
+    }
+  });
 
   const normalizedCategories = new Map();
 

--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -28,7 +28,12 @@ const getEventId = (event) => {
 
 const unwrapEvent = (entry) => entry?.event || entry?.eventSummary || entry || {};
 
-const getEventCategory = (event) => normalizeText(event?.category || event?.type);
+const getEventCategory = (event) => {
+  if (event?.categories && Array.isArray(event.categories) && event.categories.length > 0) {
+    return normalizeText(event.categories[0]);
+  }
+  return normalizeText(event?.category || event?.type);
+};
 
 const getEventType = (event) => normalizeText(event?.type);
 


### PR DESCRIPTION
## Feature request #12140: Color-coded Event Category Badges

- Allows organizers to select up to 3 predefined categories
- Displays as color-coded pill badges on event cover images
- Blue for Tech, Pink for Music, etc.
- Add color codes to existing categories in eventDefaults.js
- Update EventBasicInfo.jsx to support multi-select for up to 3 categories
- Update useEventForm.js to handle categories as array with backward compatibility
- Update EventCard.js to render multiple color-coded category badges
- Update EventCreation.jsx preview to show multiple categories
- Update user/EventCard.jsx, OrganizerEventCard.js, RecommendationCard.js
- Update filtering utilities to handle categories array
- Update backend: Event model, DTOs, and service to support categories
