### PR TITLE
fix(realtime): export LiveAudienceContext consumed by FloorPlanDesigner

### DIFF
--- a/src/context/RealTimeContext.js
+++ b/src/context/RealTimeContext.js
@@ -158,7 +158,7 @@ function AnalyticsProvider({ children }) {
 }
 
 // --- 4.5 Live Audience Coordination Provider ---
-const LiveAudienceContext = createContext(null);
+export const LiveAudienceContext = createContext(null);
 
 function liveAudienceReducer(state, action) {
   switch (action.type) {


### PR DESCRIPTION
## Problem

`src/components/events/FloorPlanDesigner.js:4` imports `{ LiveAudienceContext }` from `"context/RealTimeContext"`, but `src/context/RealTimeContext.js` declares `LiveAudienceContext` (line 161) and uses it as a provider and in `useLiveAudienceStream`, yet never exports it. The consumer gets `undefined`, so `useContext(undefined)` throws "Cannot read properties of undefined (reading '$$typeof')" when `FloorPlanDesigner` renders.

## Fix

Exported the context on its declaration line, matching how `LeaderboardContext`/`AnalyticsContext` are handled:

```js
export const LiveAudienceContext = createContext(null);
```

No other changes; provider and hook usage are untouched.

## Files changed

- `src/context/RealTimeContext.js` — `LiveAudienceContext` now exported (1 line changed).

## Testing

- `FloorPlanDesigner.js:4` named-import target now matches an actual named export of the module (`grep` confirms the only context export change; the consumer import and all three usages in `RealTimeContext.js` resolve to the same binding).
- Note: direct node import of `RealTimeContext.js` isn't possible without a JSX transform (it contains JSX at module scope), which is expected; the fix is purely an ES-module export statement.

Closes #14669
