### PR TITLE
fix(recommendationEngine): deduplicate events across interaction categories (#14550)

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -135,6 +135,17 @@ export const buildInteractionProfile = ({
     ...viewedEvents.map((entry) => ({ entry, weight: 1 })),
   ];
 
+  // Deduplicate by event ID, keeping the first (highest-weight) occurrence so
+  // an event registered + bookmarked + viewed is counted only once.
+  const seenIds = new Set();
+  const uniqueWeightedEvents = weightedEvents.filter(({ entry }) => {
+    const id = getEventId(unwrapEvent(entry));
+    if (!id) return true;
+    if (seenIds.has(id)) return false;
+    seenIds.add(id);
+    return true;
+  });
+
   const categoryWeights = {};
   const typeWeights = {};
   const tagWeights = {};
@@ -142,7 +153,7 @@ export const buildInteractionProfile = ({
   const interactedIds = new Set();
   const registeredIds = new Set();
 
-  weightedEvents.forEach(({ entry, weight }) => {
+  uniqueWeightedEvents.forEach(({ entry, weight }) => {
     const event = unwrapEvent(entry);
     const id = getEventId(event);
     const category = getEventCategory(event);
@@ -175,7 +186,7 @@ export const buildInteractionProfile = ({
     categories: categoryWeights,
     types: typeWeights,
     tags: tagWeights,
-    interactedEvents: weightedEvents.map(({ entry }) => unwrapEvent(entry)),
+    interactedEvents: uniqueWeightedEvents.map(({ entry }) => unwrapEvent(entry)),
     interactedIds,
     registeredIds,
     location: topLocation,

--- a/tests/recommendationEngine.test.mjs
+++ b/tests/recommendationEngine.test.mjs
@@ -63,7 +63,7 @@ const interactions = buildInteractionProfile({
   location: "San Francisco",
 });
 assert.equal(interactions.categories["web development"], 4);
-assert.equal(interactions.categories["ai and machine learning"], 4);
+assert.equal(interactions.categories["ai and machine learning"], 3);
 assert(interactions.tags.react > 0);
 
 const collaborativeScore = calculateRecommendationScore(


### PR DESCRIPTION
## What

Fixes #14550

`buildInteractionProfile()` in `src/utils/recommendationEngine.js` combined `registeredEvents`, `bookmarkedEvents`, and `viewedEvents` into a single `weightedEvents` array without deduplicating. If the same event appeared in multiple interaction categories, its tags, category, and type were processed multiple times, inflating the preference weights.

## Why this is a bug

The original code:
```js
const weightedEvents = [
  ...registeredEvents.map((entry) => ({ entry, weight: 4 })),
  ...bookmarkedEvents.map((entry) => ({ entry, weight: 3 })),
  ...viewedEvents.map((entry) => ({ entry, weight: 1 })),
];
```

If a user registered for an event (weight 4), bookmarked it (weight 3), and viewed it (weight 1), the event's tags accumulated a total weight of **8** instead of 4. This artificially inflated preference scores and distorted event recommendations — a single heavily-interacted event could dominate the user's preference profile.

## Fix

Deduplicate `weightedEvents` by event ID **before** accumulating weights, keeping only the first (highest-weight) occurrence. Since the array is built in priority order (registered=4 first, then bookmarked=3, then viewed=1), the first occurrence of any event ID is always the highest-priority interaction:

```js
const seenIds = new Set();
const uniqueWeightedEvents = weightedEvents.filter(({ entry }) => {
  const id = getEventId(unwrapEvent(entry));
  if (!id) return true;          // keep entries without an ID (can't dedup)
  if (seenIds.has(id)) return false;  // skip duplicates
  seenIds.add(id);
  return true;
});
```

This applies the **precedence strategy** the issue requested: registered > bookmarked > viewed. An event is counted exactly once, with the weight of its highest-priority interaction. The `interactedEvents` return value was also updated to use the deduplicated list (previously it returned duplicates too).

## Verification

Tested directly:

```
// Same event in all 3 categories:
buildInteractionProfile({
  registeredEvents: [evt],   // weight 4
  bookmarkedEvents: [evt],   // weight 3
  viewedEvents: [evt],        // weight 1
})
// Before: tags {rock:8, live:8}, categories {music:8}
// After:  tags {rock:4, live:4}, categories {music:4}  (counted once)

// Distinct events (no dedup needed):
// After: tags {rock:4, painting:3, ai:1}  (each counted once with its weight)
```

### Test update

`tests/recommendationEngine.test.mjs` had an assertion that encoded the **buggy** behavior — `events[1]` was in both `bookmarkedEvents` (weight 3) and `viewedEvents` (weight 1), and the test expected `categories["ai and machine learning"] === 4` (the double-counted 3+1). Updated this to `3` (bookmarked weight only):

```js
// events[1] is in bookmarkedEvents AND viewedEvents → counted once at weight 3
assert.equal(interactions.categories["ai and machine learning"], 3);
```

All other assertions remain unchanged. Full test suite passes:
```
node --test tests/recommendationEngine.test.mjs   # pass (1/1)
node --test tests/useRecommendations.test.mjs     # pass (16/16)
```

## Files changed

- `src/utils/recommendationEngine.js` — added `seenIds` Set deduplication filter in `buildInteractionProfile()`, updated `interactedEvents` return to use `uniqueWeightedEvents`.
- `tests/recommendationEngine.test.mjs` — updated one assertion from `4` to `3` to reflect corrected (deduplicated) weights.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._