### PR TITLE
fix(jsonUtils): guard safeParseJson against non-string inputs (#14561)

### DIFF
--- a/src/utils/jsonUtils.js
+++ b/src/utils/jsonUtils.js
@@ -6,7 +6,7 @@
  * @returns {any} The parsed object or the fallback value.
  */
 export const safeParseJson = (jsonString, fallback = null) => {
-  if (jsonString === null || jsonString === undefined || jsonString === "") return fallback;
+  if (typeof jsonString !== "string" || jsonString === "") return fallback;
   try {
     return JSON.parse(jsonString);
   } catch {


### PR DESCRIPTION
## What

Fixes #14561

`safeParseJson` previously only guarded against `null`, `undefined`, and empty string before calling `JSON.parse`. Because `JSON.parse` coerces its argument to a string, non-string primitives like the number `0` or the boolean `false` were silently coerced to `"0"` / `"false"` and parsed successfully, returning `0` / `false` instead of the documented fallback for invalid input.

## Why this is a bug

The function's contract (and JSDoc) describes a `@param {string}` — any non-string input is, by definition, invalid and must return the fallback. The old guard let `0` and `false` slip through, producing surprising results:

```js
safeParseJson(0);     // returned 0, expected null (the fallback)
safeParseJson(false); // returned false, expected null
```

This matters because several consumers (`src/storage/index.js`, `src/components/user/EventsTab.js`, `src/Pages/Events/EventHero.js`, `src/utils/errorLogger.js`) call `safeParseJson` on values read from `localStorage` / untyped API responses, where a non-string value should never be treated as valid JSON.

## Fix

Guard on `typeof jsonString !== "string"` (returning the fallback) before attempting the parse. This is stricter and correct: any non-string primitive — `0`, `false`, numbers, booleans, objects — now returns the fallback, while legitimate JSON strings (`"42"`, `"true"`, `"hello"`, objects) continue to parse exactly as before.

```js
export const safeParseJson = (jsonString, fallback = null) => {
  if (typeof jsonString !== "string" || jsonString === "") return fallback;
  try {
    return JSON.parse(jsonString);
  } catch {
    return fallback;
  }
};
```

The empty-string check is kept explicitly for clarity even though `typeof` already excludes it, since it documents the intent and short-circuits before constructing a `try` block.

## Verification

Both test suites pass:

```bash
node --test tests/jsonUtils.edge.test.mjs   # 1 pass (previously failed: "non-string input returns fallback")
node --test tests/jsonUtils.test.mjs        # pass (no regressions)
```

The edge-case test now confirms:
- `safeParseJson(0)` -> `null`
- `safeParseJson(false)` -> `null`
- `safeParseJson('"hello"')` -> `"hello"`
- `safeParseJson('42')` -> `42`
- `safeParseJson('true')` -> `true`
- `safeParseJson('{"nested":{"ok":true}}')` -> `{ nested: { ok: true } }`
- `safeParseJson('{bad json', { recovered: true })` -> `{ recovered: true }`

## Files changed

- `src/utils/jsonUtils.js` — one-line guard change.

No other files were modified. The behavior of valid JSON string inputs is unchanged.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._