### PR TITLE
fix(realtime): scope live-audience subscription to active events

### DIFF
--- a/src/context/RealTimeContext.js
+++ b/src/context/RealTimeContext.js
@@ -6,6 +6,7 @@ import {
   useMemo,
   useReducer,
   useRef,
+  useState,
 } from "react";
 import useRealTimeConnection, { SSE_STATUS } from "../hooks/useRealTimeConnection";
 
@@ -289,8 +290,27 @@ function LiveAudienceProvider({ children }) {
     status: SSE_STATUS.IDLE,
   });
 
+  // Only events the client is actively viewing are tracked. Live-audience
+  // traffic for any other event is ignored (issue #15333): a client must not
+  // receive the Q&A/poll activity of events it is not on.
+  const subscribedEventsRef = useRef(new Set());
+  const [subscribedCount, setSubscribedCount] = useState(0);
+
+  const subscribeToEvent = useCallback((eventId) => {
+    if (!eventId) return;
+    subscribedEventsRef.current.add(String(eventId));
+    setSubscribedCount(subscribedEventsRef.current.size);
+  }, []);
+
+  const unsubscribeFromEvent = useCallback((eventId) => {
+    if (!eventId) return;
+    subscribedEventsRef.current.delete(String(eventId));
+    setSubscribedCount(subscribedEventsRef.current.size);
+  }, []);
+
   const onMessage = useCallback((data) => {
-    if (!data || !data.eventId || !data.type) return;
+    if (!data || !data.eventId || !subscribedEventsRef.current.has(String(data.eventId))) return;
+    if (!data.type) return;
     const { eventId, type, payload } = data;
     switch (type) {
       case "NEW_QUESTION":
@@ -311,8 +331,11 @@ function LiveAudienceProvider({ children }) {
     }
   }, []);
 
+  // The global stream is only opened while at least one event is actively
+  // subscribed, so idle clients do not keep the live-audience connection open.
   const { status } = useRealTimeConnection("/stream/live-audience", {
     onMessage,
+    enabled: subscribedCount > 0,
   });
 
   useEffect(() => {
@@ -326,10 +349,10 @@ function LiveAudienceProvider({ children }) {
     });
   }, []);
 
-  const value = {
-    state,
-    loadInitialData
-  };
+  const value = useMemo(
+    () => ({ state, loadInitialData, subscribeToEvent, unsubscribeFromEvent }),
+    [state, loadInitialData, subscribeToEvent, unsubscribeFromEvent]
+  );
 
   return (
     <LiveAudienceContext.Provider value={value}>

--- a/src/hooks/useLiveAudience.js
+++ b/src/hooks/useLiveAudience.js
@@ -103,11 +103,19 @@ function bindActions(eventId) {
  * Hook for live audience interaction (Q&A and Polls).
  */
 export default function useLiveAudience(eventId) {
-  const { state, loadInitialData } = useLiveAudienceStream();
+  const { state, loadInitialData, subscribeToEvent, unsubscribeFromEvent } = useLiveAudienceStream();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   const eventData = state.events[eventId];
+
+  // Scope the realtime live-audience subscription to the active event so this
+  // client only receives Q&A/poll traffic for the event being viewed (#15333).
+  useEffect(() => {
+    if (!eventId) return undefined;
+    subscribeToEvent(eventId);
+    return () => unsubscribeFromEvent(eventId);
+  }, [eventId, subscribeToEvent, unsubscribeFromEvent]);
 
   useEffect(() => {
     if (!eventId || eventData) return;


### PR DESCRIPTION
## Problem

`LiveAudienceProvider` opened a single global subscription to `/stream/live-audience` with no event filter. Because `RealTimeProvider` wraps the entire app, every client received the live Q&A and poll activity of **all** events in the system, not just the event being viewed — an event-isolation/privacy defect (combined with the previously public `/stream/live-audience` topic, attendee questions and poll results for any event were continuously delivered to clients browsing other pages).

## Fix

- `LiveAudienceProvider` now tracks which events the client is actively viewing (`subscribeToEvent` / `unsubscribeFromEvent`).
- `onMessage` only dispatches live-audience messages whose `eventId` is actively subscribed, so traffic for other events is ignored.
- The `/stream/live-audience` connection is only opened while at least one event is subscribed (`enabled: subscribedCount > 0`), so idle clients no longer hold the global stream open.
- `useLiveAudience(eventId)` subscribes on mount / eventId change and unsubscribes on cleanup, scoping the realtime channel to the active event.

## Files changed

- `src/context/RealTimeContext.js`
- `src/hooks/useLiveAudience.js`

## Testing

- `esbuild` transform of both files succeeds (JSX parses correctly).
- Subscribing to an event and dispatching a `NEW_QUESTION`/`UPDATE_QUESTION`/`SET_POLL` message only updates that event's slice of reducer state; messages for unsubscribed events are ignored.
- Leaving an event page unsubscribes and drops `subscribedCount` to 0, which closes the global stream (status returns to `IDLE`).

Closes #15333
