### PR TITLE
fix(security): gate plagiarism endpoints behind ORGANIZER/ADMIN roles

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 @RestController
 @RequestMapping("/api/organizer/plagiarism")
-@CrossOrigin(origins = "*")
+@PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
 public class PlagiarismController {
 
     @Autowired


### PR DESCRIPTION
## Problem

The plagiarism endpoints in `PlagiarismController` are mapped under `/api/organizer/plagiarism` but have no role check. `SecurityConfig` only applies `.anyRequest().authenticated()` (and gates `/api/admin/**`), so there is no rule protecting `/api/organizer/**`. Any authenticated user — including a freshly registered `USER` — can call `POST /api/organizer/plagiarism/analyze` and `POST /api/organizer/plagiarism/export-report`, triggering an O(n^2) all-pairs AST comparison (`analyzeHackathonSubmissions`) and downloading the audit CSV. The controller also carried a wildcard `@CrossOrigin(origins = "*")` that contradicts the app-wide CORS configuration.

## Fix

- Added a class-level `@PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")` to `PlagiarismController`, matching the existing pattern used by `EventController`, `ProjectController`, `HackathonController`, and `AnalyticsController`. Unauthorized roles now receive 403.
- Removed `@CrossOrigin(origins = "*")` so the controller relies on the global CORS configuration defined in `SecurityConfig`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java`

## Testing

- Unauthenticated requests → 401 via the existing entry point.
- Authenticated `USER` role → 403 on `/api/organizer/plagiarism/analyze` and `/export-report`.
- `ORGANIZER` / `ADMIN` / `SUPER_ADMIN` → requests pass through as before.

Closes #14059
