### PR TITLE
fix(settings): import missing useRef/useEffect

### DIFF
--- a/src/Pages/Settings.js
+++ b/src/Pages/Settings.js
@@ -1,5 +1,5 @@
 import useUserPreferences from "hooks/useUserPreferences";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Sun, MousePointer, Bell, ShieldCheck, ArrowRight, Key, Eye, EyeOff, Clipboard, Download, ShieldAlert, RefreshCw, SlidersHorizontal } from "lucide-react";
 import useDocumentTitle from "../hooks/useDocumentTitle";


### PR DESCRIPTION
﻿## Problem

Closes #15360

## Fix

Adds useRef and useEffect to the React import so the /settings page mounts and the autosave/cleanup logic works.

## Files changed

- src/Pages/Settings.js

## Testing

- Backend: verified the referenced methods/endpoints exist and call sites resolve; full backend compile is separately blocked by a pre-existing baseline error in SvgSanitizationService.java (#15281), unrelated to this change.
- Frontend: import-only changes; verified identifiers are used at their call sites.
