### PR TITLE
fix(build): emit CRA-format asset-manifest.json for service-worker precaching

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig, loadEnv, transformWithOxc } from "vite";
 import react from "@vitejs/plugin-react";
 
 import path from "path";
+import fs from "fs";
 import { fileURLToPath } from "url";
 import dotenv from "dotenv";
 
@@ -63,6 +64,50 @@ export default defineConfig(({ mode }) => {
             );
           }
           return html;
+        },
+      },
+      // Emit a CRA-format asset-manifest.json after the production build.
+      //
+      // public/service-worker.js precaches the hashed /assets/* bundles by
+      // reading `manifest.files` from /asset-manifest.json. Vite never emits
+      // that artifact — with `build.manifest: true` it writes `.vite/manifest.json`
+      // instead — so without this plugin the install handler always hit the
+      // catch branch and only the static ASSETS_TO_CACHE list was cached,
+      // leaving the app chunks out of the precache (Issue #14664).
+      {
+        name: "emit-asset-manifest",
+        enforce: "post",
+        closeBundle() {
+          const outDir = "build";
+          const viteManifestPath = path.resolve(__dirname, outDir, ".vite/manifest.json");
+          if (!fs.existsSync(viteManifestPath)) {
+            // Dev server close — no manifest was produced; the service worker
+            // falls back to its static asset list in development.
+            return;
+          }
+
+          let viteManifest;
+          try {
+            viteManifest = JSON.parse(fs.readFileSync(viteManifestPath, "utf8"));
+          } catch (err) {
+            this.warn(`[emit-asset-manifest] Could not read ${viteManifestPath}: ${err.message}`);
+            return;
+          }
+
+          const files = {};
+          for (const [key, entry] of Object.entries(viteManifest)) {
+            files[key] = `/${entry.file}`;
+            if (Array.isArray(entry.css)) {
+              entry.css.forEach((cssFile, index) => {
+                files[`${key}:css:${index}`] = `/${cssFile}`;
+              });
+            }
+          }
+
+          fs.writeFileSync(
+            path.resolve(__dirname, outDir, "asset-manifest.json"),
+            JSON.stringify({ files }, null, 2),
+          );
         },
       },
     ],


### PR DESCRIPTION
## Summary
Service worker precaching is broken: the install handler fetches `/asset-manifest.json` (CRA format) to precache hashed `/assets/*` bundles, but Vite never emits that file — with `build.manifest: true` it writes `.vite/manifest.json` instead. So the fetch 404s, the catch branch runs, and only the 7 hardcoded `ASSETS_TO_CACHE` entries get cached. The app chunks are never precached, breaking offline support (refs #14664).

## Change
Add a small post-build Vite plugin (`emit-asset-manifest`) that reads `build/.vite/manifest.json` and writes a CRA-compatible `build/asset-manifest.json` of the shape `{ files: { ... } }`, including css entries per chunk. The service worker's existing install/precache logic is unchanged.

## Verification
Isolated `vite build` produces:

```json
{ "files": { "index.html": "/assets/index-xxx.js", "index.html:css:0": "/assets/index-xxx.css" } }
```

Full repo build could not be completed locally (pre-existing parse errors in `src/components/common/ShareMenu/ShareMenu.js` on the `jsx-in-js` transform — unrelated to this change).
