### PR TITLE
fix(rate-limit): re-export all lockout symbols from utils/rateLimitUtils (#15271)

### DIFF
--- a/src/utils/rateLimitUtils.js
+++ b/src/utils/rateLimitUtils.js
@@ -26,4 +26,10 @@ export {
   RESET_COOLDOWN_SECONDS,
   secondsUntilUnlock,
   STORAGE_KEY_RESET_LAST_SUBMIT,
+  getBackoffDelay,
+  STORAGE_KEY_ATTEMPTS,
+  STORAGE_KEY_LOCKOUT_UNTIL,
+  readPersistedRateLimit,
+  persistRateLimit,
+  clearPersistedRateLimit,
 } from "../components/utils/rateLimitUtils.js";

--- a/tests/rateLimitUtilsExports.test.mjs
+++ b/tests/rateLimitUtilsExports.test.mjs
@@ -15,6 +15,12 @@ const required = [
   "RESET_COOLDOWN_SECONDS",
   "secondsUntilUnlock",
   "STORAGE_KEY_RESET_LAST_SUBMIT",
+  "getBackoffDelay",
+  "STORAGE_KEY_ATTEMPTS",
+  "STORAGE_KEY_LOCKOUT_UNTIL",
+  "readPersistedRateLimit",
+  "persistRateLimit",
+  "clearPersistedRateLimit",
   // pre-existing exports must still be present
   "calculateJitteredBackoff",
   "isRateLimitError",
@@ -33,6 +39,12 @@ assert.equal(typeof mod.RESET_COOLDOWN_SECONDS, "number");
 assert.equal(typeof mod.parseRetryAfterMs, "function");
 assert.equal(typeof mod.secondsUntilUnlock, "function");
 assert.equal(typeof mod.STORAGE_KEY_RESET_LAST_SUBMIT, "string");
+assert.equal(typeof mod.getBackoffDelay, "function");
+assert.equal(typeof mod.STORAGE_KEY_ATTEMPTS, "string");
+assert.equal(typeof mod.STORAGE_KEY_LOCKOUT_UNTIL, "string");
+assert.equal(typeof mod.readPersistedRateLimit, "function");
+assert.equal(typeof mod.persistRateLimit, "function");
+assert.equal(typeof mod.clearPersistedRateLimit, "function");
 
 // Original exports still work as before.
 assert.equal(typeof mod.calculateJitteredBackoff, "function");
@@ -40,13 +52,20 @@ assert.equal(typeof mod.isRateLimitError, "function");
 assert.equal(mod.isRateLimitError({ status: 429 }), true);
 assert.equal(mod.isRateLimitError({ status: 500 }), false);
 
-// Mirror the exact import shape used by the auth pages.
+// Mirror the exact import shape used by the auth pages and the
+// useLoginRateLimit hook.
 const {
   MAX_LOGIN_ATTEMPTS,
   parseRetryAfterMs,
   RESET_COOLDOWN_SECONDS,
   secondsUntilUnlock,
   STORAGE_KEY_RESET_LAST_SUBMIT,
+  getBackoffDelay,
+  STORAGE_KEY_ATTEMPTS,
+  STORAGE_KEY_LOCKOUT_UNTIL,
+  readPersistedRateLimit,
+  persistRateLimit,
+  clearPersistedRateLimit,
 } = mod;
 assert.ok(MAX_LOGIN_ATTEMPTS > 0, "MAX_LOGIN_ATTEMPTS is a positive number");
 assert.ok(
@@ -54,5 +73,16 @@ assert.ok(
   "RESET_COOLDOWN_SECONDS is a positive number",
 );
 assert.ok(STORAGE_KEY_RESET_LAST_SUBMIT.length > 0, "reset storage key set");
+assert.ok(getBackoffDelay(5) > 0, "getBackoffDelay applies backoff at limit");
+assert.equal(
+  getBackoffDelay(2),
+  0,
+  "getBackoffDelay stays zero below MAX_LOGIN_ATTEMPTS",
+);
+assert.ok(STORAGE_KEY_ATTEMPTS.length > 0, "attempts storage key set");
+assert.ok(STORAGE_KEY_LOCKOUT_UNTIL.length > 0, "lockout storage key set");
+assert.equal(typeof readPersistedRateLimit, "function");
+assert.equal(typeof persistRateLimit, "function");
+assert.equal(typeof clearPersistedRateLimit, "function");
 
 console.log("rateLimitUtils login-lockout re-export tests passed");


### PR DESCRIPTION
## Problem

`src/utils/rateLimitUtils.js` (the module the auth pages import from via the Vite alias) only re-exported 5 of the login-lockout symbols. The `useLoginRateLimit` hook and auth pages also import `getBackoffDelay`, `STORAGE_KEY_ATTEMPTS`, `STORAGE_KEY_LOCKOUT_UNTIL`, `readPersistedRateLimit`, `persistRateLimit`, and `clearPersistedRateLimit`, so those named imports still failed to resolve at module load.

## Fix

- Added the 6 missing symbols to the existing re-export block in `src/utils/rateLimitUtils.js`, so all 11 lockout symbols now resolve to their implementations in `src/components/utils/rateLimitUtils.js`.
- Extended `tests/rateLimitUtilsExports.test.mjs` with a resolution test asserting every symbol the `useLoginRateLimit` hook imports is exported and functional.

## Files changed

- `src/utils/rateLimitUtils.js`
- `tests/rateLimitUtilsExports.test.mjs`

## Testing

- `node --test tests/rateLimitUtilsExports.test.mjs` passes — verifies all 11 re-exports resolve, the pre-existing exports still work, and `getBackoffDelay` behaves correctly.
- Pre-existing exports (`calculateJitteredBackoff`, `isRateLimitError`) unchanged.

Closes #15271
