### PR TITLE
fix(backend): prevent negative upvote count on concurrent question un-upvotes #14372

### DIFF
--- a/src/main/java/com/eventra/model/LiveAudienceQuestion.java
+++ b/src/main/java/com/eventra/model/LiveAudienceQuestion.java
@@ -1,0 +1,37 @@
+package com.eventra.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "live_audience_questions")
+public class LiveAudienceQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "question_text", nullable = false, length = 1000)
+    private String questionText;
+
+    @Column(name = "upvotes", nullable = false)
+    private Integer upvotes = 0;
+
+    public LiveAudienceQuestion() {}
+
+    public LiveAudienceQuestion(Long eventId, String questionText) {
+        this.eventId = eventId;
+        this.questionText = questionText;
+        this.upvotes = 0;
+    }
+
+    public Long getId() { return id; }
+    public Long getEventId() { return eventId; }
+    public void setEventId(Long eventId) { this.eventId = eventId; }
+    public String getQuestionText() { return questionText; }
+    public void setQuestionText(String questionText) { this.questionText = questionText; }
+    public Integer getUpvotes() { return upvotes; }
+    public void setUpvotes(Integer upvotes) { this.upvotes = Math.max(0, upvotes); }
+}

--- a/src/main/java/com/eventra/repository/LiveAudienceQuestionRepository.java
+++ b/src/main/java/com/eventra/repository/LiveAudienceQuestionRepository.java
@@ -1,0 +1,20 @@
+package com.eventra.repository;
+
+import com.eventra.model.LiveAudienceQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LiveAudienceQuestionRepository extends JpaRepository<LiveAudienceQuestion, Long> {
+
+    @Modifying
+    @Query("UPDATE LiveAudienceQuestion q SET q.upvotes = q.upvotes - 1 WHERE q.id = :id AND q.upvotes > 0")
+    int decrementUpvotesAtomic(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE LiveAudienceQuestion q SET q.upvotes = q.upvotes + 1 WHERE q.id = :id")
+    int incrementUpvotesAtomic(@Param("id") Long id);
+}

--- a/src/main/java/com/eventra/service/LiveAudienceQuestionService.java
+++ b/src/main/java/com/eventra/service/LiveAudienceQuestionService.java
@@ -1,0 +1,33 @@
+package com.eventra.service;
+
+import com.eventra.repository.LiveAudienceQuestionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.logging.Logger;
+
+@Service
+public class LiveAudienceQuestionService {
+
+    private static final Logger logger = Logger.getLogger(LiveAudienceQuestionService.class.getName());
+
+    @Autowired
+    private LiveAudienceQuestionRepository questionRepository;
+
+    @Transactional
+    public void unUpvoteQuestion(Long questionId) {
+        int rowsUpdated = questionRepository.decrementUpvotesAtomic(questionId);
+        if (rowsUpdated == 0) {
+            logger.warning("Un-upvote ignored: Question ID " + questionId + " upvotes already at 0 or question not found.");
+        } else {
+            logger.info("Successfully decremented upvote count atomically for Question ID: " + questionId);
+        }
+    }
+
+    @Transactional
+    public void upvoteQuestion(Long questionId) {
+        questionRepository.incrementUpvotesAtomic(questionId);
+        logger.info("Successfully incremented upvote count for Question ID: " + questionId);
+    }
+}


### PR DESCRIPTION
## Description
Fixed a race condition in `LiveAudienceQuestionService` where concurrent un-upvote operations caused audience question upvote totals to drop below zero.
gssoc 26

**Key Changes:**
- **Atomic Decrement Query:** Added `@Query("UPDATE LiveAudienceQuestion q SET q.upvotes = q.upvotes - 1 WHERE q.id = :id AND q.upvotes > 0")` in `LiveAudienceQuestionRepository` to enforce lower-bound protection at the database level.
- **Service Integration:** Updated `unUpvoteQuestion` inside `LiveAudienceQuestionService` to execute the atomic update query and log warnings if an un-upvote request occurs when upvotes are already at zero.

Fixes #14372

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified question service and repository performed
- [x] Only targeted files staged and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors