### PR TITLE
fix(tests): resolve EventRegistration integration test imports

### DIFF
--- a/src/Pages/Events/EventRegistration.integration.test.jsx
+++ b/src/Pages/Events/EventRegistration.integration.test.jsx
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
-import EventRegistration from '../Pages/Events/EventRegistration';
-import { checkRegistrationConflict, suggestAlternativeEvents } from '../utils/conflictDetection';
+import EventRegistration from './EventRegistration';
+import { checkRegistrationConflict, suggestAlternativeEvents } from '../../utils/conflictDetection';
 
 /**
  * Integration Tests: Event Conflict Resolver with Registration Flow


### PR DESCRIPTION
## Problem

`src/Pages/Events/EventRegistration.integration.test.jsx` imports `EventRegistration` from `../Pages/Events/EventRegistration` and the conflict helpers from `../utils/conflictDetection`. From `src/Pages/Events/`, `../Pages/Events/EventRegistration` resolves to `src/Pages/Pages/Events/EventRegistration` and `../utils/conflictDetection` resolves to `src/Pages/utils/conflictDetection`, neither of which exists. The test cannot load.

## Fix

Import `EventRegistration` from `./EventRegistration` and `checkRegistrationConflict`/`suggestAlternativeEvents` from `../../utils/conflictDetection`, which resolve to the real `src/Pages/Events/EventRegistration.js` and `src/utils/conflictDetection.js`.

## Files changed

- `src/Pages/Events/EventRegistration.integration.test.jsx`

## Testing

- `npx vitest run src/Pages/Events/EventRegistration.integration.test.jsx` — the file now loads and runs all 23 tests (previously it failed to resolve its imports). Remaining failures are pre-existing and unrelated to the import paths (e.g., the component requires an `AuthProvider` wrapper that the test does not set up).

Closes #14137