### PR TITLE
fix(teams): balance parens in TeamFormation participants list (#15277)

### DIFF
--- a/src/components/events/TeamFormation.js
+++ b/src/components/events/TeamFormation.js
@@ -561,7 +561,7 @@ const TeamFormation = ({
                     }
                   />
                 )
-              ))}
+              )}
             </div>
 
             {filteredParticipants.length ===


### PR DESCRIPTION
## Problem

`src/components/events/TeamFormation.js` had mismatched parentheses in the participant list render path. The closing sequence at line 564 was `))}` (two closing parens + brace) instead of `)}` — matching the adjacent `members.map` block's closing `)}` at line 508. esbuild reported `Expected "}" but found ")"` at 564:15, so the team-formation UI could not be imported without breaking the build.

## Fix

- Removed the extra `)` from line 564, restoring the intended `)}` closing: `)` closes `filteredParticipants.map(`, `}` closes the JSX expression.

## Files changed

- `src/components/events/TeamFormation.js`

## Testing

- `esbuild transformSync` (jsx loader) reports `PARSE OK` on the file.
- The fix mirrors the identical, already-valid structure in the `members.map` block (line 508).

Closes #15277
