### PR TITLE
fix: guard bubble animation repeat with prefersReducedMotion — repeat:Infinity with duration:0 caused infinite zero-duration animation loops hammering the scheduler

### DIFF
--- a/src/components/auth/Unauthorized.js
+++ b/src/components/auth/Unauthorized.js
@@ -16,14 +16,17 @@ const Unauthorized = () => {
     { top: "50%", right: "2%" },
   ];
 
-  // Framer Motion variants for floating effect
+  // Framer Motion variants for floating effect.
+  // When reduced motion is preferred, repeat is set to 0 so the animation
+  // runs once (or not at all with duration:0) instead of looping infinitely
+  // at zero duration — which would hammer the animation scheduler every frame.
   const floatingVariants = {
     float: (i) => ({
-      y: [0, -20 - i * 3, 0],
-      x: [0, 20 + i * 5, 0],
+      y: prefersReducedMotion ? 0 : [0, -20 - i * 3, 0],
+      x: prefersReducedMotion ? 0 : [0, 20 + i * 5, 0],
       transition: {
         duration: prefersReducedMotion ? 0 : 6 + i,
-        repeat: Infinity,
+        repeat: prefersReducedMotion ? 0 : Infinity,
         ease: "easeInOut",
       },
     }),


### PR DESCRIPTION

**Description:**

### Related Issue
Closes #14221 

### Description of Changes
- In `floatingVariants` in `Unauthorized.js`, added
  `repeat: prefersReducedMotion ? 0 : Infinity`.
- Also set `y` and `x` to `0` (static) when reduced motion is
  preferred, so no movement keyframes are registered at all.
- Bubbles are now completely static for users with reduced motion
  preferences instead of running an infinite zero-duration loop.