### PR TITLE
fix(offline): retain queued item on transient 5xx instead of dropping it

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -596,6 +596,7 @@ const notifyQueueProcessed = (result) => {
  */
 export const processQueueItem = async (item, fetchFn, options = {}) => {
   const { signal, onConflict } = options;
+  let lastResponseWas5xx = false;
 
   for (let attempt = 0; attempt <= MAX_RETRY_COUNT; attempt++) {
     if (signal?.aborted) return { status: "error", item, error: new DOMException("Aborted", "AbortError") };
@@ -667,8 +668,10 @@ export const processQueueItem = async (item, fetchFn, options = {}) => {
       }
 
       // 5xx — retry with backoff
+      lastResponseWas5xx = true;
       clearPendingTimeout(); if (cleanupCombined) cleanupCombined(); continue;
     } catch (error) {
+      lastResponseWas5xx = false;
       clearPendingTimeout();
       if (cleanupCombined) cleanupCombined();
       if (error.name === "AbortError") return { status: "error", item, error };
@@ -677,7 +680,18 @@ export const processQueueItem = async (item, fetchFn, options = {}) => {
     }
   }
 
-  return { status: "dropped", item };
+  // Exhausted every attempt on a transient 5xx: retain the item for the next
+  // sync cycle instead of treating it like a confirmed 4xx rejection. Only
+  // confirmed client-side rejections (4xx) permanently drop an item (#14605).
+  if (lastResponseWas5xx) {
+    return {
+      status: "error",
+      item,
+      error: new Error(`Server responded with 5xx after ${MAX_RETRY_COUNT + 1} attempts`),
+    };
+  }
+
+  return { status: "error", item, error: new Error("Request failed after all retry attempts") };
 };
 
 /**

--- a/tests/offlineQueue.test.mjs
+++ b/tests/offlineQueue.test.mjs
@@ -71,6 +71,7 @@ const {
   clearQueue,
   validateQueueSession,
   processQueue,
+  processQueueItem,
 } = await import(
   "../src/utils/offlineQueue.js"
 );
@@ -316,5 +317,48 @@ assert.equal(processResultForB.succeeded, 1, "User-b item should succeed");
 const finalQueue = getQueue();
 assert.equal(finalQueue.length, 1, "User A's item should remain in the queue");
 assert.equal(finalQueue[0].userId, "user-a", "Remaining item should belong to user-a");
+
+// ── 5xx on the final retry retains the item instead of dropping it (#14605) ──
+reset();
+// Cap long timers (exponential backoff, request timeout) so the full retry loop
+// completes quickly; the request-timeout abort still loses the race to an
+// immediately-resolving fetch response.
+const _origSetTimeout = global.setTimeout;
+global.setTimeout = (fn, delay = 0) => _origSetTimeout(fn, Math.min(delay, 5));
+
+const fivexxItem = {
+  id: "fivexx-item",
+  actionType: "REGISTER_EVENT",
+  eventId: "evt-5xx",
+  endpoint: "/api/events/register",
+  payload: { eventId: "evt-5xx" },
+  retryCount: 0,
+};
+
+let fivexxAttempts = 0;
+const fivexxResult = await processQueueItem(fivexxItem, async () => {
+  fivexxAttempts += 1;
+  return { ok: false, status: 503 };
+});
+
+assert.equal(fivexxAttempts, 6, "all retry attempts are made on a transient 5xx");
+assert.equal(
+  fivexxResult.status,
+  "error",
+  "final-attempt 5xx is classified as a transient error, not dropped"
+);
+assert.equal(
+  fivexxResult.item.id,
+  "fivexx-item",
+  "transient 5xx retains the queued item for the next sync cycle"
+);
+
+const fourxxResult = await processQueueItem(
+  { ...fivexxItem, id: "fourxx-item" },
+  async () => ({ ok: false, status: 400 })
+);
+assert.equal(fourxxResult.status, "dropped", "4xx rejection still drops the item");
+
+global.setTimeout = _origSetTimeout;
 
 console.log("All offlineQueue tests passed ✓");


### PR DESCRIPTION
## Problem

`processQueueItem` fell through to `{ status: "dropped" }` when the retry loop ended on a 5xx response. `processQueue` then removed the item from the queue permanently — identical to a confirmed 4xx rejection. A transient server error (502/503 during deploy, restart, rate-limit) that coincided with the last retry silently destroyed an offline registration/waitlist action the server never confirmed.

## Fix

- `processQueueItem` now tracks whether the loop exhausted on a 5xx (`lastResponseWas5xx`). After the final attempt it returns `{ status: "error", item, error }` (retryable) instead of `{ status: "dropped" }`, so `processQueue` retains the item in `failed` with `retryCount + 1` for the next sync cycle.
- Only confirmed client-side rejections (4xx) still map to `dropped`; non-abort network errors that exhaust the loop are also retained as `error` instead of being dropped.
- Added unit tests: a 503 on every attempt returns `status: "error"` and keeps the item (all 6 attempts made), while a 400 still drops it.

## Files changed

- `src/utils/offlineQueue.js`
- `tests/offlineQueue.test.mjs`

## Testing

- `node tests/offlineQueue.test.mjs` — all assertions pass, including the new 5xx-retention and unchanged 4xx-drop scenarios.

Closes #14605
