### PR TITLE
fix(validation): make validateImageFile async for magic-byte check (#15278)

### DIFF
--- a/src/utils/fileValidator.js
+++ b/src/utils/fileValidator.js
@@ -65,9 +65,9 @@ function readFirstBytes(file, length = 8) {
  * @param {number} options.maxSizeMB - Maximum file size in MB (default: 5)
  * @param {string[]} options.allowedTypes - Allowed MIME types
  * @param {string[]} options.allowedExtensions - Allowed extensions
- * @returns {{ valid: boolean, error?: string }}
+ * @returns {Promise<{ valid: boolean, error?: string }>}
  */
-export function validateImageFile(file, options = {}) {
+export async function validateImageFile(file, options = {}) {
   // Use nullish coalescing (??) so explicitly passing 0 is respected
   const maxSizeMB = options.maxSizeMB ?? DEFAULT_MAX_SIZE_MB;
   const allowedTypes = options.allowedTypes ?? ALLOWED_IMAGE_TYPES;

--- a/tests/fileValidator.test.mjs
+++ b/tests/fileValidator.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * Tests for src/utils/fileValidator.js
+ *
+ * Exercises the magic-byte verification path of validateImageFile using a
+ * mocked FileReader (the real FileReader is a browser API unavailable in node).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+
+const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+
+const originalFileReader = globalThis.FileReader;
+
+function mockFileReader(readResult, { fail = false } = {}) {
+  globalThis.FileReader = class {
+    readAsArrayBuffer(blob) {
+      Promise.resolve().then(() => {
+        if (fail) {
+          this.onerror(new Error('read failed'));
+        } else {
+          this.result = readResult ?? blob._bytes;
+          this.onload({});
+        }
+      });
+    }
+  };
+}
+
+function makeFile({ name = 'image.png', type = 'image/png', size = 1024, bytes = PNG_MAGIC }) {
+  return {
+    name,
+    type,
+    size,
+    slice() {
+      return { _bytes: bytes };
+    },
+  };
+}
+
+describe('validateImageFile — magic byte verification', () => {
+  beforeEach(() => {
+    mockFileReader();
+  });
+
+  afterEach(() => {
+    globalThis.FileReader = originalFileReader;
+  });
+
+  it('accepts a file whose bytes match the declared MIME type', async () => {
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({})));
+    assert.deepEqual(result, { valid: true });
+  });
+
+  it('rejects a file whose bytes do not match the declared MIME type', async () => {
+    const file = makeFile({ type: 'image/png', bytes: JPEG_MAGIC });
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(file));
+    assert.equal(result.valid, false);
+    assert.match(result.error, /does not match declared type "image\/png"/);
+  });
+
+  it('accepts a JPEG with JPEG magic bytes', async () => {
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({ name: 'a.jpg', type: 'image/jpeg', bytes: JPEG_MAGIC })));
+    assert.equal(result.valid, true);
+  });
+
+  it('returns a validation error when the file cannot be read', async () => {
+    mockFileReader(null, { fail: true });
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({})));
+    assert.equal(result.valid, false);
+    assert.equal(result.error, 'Unable to read file for validation');
+  });
+
+  it('rejects oversized files before attempting to read bytes', async () => {
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({ size: 6 * 1024 * 1024 })));
+    assert.equal(result.valid, false);
+    assert.match(result.error, /exceeds maximum of 5MB/);
+  });
+
+  it('rejects empty files', async () => {
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({ size: 0 })));
+    assert.equal(result.valid, false);
+    assert.equal(result.error, 'File is empty');
+  });
+
+  it('rejects disallowed MIME types before reading bytes', async () => {
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({ type: 'text/html' })));
+    assert.equal(result.valid, false);
+    assert.match(result.error, /is not allowed/);
+  });
+
+  it('rejects dangerous file extensions', async () => {
+    const result = await import('../src/utils/fileValidator.js')
+      .then((m) => m.validateImageFile(makeFile({ name: 'evil.png.exe' })));
+    assert.equal(result.valid, false);
+    assert.match(result.error, /not allowed for security reasons/);
+  });
+});


### PR DESCRIPTION
## Problem

`src/utils/fileValidator.js` used `await readFirstBytes(file)` inside `validateImageFile`, which was not declared `async`. esbuild reported `"await" can only be used inside an "async" function`, so the validation utility could not be imported or run.

## Fix

- Marked `validateImageFile` as `async`, so the magic-byte `await` is legal and the function returns a `Promise<{ valid, error }>`. Updated the JSDoc accordingly.
- `validateImageFile` has no callers elsewhere in the app (verified via search), so no caller changes were needed.
- Added `tests/fileValidator.test.mjs` covering magic-byte matching (matching PNG/JPEG accepted, mismatched content rejected, unreadable file handled) plus the size/empty/type/extension guards.

## Files changed

- `src/utils/fileValidator.js`
- `tests/fileValidator.test.mjs`

## Testing

- `esbuild transformSync` (js loader) reports `PARSE OK` on the file.
- `node --test tests/fileValidator.test.mjs` passes (8 assertions).

Closes #15278
