### PR TITLE
fix(backend): prevent duplicate audience poll voting with unique constraint and pre-check #14368

### DIFF
--- a/src/main/java/com/eventra/model/LiveAudiencePollVote.java
+++ b/src/main/java/com/eventra/model/LiveAudiencePollVote.java
@@ -1,0 +1,42 @@
+package com.eventra.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(
+    name = "live_audience_poll_votes",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_poll_user_vote", columnNames = {"poll_id", "user_id"})
+    }
+)
+public class LiveAudiencePollVote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "poll_id", nullable = false)
+    private Long pollId;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "option_id", nullable = false)
+    private Long optionId;
+
+    public LiveAudiencePollVote() {}
+
+    public LiveAudiencePollVote(Long pollId, String userId, Long optionId) {
+        this.pollId = pollId;
+        this.userId = userId;
+        this.optionId = optionId;
+    }
+
+    public Long getId() { return id; }
+    public Long getPollId() { return pollId; }
+    public void setPollId(Long pollId) { this.pollId = pollId; }
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+    public Long getOptionId() { return optionId; }
+    public void setOptionId(Long optionId) { this.optionId = optionId; }
+}

--- a/src/main/java/com/eventra/repository/LiveAudiencePollVoteRepository.java
+++ b/src/main/java/com/eventra/repository/LiveAudiencePollVoteRepository.java
@@ -1,0 +1,11 @@
+package com.eventra.repository;
+
+import com.eventra.model.LiveAudiencePollVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiveAudiencePollVoteRepository extends JpaRepository<LiveAudiencePollVote, Long> {
+
+    boolean existsByPollIdAndUserId(Long pollId, String userId);
+}

--- a/src/main/java/com/eventra/service/LiveAudiencePollService.java
+++ b/src/main/java/com/eventra/service/LiveAudiencePollService.java
@@ -1,0 +1,30 @@
+package com.eventra.service;
+
+import com.eventra.model.LiveAudiencePollVote;
+import com.eventra.repository.LiveAudiencePollVoteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.logging.Logger;
+
+@Service
+public class LiveAudiencePollService {
+
+    private static final Logger logger = Logger.getLogger(LiveAudiencePollService.class.getName());
+
+    @Autowired
+    private LiveAudiencePollVoteRepository voteRepository;
+
+    @Transactional
+    public void registerVote(Long pollId, String userId, Long optionId) {
+        if (voteRepository.existsByPollIdAndUserId(pollId, userId)) {
+            logger.warning("Duplicate vote attempt blocked for pollId: " + pollId + " by userId: " + userId);
+            throw new IllegalStateException("User has already submitted a vote for this poll.");
+        }
+
+        LiveAudiencePollVote vote = new LiveAudiencePollVote(pollId, userId, optionId);
+        voteRepository.save(vote);
+        logger.info("Successfully registered vote for pollId: " + pollId + " by userId: " + userId);
+    }
+}


### PR DESCRIPTION
## Description
Prevented duplicate audience poll voting by enforcing a unique constraint at the database schema level and adding a pre-persistence validation check in `LiveAudiencePollService`.
gssoc 26

**Key Changes:**
- **Database Unique Constraint:** Added `@Table(uniqueConstraints = {@UniqueConstraint(name = "uk_poll_user_vote", columnNames = {"poll_id", "user_id"})})` in `LiveAudiencePollVote` model.
- **Duplicate Check Method:** Added `existsByPollIdAndUserId` query method in `LiveAudiencePollVoteRepository`.
- **Validation Guard:** Added duplicate check in `registerVote` (`LiveAudiencePollService`) to reject repeated voting attempts before persistence.

Fixes #14368

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified poll voting service and model performed
- [x] Only targeted files staged and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors