### PR TITLE
fix: preserve nested draft data during session conflict resolution

### DIFF
--- a/src/utils/multiSessionRecovery.js
+++ b/src/utils/multiSessionRecovery.js
@@ -82,6 +82,20 @@ export const normalizeMultiSessions = (sessions = [], options = {}) => {
   return sortRecoverySessions([...byId.values()]);
 };
 
+const deepMerge = (target, source) => {
+  if (!target || typeof target !== "object") return source;
+  if (!source || typeof source !== "object") return target;
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === "object" && !Array.isArray(source[key])) {
+      result[key] = deepMerge(result[key], source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+};
+
 export const resolveMultiSessionConflict = (left, right) => {
   if (!left) return right || null;
   if (!right) return left || null;
@@ -93,10 +107,7 @@ export const resolveMultiSessionConflict = (left, right) => {
     return {
       ...left,
       ...right,
-      draftData: {
-        ...left.draftData,
-        ...right.draftData,
-      },
+      draftData: deepMerge(left.draftData, right.draftData),
       source: left.source === right.source ? left.source : "merged",
       version: Math.max(left.version || 1, right.version || 1),
     };


### PR DESCRIPTION
## Summary

Fixes #14463

- Add recursive deep merging for nested draft data.
- Prevent nested properties from being lost during multi-session conflict resolution.
- Preserve unrelated properties from both session states.

## Testing

- Ran `git diff --check`.
- Verified nested draft objects are merged recursively.
- Verified existing top-level conflict resolution behavior is preserved.