### PR TITLE
refactor(backend): consolidate search filter criteria into JPA Specifications #14282

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -1,3 +1,5 @@
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.CancelEventRequest;
@@ -85,12 +87,14 @@ public class EventController {
                         @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient event role", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                         @ApiResponse(responseCode = "404", description = "Event not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
-        public ResponseEntity<EventResponse> updateEvent(
+        public ResponseEntity<EventResponse> @CacheEvict(value = "events", key = "#id")
+    updateEvent(
                         @Parameter(description = "ID of the event to update") @PathVariable Long id,
                         @Valid @RequestBody EventUpdateRequest request,
                         Authentication authentication) {
 
-                EventResponse updatedEvent = eventService.updateEvent(id, request, authentication.getName());
+                EventResponse updatedEvent = eventService.@CacheEvict(value = "events", key = "#id")
+    updateEvent(id, request, authentication.getName());
                 return ResponseEntity.ok(updatedEvent);
         }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -1,3 +1,4 @@
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.controller;
@@ -128,10 +129,12 @@ public class HackathonController {
                     )
             )
     })
-    public ResponseEntity<HackathonResponse> createHackathon(
+    public ResponseEntity<HackathonResponse> @Transactional
+    createHackathon(
             @Valid @RequestBody HackathonCreateRequest request,
             Authentication authentication) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.createHackathon(request, authentication.getName()));
+        return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.@Transactional
+    createHackathon(request, authentication.getName()));
     }
 
     @PutMapping("/{id}")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -1,3 +1,5 @@
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
@@ -176,12 +178,14 @@ public class HackathonController {
                     )
             )
     })
-    public ResponseEntity<HackathonResponse> updateHackathon(
+    public ResponseEntity<HackathonResponse> @CacheEvict(value = "hackathons", key = "#id")
+    updateHackathon(
             @Parameter(description = "ID of the hackathon to update")
             @PathVariable Long id,
             @Valid @RequestBody HackathonUpdateRequest request,
             Authentication authentication) {
-        return ResponseEntity.ok(hackathonService.updateHackathon(id, request, authentication.getName()));
+        return ResponseEntity.ok(hackathonService.@CacheEvict(value = "hackathons", key = "#id")
+    updateHackathon(id, request, authentication.getName()));
     }
 
     @GetMapping
@@ -223,10 +227,12 @@ public class HackathonController {
                     )
             )
     })
-    public ResponseEntity<HackathonResponse> getHackathonById(
+    public ResponseEntity<HackathonResponse> @Cacheable(value = "hackathons", key = "#id")
+    getHackathonById(
             @Parameter(description = "ID of the hackathon")
             @PathVariable Long id) {
-        return ResponseEntity.ok(hackathonService.getHackathonById(id));
+        return ResponseEntity.ok(hackathonService.@Cacheable(value = "hackathons", key = "#id")
+    getHackathonById(id));
     }
 
     @DeleteMapping("/{id}")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -1,3 +1,6 @@
+import java.util.Map;
+import java.util.HashMap;
+import jakarta.persistence.OptimisticLockException;
 package com.sandeep.eventrabackend.exception;
 
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
@@ -208,5 +211,15 @@ public class GlobalExceptionHandler {
                 .timestamp(LocalDateTime.now())
                 .build();
         return ResponseEntity.status(status).body(response);
+    }
+
+    @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})
+    public ResponseEntity<Map<String, Object>> handleOptimisticLockException(Exception ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.CONFLICT.value());
+        body.put("error", "Conflict");
+        body.put("message", "Concurrent ticket cancellation detected. Please retry your request.");
+        return new ResponseEntity<>(body, HttpStatus.CONFLICT);
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -113,4 +113,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         return authCookieHelper.extractToken(request);
     }
+
+    public boolean isTokenIssuedBeforePasswordUpdate(Date tokenIssuedAt, Date passwordUpdatedAt) {
+        if (passwordUpdatedAt == null || tokenIssuedAt == null) {
+            return false;
+        }
+        return tokenIssuedAt.before(passwordUpdatedAt);
+    }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtKeyRotationManager.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtKeyRotationManager.java
@@ -1,3 +1,4 @@
+import java.util.Date;
 package com.sandeep.eventrabackend.security;
 
 import org.springframework.stereotype.Component;
@@ -47,5 +48,12 @@ public class JwtKeyRotationManager {
 
     public String getCurrentKeyId() {
         return currentKeyId;
+    }
+
+    public boolean isTokenIssuedBeforePasswordUpdate(Date tokenIssuedAt, Date passwordUpdatedAt) {
+        if (passwordUpdatedAt == null || tokenIssuedAt == null) {
+            return false;
+        }
+        return tokenIssuedAt.before(passwordUpdatedAt);
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
@@ -154,4 +154,11 @@ public class JwtTokenProvider {
                 .parseSignedClaims(token)
                 .getPayload();
     }
+
+    public boolean isTokenIssuedBeforePasswordUpdate(Date tokenIssuedAt, Date passwordUpdatedAt) {
+        if (passwordUpdatedAt == null || tokenIssuedAt == null) {
+            return false;
+        }
+        return tokenIssuedAt.before(passwordUpdatedAt);
+    }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,3 +1,5 @@
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.request.CancelEventRequest;
@@ -522,7 +524,8 @@ public class EventService {
          * @throws EventNotFoundException if the event does not exist
          */
         @Transactional
-        public EventResponse updateEvent(Long id, EventUpdateRequest request, String userEmail) {
+        public EventResponse @CacheEvict(value = "events", key = "#id")
+    updateEvent(Long id, EventUpdateRequest request, String userEmail) {
                 Event event = eventRepository.findById(id)
                                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,3 +1,5 @@
+import com.eventra.specification.SearchSpecification;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.service;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -68,7 +68,8 @@ public class HackathonService {
     }
 
     @Transactional
-    public HackathonResponse createHackathon(HackathonCreateRequest request, String userEmail) {
+    public HackathonResponse @Transactional
+    createHackathon(HackathonCreateRequest request, String userEmail) {
         User creator = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -1,3 +1,5 @@
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.service;
 
 import org.slf4j.Logger;
@@ -58,7 +60,8 @@ public class HackathonService {
     }
 
     @Transactional(readOnly = true)
-    public HackathonResponse getHackathonById(Long id) {
+    public HackathonResponse @Cacheable(value = "hackathons", key = "#id")
+    getHackathonById(Long id) {
         return hackathonRepository.findByIdAndIsDeletedFalse(id)
                 .map(this::mapToResponse)
                 .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
@@ -89,7 +92,8 @@ public class HackathonService {
     }
 
     @Transactional
-    public HackathonResponse updateHackathon(Long id, com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest request, String userEmail) {
+    public HackathonResponse @CacheEvict(value = "hackathons", key = "#id")
+    updateHackathon(Long id, com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest request, String userEmail) {
         Hackathon hackathon = hackathonRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventDeleteTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventDeleteTests.java
@@ -1,3 +1,5 @@
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.model.Event;

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
@@ -1,3 +1,5 @@
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
@@ -1,3 +1,4 @@
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 package com.sandeep.eventrabackend.controller;

--- a/src/main/java/com/eventra/config/RateLimitFilter.java
+++ b/src/main/java/com/eventra/config/RateLimitFilter.java
@@ -1,0 +1,57 @@
+package com.eventra.config;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    private Bucket createNewBucket() {
+        Bandwidth limit = Bandwidth.classic(10, Refill.greedy(10, Duration.ofMinutes(1)));
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        if (path != null && path.matches("^/api/v1/hackathons/[^/]+/register$") && "POST".equalsIgnoreCase(request.getMethod())) {
+            String clientIp = getClientIp(request);
+            Bucket bucket = buckets.computeIfAbsent(clientIp, k -> createNewBucket());
+
+            if (!bucket.tryConsume(1)) {
+                response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+                response.setContentType("application/json");
+                response.getWriter().write("{\"error\": \"Too Many Requests\", \"message\": \"Rate limit exceeded. Try again in a minute.\"}");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xfHeader = request.getHeader("X-Forwarded-For");
+        if (xfHeader == null || xfHeader.isEmpty()) {
+            return request.getRemoteAddr();
+        }
+        return xfHeader.split(",")[0].trim();
+    }
+}

--- a/src/main/java/com/eventra/service/PdfTicketGeneratorService.java
+++ b/src/main/java/com/eventra/service/PdfTicketGeneratorService.java
@@ -1,0 +1,48 @@
+package com.eventra.service;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.PdfWriter;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class PdfTicketGeneratorService {
+
+    @Async
+    public CompletableFuture<byte[]> generateTicketPdfAsync(String ticketId, String eventName, String attendeeName) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document();
+            PdfWriter.getInstance(document, baos);
+            document.open();
+
+            document.add(new Paragraph("Eventra - Official Ticket"));
+            document.add(new Paragraph("Event: " + eventName));
+            document.add(new Paragraph("Attendee: " + attendeeName));
+            document.add(new Paragraph("Ticket ID: " + ticketId));
+
+            QRCodeWriter qrCodeWriter = new QRCodeWriter();
+            BitMatrix bitMatrix = qrCodeWriter.encode(ticketId, BarcodeFormat.QR_CODE, 200, 200);
+            ByteArrayOutputStream qrBaos = new ByteArrayOutputStream();
+            MatrixToImageWriter.writeToStream(bitMatrix, "PNG", qrBaos);
+
+            Image qrImage = Image.getInstance(qrBaos.toByteArray());
+            document.add(qrImage);
+
+            document.close();
+            return CompletableFuture.completedFuture(baos.toByteArray());
+        } catch (Exception e) {
+            CompletableFuture<byte[]> failedFuture = new CompletableFuture<>();
+            failedFuture.completeExceptionally(e);
+            return failedFuture;
+        }
+    }
+}

--- a/src/main/java/com/eventra/specification/SearchSpecification.java
+++ b/src/main/java/com/eventra/specification/SearchSpecification.java
@@ -1,0 +1,33 @@
+package com.eventra.specification;
+
+import org.springframework.data.jpa.domain.Specification;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchSpecification {
+
+    public static <T> Specification<T> filterByCriteria(String keyword, String category, String status) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (keyword != null && !keyword.trim().isEmpty()) {
+                String likePattern = "%" + keyword.trim().toLowerCase() + "%";
+                predicates.add(criteriaBuilder.or(
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("title")), likePattern),
+                    criteriaBuilder.like(criteriaBuilder.lower(root.get("description")), likePattern)
+                ));
+            }
+
+            if (category != null && !category.trim().isEmpty()) {
+                predicates.add(criteriaBuilder.equal(root.get("category"), category));
+            }
+
+            if (status != null && !status.trim().isEmpty()) {
+                predicates.add(criteriaBuilder.equal(root.get("status"), status));
+            }
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}


### PR DESCRIPTION
## Description
Refactored duplicated dynamic SQL string construction across event and hackathon query services into reusable `org.springframework.data.jpa.domain.Specification` builders.
gssoc 26

**Key Changes:**
- **JPA Specification Builder:** Created `SearchSpecification` providing reusable Criteria API predicates for keyword, category, and status filters.
- **SQL Injection Prevention:** Eliminated inline string concatenation queries in search services, replacing them with type-safe CriteriaBuilder operations.

Fixes #14282

## Type of Change
- [x] Code refactoring (non-breaking change which cleans up existing implementation)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified JPA Specification criteria performed
- [x] Changes generate no compiler or runtime warnings