### PR TITLE
fix(backend): map non-unique data integrity violations to 400 instead of 409

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -108,10 +108,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(
             DataIntegrityViolationException ex,
             HttpServletRequest request) {
-        // e.g. a concurrent duplicate upvote hitting the (project_id, user_id)
-        // unique constraint should surface as a conflict, not a 500 (#11776).
-        return buildError(HttpStatus.CONFLICT, "Conflict",
-                "This resource already exists or was modified concurrently. Please try again.", request);
+        // A duplicate hitting a unique constraint (e.g. a repeat upvote on the
+        // (project_id, user_id) pair) is a genuine conflict → 409 (#11776).
+        // Any other integrity violation (NOT NULL, foreign key, CHECK, data too
+        // long...) is a client-side data problem and must surface as a 400, not
+        // a misleading 409.
+        String cause = ex.getMostSpecificCause() != null
+                ? ex.getMostSpecificCause().getMessage()
+                : ex.getMessage();
+        if (cause != null && cause.toLowerCase().contains("unique")) {
+            return buildError(HttpStatus.CONFLICT, "Conflict",
+                    "This resource already exists or was modified concurrently. Please try again.", request);
+        }
+        return buildError(HttpStatus.BAD_REQUEST, "Bad Request",
+                "The submitted data is invalid or conflicts with existing data. Please review and try again.", request);
     }
 
     @ExceptionHandler(FeedbackAlreadyExistsException.class)


### PR DESCRIPTION
## Problem

`GlobalExceptionHandler.handleDataIntegrityViolation` maps **all** `DataIntegrityViolationException`s to a 409 with the misleading message "This resource already exists or was modified concurrently. Please try again." That message is only accurate for duplicate/unique-constraint races (e.g. repeat upvotes, #11776). Foreign-key violations on deletes and other integrity violations (NOT NULL, CHECK, data too long) get the same wrong status/message, hiding the real root cause.

## Fix

Inspect the most specific cause message of the exception:

- If it indicates a **unique-constraint** violation, keep the existing 409 conflict response (preserving the #11776 behavior).
- Otherwise map the violation to a **400 Bad Request** with an accurate message, so FK-violation deletes and other data problems no longer surface as a false "concurrent modification" conflict.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java`

## Testing

- Duplicate-upvote unique-constraint violation still returns 409 with the original conflict message.
- A foreign-key violation (e.g. deleting a hackathon/user with dependent rows) now returns 400 with the corrected message instead of 409.
- Backend compiles with the change (`mvn compile`).

Closes #14193
