### PR TITLE
fix: replace direct process.env.NODE_ENV access with import.meta.env.MODE fallback to prevent ReferenceError in Vite browser environments

### DIFF
--- a/src/Pages/HealthCheckPage.jsx
+++ b/src/Pages/HealthCheckPage.jsx
@@ -32,7 +32,7 @@ const HealthCheckPage = () => {
     version: APP_VERSION,
     buildTime: BUILD_TIME,
     timestamp: new Date().toISOString(),
-    environment: process.env.NODE_ENV || "production",
+    environment: (typeof import.meta !== "undefined" && import.meta.env?.MODE) || (typeof process !== "undefined" && process.env?.NODE_ENV) || "production",
   };
 
   return (


### PR DESCRIPTION
### Related Issue
Closes #14245 

### Description of Changes
- Replaced direct `process.env.NODE_ENV` access in `HealthCheckPage.jsx` with a safe check prioritizing `import.meta.env?.MODE`.
- Added defensive `typeof process !== "undefined"` guard to prevent `ReferenceError: process is not defined` in client-side Vite builds.