### PR TITLE
fix(frontend): route change-password via API_ENDPOINTS to avoid double /api prefix

### DIFF
--- a/src/api/passwordAPI.js
+++ b/src/api/passwordAPI.js
@@ -1,4 +1,4 @@
-import { apiUtils } from "../config/api";
+import { apiUtils, API_ENDPOINTS } from "../config/api";
 
 /**
  * Secure password change API
@@ -27,7 +27,7 @@ export const passwordAPI = {
       throw new Error("New password must be different from current password");
     }
 
-    return apiUtils.put("/api/users/change-password", {
+    return apiUtils.put(API_ENDPOINTS.USERS.CHANGE_PASSWORD, {
       currentPassword: credentials.currentPassword,
       newPassword: credentials.newPassword,
     });

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -255,6 +255,7 @@ export const API_ENDPOINTS = {
     ACHIEVEMENTS: buildApiUrl("/users/achievements"),
     // (#7653) Endpoint for persisting user preferences (theme, etc.) across devices
     PREFERENCES: buildApiUrl("/users/preferences"),
+    CHANGE_PASSWORD: buildApiUrl("/users/change-password"),
   },
   ANALYTICS: {
     SUMMARY: buildApiUrl("/analytics/summary"),


### PR DESCRIPTION
## Problem

`passwordAPI.changePassword` hardcodes the path `/api/users/change-password`, but the axios client's `baseURL` already ends in `/api` (`src/config/backendConfig.js`), producing the doubled path `/api/api/users/change-password` which always 404s. Password changes through this module can never succeed.

## Fix

Route the request through the config, consistent with the rest of the codebase:

- Add `CHANGE_PASSWORD: buildApiUrl("/users/change-password")` to `API_ENDPOINTS.USERS` in `src/config/api.js`.
- Update `passwordAPI.changePassword` to call `apiUtils.put(API_ENDPOINTS.USERS.CHANGE_PASSWORD, ...)`.

This resolves to `/api/users/change-password`, matching the backend `@PutMapping("/change-password")` under `@RequestMapping("/api/users")`.

## Files changed

- `src/api/passwordAPI.js`
- `src/config/api.js`

## Testing

- Verified the resulting URL is `/api/users/change-password` (single `/api` prefix) so the request no longer 404s.
- Existing validation (current password required, new password required, match check, strength validator) is unchanged.
- `npm run lint` passes on the modified files.

Closes #14204
