### PR TITLE
fix: replace non-interactive Terms of Service and Privacy Policy spans with proper Link elements so they are navigable, keyboard-accessible, and actually clickable

### DIFF
--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -529,10 +529,20 @@ const SignupForm = () => {
             />
           )}
           <p className="text-xs text-center text-text-light">
-            By creating an account, you agree to our
-            <span className="text-primary cursor-pointer"> Terms of Service </span>
-            and
-            <span className="text-primary cursor-pointer"> Privacy Policy</span>.
+            By creating an account, you agree to our{" "}
+            <Link
+              to="/terms"
+              className="text-primary hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded"
+            >
+              Terms of Service
+            </Link>
+            {" "}and{" "}
+            <Link
+              to="/privacy"
+              className="text-primary hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded"
+            >
+              Privacy Policy
+            </Link>.
           </p>
           <motion.button
             type="submit"


### PR DESCRIPTION

**Description:**

### Related Issue
Closes #14219 

### Description of Changes
- Replaced `<span className="text-primary cursor-pointer">Terms of
  Service</span>` and the matching Privacy Policy span in `SignupForm.js`
  with `<Link to="/terms">` and `<Link to="/privacy">` respectively.
- `Link` is already imported from `react-router-dom` — no new dependency.
- Added `hover:underline` and `focus-visible:ring-2` to match the
  interactive link styling used elsewhere in auth components.