### PR TITLE
fix(sponsors): close useEffect callback in SponsorDashboard (#15267)

### DIFF
--- a/src/Pages/Sponsors/SponsorDashboard.jsx
+++ b/src/Pages/Sponsors/SponsorDashboard.jsx
@@ -46,7 +46,7 @@ const SponsorDashboard = () => {
     };
   }, []);
 
- useEffect(() => {
+  useEffect(() => {
   // Load custom settings
   const saved = localStorage.getItem("eventra_sponsor_settings");
 
@@ -74,6 +74,7 @@ const SponsorDashboard = () => {
         e
       );
     }
+  }
   }, [sponsorPrefs]);
 
   const handleSaveSettings = (e) => {


### PR DESCRIPTION
## Problem

`src/Pages/Sponsors/SponsorDashboard.jsx` had a malformed `useEffect`: the `useEffect(() => {` opened on line 49 was never closed — line 77 only closed the inner `catch` block, so the dependency array `[sponsorPrefs]` landed inside the arrow-function body. The file failed to parse (`Unexpected ","` at 77:3) and broke the production build via the lazy Sponsors route chunk.

## Fix

- Closed the `if (savedLeads)` block and the `useEffect` callback body with the missing braces before `}, [sponsorPrefs]);`.
- Fixed the stray indentation of the effect opener so it matches the rest of the component.
- The effect now loads saved sponsor settings and captured leads correctly.

## Files changed

- `src/Pages/Sponsors/SponsorDashboard.jsx`

## Testing

- Verified the file now transforms cleanly with esbuild's `jsx` loader (`PARSE OK`), confirming the lazy route chunk no longer breaks the build.

Closes #15267
