### PR TITLE
fix(feedback): gate public feedback behind event visibility (#14615)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -112,11 +112,17 @@ public class FeedbackService {
 
     @Transactional(readOnly = true)
     public List<PublicFeedbackResponse> getEventFeedback(Long eventId) {
-        if (!eventRepository.existsById(eventId)) {
-            throw new EventNotFoundException("Event not found with ID: " + eventId);
-        }
+        // Enforce the same visibility rule as the event detail API
+        // (EventService.requirePublicEvent): private events are hidden from the
+        // public read path, and cancelled events never expose their feedback.
+        // A missing, private, or cancelled event is reported as not-found so
+        // callers cannot distinguish it from a nonexistent id (issue #14615).
+        Event event = eventRepository.findById(eventId)
+                .filter(Event::isPublic)
+                .filter(e -> !"CANCELLED".equals(e.getStatus()))
+                .orElseThrow(() -> new EventNotFoundException("Event not found with ID: " + eventId));
 
-        return feedbackRepository.findByEvent_IdOrderBySubmittedAtDesc(eventId).stream()
+        return feedbackRepository.findByEvent_IdOrderBySubmittedAtDesc(event.getId()).stream()
                 .map(this::mapToPublicResponse)
                 .toList();
     }
@@ -137,8 +143,22 @@ public class FeedbackService {
                 .id(feedback.getId())
                 .eventId(feedback.getEvent().getId())
                 .rating(feedback.getRating())
-                .comment(feedback.getComment())
+                .comment(sanitizePublicComment(feedback.getComment()))
                 .submittedAt(feedback.getSubmittedAt())
                 .build();
+    }
+
+    /**
+     * Lightweight sanitization for the public feedback list: strips any HTML so
+     * comment text can never be rendered as markup, collapses whitespace, and
+     * caps the length. The organizer-facing view ({@link #mapToResponse}) keeps
+     * the raw comment. Issue #14615.
+     */
+    private static String sanitizePublicComment(String comment) {
+        if (comment == null || comment.isBlank()) {
+            return comment;
+        }
+        String stripped = comment.replaceAll("<[^>]*>", "").replaceAll("\\s+", " ").trim();
+        return stripped.length() > 1000 ? stripped.substring(0, 1000) : stripped;
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/FeedbackControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/FeedbackControllerTests.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sandeep.eventrabackend.dto.request.FeedbackRequest;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Feedback;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.*;
@@ -327,5 +328,71 @@ public class FeedbackControllerTests {
                         .with(user("admin@example.com")
                                 .authorities(new SimpleGrantedAuthority("ADMIN"))))
                 .andExpect(status().isOk());
+    }
+
+    // ── Issue #14615 — Public feedback endpoint visibility ────────────────
+
+    @Test
+    @DisplayName("GET /api/feedback?eventId= — public event, anonymous OK")
+    void testGetEventFeedbackPublicEventAnonymous() throws Exception {
+        seedFeedback("Public feedback comment");
+        mockMvc.perform(get("/api/feedback").param("eventId", eventId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].rating").value(5))
+                .andExpect(jsonPath("$[0].comment").value("Public feedback comment"));
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback?eventId= — private event hidden")
+    void testGetEventFeedbackPrivateEvent() throws Exception {
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Event");
+        privateEvent.setEventDate(LocalDateTime.now().minusDays(1));
+        privateEvent.setOwnerId(organizerId);
+        privateEvent.setPublic(false);
+        privateEvent = eventRepository.save(privateEvent);
+
+        mockMvc.perform(get("/api/feedback").param("eventId", privateEvent.getId().toString()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback?eventId= — cancelled event hidden")
+    void testGetEventFeedbackCancelledEvent() throws Exception {
+        Event cancelledEvent = new Event();
+        cancelledEvent.setTitle("Cancelled Event");
+        cancelledEvent.setEventDate(LocalDateTime.now().minusDays(1));
+        cancelledEvent.setOwnerId(organizerId);
+        cancelledEvent.setPublic(true);
+        cancelledEvent.setStatus("CANCELLED");
+        cancelledEvent = eventRepository.save(cancelledEvent);
+
+        mockMvc.perform(get("/api/feedback").param("eventId", cancelledEvent.getId().toString()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback?eventId= — nonexistent event hidden")
+    void testGetEventFeedbackNonexistentEvent() throws Exception {
+        mockMvc.perform(get("/api/feedback").param("eventId", "99999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/feedback?eventId= — public comments are sanitized (HTML stripped)")
+    void testGetEventFeedbackSanitizesComments() throws Exception {
+        seedFeedback("<script>alert(1)</script> Nice event!");
+        mockMvc.perform(get("/api/feedback").param("eventId", eventId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].comment").value("alert(1) Nice event!"));
+    }
+
+    private void seedFeedback(String comment) {
+        Feedback feedback = new Feedback();
+        feedback.setEvent(eventRepository.findById(eventId).orElseThrow());
+        feedback.setUser(userRepository.findByEmail(testUserEmail).orElseThrow());
+        feedback.setRating(5);
+        feedback.setComment(comment);
+        feedbackRepository.saveAndFlush(feedback);
     }
 }


### PR DESCRIPTION
## Problem
`GET /api/feedback?eventId={id}` returned the full, unmoderated feedback list for any event whose id exists — no authorization, no visibility check. Private events (`isPublic=false`) and cancelled events exposed their attendees' feedback to any anonymous caller who could guess the numeric event id. The only guard in `FeedbackService.getEventFeedback` was `eventRepository.existsById`, unlike the event detail API which hides non-public events via `EventService.requirePublicEvent`.

Comments were also returned verbatim, so raw HTML/script in a comment would be served to public consumers.

## Fix
`FeedbackService.getEventFeedback` now enforces the same visibility rule as the event detail API:

- Loads the event via `findById` and filters through `Event::isPublic` (mirroring `requirePublicEvent` / `getPublicEventById`).
- Blocks cancelled events (`status == "CANCELLED"`) — their feedback is never exposed.
- A missing, private, or cancelled event is reported as `EventNotFoundException` (404) so callers cannot distinguish it from a nonexistent id.

Public comments are lightly sanitized before being returned (`sanitizePublicComment`): HTML tags are stripped (no markup can ever render from the public list), whitespace is collapsed, and length is capped at the 1000-char DB limit. The organizer-facing endpoint (`getOrganizerFeedback`) keeps the raw comment.

## Files changed
- `Backend/.../service/FeedbackService.java` — visibility gate on `getEventFeedback` + `sanitizePublicComment` applied in `mapToPublicResponse`.
- `Backend/.../controller/FeedbackControllerTests.java` — integration tests: public event anonymous 200; private event 404; cancelled event 404; nonexistent event 404; HTML comment sanitization.

## Testing
Backend compile/run is not possible in this environment (Maven is unavailable — `mvnw.cmd` fails on missing wrapper properties and `mvn` is not on PATH), so the tests are code-review-verified only:

- New tests follow the existing `FeedbackControllerTests` patterns (`@SpringBootTest` + `@AutoConfigureMockMvc`, `@ActiveProfiles("test")`).
- `seedFeedback` inserts a `Feedback` row directly via `FeedbackAnalyticsRepository.saveAndFlush` (already used by `FeedbackService.submitFeedback`).
- The status null-safety is preserved: `"CANCELLED".equals(e.getStatus())` is false for a null status, so default `SCHEDULED` events pass.
- Frontend `src/utils/feedbackUtils.js` reads feedback from localStorage (not this endpoint), so the API contract change does not affect it.

Closes #14615
