### PR TITLE
fix(sse): remove orphaned case labels in sseMultiplexer.js

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -329,6 +329,12 @@ export class SseMultiplexer {
 
     msg.paths.forEach((p) => this.addGlobalSubscriber(p, msg.tabId));
 
+    if (msg.lastEventIds) {
+      Object.entries(msg.lastEventIds).forEach(([path, lastId]) => {
+        if (!this.lastEventIds.has(path)) this.lastEventIds.set(path, lastId);
+      });
+    }
+
     if (this.isLeader) {
       msg.paths.forEach((p) => {
         const currentStatus = this.pathStatuses.get(p);
@@ -342,36 +348,31 @@ export class SseMultiplexer {
             lastEventIds: Object.fromEntries(this.lastEventIds),
           });
         }
-        break;
+      });
+      this.reconcileConnections();
+    }
+  }
 
-      case "SUBSCRIBERS_RESPONSE":
-        if (msg.paths) {
-          msg.paths.forEach((p) => this.addGlobalSubscriber(p, msg.tabId));
-        }
-        if (msg.lastEventIds) {
-          Object.entries(msg.lastEventIds).forEach(([path, lastId]) => {
-            if (!this.lastEventIds.has(path)) this.lastEventIds.set(path, lastId);
-          });
-        }
-        if (this.isLeader) this.reconcileConnections();
-        break;
-
-      case "SSE_MESSAGE":
-        if (msg.lastEventId) {
-          this.lastEventIds.set(msg.path, msg.lastEventId);
-        }
-        this.dispatchLocalMessage(msg.path, msg.data, msg.eventType);
-        break;
+  handleSseMessage(msg) {
+    if (msg.lastEventId) {
+      this.lastEventIds.set(msg.path, msg.lastEventId);
+    }
+    this.dispatchLocalMessage(msg.path, msg.data, msg.eventType);
+  }
 
   handleSseStatus(msg) {
     this.updatePathStatus(msg.path, msg.status);
   }
 
-      case "RECONNECT_REQUEST":
-        if (this.isLeader) {
-          this.reconnect(msg.path);
-        }
-        break;
+  handleReconnectRequest(msg) {
+    if (this.isLeader) {
+      this.reconnect(msg.path);
+    }
+  }
+
+  handlePing() {
+    if (!this.isLeader) {
+      this.broadcastMessage({ type: "PONG", tabId: this.tabId });
     }
   }
 


### PR DESCRIPTION
## Problem

`src/utils/sseMultiplexer.js` fails to parse. A stray `break;` inside a `forEach` callback followed by orphaned `case` labels (`SUBSCRIBERS_RESPONSE`, `SSE_MESSAGE`, `RECONNECT_REQUEST`) left over from the switch-to-handler refactor cause `esbuild`/`vite build` to fail with `Unexpected "case"` at line 347. The file is imported by every realtime feature in the app (via `useRealTimeConnection`, `NotificationContext`, and `useEventAvailability`), so the whole Events/Realtime bundle is broken.

## Fix

- Removed the stray `break;` and deleted the orphaned `case` labels inside `handleSubscribersResponse`.
- Merged incoming `msg.lastEventIds` into `this.lastEventIds` (guarded by `!this.lastEventIds.has(path)`).
- Call `this.reconcileConnections()` when `this.isLeader`.
- Restored the `handleSseMessage`, `handleReconnectRequest`, and `handlePing` handler methods referenced by `msgHandlers`, preserving the `SSE_MESSAGE` last-event tracking and `RECONNECT_REQUEST` behavior.

## Files changed

- `src/utils/sseMultiplexer.js`

## Testing

- `node --check src/utils/sseMultiplexer.js` now passes (previously failed with `Unexpected "case"`).

Closes #15330
