### PR TITLE
fix: clear stale manual ticket scan result

### DIFF
--- a/src/components/admin/TicketScanner.jsx
+++ b/src/components/admin/TicketScanner.jsx
@@ -436,6 +436,8 @@ export default function TicketScanner() {
       return;
     }
 
+    setScanResult(null);
+
     const manualData = {
       ticketId: manualTicketId.trim().toUpperCase(),
       userName: manualAttendeeName.trim(),


### PR DESCRIPTION
## Description

Fixes #14625 by clearing the previous scan result before processing a
new manual ticket check-in.

### Problem

A previous manual ticket check-in could leave a flagged or error
`scanResult` in component state. When another manual check-in was
attempted, the stale result overlay could remain visible and block the
form.

### Changes

- Clear `scanResult` at the beginning of the manual check-in flow.
- Ensure each manual check-in starts with a clean result state.

### Result

Users can retry manual ticket check-ins without the previous result
overlay blocking the form.

Closes #14625