### PR TITLE
feat: add chunk segment helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/chunk-id.test.js
+++ b/src/eventra-kit/__tests__/chunk-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkId from '../chunk-id.js';
+
+describe('chunk-id', () => {
+  it('exports a module', () => {
+    expect(ChunkId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-index.test.js
+++ b/src/eventra-kit/__tests__/chunk-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkIndex from '../chunk-index.js';
+
+describe('chunk-index', () => {
+  it('exports a module', () => {
+    expect(ChunkIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-interval.test.js
+++ b/src/eventra-kit/__tests__/chunk-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkInterval from '../chunk-interval.js';
+
+describe('chunk-interval', () => {
+  it('exports a module', () => {
+    expect(ChunkInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-item.test.js
+++ b/src/eventra-kit/__tests__/chunk-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkItem from '../chunk-item.js';
+
+describe('chunk-item', () => {
+  it('exports a module', () => {
+    expect(ChunkItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-json.test.js
+++ b/src/eventra-kit/__tests__/chunk-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkJson from '../chunk-json.js';
+
+describe('chunk-json', () => {
+  it('exports a module', () => {
+    expect(ChunkJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-key.test.js
+++ b/src/eventra-kit/__tests__/chunk-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkKey from '../chunk-key.js';
+
+describe('chunk-key', () => {
+  it('exports a module', () => {
+    expect(ChunkKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-leaf.test.js
+++ b/src/eventra-kit/__tests__/chunk-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkLeaf from '../chunk-leaf.js';
+
+describe('chunk-leaf', () => {
+  it('exports a module', () => {
+    expect(ChunkLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-length.test.js
+++ b/src/eventra-kit/__tests__/chunk-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkLength from '../chunk-length.js';
+
+describe('chunk-length', () => {
+  it('exports a module', () => {
+    expect(ChunkLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-line.test.js
+++ b/src/eventra-kit/__tests__/chunk-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkLine from '../chunk-line.js';
+
+describe('chunk-line', () => {
+  it('exports a module', () => {
+    expect(ChunkLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-list.test.js
+++ b/src/eventra-kit/__tests__/chunk-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkList from '../chunk-list.js';
+
+describe('chunk-list', () => {
+  it('exports a module', () => {
+    expect(ChunkList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-map.test.js
+++ b/src/eventra-kit/__tests__/chunk-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkMap from '../chunk-map.js';
+
+describe('chunk-map', () => {
+  it('exports a module', () => {
+    expect(ChunkMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-matrix.test.js
+++ b/src/eventra-kit/__tests__/chunk-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkMatrix from '../chunk-matrix.js';
+
+describe('chunk-matrix', () => {
+  it('exports a module', () => {
+    expect(ChunkMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-name.test.js
+++ b/src/eventra-kit/__tests__/chunk-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkName from '../chunk-name.js';
+
+describe('chunk-name', () => {
+  it('exports a module', () => {
+    expect(ChunkName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-node.test.js
+++ b/src/eventra-kit/__tests__/chunk-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkNode from '../chunk-node.js';
+
+describe('chunk-node', () => {
+  it('exports a module', () => {
+    expect(ChunkNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-number.test.js
+++ b/src/eventra-kit/__tests__/chunk-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkNumber from '../chunk-number.js';
+
+describe('chunk-number', () => {
+  it('exports a module', () => {
+    expect(ChunkNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-object.test.js
+++ b/src/eventra-kit/__tests__/chunk-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkObject from '../chunk-object.js';
+
+describe('chunk-object', () => {
+  it('exports a module', () => {
+    expect(ChunkObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-order.test.js
+++ b/src/eventra-kit/__tests__/chunk-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkOrder from '../chunk-order.js';
+
+describe('chunk-order', () => {
+  it('exports a module', () => {
+    expect(ChunkOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-page.test.js
+++ b/src/eventra-kit/__tests__/chunk-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkPage from '../chunk-page.js';
+
+describe('chunk-page', () => {
+  it('exports a module', () => {
+    expect(ChunkPage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-pair.test.js
+++ b/src/eventra-kit/__tests__/chunk-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkPair from '../chunk-pair.js';
+
+describe('chunk-pair', () => {
+  it('exports a module', () => {
+    expect(ChunkPair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-path.test.js
+++ b/src/eventra-kit/__tests__/chunk-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkPath from '../chunk-path.js';
+
+describe('chunk-path', () => {
+  it('exports a module', () => {
+    expect(ChunkPath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-point.test.js
+++ b/src/eventra-kit/__tests__/chunk-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkPoint from '../chunk-point.js';
+
+describe('chunk-point', () => {
+  it('exports a module', () => {
+    expect(ChunkPoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-portion.test.js
+++ b/src/eventra-kit/__tests__/chunk-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkPortion from '../chunk-portion.js';
+
+describe('chunk-portion', () => {
+  it('exports a module', () => {
+    expect(ChunkPortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-prop.test.js
+++ b/src/eventra-kit/__tests__/chunk-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkProp from '../chunk-prop.js';
+
+describe('chunk-prop', () => {
+  it('exports a module', () => {
+    expect(ChunkProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-queue.test.js
+++ b/src/eventra-kit/__tests__/chunk-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkQueue from '../chunk-queue.js';
+
+describe('chunk-queue', () => {
+  it('exports a module', () => {
+    expect(ChunkQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-range.test.js
+++ b/src/eventra-kit/__tests__/chunk-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkRange from '../chunk-range.js';
+
+describe('chunk-range', () => {
+  it('exports a module', () => {
+    expect(ChunkRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-rank.test.js
+++ b/src/eventra-kit/__tests__/chunk-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkRank from '../chunk-rank.js';
+
+describe('chunk-rank', () => {
+  it('exports a module', () => {
+    expect(ChunkRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-record.test.js
+++ b/src/eventra-kit/__tests__/chunk-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkRecord from '../chunk-record.js';
+
+describe('chunk-record', () => {
+  it('exports a module', () => {
+    expect(ChunkRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-rect.test.js
+++ b/src/eventra-kit/__tests__/chunk-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkRect from '../chunk-rect.js';
+
+describe('chunk-rect', () => {
+  it('exports a module', () => {
+    expect(ChunkRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-score.test.js
+++ b/src/eventra-kit/__tests__/chunk-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkScore from '../chunk-score.js';
+
+describe('chunk-score', () => {
+  it('exports a module', () => {
+    expect(ChunkScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-segment.test.js
+++ b/src/eventra-kit/__tests__/chunk-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkSegment from '../chunk-segment.js';
+
+describe('chunk-segment', () => {
+  it('exports a module', () => {
+    expect(ChunkSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/chunk-id.js
+++ b/src/eventra-kit/chunk-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-id helper.
+ */
+export function chunkId(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/chunk-index.js
+++ b/src/eventra-kit/chunk-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-index helper.
+ */
+export function chunkIndex(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/chunk-interval.js
+++ b/src/eventra-kit/chunk-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-interval helper.
+ */
+export function chunkInterval(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/chunk-item.js
+++ b/src/eventra-kit/chunk-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-item helper.
+ */
+export function chunkItem(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/chunk-json.js
+++ b/src/eventra-kit/chunk-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-json helper.
+ */
+export function chunkJson(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/chunk-key.js
+++ b/src/eventra-kit/chunk-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-key helper.
+ */
+export function chunkKey(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/chunk-leaf.js
+++ b/src/eventra-kit/chunk-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-leaf helper.
+ */
+export function chunkLeaf(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/chunk-length.js
+++ b/src/eventra-kit/chunk-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-length helper.
+ */
+export function chunkLength(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/chunk-line.js
+++ b/src/eventra-kit/chunk-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-line helper.
+ */
+export function chunkLine(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/chunk-list.js
+++ b/src/eventra-kit/chunk-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-list helper.
+ */
+export function chunkList(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/chunk-map.js
+++ b/src/eventra-kit/chunk-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-map helper.
+ */
+export function chunkMap(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/chunk-matrix.js
+++ b/src/eventra-kit/chunk-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-matrix helper.
+ */
+export function chunkMatrix(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/chunk-name.js
+++ b/src/eventra-kit/chunk-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-name helper.
+ */
+export function chunkName(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/chunk-node.js
+++ b/src/eventra-kit/chunk-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-node helper.
+ */
+export function chunkNode(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/chunk-number.js
+++ b/src/eventra-kit/chunk-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-number helper.
+ */
+export function chunkNumber(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/chunk-object.js
+++ b/src/eventra-kit/chunk-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-object helper.
+ */
+export function chunkObject(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/chunk-order.js
+++ b/src/eventra-kit/chunk-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-order helper.
+ */
+export function chunkOrder(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/chunk-page.js
+++ b/src/eventra-kit/chunk-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-page helper.
+ */
+export function chunkPage(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/chunk-pair.js
+++ b/src/eventra-kit/chunk-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-pair helper.
+ */
+export function chunkPair(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/chunk-path.js
+++ b/src/eventra-kit/chunk-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-path helper.
+ */
+export function chunkPath(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/chunk-point.js
+++ b/src/eventra-kit/chunk-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-point helper.
+ */
+export function chunkPoint(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/chunk-portion.js
+++ b/src/eventra-kit/chunk-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-portion helper.
+ */
+export function chunkPortion(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/chunk-prop.js
+++ b/src/eventra-kit/chunk-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-prop helper.
+ */
+export function chunkProp(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/chunk-queue.js
+++ b/src/eventra-kit/chunk-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-queue helper.
+ */
+export function chunkQueue(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/chunk-range.js
+++ b/src/eventra-kit/chunk-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-range helper.
+ */
+export function chunkRange(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/chunk-rank.js
+++ b/src/eventra-kit/chunk-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-rank helper.
+ */
+export function chunkRank(value) {
+  return value.map((item, index) => [index, item]);
+}
+

--- a/src/eventra-kit/chunk-record.js
+++ b/src/eventra-kit/chunk-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-record helper.
+ */
+export function chunkRecord(value) {
+  return String(value).split(/\r?\n/);
+}
+

--- a/src/eventra-kit/chunk-rect.js
+++ b/src/eventra-kit/chunk-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-rect helper.
+ */
+export function chunkRect(value) {
+  return String(value).trim().split(/\s+/);
+}
+

--- a/src/eventra-kit/chunk-score.js
+++ b/src/eventra-kit/chunk-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-score helper.
+ */
+export function chunkScore(value) {
+  return value.toLocaleString();
+}
+

--- a/src/eventra-kit/chunk-segment.js
+++ b/src/eventra-kit/chunk-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-segment helper.
+ */
+export function chunkSegment(value) {
+  return Number.isFinite(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/chunk-segment.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change