### PR TITLE
fix(issue-14063): catch SignatureException in JwtTokenProvider.validateToken

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
@@ -14,11 +14,13 @@ import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 
 @Component
@@ -141,6 +143,10 @@ public class JwtTokenProvider {
             logger.error("Expired JWT token: {}", ex.getMessage());
         } catch (UnsupportedJwtException ex) {
             logger.error("Unsupported JWT token: {}", ex.getMessage());
+        } catch (SignatureException ex) {
+            logger.error("Invalid JWT signature: {}", ex.getMessage());
+        } catch (JwtException ex) {
+            logger.error("Invalid JWT token: {}", ex.getMessage());
         } catch (IllegalArgumentException ex) {
             logger.error("JWT claims string is empty: {}", ex.getMessage());
         }


### PR DESCRIPTION
## Problem
`JwtTokenProvider.validateToken` caught only `MalformedJwtException`,
`ExpiredJwtException`, `UnsupportedJwtException` and `IllegalArgumentException`.
`parseClaims` calls `Jwts.parser().verifyWith(...).parseSignedClaims(token)`;
with jjwt 0.12.x a tampered payload or wrong signing key throws
`io.jsonwebtoken.security.SignatureException`, which extends `JwtException`
(and `RuntimeException`) and is not any of the four caught types. It escaped
`validateToken`, so invalid-signature tokens produced 500s instead of the
documented `false` return — breaking `AuthService.refresh` and the intended
"Invalid JWT token" logging/401 path in `JwtAuthenticationFilter`.

## Fix
- Import `SignatureException` and `JwtException`.
- Add `SignatureException` and `JwtException` catch clauses to
  `validateToken` so every invalid token (expired, malformed, wrong
  signature) returns `false`.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java`

## Testing
- `validateToken` now returns `false` for tampered tokens instead of
  throwing `SignatureException`.
- Existing behaviour for expired/malformed/unsupported/empty tokens is
  unchanged (their specific handlers still run first).

Closes #14063
