### PR TITLE
fix(waitlist): make promotion idempotency durable via Redis SET NX with TTL (#15284)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/WaitlistService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/WaitlistService.java
@@ -1,38 +1,77 @@
 package com.sandeep.eventrabackend.service;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Service managing event waitlist promotions with strict idempotency token deduplication.
  * Prevents double-claiming seat allocations during Service Worker background sync retries.
+ *
+ * <p>The source of truth for a processed promotion token is a Redis {@code SET NX} key with a
+ * 24h TTL, which is atomic, shared across all application instances behind a load balancer, and
+ * durable across restarts. The in-memory set is only a best-effort fast path and is never used as
+ * the source of truth, so a restart or a second instance cannot re-confirm the same token.
  */
 @Service
 public class WaitlistService {
 
+    private static final String PROMOTION_TOKEN_KEY_PREFIX = "waitlist:promotion-token:";
+    private static final Duration PROMOTION_TOKEN_TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
     private final Set<String> processedPromotionTokens = ConcurrentHashMap.newKeySet();
+
+    public WaitlistService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
 
     /**
      * Process waitlist promotion acceptance.
      * Returns true if successfully processed, false if duplicate/already processed.
+     *
+     * <p>The caller must perform the actual seat allocation (e.g. the
+     * {@code WAITING -> PROMOTED} transition plus the {@code CONFIRMED} registration) within the
+     * same database transaction as this call, so the idempotency record and the allocation commit
+     * or roll back together.
      */
     public boolean confirmPromotion(String promotionToken, String userId, String eventId) {
         if (promotionToken == null || promotionToken.trim().isEmpty()) {
             return false;
         }
 
-        // Idempotency Mutex Lock: reject duplicate confirmations for the same promotion token
-        if (!processedPromotionTokens.add(promotionToken)) {
+        // Best-effort fast path only; never the source of truth.
+        if (processedPromotionTokens.contains(promotionToken)) {
             return false; // Already processed
         }
 
-        // Proceed with seat allocation logic
+        // Atomic, cross-instance, TTL-bounded dedup: SET NX is the source of truth.
+        // Fails closed if Redis is unavailable rather than silently re-introducing
+        // the double-claim risk.
+        Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(key(promotionToken), "1", PROMOTION_TOKEN_TTL);
+        if (acquired == null || !acquired) {
+            return false; // Already processed by this or another instance
+        }
+
+        processedPromotionTokens.add(promotionToken);
         return true;
     }
 
     public boolean isTokenProcessed(String promotionToken) {
-        return processedPromotionTokens.contains(promotionToken);
+        if (promotionToken == null || promotionToken.trim().isEmpty()) {
+            return false;
+        }
+        if (processedPromotionTokens.contains(promotionToken)) {
+            return true;
+        }
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key(promotionToken)));
+    }
+
+    private String key(String promotionToken) {
+        return PROMOTION_TOKEN_KEY_PREFIX + promotionToken;
     }
 }


### PR DESCRIPTION
## Problem
`WaitlistService.confirmPromotion` deduplicated promotion tokens with a single JVM-local `ConcurrentHashMap.newKeySet()`. This was:
1. **Unsafe across instances** — two instances behind a load balancer each add the same token successfully and both return `true`, so a seat can be double-allocated.
2. **Unsafe across restarts** — the set is process-local; a restart clears it and the same token can be confirmed again.
3. **Unbounded** — tokens are never evicted, so the set grows for the life of the JVM.

## Fix
- The source of truth is now a Redis `SET NX` with a **24-hour TTL** (`StringRedisTemplate.opsForValue().setIfAbsent(key, "1", 24h)`), which is:
  - atomic (only one instance wins per token),
  - shared across all application instances,
  - durable across restarts,
  - bounded (each token expires after 24h, so the store cannot grow without limit).
- The in-memory set is kept strictly as a **best-effort fast path** (`contains`/`add` after a successful Redis claim) and is never consulted as the source of truth.
- `isTokenProcessed` checks the fast path first, then Redis.
- Fail-closed behavior: if Redis is unavailable the call throws rather than silently falling back to the unsafe JVM-local set.
- Documented that the caller must perform the actual seat allocation (WAITING → PROMOTED + CONFIRMED registration) within the same DB transaction as `confirmPromotion`, so the idempotency record and the allocation commit together.

Redis was already introduced to the backend as part of the caching work (#15280, `spring-boot-starter-data-redis` in `Backend/pom.xml`), so no new dependency is needed.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/service/WaitlistService.java`

## Testing
- Compile-verified against Spring Framework 6.2.6 / Spring Data Redis 3.4.4 (`spring-data-redis`, `spring-data-keyvalue`, `spring-data-commons`, `lettuce-core`, `spring-tx`, etc.) — no errors.

Closes #15284
