### PR TITLE
fix(event-drafts): add save/update/publish draft API used by EventDraftForm

### DIFF
--- a/src/utils/eventDraftUtils.js
+++ b/src/utils/eventDraftUtils.js
@@ -76,3 +76,82 @@ export const formatDraftAge = (isoTimestamp) => {
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
   return new Date(isoTimestamp).toLocaleDateString();
 };
+
+// --- Multi-draft API (consumed by EventDraftForm) ---
+
+const DRAFTS_STORAGE_KEY = "eventra_event_drafts";
+
+export const getEventDrafts = () => {
+  if (!isStorageAvailable()) return [];
+  try {
+    const storedDrafts = localStorage.getItem(DRAFTS_STORAGE_KEY);
+    if (!storedDrafts) return [];
+    const drafts = safeJsonParse(storedDrafts, []);
+    return Array.isArray(drafts) ? drafts : [];
+  } catch (error) {
+    console.error("Failed to load event drafts:", error);
+    return [];
+  }
+};
+
+const saveEventDrafts = (drafts) => {
+  if (!isStorageAvailable()) return drafts;
+  try {
+    localStorage.setItem(DRAFTS_STORAGE_KEY, JSON.stringify(drafts));
+  } catch (error) {
+    console.error("Failed to save event drafts:", error);
+  }
+  return drafts;
+};
+
+export const saveEventDraft = (eventData = {}) => {
+  const drafts = getEventDrafts();
+  const now = new Date().toISOString();
+  const draft = {
+    ...eventData,
+    id: eventData.id || `draft-${Date.now()}`,
+    status: "draft",
+    createdAt: eventData.createdAt || now,
+    updatedAt: now,
+  };
+  return saveEventDrafts([draft, ...drafts.filter((item) => item.id !== draft.id)]);
+};
+
+export const updateEventDraft = (draftId, eventData = {}) => {
+  if (!draftId) return getEventDrafts();
+  const drafts = getEventDrafts();
+  const updatedDrafts = drafts.map((draft) =>
+    draft.id === draftId
+      ? {
+          ...draft,
+          ...eventData,
+          id: draft.id,
+          status: "draft",
+          updatedAt: new Date().toISOString(),
+        }
+      : draft
+  );
+  return saveEventDrafts(updatedDrafts);
+};
+
+export const getEventDraft = (draftId) => {
+  if (!draftId) return null;
+  return getEventDrafts().find((draft) => draft.id === draftId) || null;
+};
+
+export const deleteEventDraft = (draftId) => {
+  if (!draftId) return getEventDrafts();
+  return saveEventDrafts(getEventDrafts().filter((draft) => draft.id !== draftId));
+};
+
+export const publishEventDraft = (draftId) => {
+  const draft = getEventDraft(draftId);
+  if (!draft) return null;
+  const publishedEvent = {
+    ...draft,
+    status: "published",
+    publishedAt: new Date().toISOString(),
+  };
+  deleteEventDraft(draftId);
+  return publishedEvent;
+};


### PR DESCRIPTION
## Problem

`src/components/events/EventDraftForm.js:9-13` named-imports `saveEventDraft`, `updateEventDraft`, and `publishEventDraft` from `../../utils/eventDraftUtils`, but none of those names exist in the module (its API was `saveDraft`/`getDraft`/`getDraftData`/`getDraftTimestamp`/`clearDraft`/`formatDraftAge`). The imports are used at module scope, so evaluating `EventDraftForm.js` throws `SyntaxError: The requested module ... does not provide an export named ...`.

## Fix

Restored the multi-draft API to `src/utils/eventDraftUtils.js`, implementing the exact contract the consumer relies on (a localStorage-backed list of drafts with `id`/`status`/`createdAt`/`updatedAt`):

- `saveEventDraft(eventData)` — creates (or dedupes by `id`) a draft and returns the full draft list.
- `updateEventDraft(draftId, eventData)` — updates an existing draft and returns the list.
- `publishEventDraft(draftId)` — returns the published event (`status: "published"`, `publishedAt`) and removes the draft from the list.
- Supporting helpers: `getEventDrafts`, `getEventDraft`, `deleteEventDraft` (plus module-private `saveEventDrafts`).

The new functions use their own storage key (`eventra_event_drafts`) so they do not interfere with the existing single-draft recovery feature (`event_creation_draft`). `EventDraftForm.js` is untouched.

## Files changed

- `src/utils/eventDraftUtils.js` — added the multi-draft API (79 insertions).

## Testing

- Import probe no longer throws: `import { saveEventDraft, updateEventDraft, publishEventDraft } from '.../eventDraftUtils.js'` resolves.
- Functional check with a mocked `localStorage`:
  - `saveEventDraft({ name })` returns a list whose first item has a generated `id` and `status: "draft"`.
  - `updateEventDraft(id, { name })` merges the new fields and bumps `updatedAt`.
  - `publishEventDraft(id)` returns the published event (`status: "published"`, `publishedAt` set) and removes it from the stored list (0 drafts remaining).
- Existing `tests/eventDraftUtils.test.mjs` still passes (`saveDraft`/`getDraft`/`clearDraft` unaffected).

Closes #14666
