### PR TITLE
fix(frontend): read capacity from EventResponse fields for full-event checks

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -78,7 +78,12 @@ const useEventRegistration = (eventIdParam) => {
   });
 
   // React Compiler automatically memoizes these, no need for useMemo
-  const isEventFull = event ? event.attendees >= event.maxAttendees : false;
+  // EventResponse exposes `capacity`/`registeredCount`; keep the mock-data
+  // aliases (maxAttendees/attendees) as a fallback for hackathon paths.
+  const isEventFull = event
+    ? (event.capacity ?? event.maxAttendees ?? 0) > 0 &&
+      (event.registeredCount ?? event.attendees ?? 0) >= (event.capacity ?? event.maxAttendees ?? 0)
+    : false;
   const isPastEvent = event ? (getEventStatus(event) === "past" || getEventStatus(event) === "ended") : false;
 
   const validationRules = {
@@ -231,17 +236,17 @@ const useEventRegistration = (eventIdParam) => {
       const freshRes = await eventService.getEventDetails(id);
       if (freshRes.status === 200) {
         const freshEvent = freshRes.data;
-        const capacity = freshEvent.maxAttendees ?? 0;
-        const attendees = freshEvent.attendees ?? 0;
+        const capacity = freshEvent.capacity ?? freshEvent.maxAttendees ?? 0;
+        const attendees = freshEvent.registeredCount ?? freshEvent.attendees ?? 0;
         return capacity > 0 && attendees >= capacity;
       }
-      const capacity = currentEvent?.maxAttendees ?? 0;
-      const attendees = currentEvent?.attendees ?? 0;
+      const capacity = currentEvent?.capacity ?? currentEvent?.maxAttendees ?? 0;
+      const attendees = currentEvent?.registeredCount ?? currentEvent?.attendees ?? 0;
       return capacity > 0 && attendees >= capacity;
     } catch (error) {
       console.error("[checkEventCapacity] Failed to check capacity:", error);
-      const capacity = currentEvent?.maxAttendees ?? 0;
-      const attendees = currentEvent?.attendees ?? 0;
+      const capacity = currentEvent?.capacity ?? currentEvent?.maxAttendees ?? 0;
+      const attendees = currentEvent?.registeredCount ?? currentEvent?.attendees ?? 0;
       return capacity > 0 && attendees >= capacity;
     }
   }, []);


### PR DESCRIPTION
## Problem

`useEventRegistration.checkEventCapacity` reads `event.maxAttendees` and `event.attendees`, but the backend's `EventResponse` exposes `capacity` and `registeredCount`. On raw detail responses both fields are always `undefined`, so the `?? 0` fallbacks make the pre-submit full-capacity check compute `0 > 0 && ...` → `false`. The live capacity check never fires and full events are only caught by the server after submission.

## Fix

Read the actual `EventResponse` fields (`capacity` / `registeredCount`) in both places the issue calls out:

- `checkEventCapacity` — use `capacity`/`registeredCount` (with `maxAttendees`/`attendees` kept as fallbacks for mock/hackathon data shapes).
- The `isEventFull` memo — compute it from `capacity`/`registeredCount` with the same fallbacks, so the "event full" UI state is accurate too.

## Files changed

- `src/hooks/useEventRegistration.js`

## Testing

- With a raw `EventResponse` payload (`capacity`, `registeredCount`), the full-capacity check now returns `true` when `registeredCount >= capacity` and blocks submission.
- Fallback shape (`maxAttendees`/`attendees`) still behaves as before for existing mock/hackathon data.
- `npm run lint` passes on the modified file.

Closes #14200
