### PR TITLE
feat: add average object helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/average-element.test.js
+++ b/src/eventra-kit/__tests__/average-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageElement from '../average-element.js';
+
+describe('average-element', () => {
+  it('exports a module', () => {
+    expect(AverageElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-entry.test.js
+++ b/src/eventra-kit/__tests__/average-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageEntry from '../average-entry.js';
+
+describe('average-entry', () => {
+  it('exports a module', () => {
+    expect(AverageEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-field.test.js
+++ b/src/eventra-kit/__tests__/average-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageField from '../average-field.js';
+
+describe('average-field', () => {
+  it('exports a module', () => {
+    expect(AverageField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-file.test.js
+++ b/src/eventra-kit/__tests__/average-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageFile from '../average-file.js';
+
+describe('average-file', () => {
+  it('exports a module', () => {
+    expect(AverageFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-fraction.test.js
+++ b/src/eventra-kit/__tests__/average-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageFraction from '../average-fraction.js';
+
+describe('average-fraction', () => {
+  it('exports a module', () => {
+    expect(AverageFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-frame.test.js
+++ b/src/eventra-kit/__tests__/average-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageFrame from '../average-frame.js';
+
+describe('average-frame', () => {
+  it('exports a module', () => {
+    expect(AverageFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-gap.test.js
+++ b/src/eventra-kit/__tests__/average-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageGap from '../average-gap.js';
+
+describe('average-gap', () => {
+  it('exports a module', () => {
+    expect(AverageGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-graph.test.js
+++ b/src/eventra-kit/__tests__/average-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageGraph from '../average-graph.js';
+
+describe('average-graph', () => {
+  it('exports a module', () => {
+    expect(AverageGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-grid.test.js
+++ b/src/eventra-kit/__tests__/average-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageGrid from '../average-grid.js';
+
+describe('average-grid', () => {
+  it('exports a module', () => {
+    expect(AverageGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-group.test.js
+++ b/src/eventra-kit/__tests__/average-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageGroup from '../average-group.js';
+
+describe('average-group', () => {
+  it('exports a module', () => {
+    expect(AverageGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-hash.test.js
+++ b/src/eventra-kit/__tests__/average-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageHash from '../average-hash.js';
+
+describe('average-hash', () => {
+  it('exports a module', () => {
+    expect(AverageHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-heap.test.js
+++ b/src/eventra-kit/__tests__/average-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageHeap from '../average-heap.js';
+
+describe('average-heap', () => {
+  it('exports a module', () => {
+    expect(AverageHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-html.test.js
+++ b/src/eventra-kit/__tests__/average-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageHtml from '../average-html.js';
+
+describe('average-html', () => {
+  it('exports a module', () => {
+    expect(AverageHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-id.test.js
+++ b/src/eventra-kit/__tests__/average-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageId from '../average-id.js';
+
+describe('average-id', () => {
+  it('exports a module', () => {
+    expect(AverageId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-index.test.js
+++ b/src/eventra-kit/__tests__/average-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageIndex from '../average-index.js';
+
+describe('average-index', () => {
+  it('exports a module', () => {
+    expect(AverageIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-interval.test.js
+++ b/src/eventra-kit/__tests__/average-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageInterval from '../average-interval.js';
+
+describe('average-interval', () => {
+  it('exports a module', () => {
+    expect(AverageInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-item.test.js
+++ b/src/eventra-kit/__tests__/average-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageItem from '../average-item.js';
+
+describe('average-item', () => {
+  it('exports a module', () => {
+    expect(AverageItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-json.test.js
+++ b/src/eventra-kit/__tests__/average-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageJson from '../average-json.js';
+
+describe('average-json', () => {
+  it('exports a module', () => {
+    expect(AverageJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-key.test.js
+++ b/src/eventra-kit/__tests__/average-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageKey from '../average-key.js';
+
+describe('average-key', () => {
+  it('exports a module', () => {
+    expect(AverageKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-leaf.test.js
+++ b/src/eventra-kit/__tests__/average-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageLeaf from '../average-leaf.js';
+
+describe('average-leaf', () => {
+  it('exports a module', () => {
+    expect(AverageLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-length.test.js
+++ b/src/eventra-kit/__tests__/average-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageLength from '../average-length.js';
+
+describe('average-length', () => {
+  it('exports a module', () => {
+    expect(AverageLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-line.test.js
+++ b/src/eventra-kit/__tests__/average-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageLine from '../average-line.js';
+
+describe('average-line', () => {
+  it('exports a module', () => {
+    expect(AverageLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-list.test.js
+++ b/src/eventra-kit/__tests__/average-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageList from '../average-list.js';
+
+describe('average-list', () => {
+  it('exports a module', () => {
+    expect(AverageList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-map.test.js
+++ b/src/eventra-kit/__tests__/average-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageMap from '../average-map.js';
+
+describe('average-map', () => {
+  it('exports a module', () => {
+    expect(AverageMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-matrix.test.js
+++ b/src/eventra-kit/__tests__/average-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageMatrix from '../average-matrix.js';
+
+describe('average-matrix', () => {
+  it('exports a module', () => {
+    expect(AverageMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-name.test.js
+++ b/src/eventra-kit/__tests__/average-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageName from '../average-name.js';
+
+describe('average-name', () => {
+  it('exports a module', () => {
+    expect(AverageName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-node.test.js
+++ b/src/eventra-kit/__tests__/average-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageNode from '../average-node.js';
+
+describe('average-node', () => {
+  it('exports a module', () => {
+    expect(AverageNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-number.test.js
+++ b/src/eventra-kit/__tests__/average-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageNumber from '../average-number.js';
+
+describe('average-number', () => {
+  it('exports a module', () => {
+    expect(AverageNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/average-object.test.js
+++ b/src/eventra-kit/__tests__/average-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as AverageObject from '../average-object.js';
+
+describe('average-object', () => {
+  it('exports a module', () => {
+    expect(AverageObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/average-element.js
+++ b/src/eventra-kit/average-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-element helper.
+ */
+export function averageElement(value) {
+  return Array.isArray(value) ? value.length : String(value).length;
+}
+

--- a/src/eventra-kit/average-entry.js
+++ b/src/eventra-kit/average-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-entry helper.
+ */
+export function averageEntry(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/average-field.js
+++ b/src/eventra-kit/average-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-field helper.
+ */
+export function averageField(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/average-file.js
+++ b/src/eventra-kit/average-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-file helper.
+ */
+export function averageFile(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/average-fraction.js
+++ b/src/eventra-kit/average-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-fraction helper.
+ */
+export function averageFraction(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/average-frame.js
+++ b/src/eventra-kit/average-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-frame helper.
+ */
+export function averageFrame(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/average-gap.js
+++ b/src/eventra-kit/average-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-gap helper.
+ */
+export function averageGap(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/average-graph.js
+++ b/src/eventra-kit/average-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-graph helper.
+ */
+export function averageGraph(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/average-grid.js
+++ b/src/eventra-kit/average-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-grid helper.
+ */
+export function averageGrid(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/average-group.js
+++ b/src/eventra-kit/average-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-group helper.
+ */
+export function averageGroup(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/average-hash.js
+++ b/src/eventra-kit/average-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-hash helper.
+ */
+export function averageHash(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/average-heap.js
+++ b/src/eventra-kit/average-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-heap helper.
+ */
+export function averageHeap(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/average-html.js
+++ b/src/eventra-kit/average-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-html helper.
+ */
+export function averageHtml(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/average-id.js
+++ b/src/eventra-kit/average-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-id helper.
+ */
+export function averageId(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/average-index.js
+++ b/src/eventra-kit/average-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-index helper.
+ */
+export function averageIndex(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/average-interval.js
+++ b/src/eventra-kit/average-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-interval helper.
+ */
+export function averageInterval(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/average-item.js
+++ b/src/eventra-kit/average-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-item helper.
+ */
+export function averageItem(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/average-json.js
+++ b/src/eventra-kit/average-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-json helper.
+ */
+export function averageJson(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/average-key.js
+++ b/src/eventra-kit/average-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-key helper.
+ */
+export function averageKey(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/average-leaf.js
+++ b/src/eventra-kit/average-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-leaf helper.
+ */
+export function averageLeaf(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/average-length.js
+++ b/src/eventra-kit/average-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-length helper.
+ */
+export function averageLength(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/average-line.js
+++ b/src/eventra-kit/average-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-line helper.
+ */
+export function averageLine(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/average-list.js
+++ b/src/eventra-kit/average-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-list helper.
+ */
+export function averageList(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/average-map.js
+++ b/src/eventra-kit/average-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-map helper.
+ */
+export function averageMap(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/average-matrix.js
+++ b/src/eventra-kit/average-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-matrix helper.
+ */
+export function averageMatrix(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/average-name.js
+++ b/src/eventra-kit/average-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-name helper.
+ */
+export function averageName(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/average-node.js
+++ b/src/eventra-kit/average-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-node helper.
+ */
+export function averageNode(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/average-number.js
+++ b/src/eventra-kit/average-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-number helper.
+ */
+export function averageNumber(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/average-object.js
+++ b/src/eventra-kit/average-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a average-object helper.
+ */
+export function averageObject(value) {
+  return Math.pow(value, 2);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/average-object.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change