### PR TITLE
fix(logger): restore sensitive-data redaction and security logger (#14655)

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,4 +1,4 @@
-/* eslint-disable-next-line no-console */
+import { redactSensitiveData } from "./security/redactSensitiveData.js";
 
 // Cross-environment development check (Vite, Webpack, Node.js)
 const isDevelopment = (() => {
@@ -32,7 +32,7 @@ export const logger = {
    */
   log: (...args) => {
     if (isDevelopment) {
-      console.log(getPrefix("log"), ...args);
+      console.log(getPrefix("log"), ...redactLogArgs(args));
     }
   },
 
@@ -43,7 +43,7 @@ export const logger = {
    */
   info: (...args) => {
     if (isDevelopment) {
-      console.info(getPrefix("info"), ...args);
+      console.info(getPrefix("info"), ...redactLogArgs(args));
     }
   },
 
@@ -53,9 +53,7 @@ export const logger = {
    * @param {...*} args - Additional arguments to pass to console.warn.
    */
   warn: (...args) => {
-    if (isDevelopment) {
-      console.warn(getPrefix("warn"), ...args);
-    }
+    console.warn(getPrefix("warn"), ...redactLogArgs(args));
   },
 
   /**
@@ -64,6 +62,22 @@ export const logger = {
    * @param {...*} args - Additional arguments to pass to console.error.
    */
   error: (...args) => {
-    console.error(getPrefix("error"), ...args);
+    console.error(getPrefix("error"), ...redactLogArgs(args));
+  },
+
+  /**
+   * Logs a security event with redacted metadata.
+   * @param {string} event - Machine-readable security event name.
+   * @param {Object} [data] - Event metadata; sensitive fields are redacted.
+   */
+  security: (event, data = {}) => {
+    const timestamp = new Date().toISOString();
+    const logEntry = redactSensitiveData({ timestamp, event, ...data });
+
+    if (isDevelopment) {
+      console.warn(getPrefix("security"), redactSensitiveData(data));
+    } else {
+      console.warn(JSON.stringify(logEntry));
+    }
   },
 };

--- a/tests/logger.test.mjs
+++ b/tests/logger.test.mjs
@@ -11,10 +11,16 @@ globalThis.console = {
 import { logger } from "../src/utils/logger.js";
 
 logger.warn("Attention");
-assert.equal(logged.some(([msg]) => msg === "[WARN] Attention"), true);
+assert.equal(
+  logged.some(([prefix, msg]) => prefix === "[WARN]" && msg === "Attention"),
+  true,
+);
 
 logger.error("Failed");
-assert.equal(logged.some(([msg]) => msg === "[ERROR] Failed"), true);
+assert.equal(
+  logged.some(([prefix, msg]) => prefix === "[ERROR]" && msg === "Failed"),
+  true,
+);
 
 logger.info("User login", {
   email: "person@example.com",
@@ -23,10 +29,16 @@ logger.info("User login", {
   password: "super-secret",
 });
 
-const infoEntry = logged.find(([msg]) => msg === "[INFO] User login");
+const infoEntry = logged.find(([prefix]) => prefix === "[INFO]");
 assert.ok(infoEntry, "Should log info entry");
-assert.equal(infoEntry[1].email, "[REDACTED_SECRET]");
-assert.equal(infoEntry[1].Authorization, "[REDACTED_SECRET]");
-assert.equal(infoEntry[1].password, "[REDACTED_SECRET]");
+assert.equal(infoEntry[1], "User login");
+assert.equal(infoEntry[2].email, "[REDACTED_SECRET]");
+assert.equal(infoEntry[2].Authorization, "[REDACTED_SECRET]");
+assert.equal(infoEntry[2].password, "[REDACTED_SECRET]");
+
+logger.security("csrf_token_missing", { token: "super-secret-token" });
+const securityEntry = logged.find(([prefix]) => prefix === "[SECURITY]");
+assert.ok(securityEntry, "Should log security entry");
+assert.equal(securityEntry[1].token, "[REDACTED_SECRET]");
 
 console.log("logger tests passed");


### PR DESCRIPTION
## Problem
`src/utils/logger.js` was left inconsistent after the object-coercion fix (`d8b18e143`): it refactored `formatMessage` into a spread prefix and added the ESM `import.meta.env` check, but in doing so it dropped the `redactSensitiveData` import. The result:

- `redactLogArgs` is dead code referencing an undefined `redactSensitiveData` — a latent `ReferenceError`;
- no log path actually redacts sensitive data anymore, so `logger.info("User login", { email, Authorization, password })` prints secrets to the console;
- `logger.security(...)` was removed entirely, but `src/config/api/interceptors.js` still calls it (lines 43, 202, 212) — a `TypeError` on every request-signing failure / CSRF-missing path;
- `tests/logger.test.mjs` (which asserts the redaction behavior) fails against master.

## Fix
- Re-import `redactSensitiveData` from `./security/redactSensitiveData.js` and wire `redactLogArgs(args)` into `log`/`info`/`warn`/`error`. Non-string arguments still keep their interactive structure (the prefix is a separate console parameter — no template-string coercion, per the issue's expected behaviour).
- Restore the `security(event, data = {})` method (redacts the metadata, logs a redacted object in dev and a redacted JSON line in production) so the interceptor call sites work again.
- Remove the stale unused `/* eslint-disable-next-line no-console */` directive.
- Update `tests/logger.test.mjs` to the new console-call shape (prefix and message are separate arguments) and add a `security` coverage case.

`log`/`info` remain gated on `isDevelopment`; `warn`/`error`/`security` always log — matching the issue's proposed API.

## Files changed
- `src/utils/logger.js`
- `tests/logger.test.mjs`

## Testing
- `node tests/logger.test.mjs` — passes (message/prefix assertions + sensitive-field redaction `[REDACTED_SECRET]` + `security` case).
- `node tests/redactSensitiveData.test.mjs` — passes (module untouched).
- `npx eslint src/utils/logger.js tests/logger.test.mjs src/config/api/interceptors.js` — clean (was 2 warnings before).

Closes #14655
