### PR TITLE
fix(audio): restore this.audioChunks in audioCaptureService constructor (#15272)

### DIFF
--- a/src/services/audioCaptureService.js
+++ b/src/services/audioCaptureService.js
@@ -59,7 +59,7 @@ class AudioCaptureService {
     this.audioContext = null;
     this.processor = null;
     this.analyser = null;
-    this audioChunks = [];
+    this.audioChunks = [];
     this.isProcessing = false;
     this.deviceId = null;
     this.onAudioDataCallback = null;


### PR DESCRIPTION
## Problem

`src/services/audioCaptureService.js` line 62 was corrupted — the `.` in `this.audioChunks` was dropped, producing a syntax error (`Expected ";" but found "audioChunks"`). The file did not parse, so the audio-capture service and everything importing it (the real-time subtitle pipeline) could not be bundled or run.

## Fix

- Restored `this.audioChunks = [];` in the constructor.
- Audited the rest of the constructor for other dropped `.` tokens — no other corruption found.

## Files changed

- `src/services/audioCaptureService.js`

## Testing

- `esbuild transformSync` (js loader) reports `PARSE OK` on the file.
- No behavior changes; the constructor now initializes `audioChunks` exactly as the rest of the service (`processAudioChunk`, `stop`) expects.

Closes #15272
