### PR TITLE
fix(sharemenu): move useToast() destructuring out of component parameters (#15266)

### DIFF
--- a/src/components/common/ShareMenu/ShareMenu.js
+++ b/src/components/common/ShareMenu/ShareMenu.js
@@ -19,7 +19,6 @@ import './ShareMenu.css';
  * @param {string} props.className - Additional classNames for the container
  */
 const ShareMenu = ({
-  const { success, error } = useToast();
   shareData,
   children,
   position = 'bottom',
@@ -27,6 +26,7 @@ const ShareMenu = ({
   buttonClassName = '',
   className = '',
 }) => {
+  const { success, error } = useToast();
   const [isOpen, setIsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [calculatedPosition, setCalculatedPosition] = useState('bottom');


### PR DESCRIPTION
## Problem

`src/components/common/ShareMenu/ShareMenu.js` line 22 had a `const { success, error } = useToast();` statement pasted inside the component's arrow-function parameter list. That is invalid JavaScript and broke the esbuild/rollup production build (`[PARSE_ERROR] Expected ':' but found '{'`).

## Fix

- Removed the destructuring from the parameter list.
- Added `const { success, error } = useToast();` as the first statement inside the component body, so the hook runs unconditionally.
- The share dropdown and toast feedback (e.g. error toast on failed native share) now work.

## Files changed

- `src/components/common/ShareMenu/ShareMenu.js`

## Testing

- Verified the file now transforms cleanly with esbuild's `jsx` loader (`PARSE OK`), confirming the production build block is gone.
- ShareMenu is imported/rendered by `src/Pages/Hackathons/HackathonCard.js` and boots with the fix.

Closes #15266
