### PR TITLE
perf: optimize occupied seat query

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -37,6 +37,9 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
     @Query("SELECT DISTINCT r.event.id FROM EventRegistration r WHERE r.user.id = :userId")
     List<Long> findEventIdsByUser_Id(@Param("userId") Long userId);
 
+    @Query("SELECT r.seatId FROM EventRegistration r WHERE r.event.id = :eventId AND r.seatId IS NOT NULL AND r.seatId <> ''")
+    List<String> findSeatIdsByEvent_Id(@Param("eventId") Long eventId);
+
     void deleteByEventId(Long eventId);
 
     void deleteByUser_Id(Long userId);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1192,11 +1192,7 @@ public class EventService {
         @Transactional(readOnly = true)
         public List<String> getOccupiedSeats(Long eventId) {
                 requirePublicEvent(eventId);
-                return eventRegistrationRepository.findByEvent_Id(eventId)
-                                .stream()
-                                .map(EventRegistration::getSeatId)
-                                .filter(seatId -> seatId != null && !seatId.isBlank())
-                                .toList();
+                return eventRegistrationRepository.findSeatIdsByEvent_Id(eventId);
         }
 
         private MyRegisteredEventResponse toMyRegisteredEventResponse(


### PR DESCRIPTION
## Summary

Fixes #14467

- Add a projection query to retrieve only occupied seat IDs.
- Avoid loading complete EventRegistration entities into memory.
- Reduce JVM memory usage for events with large registration volumes.

## Problem

`getOccupiedSeats()` previously loaded all `EventRegistration` entities for an event and then extracted their seat IDs.

For events with many registrations, this unnecessarily increased memory usage and garbage collection pressure.

## Fix

Added a repository query that directly selects non-null and non-empty `seatId` values from the database.

This allows the service to retrieve only the data required by the occupied-seat calculation.

## Testing

- Verified the repository query returns only seat IDs.
- Verified `getOccupiedSeats()` uses the optimized query.