### PR TITLE
feat(backend): Add rating aggregation and sentiment classification to Feedback API #14387

### DIFF
--- a/src/main/java/com/eventra/dto/FeedbackSummaryDTO.java
+++ b/src/main/java/com/eventra/dto/FeedbackSummaryDTO.java
@@ -1,0 +1,35 @@
+package com.eventra.dto;
+
+public class FeedbackSummaryDTO {
+
+    private Long eventId;
+    private Double averageRating;
+    private long totalFeedbacks;
+    private long positiveCount;
+    private long neutralCount;
+    private long negativeCount;
+
+    public FeedbackSummaryDTO() {}
+
+    public FeedbackSummaryDTO(Long eventId, Double averageRating, long totalFeedbacks, long positiveCount, long neutralCount, long negativeCount) {
+        this.eventId = eventId;
+        this.averageRating = averageRating;
+        this.totalFeedbacks = totalFeedbacks;
+        this.positiveCount = positiveCount;
+        this.neutralCount = neutralCount;
+        this.negativeCount = negativeCount;
+    }
+
+    public Long getEventId() { return eventId; }
+    public void setEventId(Long eventId) { this.eventId = eventId; }
+    public Double getAverageRating() { return averageRating; }
+    public void setAverageRating(Double averageRating) { this.averageRating = averageRating; }
+    public long getTotalFeedbacks() { return totalFeedbacks; }
+    public void setTotalFeedbacks(long totalFeedbacks) { this.totalFeedbacks = totalFeedbacks; }
+    public long getPositiveCount() { return positiveCount; }
+    public void setPositiveCount(long positiveCount) { this.positiveCount = positiveCount; }
+    public long getNeutralCount() { return neutralCount; }
+    public void setNeutralCount(long neutralCount) { this.neutralCount = neutralCount; }
+    public long getNegativeCount() { return negativeCount; }
+    public void setNegativeCount(long negativeCount) { this.negativeCount = negativeCount; }
+}

--- a/src/main/java/com/eventra/model/Feedback.java
+++ b/src/main/java/com/eventra/model/Feedback.java
@@ -1,0 +1,55 @@
+package com.eventra.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event_feedbacks")
+public class Feedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "rating", nullable = false)
+    private Integer rating;
+
+    @Column(name = "comment", length = 2000)
+    private String comment;
+
+    @Column(name = "sentiment")
+    private String sentiment;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public Feedback() {}
+
+    public Feedback(Long eventId, String userId, Integer rating, String comment) {
+        this.eventId = eventId;
+        this.userId = userId;
+        this.rating = rating;
+        this.comment = comment;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+    public Long getEventId() { return eventId; }
+    public void setEventId(Long eventId) { this.eventId = eventId; }
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+    public Integer getRating() { return rating; }
+    public void setRating(Integer rating) { this.rating = rating; }
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+    public String getSentiment() { return sentiment; }
+    public void setSentiment(String sentiment) { this.sentiment = sentiment; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/eventra/repository/FeedbackRepository.java
+++ b/src/main/java/com/eventra/repository/FeedbackRepository.java
@@ -1,0 +1,22 @@
+package com.eventra.repository;
+
+import com.eventra.model.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+
+    List<Feedback> findByEventId(Long eventId);
+
+    @Query("SELECT AVG(f.rating) FROM Feedback f WHERE f.eventId = :eventId")
+    Optional<Double> findAverageRatingByEventId(@Param("eventId") Long eventId);
+
+    @Query("SELECT COUNT(f) FROM Feedback f WHERE f.eventId = :eventId AND f.sentiment = :sentiment")
+    long countByEventIdAndSentiment(@Param("eventId") Long eventId, @Param("sentiment") String sentiment);
+}

--- a/src/main/java/com/eventra/service/FeedbackService.java
+++ b/src/main/java/com/eventra/service/FeedbackService.java
@@ -1,0 +1,72 @@
+package com.eventra.service;
+
+import com.eventra.dto.FeedbackSummaryDTO;
+import com.eventra.model.Feedback;
+import com.eventra.repository.FeedbackRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+@Service
+public class FeedbackService {
+
+    private static final Logger logger = Logger.getLogger(FeedbackService.class.getName());
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Transactional
+    public Feedback submitFeedback(Long eventId, String userId, Integer rating, String comment) {
+        if (rating == null || rating < 1 || rating > 5) {
+            throw new IllegalArgumentException("Rating must be between 1 and 5.");
+        }
+
+        Feedback feedback = new Feedback(eventId, userId, rating, comment);
+        feedback.setSentiment(classifySentiment(rating, comment));
+
+        Feedback saved = feedbackRepository.save(feedback);
+        logger.info("Feedback saved for event ID: " + eventId + " with sentiment: " + saved.getSentiment());
+        return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackSummaryDTO getEventFeedbackSummary(Long eventId) {
+        Double avgRating = feedbackRepository.findAverageRatingByEventId(eventId).orElse(0.0);
+        List<Feedback> allFeedbacks = feedbackRepository.findByEventId(eventId);
+
+        long positiveCount = feedbackRepository.countByEventIdAndSentiment(eventId, "POSITIVE");
+        long neutralCount = feedbackRepository.countByEventIdAndSentiment(eventId, "NEUTRAL");
+        long negativeCount = feedbackRepository.countByEventIdAndSentiment(eventId, "NEGATIVE");
+
+        return new FeedbackSummaryDTO(
+                eventId,
+                Math.round(avgRating * 100.0) / 100.0,
+                allFeedbacks.size(),
+                positiveCount,
+                neutralCount,
+                negativeCount
+        );
+    }
+
+    private String classifySentiment(Integer rating, String comment) {
+        if (comment != null && !comment.trim().isEmpty()) {
+            String lowerComment = comment.toLowerCase();
+            if (lowerComment.contains("great") || lowerComment.contains("excellent") || lowerComment.contains("amazing") || lowerComment.contains("awesome") || lowerComment.contains("love")) {
+                return "POSITIVE";
+            }
+            if (lowerComment.contains("bad") || lowerComment.contains("poor") || lowerComment.contains("terrible") || lowerComment.contains("horrible") || lowerComment.contains("waste")) {
+                return "NEGATIVE";
+            }
+        }
+
+        if (rating >= 4) {
+            return "POSITIVE";
+        } else if (rating <= 2) {
+            return "NEGATIVE";
+        }
+        return "NEUTRAL";
+    }
+}


### PR DESCRIPTION
## Description
Added efficient database-level average rating aggregation and automatic sentiment classification (`POSITIVE`, `NEUTRAL`, `NEGATIVE`) for event feedback submissions in `FeedbackService` and `FeedbackRepository`.
gssoc 26

**Key Changes:**
- **Aggregated Rating Query:** Added custom JPQL query `@Query("SELECT AVG(f.rating) FROM Feedback f WHERE f.eventId = :eventId")` in `FeedbackRepository` to calculate mean ratings directly in the database layer.
- **Sentiment Classification:** Implemented sentiment heuristic rules in `FeedbackService` classifying submissions based on feedback comment analysis and star ratings.
- **Summary DTO Integration:** Created `FeedbackSummaryDTO` to return aggregated average ratings along with sentiment distribution metrics (`positiveCount`, `neutralCount`, `negativeCount`).

Fixes #14387

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of modified feedback service and repository performed
- [x] Only targeted files staged and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors