### PR TITLE
fix(filters): import useDebounce as default export (#14662)

### DIFF
--- a/src/hooks/useEventFilters.js
+++ b/src/hooks/useEventFilters.js
@@ -65,7 +65,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import { safeJsonParse } from "utils/safeJsonParse";
-import { useDebounce } from "hooks/useDebounce";
+import useDebounce from "hooks/useDebounce";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers


### PR DESCRIPTION
## Problem
`src/hooks/useEventFilters.js:68` used a named import `import { useDebounce } from "hooks/useDebounce";`, but `src/hooks/useDebounce.js` is default-export only. Vite/ESM raises `SyntaxError: The requested module does not provide an export named 'useDebounce'`, so `useEventFilters` (consumed by the Hackathons page filter) fails to evaluate.

## Fix
Switch to the default import:

```js
import useDebounce from "hooks/useDebounce";
```

This matches the module's contract and every other consumer (`useAdvancedEventSearch.js`, `SearchFilter.js`, `HackathonPage.js`, `useEventListing.js`, `CollaborationHub.js`, `ProjectsPage.js`, `GSSoCContribution.js`, `useDebounce.test.js`).

## Files changed
- `src/hooks/useEventFilters.js`

## Testing
- `npx eslint src/hooks/useEventFilters.js` — clean.
- Grep confirms no other source file named-imports `useDebounce`; all use the default import.

Closes #14662
