### PR TITLE
fix(share): implement Messenger Send Dialog using configured Facebook App ID (#15303)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,11 @@ REACT_APP_USE_REAL_API=false
 # Get yours at: https://console.cloud.google.com > APIs & Services > Credentials
 REACT_APP_GOOGLE_CLIENT_ID=your_google_client_id_here
 
+# Optional: Facebook App ID for Messenger share dialog (src/utils/shareUtils.js)
+# Required for the "messenger" share option; when unset the option is disabled.
+# Get yours at: https://developers.facebook.com > Apps > Your App > App settings
+REACT_APP_FB_APP_ID=
+
 # ============================================
 # Backend Configuration Notes
 # ============================================

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -22,6 +22,10 @@ const optionalEnvVars = {
     keys: ["VITE_SENTRY_DSN", "REACT_APP_SENTRY_DSN"],
     fallback: "", // No fallback — absence means Sentry is intentionally disabled
   },
+  FB_APP_ID: {
+    keys: ["VITE_FB_APP_ID", "REACT_APP_FB_APP_ID"],
+    fallback: "", // No fallback — absence means Messenger sharing is disabled
+  },
 };
 
 const getFirstDefinedEnvValue = (keys = []) => {
@@ -93,11 +97,20 @@ export const ENV = {
     optionalEnvVars.PUBLIC_URL.keys,
     optionalEnvVars.PUBLIC_URL.fallback
   ),
+  FB_APP_ID: getEnvVar(
+    optionalEnvVars.FB_APP_ID.keys,
+    optionalEnvVars.FB_APP_ID.fallback
+  ),
 };
 
 export const SENTRY_DSN = getEnvVar(
   optionalEnvVars.SENTRY_DSN.keys,
   optionalEnvVars.SENTRY_DSN.fallback
+);
+
+export const FB_APP_ID = getEnvVar(
+  optionalEnvVars.FB_APP_ID.keys,
+  optionalEnvVars.FB_APP_ID.fallback
 );
 
 export const isSentryEnabled = Boolean(SENTRY_DSN && currentMode === "production");

--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -93,11 +93,15 @@ export const generateSharingUrl = (shareData, platform) => {
       return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
 
     case "messenger":
-      // Messenger sharing requires a Facebook App ID (app_id parameter) which
-      // is not available in this client-side configuration.
-      // Callers should hide or disable the Messenger share button.
-      console.warn("[shareUtils] Messenger sharing is not supported — no Facebook App ID configured.");
-      return "";
+      // Facebook Send Dialog. The redirect_uri is always the validated Eventra
+      // URL (isValidShareUrl above guarantees same-origin), so it cannot be
+      // abused as an open redirect by a crafted share payload.
+      const fbAppId = ENV.FB_APP_ID;
+      if (!fbAppId) {
+        console.warn("[shareUtils] Missing REACT_APP_FB_APP_ID environment variable for Messenger sharing.");
+        return "";
+      }
+      return `https://www.facebook.com/dialog/send?link=${encodedUrl}&app_id=${encodeURIComponent(fbAppId)}&redirect_uri=${encodedUrl}`;
 
     case "linkedin":
       return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}&title=${encodedTitle}&summary=${encodedDescription}`;

--- a/tests/shareUtils.test.mjs
+++ b/tests/shareUtils.test.mjs
@@ -31,7 +31,7 @@ assert.ok(fbUrl.startsWith("https://www.facebook.com/sharer/sharer.php"));
 assert.ok(fbUrl.includes(encodeURIComponent(shareData.url)));
 
 const messengerUrl = generateSharingUrl(shareData, "messenger");
-assert.equal(messengerUrl, "", "messenger sharing is intentionally disabled");
+assert.equal(messengerUrl, "", "messenger falls back to empty when REACT_APP_FB_APP_ID is not set");
 
 const liUrl = generateSharingUrl(shareData, "linkedin");
 assert.ok(liUrl.startsWith("https://www.linkedin.com/sharing/share-offsite/"));

--- a/tests/shareUtilsMessenger.test.mjs
+++ b/tests/shareUtilsMessenger.test.mjs
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for the Messenger share dialog in src/utils/shareUtils.js
+ * Run in a separate test file so env.js loads with REACT_APP_FB_APP_ID set.
+ */
+
+import assert from "node:assert/strict";
+
+process.env.REACT_APP_FB_APP_ID = "123456789";
+
+const { generateSharingUrl } = await import("../src/utils/shareUtils.js");
+
+const shareData = {
+  title: "Tech Summit 2024",
+  description: "Annual tech conference",
+  url: "/events/99",
+  hashtags: "tech,summit",
+};
+
+const messengerUrl = generateSharingUrl(shareData, "messenger");
+assert.ok(
+  messengerUrl.startsWith("https://www.facebook.com/dialog/send"),
+  "messenger URL must use the Facebook Send Dialog"
+);
+assert.ok(messengerUrl.includes(`app_id=${encodeURIComponent("123456789")}`), "app_id must be present");
+assert.ok(messengerUrl.includes(`link=${encodeURIComponent(shareData.url)}`), "link must be the encoded share URL");
+assert.ok(messengerUrl.includes(`redirect_uri=${encodeURIComponent(shareData.url)}`), "redirect_uri must be the encoded share URL");
+
+console.log("All messenger share tests passed");


### PR DESCRIPTION
## Problem

The Messenger share option in the share menu is broken. `generateSharingUrl` in `src/utils/shareUtils.js` returns an empty string for the `"messenger"` platform with only a console warning, so users who choose "Messenger" from the share menu get no share link at all.

## Fix

Implement the Facebook Send Dialog for Messenger sharing using a Facebook App ID. The app ID is read from a new optional environment variable so the feature is disabled (button falls back gracefully) until the operator configures it:

- `src/config/env.js` — add `FB_APP_ID` to `optionalEnvVars` (resolved from `VITE_FB_APP_ID` or `REACT_APP_FB_APP_ID`) and expose it both on the exported `ENV` object and as a named export, following the existing env convention.
- `src/utils/shareUtils.js` — the `"messenger"` case now returns a Facebook Send Dialog URL: `https://www.facebook.com/dialog/send?link=...&app_id=...&redirect_uri=...`. The `link`/`redirect_uri` reuse the already same-origin-validated share URL (guaranteed by `isValidShareUrl` above), so a crafted payload cannot be used as an open redirect. When no app ID is configured, it warns and returns `""` (as before).
- `.env.example` — document `REACT_APP_FB_APP_ID=`.
- `tests/shareUtilsMessenger.test.mjs` — new test that sets `REACT_APP_FB_APP_ID` before loading `env.js` and asserts the Send Dialog URL, `app_id`, `link`, and `redirect_uri` query parameters.
- `tests/shareUtils.test.mjs` — note that when the env var is absent the messenger case still returns `""` with a warning (unchanged behavior).

## Files changed

- `src/config/env.js`
- `src/utils/shareUtils.js`
- `.env.example`
- `tests/shareUtilsMessenger.test.mjs` (new)
- `tests/shareUtils.test.mjs`

## Testing

- `node --import ./tests/setup.js "tests\shareUtilsMessenger.test.mjs"` — passes (asserts Send Dialog URL + query params).
- `node --test "tests\shareUtils.test.mjs"` — only pre-existing unrelated failure remains (line 77 asserts `sandeepvashishtha.tech` while the env fallback yields `.in`); messenger fallback path still returns `""` with a warning.

Closes #15303
