### PR TITLE
fix(security): require auth for live-audience SSE topic

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -154,8 +154,8 @@ public class SecurityConfig {
                                 "/api/events/{id}/feed.ics",
                                 "/api/events/stream"
                         ).permitAll()
-                        .requestMatchers("/stream/events", "/stream/leaderboard", "/stream/live-audience").permitAll()
-                        .requestMatchers("/stream/notifications", "/stream/analytics").authenticated()
+                        .requestMatchers("/stream/events", "/stream/leaderboard").permitAll()
+                        .requestMatchers("/stream/live-audience", "/stream/notifications", "/stream/analytics").authenticated()
                         // ── Public: Projects endpoint ────────────────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/{id}").permitAll()

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java
@@ -29,7 +29,7 @@ public class StreamController {
         this.eventStreamService = eventStreamService;
     }
 
-    private static final Set<String> AUTH_REQUIRED_TOPICS = Set.of("notifications", "analytics");
+    private static final Set<String> AUTH_REQUIRED_TOPICS = Set.of("notifications", "analytics", "live-audience");
 
     @GetMapping(value = "/{topic}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "Subscribe to a realtime SSE topic")


### PR DESCRIPTION
## Problem

`/stream/live-audience` SSE was in the `permitAll()` list in `SecurityConfig` and the topic was not part of `AUTH_REQUIRED_TOPICS` in `StreamController`. Any anonymous client could open the stream and receive, in real time, attendee question text (including display names) and poll option/vote results — exactly the data the REST Q&A endpoints (`/api/events/{eventId}/live-audience/**`) protect behind authentication.

## Fix

- Added `"live-audience"` to `AUTH_REQUIRED_TOPICS` in `StreamController.java` so the SSE endpoint returns 401 for unauthenticated subscribers.
- Moved `/stream/live-audience` out of the `permitAll()` list in `SecurityConfig.java`; it now requires authentication alongside `/stream/notifications` and `/stream/analytics`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java`

## Testing

- Verified `StreamController.subscribe` returns `401 UNAUTHORIZED` for `live-audience` when no `Authentication` is present (mirrors the existing `notifications`/`analytics` behavior).
- Verified `SecurityConfig` now maps `/stream/live-audience` to `authenticated()`.

Closes #15332
