### PR TITLE
fix(frontend): enforce cross-tab registration lock with localStorage lease #14510

### DIFF
--- a/src/hooks/useEventRegistration.js
+++ b/src/hooks/useEventRegistration.js
@@ -18,9 +18,14 @@ import { createRateLimiter } from "../utils/rateLimiter";
  *   and opens a conflict-resolution modal when one is found.
  * - Checks live event capacity immediately before submission and notifies the
  *   user when the event is at full capacity.
- * - Uses a shared module-level `Map` lock (`registrationLocks` from
- *   `utils/registrationLocks`) and a ref
- *   (`isSubmittingRef`) to guard against duplicate concurrent submissions.
+ * - Uses a shared cross-tab lock (`registrationLocks` from
+ *   `utils/registrationLocks`, backed by a `localStorage` lease with a
+ *   10-minute expiry and a per-tab fast-path cache) plus a ref
+ *   (`isSubmittingRef`) to guard against duplicate concurrent submissions
+ *   within and across tabs.
+ * - Keeps the lease held while a registration is queued offline, so the same
+ *   event cannot be registered twice while the queue item is pending; the
+ *   lease auto-expires if the tab is closed before the queue drains.
  * - Falls back to an offline queue (`offlineQueue`) when a network/timeout
  *   error is detected, so the registration syncs automatically once
  *   connectivity is restored.
@@ -309,7 +314,12 @@ const useEventRegistration = (eventIdParam) => {
 
     setShowConflictModal(false);
 
-    registrationLocks.set(eventId, true);
+    // Claim the cross-tab localStorage lease before any async work. If a
+    // concurrent tab won the race, do not start a duplicate submission.
+    if (!registrationLocks.set(eventId)) {
+      toast.error("Another registration is in progress for this event. Please wait.");
+      return;
+    }
     isSubmittingRef.current = true;
     setSubmitting(true);
 
@@ -319,6 +329,8 @@ const useEventRegistration = (eventIdParam) => {
       priority: formData.priority,
       eventId: parseInt(eventId, 10),
     };
+
+    let keepLockAfterSubmit = false;
 
     try {
       await eventService.registerForEvent(eventId, payload);
@@ -350,6 +362,9 @@ const useEventRegistration = (eventIdParam) => {
         );
 
         if (success) {
+          // Hold the lease until the queued registration is actually synced so
+          // a duplicate cannot be queued; the 10-minute expiry bounds the hold.
+          keepLockAfterSubmit = true;
           setRegistered(true);
           addRegistration(event, formData);
           clearSession();
@@ -375,7 +390,9 @@ const useEventRegistration = (eventIdParam) => {
 
       toast.error(failureMessage);
     } finally {
-      registrationLocks.delete(eventId);
+      if (!keepLockAfterSubmit) {
+        registrationLocks.delete(eventId);
+      }
       isSubmittingRef.current = false;
       setSubmitting(false);
     }

--- a/src/utils/registrationLocks.js
+++ b/src/utils/registrationLocks.js
@@ -1,18 +1,37 @@
 const LOCK_EXPIRY_MS = 600000; // 10 minutes lease time
 
+export function isRegistrationLockActive(eventId) {
+  try {
+    const existing = localStorage.getItem(`reg_lock_${eventId}`);
+    if (!existing) return false;
+
+    const lockTime = Number(existing);
+    if (Number.isNaN(lockTime)) {
+      localStorage.removeItem(`reg_lock_${eventId}`);
+      return false;
+    }
+
+    return Date.now() - lockTime < LOCK_EXPIRY_MS;
+  } catch {
+    return false;
+  }
+}
+
 export function acquireRegistrationLock(eventId) {
   try {
     const now = Date.now();
     const lockKey = `reg_lock_${eventId}`;
     const existing = localStorage.getItem(lockKey);
-    
+
     if (existing) {
       const lockTime = Number(existing);
-      if (now - lockTime < LOCK_EXPIRY_MS) {
+      if (Number.isNaN(lockTime)) {
+        localStorage.removeItem(lockKey);
+      } else if (now - lockTime < LOCK_EXPIRY_MS) {
         return false; // Lock active
       }
     }
-    
+
     localStorage.setItem(lockKey, String(now));
     return true;
   } catch {
@@ -31,14 +50,30 @@ export function releaseRegistrationLock(eventId) {
 
 const activeLocks = new Set();
 
+// Invalidate the per-tab fast-path cache the moment another tab acquires or
+// releases a lease, so a stale in-memory entry can never mask a live lease
+// from a different tab (the storage event only fires in other tabs).
+if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+  window.addEventListener("storage", (event) => {
+    if (event.key && event.key.startsWith("reg_lock_")) {
+      activeLocks.delete(event.key.slice("reg_lock_".length));
+    }
+  });
+}
+
 const registrationLocks = {
-  has: (eventId) => activeLocks.has(eventId),
+  has: (eventId) => activeLocks.has(eventId) || isRegistrationLockActive(eventId),
   set: (eventId) => {
-    activeLocks.add(eventId);
+    if (acquireRegistrationLock(eventId)) {
+      activeLocks.add(eventId);
+      return true;
+    }
+    return false;
   },
   delete: (eventId) => {
     activeLocks.delete(eventId);
-  }
+    releaseRegistrationLock(eventId);
+  },
 };
 
 export default registrationLocks;

--- a/tests/registrationLocksLease.test.mjs
+++ b/tests/registrationLocksLease.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { acquireRegistrationLock, releaseRegistrationLock } from "../src/utils/registrationLocks.js";
+import registrationLocks, {
+  acquireRegistrationLock,
+  releaseRegistrationLock,
+} from "../src/utils/registrationLocks.js";
 
 globalThis.localStorage = {
   store: {},
@@ -8,15 +11,44 @@ globalThis.localStorage = {
   removeItem(key) { delete this.store[key]; }
 };
 
+const clearStore = () => {
+  globalThis.localStorage.store = {};
+};
+
 try {
   assert.equal(acquireRegistrationLock("evt123"), true);
   assert.equal(acquireRegistrationLock("evt123"), false, "Should block secondary lock attempts");
-  
+
   // Simulate timeout lease expiry
   const past = Date.now() - 700000;
   localStorage.setItem("reg_lock_evt123", String(past));
   assert.equal(acquireRegistrationLock("evt123"), true, "Should acquire lock if expired");
-  
+
+  // Releasing the lease lets the same event be re-acquired immediately
+  assert.equal(releaseRegistrationLock("evt123"), true);
+  assert.equal(acquireRegistrationLock("evt123"), true, "Should re-acquire after release");
+
+  // The default export must mirror the localStorage lease (cross-tab source
+  // of truth), not just the per-tab in-memory Set.
+  clearStore();
+  assert.equal(registrationLocks.has("evt456"), false, "No lease yet");
+  assert.equal(registrationLocks.set("evt456"), true, "set() acquires the lease");
+  assert.equal(registrationLocks.has("evt456"), true, "has() sees the acquired lease");
+  assert.equal(registrationLocks.set("evt456"), false, "Second set() is blocked while the lease is held");
+  registrationLocks.delete("evt456");
+  assert.equal(registrationLocks.has("evt456"), false, "delete() releases the lease");
+
+  // A lease written by another tab (shared localStorage) blocks this tab.
+  localStorage.setItem("reg_lock_evt789", String(Date.now()));
+  assert.equal(registrationLocks.has("evt789"), true, "Cross-tab lease is visible to has()");
+  assert.equal(registrationLocks.set("evt789"), false, "Cannot acquire while another tab holds the lease");
+  assert.equal(releaseRegistrationLock("evt789"), true);
+
+  // An expired lease never hard-blocks a re-registration.
+  localStorage.setItem("reg_lock_evtExpired", String(Date.now() - 700000));
+  assert.equal(registrationLocks.has("evtExpired"), false, "Expired lease is not active");
+  assert.equal(registrationLocks.set("evtExpired"), true, "Expired lease can be re-acquired");
+
   console.log("registrationLocks lease time tests passed ✓");
 } finally {
   delete globalThis.localStorage;


### PR DESCRIPTION
## Problem

Two divergent registration-lock mechanisms existed in `registrationLocks.js`, and only the per-tab in-memory `Set` actually guarded submission:

- The localStorage-based cross-tab lease (`acquireRegistrationLock` / `releaseRegistrationLock`, 10-minute expiry) was **dead code** — exported but never called anywhere, so two browser tabs logged in as the same user could both pass `registrationLocks.has(eventId)` and register simultaneously, pushing an event past capacity.
- Because nothing called `releaseRegistrationLock`, a crashed tab would leave a stale lease blocking re-registration for the full 10 minutes.
- The `finally` in `proceedWithRegistration` released the lock even on the queued-offline path, so a registration sitting in the offline queue was completely unprotected against duplicate submissions.

## Fix

- **`registrationLocks.js`** — the default-export object is now backed by the localStorage lease as the single cross-tab source of truth, with the in-memory `Set` kept only as a fast-path cache:
  - `set(eventId)` acquires the lease via `acquireRegistrationLock` and returns whether the claim succeeded.
  - `has(eventId)` reports the lease (`isRegistrationLockActive`) in addition to the in-memory cache.
  - `delete(eventId)` releases the lease via `releaseRegistrationLock`.
  - Added `isRegistrationLockActive` with lease-age validation; both the active-check and `acquireRegistrationLock` clean up non-numeric/corrupt lease values.
  - A `storage` event listener invalidates the per-tab fast-path cache the moment another tab acquires or releases a lease.
- **`useEventRegistration.js`** —
  - `proceedWithRegistration` now bails out (with a toast) if `registrationLocks.set(eventId)` loses a cross-tab race instead of silently proceeding.
  - The `finally` block releases the lease on success, error, and already-registered paths, but **keeps** it held while a registration is queued offline (`keepLockAfterSubmit`) so duplicates cannot be queued; the 10-minute lease expiry bounds the hold if the tab closes before the queue drains.
  - Updated the module doc header to describe the cross-tab lease semantics.
- **`tests/registrationLocksLease.test.mjs`** — extended to prove the default export mirrors the localStorage lease: acquisition, cross-tab visibility, blocked second acquisition, release, and expiry-based re-acquisition.

Note: the issue's "Proposed Fix" mentions releasing in the offline-queue path, but its own Problem 3 / Expected Behaviour require a queued (offline) registration to hold the lock until it is actually synced; I implemented the latter (lease held while queued, bounded by expiry) as it satisfies the stated expected behaviour and prevents offline duplicates.

## Files changed

- `src/utils/registrationLocks.js`
- `src/hooks/useEventRegistration.js`
- `tests/registrationLocksLease.test.mjs`

## Testing

- `eslint src/utils/registrationLocks.js src/hooks/useEventRegistration.js` — clean.
- `node --test tests/registrationLocksLease.test.mjs tests/registrationLockGuard.test.mjs` — all pass (lease tests + 17 guard regression tests).
- Added lines verified prettier-stable (no new formatting violations); the pre-existing prettier drift in `useEventRegistration.js` on `master` is left untouched to keep this PR scoped to the issue.
- Full `npm run test:unit` — 158 pass; the 4 failures (`backgroundSyncMessageContract`, `eventRecommendationsResponsive`, `hostHackathonValidation`, `sseMultiplexer`) are pre-existing on `origin/master` and unrelated to this change (none touch these files).

Closes #14510
