### PR TITLE
fix: reject invalid event search dates

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -442,29 +442,31 @@ public class EventService {
                 }
 
                 if (startDate != null && !startDate.trim().isEmpty()) {
+                        LocalDateTime startDateTime;
                         try {
-                                LocalDateTime startDateTime = LocalDateTime.parse(startDate);
-                                List<Event> filteredEvents = events.stream()
-                                                .filter(event -> event.getEventDate() != null &&
-                                                                !event.getEventDate().isBefore(startDateTime))
-                                                .collect(Collectors.toList());
-                                events = filteredEvents;
+                                startDateTime = LocalDateTime.parse(startDate);
                         } catch (Exception e) {
-                                // Invalid date format, ignore this filter
+                                throw new IllegalArgumentException("Invalid startDate parameter: " + startDate);
                         }
+                        List<Event> filteredEvents = events.stream()
+                                        .filter(event -> event.getEventDate() != null &&
+                                                        !event.getEventDate().isBefore(startDateTime))
+                                        .collect(Collectors.toList());
+                        events = filteredEvents;
                 }
 
                 if (endDate != null && !endDate.trim().isEmpty()) {
+                        LocalDateTime endDateTime;
                         try {
-                                LocalDateTime endDateTime = LocalDateTime.parse(endDate);
-                                List<Event> filteredEvents = events.stream()
-                                                .filter(event -> event.getEventDate() != null &&
-                                                                !event.getEventDate().isAfter(endDateTime))
-                                                .collect(Collectors.toList());
-                                events = filteredEvents;
+                                endDateTime = LocalDateTime.parse(endDate);
                         } catch (Exception e) {
-                                // Invalid date format, ignore this filter
+                                throw new IllegalArgumentException("Invalid endDate parameter: " + endDate);
                         }
+                        List<Event> filteredEvents = events.stream()
+                                        .filter(event -> event.getEventDate() != null &&
+                                                        !event.getEventDate().isAfter(endDateTime))
+                                        .collect(Collectors.toList());
+                        events = filteredEvents;
                 }
 
                 // Events do not currently model price, so a free filter cannot be applied.


### PR DESCRIPTION
## Summary

Fixes #14465

- Reject invalid `startDate` search parameters instead of silently ignoring them.
- Reject invalid `endDate` search parameters instead of silently ignoring them.
- Ensure invalid date inputs are reported to the client rather than returning unfiltered search results.

## Testing

- Verified valid start and end date filtering still works.
- Verified invalid `startDate` values are rejected.
- Verified invalid `endDate` values are rejected.
