### PR TITLE
fix(hackathons): import missing useEventFilters hook

### DIFF
--- a/src/Pages/Hackathons/HackathonPage.js
+++ b/src/Pages/Hackathons/HackathonPage.js
@@ -17,6 +17,7 @@ import { filterHackathons } from "./hackathonFilterUtils.mjs";
 import { HackathonCardSkeleton } from "components/common/SkeletonLoaders";
 import useReducedMotion from "hooks/useReducedMotion.js";
 import useDebounce from "hooks/useDebounce";
+import useEventFilters from "hooks/useEventFilters";
 import ErrorBoundary from "components/common/ErrorBoundary";
 import { safeJsonParse } from "utils/safeJsonParse";
 


### PR DESCRIPTION
﻿## Problem

Closes #15359

## Fix

Imports the default-exported useEventFilters hook so the /hackathons route stops throwing ReferenceError and hydrates URL/storage filters.

## Files changed

- src/Pages/Hackathons/HackathonPage.js

## Testing

- Backend: verified the referenced methods/endpoints exist and call sites resolve; full backend compile is separately blocked by a pre-existing baseline error in SvgSanitizationService.java (#15281), unrelated to this change.
- Frontend: import-only changes; verified identifiers are used at their call sites.
