### PR TITLE
feat(backend): implement real-time SSE push updates for active LiveAudiencePoll vote tallies #14370

### DIFF
--- a/src/main/java/com/eventra/controller/LiveAudiencePollController.java
+++ b/src/main/java/com/eventra/controller/LiveAudiencePollController.java
@@ -1,0 +1,20 @@
+package com.eventra.controller;
+
+import com.eventra.service.LiveAudiencePollService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/polls")
+public class LiveAudiencePollController {
+
+    @Autowired
+    private LiveAudiencePollService pollService;
+
+    @GetMapping(value = "/{pollId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamPollTally(@PathVariable Long pollId) {
+        return pollService.subscribeToPollStream(pollId);
+    }
+}

--- a/src/main/java/com/eventra/service/LiveAudiencePollService.java
+++ b/src/main/java/com/eventra/service/LiveAudiencePollService.java
@@ -1,0 +1,81 @@
+package com.eventra.service;
+
+import com.eventra.model.LiveAudiencePollVote;
+import com.eventra.repository.LiveAudiencePollVoteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+@Service
+public class LiveAudiencePollService {
+
+    private static final Logger logger = Logger.getLogger(LiveAudiencePollService.class.getName());
+    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    @Autowired
+    private LiveAudiencePollVoteRepository voteRepository;
+
+    public SseEmitter subscribeToPollStream(Long pollId) {
+        SseEmitter emitter = new SseEmitter(0L); // Infinite timeout for active streams
+        emitters.computeIfAbsent(pollId, k -> new ArrayList<>()).add(emitter);
+
+        emitter.onCompletion(() -> removeEmitter(pollId, emitter));
+        emitter.onTimeout(() -> removeEmitter(pollId, emitter));
+        emitter.onError(e -> removeEmitter(pollId, emitter));
+
+        logger.info("New SSE client subscribed to pollId: " + pollId);
+        return emitter;
+    }
+
+    @Transactional
+    public void registerVote(Long pollId, String userId, Long optionId) {
+        if (voteRepository.existsByPollIdAndUserId(pollId, userId)) {
+            throw new IllegalStateException("User has already submitted a vote for this poll.");
+        }
+
+        LiveAudiencePollVote vote = new LiveAudiencePollVote(pollId, userId, optionId);
+        voteRepository.save(vote);
+        logger.info("Vote registered for pollId: " + pollId + " by userId: " + userId);
+
+        // Broadcast updated vote counts to all SSE subscribers
+        broadcastPollTally(pollId);
+    }
+
+    public void broadcastPollTally(Long pollId) {
+        List<SseEmitter> pollEmitters = emitters.get(pollId);
+        if (pollEmitters == null || pollEmitters.isEmpty()) {
+            return;
+        }
+
+        // Fetch updated vote counts grouped by option ID
+        Map<Long, Long> tallies = voteRepository.getVoteCountsByOptionForPoll(pollId);
+
+        List<SseEmitter> deadEmitters = new ArrayList<>();
+        for (SseEmitter emitter : pollEmitters) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("poll-tally-update")
+                        .data(tallies));
+            } catch (IOException e) {
+                deadEmitters.add(emitter);
+            }
+        }
+
+        pollEmitters.removeAll(deadEmitters);
+    }
+
+    private void removeEmitter(Long pollId, SseEmitter emitter) {
+        List<SseEmitter> pollEmitters = emitters.get(pollId);
+        if (pollEmitters != null) {
+            pollEmitters.remove(emitter);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Implemented Server-Sent Events (SSE) streaming (`SseEmitter`) to push real-time vote count updates to connected clients whenever a new vote is submitted to an active audience poll.
gssoc 26

**Key Changes:**
- **SSE Stream Endpoint:** Created `GET /api/polls/{pollId}/stream` in `LiveAudiencePollController` producing `text/event-stream`.
- **Subscriber Connection Management:** Added `SseEmitter` subscription tracking in `LiveAudiencePollService` with completion/timeout cleanup handlers.
- **Automated Broadcast:** Integrated `broadcastPollTally` into the vote registration pipeline to dispatch `poll-tally-update` SSE events with aggregated vote counts.

Fixes #14370

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified poll controller and service performed
- [x] Only targeted files staged and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors