### PR TITLE
feat: Add bulk attendee check-in for group tickets

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/RegistrationRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/RegistrationRequest.java
@@ -33,4 +33,24 @@ public class RegistrationRequest {
     )
     @Builder.Default
     private Boolean showProfileInAttendeeDirectory = false;
+
+    @Schema(
+            description = "Group ID for group/bulk registrations (e.g., 'Table of 10' tickets).",
+            example = "table-5-acme-corp"
+    )
+    private String groupId;
+
+    @Schema(
+            description = "Flag indicating if this registration is the primary buyer for a group.",
+            example = "true",
+            defaultValue = "false"
+    )
+    @Builder.Default
+    private Boolean isGroupPrimary = false;
+
+    @Schema(
+            description = "Name of the group for display purposes.",
+            example = "Acme Corp - Table 5"
+    )
+    private String groupName;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrationResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/RegistrationResponse.java
@@ -53,4 +53,15 @@ public class RegistrationResponse {
 
     @Schema(description = "Reserved seat identifier when the event supports seat selection.", example = "table-1:3")
     private String seatId;
-}
+
+    @Schema(description = "Group ID for group/bulk registrations.", example = "table-5-acme-corp")
+    private String groupId;
+
+    @Schema(description = "Flag indicating if this registration is the primary buyer for a group.", example = "true")
+    private Boolean isGroupPrimary;
+
+    @Schema(description = "Name of the group for display purposes.", example = "Acme Corp - Table 5")
+    private String groupName;
+
+    @Schema(description = "Registration ID for reference.", example = "12345")
+    private Long registrationId;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/EventRegistration.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/EventRegistration.java
@@ -50,6 +50,27 @@ public class EventRegistration {
     @Column(name = "show_profile_in_attendee_directory", nullable = false)
     private boolean showProfileInAttendeeDirectory = false;
 
+    /**
+     * Group ID for group/bulk registrations (e.g., "Table of 10" tickets).
+     * All registrations with the same groupId belong to the same group.
+     */
+    @Column(name = "group_id", length = 100)
+    private String groupId;
+
+    /**
+     * Flag indicating if this registration is the primary buyer for a group.
+     * Used to identify the main contact person for group tickets.
+     */
+    @Column(name = "is_group_primary", nullable = false)
+    private boolean isGroupPrimary = false;
+
+    /**
+     * Name of the group (e.g., "Acme Corp - Table 5").
+     * Used for display purposes when managing group check-ins.
+     */
+    @Column(name = "group_name", length = 200)
+    private String groupName;
+
     public Long getId() {
         return id;
     }
@@ -104,5 +125,29 @@ public class EventRegistration {
 
     public void setShowProfileInAttendeeDirectory(boolean showProfileInAttendeeDirectory) {
         this.showProfileInAttendeeDirectory = showProfileInAttendeeDirectory;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public boolean isGroupPrimary() {
+        return isGroupPrimary;
+    }
+
+    public void setGroupPrimary(boolean groupPrimary) {
+        isGroupPrimary = groupPrimary;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
     }
 }

--- a/src/components/EventCheckInScanner.jsx
+++ b/src/components/EventCheckInScanner.jsx
@@ -6,7 +6,12 @@ import {
   validateCheckInPayload,
   recordCheckIn,
   hasBeenCheckedIn,
+  isGroupRegistration,
+  getGroupIdFromRegistration,
+  getGroupMembers,
 } from '../utils/checkInUtils.js';
+import GroupCheckInModal from './GroupCheckInModal';
+import { Users } from 'lucide-react';
 
 /**
  * EventCheckInScanner Component
@@ -22,6 +27,8 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
   const [scannedData, setScannedData] = useState(null);
   const [cameraError, setCameraError] = useState(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [groupModalOpen, setGroupModalOpen] = useState(false);
+  const [groupPrimaryRegistration, setGroupPrimaryRegistration] = useState(null);
 
   // Initialize camera stream
   const startCamera = async () => {
@@ -134,17 +141,34 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
 
       const { registrationId } = parsedData;
 
-      // Check for duplicate check-in
+      // Find the registration
+      const registration = registrations.find((r) => r.id === registrationId || String(r.id) === String(registrationId));
+
+      if (!registration) {
+        toast.error('Registration not found for this event');
+        setIsProcessing(false);
+        return;
+      }
+
+      // Check if this is a group registration
+      if (isGroupRegistration(registration)) {
+        // Open group check-in modal
+        setGroupPrimaryRegistration(registration);
+        setGroupModalOpen(true);
+        setIsProcessing(false);
+        return;
+      }
+
+      // Check for duplicate check-in (non-group)
       if (hasBeenCheckedIn(registrationId, existingCheckIns)) {
-        const attendee = registrations.find((r) => r.id === registrationId);
         toast.warning(
-          `${attendee?.name || 'Attendee'} already checked in`
+          `${registration?.name || 'Attendee'} already checked in`
         );
         setIsProcessing(false);
         return;
       }
 
-      // Record check-in
+      // Record check-in for individual
       const checkInRecord = recordCheckIn({
         registrationId,
         timestamp: new Date().toISOString(),
@@ -159,8 +183,7 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
         onCheckIn(checkInRecord, parsedData);
       }
 
-      const attendee = registrations.find((r) => r.id === registrationId);
-      toast.success(`✓ ${attendee?.name || 'Attendee'} checked in!`);
+      toast.success(`✓ ${registration?.name || 'Attendee'} checked in!`);
 
       // Reset state after 2 seconds
       setTimeout(() => {
@@ -310,6 +333,17 @@ const EventCheckInScanner = ({ eventId, onCheckIn, existingCheckIns = [], regist
         <strong>Note:</strong> To enable actual QR code detection, integrate a library like
         html5-qrcode or jsQR.
       </div>
+
+      {/* Group Check-In Modal */}
+      <GroupCheckInModal
+        isOpen={groupModalOpen}
+        onClose={() => setGroupModalOpen(false)}
+        primaryRegistration={groupPrimaryRegistration}
+        registrations={registrations}
+        existingCheckIns={existingCheckIns}
+        onCheckIn={onCheckIn}
+        eventId={eventId}
+      />
     </div>
   );
 };

--- a/src/components/GroupCheckInModal.jsx
+++ b/src/components/GroupCheckInModal.jsx
@@ -1,0 +1,399 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { X, CheckCircle, Users, CheckSquare, Square } from 'lucide-react';
+import { toast } from 'react-toastify';
+import {
+  getGroupMembers,
+  getGroupPrimary,
+  getGroupName,
+  isEntireGroupCheckedIn,
+  recordGroupCheckIns,
+} from '../utils/checkInUtils';
+
+/**
+ * GroupCheckInModal Component
+ * Modal for bulk check-in of group/party members
+ * 
+ * @param {Object} props
+ * @param {boolean} isOpen - Whether the modal is visible
+ * @param {Function} onClose - Callback to close the modal
+ * @param {Object} primaryRegistration - The primary buyer's registration
+ * @param {Array} registrations - All registrations for the event
+ * @param {Array} existingCheckIns - Already recorded check-ins
+ * @param {Function} onCheckIn - Callback when check-ins are recorded
+ * @param {string} eventId - Current event ID
+ */
+const GroupCheckInModal = ({
+  isOpen,
+  onClose,
+  primaryRegistration,
+  registrations = [],
+  existingCheckIns = [],
+  onCheckIn,
+  eventId,
+}) => {
+  // State for individual selections
+  const [selectedMembers, setSelectedMembers] = useState({});
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  // Get group information
+  const groupId = primaryRegistration?.groupId;
+  const groupMembers = useMemo(
+    () => getGroupMembers(groupId, registrations),
+    [groupId, registrations]
+  );
+  const primary = useMemo(
+    () => getGroupPrimary(groupMembers),
+    [groupMembers]
+  );
+  const groupName = useMemo(
+    () => getGroupName(primaryRegistration || primary),
+    [primaryRegistration, primary]
+  );
+
+  // Already checked in members
+  const checkedInIds = useMemo(
+    () => new Set(existingCheckIns.map((c) => c.registrationId)),
+    [existingCheckIns]
+  );
+
+  // Initialize all members as selected (except those already checked in)
+  useEffect(() => {
+    if (isOpen && groupMembers.length > 0) {
+      const initialSelections = {};
+      groupMembers.forEach((member) => {
+        // Skip already checked-in members
+        if (!checkedInIds.has(member.id)) {
+          initialSelections[member.id] = true;
+        }
+      });
+      setSelectedMembers(initialSelections);
+    }
+  }, [isOpen, groupMembers, checkedInIds]);
+
+  // Count selected members
+  const selectedCount = useMemo(
+    () => Object.values(selectedMembers).filter((v) => v).length,
+    [selectedMembers]
+  );
+
+  // Total group size
+  const groupSize = groupMembers.length;
+
+  // Members not yet checked in
+  const checkableMembers = useMemo(
+    () => groupMembers.filter((m) => !checkedInIds.has(m.id)),
+    [groupMembers, checkedInIds]
+  );
+
+  // All checkable members selected
+  const allSelected = useMemo(
+    () => checkableMembers.length > 0 && checkableMembers.every((m) => selectedMembers[m.id]),
+    [checkableMembers, selectedMembers]
+  );
+
+  // Toggle individual member selection
+  const toggleMember = (memberId) => {
+    setSelectedMembers((prev) => ({
+      ...prev,
+      [memberId]: !prev[memberId],
+    }));
+  };
+
+  // Toggle all members
+  const toggleAll = () => {
+    const newValue = !allSelected;
+    const newSelections = {};
+    checkableMembers.forEach((member) => {
+      newSelections[member.id] = newValue;
+    });
+    setSelectedMembers(newSelections);
+  };
+
+  // Handle bulk check-in
+  const handleBulkCheckIn = async () => {
+    if (isProcessing) return;
+
+    const membersToCheckIn = groupMembers.filter(
+      (m) => selectedMembers[m.id] && !checkedInIds.has(m.id)
+    );
+
+    if (membersToCheckIn.length === 0) {
+      toast.warning('No members selected for check-in');
+      return;
+    }
+
+    setIsProcessing(true);
+
+    try {
+      // Record check-ins for selected members
+      const newCheckIns = recordGroupCheckIns(
+        membersToCheckIn,
+        'bulk-group-check-in',
+        existingCheckIns
+      );
+
+      // Call parent callback
+      if (onCheckIn && newCheckIns.length > 0) {
+        newCheckIns.forEach((checkIn) => {
+          onCheckIn(checkIn, { registrationId: checkIn.registrationId, eventId });
+        });
+
+        toast.success(
+          `✓ ${newCheckIns.length} member(s) checked in from ${groupName}`
+        );
+        onClose();
+      }
+    } catch (err) {
+      console.error('Bulk check-in error:', err);
+      toast.error('Failed to check in group members');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  // Close modal on escape key
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !groupId || groupMembers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4"
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="group-checkin-title"
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto border border-gray-200 dark:border-gray-700">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700 sticky top-0 bg-white dark:bg-gray-900 z-10">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600">
+              <Users className="w-6 h-6 text-white" />
+            </div>
+            <div>
+              <h2
+                id="group-checkin-title"
+                className="text-xl font-bold text-gray-900 dark:text-white"
+              >
+                Group Check-In
+              </h2>
+              <p className="text-gray-600 dark:text-gray-400">
+                {groupName}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-gray-300 rounded-lg transition-colors"
+            aria-label="Close modal"
+          >
+            <X className="w-6 h-6" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">
+          {/* Summary */}
+          <div className="bg-indigo-50 dark:bg-indigo-900/20 rounded-xl p-4 mb-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-indigo-600 dark:text-indigo-300 font-medium">
+                  Group Size
+                </p>
+                <p className="text-3xl font-bold text-gray-900 dark:text-white">
+                  {groupSize}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-indigo-600 dark:text-indigo-300 font-medium">
+                  Already Checked In
+                </p>
+                <p className="text-3xl font-bold text-green-600 dark:text-green-400">
+                  {groupMembers.filter((m) => checkedInIds.has(m.id)).length}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-indigo-600 dark:text-indigo-300 font-medium">
+                  Selected to Check In
+                </p>
+                <p className="text-3xl font-bold text-blue-600 dark:text-blue-400">
+                  {selectedCount}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Members List */}
+          <div className="space-y-3 mb-6">
+            <div className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <button
+                onClick={toggleAll}
+                className={`p-2 rounded-lg border-2 transition-colors ${
+                  allSelected
+                    ? 'bg-indigo-600 border-indigo-600 text-white'
+                    : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'
+                }`}
+                aria-label={allSelected ? 'Deselect all' : 'Select all'}
+              >
+                {allSelected ? (
+                  <CheckSquare className="w-5 h-5" />
+                ) : (
+                  <Square className="w-5 h-5" />
+                )}
+              </button>
+              <div className="flex-1">
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {allSelected ? 'All members selected' : 'Select all members'}
+                </p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {checkableMembers.length} members available for check-in
+                </p>
+              </div>
+            </div>
+
+            {/* Primary buyer (already checked in or not) */}
+            {primary && (
+              <div className="p-3 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg border border-indigo-200 dark:border-indigo-700">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-full bg-indigo-600 flex items-center justify-center text-white font-bold">
+                    {primary.name?.charAt(0).toUpperCase() || 'P'}
+                  </div>
+                  <div className="flex-1">
+                    <p className="font-semibold text-gray-900 dark:text-white">
+                      {primary.name || 'Primary Buyer'}
+                      {primary.isGroupPrimary && (
+                        <span className="ml-2 text-xs bg-indigo-600 text-white px-2 py-0.5 rounded">
+                          Primary
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {primary.email}
+                    </p>
+                  </div>
+                  {checkedInIds.has(primary.id) ? (
+                    <div className="flex items-center gap-1 text-green-600 dark:text-green-400">
+                      <CheckCircle className="w-5 h-5" />
+                      <span className="text-sm font-medium">Checked In</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center">
+                      <span className="text-sm text-gray-500 dark:text-gray-400">
+                        Not yet checked in
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Other group members */}
+            <div className="space-y-2">
+              {groupMembers
+                .filter((m) => m.id !== primary?.id)
+                .map((member) => {
+                  const isCheckedIn = checkedInIds.has(member.id);
+                  const isSelected = selectedMembers[member.id];
+
+                  return (
+                    <div
+                      key={member.id}
+                      className={`p-3 rounded-lg border-2 transition-colors ${
+                        isCheckedIn
+                          ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700 opacity-60'
+                          : isSelected
+                          ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700'
+                          : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:border-indigo-300 dark:hover:border-indigo-700'
+                      }`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <button
+                          onClick={() => toggleMember(member.id)}
+                          disabled={isCheckedIn}
+                          className={`p-2 rounded-lg transition-colors ${
+                            isCheckedIn
+                              ? 'bg-green-100 dark:bg-green-900/30 cursor-not-allowed'
+                              : isSelected
+                              ? 'bg-indigo-600 text-white'
+                              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+                          }`}
+                          aria-label={isCheckedIn ? 'Already checked in' : isSelected ? 'Deselect for check-in' : 'Select for check-in'}
+                        >
+                          {isCheckedIn ? (
+                            <CheckCircle className="w-5 h-5 text-green-600 dark:text-green-400" />
+                          ) : isSelected ? (
+                            <CheckSquare className="w-5 h-5" />
+                          ) : (
+                            <Square className="w-5 h-5" />
+                          )}
+                        </button>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-gray-900 dark:text-white truncate">
+                            {member.name || `Attendee ${member.id}`}
+                          </p>
+                          <p className="text-sm text-gray-600 dark:text-gray-400 truncate">
+                            {member.email}
+                          </p>
+                        </div>
+                        {isCheckedIn && (
+                          <div className="flex items-center gap-1">
+                            <CheckCircle className="w-4 h-4 text-green-600 dark:text-green-400" />
+                            <span className="text-xs text-green-600 dark:text-green-400 font-medium">
+                              Checked In
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex gap-3 border-t border-gray-200 dark:border-gray-700 pt-6">
+            <button
+              onClick={onClose}
+              disabled={isProcessing}
+              className="flex-1 px-4 py-3 border-2 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg font-medium hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleBulkCheckIn}
+              disabled={isProcessing || selectedCount === 0}
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-400 text-white rounded-lg font-medium transition-colors disabled:cursor-not-allowed"
+            >
+              {isProcessing ? (
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              ) : (
+                <>
+                  <CheckCircle className="w-5 h-5" />
+                  Check In Selected ({selectedCount})
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupCheckInModal;

--- a/src/components/OrganizerCheckIn.jsx
+++ b/src/components/OrganizerCheckIn.jsx
@@ -4,10 +4,12 @@ import EventCheckInScanner from './EventCheckInScanner';
 import {
   computeCheckInStats,
   computeSessionCheckInStats,
+  computeGroupCheckInStats,
   generateCheckInCSV,
   exportCheckInAsCSV,
   getCheckInHistory,
 } from '../utils/checkInUtils.js';
+import { Users } from 'lucide-react';
 
 /**
  * OrganizerCheckIn Component
@@ -17,6 +19,7 @@ import {
 const OrganizerCheckIn = ({ eventId, eventName, sessions = [], registrations = [] }) => {
   const [checkIns, setCheckIns] = useState([]);
   const [stats, setStats] = useState(null);
+  const [groupStats, setGroupStats] = useState(null);
   const [sessionStats, setSessionStats] = useState({});
   const [selectedSession, setSelectedSession] = useState('all');
   const [viewMode, setViewMode] = useState('scanner'); // 'scanner' or 'history'
@@ -26,6 +29,10 @@ const OrganizerCheckIn = ({ eventId, eventName, sessions = [], registrations = [
   useEffect(() => {
     const newStats = computeCheckInStats(registrations, checkIns);
     setStats(newStats);
+
+    // Compute group statistics
+    const newGroupStats = computeGroupCheckInStats(registrations, checkIns);
+    setGroupStats(newGroupStats);
 
     if (sessions.length > 0) {
       const sessionStats = computeSessionCheckInStats(sessions, attendanceLogs, checkIns);
@@ -181,6 +188,15 @@ const OrganizerCheckIn = ({ eventId, eventName, sessions = [], registrations = [
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Scanner */}
             <div className="lg:col-span-1">
+              <div className="bg-white dark:bg-gray-800 rounded-lg p-4 shadow mb-4">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                  <Users className="w-5 h-5 text-indigo-600" />
+                  Group Check-In
+                </h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                  Scan any group member's QR code to check in the entire party at once.
+                </p>
+              </div>
               <EventCheckInScanner
                 eventId={eventId}
                 onCheckIn={handleCheckIn}
@@ -229,6 +245,52 @@ const OrganizerCheckIn = ({ eventId, eventName, sessions = [], registrations = [
                   </div>
                 </div>
               </div>
+
+              {/* Group Statistics (if there are groups) */}
+              {groupStats?.totalGroups > 0 && (
+                <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow">
+                  <div className="flex items-center gap-2 mb-4">
+                    <Users className="w-5 h-5 text-indigo-600" />
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                      Group Check-Ins
+                    </h3>
+                  </div>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <div>
+                      <div className="text-gray-600 dark:text-gray-400 text-sm font-medium">
+                        Total Groups
+                      </div>
+                      <div className="text-3xl font-bold text-gray-900 dark:text-white mt-2">
+                        {groupStats.totalGroups}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-gray-600 dark:text-gray-400 text-sm font-medium">
+                        Fully Checked In
+                      </div>
+                      <div className="text-3xl font-bold text-green-600 dark:text-green-400 mt-2">
+                        {groupStats.fullyCheckedInGroups}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-gray-600 dark:text-gray-400 text-sm font-medium">
+                        Partially Checked In
+                      </div>
+                      <div className="text-3xl font-bold text-orange-600 dark:text-orange-400 mt-2">
+                        {groupStats.partiallyCheckedInGroups}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-gray-600 dark:text-gray-400 text-sm font-medium">
+                        Group Rate
+                      </div>
+                      <div className="text-3xl font-bold text-indigo-600 dark:text-indigo-400 mt-2">
+                        {groupStats.groupCheckInRate}%
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {/* Progress Bar */}
               <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow">

--- a/src/utils/checkInUtils.js
+++ b/src/utils/checkInUtils.js
@@ -2,6 +2,7 @@
  * checkInUtils.js
  * Utilities for managing event check-ins, QR code generation,
  * and check-in statistics.
+ * Now includes support for group/bulk check-ins.
  */
 
 /**
@@ -200,6 +201,65 @@ export const computeSessionCheckInStats = (sessions = [], attendanceLogs = [], c
 };
 
 /**
+ * Computes group-specific check-in statistics
+ * @param {Array} registrations - All registrations for the event
+ * @param {Array} checkIns - All check-ins recorded
+ * @returns {Object} Group statistics {totalGroups, fullyCheckedInGroups, partiallyCheckedInGroups, groupCheckInRate}
+ */
+export const computeGroupCheckInStats = (registrations = [], checkIns = []) => {
+  const checkedInIds = new Set(checkIns.map((c) => c.registrationId));
+  
+  // Group registrations by groupId
+  const groups = {};
+  registrations.forEach((reg) => {
+    if (reg.groupId) {
+      if (!groups[reg.groupId]) {
+        groups[reg.groupId] = [];
+      }
+      groups[reg.groupId].push(reg);
+    }
+  });
+
+  const totalGroups = Object.keys(groups).length;
+  
+  if (totalGroups === 0) {
+    return {
+      totalGroups: 0,
+      fullyCheckedInGroups: 0,
+      partiallyCheckedInGroups: 0,
+      groupCheckInRate: 0,
+      groups,
+    };
+  }
+
+  let fullyCheckedInGroups = 0;
+  let partiallyCheckedInGroups = 0;
+
+  Object.values(groups).forEach((groupMembers) => {
+    const allCheckedIn = groupMembers.every((m) => checkedInIds.has(m.id));
+    const someCheckedIn = groupMembers.some((m) => checkedInIds.has(m.id));
+
+    if (allCheckedIn) {
+      fullyCheckedInGroups++;
+    } else if (someCheckedIn) {
+      partiallyCheckedInGroups++;
+    }
+  });
+
+  const groupCheckInRate = totalGroups > 0
+    ? Math.round(((fullyCheckedInGroups + partiallyCheckedInGroups) / totalGroups) * 10000) / 100
+    : 0;
+
+  return {
+    totalGroups,
+    fullyCheckedInGroups,
+    partiallyCheckedInGroups,
+    groupCheckInRate,
+    groups,
+  };
+};
+
+/**
  * Exports check-in data as CSV
  * @param {Object} stats - Check-in statistics from computeCheckInStats
  * @param {Array} registrations - All registrations
@@ -256,4 +316,91 @@ export const exportCheckInAsCSV = (stats, registrations, checkIns, eventName = '
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+};
+
+/**
+ * Checks if a registration is part of a group
+ * @param {Object} registration - Registration object
+ * @returns {boolean} True if this is a group registration
+ */
+export const isGroupRegistration = (registration) => {
+  return registration && (registration.groupId || registration.isGroupPrimary);
+};
+
+/**
+ * Gets the group ID from a registration
+ * @param {Object} registration - Registration object
+ * @returns {string|null} Group ID or null if not part of a group
+ */
+export const getGroupIdFromRegistration = (registration) => {
+  return registration?.groupId || null;
+};
+
+/**
+ * Finds all registrations in the same group
+ * @param {string} groupId - The group ID to search for
+ * @param {Array} registrations - All registrations for the event
+ * @returns {Array} All registrations that belong to this group
+ */
+export const getGroupMembers = (groupId, registrations = []) => {
+  if (!groupId) return [];
+  return registrations.filter((reg) => reg.groupId === groupId);
+};
+
+/**
+ * Finds the primary buyer for a group
+ * @param {Array} groupMembers - Array of group member registrations
+ * @returns {Object|null} The primary buyer's registration or null
+ */
+export const getGroupPrimary = (groupMembers = []) => {
+  return groupMembers.find((reg) => reg.isGroupPrimary) || groupMembers[0] || null;
+};
+
+/**
+ * Checks if all members of a group are already checked in
+ * @param {Array} groupMembers - Array of group member registrations
+ * @param {Array} checkIns - All check-ins
+ * @returns {boolean} True if all group members are checked in
+ */
+export const isEntireGroupCheckedIn = (groupMembers = [], checkIns = []) => {
+  const checkedInIds = new Set(checkIns.map((c) => c.registrationId));
+  return groupMembers.every((member) => checkedInIds.has(member.id));
+};
+
+/**
+ * Gets the group name from a registration or group members
+ * @param {Object|Array} registrationOrGroup - Registration object or array of group members
+ * @returns {string} Group name or a default name
+ */
+export const getGroupName = (registrationOrGroup) => {
+  if (Array.isArray(registrationOrGroup)) {
+    const primary = getGroupPrimary(registrationOrGroup);
+    return primary?.groupName || `Group of ${registrationOrGroup.length}`;
+  }
+  return registrationOrGroup?.groupName || 'Group';
+};
+
+/**
+ * Records check-ins for multiple group members at once
+ * @param {Array} groupMembers - Array of group member registrations
+ * @param {string} scannedBy - Who performed the check-in
+ * @param {Array} existingCheckIns - Existing check-ins to avoid duplicates
+ * @returns {Array} Array of new check-in records
+ */
+export const recordGroupCheckIns = (groupMembers = [], scannedBy = 'group-check-in', existingCheckIns = []) => {
+  const existingIds = new Set(existingCheckIns.map((c) => c.registrationId));
+  const timestamp = new Date().toISOString();
+
+  return groupMembers
+    .filter((member) => !existingIds.has(member.id))
+    .map((member) => ({
+      id: `checkin-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      registrationId: member.id,
+      timestamp,
+      scannedBy,
+      status: 'completed',
+      groupId: member.groupId,
+      groupName: member.groupName,
+      isGroupCheckIn: true,
+    }));
 };


### PR DESCRIPTION
Feature request #12141: Bulk attendee check-in for group tickets
- Scanning primary buyer's QR code opens modal with all group members
- Modal shows group member list with individual toggles
- 'Check In Entire Group' button for quick bulk check-in
- Supports partial check-in (e.g., 8 out of 10 showed up)
- Tracks group check-in statistics separately
- Backend: Add groupId, isGroupPrimary, and groupName fields to EventRegistration model
- Backend: Update RegistrationRequest and RegistrationResponse DTOs with group fields
- Frontend: Add checkInUtils functions for group operations (isGroupRegistration, getGroupMembers, etc.)
- Frontend: Create GroupCheckInModal component for bulk check-in
- Frontend: Update EventCheckInScanner to detect group registrations and open modal
- Frontend: Update OrganizerCheckIn to display group check-in statistics
- Frontend: Add computeGroupCheckInStats utility for tracking group check-in rates