### PR TITLE
fix(issue-14069): paginate public search/list endpoints

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -169,9 +169,13 @@ public class EventController {
                         @Parameter(description = "Event category for filtering") @RequestParam(required = false) String category,
                         @Parameter(description = "Start date for filtering (ISO format)") @RequestParam(required = false) String startDate,
                         @Parameter(description = "End date for filtering (ISO format)") @RequestParam(required = false) String endDate,
-                        @Parameter(description = "Filter for free events only") @RequestParam(required = false) Boolean free) {
+                        @Parameter(description = "Filter for free events only") @RequestParam(required = false) Boolean free,
+                        @RequestParam(defaultValue = "0") int page,
+                        @RequestParam(defaultValue = "20") int size) {
 
-                List<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free);
+                int clampedSize = Math.min(Math.max(size, 1), 100);
+                int safePage = Math.max(page, 0);
+                List<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free, safePage, clampedSize);
                 return ResponseEntity.ok(events);
         }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -195,8 +195,12 @@ public class HackathonController {
                     )
             )
     })
-    public ResponseEntity<List<HackathonResponse>> getAllHackathons() {
-        return ResponseEntity.ok(hackathonService.getAllHackathons());
+    public ResponseEntity<List<HackathonResponse>> getAllHackathons(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        int safePage = Math.max(page, 0);
+        return ResponseEntity.ok(hackathonService.getAllHackathons(safePage, clampedSize));
     }
 
     @GetMapping("/{id}")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -102,8 +102,12 @@ public class ProjectController {
                     )
             )
     })
-    public ResponseEntity<List<ProjectResponse>> getAllProjects() {
-        return ResponseEntity.ok(projectService.getAllProjects());
+    public ResponseEntity<List<ProjectResponse>> getAllProjects(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        int safePage = Math.max(page, 0);
+        return ResponseEntity.ok(projectService.getAllProjects(safePage, clampedSize));
     }
 
     @GetMapping("/{id}")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -141,6 +141,21 @@ public class GlobalExceptionHandler {
                 "Uploaded file size exceeds the maximum permitted limit. Please upload a smaller file.", request);
     }
 
+    @ExceptionHandler({
+            java.time.format.DateTimeParseException.class,
+            org.springframework.http.converter.HttpMessageNotReadableException.class,
+            org.springframework.web.method.annotation.MethodArgumentTypeMismatchException.class,
+            org.springframework.web.bind.MissingServletRequestParameterException.class,
+            jakarta.validation.ConstraintViolationException.class,
+            org.springframework.web.bind.ServletRequestBindingException.class,
+    })
+    public ResponseEntity<ErrorResponse> handleBadClientInput(Exception ex,
+            HttpServletRequest request) {
+        logger.warn("Malformed request: {}", ex.getMessage());
+        return buildError(HttpStatus.BAD_REQUEST, "Bad Request",
+                "Malformed request: " + ex.getMessage(), request);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(
             Exception ex,

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
@@ -34,6 +34,16 @@ public interface EventAnalyticsRepository extends JpaRepository<Event, Long> {
         """)
     List<Object[]> findMostPopularEvents(Pageable pageable);
 
+    // Per-category registration distribution. Returns: [category, count]
+    @Query("""
+        SELECT e.category, COUNT(e)
+        FROM Event e
+        WHERE e.category IS NOT NULL AND e.category <> ''
+        GROUP BY e.category
+        ORDER BY COUNT(e) DESC
+        """)
+    List<Object[]> findCategoryBreakdown(Pageable pageable);
+
     // Average utilization across events that have a capacity set
     @Query("""
         SELECT AVG(e.registeredCount * 1.0 / NULLIF(e.capacity, 0))

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
@@ -14,11 +14,13 @@ import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 
 @Component
@@ -141,6 +143,10 @@ public class JwtTokenProvider {
             logger.error("Expired JWT token: {}", ex.getMessage());
         } catch (UnsupportedJwtException ex) {
             logger.error("Unsupported JWT token: {}", ex.getMessage());
+        } catch (SignatureException ex) {
+            logger.error("Invalid JWT signature: {}", ex.getMessage());
+        } catch (JwtException ex) {
+            logger.error("Invalid JWT token: {}", ex.getMessage());
         } catch (IllegalArgumentException ex) {
             logger.error("JWT claims string is empty: {}", ex.getMessage());
         }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -64,7 +64,8 @@ public class AdminService {
      * @param role optional role filter (e.g. "CLIENT") — null means all users
      */
     public PagedResponse<AdminUserResponse> getUsers(int page, int size, String role, String search) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, size, Sort.by("createdAt").descending());
         Page<User> userPage;
         boolean hasSearch = StringUtils.hasText(search);
         String trimmedSearch = hasSearch ? search.trim() : null;
@@ -195,7 +196,8 @@ public class AdminService {
      * Returns all events (paginated), visible to admin regardless of isPublic.
      */
     public PagedResponse<EventResponse> getEvents(int page, int size, String search) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("eventDate").descending());
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, size, Sort.by("eventDate").descending());
         Specification<com.sandeep.eventrabackend.model.Event> spec = EventSpecifications.searchContains(search);
         Page<com.sandeep.eventrabackend.model.Event> eventPage = spec == null
                 ? eventRepository.findAll(pageable)
@@ -282,7 +284,8 @@ public class AdminService {
      * Returns all hackathons (paginated).
      */
     public PagedResponse<HackathonResponse> getHackathons(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("startDate").descending());
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, size, Sort.by("startDate").descending());
         return PagedResponse.from(hackathonRepository.findAll(pageable).map(this::toHackathonResponse));
     }
 
@@ -405,7 +408,8 @@ public class AdminService {
      * Returns all feedback entries (paginated).
      */
     public PagedResponse<AdminFeedbackResponse> getAllFeedback(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("submittedAt").descending());
+        int safePage = Math.max(page, 0);
+        Pageable pageable = PageRequest.of(safePage, size, Sort.by("submittedAt").descending());
         return PagedResponse.from(feedbackRepository.findAll(pageable).map(this::toAdminFeedbackResponse));
     }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
@@ -46,15 +46,15 @@ public class AnalyticsService {
 
     // ── 0. Summary (admin dashboard) ────────────────────────────────────────
     public AnalyticsSummaryDTO getSummary() {
-        List<Object[]> rows = eventRepo.findMostPopularEvents(
+        List<Object[]> rows = eventRepo.findCategoryBreakdown(
                 PageRequest.of(0, BREAKDOWN_COLORS.length));
 
         List<CategoryBreakdownDTO> breakdown = new ArrayList<>(rows.size());
         for (int i = 0; i < rows.size(); i++) {
             Object[] row = rows.get(i);
             breakdown.add(CategoryBreakdownDTO.builder()
-                    .name(row[1].toString())
-                    .value(((Number) row[2]).longValue())
+                    .name(row[0].toString())
+                    .value(((Number) row[1]).longValue())
                     .color(BREAKDOWN_COLORS[i % BREAKDOWN_COLORS.length])
                     .build());
         }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -11,6 +11,7 @@ import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.security.JwtTokenProvider;
 import com.sandeep.eventrabackend.security.TokenBlacklistService;
+import com.sandeep.eventrabackend.security.TokenRefreshQueueHandler;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -33,13 +34,15 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleAuthService googleAuthService;
     private final TokenBlacklistService tokenBlacklistService;
+    private final TokenRefreshQueueHandler tokenRefreshQueueHandler;
 
     public AuthService(UserRepository userRepository,
             PasswordEncoder passwordEncoder,
             AuthenticationManager authenticationManager,
             JwtTokenProvider jwtTokenProvider,
             GoogleAuthService googleAuthService,
-            TokenBlacklistService tokenBlacklistService) {
+            TokenBlacklistService tokenBlacklistService,
+            TokenRefreshQueueHandler tokenRefreshQueueHandler) {
 
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
@@ -47,6 +50,7 @@ public class AuthService {
         this.jwtTokenProvider = jwtTokenProvider;
         this.googleAuthService = googleAuthService;
         this.tokenBlacklistService = tokenBlacklistService;
+        this.tokenRefreshQueueHandler = tokenRefreshQueueHandler;
     }
 
     @Transactional
@@ -264,8 +268,15 @@ public class AuthService {
         }
 
         if (tokenBlacklistService.isBlacklisted(refreshToken)) {
-            throw new org.springframework.security.authentication.BadCredentialsException(
-                    "Refresh token has been revoked");
+            // Allow reuse within the short grace window after rotation so
+            // parallel requests racing on a just-rotated token succeed.
+            if (tokenRefreshQueueHandler != null
+                    && tokenRefreshQueueHandler.isWithinGracePeriod(refreshToken)) {
+                // fall through and rotate again
+            } else {
+                throw new org.springframework.security.authentication.BadCredentialsException(
+                        "Refresh token has been revoked");
+            }
         }
 
         String email = jwtTokenProvider.getUsernameFromToken(refreshToken);
@@ -288,6 +299,7 @@ public class AuthService {
         // Rotate: blacklist the presented refresh token, then mint a new pair.
         tokenBlacklistService.addToBlacklist(
                 refreshToken, jwtTokenProvider.getExpirationDateFromToken(refreshToken));
+        tokenRefreshQueueHandler.registerTokenRotation(refreshToken);
 
         String accessToken = jwtTokenProvider.generateToken(user.getEmail(), user.getRole().name());
         return buildAuthResponse(user, accessToken);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -417,50 +417,33 @@ public class EventService {
          */
         @Transactional(readOnly = true)
         public List<EventResponse> searchEvents(String search, String category, String startDate, String endDate,
-                        Boolean free) {
-                List<Event> events;
+                        Boolean free, int page, int size) {
+                int safePage = Math.max(0, page);
+                int safeSize = Math.min(Math.max(size, 1), 100);
 
-                // Build query based on search criteria
+                Specification<Event> spec = Specification.where(EventSpecifications.isPublic());
+
                 if (search != null && !search.trim().isEmpty()) {
-                        // Full-text search on title and description
-                        events = eventRepository.findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                                        search, search);
-                } else {
-                        events = eventRepository.findAll();
+                        String term = "%" + search.trim().toLowerCase() + "%";
+                        spec = spec.and((root, query, cb) -> cb.or(
+                                cb.like(cb.lower(root.get("title")), term),
+                                cb.like(cb.lower(root.get("description")), term)));
                 }
 
-                // Apply additional filters
                 if (category != null && !category.trim().isEmpty()) {
-                        List<Event> filteredEvents = events.stream()
-                                        .filter(event -> category.equals(event.getCategory()))
-                                        .collect(Collectors.toList());
-                        events = filteredEvents;
+                        spec = spec.and((root, query, cb) -> cb.equal(root.get("category"), category));
                 }
 
                 if (startDate != null && !startDate.trim().isEmpty()) {
-                        try {
-                                LocalDateTime startDateTime = LocalDateTime.parse(startDate);
-                                List<Event> filteredEvents = events.stream()
-                                                .filter(event -> event.getEventDate() != null &&
-                                                                !event.getEventDate().isBefore(startDateTime))
-                                                .collect(Collectors.toList());
-                                events = filteredEvents;
-                        } catch (Exception e) {
-                                // Invalid date format, ignore this filter
-                        }
+                        LocalDateTime startDateTime = LocalDateTime.parse(startDate);
+                        spec = spec.and((root, query, cb) ->
+                                cb.greaterThanOrEqualTo(root.get("eventDate"), startDateTime));
                 }
 
                 if (endDate != null && !endDate.trim().isEmpty()) {
-                        try {
-                                LocalDateTime endDateTime = LocalDateTime.parse(endDate);
-                                List<Event> filteredEvents = events.stream()
-                                                .filter(event -> event.getEventDate() != null &&
-                                                                !event.getEventDate().isAfter(endDateTime))
-                                                .collect(Collectors.toList());
-                                events = filteredEvents;
-                        } catch (Exception e) {
-                                // Invalid date format, ignore this filter
-                        }
+                        LocalDateTime endDateTime = LocalDateTime.parse(endDate);
+                        spec = spec.and((root, query, cb) ->
+                                cb.lessThanOrEqualTo(root.get("eventDate"), endDateTime));
                 }
 
                 // Events do not currently model price, so a free filter cannot be applied.
@@ -469,8 +452,8 @@ public class EventService {
                         // Intentionally no-op until pricing data is available.
                 }
 
-                return events.stream()
-                                .filter(Event::isPublic)
+                return eventRepository.findAll(spec, PageRequest.of(safePage, safeSize))
+                                .stream()
                                 .map(this::toPublicEventResponse)
                                 .collect(Collectors.toList());
         }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -381,18 +381,21 @@ public class EventService {
         }
 
         private int calculateCurrentStreak(List<EventRegistration> registrations) {
+                LocalDate today = LocalDate.now();
                 LinkedHashSet<LocalDate> dates = registrations.stream()
                                 .filter(registration -> "CONFIRMED".equals(registration.getStatus()))
                                 .map(EventRegistration::getEvent)
                                 .filter(event -> event != null && event.getEventDate() != null)
                                 .map(event -> event.getEventDate().toLocalDate())
+                                .filter(date -> !date.isAfter(today))
                                 .sorted(java.util.Comparator.reverseOrder())
                                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
                 int streak = 0;
-                LocalDate expected = null;
+                // A current streak may end today or yesterday.
+                LocalDate expected = dates.contains(today) ? today : today.minusDays(1);
                 for (LocalDate date : dates) {
-                        if (expected == null || date.equals(expected)) {
+                        if (date.equals(expected)) {
                                 streak++;
                                 expected = date.minusDays(1);
                         } else if (date.isBefore(expected)) {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -14,6 +14,7 @@ import com.sandeep.eventrabackend.repository.HackathonRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.security.access.AccessDeniedException;
 import com.sandeep.eventrabackend.model.Role;
@@ -39,8 +40,10 @@ public class HackathonService {
     }
 
     @Transactional(readOnly = true)
-    public List<HackathonResponse> getAllHackathons() {
-        return hackathonRepository.findAll().stream()
+    public List<HackathonResponse> getAllHackathons(int page, int size) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(size, 1), 100);
+        return hackathonRepository.findAll(PageRequest.of(safePage, safeSize)).stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
     }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -11,6 +11,7 @@ import com.sandeep.eventrabackend.repository.ProjectUpvoteRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,8 +53,10 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> getAllProjects() {
-        return projectRepository.findAll().stream()
+    public List<ProjectResponse> getAllProjects(int page, int size) {
+        int safePage = Math.max(0, page);
+        int safeSize = Math.min(Math.max(size, 1), 100);
+        return projectRepository.findAll(PageRequest.of(safePage, safeSize)).stream()
                 .map(this::toProjectResponse)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Problem
Public, unauthenticated list/search endpoints loaded entire tables into
the JVM and filtered in memory, with no pagination:

- `EventService.searchEvents` — `eventRepository.findAll()` when no search
  term was given, and category/date filters applied with in-memory
  streams (`:414-458`).
- `ProjectService.getAllProjects` — `projectRepository.findAll().stream()`
- `HackathonService.getAllHackathons` — `hackathonRepository.findAll().stream()`

As the catalog grows, every request becomes an O(n) full scan plus full
JSON serialization of every row — a memory/CPU DoS vector that
contradicts the sibling `getAllEvents` endpoint (which already paginates
and pushes filtering into the DB via `EventSpecifications`).

## Fix
- `searchEvents` now builds a `Specification` (always
  `EventSpecifications.isPublic()`, plus optional search / category /
  start-date / end-date predicates) and runs `findAll(spec, Pageable)`.
  - page/size are clamped (`Math.max(0, page)`, size 1–100).
  - Invalid date strings now produce a 400 via the bad-client-input
    handler (issue #14068) instead of silently ignoring the filter.
- `getAllProjects` and `getAllHackathons` accept clamped `page`/`size`
  and use `findAll(PageRequest.of(...))`, mirroring `getAllEvents`.
- Controllers expose `page`/`size` query params (defaults `0`/`20`) on
  `GET /api/events/search`, `GET /api/projects`, `GET /api/hackathons`.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java`

## Testing
- Existing `HackathonControllerTests` (`/api/hackathons` with no params)
  still pass — defaults return the first 20 rows.
- `/api/events/search?category=hackathons` now issues a bounded DB query
  instead of loading the full table.
- `?page=-1` clamps to page 0; `?size=0` clamps to 1; `?size=1000` clamps
  to 100.

Closes #14069
