### PR TITLE
fix: handle cache API errors during asset invalidation

### DIFF
--- a/src/utils/errorRecovery.js
+++ b/src/utils/errorRecovery.js
@@ -104,8 +104,13 @@ export function logCategorizedError(error, errorInfo = null, metadata = {}) {
 
 export async function invalidateCorruptedAssetCache() {
   if (typeof caches === "undefined") return false;
-  const keys = await caches.keys();
-  const assetKeys = keys.filter((key) => /asset|vite|workbox|precache|eventra/i.test(key));
-  await Promise.all(assetKeys.map((key) => caches.delete(key)));
-  return assetKeys.length > 0;
+  try {
+    const keys = await caches.keys();
+    const assetKeys = keys.filter((key) => /asset|vite|workbox|precache|eventra/i.test(key));
+    await Promise.all(assetKeys.map((key) => caches.delete(key)));
+    return assetKeys.length > 0;
+  } catch (error) {
+    console.warn("[ErrorRecovery] Cache API unavailable:", error.message);
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #14454

- Wrap Cache API operations in `invalidateCorruptedAssetCache()` with error handling.
- Prevent uncaught promise rejections when Cache API access is restricted.
- Gracefully return `false` when cache invalidation cannot be performed.

## Testing

- Ran `git diff --check`
- Verified the Cache API failure path is handled by `try/catch`.