### PR TITLE
fix(backend): persist event schedule endDate so it survives reload

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -17,6 +17,12 @@ public class Event {
     private String description;
     private String location;
     private LocalDateTime eventDate;
+
+    /**
+     * Optional end date/time for the event schedule. Persisted so the end time
+     * chosen by the organizer survives reload (issue #14603).
+     */
+    private LocalDateTime endDate;
     private boolean isPublic = true;
 
     /**
@@ -156,6 +162,14 @@ public class Event {
 
     public void setEventDate(LocalDateTime eventDate) {
         this.eventDate = eventDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
     }
 
     public boolean isPublic() {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -591,7 +591,7 @@ public class EventService {
         public EventScheduleResponse getEventSchedule(Long id) {
                 Event event = eventRepository.findById(id)
                                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
-                return toEventScheduleResponse(event, null);
+                return toEventScheduleResponse(event);
         }
 
         @Transactional
@@ -608,15 +608,16 @@ public class EventService {
                 }
 
                 event.setEventDate(request.getStartDate());
+                event.setEndDate(request.getEndDate());
                 Event saved = eventRepository.save(event);
-                return toEventScheduleResponse(saved, request.getEndDate());
+                return toEventScheduleResponse(saved);
         }
 
-        private EventScheduleResponse toEventScheduleResponse(Event event, LocalDateTime endDate) {
+        private EventScheduleResponse toEventScheduleResponse(Event event) {
                 return EventScheduleResponse.builder()
                                 .eventId(event.getId())
                                 .startDate(event.getEventDate())
-                                .endDate(endDate != null ? endDate : event.getEventDate())
+                                .endDate(event.getEndDate() != null ? event.getEndDate() : event.getEventDate())
                                 .build();
         }
 
@@ -1343,8 +1344,10 @@ public class EventService {
                 java.time.Instant start = event.getEventDate() != null
                                 ? event.getEventDate().atZone(java.time.ZoneId.systemDefault()).toInstant()
                                 : java.time.Instant.now();
-                // Event model has no endDate; default duration is 2 hours when end is unspecified.
-                java.time.Instant end = start.plus(java.time.Duration.ofHours(2));
+                // Default duration is 2 hours when no end date was persisted.
+                java.time.Instant end = (event.getEndDate() != null
+                                ? event.getEndDate().atZone(java.time.ZoneId.systemDefault()).toInstant()
+                                : start.plus(java.time.Duration.ofHours(2)));
                 java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter
                                 .ofPattern("yyyyMMdd'T'HHmmss'Z'")
                                 .withZone(java.time.ZoneOffset.UTC);

--- a/Backend/src/main/resources/db/migration/V7__event_schedule_end_date.sql
+++ b/Backend/src/main/resources/db/migration/V7__event_schedule_end_date.sql
@@ -1,0 +1,3 @@
+-- Persist the event schedule end date/time (matches Event.endDate, issue #14603).
+-- Column is nullable so existing rows keep the default "end == start" behavior.
+ALTER TABLE events ADD COLUMN IF NOT EXISTS end_date TIMESTAMP;

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.EventScheduleRequest;
 import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.Role;
@@ -24,6 +25,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -298,5 +301,29 @@ public class EventUpdateTests {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("Event schedule endDate is persisted and survives reload (#14603)")
+    void testScheduleEndDatePersisted() throws Exception {
+        LocalDateTime start = LocalDateTime.now().plusDays(2).withNano(0);
+        LocalDateTime end = start.plusHours(3);
+
+        EventScheduleRequest request = new EventScheduleRequest();
+        request.setStartDate(start);
+        request.setEndDate(end);
+
+        mockMvc.perform(patch("/api/events/" + existingEvent.getId() + "/schedule")
+                        .with(user("organizer@example.com").authorities(() -> "ORGANIZER"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.endDate").value(end.toString()));
+
+        mockMvc.perform(get("/api/events/" + existingEvent.getId() + "/schedule")
+                        .with(user("organizer@example.com").authorities(() -> "ORGANIZER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.startDate").value(start.toString()))
+                .andExpect(jsonPath("$.endDate").value(end.toString()));
     }
 }


### PR DESCRIPTION
## Problem

`PATCH /api/events/{id}/schedule` validated and echoed an `endDate`, but the value was never persisted — the `Event` model had no end-date column. The very next `GET /schedule` returned `endDate` equal to `startDate`, silently losing the organizer's saved end time.

## Fix

- Added a nullable `endDate` (`LocalDateTime`) column to the `Event` entity plus a schema migration (`V7__event_schedule_end_date.sql`).
- `updateEventSchedule` now persists `event.setEndDate(request.getEndDate())` before saving.
- `toEventScheduleResponse` now reads the persisted `event.getEndDate()` (falling back to the start date only when none was saved), so `GET /schedule` returns the same `endDate` the organizer last saved.
- The ICS feed (`buildIcsFeed`) now uses the persisted `endDate` when present instead of always defaulting to a 2-hour duration.
- Added a round-trip test asserting the persisted `endDate` survives a subsequent `GET /schedule`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`
- `Backend/src/main/resources/db/migration/V7__event_schedule_end_date.sql`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java`

## Testing

- New `testScheduleEndDatePersisted` in `EventUpdateTests` PATCHes a schedule with an explicit `endDate` and asserts `GET /schedule` returns the same persisted value (round-trip).

Closes #14603
