### PR TITLE
fix(events): reject waitlist joins for past events (#15283)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -757,6 +757,11 @@ public class EventService {
                         throw new RegistrationConflictException("This event has been cancelled.");
                 }
 
+                // A past event will never reopen seats, so joining its waitlist would strand the user (#15283).
+                if (event.isEventPast()) {
+                        throw new RegistrationClosedException("Registration is closed for this event.");
+                }
+
                 User user = userRepository.findByEmail(userEmail)
                                 .orElseThrow(() -> new UsernameNotFoundException(
                                                 "User not found with email: " + userEmail));


### PR DESCRIPTION
## Problem
`EventService.joinWaitlist` validated that an event is public, that the user is not already registered/waitlisted, and that the event has no open seats — but it performed **no** `isEventPast()` check and, at the time this issue was filed, no cancelled-status check either. The direct registration path (`executeRegistration`) rejects past events, so users could still join the waitlist of a past/cancelled event that would never fill, stranding them in a `WAITING` state from which they could never be promoted.

## Fix
- Added an `isEventPast()` guard at the top of `joinWaitlist`, mirroring the exact check in `executeRegistration`:
  ```java
  if (event.isEventPast()) {
      throw new RegistrationClosedException("Registration is closed for this event.");
  }
  ```
- The cancelled-status guard (`"CANCELLED".equals(event.getStatus())` → `RegistrationConflictException`) already existed in `joinWaitlist` on master (added by #12080); it is retained. Together, past and cancelled events can no longer accept waitlist joins.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing
- Change follows the identical, already-proven guard pattern in `executeRegistration` (same exception, same message, same import already present in the file).
- Backend module still has unrelated pre-existing compile failures on master that are outside this issue's scope.

Closes #15283
