### PR TITLE
fix(webhook): block SSRF via URL validation and non-redirecting client (#15282)

### DIFF
--- a/Backend/src/main/java/com/eventra/config/WebhookConfig.java
+++ b/Backend/src/main/java/com/eventra/config/WebhookConfig.java
@@ -1,0 +1,27 @@
+package com.eventra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.http.HttpClient;
+
+/**
+ * Provides the HTTP client used by the webhook dispatch services.
+ *
+ * The default {@code RestTemplate} follows HTTP redirects, which turns a
+ * webhook POST into a potential SSRF vector (a redirect target can point at
+ * internal/private endpoints). This bean disables redirect following entirely.
+ */
+@Configuration
+public class WebhookConfig {
+
+    @Bean
+    public RestTemplate webhookRestTemplate() {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .build();
+        return new RestTemplate(new JdkClientHttpRequestFactory(httpClient));
+    }
+}

--- a/Backend/src/main/java/com/eventra/util/WebhookUrlValidator.java
+++ b/Backend/src/main/java/com/eventra/util/WebhookUrlValidator.java
@@ -1,0 +1,127 @@
+package com.eventra.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Validates outbound webhook targets before they are dispatched.
+ *
+ * Rejects non-HTTPS schemes, hosts outside the configured allowlist, and hosts
+ * that resolve to private/reserved/link-local addresses (SSRF protection,
+ * including basic DNS-rebinding mitigation by checking every resolved address).
+ */
+@Component
+public class WebhookUrlValidator {
+
+    private final Set<String> allowedHosts;
+
+    public WebhookUrlValidator(
+            @Value("${eventra.webhook.allowed-hosts:hooks.slack.com,discord.com,discordapp.com}")
+            String allowedHostsCsv) {
+        this.allowedHosts = Arrays.stream(allowedHostsCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Throws {@link IllegalArgumentException} if the URL is not a safe webhook target.
+     */
+    public void validate(String webhookUrl) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            throw new IllegalArgumentException("Webhook URL is blank");
+        }
+
+        URI uri;
+        try {
+            uri = URI.create(webhookUrl.trim());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Webhook URL is malformed: " + webhookUrl, e);
+        }
+
+        if (!"https".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("Webhook URL must use https: " + webhookUrl);
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("Webhook URL has no host: " + webhookUrl);
+        }
+
+        if (!isAllowedHost(host)) {
+            throw new IllegalArgumentException("Webhook host is not allowed: " + host);
+        }
+
+        if (!allResolvedAddressesPublic(host)) {
+            throw new IllegalArgumentException("Webhook host resolves to a non-public address: " + host);
+        }
+    }
+
+    private boolean isAllowedHost(String host) {
+        String h = host.toLowerCase(Locale.ROOT);
+        return allowedHosts.stream()
+                .anyMatch(allowed -> h.equals(allowed) || h.endsWith("." + allowed));
+    }
+
+    private boolean allResolvedAddressesPublic(String host) {
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            if (addresses.length == 0) {
+                return false;
+            }
+            return Arrays.stream(addresses).allMatch(WebhookUrlValidator::isPublicAddress);
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    private static boolean isPublicAddress(InetAddress address) {
+        if (address == null
+                || address.isLoopbackAddress()
+                || address.isAnyLocalAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()) {
+            return false;
+        }
+
+        if (address instanceof Inet4Address) {
+            return isPublicIpv4(address.getAddress());
+        }
+        if (address instanceof Inet6Address) {
+            return isPublicIpv6(address.getAddress());
+        }
+        return true;
+    }
+
+    private static boolean isPublicIpv4(byte[] b) {
+        int first = b[0] & 0xFF;
+        if (first == 0) return false;                     // 0.0.0.0/8 "this" network
+        if (first == 10) return false;                    // 10.0.0.0/8 private
+        if (first == 100 && (b[1] & 0xFF) >= 64 && (b[1] & 0xFF) <= 127) return false; // 100.64.0.0/10 CGNAT
+        if (first == 127) return false;                   // loopback
+        if (first == 169 && (b[1] & 0xFF) == 254) return false; // 169.254.0.0/16 link-local
+        if (first == 172 && (b[1] & 0xFF) >= 16 && (b[1] & 0xFF) <= 31) return false; // 172.16.0.0/12 private
+        if (first == 192 && (b[1] & 0xFF) == 168) return false; // 192.168.0.0/16 private
+        if (first == 198 && (b[1] & 0xFF) == 18) return false;  // 198.18.0.0/15 benchmarking
+        if (first >= 224) return false;                   // multicast + reserved
+        return true;
+    }
+
+    private static boolean isPublicIpv6(byte[] b) {
+        if ((b[0] & 0xFF) == 0xFF) return false;          // multicast ff00::/8
+        if ((b[0] & 0xFF) == 0xFC || (b[0] & 0xFF) == 0xFD) return false; // ULA fc00::/7
+        if ((b[0] & 0xFF) == 0xFE && (b[1] & 0xFF) == 0x80) return false; // link-local fe80::/10
+        return true;
+    }
+}

--- a/src/main/java/com/eventra/service/WebhookDispatchService.java
+++ b/src/main/java/com/eventra/service/WebhookDispatchService.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
+import com.eventra.util.WebhookUrlValidator;
+
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -14,7 +16,13 @@ import java.util.logging.Logger;
 public class WebhookDispatchService {
 
     private static final Logger logger = Logger.getLogger(WebhookDispatchService.class.getName());
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+    private final WebhookUrlValidator webhookUrlValidator;
+
+    public WebhookDispatchService(RestTemplate webhookRestTemplate, WebhookUrlValidator webhookUrlValidator) {
+        this.restTemplate = webhookRestTemplate;
+        this.webhookUrlValidator = webhookUrlValidator;
+    }
 
     @Async
     public void dispatchRegistrationWebhookAsync(String webhookUrl, Map<String, Object> payload) {
@@ -24,6 +32,7 @@ public class WebhookDispatchService {
             headers.set("User-Agent", "Eventra-Webhook-Dispatcher/1.0");
 
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+            webhookUrlValidator.validate(webhookUrl);
             restTemplate.postForEntity(webhookUrl, request, String.class);
             logger.info("Successfully dispatched webhook notification to: " + webhookUrl);
         } catch (Exception e) {

--- a/src/main/java/com/eventra/service/WebhookNotificationService.java
+++ b/src/main/java/com/eventra/service/WebhookNotificationService.java
@@ -8,6 +8,8 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
+import com.eventra.util.WebhookUrlValidator;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -16,7 +18,13 @@ import java.util.logging.Logger;
 public class WebhookNotificationService {
 
     private static final Logger logger = Logger.getLogger(WebhookNotificationService.class.getName());
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
+    private final WebhookUrlValidator webhookUrlValidator;
+
+    public WebhookNotificationService(RestTemplate webhookRestTemplate, WebhookUrlValidator webhookUrlValidator) {
+        this.restTemplate = webhookRestTemplate;
+        this.webhookUrlValidator = webhookUrlValidator;
+    }
 
     public record HackathonSubmissionEvent(
             Long hackathonId,
@@ -54,6 +62,7 @@ public class WebhookNotificationService {
             payload.put("text", text);
 
             HttpEntity<Map<String, String>> request = new HttpEntity<>(payload, headers);
+            webhookUrlValidator.validate(webhookUrl);
             restTemplate.postForEntity(webhookUrl, request, String.class);
             logger.info("Successfully dispatched Slack notification to webhook.");
         } catch (Exception e) {
@@ -73,6 +82,7 @@ public class WebhookNotificationService {
             payload.put("content", content);
 
             HttpEntity<Map<String, String>> request = new HttpEntity<>(payload, headers);
+            webhookUrlValidator.validate(webhookUrl);
             restTemplate.postForEntity(webhookUrl, request, String.class);
             logger.info("Successfully dispatched Discord notification to webhook.");
         } catch (Exception e) {


### PR DESCRIPTION
## Problem
`WebhookNotificationService.handleHackathonSubmissionEvent` and `WebhookDispatchService.dispatchRegistrationWebhookAsync` POST JSON payloads to whatever webhook URL is supplied, using a default `RestTemplate` that follows HTTP redirects. The URL is never validated: no scheme enforcement, no host allowlist, and no check for private/reserved/link-local targets. A participant/compromised organizer who controls a `slackWebhookUrl`/`discordWebhookUrl` can make the backend issue arbitrary requests to cloud metadata endpoints (e.g. `http://169.254.169.254/`), internal services (localhost Redis, Actuator, admin consoles), or state-changing third-party endpoints attributed to the server's IP.

## Fix
- Added `WebhookUrlValidator` that rejects, before dispatch:
  - blank/malformed URLs and non-`https` schemes,
  - hosts outside a configurable allowlist (default `hooks.slack.com`, `discord.com`, `discordapp.com`, incl. subdomains; overridable via `eventra.webhook.allowed-hosts`),
  - hosts that resolve to private/reserved addresses — every resolved `A`/`AAAA` record is checked (loopback, `10/8`, `172.16/12`, `192.168/16`, `169.254/16`, `100.64/10`, CGNAT, ULA `fc00::/7`, link-local `fe80::/10`, multicast, benchmarking, etc.), mitigating DNS rebinding.
- Added `WebhookConfig` exposing a `RestTemplate` bean built on `JdkClientHttpRequestFactory` backed by a JDK `HttpClient` with `followRedirects(NEVER)`, so a redirect response can no longer turn a dispatch into a request to an internal endpoint.
- Wired both webhook services to the validated `RestTemplate` (constructor injection) and call `webhookUrlValidator.validate(...)` before each `postForEntity`.

## Files changed
- `Backend/src/main/java/com/eventra/config/WebhookConfig.java` (new)
- `Backend/src/main/java/com/eventra/util/WebhookUrlValidator.java` (new)
- `src/main/java/com/eventra/service/WebhookDispatchService.java`
- `src/main/java/com/eventra/service/WebhookNotificationService.java`

Note: the two webhook services are among the files #15281 relocates from the frontend tree into `Backend/`; the new support classes are created directly under `Backend/`. These changes are compatible with either merge order (the relocation PR only renames files).

## Testing
- Compile-verified the four changed/new files with `javac` against Spring Framework 6.2.6 (`spring-web`, `spring-context`, `spring-beans`, `spring-core`, `spring-aop`, `spring-expression`) — no errors.
- Validator behavior (by inspection): rejects `http://...`, `http://169.254.169.254/latest/meta-data/`, `http://localhost:6379`, `https://internal.corp/`, and `hooks.slack.com` entries that resolve to a private address; accepts `https://hooks.slack.com/services/...` and `https://discord.com/api/webhooks/...`.

Closes #15282
