### PR TITLE
feat(frontend): add custom status message templates and i18n support to useValidationState

### DIFF
--- a/src/hooks/useValidationState.js
+++ b/src/hooks/useValidationState.js
@@ -97,13 +97,21 @@ export const useValidationState = (
   validationState = "idle",
   error = null,
   touched = false,
+  options = {},
 ) => {
+  const isObjectOptions = typeof fieldName === "object" && fieldName !== null;
+  const opts = isObjectOptions ? fieldName : (typeof options === "object" && options !== null ? options : {});
+  const name = isObjectOptions ? fieldName.fieldName : fieldName;
+  const state = isObjectOptions ? (fieldName.validationState ?? "idle") : validationState;
+  const err = isObjectOptions ? (fieldName.error ?? null) : error;
+  const isTouched = isObjectOptions ? (fieldName.touched ?? false) : touched;
+  const customMessages = opts.messages || {};
   /**
    * Get visual indicator based on validation state
    * 🔥 FIX: Converted from invoked useCallback to useMemo for proper computed caching
    */
   const statusIndicator = useMemo(() => {
-    switch (validationState) {
+    switch (state) {
       case "validating":
         return "validating"; // Show spinner
       case "success":
@@ -113,44 +121,62 @@ export const useValidationState = (
       default:
         return "idle"; // No indicator
     }
-  }, [validationState]);
+  }, [state]);
 
   /**
    * Get status message for accessibility announcements
    */
   const statusMessage = useMemo(() => {
-    switch (validationState) {
+    switch (state) {
       case "validating":
-        return `${fieldName} is being validated`;
+        if (typeof customMessages.validating === "function") {
+          return customMessages.validating(name);
+        }
+        if (typeof customMessages.validating === "string") {
+          return customMessages.validating;
+        }
+        return `${name} is being validated`;
       case "success":
-        return `${fieldName} is valid`;
+        if (typeof customMessages.success === "function") {
+          return customMessages.success(name);
+        }
+        if (typeof customMessages.success === "string") {
+          return customMessages.success;
+        }
+        return `${name} is valid`;
       case "error":
-        return `${fieldName} has an error: ${error || "Invalid input"}`;
+        if (typeof customMessages.error === "function") {
+          return customMessages.error(name, err);
+        }
+        if (typeof customMessages.error === "string") {
+          return customMessages.error;
+        }
+        return `${name} has an error: ${err || "Invalid input"}`;
       default:
         return "";
     }
-  }, [fieldName, error, validationState]);
+  }, [name, err, state, customMessages]);
 
   /**
    * Check if field should show error message
    */
   const shouldShowError = useMemo(() => {
-    return Boolean(touched && validationState === "error" && error);
-  }, [touched, validationState, error]);
+    return Boolean(touched && state === "error" && err);
+  }, [isTouched, state, err]);
 
   /**
    * Check if validation is in progress
    */
   const isValidating = useMemo(() => {
-    return validationState === "validating";
-  }, [validationState]);
+    return state === "validating";
+  }, [state]);
 
   /**
    * Check if validation passed
    */
   const isValid = useMemo(() => {
-    return validationState === "success";
-  }, [validationState]);
+    return state === "success";
+  }, [state]);
 
   /**
    * Get CSS classes for styling based on validation state
@@ -160,11 +186,11 @@ export const useValidationState = (
     (baseClass = "") => {
       let classes = baseClass;
 
-      if (!touched) {
+      if (!isTouched) {
         return classes;
       }
 
-      switch (validationState) {
+      switch (state) {
         case "success":
           return `${classes} border-green-500 dark:border-green-400`;
         case "error":
@@ -175,7 +201,7 @@ export const useValidationState = (
           return classes;
       }
     },
-    [touched, validationState],
+    [isTouched, state],
   );
 
   /**
@@ -185,23 +211,23 @@ export const useValidationState = (
   const ariaAttributes = useMemo(() => {
     const attributes = {};
 
-    if (error && touched) {
+    if (err && isTouched) {
       attributes["aria-invalid"] = "true";
-      attributes["aria-describedby"] = `${fieldName}-error`;
+      attributes["aria-describedby"] = `${name}-error`;
     } else {
       attributes["aria-invalid"] = "false";
     }
 
-    if (validationState === "validating") {
+    if (state === "validating") {
       attributes["aria-busy"] = "true";
     }
 
     if (isValid) {
-      attributes["aria-describedby"] = `${fieldName}-success`;
+      attributes["aria-describedby"] = `${name}-success`;
     }
 
     return attributes;
-  }, [fieldName, error, touched, validationState, isValid]);
+  }, [name, err, isTouched, state, isValid]);
 
   return {
     // Status checks
@@ -216,9 +242,9 @@ export const useValidationState = (
     ariaAttributes,
 
     // Direct accessors
-    validationState,
-    touched,
-    error,
+    validationState: state,
+    touched: isTouched,
+    error: err,
   };
 };
 


### PR DESCRIPTION
## Description
Added support for custom status message templates and internationalization (i18n) to `useValidationState`. Consumers can now supply custom static message strings or formatting functions via a `messages` configuration object or options parameter.
gssoc 26

**Changes made:**
- Extended `useValidationState` parameter handling to support an options object and `messages` property.
- Supported custom string templates and formatter functions for `validating`, `success`, and `error` status messages.
- Maintained full backward compatibility with the existing positional arguments signature.

Fixes #14167

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings