### PR TITLE
fix(backend): bound refresh-token grace map with lazy purge and hashed keys #14528

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/TokenRefreshQueueHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/TokenRefreshQueueHandler.java
@@ -1,6 +1,10 @@
 package com.sandeep.eventrabackend.security;
 
 import org.springframework.stereotype.Component;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -12,14 +16,30 @@ import java.util.concurrent.ConcurrentHashMap;
 public class TokenRefreshQueueHandler {
 
     private static final long GRACE_PERIOD_MS = 10000; // 10 seconds
+
+    /**
+     * Safety cap so a pathological rotation burst can never exhaust the heap.
+     */
+    private static final int MAX_GRACE_ENTRIES = 100_000;
+
+    private static final String TOKEN_HASH_ALGORITHM = "SHA-256";
+
+    /**
+     * SHA-256 digests of rotated tokens keyed by rotation time, keeping map
+     * keys fixed-size instead of storing full (hundreds-of-bytes) JWTs.
+     */
     private final ConcurrentHashMap<String, Long> invalidatedTokenGraceMap = new ConcurrentHashMap<>();
 
     /**
      * Mark a consumed refresh token into grace period storage.
      */
     public void registerTokenRotation(String oldToken) {
-        if (oldToken != null) {
-            invalidatedTokenGraceMap.put(oldToken, System.currentTimeMillis());
+        if (oldToken == null) {
+            return;
+        }
+        purgeExpired();
+        if (invalidatedTokenGraceMap.size() < MAX_GRACE_ENTRIES) {
+            invalidatedTokenGraceMap.put(hashToken(oldToken), System.currentTimeMillis());
         }
     }
 
@@ -27,17 +47,32 @@ public class TokenRefreshQueueHandler {
      * Check if an invalidated refresh token is still within its active grace period window.
      */
     public boolean isWithinGracePeriod(String token) {
-        if (token == null || !invalidatedTokenGraceMap.containsKey(token)) {
+        if (token == null) {
             return false;
         }
+        purgeExpired();
+        Long rotationTime = invalidatedTokenGraceMap.get(hashToken(token));
+        return rotationTime != null
+                && (System.currentTimeMillis() - rotationTime) <= GRACE_PERIOD_MS;
+    }
 
-        long rotationTime = invalidatedTokenGraceMap.get(token);
-        boolean isGraceful = (System.currentTimeMillis() - rotationTime) <= GRACE_PERIOD_MS;
+    /**
+     * Drop entries whose grace window has elapsed so the map stays bounded by
+     * the number of rotations within the last {@link #GRACE_PERIOD_MS} window
+     * instead of growing for the lifetime of the process.
+     */
+    private void purgeExpired() {
+        long now = System.currentTimeMillis();
+        invalidatedTokenGraceMap.entrySet()
+                .removeIf(entry -> now - entry.getValue() > GRACE_PERIOD_MS);
+    }
 
-        if (!isGraceful) {
-            invalidatedTokenGraceMap.remove(token);
+    private static String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(TOKEN_HASH_ALGORITHM);
+            return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
         }
-
-        return isGraceful;
     }
 }


### PR DESCRIPTION
## Problem

`TokenRefreshQueueHandler.invalidatedTokenGraceMap` grew without bound. Every call to `AuthService.refresh` → `registerTokenRotation(refreshToken)` inserted the consumed (hundreds-of-bytes) JWT into the map, and entries were only removed when the **same** token was re-checked via `isWithinGracePeriod` after its 10s grace window elapsed — which normal flows never do. Over a long-running auth server this leaked one entry per refresh forever, causing monotonic heap growth, GC pressure, and eventual OOM (the same failure mode previously fixed for the rate-limiter #12797 and the JWT blacklist #11979/#12085).

## Fix

- **Lazy purge:** `purgeExpired()` runs on every `registerTokenRotation` and `isWithinGracePeriod` call and drops entries whose grace window has elapsed (`now - rotationTime > GRACE_PERIOD_MS`). The map is now bounded by the number of rotations inside the current 10s window instead of growing for the process lifetime, and eviction no longer depends on the same token being presented again.
- **Fixed-size keys:** the full JWT is no longer stored as the map key — a SHA-256 digest (`HexFormat` hex string) is used instead, so each entry is fixed-size rather than hundreds of bytes.
- **Hard safety cap:** `MAX_GRACE_ENTRIES` (100k) prevents a pathological rotation burst from ever exhausting the heap even between sweeps.
- Semantics preserved: `isWithinGracePeriod` still hashes the presented token the same way, and the single caller (`AuthService.refresh`) is unaffected.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/security/TokenRefreshQueueHandler.java`

## Testing

- `mvn -o compile` — compile error set is **identical to the pre-existing master baseline**: only the same 8 pre-existing corrupt files (imports placed before `package`) fail; `TokenRefreshQueueHandler.java` compiles cleanly, no new errors introduced.

Closes #14528
