### PR TITLE
fix(events): point EventGridVirtualizer at the real EventCard component

### DIFF
--- a/src/Pages/Events/EventGridVirtualizer.jsx
+++ b/src/Pages/Events/EventGridVirtualizer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import EventCard from "components/events/EventCard";
+import EventCard from "Pages/Events/EventCard";
 import { notifyLenisResize, getImageAspectRatioStyle } from "utils/lenisUtils";
 
 export default function EventGridVirtualizer({ events = [], viewMode = "grid" }) {


### PR DESCRIPTION
## Problem

`src/Pages/Events/EventGridVirtualizer.jsx:2` imports `EventCard` from `"components/events/EventCard"`, but no such module exists — the real component lives at `src/Pages/Events/EventCard.js`. With the `components` path alias (`components` → `src/components`), the import resolves to `src/components/events/EventCard`, which doesn't exist, so the virtualized grid fails to render.

## Fix

Changed the import to the canonical component location, using the existing `Pages` alias:

```js
import EventCard from "Pages/Events/EventCard";
```

`EventCard`'s optional `position`/`isHighlighted` props are destructured but unused in its render, so the existing `<EventCard event={evt} index={idx} />` call stays valid.

## Files changed

- `src/Pages/Events/EventGridVirtualizer.jsx` — fixed the `EventCard` import path (1 line).

## Testing

- Confirmed the target module exists and matches the import spec: `src/Pages/Events/EventCard.js` (default export, `memo(EventCard)`).
- Confirmed other components use the same component with only the `event` prop (e.g. `src/components/common/VirtualizedEventGrid.jsx:3`, `src/components/TrendingEvents/TrendingEvents.jsx:5`), so the prop contract is satisfied.
- No other file imports `EventGridVirtualizer` (only this file defines it), so no downstream call-site changes needed.

Closes #14671
