### PR TITLE
fix: remove 8-char minimum length check from login validatePassword — presence-only check is correct for login; length rules belong on registration only

### DIFF
--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -45,17 +45,15 @@ export default function LoginForm() {
     return ""; // Valid username
   };
   
+  // Login only checks presence — length/complexity rules belong on RegisterForm only.
+  // Enforcing a minimum length here permanently locks out users with legacy
+  // short passwords because the API call is never reached.
   const validatePassword = (value) => {
-  if (!value.trim()) {
-    return "Password is required.";
-  }
-
-  if (value.length < 8) {
-    return "Password must be at least 8 characters.";
-  }
-
-  return "";
-};
+    if (!value) {
+      return "Password is required.";
+    }
+    return "";
+  };
 const handlePasswordChange = (e) => {
     const value = e.target.value;
 


### PR DESCRIPTION
### Related Issue
Closes #14211 

### Description of Changes
- Removed the `value.length < 8` check from `validatePassword` in
  `LoginForm.js`.
- Replaced `!value.trim()` with `!value` since trimming a password
  before checking presence is itself problematic (a password that
  is literally all spaces would pass the non-empty check).
- Login `validatePassword` now only confirms the field is not empty —
  all credential correctness is delegated to the backend.