### PR TITLE
fix(materials): restore if/else + setTimeout structure in EventMaterials (#15279)

### DIFF
--- a/src/components/common/EventMaterials.jsx
+++ b/src/components/common/EventMaterials.jsx
@@ -105,9 +105,10 @@ const EventMaterials = ({ materials }) => {
               delete copy[fileId];
               return copy;
             });
-          }, 3000);
+            }, 3000);
         }
-      }, 500);
+      }
+    }, 500);
     } else {
       // 4. Fallback to simulated Server Download if no peer found
       setActiveTransfer((prev) => ({


### PR DESCRIPTION
## Problem

`src/components/common/EventMaterials.jsx` had a corrupted conditional block in the P2P download interval callback: the `if (completed || attempts >= MAX_ATTEMPTS)` block was closed by `}, 500);` without its own closing brace, so the `else` branch attached to the wrong `if`. esbuild reported `Unexpected ","` at line 110, and the shared materials component could not be built or rendered.

## Fix

- Added the missing closing brace for the `if (completed || attempts >= MAX_ATTEMPTS)` block before the interval callback's closing `}`, restoring the intended structure:

```
if (completed || attempts >= MAX_ATTEMPTS) {
  clearInterval(...);
  if (completed) { ... setTimeout(...); }
}
}, 500);
} else {
```

## Files changed

- `src/components/common/EventMaterials.jsx`

## Testing

- `esbuild transformSync` (jsx loader) reports `PARSE OK` on the file.
- The `if/else` + `setTimeout` flow (P2P fallback vs. simulated server download) now parses and matches the intended branch structure.

Closes #15279
