### PR TITLE
fix(tests): correct relative import depth in useCarouselKeyboardNav.test

### DIFF
--- a/src/hooks/useCarouselKeyboardNav.test.js
+++ b/src/hooks/useCarouselKeyboardNav.test.js
@@ -3,7 +3,7 @@
  */
 
 import { renderHook, act } from "@testing-library/react";
-import useCarouselKeyboardNav from "../useCarouselKeyboardNav";
+import useCarouselKeyboardNav from "./useCarouselKeyboardNav";
 
 function makeKeyEvent(key, target, currentTarget) {
   return {


### PR DESCRIPTION
## Problem

`src/hooks/useCarouselKeyboardNav.test.js:6` imports the hook with `"../useCarouselKeyboardNav"`. The test lives in `src/hooks/`, so `../` resolves up to `src/` — there is no `src/useCarouselKeyboardNav.js`. The hook is a sibling at `src/hooks/useCarouselKeyboardNav.js`, so the test can never resolve its subject.

## Fix

Corrected the relative import to point at the sibling module:

```js
import useCarouselKeyboardNav from "./useCarouselKeyboardNav";
```

## Files changed

- `src/hooks/useCarouselKeyboardNav.test.js` — fixed the import specifier (1 line).

## Testing

- Verified the hook module resolves and exports a default: `import('.../src/hooks/useCarouselKeyboardNav.js')` → exports `['default']`.
- Running the test suite for this file requires vitest's jsdom pool; the local `node_modules` currently has a broken `@vitest/utils` install (`ERR_MODULE_NOT_FOUND: @vitest/utils/offset`), an environment issue unrelated to this change. The import fix itself is unambiguous (sibling file exists at the corrected path).

Closes #14674
