### PR TITLE
feat(backend/frontend): Add event registration pause/resume controls and status display #14403

### DIFF
--- a/src/components/events/RegistrationButton.jsx
+++ b/src/components/events/RegistrationButton.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export const RegistrationButton = ({ isPaused, pauseReason, resumeDate, onRegister }) => {
+  const buttonText = isPaused ? "Registration Temporarily Paused" : "Register Now";
+
+  return (
+    <div className="flex flex-col gap-2 w-full max-w-md">
+      <button
+        disabled={isPaused}
+        onClick={onRegister}
+        className={`w-full py-3 px-6 rounded-xl font-bold text-white transition-all shadow-md ${
+          isPaused
+            ? 'bg-amber-500/80 cursor-not-allowed opacity-90'
+            : 'bg-blue-600 hover:bg-blue-700 cursor-pointer'
+        }`}
+      >
+        {buttonText}
+      </button>
+
+      {isPaused && (
+        <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-xs text-amber-800 dark:text-amber-300 space-y-1">
+          {pauseReason && (
+            <p><span className="font-semibold">Reason:</span> {pauseReason}</p>
+          )}
+          {resumeDate && (
+            <p><span className="font-semibold">Expected Resume:</span> {new Date(resumeDate).toLocaleString()}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RegistrationButton;

--- a/src/main/java/com/eventra/dto/EventRegistrationStatusDTO.java
+++ b/src/main/java/com/eventra/dto/EventRegistrationStatusDTO.java
@@ -1,0 +1,33 @@
+package com.eventra.dto;
+
+import java.time.LocalDateTime;
+
+public class EventRegistrationStatusDTO {
+
+    private Long eventId;
+    private boolean registrationPaused;
+    private String pauseReason;
+    private LocalDateTime resumeDate;
+    private String buttonMessage;
+
+    public EventRegistrationStatusDTO() {}
+
+    public EventRegistrationStatusDTO(Long eventId, boolean registrationPaused, String pauseReason, LocalDateTime resumeDate) {
+        this.eventId = eventId;
+        this.registrationPaused = registrationPaused;
+        this.pauseReason = pauseReason;
+        this.resumeDate = resumeDate;
+        this.buttonMessage = registrationPaused ? "Registration Temporarily Paused" : "Register Now";
+    }
+
+    public Long getEventId() { return eventId; }
+    public void setEventId(Long eventId) { this.eventId = eventId; }
+    public boolean isRegistrationPaused() { return registrationPaused; }
+    public void setRegistrationPaused(boolean registrationPaused) { this.registrationPaused = registrationPaused; }
+    public String getPauseReason() { return pauseReason; }
+    public void setPauseReason(String pauseReason) { this.pauseReason = pauseReason; }
+    public LocalDateTime getResumeDate() { return resumeDate; }
+    public void setResumeDate(LocalDateTime resumeDate) { this.resumeDate = resumeDate; }
+    public String getButtonMessage() { return buttonMessage; }
+    public void setButtonMessage(String buttonMessage) { this.buttonMessage = buttonMessage; }
+}

--- a/src/main/java/com/eventra/model/Event.java
+++ b/src/main/java/com/eventra/model/Event.java
@@ -1,0 +1,48 @@
+package com.eventra.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "events")
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", length = 2000)
+    private String description;
+
+    @Column(name = "registration_paused", nullable = false)
+    private boolean registrationPaused = false;
+
+    @Column(name = "pause_reason")
+    private String pauseReason;
+
+    @Column(name = "resume_date")
+    private LocalDateTime resumeDate;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public Event() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public boolean isRegistrationPaused() { return registrationPaused; }
+    public void setRegistrationPaused(boolean registrationPaused) { this.registrationPaused = registrationPaused; }
+    public String getPauseReason() { return pauseReason; }
+    public void setPauseReason(String pauseReason) { this.pauseReason = pauseReason; }
+    public LocalDateTime getResumeDate() { return resumeDate; }
+    public void setResumeDate(LocalDateTime resumeDate) { this.resumeDate = resumeDate; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/eventra/service/EventRegistrationControlService.java
+++ b/src/main/java/com/eventra/service/EventRegistrationControlService.java
@@ -1,0 +1,47 @@
+package com.eventra.service;
+
+import com.eventra.dto.EventRegistrationStatusDTO;
+import com.eventra.model.Event;
+import com.eventra.repository.EventRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.logging.Logger;
+
+@Service
+public class EventRegistrationControlService {
+
+    private static final Logger logger = Logger.getLogger(EventRegistrationControlService.class.getName());
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Transactional
+    public Event togglePauseRegistration(Long eventId, boolean pause, String reason, LocalDateTime resumeDate) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found with ID: " + eventId));
+
+        event.setRegistrationPaused(pause);
+        event.setPauseReason(pause ? reason : null);
+        event.setResumeDate(pause ? resumeDate : null);
+
+        Event updated = eventRepository.save(event);
+        logger.info("Event ID " + eventId + " registration pause status updated to: " + pause);
+        return updated;
+    }
+
+    @Transactional(readOnly = true)
+    public EventRegistrationStatusDTO getRegistrationStatus(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("Event not found with ID: " + eventId));
+
+        return new EventRegistrationStatusDTO(
+                event.getId(),
+                event.isRegistrationPaused(),
+                event.getPauseReason(),
+                event.getResumeDate()
+        );
+    }
+}


### PR DESCRIPTION
## Description
Implemented organizer controls to temporarily pause and resume event registrations without permanent cancellation, addressing issue #14403.
gssoc 26

**Key Changes:**
- **Backend Model & DTO:** Added `registrationPaused`, `pauseReason`, and `resumeDate` fields to the `Event` entity and created `EventRegistrationStatusDTO`.
- **Service Layer Control:** Built `EventRegistrationControlService` supporting organizer pause/resume state mutations and status checks.
- **Frontend Registration Component:** Created `RegistrationButton.jsx` which displays `"Registration Temporarily Paused"`, detailed pause reasons, and optional resume dates when registrations are suspended.
- **Full Repository Staging:** Staged all repository changes using `git add .` as requested.

Fixes #14403

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of registration pause/resume logic performed
- [x] All changes staged via `git add .` and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors