### PR TITLE
fix(utils): restore parseEventToUTC and sseMultiplexer constants stripped by merge conflict

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -5,6 +5,8 @@ import { SSE_BASE_URL } from "../config/backendConfig.js";
 const MULTIPLEX_CHANNEL_NAME = "eventra_sse_multiplexer";
 const LOCK_NAME = "eventra_sse_leader_lock";
 const HEARTBEAT_KEY = "eventra_sse_leader_heartbeat";
+const LOCAL_STORAGE_CONFIRM_MIN_MS = 25;
+const LOCAL_STORAGE_CONFIRM_JITTER_MS = 75;
 const TAB_ID = Math.random().toString(36).substring(2, 9);
 
 export class SseMultiplexer {

--- a/src/utils/timezoneUtils.js
+++ b/src/utils/timezoneUtils.js
@@ -105,9 +105,9 @@ export const parseEventToUTC = (dateStr, timeStr, timezone) => {
   const [year, month, day] = normalizedDate.split('-').map(Number);
   const { hours, minutes } = parsedTime;
 
-  try {
-    const utcCandidate = Date.UTC(year, month - 1, day, hours, minutes, 0, 0);
+  const targetLocalMs = Date.UTC(year, month - 1, day, hours, minutes, 0, 0);
 
+  try {
     const formatter = new Intl.DateTimeFormat('en-CA', {
       timeZone: tz,
       year: 'numeric',
@@ -125,15 +125,25 @@ export const parseEventToUTC = (dateStr, timeStr, timezone) => {
         formatter.formatToParts(utcCandidate).map((p) => [p.type, p.value])
       );
 
-    const tzYear = parseInt(parts.year, 10);
-    const tzMonth = parseInt(parts.month, 10) - 1;
-    const tzDay = parseInt(parts.day, 10);
-    const tzHour = parseInt(parts.hour, 10) % 24;
-    const tzMinute = parseInt(parts.minute, 10);
+      const tzYear = parseInt(parts.year, 10);
+      const tzMonth = parseInt(parts.month, 10) - 1;
+      const tzDay = parseInt(parts.day, 10);
+      const tzHour = parseInt(parts.hour, 10) % 24;
+      const tzMinute = parseInt(parts.minute, 10);
+      const formattedLocalMs = Date.UTC(
+        tzYear,
+        tzMonth,
+        tzDay,
+        tzHour,
+        tzMinute,
+        0,
+        0
+      );
+      const delta = targetLocalMs - formattedLocalMs;
 
-    const diff =
-      utcCandidate -
-      Date.UTC(tzYear, tzMonth, tzDay, tzHour, tzMinute, 0, 0);
+      if (delta === 0) return utcCandidate;
+      utcCandidate += delta;
+    }
 
     return utcCandidate;
   } catch {


### PR DESCRIPTION
## Problem

Two regression bugs on master both break the test/build pipeline and are caused by conflicted merges:

1. **`src/utils/timezoneUtils.js`** — merge `3fba4220b` botched `parseEventToUTC`: a duplicate `const`/`let utcCandidate` declaration and an undefined `targetLocalMs` make the file a **SyntaxError**. This crashes *every* vitest component suite that imports it (`EventCard`, date formatting, etc.).

2. **`src/utils/sseMultiplexer.js`** — commit `d2d63e0ec` removed the `LOCAL_STORAGE_CONFIRM_MIN_MS` / `LOCAL_STORAGE_CONFIRM_JITTER_MS` constants while line 158 still uses them → `ReferenceError` at runtime. This is the "broken localStorage election confirmation" regression from #11144 — the token/ownership verification logic is intact, only the confirmation-delay constants were lost.

## Fix

1. Restore the correct iterative `parseEventToUTC` algorithm from the merge's parent (`bae7a3bb5`): a single `const targetLocalMs` computed once, plus a bounded `for` loop that shifts `utcCandidate` by the offset delta until the formatted local time matches.
2. Re-add `LOCAL_STORAGE_CONFIRM_MIN_MS = 25` and `LOCAL_STORAGE_CONFIRM_JITTER_MS = 75` to `sseMultiplexer.js`.

## Files changed

- `src/utils/timezoneUtils.js` — restored `parseEventToUTC`
- `src/utils/sseMultiplexer.js` — restored two constants

## Testing

- `node --check` passes on both files
- `npx vitest run src/utils/timezoneUtils.test.js` → 4/4 pass
- `npm test` → same result as clean `origin/master` (5 pre-existing failures tracked separately, e.g. #14573; no new failures)

Closes #11144
