### PR TITLE
fix(issue-14061): fall back to eventSummary in calendar rendering

### DIFF
--- a/src/Pages/Calendar/MyCalendar.jsx
+++ b/src/Pages/Calendar/MyCalendar.jsx
@@ -33,6 +33,10 @@ const CATEGORIES = [
 
 const MyCalendar = () => {
   const { myEvents, loading } = useMyEvents();
+  const calendarEvents = myEvents.map((item) => ({
+    ...item,
+    event: item.event || item.eventSummary || {},
+  }));
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [viewMode, setViewMode] = useState("grid");
@@ -130,7 +134,7 @@ const MyCalendar = () => {
   };
 
   const getEventsForDate = (day) => {
-    return myEvents.filter((item) => {
+    return calendarEvents.filter((item) => {
       if (!item.event?.date) return false;
       const eventDate = new Date(item.event.date);
       const inMonth =
@@ -150,7 +154,7 @@ const MyCalendar = () => {
   };
 
   const getSelectedDateEvents = () => {
-    return myEvents.filter((item) => {
+    return calendarEvents.filter((item) => {
       if (!item.event?.date) return false;
       const eventDate = new Date(item.event.date);
       const isSameDate =
@@ -162,7 +166,7 @@ const MyCalendar = () => {
   };
 
   const getFilteredAllEvents = () => {
-    return myEvents
+    return calendarEvents
       .filter((item) => item.event && matchesCategory(item.event.category, activeCategory))
       .sort((a, b) => new Date(a.event.date) - new Date(b.event.date));
   };


### PR DESCRIPTION
## Problem
`MyCalendar` reads `item.event` directly from the records returned by
`useMyEvents()`. Records persisted to IndexedDB only contain a minimal
`eventSummary` (see `MyEventsContext.toPersistedRecord` /
`toEventSummary` — the full `event` object is intentionally kept in
session state only). After a page refresh, `item.event` is `undefined`,
so `getEventsForDate`, `getSelectedDateEvents` and `getFilteredAllEvents`
never match any record and the calendar renders empty (and `item.event?.category`
etc. silently short-circuit).

## Fix
- Normalize each record once:
  `event: item.event || item.eventSummary || {}`
- Use the normalized list in `getEventsForDate`, `getSelectedDateEvents`
  and `getFilteredAllEvents` so grid cells, the day schedule sidebar and
  the timeline all render persisted registrations.

## Files changed
- `src/Pages/Calendar/MyCalendar.jsx`

## Testing
- Manually verified records with only `eventSummary` now render on the
  grid, day schedule and timeline views after a page refresh.
- Records that still carry the full in-memory `event` object are
  unaffected (the full object wins).

Closes #14061
