### PR TITLE
fix(countdown): use static import for getServerTime instead of dead require (#14660)

### DIFF
--- a/src/hooks/useCountdown.js
+++ b/src/hooks/useCountdown.js
@@ -52,19 +52,12 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { getServerTime } from "utils/timeSync";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Time source
 // ─────────────────────────────────────────────────────────────────────────────
-
-let getTime;
-try {
-  // Use getServerTime when available — prevents client clock manipulation
-  const { getServerTime } = require("utils/timeSync");
-  getTime = getServerTime;
-} catch {
-  getTime = () => new Date();
-}
+// Uses getServerTime() from timeSync.js — prevents client clock manipulation.
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Calculate time remaining to a deadline
@@ -73,7 +66,7 @@ try {
 const calculateTimeLeft = (deadline) => {
   if (!deadline) return { days: 0, hours: 0, minutes: 0, seconds: 0, ended: true, total: 0 };
 
-  const now = getTime();
+  const now = getServerTime();
   const end = deadline instanceof Date ? deadline : new Date(deadline);
   const diff = end - now;
 


### PR DESCRIPTION
## Problem
`src/hooks/useCountdown.js:63` loaded `getServerTime` with CommonJS `require("utils/timeSync")`. The file is an ES module, so `require` is not defined in the browser or in Node ESM; the `ReferenceError` was swallowed by the `try/catch` and `getTime` silently became `() => new Date()`. Every countdown (event deadlines, GSSoC end date, hackathon start/end, QR refresh timers) was computed from the local client clock, making the documented "prevents client clock manipulation" feature dead in all runtimes.

## Fix
Replace the dead `require` fallback with a static ES import — the same pattern already used by `src/Pages/Hackathons/HackathonCard.js` and `src/components/common/CountdownTimer.jsx`:

```js
import { getServerTime } from "utils/timeSync";
```

`calculateTimeLeft` now calls `getServerTime()` directly, so countdowns run off the server-synced clock. The module-level `getTime` indirection and the swallowing `try/catch` are removed.

## Files changed
- `src/hooks/useCountdown.js`

## Testing
- No `require`/`getTime` references remain in the file.
- `import(".../src/utils/timeSync.js")` loads under Node ESM and exposes `getServerTime` (function).
- `npx eslint src/hooks/useCountdown.js` — clean.
- `utils/` is a configured Vite alias (already used by two other static importers of `timeSync`), so the bare specifier resolves in the app build.

Closes #14660
