### PR TITLE
fix(realtime): drop dead leaderboard/analytics SSE subscriptions and poll when notification channel is silent

### DIFF
--- a/src/context/NotificationContext.js
+++ b/src/context/NotificationContext.js
@@ -19,11 +19,20 @@ const normalizeNotification = (n = {}) => ({
   timestamp: n.timestamp || n.createdAt || n.updatedAt || new Date().toISOString(),
 });
 
-// 🟢 This helper function handles your assigned interval cleanup task
-const useBackgroundInterval = (realtimeStatus, fetchNotifications) => {
+// Realtime channels (e.g. `/stream/notifications`) may stay connected without
+// ever delivering a message when no backend publisher exists. Polling must
+// therefore also run when the channel has been silent for a heartbeat window,
+// not only when the connection reports IDLE (issue #15334).
+const SILENT_CHANNEL_MS = 30000;
+
+const useBackgroundInterval = (realtimeStatus, fetchNotifications, lastRealtimeMessageRef) => {
   useEffect(() => {
     const intervalId = setInterval(() => {
-      if (realtimeStatus === SSE_STATUS.IDLE) {
+      const channelSilent =
+        realtimeStatus === SSE_STATUS.IDLE ||
+        (lastRealtimeMessageRef &&
+          Date.now() - lastRealtimeMessageRef.current >= SILENT_CHANNEL_MS);
+      if (channelSilent) {
         fetchNotifications?.();
       }
     }, 30000);
@@ -31,12 +40,13 @@ const useBackgroundInterval = (realtimeStatus, fetchNotifications) => {
     return () => {
       clearInterval(intervalId);
     };
-  }, [realtimeStatus, fetchNotifications]);
+  }, [realtimeStatus, fetchNotifications, lastRealtimeMessageRef]);
 };
 
 export const NotificationProvider = ({ children }) => {
   const { token } = useAuth();
   const hasCompletedInitialFetch = useRef(false);
+  const lastRealtimeMessageRef = useRef(0);
 
   const { preferences, defaultPreferences, updatePreferences, savePreferences } =
     useNotificationPreferences();
@@ -66,6 +76,7 @@ export const NotificationProvider = ({ children }) => {
 
   const handleRealtimeMessage = useCallback(
     (data) => {
+      lastRealtimeMessageRef.current = Date.now();
       if (Array.isArray(data)) { data.forEach(ingestRealtime); return; }
       ingestRealtime(data?.notification || data);
     },
@@ -79,7 +90,7 @@ export const NotificationProvider = ({ children }) => {
 
   // 🟢 FIXED: Removed the old 'realtimeStatus' state variable & its redundant useEffect entirely.
   // 🟢 Added your required background interval function call here instead.
-  useBackgroundInterval(sseStatus, fetchNotifications);
+  useBackgroundInterval(sseStatus, fetchNotifications, lastRealtimeMessageRef);
 
   useEffect(() => {
     if (!markAsReadRef) return;

--- a/src/context/NotificationContext.test.js
+++ b/src/context/NotificationContext.test.js
@@ -8,9 +8,13 @@ vi.mock("./AuthContext", () => ({
 }));
 
 let realtimeStatus = "idle";
+let notifyMessage = null;
 vi.mock("../hooks/useRealTimeConnection", () => ({
   __esModule: true,
-  default: () => ({ status: realtimeStatus }),
+  default: (_path, { onMessage }) => {
+    notifyMessage = onMessage;
+    return { status: realtimeStatus };
+  },
   SSE_STATUS: { IDLE: "idle", CONNECTED: "connected" },
 }));
 
@@ -68,6 +72,7 @@ describe("useBackgroundInterval - SSE idle polling (#12076)", () => {
     vi.useFakeTimers();
     fetchNotifications.mockClear();
     realtimeStatus = "idle";
+    notifyMessage = null;
   });
 
   afterEach(() => {
@@ -93,7 +98,7 @@ describe("useBackgroundInterval - SSE idle polling (#12076)", () => {
     expect(fetchNotifications).toHaveBeenCalledTimes(2);
   });
 
-  it("does not poll when the realtime status is connected", async () => {
+  it("polls when connected but the channel is silent (#15334)", async () => {
     realtimeStatus = "connected";
     render(
       <NotificationProvider>
@@ -104,31 +109,23 @@ describe("useBackgroundInterval - SSE idle polling (#12076)", () => {
     await act(async () => {
       vi.advanceTimersByTime(60_000);
     });
-    expect(fetchNotifications).not.toHaveBeenCalled();
+    expect(fetchNotifications).toHaveBeenCalledTimes(2);
   });
 
-  it("stops polling once the status leaves IDLE", async () => {
-    const { rerender } = render(
-      <NotificationProvider>
-        <Consumer />
-      </NotificationProvider>,
-    );
-
-    await act(async () => {
-      vi.advanceTimersByTime(30_000);
-    });
-    expect(fetchNotifications).toHaveBeenCalledTimes(1);
-
+  it("does not poll while realtime messages are being received", async () => {
     realtimeStatus = "connected";
-    rerender(
+    render(
       <NotificationProvider>
         <Consumer />
       </NotificationProvider>,
     );
 
     await act(async () => {
-      vi.advanceTimersByTime(60_000);
+      for (let i = 0; i < 3; i++) {
+        vi.advanceTimersByTime(20_000);
+        notifyMessage && notifyMessage({ id: `n${i}`, message: "hello" });
+      }
     });
-    expect(fetchNotifications).toHaveBeenCalledTimes(1);
+    expect(fetchNotifications).not.toHaveBeenCalled();
   });
 });

--- a/src/context/RealTimeContext.js
+++ b/src/context/RealTimeContext.js
@@ -23,10 +23,6 @@ const initialLeaderboardState = {
   status: SSE_STATUS.IDLE,
 };
 
-// Maximum number of checked-in attendee ids retained in the analytics reducer.
-// Bounded so long-lived, high-traffic sessions do not grow without limit.
-const CHECKED_IN_IDS_MAX = 500;
-
 const initialAnalyticsState = {
   recentCheckins: [],
   liveCount: 0,
@@ -37,163 +33,24 @@ const initialAnalyticsState = {
   checkedInIds: [],
 };
 
-// --- 3. Split the Reducers ---
-function leaderboardReducer(state, action) {
-  switch (action.type) {
-    case "UPDATE":
-      return {
-        ...state,
-        contributors: action.payload,
-        lastSynced: Date.now(),
-      };
-    case "STATUS":
-      return { ...state, status: action.payload };
-    default:
-      return state;
-  }
-}
-
-function analyticsReducer(state, action) {
-  switch (action.type) {
-    case "CHECKIN": {
-      const payload = action.payload || {};
-      const id =
-        payload.id ||
-        payload.eventId ||
-        (payload.name && payload.event ? `${payload.name}::${payload.event}` : null);
-
-      // A "checked-out / removed" broadcast (increment: -1, type CHECKOUT, or
-      // checkout flag) removes the attendee from the live set instead of adding.
-      if (payload.increment === -1 || payload.type === "CHECKOUT" || payload.checkout === true) {
-        if (id !== null && state.checkedInIds.includes(id)) {
-          const checkedInIds = state.checkedInIds.filter((existing) => existing !== id);
-          return { ...state, checkedInIds, liveCount: Math.max(0, checkedInIds.length) };
-        }
-        // Unknown attendee — nothing to remove; clamp so the count never goes below zero.
-        return { ...state, liveCount: Math.max(0, state.liveCount) };
-      }
-
-      // Duplicate delivery (e.g. SSE reconnect replay of the same check-in)
-      // must not inflate the count — an attendee already present is not counted twice.
-      if (id !== null && state.checkedInIds.includes(id)) {
-        return state;
-      }
-
-      const checkedInIds =
-        id === null
-          ? state.checkedInIds
-          : [...state.checkedInIds, id].slice(-CHECKED_IN_IDS_MAX);
-
-      return {
-        ...state,
-        checkedInIds,
-        recentCheckins: [payload, ...state.recentCheckins.slice(0, 49)],
-        // Derive the live count from the id set instead of summing deltas so a
-        // duplicate check-in can never inflate it.
-        liveCount: id === null ? state.liveCount + 1 : Math.max(0, checkedInIds.length),
-      };
-    }
-    case "UPDATE":
-      return { ...state, ...action.payload };
-    case "STATUS":
-      return { ...state, status: action.payload };
-    default:
-      return state;
-  }
-}
-
-// --- 4. Isolated Providers ---
-// FIX (#7855 Bug 3): STATUS_DEBOUNCE_MS throttles the STATUS dispatch so that
-// rapid connect/disconnect cycles (e.g. flaky connections) do not trigger a
-// re-render storm. 500 ms matches the suggested batch window in the issue.
-const STATUS_DEBOUNCE_MS = 500;
+// --- 3. Isolated Providers ---
+// The `leaderboard` and `analytics` SSE topics have no backend publisher
+// (issue #15334), so the subscriptions are dropped. Leaderboard.jsx hydrates
+// from its REST endpoint (`fetchLeaderboardData`) and AnalyticsDashboard.jsx
+// from `useAnalytics` plus local simulation, so the providers only hand out
+// their initial (IDLE) state.
 
 function LeaderboardProvider({ children }) {
-  const [state, dispatch] = useReducer(leaderboardReducer, initialLeaderboardState);
-
-  const onMessage = useCallback((data) => {
-    if (Array.isArray(data)) {
-      dispatch({ type: "UPDATE", payload: data });
-    } else if (Array.isArray(data?.contributors)) {
-      dispatch({ type: "UPDATE", payload: data.contributors });
-    }
-  }, []);
-
-  const { status } = useRealTimeConnection("/stream/leaderboard", {
-    onMessage,
-  });
-
-  // FIX (#7855 Bug 3): Debounce STATUS dispatches so rapid SSE reconnection
-  // cycles (CONNECTING → OPEN → CLOSED → RECONNECTING in quick succession)
-  // are collapsed into a single state update, preventing a re-render cascade
-  // in every consumer of LeaderboardContext.
-  const statusDebounceRef = useRef(null);
-  useEffect(() => {
-    clearTimeout(statusDebounceRef.current);
-    statusDebounceRef.current = setTimeout(() => {
-      dispatch({ type: "STATUS", payload: status });
-    }, STATUS_DEBOUNCE_MS);
-    return () => clearTimeout(statusDebounceRef.current);
-  }, [status]);
-
-  // FIX (#7855 Bug 3): Memoize the context value so that LeaderboardContext
-  // consumers wrapped in React.memo can bail out of re-renders when neither
-  // contributors nor lastSynced nor status has changed.
-  // Without this, `value={state}` creates a new object reference on every
-  // render of LeaderboardProvider, defeating all downstream memoization.
-  const contextValue = useMemo(
-    () => state,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [state.contributors, state.lastSynced, state.status]
-  );
-
   return (
-    <LeaderboardContext.Provider value={contextValue}>
+    <LeaderboardContext.Provider value={initialLeaderboardState}>
       {children}
     </LeaderboardContext.Provider>
   );
 }
 
 function AnalyticsProvider({ children }) {
-  const [state, dispatch] = useReducer(analyticsReducer, initialAnalyticsState);
-
-  const onMessage = useCallback((data) => {
-    if (data?.increment === -1 || data?.type === "CHECKOUT" || data?.checkout === true) {
-      dispatch({ type: "CHECKIN", payload: data });
-    } else if (data?.name && data?.event) {
-      dispatch({ type: "CHECKIN", payload: data });
-    } else if (data?.checkin) {
-      dispatch({ type: "CHECKIN", payload: data.checkin });
-    } else if (data?.liveCount !== undefined || data?.scanVelocity !== undefined) {
-      dispatch({ type: "UPDATE", payload: data });
-    }
-  }, []);
-
-  const { status } = useRealTimeConnection("/stream/analytics", {
-    onMessage,
-  });
-
-  // FIX (#7855 Bug 3): Same debounce pattern as LeaderboardProvider.
-  const statusDebounceRef = useRef(null);
-  useEffect(() => {
-    clearTimeout(statusDebounceRef.current);
-    statusDebounceRef.current = setTimeout(() => {
-      dispatch({ type: "STATUS", payload: status });
-    }, STATUS_DEBOUNCE_MS);
-    return () => clearTimeout(statusDebounceRef.current);
-  }, [status]);
-
-  // FIX (#7855 Bug 3): Memoize context value — AnalyticsContext consumers
-  // wrapped in React.memo can now bail out of re-renders when recentCheckins,
-  // liveCount, scanVelocity, checkedInIds, and status are all unchanged.
-  const contextValue = useMemo(
-    () => state,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [state.recentCheckins, state.liveCount, state.scanVelocity, state.checkedInIds, state.status]
-  );
-
   return (
-    <AnalyticsContext.Provider value={contextValue}>
+    <AnalyticsContext.Provider value={initialAnalyticsState}>
       {children}
     </AnalyticsContext.Provider>
   );


### PR DESCRIPTION
## Problem

Three of the five SSE topics the frontend subscribes to are never published by the backend — the connections open but never deliver a single event:

- `/stream/leaderboard` and `/stream/analytics` are subscribed in `RealTimeContext.js`, but no backend code publishes to either topic.
- `/stream/notifications` is subscribed in `NotificationContext.js`; the poller fallback (`useBackgroundInterval`) only ran when `realtimeStatus === SSE_STATUS.IDLE`, so since the dead connection stays `CONNECTED`, the 30s fallback poller never ran and notifications only updated on mount / manual refresh / push.

## Fix

1. **Drop the dead subscriptions** (`RealTimeContext.js`): `LeaderboardProvider` and `AnalyticsProvider` no longer open `/stream/leaderboard` / `/stream/analytics` connections. Both consumers already hydrate from REST — `Leaderboard.jsx` via `fetchLeaderboardData` and `AnalyticsDashboard.jsx` via `useAnalytics` plus its local background simulation (which runs whenever the stream is not `CONNECTED`). The providers now hand out their initial `IDLE` state; the unused `leaderboardReducer` / `analyticsReducer` and their constants are removed.
2. **Poll when the channel is silent** (`NotificationContext.js`): `useBackgroundInterval` now also fetches when no realtime message has arrived within a `SILENT_CHANNEL_MS` (30s) window, instead of only when the connection reports `IDLE`. `handleRealtimeMessage` stamps `lastRealtimeMessageRef` on every message so a live channel never triggers the poll.

## Files changed

- `src/context/RealTimeContext.js`
- `src/context/NotificationContext.js`
- `src/context/NotificationContext.test.js`

## Testing

- `npx vitest run src/context/NotificationContext.test.js src/hooks/useNotificationPoller.test.js` → 6/6 pass (including the updated "polls when connected but the channel is silent" case).
- New probe render of `RealTimeProvider` verified Leaderboard/Analytics consumers receive initial `IDLE` state with empty data.
- `eslint` clean on all three files.

Closes #15334
