### PR TITLE
fix(floor-plan): import floorPlanPresets via constants alias (#14675)

### DIFF
--- a/src/components/events/FloorPlan/PropertiesPanel.jsx
+++ b/src/components/events/FloorPlan/PropertiesPanel.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Trash2, Users } from "lucide-react";
-import { MOCK_ATTENDEES } from "../../constants/floorPlanPresets";
+import { MOCK_ATTENDEES } from "constants/floorPlanPresets";
 
 export default function PropertiesPanel({
   activeElement, elements, onUpdateSelected, onDeleteSelected,


### PR DESCRIPTION
## Problem
`src/components/events/FloorPlan/PropertiesPanel.jsx:3` imports `MOCK_ATTENDEES` from `"../../constants/floorPlanPresets"`. From `src/components/events/FloorPlan/` that resolves to `src/components/constants/floorPlanPresets` — which does not exist (verified: `src/components/constants/` is absent). The real module is `src/constants/floorPlanPresets.js`, which exports `MOCK_ATTENDEES` and `PRESETS`. `PropertiesPanel` is imported by `FloorPlanDesigner.js`, so the properties panel fails to load.

## Fix
Use the `constants/` Vite alias, matching `FloorPlanDesigner.js`'s own `import { PRESETS } from "constants/floorPlanPresets";`:

```js
import { MOCK_ATTENDEES } from "constants/floorPlanPresets";
```

## Files changed
- `src/components/events/FloorPlan/PropertiesPanel.jsx`

## Testing
- `npx eslint src/components/events/FloorPlan/PropertiesPanel.jsx` — clean.
- Resolves to the existing `src/constants/floorPlanPresets.js`, verified present.

Closes #14675
