### PR TITLE
fix(home): correct relative import depths in GitHubStats

### DIFF
--- a/src/Pages/Home/components/GitHubStats.jsx
+++ b/src/Pages/Home/components/GitHubStats.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { motion } from "framer-motion";
-import { GitHubStatCardSkeleton } from "../../components/common/SkeletonLoaders";
+import { GitHubStatCardSkeleton } from "../../../components/common/SkeletonLoaders";
 import {
   Star,
   GitFork,
@@ -14,9 +14,9 @@ import {
   Languages,
 } from "lucide-react";
 
-import { safeJsonParse } from "../../utils/safeJsonParse";
-import { ENV } from "../../config/env";
-import { fetchGitHubJson } from "../../utils/githubApiClient";
+import { safeJsonParse } from "../../../utils/safeJsonParse";
+import { ENV } from "../../../config/env";
+import { fetchGitHubJson } from "../../../utils/githubApiClient";
 
 const repoPath = ENV.GITHUB_REPO;
 const [GITHUB_USER, GITHUB_REPO] = repoPath.split("/");


### PR DESCRIPTION
## Problem

`src/Pages/Home/components/GitHubStats.jsx` resolves four imports with `../../`, which lands on `src/Pages/`:

- `../../components/common/SkeletonLoaders` → `src/Pages/components/...` (doesn't exist)
- `../../utils/safeJsonParse` → `src/Pages/utils/...` (doesn't exist)
- `../../config/env` → `src/Pages/config/...` (doesn't exist)
- `../../utils/githubApiClient` → `src/Pages/utils/...` (doesn't exist)

The component is three levels deep under `src/`, so it needs `../../../`. Because `safeJsonParse` and `ENV` are used at module scope (`GitHubStats.jsx:21-22`), the module fails to evaluate.

## Fix

Bumped all four relative imports to `../../../`:

- `../../../components/common/SkeletonLoaders`
- `../../../utils/safeJsonParse`
- `../../../config/env`
- `../../../utils/githubApiClient`

No logic changes.

## Files changed

- `src/Pages/Home/components/GitHubStats.jsx` — corrected 4 relative import paths.

## Testing

- Confirmed all four corrected specifiers resolve to real files:
  - `src/components/common/SkeletonLoaders.jsx` ✓
  - `src/utils/safeJsonParse.js` ✓
  - `src/config/env.js` ✓
  - `src/utils/githubApiClient.js` ✓

Closes #14676
