### PR TITLE
test(events): update EventCard bookmark tests for useBookmarks refactor

### DIFF
--- a/src/Pages/Events/EventCard.test.js
+++ b/src/Pages/Events/EventCard.test.js
@@ -25,9 +25,10 @@ jest.mock('context/AuthContext', () => ({
   useAuth: jest.fn().mockReturnValue({ user: null }),
 }));
 
-jest.mock('hooks/useBookmarks', () => ({
-  __esModule: true,
-  default: jest.fn(),
+jest.mock('utils/bookmarkUtils', () => ({
+  isEventBookmarked: jest.fn().mockReturnValue(false),
+  addBookmarkedEvent: jest.fn(),
+  removeBookmarkedEvent: jest.fn(),
 }));
 
 jest.mock('utils/conflictDetection', () => ({
@@ -75,13 +76,8 @@ const renderCard = (eventOverrides = {}) =>
   );
 
 const { checkRegistrationConflict } = require('utils/conflictDetection');
-const useBookmarks = require('hooks/useBookmarks').default;
+const { isEventBookmarked, addBookmarkedEvent, removeBookmarkedEvent } = require('utils/bookmarkUtils');
 const { useMyEvents } = require('context/MyEventsContext');
-
-const defaultBookmarks = () => ({
-  isBookmarked: jest.fn().mockReturnValue(false),
-  toggleBookmark: jest.fn(),
-});
 
 const defaultMyEvents = () => ({ myEvents: [], isRegistered: () => false });
 
@@ -90,7 +86,7 @@ describe('EventCard', () => {
     jest.clearAllMocks();
     getEventStatus.mockReturnValue('upcoming');
     checkRegistrationConflict.mockReturnValue({ hasConflict: false });
-    useBookmarks.mockReturnValue(defaultBookmarks());
+    isEventBookmarked.mockReturnValue(false);
     useMyEvents.mockReturnValue(defaultMyEvents());
   });
 
@@ -171,29 +167,24 @@ describe('EventCard', () => {
   describe('bookmark interaction', () => {
     const { toast } = require('react-toastify');
 
-    it('calls toggleBookmark and shows toast when bookmarking an unbookmarked event', async () => {
-      const toggleBookmark = jest.fn();
-      useBookmarks.mockReturnValue({
-        isBookmarked: jest.fn().mockReturnValue(false),
-        toggleBookmark,
-      });
+    it('bookmarks an unbookmarked event and shows the success toast without throwing', async () => {
+      isEventBookmarked.mockReturnValue(false);
       renderCard();
       const user = userEvent.setup();
       await user.click(screen.getByRole('button', { name: /bookmark event/i }));
-      expect(toggleBookmark).toHaveBeenCalledTimes(1);
-      expect(toast.success).toHaveBeenCalled();
+      expect(addBookmarkedEvent).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }));
+      expect(toast.success).toHaveBeenCalledWith(
+        'Event saved!',
+        expect.objectContaining({ toastId: 'bookmark-42' })
+      );
     });
 
-    it('calls toggleBookmark and shows info toast when removing a bookmark', async () => {
-      const toggleBookmark = jest.fn();
-      useBookmarks.mockReturnValue({
-        isBookmarked: jest.fn().mockReturnValue(true),
-        toggleBookmark,
-      });
+    it('unbookmarks a bookmarked event and shows the info toast', async () => {
+      isEventBookmarked.mockReturnValue(true);
       renderCard();
       const user = userEvent.setup();
-      await user.click(screen.getByRole('button', { name: /remove event bookmark/i }));
-      expect(toggleBookmark).toHaveBeenCalledWith(expect.objectContaining({ id: 42 }));
+      await user.click(screen.getByRole('button', { name: /remove bookmark/i }));
+      expect(removeBookmarkedEvent).toHaveBeenCalledWith(42);
       expect(toast.info).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Problem

Issue #15331: after the bookmark feature refactor (PR #15308, `954afa88c`), `EventCard` no longer uses `useBookmarks` — it calls `addBookmarkedEvent` / `removeBookmarkedEvent` / `isEventBookmarked` from `utils/bookmarkUtils` directly and manages its own toast. The existing `EventCard.test.js` still mocks the removed `hooks/useBookmarks` and asserts on the old `toggleBookmark` contract, so the bookmark interaction tests no longer test the real behavior.

Additionally, the second test used a stale accessible-name selector `/remove event bookmark/i`; the actual button aria-label is `"Remove bookmark"`, so that test could not find the button.

## Fix

Update `EventCard.test.js` to mock `utils/bookmarkUtils` and assert the real post-refactor behavior:

- Bookmarking a saved event calls `addBookmarkedEvent` with the event (`{ id: 42 }`) and shows the `"Event saved!"` toast with `toastId: "bookmark-42"`.
- Removing a bookmark calls `removeBookmarkedEvent(42)` and shows the info toast.
- Fixed the stale selector to `/remove bookmark/i`.
- Dropped the obsolete `defaultBookmarks()` / `toggleBookmark` scaffolding and reverted `isEventBookmarked` in the `beforeEach`.

## Files changed

- `src/Pages/Events/EventCard.test.js`

## Testing

Behavior verified against the live component with a vitest 4 probe (bookmark + unbookmark paths): assertions on `addBookmarkedEvent({ id: 42 })`, `toast.success("Event saved!", { toastId: "bookmark-42" })`, and `removeBookmarkedEvent(42)` all pass against the current `EventCard.js`. No production code changed.

Closes #15331
