### PR TITLE
fix(live-audience): reject duplicate poll options

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
@@ -28,8 +28,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -162,11 +165,16 @@ public class LiveAudienceService {
             throw new IllegalArgumentException("A poll can have at most 10 options");
         }
         List<String> options = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
         for (String option : request.getOptions()) {
             if (option == null || option.isBlank()) {
                 throw new IllegalArgumentException("Poll options cannot be blank");
             }
-            options.add(option.trim());
+            String normalized = option.trim();
+            if (!seen.add(normalized.toLowerCase(Locale.ROOT))) {
+                throw new IllegalArgumentException("Poll options must be unique");
+            }
+            options.add(normalized);
         }
         Map<String, Object> results = new HashMap<>();
         options.forEach(opt -> results.put(opt, 0));

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
@@ -344,6 +344,30 @@ public class LiveAudienceControllerTests {
     }
 
     @Test
+    @DisplayName("POST /polls — duplicate option texts rejected (#15301)")
+    void testCreatePollRejectsDuplicateOptions() throws Exception {
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "Duplicate options?",
+                                        "type", "single",
+                                        "options", List.of("Yes", "Yes", "No")))))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of(
+                                        "question", "Case-insensitive dupes?",
+                                        "type", "single",
+                                        "options", List.of("Yes", "yes", "No")))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("GET initial data — reflects persisted questions and latest poll")
     void testGetInitialDataPopulated() throws Exception {
         mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)


### PR DESCRIPTION
## Problem

`LiveAudienceService.createPoll` validates option count and blank text but never checks for duplicates. A poll created with e.g. `["Yes", "Yes", "No"]` keeps both rows in `options` while `results` is a `Map` keyed by option text, so:

- Voters see two indistinguishable "Yes" choices.
- Votes on either "Yes" row merge into one shared tally, so the reported distribution is wrong.

## Fix

`createPoll` now normalizes each option (`trim`) and rejects case-insensitive duplicates via a `Set<String>` of normalized values, mirroring the existing count/blank validations. Duplicate input throws `IllegalArgumentException("Poll options must be unique")`, which the controller boundary maps to HTTP 400.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java`

## Testing

- Added integration tests: exact duplicate options (`["Yes", "Yes", "No"]`) and case-insensitive duplicates (`["Yes", "yes", "No"]`) both return 400.
- Main sources compile-verified with `javac` (Lombok-processed).

Closes #15301
