### PR TITLE
fix(certificates): add search/filter/year/category helpers used by CertificateTracker

### DIFF
--- a/src/utils/certificateUtils.js
+++ b/src/utils/certificateUtils.js
@@ -37,3 +37,66 @@ export async function verifyCertificate(uid) {
     return { success: false, error: err.message || "Network error during verification" };
   }
 }
+
+/**
+ * Search certificates by title or event name.
+ */
+export const searchCertificates = (certificates = [], query = "") => {
+  if (!query.trim()) return certificates;
+
+  const keyword = query.toLowerCase();
+
+  return certificates.filter(
+    (certificate) =>
+      certificate.title?.toLowerCase().includes(keyword) ||
+      certificate.eventName?.toLowerCase().includes(keyword)
+  );
+};
+
+/**
+ * Filter certificates by issue year, category, and status.
+ */
+export const filterCertificates = (
+  certificates = [],
+  year = "All",
+  category = "All",
+  status = "All"
+) => {
+  return certificates.filter((certificate) => {
+    const certificateYear = certificate.issueDate
+      ? new Date(certificate.issueDate).getFullYear().toString()
+      : "";
+
+    const matchesYear = year === "All" || certificateYear === year;
+    const matchesCategory = category === "All" || certificate.category === category;
+    const matchesStatus = status === "All" || certificate.status === status;
+
+    return matchesYear && matchesCategory && matchesStatus;
+  });
+};
+
+/**
+ * Get the distinct issue years present across certificates, newest first.
+ */
+export const getCertificateYears = (certificates = []) => {
+  return [
+    ...new Set(
+      certificates
+        .filter((certificate) => certificate.issueDate)
+        .map((certificate) =>
+          new Date(certificate.issueDate).getFullYear().toString()
+        )
+    ),
+  ].sort((a, b) => b.localeCompare(a));
+};
+
+/**
+ * Get the distinct categories present across certificates.
+ */
+export const getCertificateCategories = (certificates = []) => {
+  return [
+    ...new Set(
+      certificates.map((certificate) => certificate.category).filter(Boolean)
+    ),
+  ].sort();
+};


### PR DESCRIPTION
## Problem

`src/components/events/CertificateTracker.js:4-9` named-imports `searchCertificates`, `filterCertificates`, `getCertificateYears`, and `getCertificateCategories` from `../../utils/certificateUtils`, but that module only exported `verifyCertificate`. The imports are used at module scope (`CertificateTracker.js:10-13`), so evaluating the component throws `SyntaxError: The requested module ... does not provide an export named ...`.

## Fix

Implemented the four missing helpers in `src/utils/certificateUtils.js`, matching the exact contracts the consumer uses:

- `searchCertificates(certificates, query)` — filters by title/event name (case-insensitive).
- `filterCertificates(certificates, year, category, status)` — filters by issue year, category, and status.
- `getCertificateYears(certificates)` — distinct issue years, newest first.
- `getCertificateCategories(certificates)` — distinct categories, sorted.

`CertificateTracker.js` itself is untouched — it now links against a module that satisfies its import contract.

## Files changed

- `src/utils/certificateUtils.js` — added the four exported helpers (63 insertions).

## Testing

- Verified the module's export surface now includes all four names:
  `node --input-type=module -e "import('.../src/utils/certificateUtils.js').then(m => console.log(Object.keys(m)))"`
  → `filterCertificates, getCertificateCategories, getCertificateYears, searchCertificates, verifyCertificate`
- The consumer's named-import probe (`import { searchCertificates, filterCertificates, getCertificateYears, getCertificateCategories } from '.../certificateUtils.js'`) no longer throws the `SyntaxError`.

Closes #14665
