### PR TITLE
fix: authorize organizer feedback analytics

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
@@ -70,9 +70,18 @@ public class FeedbackController {
     }
 
     @GetMapping("/organizers/{organizerId}/score")
-    @Operation(summary = "Get organizer score", description = "Returns the average rating and review count for an organizer.")
-    public ResponseEntity<Map<String, Object>> getOrganizerScore(@PathVariable Long organizerId) {
-        return ResponseEntity.ok(feedbackService.getOrganizerScore(organizerId));
+    @Operation(summary = "Get organizer score", description = "Returns the average rating and review count for an organizer. Only the organizer or an administrator may access this endpoint.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Organizer score fetched successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - JWT required",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Caller is not the organizer or an administrator",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Map<String, Object>> getOrganizerScore(
+            @PathVariable Long organizerId,
+            Authentication authentication) {
+        return ResponseEntity.ok(feedbackService.getOrganizerScore(organizerId, authentication.getName()));
     }
 
     @GetMapping("/organizers/{organizerId}")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -76,7 +76,15 @@ public class FeedbackService {
     }
 
     @Transactional(readOnly = true)
-    public Map<String, Object> getOrganizerScore(Long organizerId) {
+    public Map<String, Object> getOrganizerScore(Long organizerId, String callerEmail) {
+        User caller = userRepository.findByEmail(callerEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + callerEmail));
+
+        boolean isAdmin = caller.getRole() == Role.ADMIN || caller.getRole() == Role.SUPER_ADMIN;
+        if (!isAdmin && !caller.getId().equals(organizerId)) {
+            throw new AccessDeniedException("You are not authorized to view score for this organizer.");
+        }
+
         Double averageRating = feedbackRepository.findAverageRatingByOrganizer(organizerId);
         long reviewCount = feedbackRepository.countByOrganizer(organizerId);
 


### PR DESCRIPTION
## Description

Fixes #14627 by adding ownership and role-based authorization to the
organizer feedback analytics endpoint.

### Problem

The organizer feedback analytics service accepted an `organizerId`
without verifying that the authenticated user owned the requested
organizer or had an administrative role.

This could allow an authenticated user to request analytics belonging
to another organizer.

### Changes

- Pass the authenticated user's email from `FeedbackController`.
- Resolve the authenticated user in `FeedbackService`.
- Allow ADMIN and SUPER_ADMIN users to access organizer analytics.
- Allow organizers to access their own analytics.
- Reject unauthorized access with `AccessDeniedException`.

### Security Impact

Prevents unauthorized users from accessing feedback analytics for
other organizers.

Closes #14627