### PR TITLE
Fix missing dependencies in useMultiTrackSchedule callbacks (#14033)

### DIFF
--- a/src/hooks/useMultiTrackSchedule.js
+++ b/src/hooks/useMultiTrackSchedule.js
@@ -82,6 +82,22 @@ export const useMultiTrackSchedule = (eventId) => {
   const [state, dispatch] = useReducer(scheduleReducer, initialState);
 
   /**
+   * Detect schedule conflicts
+   */
+  const updateConflicts = useCallback((tracks, sessions) => {
+    const conflictData = detectSessionConflicts(sessions, tracks);
+    dispatch({ type: 'SET_CONFLICTS', payload: conflictData.conflicts });
+  }, []);
+
+  /**
+   * Validate schedule integrity
+   */
+  const updateValidation = useCallback((tracks, sessions) => {
+    const validationData = validateScheduleIntegrity(sessions, tracks);
+    dispatch({ type: 'SET_VALIDATION', payload: validationData });
+  }, []);
+
+  /**
    * Load schedule from server
    */
   const loadSchedule = useCallback(async () => {
@@ -101,7 +117,7 @@ export const useMultiTrackSchedule = (eventId) => {
     } finally {
       dispatch({ type: 'SET_LOADING', payload: false });
     }
-  }, [eventId]);
+  }, [eventId, updateConflicts, updateValidation]);
 
   /**
    * Save schedule to server
@@ -208,7 +224,7 @@ export const useMultiTrackSchedule = (eventId) => {
       dispatch({ type: 'SET_ERROR', payload: error.message });
       throw error;
     }
-  }, [eventId, state.tracks, state.sessions]);
+  }, [eventId, state.tracks, state.sessions, updateConflicts, updateValidation]);
 
   /**
    * Update session information
@@ -230,7 +246,7 @@ export const useMultiTrackSchedule = (eventId) => {
       dispatch({ type: 'SET_ERROR', payload: error.message });
       throw error;
     }
-  }, [eventId, state.tracks, state.sessions]);
+  }, [eventId, state.tracks, state.sessions, updateConflicts, updateValidation]);
 
   /**
    * Remove session from schedule
@@ -250,7 +266,7 @@ export const useMultiTrackSchedule = (eventId) => {
       dispatch({ type: 'SET_ERROR', payload: error.message });
       throw error;
     }
-  }, [eventId, state.tracks, state.sessions]);
+  }, [eventId, state.tracks, state.sessions, updateConflicts, updateValidation]);
 
   /**
    * Auto-assign sessions to tracks
@@ -283,23 +299,7 @@ export const useMultiTrackSchedule = (eventId) => {
       dispatch({ type: 'SET_ERROR', payload: error.message });
       throw error;
     }
-  }, [eventId, state.tracks, state.sessions]);
-
-  /**
-   * Detect schedule conflicts
-   */
-  const updateConflicts = useCallback((tracks, sessions) => {
-    const conflictData = detectSessionConflicts(sessions, tracks);
-    dispatch({ type: 'SET_CONFLICTS', payload: conflictData.conflicts });
-  }, []);
-
-  /**
-   * Validate schedule integrity
-   */
-  const updateValidation = useCallback((tracks, sessions) => {
-    const validationData = validateScheduleIntegrity(sessions, tracks);
-    dispatch({ type: 'SET_VALIDATION', payload: validationData });
-  }, []);
+  }, [eventId, state.tracks, state.sessions, updateConflicts, updateValidation]);
 
   /**
    * Publish schedule


### PR DESCRIPTION
## Description
This PR resolves the `react-hooks/exhaustive-deps` warnings in `src/hooks/useMultiTrackSchedule.js`. 

Previously, several `useCallback` hooks (`loadSchedule`, `addSession`, `updateSession`, `removeSession`, and `autoAssign`) were referencing the `updateConflicts` and `updateValidation` helper functions but missing them in their dependency arrays. 

To fix this properly without causing initialization errors during the first render:
- Hoisted the definitions of `updateConflicts` and `updateValidation` to the top of the hook (right after the `useReducer` declaration).
- Added both functions to the dependency arrays of all `useCallback` hooks that invoke them.

This ensures that the hooks always have access to the latest references and fully complies with the Rules of Hooks.

## Related Issue
Fixes #14033

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Ran `npm run lint` and confirmed the 5 `exhaustive-deps` warnings in `useMultiTrackSchedule.js` are resolved.
