### PR TITLE
fix: ensure unique IDs for imported session clones

### DIFF
--- a/src/utils/sessionExportImport.js
+++ b/src/utils/sessionExportImport.js
@@ -9,6 +9,8 @@ export const MAX_SESSION_BACKUP_BYTES = 1024 * 1024;
 
 const pad = (value) => String(value).padStart(2, "0");
 
+let cloneCounter = 0;
+
 export const getSessionBackupDateStamp = (date = new Date()) =>
   `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
 
@@ -132,8 +134,9 @@ export const validateSessionBackup = (backup) => {
 
 const cloneSessionWithNewId = (session, suffix = "imported") => {
   const now = new Date();
+  cloneCounter += 1;
   return createRecoverySession({
-    sessionId: `${session.sessionId}-${suffix}-${Date.now()}`,
+    sessionId: `${session.sessionId}-${suffix}-${Date.now()}-${cloneCounter}`,
     name: `${session.name} (Imported)`,
     type: session.type,
     draftData: session.draftData,


### PR DESCRIPTION
## Summary

Fixes #14464

- Add a clone counter to session ID generation.
- Ensure cloned sessions receive unique IDs when multiple sessions are processed within the same millisecond.
- Prevent duplicate session IDs from overwriting entries during bulk backup import.

## Testing

- Verified cloned session IDs include a unique incrementing counter.
- Verified multiple clones generated during the same millisecond receive different IDs.