### PR TITLE
fix(home): correct ContributorsCarousel import depth and render it on HomePage

### DIFF
--- a/src/Pages/Home/HomePage.jsx
+++ b/src/Pages/Home/HomePage.jsx
@@ -8,6 +8,7 @@ import RecommendationBanner from "./components/RecommendationBanner";
 import TrendingEvents from "components/TrendingEvents/TrendingEvents";
 import CollaborationNetworkMap from "components/visual/CollaborationNetworkMap";
 import CollaborationMap from "components/CollaborationMap";
+import ContributorsCarousel from "./components/ContributorsCarousel";
 import useHomeEventsData from "./hooks/useHomeEventsData";
 import useDocumentTitle from "hooks/useDocumentTitle";
 
@@ -71,6 +72,7 @@ const HomePage = () => {
       <RecommendationBanner />
       <CollaborationNetworkMap />
       <CollaborationMap />
+      <ContributorsCarousel />
       <HomeCTA />
     </main>
   );

--- a/src/Pages/Home/components/ContributorsCarousel.js
+++ b/src/Pages/Home/components/ContributorsCarousel.js
@@ -2,12 +2,12 @@ import useWindowSize from "hooks/useWindowSize";
 import { GitBranch, ChevronLeft, ChevronRight } from "lucide-react";
 import { FaMedal, FaCodeBranch, FaUserFriends, FaBuilding, FaMapMarkerAlt, FaGithub, FaExternalLinkAlt } from "react-icons/fa";
 import { useState, useEffect, useCallback, useRef, memo } from "react";
-import useReducedMotion from "../../hooks/useReducedMotion";
+import useReducedMotion from "../../../hooks/useReducedMotion";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
-import { fetchWithTimeout } from "../../utils/fetchWithTimeout";
-import { ContributorCardSkeleton } from "../../components/common/SkeletonLoaders";
-import { safeJsonParse } from "../../utils/safeJsonParse";
+import { fetchWithTimeout } from "../../../utils/fetchWithTimeout";
+import { ContributorCardSkeleton } from "../../../components/common/SkeletonLoaders";
+import { safeJsonParse } from "../../../utils/safeJsonParse";
 
 // GitHub repo
 const GITHUB_REPO = "sandeepvashishtha/Eventra";


### PR DESCRIPTION
## Problem

`src/Pages/Home/components/ContributorsCarousel.js` had four relative imports at the wrong depth, and the component was never rendered anywhere in the app:

- `useReducedMotion`, `fetchWithTimeout`, `SkeletonLoaders`, and `safeJsonParse` were imported via `../../` — from `src/Pages/Home/components/` that resolves to `src/Pages/`, but the modules live under `src/` (`src/hooks/`, `src/utils/`, `src/components/common/`). The prior fix (commit `75c1dd568`, #14146) only changed `../` to `../../`, which is still one level too shallow, so the imports remained unresolvable.
- The component was removed from `HomePage` during the framer-motion refactor (commit `9eecf3b6d`) and never wired back in, leaving it orphaned dead code.

## Fix

- Corrected the four imports to `../../../` so they resolve to `src/hooks/useReducedMotion`, `src/utils/fetchWithTimeout`, `src/components/common/SkeletonLoaders`, and `src/utils/safeJsonParse` — matching the depth used by sibling components (`WhatsHappening.js`, `GitHubStats.jsx`).
- Re-wired `ContributorsCarousel` into the Home page (`HomePage.jsx`), rendering it between `CollaborationMap` and `HomeCTA` so the contributors section is reachable again.

## Files changed

- `src/Pages/Home/components/ContributorsCarousel.js` (import depth fix)
- `src/Pages/Home/HomePage.jsx` (import + render `ContributorsCarousel`)

## Testing

- `esbuild` bundle of `ContributorsCarousel.js` (JSX loader) resolves cleanly with no errors.
- `eslint` on both changed files: 0 errors.
- Verified the four targets exist at the corrected paths: `src/hooks/useReducedMotion.js`, `src/utils/fetchWithTimeout.js`, `src/components/common/SkeletonLoaders.jsx`, `src/utils/safeJsonParse.js`.

Closes #15343
