### PR TITLE
fix(build): emit asset-manifest.json so service worker precaches hashed bundles

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig, loadEnv, transformWithOxc } from "vite";
 import react from "@vitejs/plugin-react";
 
 import path from "path";
+import fs from "fs";
 import { fileURLToPath } from "url";
 import dotenv from "dotenv";
 
@@ -63,6 +64,50 @@ export default defineConfig(({ mode }) => {
             );
           }
           return html;
+        },
+      },
+      // Emit a CRA-format asset-manifest.json after the production build.
+      //
+      // public/service-worker.js precaches the hashed /assets/* bundles by
+      // reading `manifest.files` from /asset-manifest.json. Vite never emits
+      // that artifact — with `build.manifest: true` it writes `.vite/manifest.json`
+      // instead — so without this plugin the install handler always hit the
+      // catch branch and only the static ASSETS_TO_CACHE list was cached,
+      // leaving the app chunks out of the precache (Issue #14664).
+      {
+        name: "emit-asset-manifest",
+        enforce: "post",
+        closeBundle() {
+          const outDir = "build";
+          const viteManifestPath = path.resolve(__dirname, outDir, ".vite/manifest.json");
+          if (!fs.existsSync(viteManifestPath)) {
+            // Dev server close — no manifest was produced; the service worker
+            // falls back to its static asset list in development.
+            return;
+          }
+
+          let viteManifest;
+          try {
+            viteManifest = JSON.parse(fs.readFileSync(viteManifestPath, "utf8"));
+          } catch (err) {
+            this.warn(`[emit-asset-manifest] Could not read ${viteManifestPath}: ${err.message}`);
+            return;
+          }
+
+          const files = {};
+          for (const [key, entry] of Object.entries(viteManifest)) {
+            files[key] = `/${entry.file}`;
+            if (Array.isArray(entry.css)) {
+              entry.css.forEach((cssFile, index) => {
+                files[`${key}:css:${index}`] = `/${cssFile}`;
+              });
+            }
+          }
+
+          fs.writeFileSync(
+            path.resolve(__dirname, outDir, "asset-manifest.json"),
+            JSON.stringify({ files }, null, 2),
+          );
         },
       },
     ],


### PR DESCRIPTION
## Problem

`public/service-worker.js:188` starts the install precache with `fetch('/asset-manifest.json')`. `asset-manifest.json` is a react-scripts (CRA) artifact; this repo builds with Vite, which never produces it. The fetch 404s on every install, the `.then` manifest branch is dead, and the `catch` always runs, so only the hardcoded 7-entry `ASSETS_TO_CACHE` list (`/`, `/index.html`, `/manifest.json`, `/favicon.png`, `/Eventra.png`, `/moon.svg`, `/sun.svg`) is precached. The hashed `/assets/*.js|css` bundles are never cached, so offline-after-first-load does not hold.

## Fix

Add an `emit-asset-manifest` build plugin to `vite.config.js` that, after the production bundle completes, converts Vite's own `.vite/manifest.json` (already emitted thanks to `build.manifest: true`) into a CRA-format `asset-manifest.json` with a `{ "files": { ... } }` map pointing at every hashed JS/CSS chunk.

`public/service-worker.js` is untouched: its existing install handler reads `manifest.files`, filters for `.js/.css/.png/.svg/.jpg/.json` (excluding source maps, `service-worker.js`, `manifest.json`), and precaches them — exactly the behavior the file was written for.

## Files changed

- `vite.config.js` — added `fs` import and the `emit-asset-manifest` plugin (45 insertions).

## Testing

- `node --input-type=module -e "import('./vite.config.js')"` loads the config without errors.
- `npm run build` now emits `build/asset-manifest.json` next to `index.html`, containing an entry for every hashed bundle (verified the generated `files` map includes the `/assets/*.js` and `/assets/*.css` chunks).
- Service worker install no longer falls back to the static-assets branch: `GET /asset-manifest.json` returns 200 and the hashed bundles are added to the `eventra-cache-v4` precache, so the app shell is available offline after the first load.

Closes #14664
