### PR TITLE
fix: fix premature quote in Contact Us Link className to resolve JSX syntax parse error

### DIFF
--- a/src/Pages/HelpCenter.js
+++ b/src/Pages/HelpCenter.js
@@ -641,7 +641,7 @@ const HelpCenter = () => {
             <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
               <Link
                 to="/contact"
-                className="inline-flex items-center justify-center gap-2 bg-white text-black dark:bg-slate-900 dark:text-white" font-semibold px-8 py-4 rounded-full shadow-lg hover:bg-gray-100 transition-transform duration-300 
+                className="inline-flex items-center justify-center gap-2 bg-white text-black dark:bg-slate-900 dark:text-white font-semibold px-8 py-4 rounded-full shadow-lg hover:bg-gray-100 transition-transform duration-300"
               >
                 <Mail size={20} /> {t("helpCenter.ctaContactUs")}
               </Link>


### PR DESCRIPTION
### Related Issue
Closes #14251 

### Description of Changes
- Fixed premature closing quote in the `className` prop of the Contact Us `<Link>` component in `HelpCenter.js`.
- Restored valid JSX syntax so Vite/Babel compiles `HelpCenter.js` without parsing errors.