### PR TITLE
fix(hooks): import useAuth from context/AuthContext in usePublicEvents

### DIFF
--- a/src/hooks/usePublicEvents.js
+++ b/src/hooks/usePublicEvents.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useAuth } from "./useAuth";
+import { useAuth } from "../context/AuthContext";
 import { apiUtils, API_ENDPOINTS } from "../config/api";
 
 /**


### PR DESCRIPTION
## Problem

`src/hooks/usePublicEvents.js` imports `useAuth` from `./useAuth`, but no `useAuth.{js,jsx}` module exists in `src/hooks/`. The auth hook lives in `src/context/AuthContext.js`. Any code path that imports `usePublicEvents` fails at module resolution, and static analyzers flag the missing module.

## Fix

Import the real auth context the same way the rest of the app does: `import { useAuth } from "../context/AuthContext"`.


## Files changed

- `src/hooks/usePublicEvents.js`


## Testing

- Confirmed `src/context/AuthContext.js` exports `useAuth`.
- Confirmed no `src/hooks/useAuth.{js,jsx}` module exists.
- Change is a single import-path fix; no behavior change otherwise.


Closes #14143
