### PR TITLE
fix(backend): replace dead availableSeats query with atomic registeredCount increment #14529

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -20,9 +20,17 @@ public interface EventRepository extends JpaRepository<Event, Long>, JpaSpecific
     Optional<Event> findByIdWithLock(@Param("id") Long id);
 
     /**
-     * FIX (#13914): Atomic single-query seat decrement to prevent PostgreSQL/MySQL row deadlocks
+     * FIX (#13914): Atomic single-query capacity guard for registration.
+     *
+     * <p>Increments {@code registeredCount} in one UPDATE only while a seat is
+     * free (a null {@code capacity} means unlimited), so concurrent
+     * registrations cannot both pass a read-modify-write check and overshoot
+     * capacity. The affected row count distinguishes "granted" (1) from
+     * "event full" (0). Built against the real {@code capacity} /
+     * {@code registeredCount} fields — no {@code availableSeats} column exists.
      */
-    @Modifying
-    @Query("UPDATE Event e SET e.availableSeats = e.availableSeats - 1 WHERE e.id = :id AND e.availableSeats > 0")
-    int decrementSeatsAtomically(@Param("id") Long id);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Event e SET e.registeredCount = e.registeredCount + 1 "
+            + "WHERE e.id = :id AND (e.capacity IS NULL OR e.capacity > e.registeredCount)")
+    int incrementRegisteredCountAtomically(@Param("id") Long id);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1035,8 +1035,12 @@ public class EventService {
                         }
                 }
 
+                // FIX (#13914): atomic capacity guard. The single UPDATE
+                // increments registeredCount only while a seat is free (row
+                // count 1), so two concurrent registrations cannot both pass an
+                // in-memory check and overshoot capacity. Row count 0 => full.
                 if (event.getCapacity() != null
-                                && event.getRegisteredCount() >= event.getCapacity()) {
+                                && eventRepository.incrementRegisteredCountAtomically(eventId) == 0) {
 
                         throw new EventFullException(
                                         "Event is already full. Capacity: " + event.getCapacity());


### PR DESCRIPTION
## Problem
`EventRepository.decrementSeatsAtomically(...)` (added for #13914) targets a
nonexistent `availableSeats` field — `Event` has only `capacity` (nullable,
"unlimited") and `registeredCount` (default 0). It also has zero callers, so
the intended atomic capacity guard never runs. Registration capacity is
enforced by an in-memory read-modify-write (`registeredCount >= capacity`
check + `save()`), which is racy under concurrent requests: two registrations
can both read the same `registeredCount`, both pass the check, and overshoot
capacity. The dead method is also a landmine for anyone grepping for the
"fixed" query.

## Fix
Replace the dead method with a query that targets the real fields and call it
from the registration path:

- `EventRepository.incrementRegisteredCountAtomically(id)` — one `UPDATE Event
  SET e.registeredCount = e.registeredCount + 1 WHERE e.id = :id AND
  (e.capacity IS NULL OR e.capacity > e.registeredCount)` (row count 1 =
  granted, 0 = full), matching the repo's established bulk-increment pattern
  (`ProjectRepository.incrementUpvotes` uses `@Modifying(clearAutomatically =
  true, flushAutomatically = true)`).
- `EventService.executeRegistration` now runs this atomic UPDATE as the
  capacity gate instead of the racy read-modify-write check; `EventFullException`
  is thrown when the UPDATE affects 0 rows. A null `capacity` (unlimited) is
  handled by the `capacity IS NULL` clause, preserving current behaviour.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing
- `mvn -o compile` reports the identical pre-existing error set (36 errors
  confined to the 8 already-corrupt master files); the changed files compile
  clean.
- Capacity guard is now single-query atomic; the PESSIMISTIC_WRITE lock on the
  row is already held in the same transaction, so no additional deadlock
  surface is introduced.

Closes #14529
