### PR TITLE
fix(utils): import API_BASE_URL from its source of truth in eventCancellationNotifications

### DIFF
--- a/src/utils/eventCancellationNotifications.js
+++ b/src/utils/eventCancellationNotifications.js
@@ -7,7 +7,7 @@
  */
 
 import axios from 'axios';
-import { API_BASE_URL } from '../config/api';
+import { API_BASE_URL } from '../config/backendConfig';
 
 class EventCancellationNotificationService {
   constructor() {


### PR DESCRIPTION
## Problem

`src/utils/eventCancellationNotifications.js` imports `API_BASE_URL` as a named export of `../config/api`, but `src/config/api.js` never exports it — it only re-exports `ApiError`, `RateLimitError`, and `normalizeApiError`. `API_BASE_URL` lives in `src/config/backendConfig.js` and is only *imported* into `config/api.js`. Any consumer of this util either hits a missing named-export build error or silently falls back to `http://localhost:8080/api` instead of the configured API base URL.

## Fix

Import `API_BASE_URL` from its source of truth (`../config/backendConfig`), so the configured API base URL is used instead of the localhost fallback.


## Files changed

- `src/utils/eventCancellationNotifications.js`


## Testing

- Confirmed `src/config/backendConfig.js` exports `API_BASE_URL`.
- Confirmed `src/config/api.js` does not export `API_BASE_URL` (only `ApiError`, `RateLimitError`, `normalizeApiError`).
- Change is a single import-path fix; no behavior change otherwise.


Closes #14142
