### PR TITLE
fix(matchmaking): surface real primary complementary skill and separate compatibility from complementarity

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/SkillVectorComparator.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/SkillVectorComparator.java
@@ -62,4 +62,27 @@ public class SkillVectorComparator {
 
         return categories > 0 ? Math.min(99.0, Math.max(20.0, (totalGapFilled / categories))) : 50.0;
     }
+
+    /**
+     * Identify the applicant skill that fills the largest gap in the team's
+     * current skill set. Returns "N/A" when no meaningful gap-filling skill
+     * can be determined (#15295).
+     */
+    public String computePrimaryComplementarySkill(Map<String, Integer> teamCurrentSkills, Map<String, Integer> applicantSkills) {
+        if (teamCurrentSkills == null || applicantSkills == null || applicantSkills.isEmpty()) {
+            return "N/A";
+        }
+
+        String primarySkill = null;
+        double bestFill = -1.0;
+        for (Map.Entry<String, Integer> entry : applicantSkills.entrySet()) {
+            int gap = Math.max(0, 100 - teamCurrentSkills.getOrDefault(entry.getKey(), 0));
+            double fill = (gap / 100.0) * entry.getValue();
+            if (fill > bestFill) {
+                bestFill = fill;
+                primarySkill = entry.getKey();
+            }
+        }
+        return primarySkill != null ? primarySkill : "N/A";
+    }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamMatchmakingService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamMatchmakingService.java
@@ -14,12 +14,18 @@ public class TeamMatchmakingService {
     }
 
     public Map<String, Object> proposeSmartTeamMatch(Map<String, Integer> teamSkills, Map<String, Integer> applicantSkills) {
-        double score = skillVectorComparator.computeComplementarityScore(teamSkills, applicantSkills);
+        double complementarityScore = skillVectorComparator.computeComplementarityScore(teamSkills, applicantSkills);
+        double compatibilityScore = skillVectorComparator.computeCosineSimilarity(teamSkills, applicantSkills) * 100.0;
+        String primaryComplementarySkill = skillVectorComparator.computePrimaryComplementarySkill(teamSkills, applicantSkills);
 
         Map<String, Object> result = new HashMap<>();
-        result.put("compatibilityPercentage", Math.round(score));
-        result.put("recommendedMatch", score >= 70.0);
-        result.put("primaryComplementarySkill", "UI/UX & AI");
+        // Compatibility is the match-quality percentage (cosine similarity of the
+        // skill vectors); complementarity is reported separately as the raw
+        // gap-filling score so the two are never conflated (#15295).
+        result.put("compatibilityPercentage", Math.round(compatibilityScore));
+        result.put("complementarityScore", Math.round(complementarityScore));
+        result.put("recommendedMatch", complementarityScore >= 70.0 && compatibilityScore >= 40.0);
+        result.put("primaryComplementarySkill", primaryComplementarySkill);
 
         return result;
     }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/TeamMatchmakingServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/TeamMatchmakingServiceTest.java
@@ -1,0 +1,119 @@
+package com.sandeep.eventrabackend.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TeamMatchmakingServiceTest {
+
+    private final TeamMatchmakingService service = new TeamMatchmakingService(new SkillVectorComparator());
+
+    @Test
+    @DisplayName("primaryComplementarySkill is the skill that fills the largest team gap (#15295)")
+    void primarySkillFillsLargestGap() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        team.put("backend", 80);
+        team.put("devops", 60);
+        Map<String, Integer> applicant = new LinkedHashMap<>();
+        applicant.put("backend", 70);
+        applicant.put("devops", 90);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, applicant);
+
+        assertEquals("devops", result.get("primaryComplementarySkill"));
+    }
+
+    @Test
+    @DisplayName("empty team vector: applicant skill with highest proficiency wins (#15295)")
+    void emptyTeamVectorUsesApplicantStrengths() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        Map<String, Integer> applicant = new LinkedHashMap<>();
+        applicant.put("backend", 90);
+        applicant.put("uiux", 40);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, applicant);
+
+        assertEquals("backend", result.get("primaryComplementarySkill"));
+    }
+
+    @Test
+    @DisplayName("applicant strong in a skill the team lacks entirely is the primary skill (#15295)")
+    void applicantStrongInMissingSkill() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        team.put("backend", 90);
+        Map<String, Integer> applicant = new LinkedHashMap<>();
+        applicant.put("backend", 60);
+        applicant.put("ai-ml", 85);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, applicant);
+
+        assertEquals("ai-ml", result.get("primaryComplementarySkill"));
+    }
+
+    @Test
+    @DisplayName("equal gap fills tie-break to the first encountered skill (#15295)")
+    void tieBreaksToFirstEncounteredSkill() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        team.put("backend", 0);
+        team.put("devops", 0);
+        Map<String, Integer> applicant = new LinkedHashMap<>();
+        applicant.put("backend", 50);
+        applicant.put("devops", 50);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, applicant);
+
+        assertEquals("backend", result.get("primaryComplementarySkill"));
+    }
+
+    @Test
+    @DisplayName("empty applicant skills yield N/A and no recommendation (#15295)")
+    void emptyApplicantSkillsYieldNA() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        team.put("backend", 50);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, new LinkedHashMap<>());
+
+        assertEquals("N/A", result.get("primaryComplementarySkill"));
+    }
+
+    @Test
+    @DisplayName("compatibility and complementarity are reported as distinct metrics (#15295)")
+    void metricsAreNotConflated() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        team.put("backend", 0);
+        team.put("uiux", 90);
+        Map<String, Integer> applicant = new LinkedHashMap<>();
+        applicant.put("backend", 90);
+        applicant.put("uiux", 90);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, applicant);
+
+        assertTrue(result.containsKey("compatibilityPercentage"));
+        assertTrue(result.containsKey("complementarityScore"));
+        assertFalse(result.containsKey("primaryComplementarySkill") && result.get("primaryComplementarySkill").equals("UI/UX & AI"));
+    }
+
+    @Test
+    @DisplayName("recommendedMatch reflects both gap-filling and compatibility (#15295)")
+    void recommendedMatchRequiresBothMetrics() {
+        Map<String, Integer> team = new LinkedHashMap<>();
+        team.put("backend", 0);
+        team.put("ai", 100);
+        team.put("uiux", 100);
+        Map<String, Integer> applicant = new LinkedHashMap<>();
+        applicant.put("backend", 90);
+
+        Map<String, Object> result = service.proposeSmartTeamMatch(team, applicant);
+
+        // High gap-fill (90) but zero overlap with the team's skill set -> low compatibility.
+        assertEquals(90L, result.get("complementarityScore"));
+        assertEquals(0L, result.get("compatibilityPercentage"));
+        assertEquals(Boolean.FALSE, result.get("recommendedMatch"));
+    }
+}


### PR DESCRIPTION
## Problem

`TeamMatchmakingService.proposeSmartTeamMatch` always returns `primaryComplementarySkill: "UI/UX & AI"` regardless of the actual skill vectors, and publishes the complementarity (gap-filling) score under `compatibilityPercentage`, conflating two distinct metrics. The output is invariant to the inputs except for the scalar threshold, so the feature gives no actionable team-formation guidance.

## Fix

- Added `SkillVectorComparator.computePrimaryComplementarySkill(...)`: argmax over `(100 - teamProficiency) * applicantProficiency`, returning `"N/A"` when no meaningful gap-filling skill exists.
- `proposeSmartTeamMatch` now returns:
  - `compatibilityPercentage` — true match quality (cosine similarity of the skill vectors, ×100),
  - `complementarityScore` — the raw gap-filling score (reported separately, no longer conflated),
  - `primaryComplementarySkill` — the actual skill that fills the largest team gap,
  - `recommendedMatch` — derived from both metrics (gap-fill ≥ 70 and compatibility ≥ 40).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/SkillVectorComparator.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/TeamMatchmakingService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/TeamMatchmakingServiceTest.java`

## Testing

- New `TeamMatchmakingServiceTest` with 7 tests: largest-gap selection, empty team vector, applicant strong in a missing skill, deterministic tie-breaking between equal gap fills, empty applicant input → `N/A`, distinct compatibility/complementarity fields, and `recommendedMatch` requiring both metrics. All 7 pass (JUnit 5, run via `javac` + launcher).

Closes #15295
