### PR TITLE
fix(theme): import missing useAuth/themeSync in ThemeContext

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -11,6 +11,8 @@ import { MotionConfig } from "framer-motion";
 import { THEMES } from "../components/styles/theme";
 import { useReducedMotion } from "../hooks/useReducedMotion";
 import { safeJsonParse } from "../utils/safeJsonParse";
+import { useAuth } from "../context/AuthContext";
+import { getProfileTheme, syncThemeToProfile } from "../utils/themeSync";
 const THEME_STORAGE_KEY = "eventra_theme";
 
 export const ThemeContext = createContext(null);


### PR DESCRIPTION
﻿## Problem

Closes #15358

## Fix

Adds the missing imports (useAuth from AuthContext, getProfileTheme/syncThemeToProfile from utils/themeSync) that ThemeProvider already calls, so the app root no longer throws ReferenceError on mount.

## Files changed

- src/context/ThemeContext.js

## Testing

- Backend: verified the referenced methods/endpoints exist and call sites resolve; full backend compile is separately blocked by a pre-existing baseline error in SvgSanitizationService.java (#15281), unrelated to this change.
- Frontend: import-only changes; verified identifiers are used at their call sites.
