### PR TITLE
fix(repository): remove invalid EntityGraph queries from HackathonRepository (#15285)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java
@@ -1,8 +1,3 @@
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import java.util.List;
-import java.util.Optional;
 package com.sandeep.eventrabackend.repository;
 
 import com.sandeep.eventrabackend.model.Hackathon;
@@ -27,12 +22,4 @@ public interface HackathonRepository extends JpaRepository<Hackathon, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT h FROM Hackathon h WHERE h.id = :id AND h.isDeleted = false")
     Optional<Hackathon> findByIdWithLock(@Param("id") Long id);
-
-    @EntityGraph(attributePaths = {"tracks", "teams", "teams.members"})
-    @Query("SELECT h FROM Hackathon h WHERE h.id = :id")
-    Optional<Object> findByIdWithTracksAndTeams(Long id);
-
-    @EntityGraph(attributePaths = {"tracks", "teams"})
-    @Query("SELECT DISTINCT h FROM Hackathon h")
-    List<Object> findAllWithTracksAndTeams();
 }


### PR DESCRIPTION
## Problem
`HackathonRepository` declared two derived-query methods whose `@EntityGraph` attribute paths (`tracks`, `teams`, `teams.members`) do not exist on the `Hackathon` entity — it has no associations matching those names — and whose return types were generic `Object`/`List<Object>`. Spring Data JPA validates `@EntityGraph` attribute paths for derived queries at application startup, so these methods caused a JPA bootstrap failure (`PropertyReferenceException`: "Unable to locate Attribute with the given name") independent of whether they were ever called, and the `Object` return types discarded all type safety. The file also had a corrupted header (package declaration below imports plus duplicate imports).

## Fix
- Removed both dead methods (`findByIdWithTracksAndTeams`, `findAllWithTracksAndTeams`). They have zero callers in the codebase, and the `Hackathon` entity has no `tracks`/`teams` associations to eagerly fetch, so mapping new JPA relationships (with schema changes) would be the wrong fix for an entity that is intentionally flat.
- Repaired the file header: `package` declaration moved to the top, duplicate imports removed. The remaining methods (`findByIdAndIsDeletedFalse`, `findByIsDeletedFalse`, `findByIdWithLock`) are unchanged.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java`

## Testing
- Compile-verified the repository interface + `Hackathon` model with `javac` against Spring Data JPA 3.4.4, jakarta.persistence-api 3.1.0, and Lombok 1.18.30 — no errors.
- `@EntityGraph` is no longer referenced anywhere in the file, so there is nothing left for Spring Data JPA to fail on at startup.

Closes #15285
