### PR TITLE
fix(transcription): restore this.provider in TranscriptionResult constructor (#15273)

### DIFF
--- a/src/services/transcriptionService.js
+++ b/src/services/transcriptionService.js
@@ -72,7 +72,7 @@ export class TranscriptionResult {
     this.language = data.language || TRANSCRIPTION_CONFIG.DEFAULT_LANGUAGE;
     this.timestamp = data.timestamp || Date.now();
     this.duration = data.duration || 0;
-    this provider = data.provider || TRANSCRIPTION_CONFIG.DEFAULT_PROVIDER;
+    this.provider = data.provider || TRANSCRIPTION_CONFIG.DEFAULT_PROVIDER;
     this.rawData = data.rawData || null;
   }
   


### PR DESCRIPTION
## Problem

`src/services/transcriptionService.js` line 75 was corrupted — the `.` in `this.provider` was dropped, producing a syntax error (`Expected ";" but found "provider"`). The file did not parse, so the transcription service and the real-time subtitle/translation pipeline could not be bundled or run.

## Fix

- Restored `this.provider = data.provider || TRANSCRIPTION_CONFIG.DEFAULT_PROVIDER;` in the `TranscriptionResult` constructor.
- Audited the constructor for other dropped `.` tokens — no other corruption found.

## Files changed

- `src/services/transcriptionService.js`

## Testing

- `esbuild transformSync` (js loader) reports `PARSE OK` on the file.
- No behavior changes; `toJSON()` already serializes `this.provider`, which now initializes correctly.

Closes #15273
