### PR TITLE
fix: reset isSubmittingRef.current to false on success path so back-navigation within the redirect window does not permanently block future submits

### DIFF
--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -293,6 +293,7 @@ const SignupForm = () => {
 
       setAuthSession(sessionToken, sessionUser, refreshToken);
       setLoading(false);
+      isSubmittingRef.current = false; // reset so back-navigation can retry if needed
       setSuccess("Account created successfully. Redirecting to dashboard...");
       toast.success("Account created successfully!");
       setTimeout(() => navigate("/dashboard", { replace: true }), 1000);


### PR DESCRIPTION

**Description:**

### Related Issue
Closes #14215 

### Description of Changes
- Added `isSubmittingRef.current = false` immediately after
  `setLoading(false)` in the success path of `handleSubmit` in
  `SignupForm.js`.
- The ref is now reset on all three exit paths: validation failure,
  success, and error — making the guard symmetrical.