### PR TITLE
fix(events): resolve EventDetails crash from undefined identifiers

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -50,6 +50,8 @@ import { apiUtils, API_ENDPOINTS } from "config/api";
 import { getLastUpdated } from "utils/LastUpdatedUtils";
 import CopyButton from "components/ui/CopyButton";
 import AddToCalendar from "components/common/AddToCalendar";
+import useClipboard from "hooks/useClipboard";
+import { calculateReadTime, formatReadTime } from "utils/readTimeUtils";
 
 const formatEventDate = (dateValue) => {
   if (!dateValue) return { short: "TBD", full: "Date TBD", relative: "" };
@@ -84,6 +86,46 @@ const formatEventDate = (dateValue) => {
   const time = d.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
 
   return { short, full, relative, time };
+};
+
+const padNumber = (value) => String(value).padStart(2, "0");
+
+const toCalendarDate = (dateValue) => {
+  if (!dateValue) return "";
+  const d = new Date(dateValue);
+  if (isNaN(d.getTime())) return "";
+  return `${d.getFullYear()}-${padNumber(d.getMonth() + 1)}-${padNumber(d.getDate())}`;
+};
+
+const toCalendarTime = (event, eventDate) => {
+  if (event?.time) {
+    const match = String(event.time).match(/(\d{1,2}):(\d{2})/);
+    if (match) return `${padNumber(match[1])}:${match[2]}`;
+  }
+  const d = eventDate ? new Date(eventDate) : null;
+  if (!d || isNaN(d.getTime())) return "00:00";
+  return `${padNumber(d.getHours())}:${padNumber(d.getMinutes())}`;
+};
+
+const getDurationMinutes = (startValue, endValue) => {
+  if (!startValue || !endValue) return 60;
+  const start = new Date(startValue);
+  const end = new Date(endValue);
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return 60;
+  const minutes = Math.round((end - start) / 60000);
+  return Number.isFinite(minutes) && minutes > 0 ? minutes : 60;
+};
+
+const getCalendarLocation = (event) => {
+  const loc = event?.location;
+  if (!loc) return event?.isVirtual ? "Online" : "";
+  if (typeof loc === "string") return loc;
+  return loc.name || loc.address || (event?.isVirtual ? "Online" : "");
+};
+
+const getReadingTime = (text) => {
+  const display = formatReadTime(calculateReadTime(text));
+  return display || "0 min read";
 };
 
 const isRequestCanceled = (error, signal) =>
@@ -129,6 +171,7 @@ const EventDetails = () => {
   const { isRegistered } = useMyEvents();
   const { copy, isCopied } = useClipboard({ resetMs: 2000 });
   const abortControllerRef = useRef(null);
+  const latestRequestIdRef = useRef(0);
 
   // Live, real-time seat availability for this event. Subscribes to the shared
   // SSE stream and falls back to polling. Safe to call with a null eventId
@@ -137,18 +180,9 @@ const EventDetails = () => {
     enabled: eventId != null,
   });
   const copyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      setLinkCopied(true);
-
-      setTimeout(() => {
-        setLinkCopied(false);
-      }, 2000);
-
-      alert("Link copied successfully!");
-    } catch (error) {
-      alert("Unable to copy link.");
-    }
+    const success = await copy(window.location.href, "eventLink");
+    if (success) toast.success("Event link copied to clipboard!");
+    else toast.error("Unable to copy link. Please copy the URL from your browser's address bar.");
   };
   const loadEvent = useCallback(async () => {
     abortControllerRef.current?.abort();
@@ -466,14 +500,14 @@ ${window.location.href}
                 <button
                   onClick={handleCopy}
                   className={`p-2 rounded-full transition-colors ${
-                    linkCopied
+                    isCopied("eventLink")
                       ? "text-green-600 bg-green-50 dark:bg-green-900/30"
                       : "text-gray-500 hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
                   }`}
-                  aria-label={linkCopied ? "Link copied!" : "Copy event link"}
-                  title={linkCopied ? "Copied!" : "Copy link"}
+                  aria-label={isCopied("eventLink") ? "Link copied!" : "Copy event link"}
+                  title={isCopied("eventLink") ? "Copied!" : "Copy link"}
                 >
-                  {linkCopied ? <Check size={28} /> : <Link2 size={28} />}
+                  {isCopied("eventLink") ? <Check size={28} /> : <Link2 size={28} />}
                 </button>
               </div>
               <div
@@ -560,7 +594,7 @@ ${window.location.href}
                     className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-300 bg-white px-6 py-3 text-sm font-semibold text-gray-800 shadow-sm hover:bg-gray-50 transition dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
                     aria-label="Copy event link"
                   >
-                    {linkCopied ? "Copied!" : "Copy Link"}
+                    {isCopied("eventLink") ? "Copied!" : "Copy Link"}
                   </button>
                   <div className="relative print-hide">
                     <button


### PR DESCRIPTION
## Problem

The public event detail page (`/events/:id`) crashes on mount with `ReferenceError: useClipboard is not defined` because the component references identifiers that are never imported or defined:

- `useClipboard` is called in the component body but never imported.
- `latestRequestIdRef` is dereferenced but only `abortControllerRef` is declared.
- `setLinkCopied` / `linkCopied` are used in state and JSX but no such state exists.
- `toCalendarDate`, `toCalendarTime`, `getDurationMinutes`, `getCalendarLocation` are used to build the `AddToCalendar` payload but never defined.
- `getReadingTime` is used in the Summary card but never defined.

This makes every public event URL render the error boundary instead of the event.

## Fix

- Import `useClipboard` and wire the copy-link flow through its `copy` + `isCopied` API, removing the manual `navigator.clipboard`/`alert()` logic and the missing `linkCopied` state.
- Declare `latestRequestIdRef` so stale-request protection works.
- Add the four calendar payload helpers (`toCalendarDate`, `toCalendarTime`, `getDurationMinutes`, `getCalendarLocation`) so the `calendarEvent` object is valid.
- Add `getReadingTime` using `calculateReadTime`/`formatReadTime` from `utils/readTimeUtils`.

## Files changed

- `src/Pages/Events/EventDetails.js`

## Testing

- Confirmed every previously-undefined identifier is now defined/imported.
- The event detail page mounts without a `ReferenceError`; copy-link feedback shows "Copied!" via `isCopied("eventLink")`, and the Add to Calendar payload is populated.

Closes #14055
