### PR TITLE
fix(hooks): use default import for useDebounce in useAdvancedEventSearch

### DIFF
--- a/src/hooks/useAdvancedEventSearch.js
+++ b/src/hooks/useAdvancedEventSearch.js
@@ -19,7 +19,7 @@
 
 import { useState, useMemo, useCallback } from "react";
 import { safeLocalStorage } from "../utils/safeStorage";
-import { useDebounce } from "./useDebounce";
+import useDebounce from "./useDebounce";
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/src/hooks/useAdvancedEventSearch.test.js
+++ b/src/hooks/useAdvancedEventSearch.test.js
@@ -3,7 +3,7 @@
  */
 
 import { renderHook, act } from "@testing-library/react";
-import useAdvancedEventSearch, { DEFAULT_FILTERS, SORT_OPTIONS } from "../useAdvancedEventSearch";
+import useAdvancedEventSearch, { DEFAULT_FILTERS, SORT_OPTIONS } from "./useAdvancedEventSearch";
 
 // ---------------------------------------------------------------------------
 // Fixtures


### PR DESCRIPTION
## Problem

`src/hooks/useAdvancedEventSearch.js` imports `useDebounce` as a named export (`import { useDebounce } from ./useDebounce;`), but `src/hooks/useDebounce.js` only provides a default export. This module-linking error breaks the hook and its consumers.

Additionally, `src/hooks/useAdvancedEventSearch.test.js` imports the hook from `../useAdvancedEventSearch`, which resolves one directory too high and prevents the test from loading the hook at all.

## Fix

- Switch to a default import: `import useDebounce from ./useDebounce;`.
- Correct the test import to `./useAdvancedEventSearch` so it loads the real hook module.

## Files changed

- `src/hooks/useAdvancedEventSearch.js`
- `src/hooks/useAdvancedEventSearch.test.js`

## Testing

- `src/hooks/useDebounce.js` exposes only `export default useDebounce`, so the default import links correctly.
- `npx vitest run src/hooks/useAdvancedEventSearch.test.js` — the file now loads and 8 of 10 tests pass. The 2 remaining failures are pre-existing behavior issues (fuzzy query matching and the preset localStorage round-trip), unrelated to the import fix.

Closes #14139