### PR TITLE
fix(util): keep KW/literal tokens distinct and score empty code as 0

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/util/ASTTokenizerUtil.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/util/ASTTokenizerUtil.java
@@ -20,8 +20,8 @@ public class ASTTokenizerUtil {
                 .replaceAll("//.*|/\\*[\\s\\S]*?\\*/", "") // Remove comments
                 .replaceAll("\"[^\"]*\"|'[^']*'", "STR_LITERAL") // Normalize string literals
                 .replaceAll("\\b\\d+\\b", "NUM_LITERAL") // Normalize number literals
-                .replaceAll("\\b(let|var|const|function|class|return|if|else|for|while|import|from|export|def|public|private|class|static|void|int|double)\\b", "KW_$1") // Key words
-                .replaceAll("\\b[a-zA-Z_][a-zA-Z0-9_]*\\b", "IDENT"); // Replace generic identifier names
+                .replaceAll("\\b(let|var|const|function|class|return|if|else|for|while|import|from|export|def|public|private|static|void|int|double)\\b", "KW_$1") // Key words
+                .replaceAll("\\b(?!(?:KW_|STR_LITERAL|NUM_LITERAL))[a-zA-Z_][a-zA-Z0-9_]*\\b", "IDENT"); // Replace generic identifier names (preserving KW_*, STR_LITERAL, NUM_LITERAL)
 
         String[] tokens = normalized.split("\\s+");
         List<String> tokenList = new ArrayList<>();
@@ -38,6 +38,9 @@ public class ASTTokenizerUtil {
      */
     public static Set<Integer> generateKGramHashes(List<String> tokens) {
         Set<Integer> hashes = new HashSet<>();
+        if (tokens.isEmpty()) {
+            return hashes;
+        }
         if (tokens.size() < K_GRAM_SIZE) {
             hashes.add(Objects.hash(tokens));
             return hashes;
@@ -60,7 +63,6 @@ public class ASTTokenizerUtil {
         Set<Integer> hashesA = generateKGramHashes(tokensA);
         Set<Integer> hashesB = generateKGramHashes(tokensB);
 
-        if (hashesA.isEmpty() && hashesB.isEmpty()) return 100.0;
         if (hashesA.isEmpty() || hashesB.isEmpty()) return 0.0;
 
         Set<Integer> intersection = new HashSet<>(hashesA);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/util/ASTTokenizerUtilTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/util/ASTTokenizerUtilTest.java
@@ -1,0 +1,85 @@
+package com.sandeep.eventrabackend.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ASTTokenizerUtilTest {
+
+    @Test
+    @DisplayName("Empty code produces no tokens and a 0.0 similarity score (#15288)")
+    void emptyCodeScoresZero() {
+        assertTrue(ASTTokenizerUtil.tokenizeCode("").isEmpty());
+        assertEquals(0.0, ASTTokenizerUtil.calculateSimilarityScore("", ""));
+    }
+
+    @Test
+    @DisplayName("Comment-only code produces no tokens and a 0.0 similarity score (#15288)")
+    void commentOnlyCodeScoresZero() {
+        String commentOnly = "// just a comment\n/* block comment */";
+        assertTrue(ASTTokenizerUtil.tokenizeCode(commentOnly).isEmpty());
+        assertEquals(0.0, ASTTokenizerUtil.calculateSimilarityScore(commentOnly, ""));
+    }
+
+    @Test
+    @DisplayName("Keywords remain distinct KW_ tokens instead of collapsing into IDENT (#15288)")
+    void keywordsStayDistinct() {
+        List<String> tokens = ASTTokenizerUtil.tokenizeCode("return if else for while public");
+        assertEquals(List.of("KW_return", "KW_if", "KW_else", "KW_for", "KW_while", "KW_public"), tokens);
+    }
+
+    @Test
+    @DisplayName("Identifiers normalize to IDENT while keywords are preserved (#15288)")
+    void identifiersNormalizeButKeywordsSurvive() {
+        List<String> tokens = ASTTokenizerUtil.tokenizeCode("function computeSum(a, b) { let total = a + b; return total; }");
+        assertTrue(tokens.contains("KW_function"));
+        assertTrue(tokens.contains("KW_return"));
+        assertTrue(tokens.stream().noneMatch(t -> t.equals("computeSum") || t.equals("total") || t.equals("a") || t.equals("b")));
+        assertEquals(tokens, ASTTokenizerUtil.tokenizeCode("function computeProduct(x, y) { let result = x + y; return result; }"));
+    }
+
+    @Test
+    @DisplayName("Identical code scores 100.0 (#15288)")
+    void identicalCodeScoresFull() {
+        String code = "function computeSum(a, b) { return a + b; }";
+        assertEquals(100.0, ASTTokenizerUtil.calculateSimilarityScore(code, code));
+    }
+
+    @Test
+    @DisplayName("Code with only identifiers renamed is structurally identical and scores 100.0 (#15288)")
+    void renamedVariablesRemainStructurallyIdentical() {
+        String original = "function computeSum(a, b) { let total = a + b; return total; }";
+        String renamed = "function add(x, y) { let result = x + y; return result; }";
+        assertEquals(100.0, ASTTokenizerUtil.calculateSimilarityScore(original, renamed));
+    }
+
+    @Test
+    @DisplayName("Structurally similar code with control-flow differences scores high but below 100.0 (#15288)")
+    void similarButNotIdenticalCodeScoresHighButNotFull() {
+        String flat = "if (x > 0) { x = x - 1; }";
+        String nested = "if (x > 0) { if (x > 5) { x = x - 1; } }";
+        double score = ASTTokenizerUtil.calculateSimilarityScore(flat, nested);
+        assertTrue(score > 40.0 && score < 100.0, "expected a high-but-not-perfect score, got " + score);
+    }
+
+    @Test
+    @DisplayName("String and number literal markers survive identifier normalization (#15288)")
+    void literalMarkersSurvive() {
+        List<String> tokens = ASTTokenizerUtil.tokenizeCode("let msg = \"hello\"; let n = 42;");
+        assertTrue(tokens.stream().anyMatch(t -> t.startsWith("STR_LITERAL")));
+        assertTrue(tokens.stream().anyMatch(t -> t.startsWith("NUM_LITERAL")));
+        assertTrue(tokens.stream().noneMatch(t -> t.equals("hello") || t.equals("42")));
+    }
+
+    @Test
+    @DisplayName("Different programs score low (#15288)")
+    void differentProgramsScoreLow() {
+        String forLoop = "for (let i = 0; i < n; i++) { total += i; }";
+        String ioCode = "import fs from 'fs'; fs.readFileSync('x.txt');";
+        assertTrue(ASTTokenizerUtil.calculateSimilarityScore(forLoop, ioCode) < 40.0);
+    }
+}


### PR DESCRIPTION
## Problem
`ASTTokenizerUtil` had two defects that made `PlagiarismDetectionService` report nonsense:

1. **Keywords collapsed into `IDENT`** — the keyword rewrite produced `KW_public`, `KW_if`, ... but the identifier normalization that immediately followed matched `KW_*` too, so every keyword became `IDENT`. The token stream degenerated to a bag of `IDENT`/`STR_LITERAL`/`NUM_LITERAL`, carrying zero structural signal. (Same collision also silently destroyed the `STR_LITERAL`/`NUM_LITERAL` markers.)
2. **Empty/comment-only code scored 100%** — `generateKGramHashes([])` added `hash([])` instead of returning an empty set, so two blank submissions produced identical hash sets → Jaccard `1.0`. The `calculateSimilarityScore` both-empty branch returning `100.0` was unreachable dead code.

Result: blank submissions were flagged as HIGH plagiarism, and structurally-copied code could pass because keyword structure was invisible.

## Fix
- `tokenizeCode` now preserves structural markers: the identifier regex uses `\b(?!KW_|STR_LITERAL|NUM_LITERAL)\b` so `KW_*`, `STR_LITERAL`, and `NUM_LITERAL` survive normalization. Keywords stay distinct (`KW_return`, `KW_if`, ...) vs `IDENT`, so control-flow and declaration patterns carry similarity signal.
- `generateKGramHashes` returns an **empty set** for empty token lists.
- `calculateSimilarityScore` returns `0.0` whenever either hash set is empty (covers empty vs empty and empty vs non-empty), removing the dead `100.0` branch.

## Files changed
- `Backend/src/main/java/com/sandeep/eventrabackend/util/ASTTokenizerUtil.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/util/ASTTokenizerUtilTest.java` (new)

## Testing
Ran 9 new unit tests (compiled with javac, executed via a lightweight JUnit 5 runner) — all pass:
- empty code → 0.0; comment-only code → 0.0 (and both produce no tokens)
- keywords stay distinct: `tokenizeCode("return if else for while public")` → `[KW_return, KW_if, KW_else, KW_for, KW_while, KW_public]`
- `STR_LITERAL`/`NUM_LITERAL` markers survive identifier normalization
- identical code → 100.0; code differing only by renamed identifiers → 100.0 (structurally identical by design)
- structurally similar code (nested `if` vs flat) → 58.33 (high but < 100)
- unrelated programs → < 40

Note: with structural tokenization, submissions that differ *only* in identifier names are by construction identical token streams and correctly score 100.0; the "high but < 100" case is demonstrated with code that has real structural differences.

Closes #15288
