### PR TITLE
fix(components): correct eventDefaults import depth in EventBasicInfo

### DIFF
--- a/src/components/common/EventCreation/EventBasicInfo.jsx
+++ b/src/components/common/EventCreation/EventBasicInfo.jsx
@@ -1,7 +1,7 @@
 
 import { motion } from "framer-motion";
 import { FileText, Tag, Users } from "lucide-react";
-import { categories } from "../constants/eventDefaults";
+import { categories } from "../../constants/eventDefaults";
 import CharacterCounter from "../CharacterCounter";
 
 const FormField = ({ label, icon: Icon, error, children, required, hint }) => (


### PR DESCRIPTION
## Problem

`src/components/common/EventCreation/EventBasicInfo.jsx` imports `categories` from `../constants/eventDefaults`, which resolves to the non-existent `components/common/EventCreation/constants/eventDefaults`. The constants file actually lives at `src/constants/eventDefaults.js`. Importing the component fails with a module-resolution error.

## Fix

Correct the relative path depth so the import resolves to `src/constants/eventDefaults`: `../../constants/eventDefaults`.


## Files changed

- `src/components/common/EventCreation/EventBasicInfo.jsx`


## Testing

- Confirmed `src/constants/eventDefaults.js` exports `categories`.
- Confirmed `components/common/EventCreation/constants/eventDefaults` does not exist.
- Change is a single import-path fix; no behavior change otherwise.


Closes #14144
