### PR TITLE
fix(events): restore getFomoStatus in eventUtils (#15269)

### DIFF
--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -101,6 +101,33 @@ export const isEventRegistrationClosed = (eventOrStatus) => {
   return status === "past" || status === "ended" || status === "cancelled";
 };
 
+/**
+ * Check if an event has low inventory and should show FOMO badge.
+ * FOMO (Fear Of Missing Out) is triggered when remaining tickets drop below 10%
+ * of capacity OR below 20 absolute tickets.
+ *
+ * @param {number} capacity - Total event capacity
+ * @param {number} registeredCount - Number of registered participants
+ * @returns {Object} Object containing isLowInventory boolean and message string
+ */
+export const getFomoStatus = (capacity, registeredCount) => {
+  if (capacity == null || capacity <= 0) return { isLowInventory: false, message: null };
+
+  const remaining = capacity - (registeredCount ?? 0);
+  if (remaining <= 0) return { isLowInventory: false, message: null }; // Event is full, not "selling fast"
+
+  const lowThreshold = Math.max(20, Math.ceil(capacity * 0.1));
+  const isLowInventory = remaining <= lowThreshold;
+
+  if (!isLowInventory) return { isLowInventory: false, message: null };
+
+  // Generate appropriate FOMO message
+  if (remaining <= 5) {
+    return { isLowInventory: true, message: `Only ${remaining} Tickets Left!` };
+  }
+  return { isLowInventory: true, message: "Selling Fast!" };
+};
+
 export const normalizeEvent = (event) => {
   if (!event) return null;
 


### PR DESCRIPTION
## Problem

`src/utils/eventUtils.js` no longer exports `getFomoStatus` — the function was dropped when the file was rewritten — but `EventCard.js` (selling-fast badge) and the `eventUtils` test suite (11 FOMO test cases) still import it. The production build failed with `"getFomoStatus" is not exported by "src/utils/eventUtils.js"`.

## Fix

- Restored `getFomoStatus(capacity, registeredCount)` to `src/utils/eventUtils.js`. It computes the low-inventory/urgency state from remaining capacity (`remaining <= max(20, ceil(capacity * 0.1))`), returning `"Only X Tickets Left!"` when 5 or fewer remain and `"Selling Fast!"` otherwise, and `{ isLowInventory: false, message: null }` for null/zero/full capacity.
- Verified the restored implementation satisfies all 11 test expectations in `eventUtils.test.js`.

## Files changed

- `src/utils/eventUtils.js`

## Testing

- Ran the 11 FOMO test cases from `eventUtils.test.js` against the restored implementation — all pass.
- `EventCard.js` import/call (`getFomoStatus(capacity, registeredCount)`) now links and the selling-fast badge works.
- File transforms cleanly with esbuild.

Closes #15269
