### PR TITLE
sec(backend): add scheduled TTL cleanup job for expired blacklisted tokens #14380

### DIFF
--- a/src/main/java/com/eventra/model/BlacklistedToken.java
+++ b/src/main/java/com/eventra/model/BlacklistedToken.java
@@ -1,0 +1,32 @@
+package com.eventra.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "blacklisted_tokens")
+public class BlacklistedToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "token", nullable = false, unique = true, length = 1000)
+    private String token;
+
+    @Column(name = "expiry_date", nullable = false)
+    private LocalDateTime expiryDate;
+
+    public BlacklistedToken() {}
+
+    public BlacklistedToken(String token, LocalDateTime expiryDate) {
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+
+    public Long getId() { return id; }
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+    public LocalDateTime getExpiryDate() { return expiryDate; }
+    public void setExpiryDate(LocalDateTime expiryDate) { this.expiryDate = expiryDate; }
+}

--- a/src/main/java/com/eventra/repository/BlacklistedTokenRepository.java
+++ b/src/main/java/com/eventra/repository/BlacklistedTokenRepository.java
@@ -1,0 +1,20 @@
+package com.eventra.repository;
+
+import com.eventra.model.BlacklistedToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface BlacklistedTokenRepository extends JpaRepository<BlacklistedToken, Long> {
+
+    boolean existsByToken(String token);
+
+    @Modifying
+    @Query("DELETE FROM BlacklistedToken b WHERE b.expiryDate < :now")
+    int deleteByExpiryDateBefore(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/eventra/scheduler/TokenCleanupScheduler.java
+++ b/src/main/java/com/eventra/scheduler/TokenCleanupScheduler.java
@@ -1,0 +1,31 @@
+package com.eventra.scheduler;
+
+import com.eventra.repository.BlacklistedTokenRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.logging.Logger;
+
+@Component
+public class TokenCleanupScheduler {
+
+    private static final Logger logger = Logger.getLogger(TokenCleanupScheduler.class.getName());
+
+    @Autowired
+    private BlacklistedTokenRepository tokenRepository;
+
+    /**
+     * Daily scheduled task running at 3:00 AM to purge expired blacklisted JWT tokens,
+     * preventing database table bloat and maintaining lookup efficiency.
+     */
+    @Scheduled(cron = "0 0 3 * * ?")
+    @Transactional
+    public void purgeExpiredBlacklistedTokens() {
+        LocalDateTime now = LocalDateTime.now();
+        int deletedCount = tokenRepository.deleteByExpiryDateBefore(now);
+        logger.info("Executed scheduled BlacklistedToken TTL cleanup. Purged " + deletedCount + " expired tokens at " + now);
+    }
+}


### PR DESCRIPTION
## Description
Implemented an automated TTL cleanup worker to periodically purge expired `BlacklistedToken` records from the database, preventing table bloat and maintaining fast index lookup performance during authentication token validation.
gssoc 26

**Key Changes:**
- **Bulk Delete Repository Method:** Added `@Query("DELETE FROM BlacklistedToken b WHERE b.expiryDate < :now")` in `BlacklistedTokenRepository`.
- **Scheduled Cron Task:** Created `TokenCleanupScheduler` running daily at 03:00 AM (`@Scheduled(cron = "0 0 3 * * ?")`) wrapped in `@Transactional` to automatically remove stale revoked tokens.
- **Clean Branch Isolation:** Created directly off `upstream/master` and staged only target entity, repository, and scheduler files.

Fixes #14380

## Type of Change
- [x] Security / Maintenance fix (non-breaking change which optimizes token management)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified token cleanup scheduler and repository performed
- [x] Only targeted files staged and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors