### PR TITLE
fix: normalize registration date validation

### DIFF
--- a/src/utils/eventFormValidation.js
+++ b/src/utils/eventFormValidation.js
@@ -59,24 +59,38 @@ export const validateForm = (formData) => {
     const registrationEnd = formData.registrationEnd
       ? new Date(formData.registrationEnd)
       : null;
-    const eventStart = new Date(
-      `${formData.isMultiDay ? formData.startDate : formData.date}T${formData.startTime}`
-    );
 
-    if (registrationStart && registrationStart < now) {
+    // Normalize date to YYYY-MM-DD format before combining with time
+    const rawDate = formData.isMultiDay ? formData.startDate : formData.date;
+    const dateStr = rawDate?.includes("T") ? rawDate.split("T")[0] : rawDate;
+    const eventStart = new Date(`${dateStr}T${formData.startTime}`);
+
+    if (registrationStart && isNaN(registrationStart.getTime())) {
+      newErrors.registrationStart = "Invalid registration start date";
+    } else if (registrationStart && registrationStart < now) {
       newErrors.registrationStart = "Registration start cannot be in the past";
     }
 
-    if (registrationStart && registrationEnd && registrationStart >= registrationEnd) {
-      newErrors.registrationEnd = "Registration end must be after registration start";
+    if (registrationEnd && isNaN(registrationEnd.getTime())) {
+      newErrors.registrationEnd = "Invalid registration end date";
     }
 
-    if (registrationStart && !isNaN(eventStart.getTime()) && registrationStart >= eventStart) {
-      newErrors.registrationStart = "Registration start must be before the event starts";
+    if (registrationStart && registrationEnd && !isNaN(registrationStart.getTime()) && !isNaN(registrationEnd.getTime())) {
+      if (registrationStart >= registrationEnd) {
+        newErrors.registrationEnd = "Registration end must be after registration start";
+      }
     }
 
-    if (registrationEnd && !isNaN(eventStart.getTime()) && registrationEnd >= eventStart) {
-      newErrors.registrationEnd = "Registration must close before the event starts";
+    if (registrationStart && !isNaN(eventStart.getTime()) && !isNaN(registrationStart.getTime())) {
+      if (registrationStart >= eventStart) {
+        newErrors.registrationStart = "Registration start must be before the event starts";
+      }
+    }
+
+    if (registrationEnd && !isNaN(eventStart.getTime()) && !isNaN(registrationEnd.getTime())) {
+      if (registrationEnd >= eventStart) {
+        newErrors.registrationEnd = "Registration must close before the event starts";
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #14450.

- Normalize event dates before combining them with time values.
- Prevent invalid ISO timestamps from producing `Invalid Date`.
- Add explicit validation for invalid registration start and end dates.
- Ensure date comparisons only run when the parsed dates are valid.

## Testing

- Verified the updated date normalization logic.
- Verified invalid date values are rejected.
- Verified registration date comparisons are performed only with valid dates.