### PR TITLE
fix(realtime): gate availability polling on SSE and share one poller

### DIFF
--- a/src/hooks/useEventAvailability.js
+++ b/src/hooks/useEventAvailability.js
@@ -20,6 +20,60 @@ const MAX_POLL_EVENTS = 50;
 // Polling fallback interval (ms) used only when SSE is unavailable or fails.
 const POLL_INTERVAL_MS = 15_000;
 
+// ── Shared fallback poller ───────────────────────────────────────────────────
+// A grid of event cards would otherwise create one `setInterval` per card,
+// each firing `GET /api/events/{id}/availability` every 15s (a 50-card listing
+// = 200 req/min from a single client, tripping the backend rate limiter). We
+// keep a single module-level interval that iterates the tracked event ids and
+// notify every subscriber instance, capped at MAX_POLL_EVENTS (issue #15337).
+const pollSubscribers = new Map(); // eventId (String) -> Set<callback>
+let sharedPollTimer = null;
+
+const runSharedPoll = () => {
+  const ids = [...pollSubscribers.keys()].slice(0, MAX_POLL_EVENTS);
+  ids.forEach((eventId) => {
+    eventService
+      .getAvailability(eventId)
+      .then((res) => res.json())
+      .then((body) => {
+        const availability = normalizeEventAvailability(body);
+        const listeners = pollSubscribers.get(String(eventId));
+        if (listeners) {
+          listeners.forEach((cb) => cb(availability));
+        }
+      })
+      .catch(() => {
+        // Keep whatever the UI already has; the next tick / SSE event retries.
+      });
+  });
+};
+
+const subscribeAvailabilityPoll = (eventId, callback) => {
+  const key = String(eventId);
+  let listeners = pollSubscribers.get(key);
+  if (!listeners) {
+    listeners = new Set();
+    pollSubscribers.set(key, listeners);
+  }
+  listeners.add(callback);
+  if (!sharedPollTimer) {
+    sharedPollTimer = setInterval(runSharedPoll, POLL_INTERVAL_MS);
+  }
+  return () => {
+    const set = pollSubscribers.get(key);
+    if (set) {
+      set.delete(callback);
+      if (set.size === 0) {
+        pollSubscribers.delete(key);
+      }
+    }
+    if (pollSubscribers.size === 0 && sharedPollTimer) {
+      clearInterval(sharedPollTimer);
+      sharedPollTimer = null;
+    }
+  };
+};
+
 /**
  * React hook that provides live, real-time event seat availability with a
  * graceful degradation strategy:
@@ -83,7 +137,8 @@ export default function useEventAvailability(eventId, { enabled = true } = {}) {
     setStatus(sseStatus);
   }, [sseStatus]);
 
-  // Initial + SSE fallback polling fetch.
+  // Initial fetch + SSE fallback polling. The recurring poll is shared across
+  // hook instances and only runs while the SSE stream is not connected.
   useEffect(() => {
     if (!enabled || eventId == null) {
       return undefined;
@@ -91,7 +146,6 @@ export default function useEventAvailability(eventId, { enabled = true } = {}) {
 
     const normalizedEventId = String(eventId);
     let isMounted = true;
-    let pollTimer = null;
 
     const fetchAvailability = async () => {
       try {
@@ -111,20 +165,21 @@ export default function useEventAvailability(eventId, { enabled = true } = {}) {
     // Fetch immediately so the UI shows a value before the first SSE event.
     fetchAvailability();
 
-    // Polling fallback: only useful when SSE is not connected. We check the
-    // connection status through the cache-safe path (state update is async),
-    // so we poll unconditionally but at a low frequency.
-    const startPolling = () => {
-      pollTimer = setInterval(fetchAvailability, POLL_INTERVAL_MS);
-    };
-    startPolling();
+    // Polling fallback: only useful while SSE is not connected, and shared so
+    // a grid of N cards produces one interval, not N.
+    const unsubscribePoll =
+      sseStatus === SSE_STATUS.CONNECTED
+        ? () => {}
+        : subscribeAvailabilityPoll(normalizedEventId, (availability) => {
+            setCache((prev) => ({ ...prev, [normalizedEventId]: availability }));
+          });
 
     return () => {
       isMounted = false;
-      if (pollTimer) clearInterval(pollTimer);
+      unsubscribePoll();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [eventId, enabled]);
+  }, [eventId, enabled, sseStatus]);
 
   // Memoised derived value for the tracked event.
   const availability = useMemo(


### PR DESCRIPTION
## Problem

`useEventAvailability` polled the REST availability endpoint unconditionally — even while the SSE stream was connected — and `MAX_POLL_EVENTS` was dead code. Because `EventCard` calls the hook once per card, a grid of N cards produced N `setInterval`s, each firing `GET /api/events/{id}/availability` every 15s (a 50-card listing ≈ 200 req/min from one client), triggering backend 429s and duplicating what SSE already delivers.

## Fix

- **SSE-gated polling**: the polling effect now only subscribes to the recurring poller while `sseStatus !== SSE_STATUS.CONNECTED`; it is cleared when SSE becomes `CONNECTED`. The immediate first fetch (initial value before the first SSE event) is kept.
- **Shared poller**: replaced per-card `setInterval`s with one module-level interval (`subscribeAvailabilityPoll` / `runSharedPoll`) that iterates the tracked event ids and notifies every subscriber instance. A grid of N cards now produces a single interval.
- **`MAX_POLL_EVENTS` cap**: the shared poller only polls the first `MAX_POLL_EVENTS` tracked events (`[...keys()].slice(0, MAX_POLL_EVENTS)`), so the advertised cap is finally applied. The interval is cleared when the last subscriber unregisters.

## Files changed

- `src/hooks/useEventAvailability.js`

## Testing

- `esbuild` transform succeeds (JSX parses).
- With SSE `CONNECTED`, the recurring poller is not subscribed; when SSE drops to `IDLE`/`RECONNECTING`, the hook subscribes to the shared interval and receives fallback updates.
- Multiple hook instances for the same event share one fetch per tick; the interval stops when all instances unmount.

Closes #15337
