### PR TITLE
feat: add assert interval helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/assert-array.test.js
+++ b/src/eventra-kit/__tests__/assert-array.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertArray from '../assert-array.js';
+
+describe('assert-array', () => {
+  it('exports a module', () => {
+    expect(AssertArray).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-block.test.js
+++ b/src/eventra-kit/__tests__/assert-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertBlock from '../assert-block.js';
+
+describe('assert-block', () => {
+  it('exports a module', () => {
+    expect(AssertBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-box.test.js
+++ b/src/eventra-kit/__tests__/assert-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertBox from '../assert-box.js';
+
+describe('assert-box', () => {
+  it('exports a module', () => {
+    expect(AssertBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-byte.test.js
+++ b/src/eventra-kit/__tests__/assert-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertByte from '../assert-byte.js';
+
+describe('assert-byte', () => {
+  it('exports a module', () => {
+    expect(AssertByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-char.test.js
+++ b/src/eventra-kit/__tests__/assert-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertChar from '../assert-char.js';
+
+describe('assert-char', () => {
+  it('exports a module', () => {
+    expect(AssertChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-chunk.test.js
+++ b/src/eventra-kit/__tests__/assert-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertChunk from '../assert-chunk.js';
+
+describe('assert-chunk', () => {
+  it('exports a module', () => {
+    expect(AssertChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-circle.test.js
+++ b/src/eventra-kit/__tests__/assert-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertCircle from '../assert-circle.js';
+
+describe('assert-circle', () => {
+  it('exports a module', () => {
+    expect(AssertCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-count.test.js
+++ b/src/eventra-kit/__tests__/assert-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertCount from '../assert-count.js';
+
+describe('assert-count', () => {
+  it('exports a module', () => {
+    expect(AssertCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-date.test.js
+++ b/src/eventra-kit/__tests__/assert-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertDate from '../assert-date.js';
+
+describe('assert-date', () => {
+  it('exports a module', () => {
+    expect(AssertDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-delta.test.js
+++ b/src/eventra-kit/__tests__/assert-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertDelta from '../assert-delta.js';
+
+describe('assert-delta', () => {
+  it('exports a module', () => {
+    expect(AssertDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-dict.test.js
+++ b/src/eventra-kit/__tests__/assert-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertDict from '../assert-dict.js';
+
+describe('assert-dict', () => {
+  it('exports a module', () => {
+    expect(AssertDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-dir.test.js
+++ b/src/eventra-kit/__tests__/assert-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertDir from '../assert-dir.js';
+
+describe('assert-dir', () => {
+  it('exports a module', () => {
+    expect(AssertDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-edge.test.js
+++ b/src/eventra-kit/__tests__/assert-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertEdge from '../assert-edge.js';
+
+describe('assert-edge', () => {
+  it('exports a module', () => {
+    expect(AssertEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-element.test.js
+++ b/src/eventra-kit/__tests__/assert-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertElement from '../assert-element.js';
+
+describe('assert-element', () => {
+  it('exports a module', () => {
+    expect(AssertElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-entry.test.js
+++ b/src/eventra-kit/__tests__/assert-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertEntry from '../assert-entry.js';
+
+describe('assert-entry', () => {
+  it('exports a module', () => {
+    expect(AssertEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-field.test.js
+++ b/src/eventra-kit/__tests__/assert-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertField from '../assert-field.js';
+
+describe('assert-field', () => {
+  it('exports a module', () => {
+    expect(AssertField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-file.test.js
+++ b/src/eventra-kit/__tests__/assert-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertFile from '../assert-file.js';
+
+describe('assert-file', () => {
+  it('exports a module', () => {
+    expect(AssertFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-fraction.test.js
+++ b/src/eventra-kit/__tests__/assert-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertFraction from '../assert-fraction.js';
+
+describe('assert-fraction', () => {
+  it('exports a module', () => {
+    expect(AssertFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-frame.test.js
+++ b/src/eventra-kit/__tests__/assert-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertFrame from '../assert-frame.js';
+
+describe('assert-frame', () => {
+  it('exports a module', () => {
+    expect(AssertFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-gap.test.js
+++ b/src/eventra-kit/__tests__/assert-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertGap from '../assert-gap.js';
+
+describe('assert-gap', () => {
+  it('exports a module', () => {
+    expect(AssertGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-graph.test.js
+++ b/src/eventra-kit/__tests__/assert-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertGraph from '../assert-graph.js';
+
+describe('assert-graph', () => {
+  it('exports a module', () => {
+    expect(AssertGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-grid.test.js
+++ b/src/eventra-kit/__tests__/assert-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertGrid from '../assert-grid.js';
+
+describe('assert-grid', () => {
+  it('exports a module', () => {
+    expect(AssertGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-group.test.js
+++ b/src/eventra-kit/__tests__/assert-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertGroup from '../assert-group.js';
+
+describe('assert-group', () => {
+  it('exports a module', () => {
+    expect(AssertGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-hash.test.js
+++ b/src/eventra-kit/__tests__/assert-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertHash from '../assert-hash.js';
+
+describe('assert-hash', () => {
+  it('exports a module', () => {
+    expect(AssertHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-heap.test.js
+++ b/src/eventra-kit/__tests__/assert-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertHeap from '../assert-heap.js';
+
+describe('assert-heap', () => {
+  it('exports a module', () => {
+    expect(AssertHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-html.test.js
+++ b/src/eventra-kit/__tests__/assert-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertHtml from '../assert-html.js';
+
+describe('assert-html', () => {
+  it('exports a module', () => {
+    expect(AssertHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-id.test.js
+++ b/src/eventra-kit/__tests__/assert-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertId from '../assert-id.js';
+
+describe('assert-id', () => {
+  it('exports a module', () => {
+    expect(AssertId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-index.test.js
+++ b/src/eventra-kit/__tests__/assert-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertIndex from '../assert-index.js';
+
+describe('assert-index', () => {
+  it('exports a module', () => {
+    expect(AssertIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/assert-interval.test.js
+++ b/src/eventra-kit/__tests__/assert-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AssertInterval from '../assert-interval.js';
+
+describe('assert-interval', () => {
+  it('exports a module', () => {
+    expect(AssertInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/assert-array.js
+++ b/src/eventra-kit/assert-array.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-array helper.
+ */
+export function assertArray(value, fallback = 0) {
+  return value == null ? fallback : value;
+}
+

--- a/src/eventra-kit/assert-block.js
+++ b/src/eventra-kit/assert-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-block helper.
+ */
+export function assertBlock(value) {
+  return Array.isArray(value) ? value.length : String(value).length;
+}
+

--- a/src/eventra-kit/assert-box.js
+++ b/src/eventra-kit/assert-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-box helper.
+ */
+export function assertBox(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/assert-byte.js
+++ b/src/eventra-kit/assert-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-byte helper.
+ */
+export function assertByte(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/assert-char.js
+++ b/src/eventra-kit/assert-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-char helper.
+ */
+export function assertChar(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/assert-chunk.js
+++ b/src/eventra-kit/assert-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-chunk helper.
+ */
+export function assertChunk(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/assert-circle.js
+++ b/src/eventra-kit/assert-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-circle helper.
+ */
+export function assertCircle(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/assert-count.js
+++ b/src/eventra-kit/assert-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-count helper.
+ */
+export function assertCount(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/assert-date.js
+++ b/src/eventra-kit/assert-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-date helper.
+ */
+export function assertDate(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/assert-delta.js
+++ b/src/eventra-kit/assert-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-delta helper.
+ */
+export function assertDelta(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/assert-dict.js
+++ b/src/eventra-kit/assert-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-dict helper.
+ */
+export function assertDict(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/assert-dir.js
+++ b/src/eventra-kit/assert-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-dir helper.
+ */
+export function assertDir(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/assert-edge.js
+++ b/src/eventra-kit/assert-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-edge helper.
+ */
+export function assertEdge(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/assert-element.js
+++ b/src/eventra-kit/assert-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-element helper.
+ */
+export function assertElement(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/assert-entry.js
+++ b/src/eventra-kit/assert-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-entry helper.
+ */
+export function assertEntry(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/assert-field.js
+++ b/src/eventra-kit/assert-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-field helper.
+ */
+export function assertField(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/assert-file.js
+++ b/src/eventra-kit/assert-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-file helper.
+ */
+export function assertFile(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/assert-fraction.js
+++ b/src/eventra-kit/assert-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-fraction helper.
+ */
+export function assertFraction(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/assert-frame.js
+++ b/src/eventra-kit/assert-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-frame helper.
+ */
+export function assertFrame(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/assert-gap.js
+++ b/src/eventra-kit/assert-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-gap helper.
+ */
+export function assertGap(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/assert-graph.js
+++ b/src/eventra-kit/assert-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-graph helper.
+ */
+export function assertGraph(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/assert-grid.js
+++ b/src/eventra-kit/assert-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-grid helper.
+ */
+export function assertGrid(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/assert-group.js
+++ b/src/eventra-kit/assert-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-group helper.
+ */
+export function assertGroup(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/assert-hash.js
+++ b/src/eventra-kit/assert-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-hash helper.
+ */
+export function assertHash(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/assert-heap.js
+++ b/src/eventra-kit/assert-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-heap helper.
+ */
+export function assertHeap(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/assert-html.js
+++ b/src/eventra-kit/assert-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-html helper.
+ */
+export function assertHtml(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/assert-id.js
+++ b/src/eventra-kit/assert-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-id helper.
+ */
+export function assertId(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/assert-index.js
+++ b/src/eventra-kit/assert-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-index helper.
+ */
+export function assertIndex(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/assert-interval.js
+++ b/src/eventra-kit/assert-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a assert-interval helper.
+ */
+export function assertInterval(value) {
+  return Math.sign(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/assert-interval.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change