### PR TITLE
fix: prevent negative draft age values

### DIFF
--- a/src/utils/eventDraftUtils.js
+++ b/src/utils/eventDraftUtils.js
@@ -70,7 +70,7 @@ export const clearDraft = () => {
 
 export const formatDraftAge = (isoTimestamp) => {
   if (!isoTimestamp) return null;
-  const diff = Math.floor((Date.now() - new Date(isoTimestamp)) / 1000);
+  const diff = Math.max(0, Math.floor((Date.now() - new Date(isoTimestamp)) / 1000));
   if (diff < 60) return `${diff}s ago`;
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;


### PR DESCRIPTION
## Summary

Fixes #14453.

- Clamp negative draft age durations to zero.
- Prevent future timestamps from displaying negative relative times.
- Preserve the existing relative time formatting for valid past timestamps.

## Testing

- Verified future timestamps return `0s ago`.
- Verified current timestamps are handled correctly.
- Verified normal past timestamps retain their existing formatting.