### PR TITLE
fix: return registration.unregister() promise in unregister() so rejections propagate to the catch handler instead of being silently swallowed

### DIFF
--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -167,7 +167,7 @@ export function unregister() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready
       .then((registration) => {
-        registration.unregister();
+        return registration.unregister(); // return Promise<boolean> so rejections propagate to .catch()
       })
       .catch((error) => {
         if (isDev) {


### PR DESCRIPTION
### Related Issue
Closes #14235 

### Description of Changes
- Added `return` before `registration.unregister()` in the unregister()
  function in serviceWorkerRegistration.js.
- The Promise<boolean> returned by unregister() is now part of the
  .then()/.catch() chain, ensuring rejections are caught and logged
  in development mode.
- One-character fix with no behavioral change on the success path.