### PR TITLE
fix(tests): resolve LoginForm.test.jsx import paths for AuthContext and toast

### DIFF
--- a/src/components/auth/__tests__/LoginForm.test.jsx
+++ b/src/components/auth/__tests__/LoginForm.test.jsx
@@ -2,13 +2,13 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import LoginForm from "../LoginForm";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../../../context/AuthContext";
 
-jest.mock("../context/AuthContext", () => ({
+jest.mock("../../../context/AuthContext", () => ({
   useAuth: jest.fn(),
 }));
 
-jest.mock("../utils/toast", () => ({
+jest.mock("../../../utils/toast", () => ({
   showAuthToast: jest.fn((message, onClose) => {
     if (onClose) onClose();
   }),


### PR DESCRIPTION
## Problem

`src/components/auth/__tests__/LoginForm.test.jsx` imports `useAuth` from `../context/AuthContext` and mocks `../context/AuthContext` and `../utils/toast`. From `src/components/auth/__tests__/`, those paths resolve to `src/components/auth/context/AuthContext` and `src/components/auth/utils/toast`, which do not exist. The real modules live at `src/context/AuthContext.js` and `src/utils/toast.js`, so the test cannot resolve its imports.

## Fix

Correct the `useAuth` import and both `jest.mock` paths to `../../../context/AuthContext` and `../../../utils/toast` so they resolve to the actual `src/context/AuthContext.js` and `src/utils/toast.js` modules.

## Files changed

- `src/components/auth/__tests__/LoginForm.test.jsx`

## Testing

- `npx vitest run src/components/auth/__tests__/LoginForm.test.jsx` no longer fails on import resolution; the file now loads and executes. Remaining failures are pre-existing and unrelated to the import paths (the file references the global `jest` object, which is not provided by this Vitest setup).

Closes #14135