### PR TITLE
Fix React Compiler skipped error in usePaginatedFetch (#14034)

### DIFF
--- a/src/hooks/usePaginatedFetch.js
+++ b/src/hooks/usePaginatedFetch.js
@@ -65,7 +65,7 @@
  *   );
  */
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { logger } from "utils/logger";
 
 const DEFAULT_OPTIONS = {
@@ -136,7 +136,7 @@ const usePaginatedFetch = (fetchFn, options = {}) => {
     };
   }, []);
 
-  const execute = useCallback(async (currentPage, currentPerPage) => {
+  const execute = async (currentPage, currentPerPage) => {
     if (!enabled) return;
 
     // Abort any in-flight request
@@ -207,7 +207,7 @@ const usePaginatedFetch = (fetchFn, options = {}) => {
     }
 
     if (isMountedRef.current) setIsLoading(false);
-  }, [enabled, maxRetries, retryBaseMs, paginated]);
+  };
 
   // Trigger fetch when deps, page, or perPage change
   useEffect(() => {
@@ -215,9 +215,9 @@ const usePaginatedFetch = (fetchFn, options = {}) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page, perPage, enabled, ...dependencies]);
 
-  const refetch = useCallback(() => {
+  const refetch = () => {
     execute(page, perPage);
-  }, [execute, page, perPage]);
+  };
 
   return {
     data,


### PR DESCRIPTION
## Description
This PR resolves an ESLint error (`Compilation Skipped: Existing memoization could not be preserved`) emitted by the React Compiler in `src/hooks/usePaginatedFetch.js`.

Previously, the `execute` and `refetch` functions were manually wrapped in `useCallback`. The React Compiler attempts to compile away manual memoizations, but the destructured options variable `enabled` caused the compiler to skip optimizing the component altogether, as it identified a dependency that might mutate and produce unexpected results.

To fix this:
- Removed the manual `useCallback` wrapper from both `execute` and `refetch`.
- Removed `useCallback` from the imports since it's no longer used.

By dropping the manual hooks, we allow the React Compiler to natively track references and optimize the component safely.

## Related Issue
Fixes #14034

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Ran `npm run lint` locally and verified that the `Compilation Skipped` error and the exhaustive-deps warnings are no longer present for `usePaginatedFetch.js`.
