### PR TITLE
fix(waitlistUtils): handle invalid joinedAt timestamps in waitlist sorting (#14552)

### DIFF
--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -294,7 +294,16 @@ export const getEventWaitlist = async (eventId, userId) => {
   const records = await getGlobalWaitlist(userId);
   return records
     .filter((r) => r.eventId === id && r.status === "waiting")
-    .sort((a, b) => (new Date(a.joinedAt).getTime() || Infinity) - (new Date(b.joinedAt).getTime() || Infinity));
+    .sort((a, b) => {
+      const ta = new Date(a.joinedAt).getTime();
+      const tb = new Date(b.joinedAt).getTime();
+      const aValid = Number.isFinite(ta);
+      const bValid = Number.isFinite(tb);
+      if (!aValid && !bValid) return 0;
+      if (!aValid) return 1;
+      if (!bValid) return -1;
+      return ta - tb;
+    });
 };
 
 // Calculate queue position (1-indexed) for a user on a specific event


### PR DESCRIPTION
## What

Fixes #14552

`getEventWaitlist()` in `src/utils/waitlistUtils.js` sorted waiting records by `joinedAt` timestamp using:

```js
.sort((a, b) => (new Date(a.joinedAt).getTime() || Infinity) - (new Date(b.joinedAt).getTime() || Infinity));
```

When `joinedAt` contained a malformed date string, `new Date(invalid).getTime()` returned `NaN`. While `NaN || Infinity` does evaluate to `Infinity` (NaN is falsy), the comparator then computed `Infinity - Infinity`, which is `NaN` per the IEEE 754 spec. A sort comparator returning `NaN` produces undefined / unstable ordering across JavaScript engines, causing inconsistent queue positions for records with invalid timestamps.

## Why this is a bug

The waitlist queue order determines promotion priority when event capacity increases. If cached/offline waitlist data contains a malformed `joinedAt` value (e.g. from a storage corruption or a sync edge case), the sort comparator returned `NaN`:

```
new Date('invalid').getTime()  → NaN
NaN || Infinity               → Infinity
Infinity - Infinity           → NaN  (NOT 0!)
```

`Array.prototype.sort()` with a comparator that returns `NaN` has implementation-defined behavior. In V8 it tends to leave elements in place, but this is not guaranteed and can produce different orderings across browsers/environments, making the queue non-deterministic. Records with valid timestamps could also be displaced unpredictably when mixed with invalid ones.

## Fix

Replace the arithmetic-based comparator with an explicit three-case comparator that never produces `NaN`:

```js
.sort((a, b) => {
  const ta = new Date(a.joinedAt).getTime();
  const tb = new Date(b.joinedAt).getTime();
  const aValid = Number.isFinite(ta);
  const bValid = Number.isFinite(tb);
  if (!aValid && !bValid) return 0;   // both invalid: stable, preserve order
  if (!aValid) return 1;              // invalid sorts to end
  if (!bValid) return -1;             // valid sorts before invalid
  return ta - tb;                     // both valid: normal numeric compare
});
```

Using `Number.isFinite()` correctly detects `NaN` (and `Infinity`, which `getTime()` never legitimately returns). The explicit branches ensure the comparator always returns a well-defined integer (`-1`, `0`, or `1` for invalid cases; the numeric difference for valid cases), never `NaN`.

Behavior:
- **Both valid**: normal ascending sort by join time (earliest first) — unchanged.
- **One invalid, one valid**: invalid record sorts to the end, valid records keep their proper queue order.
- **Both invalid**: comparator returns `0`, preserving relative order (stable).

## Verification

Tested all three cases with a standalone comparator:

```
both invalid: [ 'X', 'Y' ]        → stable (comparator returns 0, not NaN)
mixed:       [ 'A', 'B', 'X' ]   → valid records sorted, invalid at end
all valid:   [ 'A', 'B', 'C' ]    → correct ascending order
```

The both-invalid comparator now returns `0` (was `NaN`), and all sort orderings are deterministic.

Note: `tests/waitlist.test.mjs` has a pre-existing module resolution failure (`Cannot find module 'src/config/env'` — a Vite alias not resolved by `node --test`) unrelated to this change.

## Files changed

- `src/utils/waitlistUtils.js` — replaced the `|| Infinity` arithmetic comparator in `getEventWaitlist()` with an explicit `Number.isFinite`-based comparator (10 lines added, 1 removed).

No other files were modified.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._