### PR TITLE
fix: deduplicate event interactions in recommendations

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -129,11 +129,24 @@ export const buildInteractionProfile = ({
   viewedEvents = [],
   location = "",
 } = {}) => {
-  const weightedEvents = [
-    ...registeredEvents.map((entry) => ({ entry, weight: 4 })),
-    ...bookmarkedEvents.map((entry) => ({ entry, weight: 3 })),
-    ...viewedEvents.map((entry) => ({ entry, weight: 1 })),
-  ];
+  const deduped = new Map();
+  [
+    { list: registeredEvents, weight: 4 },
+    { list: bookmarkedEvents, weight: 3 },
+    { list: viewedEvents, weight: 1 },
+  ].forEach(({ list, weight }) => {
+    list.forEach((entry) => {
+      const event = unwrapEvent(entry);
+      const id = getEventId(event);
+      if (!id) return;
+      const existing = deduped.get(id);
+      if (!existing || weight > existing.weight) {
+        deduped.set(id, { entry, weight, event });
+      }
+    });
+  });
+
+  const weightedEvents = [...deduped.values()];
 
   const categoryWeights = {};
   const typeWeights = {};
@@ -142,8 +155,7 @@ export const buildInteractionProfile = ({
   const interactedIds = new Set();
   const registeredIds = new Set();
 
-  weightedEvents.forEach(({ entry, weight }) => {
-    const event = unwrapEvent(entry);
+  weightedEvents.forEach(({ entry, weight, event }) => {
     const id = getEventId(event);
     const category = getEventCategory(event);
     const type = getEventType(event);


### PR DESCRIPTION
## Summary

Fixes #14458

- Deduplicate events when building the interaction profile.
- Prevent the same event from being counted multiple times across registered, bookmarked, and viewed interactions.
- Preserve the highest interaction weight for duplicate event entries.
- Prevent duplicate interactions from inflating recommendation preference scores.

## Testing

- Ran `git diff --check`
- Verified duplicate event IDs are processed only once.
- Verified the highest interaction weight is retained for duplicate events.
- Verified unique events continue to contribute normally.