### PR TITLE
fix: handle empty matchmaking slots

### DIFF
--- a/src/utils/aiMatchmaking.js
+++ b/src/utils/aiMatchmaking.js
@@ -62,7 +62,9 @@ export const suggestMeetingSlots = (userA, userB, dateStr) => {
     { start: "02:00 PM", end: "02:30 PM", type: "Coffee Area" },
     { start: "04:30 PM", end: "05:00 PM", type: "Virtual Lounge" }
   ];
-  
+
+  if (!slots.length) return [];
+
   const offset = generateSeed(userA, userB, dateStr) % slots.length;
   return [...slots.slice(offset), ...slots.slice(0, offset)];
 };


### PR DESCRIPTION
Closes #14546

## Description

Fixes an issue where AI matchmaking could produce an invalid slot offset
when no meeting slots were available.

### Problem

`suggestMeetingSlots()` calculated the slot offset using the number of
available slots as the modulo divisor.

When the slots array was empty, the calculation effectively performed
modulo by zero, producing `NaN`. This value was then passed to array
slicing operations and could result in invalid matchmaking results.

### Changes

- Added an early return when no meeting slots are available.
- Prevented modulo-by-zero calculations.
- Ensured the function returns an empty array for empty slot configurations.

### Result

AI matchmaking now handles empty or dynamically cleared meeting-slot
configurations safely.

