### PR TITLE
fix(event-drafts): add formatDraftUpdatedAt helper used by DraftEventCard

### DIFF
--- a/src/utils/eventDraftUtils.js
+++ b/src/utils/eventDraftUtils.js
@@ -76,3 +76,22 @@ export const formatDraftAge = (isoTimestamp) => {
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
   return new Date(isoTimestamp).toLocaleDateString();
 };
+
+export const getDraftLastUpdated = (draft) => {
+  if (!draft?.updatedAt) return null;
+  const date = new Date(draft.updatedAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+};
+
+export const formatDraftUpdatedAt = (draft) => {
+  const date = getDraftLastUpdated(draft);
+  if (!date) return "Not updated yet";
+  return date.toLocaleString("en-IN", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};


### PR DESCRIPTION
## Problem

`src/components/events/DraftEventCard.js:7-8` named-imports `formatDraftUpdatedAt` from `../../utils/eventDraftUtils`, but the module only exported `formatDraftAge`. The import is used at module scope (`DraftEventCard.js:10-11`), so evaluating the component throws `SyntaxError: The requested module ... does not provide an export named 'formatDraftUpdatedAt'`.

## Fix

Added `formatDraftUpdatedAt(draft)` (plus the small helper `getDraftLastUpdated(draft)`) to `src/utils/eventDraftUtils.js`:

- `getDraftLastUpdated(draft)` — parses `draft.updatedAt` into a `Date`, returning `null` when missing or invalid.
- `formatDraftUpdatedAt(draft)` — renders "Not updated yet" when there is no valid `updatedAt`, otherwise a human-readable `en-IN` string like `01 Aug 2026, 04:00 pm`.

`DraftEventCard.js` is untouched.

## Files changed

- `src/utils/eventDraftUtils.js` — added `getDraftLastUpdated` + `formatDraftUpdatedAt` (19 insertions).

## Testing

- Import probe no longer throws: `import { formatDraftUpdatedAt } from '.../eventDraftUtils.js'` resolves.
- Behavior verified with node:
  - `formatDraftUpdatedAt({})` → `"Not updated yet"`
  - `formatDraftUpdatedAt({ updatedAt: "2026-08-01T10:30:00Z" })` → `"01 Aug 2026, 04:00 pm"`
  - `formatDraftUpdatedAt({ updatedAt: "nope" })` → `"Not updated yet"`

Closes #14667
