### PR TITLE
feat: add build stack helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/build-length.test.js
+++ b/src/eventra-kit/__tests__/build-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildLength from '../build-length.js';
+
+describe('build-length', () => {
+  it('exports a module', () => {
+    expect(BuildLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-line.test.js
+++ b/src/eventra-kit/__tests__/build-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildLine from '../build-line.js';
+
+describe('build-line', () => {
+  it('exports a module', () => {
+    expect(BuildLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-list.test.js
+++ b/src/eventra-kit/__tests__/build-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildList from '../build-list.js';
+
+describe('build-list', () => {
+  it('exports a module', () => {
+    expect(BuildList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-map.test.js
+++ b/src/eventra-kit/__tests__/build-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildMap from '../build-map.js';
+
+describe('build-map', () => {
+  it('exports a module', () => {
+    expect(BuildMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-matrix.test.js
+++ b/src/eventra-kit/__tests__/build-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildMatrix from '../build-matrix.js';
+
+describe('build-matrix', () => {
+  it('exports a module', () => {
+    expect(BuildMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-name.test.js
+++ b/src/eventra-kit/__tests__/build-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildName from '../build-name.js';
+
+describe('build-name', () => {
+  it('exports a module', () => {
+    expect(BuildName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-node.test.js
+++ b/src/eventra-kit/__tests__/build-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildNode from '../build-node.js';
+
+describe('build-node', () => {
+  it('exports a module', () => {
+    expect(BuildNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-number.test.js
+++ b/src/eventra-kit/__tests__/build-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildNumber from '../build-number.js';
+
+describe('build-number', () => {
+  it('exports a module', () => {
+    expect(BuildNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-object.test.js
+++ b/src/eventra-kit/__tests__/build-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildObject from '../build-object.js';
+
+describe('build-object', () => {
+  it('exports a module', () => {
+    expect(BuildObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-order.test.js
+++ b/src/eventra-kit/__tests__/build-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildOrder from '../build-order.js';
+
+describe('build-order', () => {
+  it('exports a module', () => {
+    expect(BuildOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-page.test.js
+++ b/src/eventra-kit/__tests__/build-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildPage from '../build-page.js';
+
+describe('build-page', () => {
+  it('exports a module', () => {
+    expect(BuildPage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-pair.test.js
+++ b/src/eventra-kit/__tests__/build-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildPair from '../build-pair.js';
+
+describe('build-pair', () => {
+  it('exports a module', () => {
+    expect(BuildPair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-path.test.js
+++ b/src/eventra-kit/__tests__/build-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildPath from '../build-path.js';
+
+describe('build-path', () => {
+  it('exports a module', () => {
+    expect(BuildPath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-point.test.js
+++ b/src/eventra-kit/__tests__/build-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildPoint from '../build-point.js';
+
+describe('build-point', () => {
+  it('exports a module', () => {
+    expect(BuildPoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-portion.test.js
+++ b/src/eventra-kit/__tests__/build-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildPortion from '../build-portion.js';
+
+describe('build-portion', () => {
+  it('exports a module', () => {
+    expect(BuildPortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-prop.test.js
+++ b/src/eventra-kit/__tests__/build-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildProp from '../build-prop.js';
+
+describe('build-prop', () => {
+  it('exports a module', () => {
+    expect(BuildProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-queue.test.js
+++ b/src/eventra-kit/__tests__/build-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildQueue from '../build-queue.js';
+
+describe('build-queue', () => {
+  it('exports a module', () => {
+    expect(BuildQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-range.test.js
+++ b/src/eventra-kit/__tests__/build-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildRange from '../build-range.js';
+
+describe('build-range', () => {
+  it('exports a module', () => {
+    expect(BuildRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-rank.test.js
+++ b/src/eventra-kit/__tests__/build-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildRank from '../build-rank.js';
+
+describe('build-rank', () => {
+  it('exports a module', () => {
+    expect(BuildRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-record.test.js
+++ b/src/eventra-kit/__tests__/build-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildRecord from '../build-record.js';
+
+describe('build-record', () => {
+  it('exports a module', () => {
+    expect(BuildRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-rect.test.js
+++ b/src/eventra-kit/__tests__/build-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildRect from '../build-rect.js';
+
+describe('build-rect', () => {
+  it('exports a module', () => {
+    expect(BuildRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-score.test.js
+++ b/src/eventra-kit/__tests__/build-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildScore from '../build-score.js';
+
+describe('build-score', () => {
+  it('exports a module', () => {
+    expect(BuildScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-segment.test.js
+++ b/src/eventra-kit/__tests__/build-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildSegment from '../build-segment.js';
+
+describe('build-segment', () => {
+  it('exports a module', () => {
+    expect(BuildSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-set.test.js
+++ b/src/eventra-kit/__tests__/build-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildSet from '../build-set.js';
+
+describe('build-set', () => {
+  it('exports a module', () => {
+    expect(BuildSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-size.test.js
+++ b/src/eventra-kit/__tests__/build-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildSize from '../build-size.js';
+
+describe('build-size', () => {
+  it('exports a module', () => {
+    expect(BuildSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-slice.test.js
+++ b/src/eventra-kit/__tests__/build-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildSlice from '../build-slice.js';
+
+describe('build-slice', () => {
+  it('exports a module', () => {
+    expect(BuildSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-space.test.js
+++ b/src/eventra-kit/__tests__/build-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildSpace from '../build-space.js';
+
+describe('build-space', () => {
+  it('exports a module', () => {
+    expect(BuildSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-span.test.js
+++ b/src/eventra-kit/__tests__/build-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildSpan from '../build-span.js';
+
+describe('build-span', () => {
+  it('exports a module', () => {
+    expect(BuildSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/build-stack.test.js
+++ b/src/eventra-kit/__tests__/build-stack.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildStack from '../build-stack.js';
+
+describe('build-stack', () => {
+  it('exports a module', () => {
+    expect(BuildStack).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/build-length.js
+++ b/src/eventra-kit/build-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-length helper.
+ */
+export function buildLength(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/build-line.js
+++ b/src/eventra-kit/build-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-line helper.
+ */
+export function buildLine(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/build-list.js
+++ b/src/eventra-kit/build-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-list helper.
+ */
+export function buildList(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/build-map.js
+++ b/src/eventra-kit/build-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-map helper.
+ */
+export function buildMap(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/build-matrix.js
+++ b/src/eventra-kit/build-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-matrix helper.
+ */
+export function buildMatrix(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/build-name.js
+++ b/src/eventra-kit/build-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-name helper.
+ */
+export function buildName(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/build-node.js
+++ b/src/eventra-kit/build-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-node helper.
+ */
+export function buildNode(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/build-number.js
+++ b/src/eventra-kit/build-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-number helper.
+ */
+export function buildNumber(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/build-object.js
+++ b/src/eventra-kit/build-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-object helper.
+ */
+export function buildObject(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/build-order.js
+++ b/src/eventra-kit/build-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-order helper.
+ */
+export function buildOrder(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/build-page.js
+++ b/src/eventra-kit/build-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-page helper.
+ */
+export function buildPage(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/build-pair.js
+++ b/src/eventra-kit/build-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-pair helper.
+ */
+export function buildPair(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/build-path.js
+++ b/src/eventra-kit/build-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-path helper.
+ */
+export function buildPath(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/build-point.js
+++ b/src/eventra-kit/build-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-point helper.
+ */
+export function buildPoint(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/build-portion.js
+++ b/src/eventra-kit/build-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-portion helper.
+ */
+export function buildPortion(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/build-prop.js
+++ b/src/eventra-kit/build-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-prop helper.
+ */
+export function buildProp(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/build-queue.js
+++ b/src/eventra-kit/build-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-queue helper.
+ */
+export function buildQueue(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/build-range.js
+++ b/src/eventra-kit/build-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-range helper.
+ */
+export function buildRange(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/build-rank.js
+++ b/src/eventra-kit/build-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-rank helper.
+ */
+export function buildRank(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/build-record.js
+++ b/src/eventra-kit/build-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-record helper.
+ */
+export function buildRecord(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/build-rect.js
+++ b/src/eventra-kit/build-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-rect helper.
+ */
+export function buildRect(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/build-score.js
+++ b/src/eventra-kit/build-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-score helper.
+ */
+export function buildScore(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/build-segment.js
+++ b/src/eventra-kit/build-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-segment helper.
+ */
+export function buildSegment(value) {
+  return Math.exp(value);
+}
+

--- a/src/eventra-kit/build-set.js
+++ b/src/eventra-kit/build-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-set helper.
+ */
+export function buildSet(value) {
+  return value == null ? '' : String(value).trim();
+}
+

--- a/src/eventra-kit/build-size.js
+++ b/src/eventra-kit/build-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-size helper.
+ */
+export function buildSize(value) {
+  return String(value).length;
+}
+

--- a/src/eventra-kit/build-slice.js
+++ b/src/eventra-kit/build-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-slice helper.
+ */
+export function buildSlice(value) {
+  return String(value).split(' ').length;
+}
+

--- a/src/eventra-kit/build-space.js
+++ b/src/eventra-kit/build-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-space helper.
+ */
+export function buildSpace(value) {
+  return String(value).match(/[a-z]/gi)?.length ?? 0;
+}
+

--- a/src/eventra-kit/build-span.js
+++ b/src/eventra-kit/build-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-span helper.
+ */
+export function buildSpan(value) {
+  return String(value).match(/[0-9]/g)?.length ?? 0;
+}
+

--- a/src/eventra-kit/build-stack.js
+++ b/src/eventra-kit/build-stack.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-stack helper.
+ */
+export function buildStack(value) {
+  return value.filter(Boolean).length;
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/build-stack.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change