### PR TITLE
fix(EventBasicInfo): correct eventDefaults import depth so create-event form resolves (#14663)

### DIFF
--- a/src/components/common/EventCreation/EventBasicInfo.jsx
+++ b/src/components/common/EventCreation/EventBasicInfo.jsx
@@ -1,7 +1,7 @@
 
 import { motion } from "framer-motion";
 import { FileText, Tag, Users } from "lucide-react";
-import { categories } from "../../constants/eventDefaults";
+import { categories } from "../../../constants/eventDefaults";
 import CharacterCounter from "../CharacterCounter";
 
 const FormField = ({ label, icon: Icon, error, children, required, hint }) => (


### PR DESCRIPTION
## Problem

`src/components/common/EventCreation/EventBasicInfo.jsx` imports the `categories` constant from `"../../constants/eventDefaults"`. This file lives three levels deep, at `src/components/common/EventCreation/EventBasicInfo.jsx`, so a two-level relative import (`../../`) resolves to `src/components/constants/eventDefaults` — a path that does not exist anywhere in the repo. The real module lives at `src/constants/eventDefaults.js`, which requires a **three-level** relative path (`../../../constants/eventDefaults`).

Because the import cannot be resolved, the module fails to compile. Requesting the module from the Vite dev server returns an HTTP 500 with:

> Failed to resolve import "../../constants/eventDefaults" from "src/components/common/EventCreation/EventBasicInfo.jsx". Does the file exist?

This breaks the create-event flow. `EventCreation.jsx` mounts `EventBasicInfo` (line 9 import, line 156 usage) as the first step of the new-event wizard, where the user enters the event title, categories, description, and capacity. With the import broken, the entire create-event experience cannot render, and `categories` (used at line 80 via `categories.map((cat) => ...)`) is unavailable to populate the multi-select category input.

## Fix

Change the single broken import to the correct depth so it resolves to `src/constants/eventDefaults.js`:

```diff
-import { categories } from "../../constants/eventDefaults";
+import { categories } from "../../../constants/eventDefaults";
```

No other imports in the file are affected: `framer-motion`, `lucide-react`, and the sibling `../CharacterCounter` all resolve correctly. The named export `categories` already exists in `src/constants/eventDefaults.js` (line 5), so no change to the constants module is required.

## Verification

- Before: `curl http://localhost:3001/src/components/common/EventCreation/EventBasicInfo.jsx` -> HTTP 500, "Failed to resolve import".
- After: same request -> HTTP 200, module transforms cleanly with no resolve error.
- `src/constants/eventDefaults.js` loads (HTTP 200) and exports `categories`.
- Reachability confirmed: `EventCreation.jsx` imports `EventBasicInfo` from `"./common/EventCreation/EventBasicInfo"` and renders it in the create-event form.

## Scope

A single one-line change confined to the broken import. No behavior, styling, or logic is altered — this purely restores a path that was already intended to work. Closes #14663.