### PR TITLE
fix(tests): correct useAsyncValidation test import path

### DIFF
--- a/tests/useAsyncValidation.test.mjs
+++ b/tests/useAsyncValidation.test.mjs
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import useAsyncValidation from '../../src/hooks/useAsyncValidation';
+import useAsyncValidation from '../src/hooks/useAsyncValidation';
 
 // Use fake timers so debounce is testable without real delays
 beforeEach(() => { vi.useFakeTimers(); });


### PR DESCRIPTION
## Problem

`tests/useAsyncValidation.test.mjs` imports the hook from `../../src/hooks/useAsyncValidation`. From `tests/`, `../../` resolves outside the repository root, so the module cannot be found and the test file fails to load.

## Fix

Correct the import to `../src/hooks/useAsyncValidation`, which resolves to `src/hooks/useAsyncValidation.js`.

## Files changed

- `tests/useAsyncValidation.test.mjs`

## Testing

- `npx vitest run tests/useAsyncValidation.test.mjs` — the file now loads and 7 of 9 tests pass. The 2 remaining failures are pre-existing hook/test-contract issues (in-flight request abort behavior and cleanup timing), unrelated to the import fix.

Closes #14140