### PR TITLE
fix(redact): redact email-keyed values as [REDACTED_SECRET] (#14588)

### DIFF
--- a/src/utils/security/redactSensitiveData.js
+++ b/src/utils/security/redactSensitiveData.js
@@ -15,7 +15,7 @@ const API_KEY_PATTERN =
   /\b(api[-_ ]?key|apikey|x-api-key|client_secret|secret)\s*[:=]\s*["']?[^"',\s}]+["']?/gi;
 
 const SENSITIVE_KEY_PATTERN =
-  /(^|[-_\s.])(authorization|password|passwd|pwd|api[-_\s]?key|apikey|x-api-key|access[-_\s]?token|refresh[-_\s]?token|id[-_\s]?token|auth[-_\s]?token|jwt|secret|client[-_\s]?secret|token)([-_\s.]|$)/i;
+  /(^|[-_\s.])(authorization|password|passwd|pwd|api[-_\s]?key|apikey|x-api-key|access[-_\s]?token|refresh[-_\s]?token|id[-_\s]?token|auth[-_\s]?token|jwt|secret|client[-_\s]?secret|token|email)([-_\s.]|$)/i;
 
 const redactString = (value) =>
   value

--- a/tests/redactEmailKey.test.mjs
+++ b/tests/redactEmailKey.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import {
+  redactSensitiveData,
+  redactionPlaceholders,
+} from "../src/utils/security/redactSensitiveData.js";
+
+// #14588: an `email`-keyed field value must be redacted as [REDACTED_SECRET]
+// (it is a sensitive key), while emails embedded inside arbitrary string
+// values must still become [REDACTED_EMAIL].
+const input = {
+  email: "dev@example.com",
+  contact: "Ask admin@example.org for help",
+  nested: { email: "inner@example.com", note: "cc ops@example.com" },
+};
+
+const redacted = redactSensitiveData(input);
+
+assert.equal(
+  redacted.email,
+  redactionPlaceholders.secret,
+  "email-keyed value must be [REDACTED_SECRET]",
+);
+assert.equal(
+  redacted.nested.email,
+  redactionPlaceholders.secret,
+  "nested email-keyed value must be [REDACTED_SECRET]",
+);
+assert.ok(
+  redacted.contact.includes(redactionPlaceholders.email),
+  "email embedded in a string value must stay [REDACTED_EMAIL]",
+);
+assert.ok(
+  !redacted.contact.includes("admin@example.org"),
+  "raw email must be gone from the string value",
+);
+assert.ok(
+  redacted.nested.note.includes(redactionPlaceholders.email),
+  "email embedded in nested string must stay [REDACTED_EMAIL]",
+);
+
+console.log("redact email-key regression tests passed");


### PR DESCRIPTION
## What

Fixes #14588

`src/utils/security/redactSensitiveData.js` redacts an `email`-keyed field's value as `[REDACTED_EMAIL]` instead of `[REDACTED_SECRET]`. Root cause: `email` is not listed in `SENSITIVE_KEY_PATTERN`, so `isSensitiveKey("email")` is `false`. The email value then falls through to `redactString`, where `EMAIL_PATTERN` replaces it with `[REDACTED_EMAIL]`.

Both failing suites document the intended contract: the `email` **key** value should be `[REDACTED_SECRET]`, while emails embedded inside arbitrary string values (e.g. `nested.contact`) should still become `[REDACTED_EMAIL]`.

## Fix

Add `email` to the alternation in `SENSITIVE_KEY_PATTERN`:

```diff
-  /(^|[-_\s.])(authorization|password|passwd|pwd|api[-_\s]?key|apikey|x-api-key|access[-_\s]?token|refresh[-_\s]?token|id[-_\s]?token|auth[-_\s]?token|jwt|secret|client[-_\s]?secret|token)([-_\s.]|$)/i;
+  /(^|[-_\s.])(authorization|password|passwd|pwd|api[-_\s]?key|apikey|x-api-key|access[-_\s]?token|refresh[-_\s]?token|id[-_\s]?token|auth[-_\s]?token|jwt|secret|client[-_\s]?secret|token|email)([-_\s.]|$)/i;
```

Now `isSensitiveKey("email")` is `true`, so an `email`-keyed field is replaced wholesale with `REDACTED_SECRET` (`[REDACTED_SECRET]`), matching the contract. Emails embedded inside arbitrary string values are unaffected — those still flow through `redactString` → `EMAIL_PATTERN` → `[REDACTED_EMAIL]`, exactly as the tests for `nested.contact` require.

## Verification

- `tests/redactSensitiveData.test.mjs` — passes (the `redacted.email === redactionPlaceholders.secret` assertion and the `nested.contact` → `[REDACTED_EMAIL]` assertion both hold).
- `tests/logger.test.mjs` — passes (`infoEntry[1].email === "[REDACTED_SECRET]"`).
- New regression `tests/redactEmailKey.test.mjs` — passes, explicitly locking both sides of the contract: `email`-keyed value → `[REDACTED_SECRET]`; email embedded in a string value → `[REDACTED_EMAIL]`.

## Impact

- Email field values in logs/redactions are now treated as sensitive-key material (`[REDACTED_SECRET]`), consistent with the documented contract and the other secret keys.
- Emails that appear incidentally inside free-text string values are still redacted to `[REDACTED_EMAIL]` — no behaviour change for that path.
- No new dependencies; one-line regex change.

## Files changed

- `src/utils/security/redactSensitiveData.js` — add `email` to `SENSITIVE_KEY_PATTERN`.
- `tests/redactEmailKey.test.mjs` — new regression test.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._