### PR TITLE
fix(calendar): anchor month nav on day 1 to avoid setMonth day-clamp skip (#14614)

### DIFF
--- a/src/utils/eventSchedulingUtils.js
+++ b/src/utils/eventSchedulingUtils.js
@@ -327,9 +327,18 @@ export const navigateCalendarDate = (date, view, direction) => {
   const next = new Date(date);
   const amount = direction === "next" ? 1 : -1;
 
-  if (view === "month") next.setMonth(next.getMonth() + amount);
-  else if (view === "week") next.setDate(next.getDate() + amount * 7);
-  else next.setDate(next.getDate() + amount);
+  if (view === "month") {
+    // Clamp the anchor day to the 1st before advancing the month, otherwise
+    // JS Date rolls over: setMonth on Jan 31 lands on Mar 3 (Feb 31 doesn't
+    // exist), skipping February entirely. Anchoring on day 1 guarantees the
+    // target month is reached; the caller reselects a concrete day later.
+    next.setDate(1);
+    next.setMonth(next.getMonth() + amount);
+  } else if (view === "week") {
+    next.setDate(next.getDate() + amount * 7);
+  } else {
+    next.setDate(next.getDate() + amount);
+  }
 
   return next;
 };

--- a/tests/calendarMonthNavigation.test.mjs
+++ b/tests/calendarMonthNavigation.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { navigateCalendarDate } from "../src/utils/eventSchedulingUtils.js";
+
+// #14614: navigating months from a 29th/30th/31st anchor must not skip a month.
+// JS Date setMonth clamps the day, so Jan 31 + 1 month would roll to Mar 3.
+
+function ymd(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 0, 31), "month", "next")),
+  "2026-02-01",
+  "Jan 31 -> next month must land in February, not March",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 2, 31), "month", "next")),
+  "2026-04-01",
+  "Mar 31 -> next month must land in April",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 2, 30), "month", "next")),
+  "2026-04-01",
+  "Mar 30 -> next month must land in April",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 2, 31), "month", "prev")),
+  "2026-02-01",
+  "Mar 31 -> prev month must land in February",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 6, 31), "month", "next")),
+  "2026-08-01",
+  "Jul 31 -> next month must land in August (31-day target)",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 0, 15), "month", "next")),
+  "2026-02-01",
+  "Jan 15 -> next month lands on the 1st of February",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 0, 15), "month", "prev")),
+  "2025-12-01",
+  "Jan 15 -> prev month lands on the 1st of December",
+);
+
+// Week / day navigation unaffected
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 0, 15), "week", "next")),
+  "2026-01-22",
+  "week nav unchanged",
+);
+assert.equal(
+  ymd(navigateCalendarDate(new Date(2026, 0, 15), "day", "next")),
+  "2026-01-16",
+  "day nav unchanged",
+);
+
+console.log("calendar month navigation tests passed");


### PR DESCRIPTION
## What

Fixes #14614

`navigateCalendarDate` in `src/utils/eventSchedulingUtils.js` advanced the month with `next.setMonth(next.getMonth() + amount)`. JavaScript's `Date#setMonth` clamps the day-of-month to the target month's length, so navigating **from any 29th/30th/31st** to a shorter month silently skips a full month: viewing **January 31** and pressing "next month" lands on **March 3** — February never appears. Users on day 29–31 could never reach the adjacent calendar month through the scheduler UI.

## Fix

In the `month` view branch, set the day to `1` **before** advancing the month:

```js
if (view === "month") {
  next.setDate(1);
  next.setMonth(next.getMonth() + amount);
}
```

Anchoring on day 1 guarantees the target month is always reached regardless of the anchor day's magnitude, since day 1 exists in every month. The caller reselects a concrete day afterwards. The `week` and `day` branches are unchanged.

## Verification

New test `tests/calendarMonthNavigation.test.mjs` (9 assertions, pass):
- `Jan 31 → next` lands on `2026-02-01` (previously `2026-03-03`).
- `Mar 31 → next` lands on `2026-04-01`.
- `Mar 30 → next` lands on `2026-04-01`.
- `Mar 31 → prev` lands on `2026-02-01`.
- `Jul 31 → next` lands on `2026-08-01` (31-day target still anchored on the 1st).
- `Jan 15 → next/prev` land on the 1st of the target month.
- `week` and `day` navigation are unchanged.

## Impact

- Month navigation now always advances exactly one calendar month, regardless of the selected day.
- No behaviour change for `week`/`day` navigation.
- No new dependencies.

## Files changed

- `src/utils/eventSchedulingUtils.js` — anchor on day 1 before `setMonth` in the `month` branch.
- `tests/calendarMonthNavigation.test.mjs` — new, 9 assertions.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._