### PR TITLE
fix: handle registration storage persistence failures

### DIFF
--- a/src/utils/registrationGuard.js
+++ b/src/utils/registrationGuard.js
@@ -41,13 +41,22 @@ export const recordRegistration = (userId, eventId, metadata = {}) => {
   const registry = getRegistry();
   const key = `${userId}_${eventId}`;
   if (registry[key]) return false;
-  registry[key] = {
-    userId,
-    eventId,
-    registeredAt: new Date().toISOString(),
-    ...metadata,
+
+  const updatedRegistry = {
+    ...registry,
+    [key]: {
+      userId,
+      eventId,
+      registeredAt: new Date().toISOString(),
+      ...metadata,
+    },
   };
-  return saveRegistry(registry);
+
+  const saved = saveRegistry(updatedRegistry);
+  if (saved) {
+    registry[key] = updatedRegistry[key];
+  }
+  return saved;
 };
 
 export const cancelRegistration = (userId, eventId) => {
@@ -55,8 +64,15 @@ export const cancelRegistration = (userId, eventId) => {
   const registry = getRegistry();
   const key = `${userId}_${eventId}`;
   if (!registry[key]) return false;
-  delete registry[key];
-  return saveRegistry(registry);
+
+  const updatedRegistry = { ...registry };
+  delete updatedRegistry[key];
+
+  const saved = saveRegistry(updatedRegistry);
+  if (saved) {
+    delete registry[key];
+  }
+  return saved;
 };
 
 export const getUserRegistrations = (userId) => {


### PR DESCRIPTION
## Description

Fixes an issue where registration state could become desynchronized when
localStorage persistence fails.

### Problem

`recordRegistration()` previously modified the in-memory registration
registry before confirming that the updated state was successfully persisted.

If localStorage was unavailable or its quota was exceeded, `saveRegistry()`
could return `false` while the registration remained present in memory.
This made the registration appear successful until the page was reloaded.

### Changes

- Build an updated registry without mutating the current in-memory state.
- Persist the updated registry before updating the in-memory registry.
- Only update the in-memory registration state when persistence succeeds.
- Return the persistence result to the caller.
- Apply the same safe persistence handling to `cancelRegistration()`.

### Result

Registration state now remains consistent when localStorage persistence fails.

Closes #14544