### PR TITLE
fix(subtitles): apply language filter to live subtitle broadcasts

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleStreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleStreamController.java
@@ -29,9 +29,12 @@ public class SubtitleStreamController {
     private final SubtitleService subtitleService;
     
     /**
-     * Map of event ID to list of active SSE emitters
+     * Map of event ID to active SSE emitters and their requested target
+     * language. A {@code null} language means the emitter receives subtitles
+     * in every language; a non-null language restricts live delivery to that
+     * language (issue #15335).
      */
-    private final Map<Long, List<SseEmitter>> eventEmitters = new ConcurrentHashMap<>();
+    private final Map<Long, Map<SseEmitter, String>> eventEmitters = new ConcurrentHashMap<>();
     
     /**
      * Map of session ID to list of active SSE emitters
@@ -122,7 +125,7 @@ public class SubtitleStreamController {
         SseEmitter emitter = createEmitter();
         
         // Register emitter with language filter
-        registerEventEmitter(eventId, emitter);
+        registerEventEmitter(eventId, emitter, language);
         
         // Send initial data (active subtitles in the specified language)
         List<Subtitle> subtitles = subtitleService.getSubtitlesByEventId(eventId);
@@ -157,11 +160,18 @@ public class SubtitleStreamController {
     }
     
     /**
-     * Register an emitter for an event
+     * Register an emitter for an event (receives every language)
      */
     private void registerEventEmitter(Long eventId, SseEmitter emitter) {
-        eventEmitters.computeIfAbsent(eventId, k -> new CopyOnWriteArrayList<>()).add(emitter);
-        
+        registerEventEmitter(eventId, emitter, null);
+    }
+
+    /**
+     * Register an emitter for an event, optionally scoped to a target language
+     */
+    private void registerEventEmitter(Long eventId, SseEmitter emitter, String language) {
+        eventEmitters.computeIfAbsent(eventId, k -> new ConcurrentHashMap<>()).put(emitter, language);
+
         log.debug("Registered emitter for event {}", eventId);
     }
     
@@ -178,7 +188,7 @@ public class SubtitleStreamController {
      * Unregister an emitter for an event
      */
     private void unregisterEventEmitter(Long eventId, SseEmitter emitter) {
-        List<SseEmitter> emitters = eventEmitters.get(eventId);
+        Map<SseEmitter, String> emitters = eventEmitters.get(eventId);
         if (emitters != null) {
             emitters.remove(emitter);
             if (emitters.isEmpty()) {
@@ -270,9 +280,13 @@ public class SubtitleStreamController {
      * Broadcast a subtitle to all clients subscribed to an event
      */
     public void broadcastToEvent(Long eventId, Subtitle subtitle) {
-        List<SseEmitter> emitters = eventEmitters.get(eventId);
+        Map<SseEmitter, String> emitters = eventEmitters.get(eventId);
         if (emitters != null) {
-            emitters.forEach(emitter -> sendSubtitle(emitter, subtitle, "subtitle"));
+            emitters.forEach((emitter, language) -> {
+                if (language == null || language.equalsIgnoreCase(subtitle.getTargetLanguage())) {
+                    sendSubtitle(emitter, subtitle, "subtitle");
+                }
+            });
         }
     }
     
@@ -290,9 +304,9 @@ public class SubtitleStreamController {
      * Broadcast an event to all clients subscribed to an event
      */
     public void broadcastEvent(Long eventId, String eventName, Object data) {
-        List<SseEmitter> emitters = eventEmitters.get(eventId);
+        Map<SseEmitter, String> emitters = eventEmitters.get(eventId);
         if (emitters != null) {
-            emitters.forEach(emitter -> {
+            emitters.keySet().forEach(emitter -> {
                 try {
                     emitter.send(SseEmitter.event()
                             .name(eventName)
@@ -322,7 +336,7 @@ public class SubtitleStreamController {
         sessionEmitters.forEach((sessionId, emitters) -> 
             sessionCounts.put(sessionId, emitters.size()));
         
-        stats.put("totalEventConnections", eventEmitters.values().stream().mapToInt(List::size).sum());
+        stats.put("totalEventConnections", eventEmitters.values().stream().mapToInt(Map::size).sum());
         stats.put("totalSessionConnections", sessionEmitters.values().stream().mapToInt(List::size).sum());
         stats.put("activeEvents", eventCounts);
         stats.put("activeSessions", sessionCounts);
@@ -336,10 +350,10 @@ public class SubtitleStreamController {
      */
     @PostMapping("/event/{eventId}/disconnect")
     public ResponseEntity<Map<String, Object>> disconnectEventClients(@PathVariable Long eventId) {
-        List<SseEmitter> emitters = eventEmitters.remove(eventId);
+        Map<SseEmitter, String> emitters = eventEmitters.remove(eventId);
         
         if (emitters != null) {
-            emitters.forEach(emitter -> {
+            emitters.keySet().forEach(emitter -> {
                 try {
                     emitter.complete();
                 } catch (Exception e) {


### PR DESCRIPTION
## Problem

`streamEventSubtitlesByLanguage` only applied the requested language filter to the **initial replay**. The language was never stored per emitter, so `broadcastToEvent`/`notifyEventSubscribers` sent **every** live subtitle in **every** language to all emitters registered for the event. A client connected with `language=es` received Spanish-only subtitles for the first few seconds, then every live subtitle in all languages.

## Fix

- Changed `eventEmitters` from `Map<Long, List<SseEmitter>>` to `Map<Long, Map<SseEmitter, String>>`, storing each emitter's requested target language (`null` = receive every language).
- `streamEventSubtitlesByLanguage` now registers the emitter with its language (`registerEventEmitter(eventId, emitter, language)`).
- `broadcastToEvent` skips subtitles whose `getTargetLanguage()` does not match the emitter's stored language (case-insensitive), so live subtitle delivery honors the requested language.
- `unregisterEventEmitter`, `getConnectionStats`, `broadcastEvent`, and `disconnectEventClients` were updated for the new structure.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleStreamController.java`

## Testing

- Reviewed all `eventEmitters` usages (register/unregister/broadcast/stats/disconnect) against the new `Map<SseEmitter, String>` structure.
- `Subtitle` exposes `getTargetLanguage()` via Lombok `@Getter`, and the filter compares with `equalsIgnoreCase` matching the initial-replay filter.

Closes #15335
