### PR TITLE
fix(components): correct floorPlanPresets import depth in PropertiesPanel

### DIFF
--- a/src/components/events/FloorPlan/PropertiesPanel.jsx
+++ b/src/components/events/FloorPlan/PropertiesPanel.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Trash2, Users } from "lucide-react";
-import { MOCK_ATTENDEES } from "../constants/floorPlanPresets";
+import { MOCK_ATTENDEES } from "../../constants/floorPlanPresets";
 
 export default function PropertiesPanel({
   activeElement, elements, onUpdateSelected, onDeleteSelected,


### PR DESCRIPTION
## Problem

`src/components/events/FloorPlan/PropertiesPanel.jsx` imports `MOCK_ATTENDEES` from `../constants/floorPlanPresets`, which resolves to the non-existent `components/events/FloorPlan/constants/floorPlanPresets`. The presets file actually lives at `src/constants/floorPlanPresets.js`. Importing the component fails with a module-resolution error.

## Fix

Correct the relative path depth so the import resolves to `src/constants/floorPlanPresets`: `../../constants/floorPlanPresets`.


## Files changed

- `src/components/events/FloorPlan/PropertiesPanel.jsx`


## Testing

- Confirmed `src/constants/floorPlanPresets.js` exports `MOCK_ATTENDEES`.
- Confirmed `components/events/FloorPlan/constants/floorPlanPresets` does not exist.
- Change is a single import-path fix; no behavior change otherwise.


Closes #14145
