### PR TITLE
fix: change primary heading from h2 to h1 on Unauthorized page — page had no h1, breaking heading hierarchy and screen reader navigation

### DIFF
--- a/src/components/auth/Unauthorized.js
+++ b/src/components/auth/Unauthorized.js
@@ -59,9 +59,9 @@ const Unauthorized = () => {
             <XCircle className="h-20 w-20 text-red-500" />
           </motion.div>
 
-          <h2 className="text-3xl font-extrabold text-gray-800 dark:text-gray-100">
+          <h1 className="text-3xl font-extrabold text-gray-800 dark:text-gray-100">
             Access Denied
-          </h2>
+          </h1>
           <p className="text-gray-600 dark:text-gray-400">
             You don’t have permission to access this page.
           </p>


### PR DESCRIPTION

**Description:**

### Related Issue
Closes #14223 

### Description of Changes
- Changed `<h2>Access Denied</h2>` to `<h1>Access Denied</h1>` in
  `Unauthorized.js`.
- No className or style changes — purely a semantic element correction.
- Aligns with `LoginForm`, `PasswordReset`, and `SignupForm` which all
  use `<h1>` for their primary heading.