### PR TITLE
feat(backend): Add honeypot field and IP rate limiting on ContactMessage endpoint

### DIFF
--- a/src/main/java/com/eventra/controller/ContactMessageController.java
+++ b/src/main/java/com/eventra/controller/ContactMessageController.java
@@ -1,0 +1,31 @@
+package com.eventra.controller;
+
+import com.eventra.dto.ContactMessageDTO;
+import com.eventra.service.ContactMessageService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/contact")
+public class ContactMessageController {
+
+    @Autowired
+    private ContactMessageService contactMessageService;
+
+    @PostMapping
+    public ResponseEntity<String> submitContactMessage(@RequestBody ContactMessageDTO dto, HttpServletRequest request) {
+        String clientIp = extractClientIp(request);
+        contactMessageService.processContactMessage(dto, clientIp);
+        return ResponseEntity.ok("Message submitted successfully.");
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String xfHeader = request.getHeader("X-Forwarded-For");
+        if (xfHeader == null || xfHeader.isEmpty()) {
+            return request.getRemoteAddr();
+        }
+        return xfHeader.split(",")[0].trim();
+    }
+}

--- a/src/main/java/com/eventra/dto/ContactMessageDTO.java
+++ b/src/main/java/com/eventra/dto/ContactMessageDTO.java
@@ -1,0 +1,33 @@
+package com.eventra.dto;
+
+public class ContactMessageDTO {
+
+    private String name;
+    private String email;
+    private String subject;
+    private String message;
+    
+    // Hidden honeypot field intended to catch automated bots
+    private String honeypot;
+
+    public ContactMessageDTO() {}
+
+    public ContactMessageDTO(String name, String email, String subject, String message, String honeypot) {
+        this.name = name;
+        this.email = email;
+        this.subject = subject;
+        this.message = message;
+        this.honeypot = honeypot;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public String getHoneypot() { return honeypot; }
+    public void setHoneypot(String honeypot) { this.honeypot = honeypot; }
+}

--- a/src/main/java/com/eventra/service/ContactMessageService.java
+++ b/src/main/java/com/eventra/service/ContactMessageService.java
@@ -1,0 +1,45 @@
+package com.eventra.service;
+
+import com.eventra.dto.ContactMessageDTO;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+@Service
+public class ContactMessageService {
+
+    private static final Logger logger = Logger.getLogger(ContactMessageService.class.getName());
+    private static final int MAX_REQUESTS_PER_MINUTE = 3;
+    private static final long ONE_MINUTE_IN_MS = 60 * 1000L;
+
+    private final Map<String, List<Long>> ipRequestTimestamps = new ConcurrentHashMap<>();
+
+    public void processContactMessage(ContactMessageDTO dto, String clientIp) {
+        // 1. Honeypot check: reject if the hidden field is populated
+        if (dto.getHoneypot() != null && !dto.getHoneypot().trim().isEmpty()) {
+            logger.warning("Spam submission blocked via honeypot trap from IP: " + clientIp);
+            throw new IllegalArgumentException("Invalid submission payload.");
+        }
+
+        // 2. IP Rate Limiting check: max 3 submissions per minute
+        long now = System.currentTimeMillis();
+        List<Long> timestamps = ipRequestTimestamps.computeIfAbsent(clientIp, k -> new ArrayList<>());
+
+        synchronized (timestamps) {
+            timestamps.removeIf(timestamp -> (now - timestamp) > ONE_MINUTE_IN_MS);
+
+            if (timestamps.size() >= MAX_REQUESTS_PER_MINUTE) {
+                logger.warning("Rate limit exceeded for contact form from IP: " + clientIp);
+                throw new IllegalStateException("Rate limit exceeded. Maximum 3 submissions per minute allowed.");
+            }
+
+            timestamps.add(now);
+        }
+
+        logger.info("Contact message processed successfully from IP: " + clientIp + ", Email: " + dto.getEmail());
+    }
+}


### PR DESCRIPTION
## Description
Implemented anti-spam protections on the contact form submission endpoint (`/api/contact`) by introducing a hidden honeypot field trap and enforcing client IP submission rate limiting.
gssoc 26

**Key Changes:**
- **Honeypot Trap Validation:** Added hidden `honeypot` property in `ContactMessageDTO`. Requests filling this field are immediately rejected as automated spam.
- **IP Rate Limiting:** Enforced a rate limit of **3 requests per minute per IP address** in `ContactMessageService` using sliding window timestamp tracking.
- **Client IP Extraction:** Extracted client IP addresses in `ContactMessageController` with support for `X-Forwarded-For` reverse proxy headers.

Fixes #14384

## Type of Change
- [x] New feature / Security enhancement (non-breaking change which prevents contact form spam)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified contact message controller, DTO, and service performed
- [x] Only targeted files staged and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors