### PR TITLE
fix(eventFormValidation): reject fractional capacity values (#14543)

### DIFF
--- a/src/utils/eventFormValidation.js
+++ b/src/utils/eventFormValidation.js
@@ -46,6 +46,8 @@ export const validateForm = (formData) => {
     const capacity = Number(formData.capacity);
     if (!capacity || capacity <= 0) {
       newErrors.capacity = "Please enter a valid number of attendees";
+    } else if (!Number.isInteger(capacity)) {
+      newErrors.capacity = "Capacity must be a whole number";
     } else if (capacity > 100000) {
       newErrors.capacity = "Maximum capacity is 100,000 attendees";
     }
@@ -91,6 +93,8 @@ export const validateForm = (formData) => {
           const capacity = Number(tier.capacity);
           if (capacity <= 0) {
             newErrors[`ticketCapacity_${tier.id}`] = "Ticket capacity must be greater than 0";
+          } else if (!Number.isInteger(capacity)) {
+            newErrors[`ticketCapacity_${tier.id}`] = "Ticket capacity must be a whole number";
           }
         }
       }


### PR DESCRIPTION
## What

Fixes #14543

The event capacity validation in `src/utils/eventFormValidation.js` converted the capacity using `Number()` and checked its numeric range, but never verified the value was an integer. As a result, fractional values like `15.5` or `0.8` passed validation and could propagate into capacity calculations, seat counts, and availability logic.

## Why this is a bug

Capacity represents a count of people. A fractional capacity is semantically meaningless and, once stored, can cause downstream inconsistencies:
- `availableSeats = capacity - registered` can produce fractional remainders.
- Progress bars / "X% full" indicators can render odd decimals.
- Database integer columns may silently truncate, producing a mismatch between the validated and persisted values.
- Ticket-tier capacity had the same gap.

The original check:
```js
const capacity = Number(formData.capacity);
if (!capacity || capacity <= 0) {
  newErrors.capacity = "Please enter a valid number of attendees";
} else if (capacity > 100000) {
  newErrors.capacity = "Maximum capacity is 100,000 attendees";
}
```

`Number("15.5")` is `15.5`, which is truthy and `> 0`, so it passed every branch.

## Fix

Add a `Number.isInteger(capacity)` branch between the positive-value check and the max check, for both the main event capacity and each ticket-tier capacity:

```js
if (formData.capacity) {
  const capacity = Number(formData.capacity);
  if (!capacity || capacity <= 0) {
    newErrors.capacity = "Please enter a valid number of attendees";
  } else if (!Number.isInteger(capacity)) {
    newErrors.capacity = "Capacity must be a whole number";
  } else if (capacity > 100000) {
    newErrors.capacity = "Maximum capacity is 100,000 attendees";
  }
}
```

And the same pattern for ticket tiers:
```js
if (tier.capacity) {
  const capacity = Number(tier.capacity);
  if (capacity <= 0) {
    newErrors[`ticketCapacity_${tier.id}`] = "Ticket capacity must be greater than 0";
  } else if (!Number.isInteger(capacity)) {
    newErrors[`ticketCapacity_${tier.id}`] = "Ticket capacity must be a whole number";
  }
}
```

The `isInteger` check is placed after the `<= 0` check so that zero/negative values still report the more specific "valid number / greater than 0" message, and fractional positives get the new "whole number" message.

## Verification

Tested the validation logic directly:

| Input | Before | After |
|---|---|---|
| `15.5` | no error (BUG) | "Capacity must be a whole number" |
| `0.8` | no error (BUG) | "Capacity must be a whole number" |
| `50` | no error | no error (unchanged) |
| `100` | no error | no error (unchanged) |
| `-5` | "Please enter a valid number of attendees" | unchanged |
| `0` | "Please enter a valid number of attendees" | unchanged |
| `100001` | "Maximum capacity is 100,000 attendees" | unchanged |

The same fractional-rejection behavior is applied to ticket-tier capacity. Valid integer inputs are completely unaffected.

## Files changed

- `src/utils/eventFormValidation.js` — added `Number.isInteger` checks for both main event capacity and ticket-tier capacity (4 lines added).

No other files were modified.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._