### PR TITLE
Fix exhaustive-deps re-render loop in useUserPreferences (#14035)

### DIFF
--- a/src/hooks/useUserPreferences.js
+++ b/src/hooks/useUserPreferences.js
@@ -90,6 +90,8 @@ const STORAGE_KEY_PREFIX = "eventra:prefs";
 const getStorageKey = (namespace) =>
   namespace ? `${STORAGE_KEY_PREFIX}:${namespace}` : STORAGE_KEY_PREFIX;
 
+const EMPTY_DEFAULTS = {};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Storage helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -137,7 +139,7 @@ const writeToStorage = (key, value) => {
 const useUserPreferences = ({ namespace } = {}) => {
   const storageKey = getStorageKey(namespace);
   const defaults = namespace
-    ? NAMESPACE_DEFAULTS[namespace] ?? {}
+    ? NAMESPACE_DEFAULTS[namespace] ?? EMPTY_DEFAULTS
     : GLOBAL_DEFAULTS;
 
   const [preferences, setPreferencesState] = useState(() =>


### PR DESCRIPTION
## Description
This PR resolves an ESLint warning (`react-hooks/exhaustive-deps`) in `src/hooks/useUserPreferences.js` that was caused by an unstable object reference being created on every render.

Previously, if a provided `namespace` was not found in `NAMESPACE_DEFAULTS`, the `defaults` variable fell back to an inline empty object `{}`. Since `{}` allocates a new object reference on every component render, this caused downstream hooks (like the `useEffect` handling storage sync and the `resetPreferences` callback) to constantly re-evaluate and re-attach event listeners on every cycle.

To fix this:
- Introduced a stable `EMPTY_DEFAULTS` constant outside the component.
- Used this stable constant as the fallback instead of `{}`.

This completely prevents the unnecessary re-evaluation loop and resolves the warning.

## Related Issue
Fixes #14035

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Ran `npm run lint` locally and confirmed that the warning on `useUserPreferences.js` has been eliminated.
