### PR TITLE
fix: handle empty meeting slot arrays

### DIFF
--- a/src/utils/aiMatchmaking.js
+++ b/src/utils/aiMatchmaking.js
@@ -63,6 +63,8 @@ export const suggestMeetingSlots = (userA, userB, dateStr) => {
     { start: "04:30 PM", end: "05:00 PM", type: "Virtual Lounge" }
   ];
   
+  if (slots.length === 0) return [];
+  
   const offset = generateSeed(userA, userB, dateStr) % slots.length;
   return [...slots.slice(offset), ...slots.slice(0, offset)];
 };


### PR DESCRIPTION
## Summary

Fixes #14455

- Handle empty meeting slot arrays before calculating the slot offset.
- Prevent modulo-by-zero and `NaN` offset calculations.
- Return an empty result when no meeting slots are available.

## Testing

- Ran `git diff --check`
- Verified empty slot arrays return safely without performing modulo arithmetic.