### PR TITLE
fix(EventCard): prevent title overflow with break-words, min-w-0, and title attr (#14563)

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -146,9 +146,9 @@ const EventCard = ({ event, position, isHighlighted = false }) => {
       <div className="flex flex-col flex-1 p-5 sm:p-6">
         <h3
           id={titleId}
-          className="text-text font-bold text-lg sm:text-xl leading-snug mb-2 group-hover:text-primary transition-colors duration-200 line-clamp-2"
+          className="text-text font-bold text-lg sm:text-xl leading-snug mb-2 group-hover:text-primary transition-colors duration-200 line-clamp-2 break-words min-w-0"
         >
-          <Link to={`/events/${event.id}`}>{event.title}</Link>
+          <Link to={`/events/${event.id}`} title={event.title}>{event.title}</Link>
         </h3>
 
         <p className="text-text-light text-sm font-normal leading-relaxed mb-6 line-clamp-2">


### PR DESCRIPTION
## What

Fixes #14563

The Events page card title heading (`src/Pages/Events/EventCard.js`) had `line-clamp-2` but was missing `break-words` / `min-w-0`, and the inner `<Link>` had no `title={event.title}` attribute. A long title containing an unbroken token (a long URL or very long single word) could overflow the flex card, since `line-clamp` alone does not break mid-word.

## Why this is a bug

The card lives inside a flex column (`flex flex-col flex-1`). Without `min-w-0`, the flex child cannot shrink below its content's intrinsic width, so an unbroken token forces the card wider than its container and the text overflows horizontally. `line-clamp-2` controls vertical clamping (line count) but does not enable word breaking, so wide unbroken tokens still escape. The missing `title` attribute also hurts accessibility — users hovering a truncated title get no tooltip.

Every other title component covered by `tests/eventTitleOverflow.test.mjs` (`WhatsHappening.js`, `EventRecommendation.jsx`, `EventRecommendations.jsx`, `SavedEventsPage.jsx`, `CalendarPage.jsx`, `MyCalendar.jsx`, `EventRegistration.js`, `EventDetails.js`, `RemindersPage.js`, `UserDashboard`, `NotFound`) already has this treatment. `EventCard.js` was the only one missing it, and its test sub-case was the only failing assertion:

```
not ok 1 - should verify EventCard has break-words, min-w-0, and title attribute
```

## Fix

Add `break-words min-w-0` to the `<h3>` className and `title={event.title}` to the inner `<Link>`:

```jsx
<h3
  id={titleId}
  className="text-text font-bold text-lg sm:text-xl leading-snug mb-2 group-hover:text-primary transition-colors duration-200 line-clamp-2 break-words min-w-0"
>
  <Link to={`/events/${event.id}`} title={event.title}>{event.title}</Link>
</h3>
```

- `break-words` — Tailwind utility mapping to `overflow-wrap: break-word`, allowing long unbroken tokens to wrap.
- `min-w-0` — lets the flex child shrink so clamping/wrapping actually takes effect within the card width.
- `title={event.title}` — provides a native tooltip for truncated titles (accessibility/UX), matching the other components.

## Verification

The static integrity test now passes all 13 sub-cases:

```bash
node --test tests/eventTitleOverflow.test.mjs
# tests 13, suites 1, pass 13, fail 0
```

Previously test 1 failed; now all 13 pass with no regressions to the other 12 components.

## Files changed

- `src/Pages/Events/EventCard.js` — added `break-words min-w-0` to the title heading className and `title={event.title}` to the inner `<Link>`.

No other files were modified.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._