### PR TITLE
fix(events): restore useToast destructure in EventCard (#15268)

### DIFF
--- a/src/Pages/Events/EventCard.js
+++ b/src/Pages/Events/EventCard.js
@@ -25,6 +25,7 @@ const EventCard = ({ event, position, isHighlighted = false }) => {
   const [imageFailed, setImageFailed] = useState(false);
   const titleId = useId();
   const { isRegistered } = useMyEvents();
+  const { success, info } = useToast();
 
   // Live, real-time seat availability for this event. Subscribes to the shared
   // SSE stream and falls back to polling so seat counters stay fresh without a

--- a/src/Pages/Events/EventCard.test.js
+++ b/src/Pages/Events/EventCard.test.js
@@ -53,7 +53,7 @@ jest.mock('components/common/SellingFastBadge', () => () => null);
 jest.mock('components/reminders/ReminderControls', () => () => null);
 
 jest.mock('react-toastify', () => ({
-  toast: { success: jest.fn(), error: jest.fn(), info: jest.fn() },
+  toast: { success: jest.fn(), error: jest.fn(), info: jest.fn(), dismiss: jest.fn() },
 }));
 
 const baseEvent = {


### PR DESCRIPTION
## Problem

`src/Pages/Events/EventCard.js` imports `useToast` but never destructured it, so line 63's `success("Event saved!", ...)` threw `ReferenceError: success is not defined` when saving a bookmark — the UI never confirmed the save.

## Fix

- Added the missing `const { success, info } = useToast();` destructure inside the component body.
- Extended the `react-toastify` mock in `EventCard.test.js` with `dismiss` so the existing bookmark regression test (which asserts `toast.success` is called on bookmark) exercises the fix through `useToast`'s deduplication path.

## Files changed

- `src/Pages/Events/EventCard.js`
- `src/Pages/Events/EventCard.test.js`

## Testing

- Bookmark save now calls `success("Event saved!", { toastId: ... })` without throwing.
- The existing "calls toggleBookmark and shows toast when bookmarking an unbookmarked event" regression test asserts `toast.success` is called on bookmark save.

Closes #15268
