### PR TITLE
fix(visual): add missing AuroraBackground stylesheet

### DIFF
--- a/src/components/visual/AuroraBackground.css
+++ b/src/components/visual/AuroraBackground.css
@@ -1,0 +1,87 @@
+.aurora-bg {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.aurora-layer {
+  position: absolute;
+  width: 120%;
+  height: 120%;
+  top: -10%;
+  left: -10%;
+  opacity: 0.35;
+  mix-blend-mode: screen;
+  filter: blur(60px);
+  will-change: transform, opacity;
+}
+
+.aurora-layer.layer-1 {
+  background: radial-gradient(
+    ellipse at 20% 20%,
+    rgba(99, 102, 241, 0.8) 0%,
+    transparent 60%
+  );
+  animation: aurora-drift-1 18s ease-in-out infinite;
+}
+
+.aurora-layer.layer-2 {
+  background: radial-gradient(
+    ellipse at 80% 30%,
+    rgba(236, 72, 153, 0.7) 0%,
+    transparent 60%
+  );
+  animation: aurora-drift-2 22s ease-in-out infinite;
+}
+
+.aurora-layer.layer-3 {
+  background: radial-gradient(
+    ellipse at 50% 80%,
+    rgba(16, 185, 129, 0.7) 0%,
+    transparent 60%
+  );
+  animation: aurora-drift-3 26s ease-in-out infinite;
+}
+
+@keyframes aurora-drift-1 {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.35;
+  }
+  50% {
+    transform: translate3d(6%, -4%, 0) scale(1.1);
+    opacity: 0.5;
+  }
+}
+
+@keyframes aurora-drift-2 {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.1);
+    opacity: 0.3;
+  }
+  50% {
+    transform: translate3d(-5%, 5%, 0) scale(1);
+    opacity: 0.45;
+  }
+}
+
+@keyframes aurora-drift-3 {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.3;
+  }
+  50% {
+    transform: translate3d(4%, -6%, 0) scale(1.15);
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-layer {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Problem

`src/components/visual/AuroraBackground.jsx` line 1 imports `./AuroraBackground.css`, but that stylesheet does not exist in `src/components/visual/`. Any bundler importing the component fails with a missing-module resolution error. The fix from the closed issue #10293 never landed on `master`.

## Fix

Added `src/components/visual/AuroraBackground.css`, styling the exact class names the component renders (`aurora-bg`, `aurora-layer`, `layer-1`, `layer-2`, `layer-3`). The stylesheet matches the component's documented behavior:
- Three overlapping radial-gradient layers that drift slowly for an aurora-like effect.
- GPU-friendly animation using only `transform` and `opacity` (`will-change` hint included).
- Respects `prefers-reduced-motion` by disabling the animation.

## Files changed

- `src/components/visual/AuroraBackground.css` (new)

## Testing

- Verified `AuroraBackground.jsx` references only the three class names that the new stylesheet defines (`aurora-bg`, `aurora-layer`, `layer-1/2/3`).
- Confirmed no other aurora styles exist in `src/`, so this is the only stylesheet backing the component.

Closes #15342
