### PR TITLE
fix(frontend): drain real IndexedDB offline queue on connectivity restore #14506

### DIFF
--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -1,39 +1,120 @@
-import { useState, useEffect } from "react";
-import { OfflineStorageQueue } from "../utils/offlineStorage";
+/**
+ * useOfflineSync — drains the IndexedDB-backed offline action queue whenever
+ * connectivity returns, the service worker fires a background sync, or the
+ * user presses "Sync Now" in the OfflineManager.
+ *
+ * Replay is delegated to processQueue(userId, fetchFn) in utils/offlineQueue.js,
+ * which handles retries/backoff, conflict resolution, sync budget, ownership
+ * and session validation, and persists the resulting queue state.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuth } from "../context/AuthContext";
+import { processQueue } from "../utils/offlineQueue";
+import { logger } from "../utils/logger";
+
+// Message types the service worker may post to request an offline queue sync.
+// EVENTRA_BACKGROUND_SYNC is posted by public/service-worker.js when the
+// browser fires the "sync" event for the eventra-offline-queue-sync tag.
+// SYNC_REQUESTED is retained for backward compatibility with older SW builds.
+// Guarded by tests/backgroundSyncMessageContract.test.mjs.
+const SYNC_MESSAGE_TYPES = new Set(["SYNC_REQUESTED", "EVENTRA_BACKGROUND_SYNC"]);
 
 export default function useOfflineSync() {
-  const [queue] = useState(() => new OfflineStorageQueue());
-  const [isOnline, setIsOnline] = useState(() => typeof navigator !== "undefined" ? navigator.onLine : true);
+  const auth = useAuth();
+  const { token, user, isAuthenticated, loading } = auth;
   const [syncStatus, setSyncStatus] = useState("IDLE");
+  const isSyncing = useRef(false);
+
+  // Keep the latest auth snapshot in a ref so the event listeners never
+  // operate on stale closure values (token/user can change on login/logout).
+  const authRef = useRef({ token, user, isAuthenticated, loading });
+  useEffect(() => {
+    authRef.current = { token, user, isAuthenticated, loading };
+  }, [token, user, isAuthenticated, loading]);
+
+  const syncNow = useCallback(async () => {
+    if (isSyncing.current) return;
+
+    const {
+      token: currentToken,
+      user: currentUser,
+      isAuthenticated: currentIsAuthenticated,
+      loading: currentLoading,
+    } = authRef.current;
+
+    // Wait for AuthContext to finish initial session validation and only
+    // replay under a verified authenticated session. processQueue itself
+    // rejects (and blocks) when no current user ID is supplied, which
+    // prevents cross-user action replay.
+    if (currentLoading || !currentIsAuthenticated() || !currentUser?.id) {
+      return;
+    }
+
+    isSyncing.current = true;
+    setSyncStatus("SYNCING");
+
+    try {
+      // Cookie-managed sessions authenticate via the HttpOnly session cookie;
+      // do not forward the "cookie-managed" sentinel as a Bearer token.
+      const authToken = currentToken === "cookie-managed" ? null : currentToken;
+      const fetchFn = (url, options) => {
+        const headers = { ...(options?.headers || {}) };
+        if (authToken) {
+          headers.Authorization = `Bearer ${authToken}`;
+        }
+        return fetch(url, { ...options, headers });
+      };
+
+      const result = await processQueue(currentUser.id, fetchFn, {
+        onConflict: () => "discard",
+      });
+
+      const { dropped = 0, remaining = 0 } = result || {};
+      setSyncStatus(remaining > 0 || dropped > 0 ? "PARTIAL" : "SUCCESS");
+      return result;
+    } catch (error) {
+      logger.error("[useOfflineSync] Sync run failed:", error);
+      setSyncStatus("FAILED");
+    } finally {
+      isSyncing.current = false;
+      // Emit the unified completion event so the OfflineManager spinner is
+      // reset even when processQueue short-circuits (empty queue, no valid
+      // items for the current user, etc.).
+      if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+        window.dispatchEvent(new CustomEvent("eventra-offline-queue-processed", { detail: {} }));
+      }
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const handleOnline = async () => {
-      setIsOnline(true);
-      setSyncStatus("SYNCING");
-      // Trigger background sync task
-      await new Promise((res) => setTimeout(res, 500));
-      setSyncStatus("SUCCESS");
+    const handleOnline = () => {
+      void syncNow();
     };
-
-    const handleOffline = () => {
-      setIsOnline(false);
-      setSyncStatus("OFFLINE_QUEUED");
+    const handleSyncRequested = () => {
+      void syncNow();
+    };
+    const handleServiceWorkerMessage = (event) => {
+      if (SYNC_MESSAGE_TYPES.has(event?.data?.type)) {
+        void syncNow();
+      }
     };
 
     window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
+    window.addEventListener("eventra-background-sync", handleSyncRequested);
+    window.addEventListener("eventra-offline-queue-updated", handleSyncRequested);
+    window.addEventListener("eventra-session-restored", handleSyncRequested);
+    navigator.serviceWorker?.addEventListener?.("message", handleServiceWorkerMessage);
 
     return () => {
       window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("eventra-background-sync", handleSyncRequested);
+      window.removeEventListener("eventra-offline-queue-updated", handleSyncRequested);
+      window.removeEventListener("eventra-session-restored", handleSyncRequested);
+      navigator.serviceWorker?.removeEventListener?.("message", handleServiceWorkerMessage);
     };
-  }, []);
+  }, [syncNow]);
 
-  return {
-    queue,
-    isOnline,
-    syncStatus,
-  };
+  return { syncStatus };
 }

--- a/src/hooks/useOfflineSync.test.js
+++ b/src/hooks/useOfflineSync.test.js
@@ -1,10 +1,17 @@
 import { createRoot } from "react-dom/client";
 import { act } from "react";
 import useOfflineSync from "./useOfflineSync";
-import { getQueueIndexedDB, setQueue, clearQueue } from "../utils/offlineQueue";
+import { processQueue } from "../utils/offlineQueue";
+
+let mockAuthState = {
+  token: "mock-valid-token",
+  user: { id: "mock-user-id" },
+  isAuthenticated: () => true,
+  loading: false,
+};
 
 jest.mock("../context/AuthContext", () => ({
-  useAuth: () => ({ token: "mock-valid-token", user: { id: "mock-user-id" }, isAuthenticated: () => true, loading: false }),
+  useAuth: () => mockAuthState,
 }));
 
 jest.mock("../utils/tokenUtils", () => ({
@@ -12,51 +19,47 @@ jest.mock("../utils/tokenUtils", () => ({
 }));
 
 jest.mock("../utils/offlineQueue", () => ({
-  getQueueIndexedDB: jest.fn(),
-  setQueue: jest.fn(),
-  clearQueue: jest.fn(),
-  filterQueueByOwnership: jest.fn((queue) => queue),
-  validateQueueSession: jest.fn((queue) => queue),
+  processQueue: jest.fn(),
 }));
-
 
 describe("useOfflineSync", () => {
   let container;
   let root;
+  let swListeners;
 
-  let originalOnLine;
+  const defaultProcessResult = { processed: 2, succeeded: 2, dropped: 0, remaining: 0 };
 
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
     jest.clearAllMocks();
 
-    originalOnLine = navigator.onLine;
-    Object.defineProperty(navigator, "onLine", {
-      value: false,
+    mockAuthState = {
+      token: "mock-valid-token",
+      user: { id: "mock-user-id" },
+      isAuthenticated: () => true,
+      loading: false,
+    };
+
+    processQueue.mockResolvedValue(defaultProcessResult);
+
+    // jsdom does not provide navigator.serviceWorker; give the hook a stub so
+    // we can assert the SW message -> drain wiring.
+    swListeners = {};
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: {
+        addEventListener: jest.fn((type, cb) => {
+          swListeners[type] = cb;
+        }),
+        removeEventListener: jest.fn((type) => {
+          delete swListeners[type];
+        }),
+      },
       configurable: true,
     });
-
-    // Mock global fetch
-    global.fetch = jest.fn().mockImplementation(() =>
-      Promise.resolve({
-        ok: true,
-        status: 200,
-        text: () => Promise.resolve("ok"),
-      })
-    );
-
-    jest
-      .requireMock("../utils/offlineQueue")
-      .filterQueueByOwnership.mockImplementation((queue) => queue);
-
-    jest
-      .requireMock("../utils/offlineQueue")
-      .validateQueueSession.mockImplementation((queue) => queue);
   });
 
   afterEach(() => {
-     
     act(() => {
       if (root) {
         root.unmount();
@@ -64,61 +67,14 @@ describe("useOfflineSync", () => {
     });
     document.body.removeChild(container);
     container = null;
-    delete global.fetch;
-    Object.defineProperty(navigator, "onLine", {
-      value: originalOnLine,
-      configurable: true,
-    });
+    delete navigator.serviceWorker;
+    jest.restoreAllMocks();
   });
 
-  it("attempts to sync immediately without backoff delay on first try in active sync run", async () => {
-    const queue = [
-      { id: "1", userId: "mock-user-id", retryCount: 0, payload: { name: "test-1" } },
-      { id: "2", userId: "mock-user-id", retryCount: 0, payload: { name: "test-2" } }
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
-
+  const renderHook = async () => {
+    let hookResult;
     const TestComponent = () => {
-      useOfflineSync();
-      return null;
-    };
-
-     
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<TestComponent />);
-    });
-    const startTime = Date.now();
-
-    // Trigger online event to run the sync
-     
-    await act(async () => {
-      window.dispatchEvent(new Event("online"));
-
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    });
-
-    const duration = Date.now() - startTime;
-
-    // Verify both items were synced and fetch was called
-    expect(global.fetch).toHaveBeenCalledTimes(2);
-    expect(clearQueue).toHaveBeenCalled();
-
-    // Verify it completed quickly (meaning no 1s/2s sequential backoff was applied)
-    // Since items had retryCount: 2 and 1 respectively, the original implementation
-    // would have blocked for 2s + 1s = 3 seconds.
-    // Our fix should complete it in under 500ms.
-    expect(duration).toBeLessThan(500);
-  });
-
-  it("preserves items with retryCount >= MAX_RETRIES in the offline queue instead of deleting them", async () => {
-    const queue = [
-      { id: "1", userId: "mock-user-id", retryCount: 3, payload: { name: "test-expired" } }
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
-
-    const TestComponent = () => {
-      useOfflineSync();
+      hookResult = useOfflineSync();
       return null;
     };
 
@@ -126,205 +82,191 @@ describe("useOfflineSync", () => {
       root = createRoot(container);
       root.render(<TestComponent />);
     });
+    return () => hookResult;
+  };
+
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+  it("drains the IndexedDB queue via processQueue when the connection returns", async () => {
+    const getResult = await renderHook();
 
     await act(async () => {
       window.dispatchEvent(new Event("online"));
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await flush();
     });
 
-    // Verify fetch was NOT called because retryCount >= 3
-    expect(global.fetch).not.toHaveBeenCalled();
-    // Verify setQueue was called to preserve the item
-    expect(setQueue).toHaveBeenCalledWith(queue);
-    expect(clearQueue).not.toHaveBeenCalled();
+    expect(processQueue).toHaveBeenCalledTimes(1);
+    expect(processQueue).toHaveBeenCalledWith(
+      "mock-user-id",
+      expect.any(Function),
+      expect.anything()
+    );
+    expect(getResult().syncStatus).toBe("SUCCESS");
   });
 
-  it("preserves the unattempted remainder of the queue when the sync budget is exceeded (#12455)", async () => {
-    const queue = [
-      { id: "b1", userId: "mock-user-id", retryCount: 0, payload: { name: "b1" } },
-      { id: "b2", userId: "mock-user-id", retryCount: 0, payload: { name: "b2" } },
-      { id: "b3", userId: "mock-user-id", retryCount: 0, payload: { name: "b3" } },
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
+  it("triggers a drain when the OfflineManager dispatches eventra-background-sync", async () => {
+    await renderHook();
 
-    // Every Date.now() call advances the clock beyond SYNC_BUDGET_MS, so the
-    // budget check fails before the first item is even attempted.
-    const nowSpy = jest.spyOn(Date, "now");
-    let now = nowSpy();
-    nowSpy.mockImplementation(() => {
-      now += 16_000;
-      return now;
-    });
-
-    try {
-      const TestComponent = () => {
-        useOfflineSync();
-        return null;
-      };
-
-      await act(async () => {
-        root = createRoot(container);
-        root.render(<TestComponent />);
-      });
-
-      await act(async () => {
-        window.dispatchEvent(new Event("online"));
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      });
-
-      // No item was attempted because the budget was already exhausted.
-      expect(global.fetch).not.toHaveBeenCalled();
-      // The untouched tail must be re-persisted for the next run, not dropped.
-      expect(setQueue).toHaveBeenCalledWith(queue);
-      expect(clearQueue).not.toHaveBeenCalled();
-    } finally {
-      nowSpy.mockRestore();
-    }
-  });
-
-  // ── Security: Issue #5727 — cross-user action replay prevention ───────────
-
-  it("[Security] does not replay queued actions that belong to a different user", async () => {
-    // Queue contains items from user-A only
-    const queue = [
-      { id: "x1", userId: "user-A", retryCount: 0, payload: { name: "stale-action" } },
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
-
-    // filterQueueByOwnership drops all items since current user is mock-user-id, not user-A
-    jest
-      .requireMock("../utils/offlineQueue")
-      .filterQueueByOwnership.mockImplementation((_queue, currentUserId) =>
-        _queue.filter((item) => item.userId === currentUserId)
-      );
-
-    const TestComponent = () => {
-      useOfflineSync();
-      return null;
-    };
-
-     
     await act(async () => {
-      root = createRoot(container);
-      root.render(<TestComponent />);
+      window.dispatchEvent(new CustomEvent("eventra-background-sync"));
+      await flush();
     });
 
-     
+    expect(processQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers a drain when the service worker posts EVENTRA_BACKGROUND_SYNC", async () => {
+    await renderHook();
+
+    await act(async () => {
+      swListeners["message"]({ data: { type: "EVENTRA_BACKGROUND_SYNC" } });
+      await flush();
+    });
+
+    expect(processQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds a fetch function that attaches the Bearer token from auth context", async () => {
+    await renderHook();
+
+    let capturedFetchFn;
+    processQueue.mockImplementationOnce(async (userId, fetchFn) => {
+      capturedFetchFn = fetchFn;
+      return defaultProcessResult;
+    });
+
     await act(async () => {
       window.dispatchEvent(new Event("online"));
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await flush();
     });
 
-    // Fetch must NOT have been called — user-A's action should not run under mock-user-id's session
-    expect(global.fetch).not.toHaveBeenCalled();
-    // Queue should be cleared since all items were foreign
-    expect(clearQueue).toHaveBeenCalled();
+    expect(capturedFetchFn).toBeDefined();
+    await capturedFetchFn("https://api.example.test/events/1/register", {
+      method: "POST",
+      body: "{}",
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.test/events/1/register",
+      expect.objectContaining({
+        method: "POST",
+        body: "{}",
+        headers: { Authorization: "Bearer mock-valid-token" },
+      })
+    );
   });
 
-  it("[Security] does not replay actions with a stale session ID", async () => {
-    const queue = [
-      { id: "s1", userId: "mock-user-id", sessionId: "old-session-xyz", retryCount: 0, payload: { name: "stale-session-action" } },
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
+  it("does not send a Bearer header when the session is cookie-managed", async () => {
+    mockAuthState = { ...mockAuthState, token: "cookie-managed" };
+    await renderHook();
 
-    // validateQueueSession drops all items because their sessionId doesn't match the current session
-    jest
-      .requireMock("../utils/offlineQueue")
-      .validateQueueSession.mockImplementation((_queue, _currentSession) =>
-        _queue.filter((item) => item.sessionId === _currentSession)
-      );
-
-    // Simulate a different current session
-    const originalSessionStorage = global.sessionStorage;
-    Object.defineProperty(window, "sessionStorage", {
-      value: { getItem: jest.fn(() => "new-session-abc") },
-      configurable: true,
+    let capturedFetchFn;
+    processQueue.mockImplementationOnce(async (userId, fetchFn) => {
+      capturedFetchFn = fetchFn;
+      return defaultProcessResult;
     });
 
-    const TestComponent = () => {
-      useOfflineSync();
-      return null;
-    };
-
-     
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<TestComponent />);
-    });
-
-     
     await act(async () => {
       window.dispatchEvent(new Event("online"));
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await flush();
     });
 
-    // Fetch must NOT be called — stale session items should be dropped
-    expect(global.fetch).not.toHaveBeenCalled();
-    expect(clearQueue).toHaveBeenCalled();
+    await capturedFetchFn("https://api.example.test/events/1/register", {
+      method: "POST",
+      body: "{}",
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.test/events/1/register",
+      expect.not.objectContaining({ Authorization: expect.any(String) })
+    );
+  });
 
-    Object.defineProperty(window, "sessionStorage", {
-      value: originalSessionStorage,
-      configurable: true,
+  it("does not drain the queue while the auth session is still loading", async () => {
+    mockAuthState = { ...mockAuthState, loading: true };
+    await renderHook();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await flush();
+    });
+
+    expect(processQueue).not.toHaveBeenCalled();
+  });
+
+  it("does not drain the queue for an unauthenticated visitor", async () => {
+    mockAuthState = { ...mockAuthState, isAuthenticated: () => false, user: null };
+    await renderHook();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await flush();
+    });
+
+    expect(processQueue).not.toHaveBeenCalled();
+  });
+
+  it("reports PARTIAL when some items remain or were dropped", async () => {
+    processQueue.mockResolvedValue({ processed: 3, succeeded: 1, dropped: 1, remaining: 1 });
+    const getResult = await renderHook();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await flush();
+    });
+
+    expect(getResult().syncStatus).toBe("PARTIAL");
+  });
+
+  it("reports FAILED when processQueue rejects", async () => {
+    processQueue.mockRejectedValue(new Error("network down"));
+    const getResult = await renderHook();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await flush();
+    });
+
+    expect(getResult().syncStatus).toBe("FAILED");
+  });
+
+  it("does not start a second drain while one is already running", async () => {
+    let resolveProcess;
+    processQueue.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveProcess = resolve;
+        })
+    );
+    await renderHook();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      window.dispatchEvent(new CustomEvent("eventra-background-sync"));
+      await flush();
+    });
+
+    expect(processQueue).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveProcess(defaultProcessResult);
     });
   });
 
-  it("[Security] filterQueueByOwnership is always called during replay — not optional", async () => {
-    const queue = [
-      { id: "f1", userId: "mock-user-id", retryCount: 0, payload: { name: "normal-action" } },
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
-
-    const { filterQueueByOwnership } = jest.requireMock("../utils/offlineQueue");
-
-    const TestComponent = () => {
-      useOfflineSync();
-      return null;
-    };
-
-     
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<TestComponent />);
+  it("dispatches eventra-offline-queue-processed after a run so OfflineManager resets", async () => {
+    const dispatched = [];
+    const originalDispatch = window.dispatchEvent.bind(window);
+    jest.spyOn(window, "dispatchEvent").mockImplementation((event) => {
+      if (event.type === "eventra-offline-queue-processed") {
+        dispatched.push(event.type);
+      }
+      return originalDispatch(event);
     });
 
-     
+    await renderHook();
+
     await act(async () => {
       window.dispatchEvent(new Event("online"));
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await flush();
     });
 
-    // filterQueueByOwnership MUST have been called — it is not optional
-    expect(filterQueueByOwnership).toHaveBeenCalled();
-    // It must be called with the current user's ID
-    expect(filterQueueByOwnership).toHaveBeenCalledWith(queue, "mock-user-id");
-  });
-
-  it("[Security] validateQueueSession is always called during replay", async () => {
-    const queue = [
-      { id: "v1", userId: "mock-user-id", sessionId: "sess-abc", retryCount: 0, payload: { name: "action" } },
-    ];
-    getQueueIndexedDB.mockResolvedValue(queue);
-
-    const { validateQueueSession } = jest.requireMock("../utils/offlineQueue");
-
-    const TestComponent = () => {
-      useOfflineSync();
-      return null;
-    };
-
-     
-    await act(async () => {
-      root = createRoot(container);
-      root.render(<TestComponent />);
-    });
-
-     
-    await act(async () => {
-      window.dispatchEvent(new Event("online"));
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    });
-
-    // validateQueueSession MUST have been called in all replay paths
-    expect(validateQueueSession).toHaveBeenCalled();
+    expect(dispatched).toContain("eventra-offline-queue-processed");
   });
 });

--- a/src/serviceWorkerRegistration.js
+++ b/src/serviceWorkerRegistration.js
@@ -90,6 +90,11 @@ function registerValidSW(swUrl, config) {
           log('[Service Worker] Cache updated to version:', event.data.version);
           window.dispatchEvent(new CustomEvent('sw-cache-updated', { detail: event.data }));
         }
+        if (event.data && (event.data.type === 'EVENTRA_BACKGROUND_SYNC' || event.data.type === 'SYNC_REQUESTED')) {
+          // The SW fired the offline queue background sync; re-dispatch as a
+          // DOM CustomEvent so the hook (and any other client) can react.
+          window.dispatchEvent(new CustomEvent('eventra-background-sync', { detail: event.data }));
+        }
       });
 
       if ('periodicSync' in registration && registration.periodicSync) {


### PR DESCRIPTION
## Problem

The offline action queue is never actually drained. `useOfflineSync` was reduced to a stub that held an in-memory `OfflineStorageQueue` and reported `SUCCESS` after a hardcoded 500 ms timeout — it never touched the real IndexedDB queue, so queued registrations/waitlist/check-in actions stayed pending forever. The pieces existed but were never wired together:

- `processQueue` in `src/utils/offlineQueue.js` had zero callers.
- The service worker posts an `EVENTRA_BACKGROUND_SYNC` message when the browser fires background sync, but `serviceWorkerRegistration.js` only handled `CACHE_UPDATED`.
- The OfflineManager "Sync Now" button dispatched an `eventra-background-sync` CustomEvent that nobody listened for.

## Fix

- Rewrote `src/hooks/useOfflineSync.js` to drain the real IndexedDB queue through `processQueue(userId, fetchFn)` (the same path used by the waitlist promotion flow), which handles retries/backoff, conflict resolution, sync budget, per-user ownership filtering and session validation.
- Drains are triggered by: browser `online`, the `eventra-background-sync` CustomEvent (OfflineManager "Sync Now"), the `eventra-offline-queue-updated` event, session restore, and service worker messages of type `EVENTRA_BACKGROUND_SYNC` / `SYNC_REQUESTED`.
- `syncStatus` now reflects the real outcome (`SUCCESS` / `PARTIAL` / `FAILED`) instead of a hardcoded value after 500 ms.
- Replays only under a verified authenticated session, attaches the Bearer token from auth context (and skips it for cookie-managed sessions), and never starts a second drain while one is running.
- Dispatches `eventra-offline-queue-processed` after every run so the OfflineManager spinner resets and the banner reflects the real pending-queue state.
- `src/serviceWorkerRegistration.js` now forwards `EVENTRA_BACKGROUND_SYNC` / `SYNC_REQUESTED` service worker messages as the `eventra-background-sync` CustomEvent so the hook (and any client) can react.
- Updated `src/hooks/useOfflineSync.test.js` to verify the drain contract (trigger sources, auth gating, Bearer header, no double-sync, completion event, status transitions).

## Files changed

- `src/hooks/useOfflineSync.js`
- `src/hooks/useOfflineSync.test.js`
- `src/serviceWorkerRegistration.js`

## Testing

- `npm run lint` passes (0 warnings on changed files).
- `npm run format:check` passes on changed files.
- `node --test tests/offlineQueue.test.mjs tests/backgroundSyncMessageContract.test.mjs tests/waitlistOfflineSync.test.mjs` — all pass (background-sync message contract is preserved: the SW posts `EVENTRA_BACKGROUND_SYNC` and the hook still declares/consumes it).
- Full `npm test` (CI `test:unit` list): 159/162 pass; the 3 failures (`eventRecommendationsResponsive`, `hostHackathonValidation`, `sseMultiplexer`) are pre-existing on `master` and unrelated to this change (verified by running them against pristine `master`).

Closes #14506
