### PR TITLE
fix: handle asset cache invalidation failures

### DIFF
--- a/src/utils/errorRecovery.js
+++ b/src/utils/errorRecovery.js
@@ -103,9 +103,13 @@ export function logCategorizedError(error, errorInfo = null, metadata = {}) {
 }
 
 export async function invalidateCorruptedAssetCache() {
-  if (typeof caches === "undefined") return false;
-  const keys = await caches.keys();
-  const assetKeys = keys.filter((key) => /asset|vite|workbox|precache|eventra/i.test(key));
-  await Promise.all(assetKeys.map((key) => caches.delete(key)));
-  return assetKeys.length > 0;
+  try {
+    if (typeof caches === "undefined") return false;
+    const keys = await caches.keys();
+    const assetKeys = keys.filter((key) => /asset|vite|workbox|precache|eventra/i.test(key));
+    await Promise.all(assetKeys.map((key) => caches.delete(key)));
+    return assetKeys.length > 0;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Closes #14545

## Description

Fixes an issue where asset cache invalidation could produce an uncaught
promise rejection when Cache API operations are restricted or unavailable.

### Problem

`invalidateCorruptedAssetCache()` checked whether the Cache API existed,
but exceptions from `caches.keys()` or cache deletion operations were not
handled.

In restricted browsing contexts, these operations can throw a
`SecurityError` or `DOMException`, causing the error recovery flow to
produce an uncaught promise rejection.

### Changes

- Wrapped Cache API access in `try/catch`.
- Safely handles failures from `caches.keys()`.
- Safely handles failures from `caches.delete()`.
- Returns `false` when cache invalidation cannot be performed.
- Prevents cache cleanup failures from interrupting error recovery.

### Result

Asset cache invalidation now fails gracefully when browser cache access
is restricted.

