### PR TITLE
fix(ical): validate reminder minutes before emitting VALARM TRIGGER (#14629)

### DIFF
--- a/src/components/common/AddToCalendar.jsx
+++ b/src/components/common/AddToCalendar.jsx
@@ -20,6 +20,19 @@ const to24HourTime = (timeStr) => {
 };
 
 const generateICalContent = (event, reminderMinutes = 30) => {
+  const rawReminder =
+    typeof reminderMinutes === "number"
+      ? reminderMinutes
+      : parseInt(reminderMinutes, 10);
+  // Only emit a VALARM for a finite, positive, integer minute value; anything
+  // else (negative, NaN, fractional, non-numeric) would produce a malformed
+  // iCalendar TRIGGER such as -PT-15M or -PTNaNM. Invalid values disable the
+  // reminder instead of emitting broken syntax.
+  const validatedReminderMinutes =
+    Number.isFinite(rawReminder) && rawReminder > 0 && Number.isInteger(rawReminder)
+      ? rawReminder
+      : 0;
+
   const formatICalDate = (dateStr, timeStr) => {
     if (!dateStr) return '';
     const dt = new Date(`${dateStr}T${to24HourTime(timeStr)}:00`);
@@ -41,11 +54,15 @@ const generateICalContent = (event, reminderMinutes = 30) => {
     `LOCATION:${event.location || ''}`,
     `URL:${event.joiningLink || window.location.href}`,
     `UID:${event.id || Date.now()}@eventra`,
-    'BEGIN:VALARM',
-    `TRIGGER:-PT${reminderMinutes}M`,
-    'ACTION:DISPLAY',
-    'DESCRIPTION:Reminder',
-    'END:VALARM',
+    ...(validatedReminderMinutes > 0
+      ? [
+          'BEGIN:VALARM',
+          `TRIGGER:-PT${validatedReminderMinutes}M`,
+          'ACTION:DISPLAY',
+          'DESCRIPTION:Reminder',
+          'END:VALARM',
+        ]
+      : []),
     'END:VEVENT',
     'END:VCALENDAR',
   ].join('\r\n');

--- a/src/utils/calendarUrlUtils.js
+++ b/src/utils/calendarUrlUtils.js
@@ -285,7 +285,10 @@ export const generateIcsFileBlobUrl = (event, timezone, reminderMinutes) => {
 
   const now = new Date().toISOString().replace(/-|:|\.\d+/g, '');
 
-  const reminderMinutesNum = parseInt(reminderMinutes, 10);
+  const reminderMinutesNum =
+    typeof reminderMinutes === "number" && Number.isFinite(reminderMinutes)
+      ? reminderMinutes
+      : parseInt(reminderMinutes, 10);
 
   const icsContent = [
     'BEGIN:VCALENDAR',
@@ -301,7 +304,9 @@ export const generateIcsFileBlobUrl = (event, timezone, reminderMinutes) => {
     `SUMMARY:${(event.title || '').replace(/,/g, '\\,')}`,
     `DESCRIPTION:${(event.description || '').replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/,/g, '\\,')}`,
     `LOCATION:${(event.location || '').replace(/,/g, '\\,')}`,
-    ...(reminderMinutesNum > 0
+    ...(Number.isFinite(reminderMinutesNum) &&
+      reminderMinutesNum > 0 &&
+      Number.isInteger(reminderMinutesNum)
       ? [
           'BEGIN:VALARM',
           `TRIGGER:-PT${reminderMinutesNum}M`,

--- a/tests/icalAlarmTriggerValidation.test.mjs
+++ b/tests/icalAlarmTriggerValidation.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+
+// #14629: invalid reminder values must not produce a malformed iCalendar
+// VALARM TRIGGER such as -PT-15M or -PTNaNM. The reminder should be disabled
+// instead.
+
+globalThis.Blob = class {
+  constructor(parts) {
+    this.text = async () => parts.map((p) => String(p)).join("");
+  }
+};
+globalThis.URL = {
+  createObjectURL: (blob) => blob,
+  revokeObjectURL: () => {},
+};
+
+const { generateIcsFileBlobUrl } = await import(
+  "../src/utils/calendarUrlUtils.js"
+);
+
+const event = {
+  id: "evt-123",
+  title: "GSSoC Meetup",
+  description: "Networking",
+  date: "2026-05-28",
+  time: "10:00",
+  durationMinutes: 60,
+  location: "Zoom",
+};
+
+async function icsFor(reminder) {
+  const blob = generateIcsFileBlobUrl(event, undefined, reminder);
+  return await blob.text();
+}
+
+const valid = await icsFor(15);
+assert.ok(valid.includes("TRIGGER:-PT15M"), "valid reminder emits -PT15M");
+assert.ok(valid.includes("BEGIN:VALARM"), "valid reminder includes VALARM");
+
+for (const bad of [-15, "-15", "abc", NaN, 0, "", null, undefined, 15.7, -0]) {
+  const out = await icsFor(bad);
+  assert.ok(
+    !out.includes("VALARM"),
+    `reminder ${JSON.stringify(bad)} must NOT emit a VALARM (got: ${out.includes("VALARM") ? "present" : "absent"})`,
+  );
+  assert.ok(
+    !out.includes("-PT-"),
+    `reminder ${JSON.stringify(bad)} must not produce -PT- (malformed negative)`,
+  );
+  assert.ok(
+    !out.includes("PTNaN"),
+    `reminder ${JSON.stringify(bad)} must not produce PTNaN`,
+  );
+}
+
+// default (no reminder arg) — no VALARM
+const none = await icsFor();
+assert.ok(!none.includes("VALARM"), "omitted reminder must not emit VALARM");
+
+console.log("iCalendar VALARM trigger validation tests passed");


### PR DESCRIPTION
## What

Fixes #14629

Two iCalendar emitters interpolated the reminder value into the `TRIGGER` line without validating it, so invalid values produced malformed iCalendar that calendar applications reject:

- `src/components/common/AddToCalendar.jsx` — `generateICalContent` built `TRIGGER:-PT${reminderMinutes}M` with **no guard at all**. `reminderMinutes = -15` → `TRIGGER:-PT-15M`; `reminderMinutes = "abc"`/`NaN` → `TRIGGER:-PTNaNM`.
- `src/utils/calendarUrlUtils.js` — `generateIcsFileBlobUrl` only checked `reminderMinutesNum > 0` after `parseInt`, which still let fractional values through (e.g. `15.7` → `TRIGGER:-PT15.7M`, non-standard) and let `NaN > 0` silently skip but left the parsing fragile.

## Fix

Both emitters now derive a single validated value before constructing the `VALARM`:

- accept the raw reminder as a number directly (when finite), else `parseInt` it;
- only emit a `VALARM` when the value is `Number.isFinite`, strictly positive, **and** an integer;
- otherwise the reminder is **disabled** (no `VALARM` block), instead of emitting broken syntax.

`AddToCalendar.jsx` computes `validatedReminderMinutes` up front and guards the spread; `calendarUrlUtils.js` applies the same three-way guard around the existing `TRIGGER:-PT{n}M` line.

## Verification

New test `tests/icalAlarmTriggerValidation.test.mjs` (passes):
- `15` → emits `TRIGGER:-PT15M` with a `VALARM` block.
- for `-15`, `"-15"`, `"abc"`, `NaN`, `0`, `""`, `null`, `undefined`, `15.7`, `-0`: asserts **no** `VALARM` is emitted and **no** `-PT-`/`PTNaN` substring appears.
- omitted reminder → no `VALARM`.

The existing `tests/calendarExporter.test.mjs` still passes. (`tests/calendarUtils.test.mjs` fails on `master` independently of this change — it imports `addEventToGoogleCalendar`, which does not exist; that is a separate open issue #14564, not touched here.)

## Impact

- Generated `.ics` files no longer contain malformed `TRIGGER` values; invalid/non-positive reminder values disable the reminder instead of producing broken syntax.
- Valid integer reminders behave exactly as before.
- No new dependencies.

## Files changed

- `src/utils/calendarUrlUtils.js` — guard `VALARM` emission on finite + positive + integer.
- `src/components/common/AddToCalendar.jsx` — validate `reminderMinutes` up front; guard `VALARM` emission.
- `tests/icalAlarmTriggerValidation.test.mjs` — new, covers valid + invalid cases.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._