### PR TITLE
feat: add calculate heap helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/build-xml.test.js
+++ b/src/eventra-kit/__tests__/build-xml.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as BuildXml from '../build-xml.js';
+
+describe('build-xml', () => {
+  it('exports a module', () => {
+    expect(BuildXml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-array.test.js
+++ b/src/eventra-kit/__tests__/calculate-array.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateArray from '../calculate-array.js';
+
+describe('calculate-array', () => {
+  it('exports a module', () => {
+    expect(CalculateArray).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-block.test.js
+++ b/src/eventra-kit/__tests__/calculate-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateBlock from '../calculate-block.js';
+
+describe('calculate-block', () => {
+  it('exports a module', () => {
+    expect(CalculateBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-box.test.js
+++ b/src/eventra-kit/__tests__/calculate-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateBox from '../calculate-box.js';
+
+describe('calculate-box', () => {
+  it('exports a module', () => {
+    expect(CalculateBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-byte.test.js
+++ b/src/eventra-kit/__tests__/calculate-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateByte from '../calculate-byte.js';
+
+describe('calculate-byte', () => {
+  it('exports a module', () => {
+    expect(CalculateByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-char.test.js
+++ b/src/eventra-kit/__tests__/calculate-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateChar from '../calculate-char.js';
+
+describe('calculate-char', () => {
+  it('exports a module', () => {
+    expect(CalculateChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-chunk.test.js
+++ b/src/eventra-kit/__tests__/calculate-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateChunk from '../calculate-chunk.js';
+
+describe('calculate-chunk', () => {
+  it('exports a module', () => {
+    expect(CalculateChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-circle.test.js
+++ b/src/eventra-kit/__tests__/calculate-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateCircle from '../calculate-circle.js';
+
+describe('calculate-circle', () => {
+  it('exports a module', () => {
+    expect(CalculateCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-count.test.js
+++ b/src/eventra-kit/__tests__/calculate-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateCount from '../calculate-count.js';
+
+describe('calculate-count', () => {
+  it('exports a module', () => {
+    expect(CalculateCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-date.test.js
+++ b/src/eventra-kit/__tests__/calculate-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateDate from '../calculate-date.js';
+
+describe('calculate-date', () => {
+  it('exports a module', () => {
+    expect(CalculateDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-delta.test.js
+++ b/src/eventra-kit/__tests__/calculate-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateDelta from '../calculate-delta.js';
+
+describe('calculate-delta', () => {
+  it('exports a module', () => {
+    expect(CalculateDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-dict.test.js
+++ b/src/eventra-kit/__tests__/calculate-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateDict from '../calculate-dict.js';
+
+describe('calculate-dict', () => {
+  it('exports a module', () => {
+    expect(CalculateDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-dir.test.js
+++ b/src/eventra-kit/__tests__/calculate-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateDir from '../calculate-dir.js';
+
+describe('calculate-dir', () => {
+  it('exports a module', () => {
+    expect(CalculateDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-edge.test.js
+++ b/src/eventra-kit/__tests__/calculate-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateEdge from '../calculate-edge.js';
+
+describe('calculate-edge', () => {
+  it('exports a module', () => {
+    expect(CalculateEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-element.test.js
+++ b/src/eventra-kit/__tests__/calculate-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateElement from '../calculate-element.js';
+
+describe('calculate-element', () => {
+  it('exports a module', () => {
+    expect(CalculateElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-entry.test.js
+++ b/src/eventra-kit/__tests__/calculate-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateEntry from '../calculate-entry.js';
+
+describe('calculate-entry', () => {
+  it('exports a module', () => {
+    expect(CalculateEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-field.test.js
+++ b/src/eventra-kit/__tests__/calculate-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateField from '../calculate-field.js';
+
+describe('calculate-field', () => {
+  it('exports a module', () => {
+    expect(CalculateField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-file.test.js
+++ b/src/eventra-kit/__tests__/calculate-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateFile from '../calculate-file.js';
+
+describe('calculate-file', () => {
+  it('exports a module', () => {
+    expect(CalculateFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-fraction.test.js
+++ b/src/eventra-kit/__tests__/calculate-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateFraction from '../calculate-fraction.js';
+
+describe('calculate-fraction', () => {
+  it('exports a module', () => {
+    expect(CalculateFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-frame.test.js
+++ b/src/eventra-kit/__tests__/calculate-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateFrame from '../calculate-frame.js';
+
+describe('calculate-frame', () => {
+  it('exports a module', () => {
+    expect(CalculateFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-gap.test.js
+++ b/src/eventra-kit/__tests__/calculate-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateGap from '../calculate-gap.js';
+
+describe('calculate-gap', () => {
+  it('exports a module', () => {
+    expect(CalculateGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-graph.test.js
+++ b/src/eventra-kit/__tests__/calculate-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateGraph from '../calculate-graph.js';
+
+describe('calculate-graph', () => {
+  it('exports a module', () => {
+    expect(CalculateGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-grid.test.js
+++ b/src/eventra-kit/__tests__/calculate-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateGrid from '../calculate-grid.js';
+
+describe('calculate-grid', () => {
+  it('exports a module', () => {
+    expect(CalculateGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-group.test.js
+++ b/src/eventra-kit/__tests__/calculate-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateGroup from '../calculate-group.js';
+
+describe('calculate-group', () => {
+  it('exports a module', () => {
+    expect(CalculateGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-hash.test.js
+++ b/src/eventra-kit/__tests__/calculate-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateHash from '../calculate-hash.js';
+
+describe('calculate-hash', () => {
+  it('exports a module', () => {
+    expect(CalculateHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-heap.test.js
+++ b/src/eventra-kit/__tests__/calculate-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateHeap from '../calculate-heap.js';
+
+describe('calculate-heap', () => {
+  it('exports a module', () => {
+    expect(CalculateHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/build-xml.js
+++ b/src/eventra-kit/build-xml.js
@@ -1,0 +1,7 @@
+/**
+ * adds a build-xml helper.
+ */
+export function buildXml(value) {
+  return value.flat();
+}
+

--- a/src/eventra-kit/calculate-array.js
+++ b/src/eventra-kit/calculate-array.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-array helper.
+ */
+export function calculateArray(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/calculate-block.js
+++ b/src/eventra-kit/calculate-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-block helper.
+ */
+export function calculateBlock(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/calculate-box.js
+++ b/src/eventra-kit/calculate-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-box helper.
+ */
+export function calculateBox(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/calculate-byte.js
+++ b/src/eventra-kit/calculate-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-byte helper.
+ */
+export function calculateByte(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/calculate-char.js
+++ b/src/eventra-kit/calculate-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-char helper.
+ */
+export function calculateChar(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/calculate-chunk.js
+++ b/src/eventra-kit/calculate-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-chunk helper.
+ */
+export function calculateChunk(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/calculate-circle.js
+++ b/src/eventra-kit/calculate-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-circle helper.
+ */
+export function calculateCircle(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/calculate-count.js
+++ b/src/eventra-kit/calculate-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-count helper.
+ */
+export function calculateCount(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/calculate-date.js
+++ b/src/eventra-kit/calculate-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-date helper.
+ */
+export function calculateDate(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/calculate-delta.js
+++ b/src/eventra-kit/calculate-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-delta helper.
+ */
+export function calculateDelta(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/calculate-dict.js
+++ b/src/eventra-kit/calculate-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-dict helper.
+ */
+export function calculateDict(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/calculate-dir.js
+++ b/src/eventra-kit/calculate-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-dir helper.
+ */
+export function calculateDir(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/calculate-edge.js
+++ b/src/eventra-kit/calculate-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-edge helper.
+ */
+export function calculateEdge(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/calculate-element.js
+++ b/src/eventra-kit/calculate-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-element helper.
+ */
+export function calculateElement(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/calculate-entry.js
+++ b/src/eventra-kit/calculate-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-entry helper.
+ */
+export function calculateEntry(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/calculate-field.js
+++ b/src/eventra-kit/calculate-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-field helper.
+ */
+export function calculateField(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/calculate-file.js
+++ b/src/eventra-kit/calculate-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-file helper.
+ */
+export function calculateFile(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/calculate-fraction.js
+++ b/src/eventra-kit/calculate-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-fraction helper.
+ */
+export function calculateFraction(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/calculate-frame.js
+++ b/src/eventra-kit/calculate-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-frame helper.
+ */
+export function calculateFrame(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/calculate-gap.js
+++ b/src/eventra-kit/calculate-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-gap helper.
+ */
+export function calculateGap(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/calculate-graph.js
+++ b/src/eventra-kit/calculate-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-graph helper.
+ */
+export function calculateGraph(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/calculate-grid.js
+++ b/src/eventra-kit/calculate-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-grid helper.
+ */
+export function calculateGrid(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/calculate-group.js
+++ b/src/eventra-kit/calculate-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-group helper.
+ */
+export function calculateGroup(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/calculate-hash.js
+++ b/src/eventra-kit/calculate-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-hash helper.
+ */
+export function calculateHash(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/calculate-heap.js
+++ b/src/eventra-kit/calculate-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-heap helper.
+ */
+export function calculateHeap(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/calculate-heap.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change