### PR TITLE
fix(issue-14060): dispatch named SSE events via addEventListener

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -29,7 +29,7 @@ const MESSAGE_REQUIRED_FIELDS = {
   UNSUBSCRIBE_ALL: ["tabId", "paths"],
   QUERY_SUBSCRIBERS: ["tabId"],
   SUBSCRIBERS_RESPONSE: ["tabId", "paths"],
-  SSE_MESSAGE: ["path", "data", "tabId"],
+  SSE_MESSAGE: ["path", "data", "eventType", "tabId"],
   SSE_STATUS: ["path", "status", "tabId"],
   RECONNECT_REQUEST: ["path"],
   PING: ["tabId"],
@@ -557,24 +557,33 @@ class SseMultiplexer {
       this.updatePathStatus(path, "connected");
     };
 
-    source.onmessage = (evt) => {
+    // Named SSE events (backend sends e.g. SseEmitter.event().name("availability"))
+    // never reached the default `onmessage` handler — EventSource only routes
+    // named events through addEventListener, and `evt.type` is always "message"
+    // for the default handler. Dispatch both so consumers can key on eventType.
+    const handleEvent = (eventType) => (evt) => {
       let payload = evt.data;
       try {
         payload = JSON.parse(evt.data);
       } catch { console.warn("[sseMultiplexer] JSON parse failed"); }
 
       // Dispatch locally
-      this.dispatchLocalMessage(path, payload, evt.type);
+      this.dispatchLocalMessage(path, payload, eventType);
 
       // Broadcast to follower tabs
       this.broadcastMessage({
         type: "SSE_MESSAGE",
         path,
         data: payload,
-        eventType: evt.type,
+        eventType,
         tabId: this.tabId,
       });
     };
+
+    source.onmessage = handleEvent("message");
+    ["availability", "init", "notification", "leaderboard", "analytics"].forEach((name) => {
+      source.addEventListener(name, handleEvent(name));
+    });
 
     source.onerror = () => {
       // FIX (#7855 Bug 4): Replace the browser's native immediate-retry


### PR DESCRIPTION
## Problem
`SseMultiplexer.openEventSource` only registered `source.onmessage`. The
backend pushes availability updates as **named** SSE events
(`SseEmitter.event().name("availability")`), which EventSource only routes
through `addEventListener` — the default `onmessage` handler receives them
with `evt.type` always set to `"message"`.

This meant `useEventAvailability`'s guard `eventType !== "availability"` always
short-circuited, so real-time seat availability updates were silently dropped.

## Fix
- Register named event listeners (`availability`, `init`, `notification`,
  `leaderboard`, `analytics`) via `source.addEventListener` in addition to the
  default `onmessage` handler.
- Include the resolved `eventType` in the `SSE_MESSAGE` broadcast payload and
  add it to `MESSAGE_REQUIRED_FIELDS.SSE_MESSAGE` so follower tabs receive it.
- `handleSseMessage` / `dispatchLocalMessage` already forward `eventType`, and
  `useRealTimeConnection` already passes `(data, eventType)` to subscribers —
  no consumer changes required.

## Files changed
- `src/utils/sseMultiplexer.js`

## Testing
- Manually verified named `availability` events dispatched via
  `addEventListener` reach `useEventAvailability` with `eventType ===
  "availability"`.
- Verified broadcast messages now pass `isValidBroadcastMessage` (eventType
  present in `MESSAGE_REQUIRED_FIELDS.SSE_MESSAGE`).

Closes #14060
