### PR TITLE
fix: preserve nested session draft data

### DIFF
--- a/src/utils/multiSessionRecovery.js
+++ b/src/utils/multiSessionRecovery.js
@@ -82,6 +82,20 @@ export const normalizeMultiSessions = (sessions = [], options = {}) => {
   return sortRecoverySessions([...byId.values()]);
 };
 
+const deepMerge = (target, source) => {
+  if (!target || typeof target !== "object") return source;
+  if (!source || typeof source !== "object") return target;
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === "object" && !Array.isArray(source[key])) {
+      result[key] = deepMerge(result[key], source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+};
+
 export const resolveMultiSessionConflict = (left, right) => {
   if (!left) return right || null;
   if (!right) return left || null;
@@ -93,10 +107,7 @@ export const resolveMultiSessionConflict = (left, right) => {
     return {
       ...left,
       ...right,
-      draftData: {
-        ...left.draftData,
-        ...right.draftData,
-      },
+      draftData: deepMerge(left.draftData, right.draftData),
       source: left.source === right.source ? left.source : "merged",
       version: Math.max(left.version || 1, right.version || 1),
     };


### PR DESCRIPTION
## Description

Fixes #14626 by using a deep merge when resolving multi-session draft
conflicts.

### Problem

`resolveMultiSessionConflict()` previously used a shallow object spread
when merging `draftData`.

When both session states contained the same nested object, the entire
object from the right-hand session replaced the corresponding object
from the left-hand session, causing unrelated nested properties to be
lost.

### Changes

- Added a recursive `deepMerge()` helper.
- Preserve non-conflicting nested properties from both session states.
- Allow right-side values to override conflicting primitive values.
- Avoid recursively merging arrays.

### Result

Multi-session conflict resolution now preserves non-conflicting nested
draft data instead of silently overwriting it.

Closes #14626