### PR TITLE
fix: clear stale ticket scan result before manual check-in

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -436,6 +436,8 @@ export default function TicketScanner() {
       return;
     }
 
+    setScanResult(null);
+
     const manualData = {
       ticketId: manualTicketId.trim().toUpperCase(),
       userName: manualAttendeeName.trim(),


### PR DESCRIPTION
## Summary

Fixes #14461

- Clear the previous scan result when starting a manual ticket check-in.
- Prevent a stale result overlay from remaining visible during a new check-in attempt.
- Keep the manual check-in form usable after an invalid ticket submission.

## Testing

- Ran `git diff --check`
- Verified the previous scan result is cleared before a new manual check-in.
- Verified the manual check-in flow can be retried after an invalid ticket code.