### PR TITLE
fix(backend): make googleLogin race-safe with retry on unique constraint #14513

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -12,6 +12,7 @@ import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.security.JwtTokenProvider;
 import com.sandeep.eventrabackend.security.TokenBlacklistService;
 import com.sandeep.eventrabackend.security.TokenRefreshQueueHandler;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,11 +23,15 @@ import com.sandeep.eventrabackend.dto.request.GoogleAuthRequest;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Optional;
 import java.time.ZoneId;
 import java.util.Date;
 
 @Service
 public class AuthService {
+
+    /** Bounded retries for unique-username collisions under concurrent first logins. */
+    private static final int MAX_USERNAME_RETRIES = 5;
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -152,25 +157,10 @@ public class AuthService {
 
                 String baseUsername = email.split("@")[0].toLowerCase();
 
-                String username = generateUniqueUsername(baseUsername);
-
-                SecureRandom secureRandom = new SecureRandom();
-                byte[] randomBytes = new byte[32];
-                secureRandom.nextBytes(randomBytes);
-                String securePassword = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
-
-                user = User.builder()
-                        .firstName(firstName)
-                        .lastName(lastName)
-                        .email(email.toLowerCase())
-                        .username(username)
-                        .password(passwordEncoder.encode(securePassword))
-                        .role(Role.ATTENDEE)
-                        .emailVerified(true)
-                        .authProvider("GOOGLE")
-                        .build();
-
-                user = userRepository.save(user);
+                // Race-safe create: a concurrent first login for the same email
+                // either wins the insert or adopts the winner; unique-username
+                // collisions are retried with a fresh candidate (bounded).
+                user = createOrGetGoogleUser(email, firstName, lastName, baseUsername);
             } else if (!user.isEmailVerified()
                     && (user.getAuthProvider() == null || "LOCAL".equalsIgnoreCase(user.getAuthProvider()))) {
                 // Unverified LOCAL accounts can be claimed by a verified Google identity
@@ -203,6 +193,10 @@ public class AuthService {
             return buildAuthResponse(user, token);
 
         } catch (InvalidGoogleTokenException e) {
+            throw e;
+        } catch (DataIntegrityViolationException e) {
+            // A unique-constraint race could not be resolved within the bounded
+            // retries; surface it as a 409 (Conflict) instead of a wrapped 500.
             throw e;
         } catch (Exception e) {
             throw new RuntimeException("Google authentication failed", e);
@@ -243,6 +237,52 @@ public class AuthService {
             candidate = base + counter++;
         }
         return candidate;
+    }
+
+    private String generateSecurePassword() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] randomBytes = new byte[32];
+        secureRandom.nextBytes(randomBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    }
+
+    /**
+     * Atomically create a brand-new Google account, tolerating concurrent first
+     * logins for the same email or username.
+     *
+     * <p>If {@code save()} hits the unique-email constraint, the winning request
+     * already committed the user — fetch and adopt it. If it hits the
+     * unique-username constraint, a concurrent login claimed the candidate;
+     * regenerate the username (the winning row is now visible) and retry,
+     * bounded by {@link #MAX_USERNAME_RETRIES}.
+     */
+    private User createOrGetGoogleUser(String email, String firstName, String lastName, String baseUsername) {
+        for (int attempt = 0; attempt < MAX_USERNAME_RETRIES; attempt++) {
+            User candidate = User.builder()
+                    .firstName(firstName)
+                    .lastName(lastName)
+                    .email(email)
+                    .username(generateUniqueUsername(baseUsername))
+                    .password(passwordEncoder.encode(generateSecurePassword()))
+                    .role(Role.ATTENDEE)
+                    .emailVerified(true)
+                    .authProvider("GOOGLE")
+                    .build();
+
+            try {
+                return userRepository.save(candidate);
+            } catch (DataIntegrityViolationException e) {
+                Optional<User> existing = userRepository.findByEmail(email);
+                if (existing.isPresent()) {
+                    return existing.get();
+                }
+                // Username collision — retry with a fresh candidate next loop.
+            }
+        }
+
+        throw new DataIntegrityViolationException(
+                "Could not create Google account for " + email + " after "
+                        + MAX_USERNAME_RETRIES + " attempts");
     }
 
     private AuthResponse buildAuthResponse(User user, String token) {


### PR DESCRIPTION
## Problem

`AuthService.googleLogin` performed a check-then-create for brand-new users with no concurrency control, so two parallel Google sign-ins for the same never-before-seen email both entered the create branch and one crashed on the unique constraints:

- **Race 1 — duplicate email insert:** both requests read `findByEmail(email)` → empty, both call `save()`, and the second hits the unique `email` constraint. The generic `catch (Exception e)` at the old line 207 wrapped it as `RuntimeException("Google authentication failed")` → HTTP 500 on a legitimate first login (e.g. the same Google account signed in on two devices at once).
- **Race 2 — duplicate username insert:** `generateUniqueUsername` uses a non-atomic `existsByUsername` probe then inserts, so two concurrent logins with colliding base usernames (e.g. `john@gmail.com` vs `john@yahoo.com`) could pick the same candidate and one would 500 on the unique `username` constraint.

No path retried on `DataIntegrityViolationException`, so a transient race permanently broke one user's login attempt.

## Fix

- Extracted the create path into `createOrGetGoogleUser(...)`, which wraps `save()` in a bounded retry loop (`MAX_USERNAME_RETRIES = 5`):
  - On a **unique-email collision**, it re-reads `findByEmail(email)` and adopts the winner — both callers end up with a valid session.
  - On a **unique-username collision**, the winning row is now visible, so the next loop picks a fresh candidate via `generateUniqueUsername` (bounded retry).
- If the race cannot be resolved within the bound, the method throws `DataIntegrityViolationException` directly and a dedicated `catch` clause rethrows it (instead of the generic wrapper), so it surfaces as a structured **409 Conflict** via the existing `GlobalExceptionHandler` mapping — never a wrapped 500.
- `googleLogin` remains non-`@Transactional` deliberately: each `save()`/`findByEmail` runs in its own repository transaction, which is what makes the retry work (a rolled-back failed save does not poison a surrounding transaction).
- Extracted the duplicated random-password generation into `generateSecurePassword()` for reuse by the new helper.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`

## Testing

- `mvn -o compile` — compile error set is **identical to the pre-existing master baseline**: the only errors are the same 8 pre-existing corrupt files (`EventController`, `HackathonController`, `RegistrationResponse`, `GlobalExceptionHandler`, `HackathonRepository`, `JwtKeyRotationManager`, `EventService`, `HackathonService` — imports placed before `package`). `AuthService.java` and `UserRepository.java` compile cleanly; no new errors introduced.

Closes #14513
