### PR TITLE
fix(live-audience): never surface closed polls as the active poll in initial data

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java
@@ -14,6 +14,8 @@ public interface LiveAudiencePollRepository extends JpaRepository<LiveAudiencePo
 
     List<LiveAudiencePoll> findByEventIdOrderByCreatedAtDesc(Long eventId);
 
+    List<LiveAudiencePoll> findByEventIdAndStatusOrderByCreatedAtDesc(Long eventId, String status);
+
     Optional<LiveAudiencePoll> findByIdAndEventId(Long id, Long eventId);
 
     /**

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
@@ -57,9 +57,12 @@ public class LiveAudienceService {
                 .map(this::toQuestionResponse)
                 .toList();
         LiveAudiencePollResponse activePoll = pollRepository
-                .findByEventIdOrderByCreatedAtDesc(eventId)
+                .findByEventIdAndStatusOrderByCreatedAtDesc(eventId, "active")
                 .stream()
                 .findFirst()
+                .or(() -> pollRepository.findByEventIdOrderByCreatedAtDesc(eventId).stream()
+                        .filter(poll -> !"closed".equals(poll.getStatus()))
+                        .findFirst())
                 .map(this::toPollResponse)
                 .orElse(null);
         return LiveAudienceDataResponse.builder()

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
@@ -344,6 +344,43 @@ public class LiveAudienceControllerTests {
     }
 
     @Test
+    @DisplayName("GET initial data — closed poll not returned as active; reopened poll appears (#15299)")
+    void testGetInitialDataIgnoresClosedPoll() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("question", "Closed poll", "options", List.of("A", "B")))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long pollId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/status", eventId, pollId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("status", "closed"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activePoll").doesNotExist());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/status", eventId, pollId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("status", "active"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("active"));
+
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activePoll.id").value(pollId));
+    }
+
+    @Test
     @DisplayName("GET initial data — reflects persisted questions and latest poll")
     void testGetInitialDataPopulated() throws Exception {
         mockMvc.perform(post("/api/events/{id}/live-audience/questions", eventId)


### PR DESCRIPTION
## Problem

`LiveAudienceService.getInitialData` selects the "active" poll with no status filter (`findByEventIdOrderByCreatedAtDesc(...).findFirst()`), so after a host closes the current poll the initial snapshot keeps returning that closed/paused poll as `activePoll`. Reconnecting clients render a stale live poll with a vote form, and every vote is then rejected by `submitVote`.

## Fix

Added `findByEventIdAndStatusOrderByCreatedAtDesc(Long, String)` to `LiveAudiencePollRepository`. `getInitialData` now:

1. Prefers the latest poll with status `active`.
2. Falls back to the latest non-closed poll (e.g. paused) for display-only history.
3. Returns `null` when no such poll exists.

Closed polls are never surfaced as `activePoll`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java`

## Testing

- Added integration test: create poll → close it → `getInitialData` no longer returns it as `activePoll`; reopen it (status → `active`) → it appears again.
- Main sources compile-verified with `javac` (Lombok-processed).

Closes #15299
