### PR TITLE
fix(tests): resolve SignupForm.test.jsx import paths for config/api and AuthContext

### DIFF
--- a/src/components/auth/__tests__/SignupForm.test.jsx
+++ b/src/components/auth/__tests__/SignupForm.test.jsx
@@ -2,13 +2,13 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import SignupForm, { normalizeSignupRoles } from "../SignupForm";
-import { apiUtils } from "../config/api";
+import { apiUtils } from "../../../config/api";
 import {
   validateEmailAvailability,
   validatePasswordStrength,
 } from "../../../validation";
 
-vi.mock("../config/api", () => ({
+vi.mock("../../../config/api", () => ({
   API_ENDPOINTS: {
     AUTH: {
       SIGNUP: "/auth/signup",
@@ -19,7 +19,7 @@ vi.mock("../config/api", () => ({
   },
 }));
 
-vi.mock("../context/AuthContext", () => ({
+vi.mock("../../../context/AuthContext", () => ({
   useAuth: () => ({
     setAuthSession: vi.fn(),
   }),


### PR DESCRIPTION
## Problem

`src/components/auth/__tests__/SignupForm.test.jsx` imports `apiUtils` from `../config/api` and mocks `../config/api` and `../context/AuthContext`. From `src/components/auth/__tests__/`, those paths resolve to `src/components/auth/config/api` and `src/components/auth/context/AuthContext`, which do not exist. The real modules live at `src/config/api.js` and `src/context/AuthContext.js`, so the test cannot resolve its imports.

## Fix

Correct the `apiUtils` import and both `vi.mock` paths to `../../../config/api` and `../../../context/AuthContext` so they resolve to the actual `src/config/api.js` and `src/context/AuthContext.js` modules.

## Files changed

- `src/components/auth/__tests__/SignupForm.test.jsx`

## Testing

- `npx vitest run src/components/auth/__tests__/SignupForm.test.jsx` no longer fails on import resolution; the file now loads and 7 of 11 tests pass. Remaining failures are pre-existing and unrelated to the import paths (e.g., `minLength is not defined` raised by `src/components/auth/PasswordStrengthIndicator.js`).

Closes #14136