### PR TITLE
fix(offline): stop pushToQueue from hanging when no service worker is active

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -12,13 +12,23 @@ const DB_NAME = "eventra_offline_db";
 const STORE_NAME = "actions_queue";
 const BACKGROUND_SYNC_TAG = "eventra-offline-queue-sync";
 
+// Background-sync registration is best-effort: never let service-worker
+// availability block a durable queue write (see #14604).
+const BACKGROUND_SYNC_TIMEOUT_MS = 2000;
+
 const requestBackgroundSync = async () => {
   if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
     return false;
   }
 
   try {
-    const registration = await navigator.serviceWorker.ready;
+    // navigator.serviceWorker.ready never settles when no service worker is
+    // active (blocked registration, failed install, incognito). Race it against
+    // a timeout so callers are never blocked on background-sync availability.
+    const registration = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise((resolve) => setTimeout(() => resolve(null), BACKGROUND_SYNC_TIMEOUT_MS)),
+    ]);
     if (registration?.sync && typeof registration.sync.register === "function") {
       await registration.sync.register(BACKGROUND_SYNC_TAG);
       return true;
@@ -395,7 +405,11 @@ queue.push(actionItem);
 
   if (queued) {
     notifyQueueUpdated(actionItem);
-    await requestBackgroundSync();
+    // Fire-and-forget: background-sync registration must never block the
+    // caller, even when no service worker becomes active (see #14604).
+    requestBackgroundSync().catch((error) => {
+      logger.warn("[OfflineQueue] Background sync request failed:", error);
+    });
   }
 
   return queued;

--- a/tests/offlineQueue.test.mjs
+++ b/tests/offlineQueue.test.mjs
@@ -317,4 +317,47 @@ const finalQueue = getQueue();
 assert.equal(finalQueue.length, 1, "User A's item should remain in the queue");
 assert.equal(finalQueue[0].userId, "user-a", "Remaining item should belong to user-a");
 
+// ── pushToQueue with a service worker that never becomes active (#14604) ─────
+reset();
+// Simulate an environment where navigator.serviceWorker.ready never settles
+// (blocked/failed registration, first load, incognito). pushToQueue must
+// resolve promptly instead of hanging forever.
+const _hadNavigator = Object.prototype.hasOwnProperty.call(global, "navigator");
+const _prevNavigator = _hadNavigator ? global.navigator : undefined;
+Object.defineProperty(global, "navigator", {
+  configurable: true,
+  value: {
+    serviceWorker: {
+      ready: new Promise(() => {}), // never resolves
+    },
+  },
+});
+
+const noSwStart = Date.now();
+const noSwResult = await pushToQueue({ eventId: "evt-no-sw" });
+const noSwElapsed = Date.now() - noSwStart;
+assert.equal(
+  noSwResult,
+  true,
+  "pushToQueue() resolves true when no service worker becomes active"
+);
+assert.ok(
+  noSwElapsed < 1000,
+  `pushToQueue() must not block on serviceWorker.ready (took ${noSwElapsed}ms)`
+);
+assert.equal(
+  getQueue().length,
+  1,
+  "item is still durably queued without an active service worker"
+);
+
+if (_hadNavigator) {
+  Object.defineProperty(global, "navigator", {
+    configurable: true,
+    value: _prevNavigator,
+  });
+} else {
+  delete global.navigator;
+}
+
 console.log("All offlineQueue tests passed ✓");


### PR DESCRIPTION
## Problem

`pushToQueue` unconditionally awaited `requestBackgroundSync()`, which awaits `navigator.serviceWorker.ready` with no timeout. When no service worker registration ever becomes active (blocked registration, failed install, first load, incognito/private modes), that promise never settles and `pushToQueue` hangs forever — the registration/check-in/waitlist UI stays stuck in "Submitting" with no toast and no retry.

## Fix

- `requestBackgroundSync` now races `navigator.serviceWorker.ready` against a 2s timeout (`Promise.race`); a timeout is treated as "no background sync available" and returns `false`.
- `pushToQueue` no longer awaits the background-sync request — it is fired-and-forgotten with a `.catch` guard, so the caller resolves as soon as the item is durably persisted.
- Added a unit test simulating an environment where `navigator.serviceWorker.ready` never resolves, asserting `pushToQueue` resolves promptly and the item is still queued.

## Files changed

- `src/utils/offlineQueue.js`
- `tests/offlineQueue.test.mjs`

## Testing

- `node tests/offlineQueue.test.mjs` — all assertions pass, including the new no-service-worker scenario.
- `node tests/offlineSync.test.mjs` — passes (unaffected).

Closes #14604
