### PR TITLE
feat(backend/frontend): Add organizer dashboard quick actions for common event management tasks #14415

### DIFF
--- a/src/components/organizer/OrganizerDashboardQuickActions.jsx
+++ b/src/components/organizer/OrganizerDashboardQuickActions.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+export const OrganizerDashboardQuickActions = ({ eventId = 101, onQuickActionTrigger }) => {
+  const [activeMessage, setActiveMessage] = useState('');
+
+  const actions = [
+    { type: 'CREATE_EVENT', label: 'Create Event', icon: '➕', color: 'bg-blue-600 hover:bg-blue-700' },
+    { type: 'EDIT_EVENT', label: 'Edit Event', icon: '✏️', color: 'bg-amber-600 hover:bg-amber-700' },
+    { type: 'VIEW_PARTICIPANTS', label: 'View Participants', icon: '👥', color: 'bg-emerald-600 hover:bg-emerald-700' },
+    { type: 'SEND_ANNOUNCEMENT', label: 'Send Announcement', icon: '📢', color: 'bg-purple-600 hover:bg-purple-700' },
+    { type: 'EXPORT_REGISTRATIONS', label: 'Export Registrations', icon: '📥', color: 'bg-indigo-600 hover:bg-indigo-700' },
+    { type: 'MANAGE_FEEDBACK', label: 'Manage Feedback', icon: '💬', color: 'bg-teal-600 hover:bg-teal-700' },
+    { type: 'CLOSE_REGISTRATION', label: 'Close Registration', icon: '🔒', color: 'bg-rose-600 hover:bg-rose-700' },
+  ];
+
+  const handleActionClick = (action) => {
+    if (onQuickActionTrigger) {
+      onQuickActionTrigger({ eventId, actionType: action.type });
+    }
+    setActiveMessage(`Triggered action: ${action.label}`);
+    setTimeout(() => setActiveMessage(''), 3000);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-md space-y-6">
+      <div className="border-b border-gray-200 dark:border-gray-700 pb-4">
+        <h2 className="text-2xl font-extrabold text-gray-900 dark:text-gray-100">
+          Organizer Dashboard Quick Actions
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Perform frequent event-management tasks instantly to boost productivity.
+        </p>
+      </div>
+
+      {activeMessage && (
+        <div className="p-4 bg-blue-50 dark:bg-blue-900/30 border border-blue-500 text-blue-700 dark:text-blue-300 rounded-lg">
+          {activeMessage}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {actions.map((action) => (
+          <button
+            key={action.type}
+            onClick={() => handleActionClick(action)}
+            className={`flex items-center gap-3 p-4 text-white font-semibold rounded-xl shadow-sm transition transform hover:-translate-y-0.5 ${action.color}`}
+          >
+            <span className="text-2xl">{action.icon}</span>
+            <span className="text-sm">{action.label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default OrganizerDashboardQuickActions;

--- a/src/main/java/com/eventra/dto/OrganizerQuickActionDTO.java
+++ b/src/main/java/com/eventra/dto/OrganizerQuickActionDTO.java
@@ -1,0 +1,35 @@
+package com.eventra.dto;
+
+public class OrganizerQuickActionDTO {
+
+    public enum QuickActionType {
+        CREATE_EVENT,
+        EDIT_EVENT,
+        VIEW_PARTICIPANTS,
+        SEND_ANNOUNCEMENT,
+        EXPORT_REGISTRATIONS,
+        MANAGE_FEEDBACK,
+        CLOSE_REGISTRATION
+    }
+
+    private Long eventId;
+    private QuickActionType actionType;
+    private String actionLabel;
+
+    public OrganizerQuickActionDTO() {}
+
+    public OrganizerQuickActionDTO(Long eventId, QuickActionType actionType, String actionLabel) {
+        this.eventId = eventId;
+        this.actionType = actionType;
+        this.actionLabel = actionLabel;
+    }
+
+    public Long getEventId() { return eventId; }
+    public void setEventId(Long eventId) { this.eventId = eventId; }
+
+    public QuickActionType getActionType() { return actionType; }
+    public void setActionType(QuickActionType actionType) { this.actionType = actionType; }
+
+    public String getActionLabel() { return actionLabel; }
+    public void setActionLabel(String actionLabel) { this.actionLabel = actionLabel; }
+}


### PR DESCRIPTION
## Description
Implemented quick-action controls on the organizer dashboard for frequent event-management tasks to reduce navigation time and enhance organizer productivity.
gssoc 26

**Key Changes:**
- **Backend DTO:** Created `OrganizerQuickActionDTO` supporting action types (`CREATE_EVENT`, `EDIT_EVENT`, `VIEW_PARTICIPANTS`, `SEND_ANNOUNCEMENT`, `EXPORT_REGISTRATIONS`, `MANAGE_FEEDBACK`, `CLOSE_REGISTRATION`).
- **Organizer Frontend Component:** Developed `OrganizerDashboardQuickActions.jsx` featuring grid shortcuts with icons, action handlers, and instant feedback alerts.
- **Full Repository Staging:** Staged all repository updates using `git add .` as required.

Fixes #14415

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of organizer dashboard quick actions component performed
- [x] All changes staged via `git add .` and committed off clean `upstream/master`
- [x] Changes generate no compiler or runtime errors