### PR TITLE
fix: replace navigator.serviceWorker.ready with getRegistration in checkValidServiceWorker so page reload is not blocked when no service worker is active

### DIFF
--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -147,11 +147,15 @@ function checkValidServiceWorker(swUrl, config) {
         response.status === 404 ||
         (contentType != null && contentType.indexOf('javascript') === -1)
       ) {
-        // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then((registration) => {
-          registration.unregister().then(() => {
+        // No service worker found. Unregister if exists and reload.
+        navigator.serviceWorker.getRegistration().then((registration) => {
+          if (registration) {
+            registration.unregister().then(() => {
+              window.location.reload();
+            });
+          } else {
             window.location.reload();
-          });
+          }
         });
       } else {
         // Service worker found. Proceed as normal.


### PR DESCRIPTION
### Related Issue
Closes #14243 

### Description of Changes
- Replaced `navigator.serviceWorker.ready` with `navigator.serviceWorker.getRegistration()` inside `checkValidServiceWorker()` in `serviceWorkerRegistration.js`.
- Guaranteed that if `service-worker.js` yields a 404 or invalid content-type, `window.location.reload()` will execute even if no active service worker currently exists.