### PR TITLE
fix(admin): reject email changes that orphan active JWTs and email-keyed data

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -5,6 +5,7 @@ import com.sandeep.eventrabackend.dto.AdminStatsResponse;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
 import com.sandeep.eventrabackend.dto.response.*;
 import com.sandeep.eventrabackend.exception.RegistrationConflictException;
+import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.Feedback;
 import com.sandeep.eventrabackend.model.Hackathon;
 import com.sandeep.eventrabackend.model.Role;
@@ -133,11 +134,13 @@ public class AdminService {
             targetUser.setUsername(username);
         }
         if (request.getEmail() != null) {
-            String email = request.getEmail().trim().toLowerCase();
-            if (!email.equalsIgnoreCase(targetUser.getEmail()) && userRepository.existsByEmail(email)) {
-                throw new IllegalArgumentException("Email is already taken");
+            String requestedEmail = request.getEmail().trim().toLowerCase();
+            if (!targetUser.getEmail().equalsIgnoreCase(requestedEmail)) {
+                throw new IllegalArgumentException(
+                        "Email changes are not allowed through the admin panel. "
+                                + "Changing an email would orphan the user's active JWT session and email-keyed data. "
+                                + "Email must be changed through a dedicated, verified self-service flow.");
             }
-            targetUser.setEmail(email);
         }
         if (request.getRole() != null && !request.getRole().isBlank()) {
             Role requestedRole = parseRole(request.getRole());

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/AdminServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/AdminServiceTest.java
@@ -1,0 +1,82 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.request.AdminUpdateUserRequest;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private AdminService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminService(userRepository, null, null, null, null, null, null, null, null, null, null, null, null, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticateAsSuperAdmin() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        "admin@example.com", null, List.of(new SimpleGrantedAuthority("SUPER_ADMIN"))));
+    }
+
+    private User user(Long id, String email) {
+        return User.builder().id(id).firstName("Alice").lastName("Doe").username("alice").email(email).password("x").role(Role.ATTENDEE).build();
+    }
+
+    @Test
+    @DisplayName("admin email change is rejected so the JWT and email-keyed data are not orphaned (#15297)")
+    void emailChangeIsRejected() {
+        authenticateAsSuperAdmin();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user(1L, "alice@example.com")));
+
+        AdminUpdateUserRequest request = new AdminUpdateUserRequest();
+        request.setEmail("bob@example.com");
+
+        assertThrows(IllegalArgumentException.class, () -> service.updateUser(1L, request));
+    }
+
+    @Test
+    @DisplayName("sending the current email back is a harmless no-op (#15297)")
+    void sameEmailIsAllowed() {
+        authenticateAsSuperAdmin();
+        User alice = user(1L, "alice@example.com");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(alice));
+        when(userRepository.save(alice)).thenReturn(alice);
+
+        AdminUpdateUserRequest request = new AdminUpdateUserRequest();
+        request.setEmail("ALICE@example.com");
+        request.setFirstName("Alicia");
+
+        assertDoesNotThrow(() -> service.updateUser(1L, request));
+        assertEquals("alice@example.com", alice.getEmail());
+        assertEquals("Alicia", alice.getFirstName());
+    }
+}


### PR DESCRIPTION
## Problem

`AdminService.updateUser` (lines ~135–141) let an admin overwrite a user's email. This backend keys sessions and lookups on the email address:

- The JWT subject (`sub`) is the email, so existing access tokens keep carrying the **old** email until expiry.
- Controllers/services resolve the principal via `findByEmail(authentication.getName())`, so after a change every call with the old token throws → HTTP 500.
- `AuthService.refresh` resolves by email too, so refreshing becomes impossible → the client loses its session mid-session.
- Email-keyed data (notifications, waitlist, newsletter) is orphaned and no longer links to the account.

## Fix

Email changes are **rejected** through the admin panel: `updateUser` now throws `IllegalArgumentException` (→ HTTP 400) whenever the requested email differs from the user's current email, so the admin path can never orphan an active JWT session or email-keyed data. Sending the current email back (case-insensitive) remains a harmless no-op so existing admin clients that round-trip the full profile are unaffected.

The user-id-keyed JWT migration is the long-term path (per the issue), but blocking the admin email overwrite closes the immediate breakage without a risky repo-wide principal migration.

Also added the missing `model.Event` import in `AdminService` (the class used `Event` but never imported it, so it did not compile).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/AdminServiceTest.java` (new)

## Testing

- New `AdminServiceTest` (Mockito): `emailChangeIsRejected` (admin email change → `IllegalArgumentException`, account untouched) and `sameEmailIsAllowed` (round-tripping the same email still succeeds). Both pass.
- `AdminService` closure compiles cleanly with `javac` + Lombok.

Closes #15297
