### PR TITLE
fix(issue-15432): remove stray closing braces in compressor.js

### DIFF
--- a/src/utils/compressor.js
+++ b/src/utils/compressor.js
@@ -2,8 +2,7 @@ export const simpleCompress = (str) => {
   try {
     return btoa(encodeURIComponent(str));
   } catch (err) {
-      console.warn("[compressor] Compression failed:", err);
-    }
+    console.warn("[compressor] Compression failed:", err);
     return str;
   }
 };
@@ -12,8 +11,7 @@ export const simpleDecompress = (compressed) => {
   try {
     return decodeURIComponent(atob(compressed));
   } catch (err) {
-      console.warn("[compressor] Compression failed:", err);
-    }
+    console.warn("[compressor] Compression failed:", err);
     return compressed;
   }
 };


### PR DESCRIPTION
﻿## Problem

src/utils/compressor.js fails to parse due to stray closing braces in both exported functions. The try/catch block closes the function too early and an orphaned } remains, causing esbuild to report SyntaxError: Unexpected "}".

## Fix

Moved the return str / return compressed statements inside the catch blocks and removed the stray closing braces so both simpleCompress and simpleDecompress parse correctly and fall back to the original string on compression/decompression failure.

## Files changed

- src/utils/compressor.js

## Testing

- node --check src/utils/compressor.js — clean parse
- npx esbuild src/utils/compressor.js — no transform errors

Closes #15432
