### PR TITLE
fix(hooks): wire useAsyncValidation into useFormValidation

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -506,7 +506,7 @@ const EventRegistration = () => {
         return { success: false, error: "Login required", waitlistPosition: -1 };
       }
 
-      if (!validateAll()) {
+      if (!(await validateAll())) {
         toast.error(t("eventRegistration.toastValidationError"));
         return { success: false, error: "Validation failed", waitlistPosition: -1 };
       }

--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -395,7 +395,7 @@ const useEventRegistration = (eventIdParam) => {
       return;
     }
 
-    if (!validateAll()) {
+    if (!(await validateAll())) {
       toast.error("Please fill in all required fields correctly");
       return;
     }

--- a/src/hooks/useFormValidation.js
+++ b/src/hooks/useFormValidation.js
@@ -35,6 +35,17 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
   const [isFormValid, setIsFormValid] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
 
+  const {
+    asyncErrors,
+    asyncTouched,
+    isAsyncValidating,
+    isAnyAsyncValidating,
+    hasAsyncErrors,
+    validateAsync,
+    clearAsyncError,
+    cleanup: cleanupAsync,
+  } = useAsyncValidation(asyncValidators);
+
   useEffect(() => {
     validationRulesRef.current = validationRules;
   }, [validationRules]);
@@ -94,19 +105,22 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
     return error === true ? null : error;
   }, []);
 
-  // Validate all sync fields. Returns true when all pass.
-  const validateAll = useCallback(() => {
+  // Validate all fields (sync + async). Resolves async validator results so a
+  // pending Promise is never treated as a sync error.
+  const validateAll = useCallback(async () => {
     const newErrors = {};
     const newTouched = {};
     let isValid = true;
-    Object.keys(validationRulesRef.current).forEach((name) => {
-      newTouched[name] = true;
-      const error = validateField(name, values[name], values);
-      if (error) {
-        newErrors[name] = error;
-        isValid = false;
-      }
-    });
+    await Promise.all(
+      Object.keys(validationRulesRef.current).map(async (name) => {
+        newTouched[name] = true;
+        const error = await validateField(name, values[name], values);
+        if (error) {
+          newErrors[name] = error;
+          isValid = false;
+        }
+      })
+    );
     if (hasAsyncErrors) isValid = false;
     setTouched((prev) => ({ ...prev, ...newTouched }));
     setErrors(newErrors);


### PR DESCRIPTION
## Problem

`src/hooks/useFormValidation.js` imports `useAsyncValidation` but never calls/destructures it, so every consumer crashes with `ReferenceError` on mount:

- `cleanupAsync` — called in the mount-effect cleanup but never defined.
- `hasAsyncErrors` — read in `validateAll` and the derived-validity effect but never defined.
- `validateAsync` — called in `handleChange` but never defined.
- `clearAsyncError` — called in `resetForm` but never defined.
- `asyncErrors`, `asyncTouched`, `isAsyncValidating`, `isAnyAsyncValidating` — returned to consumers but never defined.

Both registration pages (`useEventRegistration.js` and `EventRegistration.js`) crashed with `ReferenceError: cleanupAsync is not defined` immediately on mount.

## Fix

- Wire `useAsyncValidation` into `useFormValidation.js` by destructuring its full return value (aliasing `cleanup` -> `cleanupAsync`), resolving every undefined identifier.
- Make `validateAll` async and `await` each field's `validateField` result so a pending async validator Promise is no longer treated as a synchronous error (`[object Promise]`).
- Update the two submission call sites (`useEventRegistration.js`, `EventRegistration.js`) to `await validateAll()`.

## Files changed

- `src/hooks/useFormValidation.js`
- `src/hooks/useEventRegistration.js`
- `src/Pages/Events/EventRegistration.js`

## Testing

- Confirmed every previously-undefined identifier is now defined via `useAsyncValidation`.
- Registration flows validate synchronously and asynchronously without throwing on mount or submit.

Closes #14056
