### PR TITLE
fix(issue-14070): prevent stacked fallback polling intervals in TeamWorkspace

### DIFF
--- a/src/components/hackathons/TeamWorkspace.jsx
+++ b/src/components/hackathons/TeamWorkspace.jsx
@@ -93,6 +93,11 @@ const TeamWorkspace = () => {
         "SSE connection error. Started HTTP short-polling fallback stream every 4s.",
       ]);
 
+      if (fallbackInterval) {
+        clearInterval(fallbackInterval);
+        fallbackInterval = null;
+      }
+
       const fetchState = async () => {
         if (!isMounted) return;
         try {
@@ -132,6 +137,10 @@ const TeamWorkspace = () => {
         sseSource.onopen = () => {
           setConnectionStatus("sse");
           logger.info(`${logPrefix} Connection opened. Realtime SSE stream active.`);
+          if (fallbackInterval) {
+            clearInterval(fallbackInterval);
+            fallbackInterval = null;
+          }
         };
 
         sseSource.onmessage = (event) => {


### PR DESCRIPTION
## Problem
`TeamWorkspace.jsx` manages an SSE stream plus a 4s HTTP short-polling
fallback, but the fallback interval was never properly stopped:

- `triggerPollingFallback` assigned `fallbackInterval = setInterval(...)`
  without clearing a prior handle — every call stacked another interval.
- `sseSource.onerror` closes the SSE source and calls
  `triggerPollingFallback()`, so every SSE error added a new 4s interval.
- `sseSource.onopen` set status to `"sse"` but never stopped the running
  fallback interval — after a reconnect, SSE was active **and** the stale
  poller kept running.
- `disconnectStream` cleared only the single latest handle, so stacked
  intervals survived the disconnect.

Result: duplicate `POST /api/hackathons/team/sync` calls, redundant state
updates, and unbounded background requests from one open tab.

## Fix
- `triggerPollingFallback` now clears any existing interval before
  creating a new one (so at most one poller exists).
- `sseSource.onopen` now clears the fallback interval on reconnect.
- `disconnectStream` already clears + nulls the handle, and with only one
  interval ever existing it now tears the poller down completely.

## Files changed
- `src/components/hackathons/TeamWorkspace.jsx`

## Testing
- Simulated repeated SSE errors → only a single active 4s poller.
- SSE reconnect (`onopen`) → poller stopped; no further sync requests.
- Component unmount / tab idle → `disconnectStream` stops all polling.

Closes #14070
