### PR TITLE
fix(session): cancel pending debounced save in clearSession to prevent data resurrection

### DIFF
--- a/src/context/SessionRecoveryContext.js
+++ b/src/context/SessionRecoveryContext.js
@@ -117,6 +117,9 @@ export const SessionRecoveryProvider = ({ children }) => {
   const isLoadingRef = useRef(true);
   const saveTimeoutRef = useRef(null);
   const activityTimeoutRef = useRef(null);
+  // Guard flag so a debounced save scheduled before clearSession is ignored
+  // instead of re-persisting cleared data (issue #14606).
+  const saveCancelledRef = useRef(false);
   const cloudRecovery = useCloudSessionRecovery({
     user,
     isAuthenticated: isAuthenticated?.() || false,
@@ -231,12 +234,15 @@ export const SessionRecoveryProvider = ({ children }) => {
 
   const saveSession = useCallback(
     (state) => {
+      // A fresh save supersedes any previously cancelled intent (issue #14606)
+      saveCancelledRef.current = false;
+
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
       }
 
       saveTimeoutRef.current = setTimeout(async () => {
-        if (isLoadingRef.current) return;
+        if (isLoadingRef.current || saveCancelledRef.current) return;
         try {
           if (!isCryptoAvailable()) return;
 
@@ -265,6 +271,10 @@ export const SessionRecoveryProvider = ({ children }) => {
           };
 
           const ciphertext = await encryptSession(JSON.stringify(currentSession), key);
+
+          // Abort if the session was cleared while we were encrypting (issue #14606)
+          if (saveCancelledRef.current) return;
+
           localStorage.setItem(SESSION_KEY, ciphertext);
           setSessionData(currentSession);
           setHasSession(true);
@@ -292,6 +302,13 @@ export const SessionRecoveryProvider = ({ children }) => {
 
   const clearSession = useCallback(() => {
     try {
+      // Cancel any pending debounced save so cleared data cannot be
+      // re-persisted after sign-out / clear-session (issue #14606).
+      saveCancelledRef.current = true;
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
       localStorage.removeItem(SESSION_KEY);
       setSessionData(null);
       setHasSession(false);

--- a/tests/sessionRecovery.test.mjs
+++ b/tests/sessionRecovery.test.mjs
@@ -170,8 +170,34 @@ assert.ok(
   "Must set isLoadingRef.current to false when session loading completes"
 );
 assert.ok(
-  contextSrc.includes("if (isLoadingRef.current) return"),
+  contextSrc.includes("isLoadingRef.current || saveCancelledRef.current"),
   "Must guard saveSession from writing to localStorage if initial session load is in progress"
+);
+
+// ── Test 6: clearSession cancels pending debounced save (#14606) ─────────────
+const clearSessionStart = contextSrc.indexOf("const clearSession = useCallback");
+const clearSessionEnd = contextSrc.indexOf("const restoreSession = useCallback");
+const clearSessionBody = contextSrc.slice(clearSessionStart, clearSessionEnd);
+assert.ok(
+  clearSessionBody.includes("clearTimeout(saveTimeoutRef.current)"),
+  "clearSession must cancel any pending debounced save timer"
+);
+assert.ok(
+  clearSessionBody.includes("saveCancelledRef.current = true"),
+  "clearSession must set the cancelled guard flag so stale saves are ignored"
+);
+
+const setItemPos = contextSrc.indexOf("localStorage.setItem(SESSION_KEY, ciphertext)");
+const postEncryptGuardPos = contextSrc.indexOf("if (saveCancelledRef.current) return;");
+assert.ok(
+  postEncryptGuardPos !== -1 &&
+    setItemPos !== -1 &&
+    postEncryptGuardPos < setItemPos,
+  "saveSession must re-check the cancelled guard flag after encrypting and before persisting"
+);
+assert.ok(
+  contextSrc.includes("isLoadingRef.current || saveCancelledRef.current"),
+  "saveSession must skip its work when the save was cancelled"
 );
 
 console.log("All Session Recovery Sanitization & Cryptography tests passed successfully ✓");


### PR DESCRIPTION
## Problem

`clearSession()` cleared the in-memory session but never cancelled the pending debounced `saveSession` timeout. A sign-out (or "clear session") right after editing draft data let the already-scheduled `setTimeout` fire, re-persisting the just-cleared session — resurrecting deleted user data. On shared devices this could leak one user's restored draft to the next user.

## Fix

- `clearSession` now cancels the pending timer with `clearTimeout(saveTimeoutRef.current)` (and resets it to `null`) before removing the stored session.
- Added a `saveCancelledRef` guard flag: `clearSession` sets it, and `saveSession` checks it both when the debounced callback starts and again after `await encryptSession(...)` — immediately before `localStorage.setItem` — so a save that was already in-flight can never re-persist cleared data.
- A fresh `saveSession` call resets the flag, preserving normal re-save behavior after a cleared session.
- Added regression assertions to `tests/sessionRecovery.test.mjs` (Test 6) covering the timer cancellation, the guard flag, and the post-encryption guard; updated the pre-existing "isLoadingRef guard" assertion to the new combined guard.

## Files changed

- `src/context/SessionRecoveryContext.js`
- `tests/sessionRecovery.test.mjs`

## Testing

- `node tests/sessionRecovery.test.mjs` — all Session Recovery Sanitization & Cryptography tests pass, including the new clearSession guard assertions.

Closes #14606
