### PR TITLE
fix(backend): deny event roles when user has no team membership

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java
@@ -54,7 +54,7 @@ public class EventRoleService {
 
         return eventTeamMemberRepository.findByEvent_IdAndUser_Id(eventId, user.getId())
                 .map(member -> member.getRole().includes(requiredRole))
-                .orElse(requiredRole == EventRole.ATTENDEE);
+                .orElse(false);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Problem

`EventRoleService.hasRole` defaults to **allow** for the `ATTENDEE` role whenever no team-membership row exists. Because the fallback is `orElse(requiredRole == EventRole.ATTENDEE)`, `requireRole(..., EventRole.ATTENDEE)` passes for *any* registered user in the system — not just attendees of that event. This makes the attendee gate a no-op and is a latent authorization hole.

## Fix

Default the missing team-membership case to **deny** by replacing `.orElse(requiredRole == EventRole.ATTENDEE)` with `.orElse(false)`. Users without a team-membership row for an event no longer get any role by default; only platform admins and event owners (the other explicit allow paths in `hasRole`) are granted access.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventRoleService.java`

## Testing

- Verified `hasRole` returns `false` for a user with no `EventTeamMember` row for the event, so `requireRole(eventId, email, EventRole.ATTENDEE)` now throws `AccessDeniedException` instead of silently passing.
- Confirmed platform-admin and owner paths are unchanged (still short-circuit to `true`).
- Backend compiles with the change (`mvn compile`).

Closes #14192
