### PR TITLE
fix(recommendations): repair trending engine and add decay, urgency, and MMR unit tests (#15309)

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -437,10 +437,11 @@ export const calculateRecommendationScore = (
   };
 };
 
-export const getTrendingEventsForArea = (events = [], location = "", limit = 4) =>
-  [...events]
+export const getTrendingEventsForArea = (events = [], location = "", limit = 4) => {
+  const matchesArea = createLocationMatcher(location);
+  return [...events]
     .filter((event) => !calculateTemporalUrgencyScore(event.date || event.startDate).isExpired)
-    .filter((event) => eventMatchesArea(event, location) || event.eventMode === "online")
+    .filter((event) => matchesArea(normalizeText(event?.location)) || event.eventMode === "online")
     .map((event) => ({
       ...event,
       trendingScore: Math.round(getPopularityScore(event) * 10),

--- a/tests/recommendationEngine.test.mjs
+++ b/tests/recommendationEngine.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import {
+  applyMaximalMarginalRelevance,
+  applyTimeDecay,
   buildInteractionProfile,
   buildPersonalizedRecommendations,
+  calculateDiversitySimilarity,
   calculateRecommendationScore,
+  calculateTemporalUrgencyScore,
   getTrendingEventsForArea,
 } from "../src/utils/recommendationEngine.js";
 
@@ -91,5 +95,131 @@ assert(recommendations[0].recommendationReasons.length > 0);
 const localTrending = getTrendingEventsForArea(events, "San Francisco", 2);
 assert.equal(localTrending[0].id, 1);
 assert(localTrending.every((event) => typeof event.trendingScore === "number"));
+
+// ===========================================================================
+// Time decay (e^(-lambda * age), half-life = 14 days by default)
+// ===========================================================================
+
+const NOW = Date.now();
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+assert(Math.abs(applyTimeDecay(new Date(NOW - 1000)) - 1) < 0.01, "recent interaction should have ~full weight");
+assert(Math.abs(applyTimeDecay(new Date(NOW - 14 * DAY_MS)) - 0.5) < 0.02, "interaction at half-life should decay to ~0.5");
+assert(Math.abs(applyTimeDecay(new Date(NOW - 28 * DAY_MS)) - 0.25) < 0.02, "interaction at two half-lives should decay to ~0.25");
+assert(Math.abs(applyTimeDecay(new Date(NOW + 5 * DAY_MS)) - 1) < 0.01, "future timestamps should be treated as full weight");
+assert.equal(applyTimeDecay(null), 1, "missing timestamps should not decay");
+assert.equal(applyTimeDecay("not-a-date"), 1, "invalid timestamps should not decay");
+
+// Decay feeds into interaction weights
+const decayedProfile = buildInteractionProfile({
+  viewedEvents: [{ ...events[0], createdAt: new Date(NOW - 14 * DAY_MS).toISOString() }],
+});
+assert(
+  Math.abs(decayedProfile.categories["web development"] - 1 * 0.5) < 0.02,
+  "decay factor should scale interaction weights",
+);
+
+// ===========================================================================
+// Temporal urgency & expiration filtering
+// ===========================================================================
+
+assert(
+  calculateTemporalUrgencyScore(new Date(NOW - 7 * DAY_MS)).isExpired === true,
+  "past events should be flagged as expired",
+);
+assert(
+  calculateTemporalUrgencyScore(new Date(NOW - 7 * DAY_MS)).score === 0,
+  "expired events should score 0 for urgency",
+);
+assert.equal(
+  calculateTemporalUrgencyScore(new Date(NOW + 60 * 60 * 1000)).score,
+  10,
+  "events starting within 24h should get the max urgency score",
+);
+assert(
+  calculateTemporalUrgencyScore(new Date(NOW + 7 * DAY_MS)).score > 0,
+  "events starting within 1-14 days should get a proximity boost",
+);
+assert(
+  calculateTemporalUrgencyScore(new Date(NOW + 7 * DAY_MS)).score < 10,
+  "events further out should get a smaller proximity boost",
+);
+assert.equal(
+  calculateTemporalUrgencyScore(new Date(NOW + 30 * DAY_MS)).score,
+  2,
+  "distant upcoming events should keep a small baseline score",
+);
+
+// Expired events are excluded from recommendation results
+const expiredEvent = { ...events[1], id: 99, date: new Date(NOW - 2 * DAY_MS).toISOString() };
+const expiredScore = calculateRecommendationScore(expiredEvent, {}, {});
+assert.equal(expiredScore.score, 0, "expired events should be excluded from scoring");
+assert.equal(expiredScore.isExpired, true, "expired events should be flagged");
+
+// ===========================================================================
+// MMR diversity re-ranking
+// ===========================================================================
+
+const makeScored = (id, category, tags, score) => ({
+  id,
+  category,
+  title: id,
+  tags,
+  recommendationScore: score,
+});
+const homogenous = [
+  makeScored("a", "Web", ["React", "JS"], 100),
+  makeScored("b", "Web", ["React", "JS"], 100),
+  makeScored("c", "AI", ["Python"], 100),
+  makeScored("d", "Cloud", ["K8s"], 100),
+];
+
+const diverse = applyMaximalMarginalRelevance(homogenous, 0.7, 4);
+assert.equal(diverse.length, 4, "MMR should return up to the requested limit");
+assert.equal(diverse[0].id, "a", "highest relevance item should come first");
+assert(
+  diverse[1].id !== "b",
+  "MMR should prefer a diverse second item over a redundant duplicate",
+);
+assert(
+  diverse[3].id === "b",
+  "the redundant duplicate should be pushed to the end by diversity re-ranking",
+);
+
+const relevanceOnly = applyMaximalMarginalRelevance(homogenous, 1.0, 4);
+assert.equal(relevanceOnly[0].id, "a", "lambda=1.0 keeps pure relevance ordering");
+
+const bounded = applyMaximalMarginalRelevance(homogenous, 0.7, 2);
+assert.equal(bounded.length, 2, "MMR should respect the limit");
+
+// Diversity distance between similar vs dissimilar events
+const same = calculateDiversitySimilarity(
+  makeScored("a", "Web", ["React", "JS"], 100),
+  makeScored("b", "Web", ["React", "JS"], 100),
+);
+const different = calculateDiversitySimilarity(
+  makeScored("a", "Web", ["React", "JS"], 100),
+  makeScored("d", "Cloud", ["K8s"], 100),
+);
+assert(same > different, "similar events should have a higher diversity distance than unrelated ones");
+assert(different === 0, "unrelated events should have zero similarity");
+
+// ===========================================================================
+// Cold-start fallback: no interaction history -> popularity/trending path
+// ===========================================================================
+
+const coldStart = buildPersonalizedRecommendations({
+  events,
+  userProfile: { interests: ["AI & Machine Learning"] },
+  registeredEvents: [],
+  bookmarkedEvents: [],
+  viewedEvents: [],
+  location: "",
+});
+assert(coldStart.length > 0, "cold-start users should still receive recommendations");
+assert(
+  coldStart.every((event) => event.recommendationScore > 0),
+  "cold-start recommendations should all be positively scored",
+);
 
 console.log("recommendationEngine tests passed ✓");


### PR DESCRIPTION
## Problem

The recommendation engine already contained the time-decay, temporal-urgency, and MMR diversity implementation, but the module was unparseable on `master`: a bad merge (`46ca3b1bc`) left `getTrendingEventsForArea` referencing the removed `eventMatchesArea` helper and a stray `};` brace, producing a `SyntaxError` at module load (`Unexpected token '}'`, line 450). The engine's new capabilities also had no unit-test coverage for decay calculations, expiration filtering, or MMR diversity scoring.

## Fix

- `src/utils/recommendationEngine.js` — repair `getTrendingEventsForArea` to use the current `createLocationMatcher` API (matching how `calculateRecommendationScore` already consumes it) and remove the stray closing brace so the module parses again.
- `tests/recommendationEngine.test.mjs` — add unit tests covering the acceptance criteria:
  - **Time decay**: half-life decay at 14/28 days ≈ 0.5/0.25, full weight for recent/future/invalid/missing timestamps, and that the decay factor scales interaction weights in `buildInteractionProfile`.
  - **Temporal urgency**: past events flagged `isExpired` with zero score, max boost within 24h, graded proximity boost within 1–14 days, baseline for distant events, and exclusion of expired events from `calculateRecommendationScore`.
  - **MMR diversity**: greedy re-ranking pushes redundant duplicates to the end while keeping top relevance first, `lambda = 1.0` preserves pure-relevance ordering, limit is respected, and `calculateDiversitySimilarity` is higher for similar events and zero for unrelated ones.
  - **Cold-start fallback**: a user with no interaction history still receives positively scored recommendations.

## Files changed

- `src/utils/recommendationEngine.js`
- `tests/recommendationEngine.test.mjs`

## Testing

- `node --test "tests\recommendationEngine.test.mjs"` — all assertions pass (1 test, 0 failures).
- `node --check src/utils/recommendationEngine.js` — clean parse.

Closes #15309
