### PR TITLE
fix(event-form): import eventDefaults via constants alias (#14663)

### DIFF
--- a/src/components/common/EventCreation/EventBasicInfo.jsx
+++ b/src/components/common/EventCreation/EventBasicInfo.jsx
@@ -1,7 +1,7 @@
 
 import { motion } from "framer-motion";
 import { FileText, Tag, Users } from "lucide-react";
-import { categories } from "../../constants/eventDefaults";
+import { categories } from "constants/eventDefaults";
 import CharacterCounter from "../CharacterCounter";
 
 const FormField = ({ label, icon: Icon, error, children, required, hint }) => (


### PR DESCRIPTION
## Problem
`src/components/common/EventCreation/EventBasicInfo.jsx:4` imports `categories` from `"../../constants/eventDefaults"`. From `src/components/common/EventCreation/` that resolves to `src/components/constants/eventDefaults` — which does not exist (verified: `src/components/constants/` is absent). The real module is `src/constants/eventDefaults.js`. `EventBasicInfo` is loaded via the lazy create-event route, so the first form step fails to resolve at build/route time.

## Fix
Use the `constants/` Vite alias, matching the established import style in `EventCard.js`, `EventDetails.js`, `RecommendationCard.js`, `OrganizerEventCard.js` and `user/EventCard.jsx`:

```js
import { categories } from "constants/eventDefaults";
```

## Files changed
- `src/components/common/EventCreation/EventBasicInfo.jsx`

## Testing
- `npx eslint src/components/common/EventCreation/EventBasicInfo.jsx` — clean.
- Resolves to the existing `src/constants/eventDefaults.js` (exports `categories`), verified present.

Closes #14663
