### PR TITLE
fix(waitlist): remove duplicated .catch chain in WaitlistButton (#15274)

### DIFF
--- a/src/components/common/WaitlistButton.js
+++ b/src/components/common/WaitlistButton.js
@@ -19,7 +19,6 @@ const useWaitlist = ({ eventId, isFullyBooked, waitlistEnabled, isAuthenticated,
       .then(data => {
         if (!cancelled) setWaitlistCount(data.count ?? null);
       })
-      .catch(() => console.warn("[WaitlistButton] API call failed"));
       .catch((err) => {
         console.warn('Failed to fetch waitlist data:', err);
       });


### PR DESCRIPTION
## Problem

`src/components/common/WaitlistButton.js` chained two `.catch()` handlers with a stray `);` between them — merge corruption. The file did not parse (`Unexpected "."` at the second `.catch`), so the shared waitlist/notify-me button component could not be bundled or used.

## Fix

- Removed the leftover `);` and the duplicated first `.catch(() => ...)`.
- Kept a single `.catch((err) => { console.warn('Failed to fetch waitlist data:', err); });` handler, preserving error logging with the error details.

## Files changed

- `src/components/common/WaitlistButton.js`

## Testing

- `esbuild transformSync` (jsx loader) reports `PARSE OK` on the file.
- The waitlist-count fetch now fails through exactly one catch handler, as intended.

Closes #15274
