### PR TITLE
fix(notifications): converge SSE and poller dedupe on a canonical key (#14612)

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -1,7 +1,7 @@
 import { createContext, useContext, useCallback, useMemo, useEffect, useRef } from "react";
 import { useAuth } from "./AuthContext";
 import useRealTimeConnection, { SSE_STATUS } from "../hooks/useRealTimeConnection";
-import { getNotificationCategory, getNotificationMessage, getNotificationTitle } from "../utils/notificationPreferences";
+import { getNotificationCategory, getNotificationDedupeKey, getNotificationMessage, getNotificationTitle } from "../utils/notificationPreferences";
 import { useNotificationPreferences } from "../hooks/useNotificationPreferences";
 import { usePushSubscription } from "../hooks/usePushSubscription";
 import { useNotificationDelivery } from "../hooks/useNotificationDelivery";
@@ -12,7 +12,7 @@ const NotificationContext = createContext();
 
 const normalizeNotification = (n = {}) => ({
   ...n,
-  id: n.id || n._id || `${n.timestamp || n.createdAt || Date.now()}-${getNotificationMessage(n)}`,
+  id: getNotificationDedupeKey(n) || `${Date.now()}-${Math.random().toString(36).slice(2)}`,
   title: getNotificationTitle(n),
   message: getNotificationMessage(n),
   category: getNotificationCategory(n),

--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -4,7 +4,7 @@ import { apiUtils, API_ENDPOINTS } from "../config/api.js";
 import { useAuth } from "../context/AuthContext.js";
 import usePageVisibility from "./usePageVisibility.js";
 import { safeJsonParse } from "../utils/safeJsonParse.js";
-import { getNotificationMessage } from "../utils/notificationPreferences.js";
+import { getNotificationDedupeKey } from "../utils/notificationPreferences.js";
 import { get as idbGet, del as idbDel } from "idb-keyval";
 import { showUndoToast } from "../utils/toast.js";
 
@@ -29,7 +29,7 @@ const getStorageKey = (userId) => {
 
 const normalize = (n = {}) => ({
   ...n,
-  id: n.id || n._id || `${n.timestamp || n.createdAt || Date.now()}-${Math.random().toString(36).slice(2)}`,
+  id: getNotificationDedupeKey(n) || `${n.timestamp || n.createdAt || Date.now()}-${Math.random().toString(36).slice(2)}`,
   timestamp: n.timestamp || n.createdAt || n.updatedAt || new Date().toISOString(),
   isRead: Boolean(n.isRead ?? n.read),
 });
@@ -110,20 +110,31 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
 
   const applyList = useCallback(
     (list, { deliverNew: shouldDeliver = false } = {}) => {
-      const normalized = list.map(normalize);
-      const incomingUnread = normalized.filter((n) => {
+      // Dedupe the batch by canonical id, then merge against the latest known
+      // list (notificationsRef keeps the freshest state between renders). The
+      // same logical notification arriving over SSE and the poller therefore
+      // converges on a single entry, and unreadCount is recomputed from that
+      // deduped set so it can never be counted twice (issue #14612).
+      const byId = new Map();
+      const deduped = [];
+      for (const raw of list) {
+        const n = normalize(raw);
+        if (byId.has(n.id)) continue;
+        byId.set(n.id, n);
+        deduped.push(n);
+      }
+      const incomingUnread = deduped.filter((n) => {
         const isNew = !seenIds.current.has(n.id);
         return isNew && !n.isRead;
       });
-      normalized.forEach((n) => addSeenId(n.id));
-      setNotifications((prev) => {
-        const byId = new Map(normalized.map((n) => [n.id, n]));
-        const merged = normalized.concat(prev.filter((p) => !byId.has(p.id)));
-        const sorted = merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-        persist(sorted, storageKeyRef.current);
-        return sorted;
-      });
-      setUnreadCount((prev) => Math.max(0, prev + incomingUnread.length));
+      deduped.forEach((n) => addSeenId(n.id));
+      const prev = notificationsRef.current || [];
+      const merged = deduped.concat(prev.filter((p) => !byId.has(p.id)));
+      const sorted = merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      notificationsRef.current = sorted;
+      setNotifications(sorted);
+      persist(sorted, storageKeyRef.current);
+      setUnreadCount(Math.max(0, sorted.filter((n) => !n.isRead).length));
       if (shouldDeliver && hasCompletedInitialFetchRef.current && incomingUnread.length > 0) {
         deliverNew(incomingUnread);
       }
@@ -163,6 +174,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
   useEffect(() => {
     if (!token) {
       setNotifications([]);
+      notificationsRef.current = [];
       setUnreadCount(0);
       seenIds.current = new Set();
       hasCompletedInitialFetchRef.current = false;
@@ -205,6 +217,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
         if (!isMounted.current || tokenRef.current !== t) return;
         setNotifications((prev) => {
           const updated = prev.map((n) => (n.id === id ? { ...n, isRead: true } : n));
+          notificationsRef.current = updated;
           persist(updated, storageKeyRef.current);
           return updated;
         });
@@ -230,6 +243,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
     if (!endpoint) return;
     setNotifications((prev) => {
       const updated = prev.map((n) => ({ ...n, isRead: true }));
+      notificationsRef.current = updated;
       persist(updated, storageKeyRef.current);
       return updated;
     });
@@ -252,6 +266,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
       const removedWasUnread = target ? !target.isRead : false;
       setNotifications((prev) => {
         const updated = prev.filter((n) => n.id !== id);
+        notificationsRef.current = updated;
         persist(updated, storageKeyRef.current);
         return updated;
       });
@@ -305,6 +320,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
           (n) => n.id && !seenIds.current.has(n.id) && !n.isRead
         );
         setNotifications(persisted);
+        notificationsRef.current = persisted;
         setUnreadCount(persisted.filter((n) => !n.isRead).length);
         persisted.forEach((n) => {
           if (n.id) addSeenId(n.id);
@@ -361,6 +377,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
             merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
             persist(merged, storageKeyRef.current);
             setNotifications(merged);
+            notificationsRef.current = merged;
             setUnreadCount(merged.filter((n) => !n.isRead).length);
             merged.forEach((n) => {
               if (n.id) seenIds.current.add(n.id);

--- a/src/utils/notificationPreferences.js
+++ b/src/utils/notificationPreferences.js
@@ -160,6 +160,26 @@ export const getNotificationTitle = (notification = {}) =>
 export const getNotificationMessage = (notification = {}) =>
   notification.message || notification.body || notification.description || "You have a new update.";
 
+/**
+ * Canonical dedupe key for a notification. The server id wins; otherwise an
+ * event-scoped key (eventId) when present; otherwise a deterministic key
+ * derived from timestamp + content. Both the SSE path and the poller derive
+ * ids from this helper, so the same logical notification delivered over both
+ * transports converges on a single entry instead of being counted twice
+ * (issue #14612).
+ */
+export const getNotificationDedupeKey = (notification = {}) => {
+  if (!notification) return "";
+  const serverId = notification.id || notification._id;
+  if (serverId) return String(serverId);
+  if (notification.eventId) return `event:${notification.eventId}`;
+  const timestamp =
+    notification.timestamp || notification.createdAt || notification.updatedAt || "";
+  const content = notification.message || notification.body || notification.description || "";
+  if (timestamp || content) return `${timestamp}-${content}`;
+  return "";
+};
+
 export const playNotificationSound = (soundKey) => {
   if (typeof window === "undefined") return;
   const sound = NOTIFICATION_SOUNDS[soundKey];

--- a/tests/notificationDedupe.test.mjs
+++ b/tests/notificationDedupe.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the SSE / poller notification dedupe convergence (issue
+ * #14612).
+ *
+ * Before the fix, the SSE path (NotificationContext.normalizeNotification)
+ * derived an id for id-less notifications from `getNotificationMessage(n)`
+ * while the poller (useNotificationPoller.normalize) synthesized one from
+ * Math.random(). The same logical notification delivered over both transports
+ * therefore produced two different ids, so the poller's seen-id + merge
+ * dedupe never matched and unreadCount inflated.
+ *
+ * Both normalizers now derive ids from the shared
+ * getNotificationDedupeKey() helper, and the poller recomputes unreadCount
+ * from the deduped set instead of incrementing it per new arrival.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const { getNotificationDedupeKey } = await import("../src/utils/notificationPreferences.js");
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Minimal replica of the merge applied by useNotificationPoller.applyList:
+// dedupe the batch by canonical id, merge against the freshest list, keep
+// newest-first, and derive unreadCount from the deduped set.
+function createInbox() {
+  let current = [];
+  const seenIds = new Set();
+  return {
+    applyList(list) {
+      const byId = new Map();
+      const deduped = [];
+      for (const raw of list) {
+        // Mirror useNotificationPoller.normalize: id-less payloads get the
+        // canonical dedupe key.
+        const n = { ...raw, id: raw.id || getNotificationDedupeKey(raw) };
+        if (byId.has(n.id)) continue;
+        byId.set(n.id, n);
+        deduped.push(n);
+      }
+      deduped.forEach((n) => seenIds.add(n.id));
+      const prev = current;
+      const merged = deduped.concat(prev.filter((p) => !byId.has(p.id)));
+      current = merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      return this;
+    },
+    get list() {
+      return current;
+    },
+    get unreadCount() {
+      return current.filter((n) => !n.isRead).length;
+    },
+    seen(id) {
+      return seenIds.has(id);
+    },
+  };
+}
+
+const sseKey = (raw) => getNotificationDedupeKey(raw);
+const pollerKey = (raw) => getNotificationDedupeKey(raw);
+
+const idless = {
+  eventId: "evt_123",
+  title: "Event reminder",
+  message: "Starts in 30 minutes",
+  timestamp: "2026-08-12T10:00:00.000Z",
+  isRead: false,
+};
+
+// 1. getNotificationDedupeKey priority and determinism.
+assert.equal(getNotificationDedupeKey({ id: "a1", eventId: "e1" }), "a1", "server id wins");
+assert.equal(getNotificationDedupeKey({ _id: "a2", eventId: "e2" }), "a2", "_id wins");
+assert.equal(getNotificationDedupeKey({ eventId: "e3" }), "event:e3", "eventId keyed");
+assert.equal(
+  getNotificationDedupeKey(idless),
+  "event:evt_123",
+  "notification with an eventId is keyed by the event, not random"
+);
+const contentOnly = { title: "Reminder", message: "Starts in 30 minutes", timestamp: "2026-08-12T10:00:00.000Z" };
+assert.equal(
+  getNotificationDedupeKey(contentOnly),
+  `${contentOnly.timestamp}-${contentOnly.message}`,
+  "id-less, event-less notifications get a deterministic timestamp+content key"
+);
+assert.equal(
+  getNotificationDedupeKey(contentOnly),
+  getNotificationDedupeKey({ ...contentOnly }),
+  "same logical id-less notification always derives the same key"
+);
+assert.equal(getNotificationDedupeKey({}), "", "empty notification yields empty key");
+assert.equal(getNotificationDedupeKey(null), "", "null notification yields empty key");
+
+// 2. SSE then poller: same id-less notification must converge to one entry
+//    and a single unread count (the reported bug).
+{
+  const inbox = createInbox();
+  const sseRaw = { ...idless, id: sseKey(idless) };
+  inbox.applyList([sseRaw]);
+  const pollerRaw = { ...idless, id: pollerKey(idless) };
+  inbox.applyList([pollerRaw]);
+  assert.equal(inbox.list.length, 1, "SSE + poller duplicate collapses to one entry");
+  assert.equal(inbox.unreadCount, 1, "unreadCount is 1, not 2");
+  assert.ok(inbox.seen(pollerKey(idless)), "canonical id registered in seen-ids");
+}
+
+// 3. Poller then SSE (reverse order) converges the same way.
+{
+  const inbox = createInbox();
+  inbox.applyList([{ ...idless, id: pollerKey(idless) }]);
+  inbox.applyList([{ ...idless, id: sseKey(idless) }]);
+  assert.equal(inbox.list.length, 1, "reverse order also collapses to one entry");
+  assert.equal(inbox.unreadCount, 1, "reverse order unreadCount stays 1");
+}
+
+// 4. Server-id notifications delivered over both transports stay single.
+{
+  const inbox = createInbox();
+  const server = { id: "srv_99", title: "T", message: "M", timestamp: "2026-08-12T09:00:00.000Z", isRead: false };
+  inbox.applyList([{ ...server }]);
+  inbox.applyList([{ ...server }]);
+  assert.equal(inbox.list.length, 1, "same server id over both transports is one entry");
+  assert.equal(inbox.unreadCount, 1, "server-id duplicate counted once");
+}
+
+// 5. Distinct notifications (different events / different content) are never
+//    conflated.
+{
+  const inbox = createInbox();
+  inbox.applyList([{ ...idless, eventId: "evt_1", message: "First message", timestamp: "2026-08-12T08:00:00.000Z" }]);
+  inbox.applyList([{ ...idless, eventId: "evt_2", message: "Second message", timestamp: "2026-08-12T09:00:00.000Z" }]);
+  assert.equal(inbox.list.length, 2, "different events stay separate");
+  assert.equal(inbox.unreadCount, 2, "two distinct unread notifications counted");
+  assert.equal(
+    inbox.list[0].id,
+    "event:evt_2",
+    "keys are event-scoped so a later notification for the same event replaces the slot"
+  );
+}
+
+// 6. A duplicate inside a single batch is collapsed by the batch-level dedupe.
+{
+  const inbox = createInbox();
+  inbox.applyList([{ ...idless, id: sseKey(idless) }, { ...idless, id: pollerKey(idless) }]);
+  assert.equal(inbox.list.length, 1, "intra-batch duplicate collapses to one entry");
+  assert.equal(inbox.unreadCount, 1, "intra-batch duplicate counted once");
+}
+
+// 7. After marking read locally, a re-poll (server reflects isRead: true)
+//    keeps the single entry and does not resurrect unread state.
+{
+  const inbox = createInbox();
+  inbox.applyList([{ ...idless, id: sseKey(idless) }]);
+  inbox.list[0] = { ...inbox.list[0], isRead: true };
+  inbox.applyList([{ ...idless, id: pollerKey(idless), isRead: true }]);
+  assert.equal(inbox.list.length, 1, "re-poll after read keeps single entry");
+  assert.equal(inbox.unreadCount, 0, "read notification is not recounted as unread");
+}
+
+// 8. Source contract: both transports must actually derive ids from the
+//    shared helper, and the poller must recompute unread from the deduped set.
+const contextSrc = readFileSync(join(__dirname, "../src/context/NotificationContext.js"), "utf8");
+const pollerSrc = readFileSync(join(__dirname, "../src/hooks/useNotificationPoller.js"), "utf8");
+assert.ok(
+  contextSrc.includes("getNotificationDedupeKey") &&
+    /id:\s*getNotificationDedupeKey\(n\)/.test(contextSrc),
+  "NotificationContext.normalizeNotification derives id from the shared key"
+);
+assert.ok(
+  pollerSrc.includes("getNotificationDedupeKey") &&
+    /id:\s*getNotificationDedupeKey\(n\)/.test(pollerSrc),
+  "useNotificationPoller.normalize derives id from the shared key"
+);
+assert.ok(
+  /setUnreadCount\(Math\.max\(0, sorted\.filter\(\(n\) => !n\.isRead\)\.length\)\)/.test(pollerSrc),
+  "poller recomputes unreadCount from the deduped set"
+);
+
+console.log("All notification dedupe convergence tests passed");


### PR DESCRIPTION
## Problem
The same logical notification delivered over both transports — the SSE stream (`NotificationContext.ingestRealtime`) and the 60s fallback poller (`useNotificationPoller`) — was synthesized into **two different ids**:

- SSE path (`normalizeNotification`) derived an id for id-less payloads from `getNotificationMessage(n)` (deterministic).
- Poller path (`normalize`) derived it from `Math.random()` (non-deterministic).

Because the poller's dedupe (seen-ids + id-keyed merge) keys off `n.id`, a notification that arrived over SSE and then again over the poller never matched. The duplicate stayed in the inbox and `unreadCount` inflated (the poller incremented it per *new-looking* arrival rather than counting distinct entries).

## Fix
- Added a shared canonical dedupe key, `getNotificationDedupeKey`, in `src/utils/notificationPreferences.js`. Priority: server `id`/`_id` → `event:` + `eventId` → deterministic `timestamp-content` → `""` (random fallback).
- Both `NotificationContext.normalizeNotification` and `useNotificationPoller.normalize` now derive ids from this helper, so the same logical payload converges on one key regardless of transport.
- `applyList` now dedupes the incoming batch by canonical id, merges against the freshest known list (`notificationsRef.current` is kept in sync synchronously, matching the existing `restoreNotification` convention), and **recomputes `unreadCount` from the deduped set** instead of incrementing per arrival.
- All other state-writers in the poller (`markAsRead`, `markAllAsRead`, `deleteNotification`, same-tab handler, legacy migration, token-clear) keep `notificationsRef.current` in sync so `applyList` always merges against current state.

## Files changed
- `src/utils/notificationPreferences.js` — new `getNotificationDedupeKey` helper.
- `src/context/NotificationContext.js` — `normalizeNotification` uses the shared key.
- `src/hooks/useNotificationPoller.js` — `normalize` uses the shared key; `applyList` dedupes by canonical id and recomputes unread from the deduped set; ref kept in sync across all writers.
- `tests/notificationDedupe.test.mjs` — new test file.

## Testing
- New `tests/notificationDedupe.test.mjs` (key priority/determinism, SSE→poller and poller→SSE convergence, server-id duplicates, distinct-notification separation, intra-batch dedupe, post-read re-poll, source-contract assertions) — all pass.
- Existing `tests/notificationPreferences.test.mjs`, `tests/useNotifications.test.mjs`, `tests/eventCancellationNotifications.test.mjs` — pass.
- `eslint` on all three changed source files — clean.

Closes #14612
