### PR TITLE
fix(secureStorage): serialize all mutations through one writer (#14613)

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -689,6 +689,16 @@ if (typeof window !== "undefined") {
 // written to localStorage, so this Map is the only in-flight plaintext store.
 const pendingWrites = new Map();
 
+// Keys with a queued / in-flight / completed remove. Read helpers treat them
+// as absent immediately, before the queued remove op reaches localStorage, so
+// a synchronous removeItem is visible to getItem / getItemAsync right away.
+const removedKeys = new Set();
+
+// True between a clear() call and its queued clear op reaching localStorage.
+// While set, every read reports null so a clear is visible immediately even
+// though the disk wipe is serialized behind earlier queued writes.
+let pendingClear = false;
+
 /**
  * Encrypts `value` and writes the ciphertext to localStorage under `key`.
  *
@@ -715,28 +725,54 @@ const writeWithEncryption = async (key, value) => {
 };
 
 export const syncSecureStorage = {
-  // Serialized write queue: ensures last-write-wins and no plaintext window.
-  // Each key enqueues its latest value; the queue processes one at a time,
-  // writing only the ciphertext to localStorage. If the queue is already
-  // processing, a new enqueue updates the pending value for that key without
-  // starting a new chain, so the final write always reflects the last call.
-  _writeQueue: new Map(),
+  // Serialized mutation queue: every set / remove / clear is enqueued in call
+  // order and executed one at a time by _drainQueue. This guarantees
+  // last-write-wins on disk for the same key (concurrent setItem calls can no
+  // longer write out of order because encryption happens inside the queue),
+  // and that a remove / clear issued after a set can never land on disk
+  // before that set (issue #14613). Reads stay consistent because the
+  // in-memory state (pendingWrites / removedKeys / pendingClear) is updated
+  // synchronously, before the queued op reaches localStorage.
+  _opQueue: [],
   _processing: false,
 
-  _processQueue: async function () {
+  /**
+   * Append a mutation op and return a promise that resolves when it lands on
+   * disk. Never enqueues inside _drainQueue, so the writer cannot recursively
+   * re-acquire itself.
+   * @private
+   */
+  _enqueue: function (op) {
+    return new Promise((resolve, reject) => {
+      this._opQueue.push({ ...op, resolve, reject });
+      this._drainQueue();
+    });
+  },
+
+  /**
+   * Serialized writer. Processes queued ops one at a time; ops enqueued while
+   * a batch is running are picked up by the next loop iteration.
+   * @private
+   */
+  _drainQueue: async function () {
     if (this._processing) return;
     this._processing = true;
     try {
-      while (this._writeQueue.size > 0) {
-        const entries = [...this._writeQueue.entries()];
-        this._writeQueue.clear();
-        for (const [key, plaintext] of entries) {
-          try {
-            const encrypted = await encryptValue(key, plaintext);
-            localStorage.setItem(key, encrypted);
-          } catch (err) {
-            console.error("[secureStorage] Encryption failed for", key, err);
+      while (this._opQueue.length > 0) {
+        const { key, type, value, resolve, reject } = this._opQueue.shift();
+        try {
+          if (type === "clear") {
+            localStorage.clear();
+            pendingClear = false;
+          } else if (type === "remove") {
+            localStorage.removeItem(key);
+          } else {
+            await writeWithEncryption(key, value);
           }
+          resolve();
+        } catch (err) {
+          console.error("[secureStorage] Mutation failed for", key, err);
+          reject(err);
         }
       }
     } finally {
@@ -765,10 +801,11 @@ export const syncSecureStorage = {
    * @returns {Promise<boolean>} `true` on success; `false` when the write
    *   could not be persisted (localStorage full, encryption error, etc.).
    */
-  setItem: async (key, value) => {
+  setItem: async function (key, value) {
     try {
       pendingWrites.set(key, value);
-      await writeWithEncryption(key, value);
+      removedKeys.delete(key);
+      await this._enqueue({ key, type: "set", value });
       if (pendingWrites.get(key) === value) {
         pendingWrites.delete(key);
       }
@@ -798,8 +835,14 @@ export const syncSecureStorage = {
    */
   getItem: (key) => {
     try {
+      if (pendingClear) {
+        return null;
+      }
       if (pendingWrites.has(key)) {
         return pendingWrites.get(key);
+      }
+      if (removedKeys.has(key)) {
+        return null;
       }
       return localStorage.getItem(key);
     } catch (error) {
@@ -827,8 +870,14 @@ export const syncSecureStorage = {
    */
   getItemAsync: async (key) => {
     try {
+      if (pendingClear) {
+        return null;
+      }
       if (pendingWrites.has(key)) {
         return pendingWrites.get(key);
+      }
+      if (removedKeys.has(key)) {
+        return null;
       }
 
       const stored = localStorage.getItem(key);
@@ -858,11 +907,15 @@ export const syncSecureStorage = {
    *
    * @param {string} key
    */
-  removeItem: (key) => {
+  removeItem: function (key) {
     try {
       /* Removed destructive cleanup to prevent queued writes from being dropped silently */
       pendingWrites.delete(key);
-      localStorage.removeItem(key);
+      removedKeys.add(key);
+      // Enqueued after any prior setItem for this key, so the disk removal is
+      // guaranteed to happen after that write (issue #14613). Reads already
+      // see null via removedKeys.
+      this._enqueue({ key, type: "remove" }).catch(() => {});
       localStorage.removeItem(key + PLAINTEXT_SUFFIX);
     } catch (error) {
       console.error("[secureStorage] removeItem failed:", error);
@@ -873,10 +926,14 @@ export const syncSecureStorage = {
    * Clears all localStorage data for the current origin.
    * Use with caution: this removes ALL keys, not just Eventra's.
    */
-  clear: () => {
+  clear: function () {
     try {
       pendingWrites.clear();
-      localStorage.clear();
+      pendingClear = true;
+      // Enqueued behind any prior setItem / removeItem, so the wipe happens
+      // after them rather than racing with them (issue #14613). Reads report
+      // null immediately via pendingClear.
+      this._enqueue({ key: null, type: "clear" }).catch(() => {});
       _keyPromise = null;
     } catch (error) {
       console.error("[secureStorage] clear failed:", error);

--- a/tests/secureStorageQueue.test.mjs
+++ b/tests/secureStorageQueue.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the secureStorage serialized mutation queue (issue #14613).
+ *
+ * Before the fix, setItem encrypted and wrote directly to localStorage while
+ * removeItem/clear wrote synchronously — the orphaned _writeQueue/_processQueue
+ * were never wired up. Two concurrent setItem calls for the same key could
+ * therefore land out of order (the slower encryption could finish last and
+ * overwrite a newer value), and a removeItem/clear issued after a setItem could
+ * run on disk before that setItem. These tests pin the ordering guarantees:
+ * all mutations go through one serialized writer and reads stay consistent
+ * synchronously via in-memory state.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+
+class LocalStorageMock {
+  constructor() {
+    this._store = {};
+  }
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this._store, key) ? this._store[key] : null;
+  }
+  setItem(key, value) {
+    this._store[key] = String(value);
+  }
+  removeItem(key) {
+    delete this._store[key];
+  }
+  clear() {
+    this._store = {};
+  }
+  get length() {
+    return Object.keys(this._store).length;
+  }
+  key(index) {
+    return Object.keys(this._store)[index] ?? null;
+  }
+}
+
+let delayNextEncrypt = false;
+const DELAY_MS = 50;
+
+class CryptoStub {
+  getRandomValues(array) {
+    for (let i = 0; i < array.length; i++) array[i] = Math.floor(Math.random() * 256);
+    return array;
+  }
+  get subtle() {
+    return {
+      importKey: async () => ({ type: 'raw' }),
+      deriveKey: async () => ({ type: 'derived' }),
+      encrypt: async (_algo, _key, data) => {
+        if (delayNextEncrypt) {
+          delayNextEncrypt = false;
+          await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+        }
+        const src = new Uint8Array(data.buffer ?? data);
+        const out = new Uint8Array(src.length);
+        for (let i = 0; i < src.length; i++) out[i] = src[i] ^ 0x42;
+        return out.buffer;
+      },
+      decrypt: async (_algo, _key, data) => {
+        const src = new Uint8Array(data.buffer ?? data);
+        const out = new Uint8Array(src.length);
+        for (let i = 0; i < src.length; i++) out[i] = src[i] ^ 0x42;
+        return out.buffer;
+      },
+    };
+  }
+}
+
+const mockStorage = new LocalStorageMock();
+global.localStorage = mockStorage;
+global.window = {
+  localStorage: mockStorage,
+  location: { origin: 'http://localhost' },
+  isSecureContext: true,
+  crypto: new CryptoStub(),
+};
+Object.defineProperty(global, 'crypto', { value: new CryptoStub(), writable: true, configurable: true });
+
+const { syncSecureStorage } = await import("../src/utils/secureStorage.js");
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("secureStorage serialized mutation queue (#14613)", () => {
+  beforeEach(() => {
+    mockStorage.clear();
+  });
+
+  afterEach(async () => {
+    mockStorage.clear();
+    await delay(20);
+  });
+
+  it("concurrent setItem calls land in call order (last-write-wins on disk)", async () => {
+    // First write is artificially slow. Without the queue the fast write would
+    // hit localStorage first and the slow write would then overwrite it, so
+    // the disk would end up with the OLD value. With the queue, the first call
+    // is fully flushed before the second starts.
+    delayNextEncrypt = true;
+    const first = syncSecureStorage.setItem("k", "first");
+    const second = syncSecureStorage.setItem("k", "second");
+    await Promise.all([first, second]);
+    const decrypted = await syncSecureStorage.getItemAsync("k");
+    assert.strictEqual(decrypted, "second", "newer value must win, not the slower one");
+  });
+
+  it("setItem then removeItem keeps the removal after the write on disk", async () => {
+    await syncSecureStorage.setItem("k", "value");
+    syncSecureStorage.removeItem("k");
+    assert.strictEqual(syncSecureStorage.getItem("k"), null, "read sees the removal immediately");
+    await delay(DELAY_MS + 40);
+    assert.strictEqual(mockStorage.getItem("k"), null, "disk removal lands after the write");
+  });
+
+  it("removeItem enqueued while a write is in flight still wins", async () => {
+    delayNextEncrypt = true;
+    const pending = syncSecureStorage.setItem("k", "value");
+    syncSecureStorage.removeItem("k");
+    await pending;
+    await delay(DELAY_MS + 40);
+    assert.strictEqual(mockStorage.getItem("k"), null, "queued remove beats the queued write");
+    assert.strictEqual(await syncSecureStorage.getItemAsync("k"), null);
+  });
+
+  it("clear() is serialized after prior writes", async () => {
+    await syncSecureStorage.setItem("a", "1");
+    await syncSecureStorage.setItem("b", "2");
+    syncSecureStorage.clear();
+    assert.strictEqual(syncSecureStorage.getItem("a"), null, "clear is visible to reads immediately");
+    assert.strictEqual(syncSecureStorage.getItem("b"), null);
+    await delay(DELAY_MS + 40);
+    assert.strictEqual(mockStorage.getItem("a"), null, "disk wipe lands after prior writes");
+    assert.strictEqual(mockStorage.getItem("b"), null);
+  });
+
+  it("clear() enqueued behind a slow write clears it, not the reverse", async () => {
+    delayNextEncrypt = true;
+    const pending = syncSecureStorage.setItem("a", "1");
+    syncSecureStorage.clear();
+    await pending;
+    await delay(DELAY_MS + 40);
+    assert.strictEqual(mockStorage.getItem("a"), null, "clear runs after the queued write");
+  });
+
+  it("a new setItem clears the remove tombstone", async () => {
+    await syncSecureStorage.setItem("k", "old");
+    syncSecureStorage.removeItem("k");
+    assert.strictEqual(syncSecureStorage.getItem("k"), null);
+    await syncSecureStorage.setItem("k", "new");
+    assert.strictEqual(await syncSecureStorage.getItemAsync("k"), "new");
+  });
+
+  it("sequential setItem calls for the same key are ordered", async () => {
+    await syncSecureStorage.setItem("k", "one");
+    await syncSecureStorage.setItem("k", "two");
+    await syncSecureStorage.setItem("k", "three");
+    assert.strictEqual(await syncSecureStorage.getItemAsync("k"), "three");
+  });
+
+  it("a setItem still resolves false when localStorage.setItem throws", async () => {
+    const original = mockStorage.setItem.bind(mockStorage);
+    try {
+      mockStorage.setItem = () => { throw new Error("QuotaExceededError"); };
+      const result = await syncSecureStorage.setItem("k", "v");
+      assert.strictEqual(result, false);
+    } finally {
+      mockStorage.setItem = original;
+    }
+  });
+
+  it("multiple keys serialize through the single writer without loss", async () => {
+    const keys = ["a", "b", "c", "d"];
+    await Promise.all(keys.map((k, i) => syncSecureStorage.setItem(k, `v${i}`)));
+    for (let i = 0; i < keys.length; i++) {
+      assert.strictEqual(await syncSecureStorage.getItemAsync(keys[i]), `v${i}`);
+    }
+  });
+});


### PR DESCRIPTION
## Problem
`secureStorage.setItem` encrypted and wrote to localStorage directly, bypassing the shared serialized writer. `removeItem` and `clear` wrote synchronously and out-of-band, and the `_writeQueue`/`_processQueue` that were supposed to serialize mutations were orphaned dead code — nothing ever enqueued into them.

Consequences:
- Two concurrent `setItem` calls for the same key could land out of order: whichever `encryptValue` promise resolved last physically overwrote the other, so a **stale value could win over a newer one** on disk (cross-tab `storage` events then delivered the stale value).
- A `removeItem`/`clear` issued after a `setItem` could run on disk *before* that write landed, so a value survived a delete that was ordered after it.
- In-flight `getItem` reads could observe a partially-updated state.

## Fix
All mutations now flow through **one serialized FIFO writer** (`_opQueue` / `_drainQueue`), which replaces the orphaned `_writeQueue` / `_processQueue`:

- `setItem` enqueues a `set` op and awaits it, so a resolved `setItem` means the value is on disk and call order == disk write order (last-write-wins is guaranteed even when encryption latencies differ).
- `removeItem` and `clear` enqueue `remove` / `clear` ops in the same queue, so a delete issued after a write is physically applied after that write.
- The writer is reentrancy-safe: ops are never enqueued from inside `_drainQueue`, and the `_processing` guard prevents recursive re-acquisition (a previously reported hang pattern).
- Reads stay consistent **synchronously** via in-memory state updated before the queued op reaches localStorage: `pendingWrites` (unchanged), plus a new `removedKeys` tombstone set and a `pendingClear` flag consulted by both `getItem` and `getItemAsync`.
- The `localStorage.setItem` quota/throw path still surfaces as `setItem` returning `false` (the op rejects, `setItem` catches and returns `false`).

Note on the issue's proposed ordering metadata: within a tab, the serialized queue already guarantees ordered, atomic writes (so each tab's own writes are never stale-inverted). Cross-tab *last-write-wins* is inherently enforced by the storage layer; a timestamp/seq comparison across tabs would need to live in the `storage`-event consumers and is outside this file — no speculative dead metadata was added.

## Files changed
- `src/utils/secureStorage.js` — serialized mutation queue (`_opQueue`/`_enqueue`/`_drainQueue`) replacing the dead `_writeQueue`/`_processQueue`; `setItem`/`removeItem`/`clear` enqueue; `removedKeys` tombstone + `pendingClear` flag consulted by `getItem`/`getItemAsync`; removed `writeWithEncryption` direct-call from `setItem` (queue now owns the write).
- `tests/secureStorageQueue.test.mjs` — new test file (9 scenarios) proving last-write-wins under divergent encryption latency, set→remove ordering, set→clear ordering, tombstone clearing, quota-error → `false`, and multi-key serialization.

## Testing
- New `tests/secureStorageQueue.test.mjs` — 9/9 pass.
- Existing `tests/secureStorage.test.mjs` — 77/77 pass (unchanged contract: `await setItem` resolves `true`, `removeItem`/`clear` are visible synchronously, rotation tests intact).
- `npm run test:unit` — 158/163; the 5 failures (`sseMultiplexer`, `feedbackUtils`, `hostHackathonValidation`) are pre-existing on `origin/master` (none import `secureStorage`; e.g. `sseMultiplexer` fails on an EventSource mock `source.addEventListener is not a function`).
- `eslint src/utils/secureStorage.js` — clean.

Closes #14613
