### PR TITLE
fix: split validate.email empty and too-long checks into distinct error messages so blank email shows required error not format error

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -43,7 +43,8 @@ export const validate = {
    * Input is length-capped before regex to guard against long-string attacks.
    */
   email: (val) => {
-    if (!val || val.length > MAX_EMAIL_LENGTH) return "Invalid email format";
+    if (!val) return "Email is required";
+    if (val.length > MAX_EMAIL_LENGTH) return "Email address is too long";
     return EMAIL_REGEX.test(val) || "Invalid email format";
   },
 


### PR DESCRIPTION
### Related Issue
Closes #14231 

### Description of Changes
- Split the combined `!val || val.length > MAX_EMAIL_LENGTH` check in
  validate.email in validation.js into two separate guards.
- Empty/null values now return "Email is required" matching the pattern
  used by all other validators in the file.
- Over-length values now return "Email address is too long" instead of
  the misleading "Invalid email format".
- The regex check and its "Invalid email format" message are now only
  reached for non-empty, length-valid inputs.