### PR TITLE
feat: add calculate vertex helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/calculate-prop.test.js
+++ b/src/eventra-kit/__tests__/calculate-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateProp from '../calculate-prop.js';
+
+describe('calculate-prop', () => {
+  it('exports a module', () => {
+    expect(CalculateProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-queue.test.js
+++ b/src/eventra-kit/__tests__/calculate-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateQueue from '../calculate-queue.js';
+
+describe('calculate-queue', () => {
+  it('exports a module', () => {
+    expect(CalculateQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-range.test.js
+++ b/src/eventra-kit/__tests__/calculate-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateRange from '../calculate-range.js';
+
+describe('calculate-range', () => {
+  it('exports a module', () => {
+    expect(CalculateRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-rank.test.js
+++ b/src/eventra-kit/__tests__/calculate-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateRank from '../calculate-rank.js';
+
+describe('calculate-rank', () => {
+  it('exports a module', () => {
+    expect(CalculateRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-record.test.js
+++ b/src/eventra-kit/__tests__/calculate-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateRecord from '../calculate-record.js';
+
+describe('calculate-record', () => {
+  it('exports a module', () => {
+    expect(CalculateRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-rect.test.js
+++ b/src/eventra-kit/__tests__/calculate-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateRect from '../calculate-rect.js';
+
+describe('calculate-rect', () => {
+  it('exports a module', () => {
+    expect(CalculateRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-score.test.js
+++ b/src/eventra-kit/__tests__/calculate-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateScore from '../calculate-score.js';
+
+describe('calculate-score', () => {
+  it('exports a module', () => {
+    expect(CalculateScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-segment.test.js
+++ b/src/eventra-kit/__tests__/calculate-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateSegment from '../calculate-segment.js';
+
+describe('calculate-segment', () => {
+  it('exports a module', () => {
+    expect(CalculateSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-set.test.js
+++ b/src/eventra-kit/__tests__/calculate-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateSet from '../calculate-set.js';
+
+describe('calculate-set', () => {
+  it('exports a module', () => {
+    expect(CalculateSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-size.test.js
+++ b/src/eventra-kit/__tests__/calculate-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateSize from '../calculate-size.js';
+
+describe('calculate-size', () => {
+  it('exports a module', () => {
+    expect(CalculateSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-slice.test.js
+++ b/src/eventra-kit/__tests__/calculate-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateSlice from '../calculate-slice.js';
+
+describe('calculate-slice', () => {
+  it('exports a module', () => {
+    expect(CalculateSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-space.test.js
+++ b/src/eventra-kit/__tests__/calculate-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateSpace from '../calculate-space.js';
+
+describe('calculate-space', () => {
+  it('exports a module', () => {
+    expect(CalculateSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-span.test.js
+++ b/src/eventra-kit/__tests__/calculate-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateSpan from '../calculate-span.js';
+
+describe('calculate-span', () => {
+  it('exports a module', () => {
+    expect(CalculateSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-stack.test.js
+++ b/src/eventra-kit/__tests__/calculate-stack.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateStack from '../calculate-stack.js';
+
+describe('calculate-stack', () => {
+  it('exports a module', () => {
+    expect(CalculateStack).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-step.test.js
+++ b/src/eventra-kit/__tests__/calculate-step.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateStep from '../calculate-step.js';
+
+describe('calculate-step', () => {
+  it('exports a module', () => {
+    expect(CalculateStep).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-string.test.js
+++ b/src/eventra-kit/__tests__/calculate-string.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateString from '../calculate-string.js';
+
+describe('calculate-string', () => {
+  it('exports a module', () => {
+    expect(CalculateString).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-text.test.js
+++ b/src/eventra-kit/__tests__/calculate-text.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateText from '../calculate-text.js';
+
+describe('calculate-text', () => {
+  it('exports a module', () => {
+    expect(CalculateText).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-time.test.js
+++ b/src/eventra-kit/__tests__/calculate-time.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateTime from '../calculate-time.js';
+
+describe('calculate-time', () => {
+  it('exports a module', () => {
+    expect(CalculateTime).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-token.test.js
+++ b/src/eventra-kit/__tests__/calculate-token.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateToken from '../calculate-token.js';
+
+describe('calculate-token', () => {
+  it('exports a module', () => {
+    expect(CalculateToken).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-tree.test.js
+++ b/src/eventra-kit/__tests__/calculate-tree.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateTree from '../calculate-tree.js';
+
+describe('calculate-tree', () => {
+  it('exports a module', () => {
+    expect(CalculateTree).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-triple.test.js
+++ b/src/eventra-kit/__tests__/calculate-triple.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateTriple from '../calculate-triple.js';
+
+describe('calculate-triple', () => {
+  it('exports a module', () => {
+    expect(CalculateTriple).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-uri.test.js
+++ b/src/eventra-kit/__tests__/calculate-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateUri from '../calculate-uri.js';
+
+describe('calculate-uri', () => {
+  it('exports a module', () => {
+    expect(CalculateUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-url.test.js
+++ b/src/eventra-kit/__tests__/calculate-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateUrl from '../calculate-url.js';
+
+describe('calculate-url', () => {
+  it('exports a module', () => {
+    expect(CalculateUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-value.test.js
+++ b/src/eventra-kit/__tests__/calculate-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateValue from '../calculate-value.js';
+
+describe('calculate-value', () => {
+  it('exports a module', () => {
+    expect(CalculateValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-vector.test.js
+++ b/src/eventra-kit/__tests__/calculate-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateVector from '../calculate-vector.js';
+
+describe('calculate-vector', () => {
+  it('exports a module', () => {
+    expect(CalculateVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/calculate-vertex.test.js
+++ b/src/eventra-kit/__tests__/calculate-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CalculateVertex from '../calculate-vertex.js';
+
+describe('calculate-vertex', () => {
+  it('exports a module', () => {
+    expect(CalculateVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/calculate-prop.js
+++ b/src/eventra-kit/calculate-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-prop helper.
+ */
+export function calculateProp(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/calculate-queue.js
+++ b/src/eventra-kit/calculate-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-queue helper.
+ */
+export function calculateQueue(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/calculate-range.js
+++ b/src/eventra-kit/calculate-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-range helper.
+ */
+export function calculateRange(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/calculate-rank.js
+++ b/src/eventra-kit/calculate-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-rank helper.
+ */
+export function calculateRank(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/calculate-record.js
+++ b/src/eventra-kit/calculate-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-record helper.
+ */
+export function calculateRecord(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/calculate-rect.js
+++ b/src/eventra-kit/calculate-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-rect helper.
+ */
+export function calculateRect(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/calculate-score.js
+++ b/src/eventra-kit/calculate-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-score helper.
+ */
+export function calculateScore(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/calculate-segment.js
+++ b/src/eventra-kit/calculate-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-segment helper.
+ */
+export function calculateSegment(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/calculate-set.js
+++ b/src/eventra-kit/calculate-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-set helper.
+ */
+export function calculateSet(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/calculate-size.js
+++ b/src/eventra-kit/calculate-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-size helper.
+ */
+export function calculateSize(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/calculate-slice.js
+++ b/src/eventra-kit/calculate-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-slice helper.
+ */
+export function calculateSlice(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/calculate-space.js
+++ b/src/eventra-kit/calculate-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-space helper.
+ */
+export function calculateSpace(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/calculate-span.js
+++ b/src/eventra-kit/calculate-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-span helper.
+ */
+export function calculateSpan(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/calculate-stack.js
+++ b/src/eventra-kit/calculate-stack.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-stack helper.
+ */
+export function calculateStack(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/calculate-step.js
+++ b/src/eventra-kit/calculate-step.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-step helper.
+ */
+export function calculateStep(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/calculate-string.js
+++ b/src/eventra-kit/calculate-string.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-string helper.
+ */
+export function calculateString(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/calculate-text.js
+++ b/src/eventra-kit/calculate-text.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-text helper.
+ */
+export function calculateText(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/calculate-time.js
+++ b/src/eventra-kit/calculate-time.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-time helper.
+ */
+export function calculateTime(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/calculate-token.js
+++ b/src/eventra-kit/calculate-token.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-token helper.
+ */
+export function calculateToken(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/calculate-tree.js
+++ b/src/eventra-kit/calculate-tree.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-tree helper.
+ */
+export function calculateTree(value) {
+  return Math.exp(value);
+}
+

--- a/src/eventra-kit/calculate-triple.js
+++ b/src/eventra-kit/calculate-triple.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-triple helper.
+ */
+export function calculateTriple(value) {
+  return value == null ? '' : String(value).trim();
+}
+

--- a/src/eventra-kit/calculate-uri.js
+++ b/src/eventra-kit/calculate-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-uri helper.
+ */
+export function calculateUri(value) {
+  return String(value).length;
+}
+

--- a/src/eventra-kit/calculate-url.js
+++ b/src/eventra-kit/calculate-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-url helper.
+ */
+export function calculateUrl(value) {
+  return String(value).split(' ').length;
+}
+

--- a/src/eventra-kit/calculate-value.js
+++ b/src/eventra-kit/calculate-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-value helper.
+ */
+export function calculateValue(value) {
+  return String(value).match(/[a-z]/gi)?.length ?? 0;
+}
+

--- a/src/eventra-kit/calculate-vector.js
+++ b/src/eventra-kit/calculate-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-vector helper.
+ */
+export function calculateVector(value) {
+  return String(value).match(/[0-9]/g)?.length ?? 0;
+}
+

--- a/src/eventra-kit/calculate-vertex.js
+++ b/src/eventra-kit/calculate-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a calculate-vertex helper.
+ */
+export function calculateVertex(value) {
+  return value.filter(Boolean).length;
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/calculate-vertex.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change