### PR TITLE
fix(subtitles): rename corrupted latency ref and dedupe exports in RealTimeSubtitleContext (#15276)

### DIFF
--- a/src/context/RealTimeSubtitleContext.jsx
+++ b/src/context/RealTimeSubtitleContext.jsx
@@ -177,7 +177,7 @@ export function RealTimeSubtitleProvider({ children }) {
   
   // Service references
   const subtitleQueue = useRef([]);
-  const latency Measurements = useRef([]);
+  const latencyMeasurements = useRef([]);
   const startTimeRef = useRef(null);
   const lastActivityRef = useRef(Date.now());
   
@@ -692,6 +692,6 @@ export function useSubtitleStats() {
 }
 
 // Export components
-export { RealTimeSubtitleContext, SUBTITLE_CONFIG, SUBTITLE_STATE, Subtitle };
+export { RealTimeSubtitleContext };
 
 export default RealTimeSubtitleProvider;

--- a/tests/realTimeSubtitleContext.test.mjs
+++ b/tests/realTimeSubtitleContext.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Source-contract tests for src/context/RealTimeSubtitleContext.jsx
+ *
+ * Verifies the latency-tracking wiring survives refactors and that the module
+ * exports its public surface exactly once (no duplicate-export corruption).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const src = readFileSync(
+  path.resolve(__dirname, '../src/context/RealTimeSubtitleContext.jsx'),
+  'utf8',
+);
+
+describe('RealTimeSubtitleContext — latency tracking', () => {
+  it('declares latencyMeasurements ref with a valid identifier', () => {
+    assert.match(
+      src,
+      /const latencyMeasurements = useRef\(\[\]\);/,
+      'Must declare `const latencyMeasurements = useRef([])`',
+    );
+  });
+
+  it('does not contain the corrupted `latency Measurements` identifier', () => {
+    assert.ok(
+      !src.includes('latency Measurements'),
+      'Corrupted `latency Measurements` identifier must not be present',
+    );
+  });
+
+  it('records each transcription latency into latencyMeasurements', () => {
+    assert.match(
+      src,
+      /latencyMeasurements\.current\.push\(latency\);/,
+      'Must push computed latency into latencyMeasurements.current',
+    );
+  });
+
+  it('caps the latency ring buffer at 10 entries', () => {
+    assert.match(
+      src,
+      /if \(latencyMeasurements\.current\.length > 10\)\s*\{\s*latencyMeasurements\.current\.shift\(\);/,
+      'Must shift the oldest entry once the buffer exceeds 10',
+    );
+  });
+
+  it('computes average latency from the recorded measurements', () => {
+    assert.match(
+      src,
+      /const avgLatency = latencyMeasurements\.current\.reduce/,
+      'Must derive averageLatency from latencyMeasurements.current',
+    );
+  });
+
+  it('clears latencyMeasurements on stop/reset', () => {
+    assert.match(
+      src,
+      /latencyMeasurements\.current = \[\];/,
+      'Must reset latencyMeasurements when services stop',
+    );
+  });
+});
+
+describe('RealTimeSubtitleContext — exports', () => {
+  it('exports SUBTITLE_CONFIG, SUBTITLE_STATE and Subtitle via declarations', () => {
+    assert.match(src, /export const SUBTITLE_CONFIG = \{/);
+    assert.match(src, /export const SUBTITLE_STATE = \{/);
+    assert.match(src, /export class Subtitle \{/);
+  });
+
+  it('does not re-export the already-exported symbols (no duplicate exports)', () => {
+    assert.match(
+      src,
+      /export \{ RealTimeSubtitleContext \};/,
+      'Trailing export should only re-export the context constant',
+    );
+    assert.ok(
+      !src.includes(
+        'export { RealTimeSubtitleContext, SUBTITLE_CONFIG, SUBTITLE_STATE, Subtitle };',
+      ),
+      'Must not duplicate SUBTITLE_CONFIG/SUBTITLE_STATE/Subtitle exports',
+    );
+  });
+
+  it('default-exports RealTimeSubtitleProvider', () => {
+    assert.ok(
+      src.includes('export default RealTimeSubtitleProvider;'),
+      'Must default-export RealTimeSubtitleProvider',
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`src/context/RealTimeSubtitleContext.jsx` line 180 declared `const latency Measurements = useRef([]);` — a stray token merged into the identifier, which is not valid JS. The file did not parse (`Expected ";" but found "Measurements"`), so the real-time subtitle context and everything importing it could not be bundled or run.

## Fix

- Renamed the declaration to the valid identifier `latencyMeasurements` (all existing references already used that name), restoring per-transcription latency measurement collection.
- Removed the duplicate-export corruption on the trailing export line: `SUBTITLE_CONFIG`, `SUBTITLE_STATE`, and `Subtitle` were already exported via their declarations, so re-exporting them again produced "Multiple exports with the same name" errors and blocked the build. The line now only exports `RealTimeSubtitleContext`.
- Added `tests/realTimeSubtitleContext.test.mjs` covering the latency-tracking wiring and the export surface.

## Files changed

- `src/context/RealTimeSubtitleContext.jsx`
- `tests/realTimeSubtitleContext.test.mjs`

## Testing

- `esbuild transformSync` (jsx loader) reports `PARSE OK` on the file.
- `node --test tests/realTimeSubtitleContext.test.mjs` passes (9 assertions: valid identifier, latency push/ring-buffer cap/average/reset, and single-export surface).

Closes #15276
