### PR TITLE
fix(analytics): exclude cancelled and private events from active/completed counts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
@@ -13,12 +13,12 @@ import java.util.List;
 @Repository
 public interface EventAnalyticsRepository extends JpaRepository<Event, Long> {
 
-    // "Active" = event date is in the future (no status field on Event)
-    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate > :now")
+    // "Active" = public, non-cancelled event whose date is in the future
+    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate > :now AND e.isPublic = TRUE AND (e.status IS NULL OR e.status <> 'CANCELLED')")
     long countActiveEvents(@Param("now") LocalDateTime now);
 
-    // "Completed" = event date is in the past
-    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate <= :now")
+    // "Completed" = public, non-cancelled event whose date is in the past
+    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate <= :now AND e.isPublic = TRUE AND (e.status IS NULL OR e.status <> 'CANCELLED')")
     long countCompletedEvents(@Param("now") LocalDateTime now);
 
     // Uses registeredCount (denormalised counter already on Event — free query!)

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AnalyticsSummaryTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AnalyticsSummaryTests.java
@@ -116,4 +116,31 @@ public class AnalyticsSummaryTests {
         mockMvc.perform(get("/api/analytics/summary"))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("GET /api/analytics/summary - cancelled and private events are excluded from active/completed counts")
+    void testSummaryExcludesCancelledAndPrivateEvents() throws Exception {
+        Event cancelled = new Event();
+        cancelled.setTitle("Cancelled Tech Talk");
+        cancelled.setEventDate(LocalDateTime.now().plusDays(5));
+        cancelled.setStatus("CANCELLED");
+        eventRepository.save(cancelled);
+
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Workshop");
+        privateEvent.setEventDate(LocalDateTime.now().plusDays(3));
+        privateEvent.setPublic(false);
+        eventRepository.save(privateEvent);
+
+        Event completed = new Event();
+        completed.setTitle("Past Conference");
+        completed.setEventDate(LocalDateTime.now().minusDays(2));
+        eventRepository.save(completed);
+
+        mockMvc.perform(get("/api/analytics/summary")
+                        .with(user("admin@example.com").authorities(() -> "SUPER_ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stats.activeEvents").value(1))
+                .andExpect(jsonPath("$.stats.completedEvents").value(1));
+    }
 }


### PR DESCRIPTION
## Problem

Dashboard analytics `countActiveEvents` and `countCompletedEvents` classify events purely by `eventDate` and ignore the `status` field (`CANCELLED`) and the `isPublic` flag. Cancelled events keep inflating one of the two counters forever, and private events are always counted in the aggregate, corrupting the admin/organizer dashboard headline stats.

## Fix

- `EventAnalyticsRepository.java`: both queries now exclude cancelled events (`status = 'CANCELLED'`, handling legacy `null` status) and private events (`isPublic = FALSE`), and the misleading comments were corrected.
- `AnalyticsSummaryTests.java`: added a regression test that creates a cancelled event, a private event and a completed event and asserts only the public, non-cancelled events appear in the `activeEvents` / `completedEvents` counts.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/AnalyticsSummaryTests.java`

## Testing

- `AnalyticsSummaryTests` (Spring Boot + H2 test profile) passes with the new regression test asserting cancelled/private events are excluded.

Closes #14602
