### PR TITLE
fix(issue-15437): escape apostrophe in SPLTopographyMapping.jsx

### DIFF
--- a/src/components/events/SPLTopographyMapping.jsx
+++ b/src/components/events/SPLTopographyMapping.jsx
@@ -51,7 +51,7 @@ const SPLTopographyMapping = () => {
     if (mappingActive && !delayTowersAdjusted) {
       addLog('ACTION', 'Recalculating DSP time-alignment for Delay Towers L & R.');
       setTimeout(() => {
-        addLog('SYS', 'Pushing phase alignment correction to L'Acoustics K1 array.');
+        addLog('SYS', "Pushing phase alignment correction to L'Acoustics K1 array.");
         setTimeout(() => {
           setDelayTowersAdjusted(true);
           addLog('SUCCESS', 'Dead zones eliminated. Bass traps dispersed. SPL normalized across field.');


### PR DESCRIPTION
﻿## Problem

src/components/events/SPLTopographyMapping.jsx line 54 contains an unescaped apostrophe inside a single-quoted string: 'L'Acoustics'. This terminates the string early and leaves 'Acoustics K1 array.' as bare identifiers, causing a parse error: Expected ")" but found "Acoustics".

## Fix

Changed the string to use double quotes so the apostrophe in L'Acoustics is valid: "Pushing phase alignment correction to L'Acoustics K1 array."

## Files changed

- src/components/events/SPLTopographyMapping.jsx

## Testing

- npx esbuild src/components/events/SPLTopographyMapping.jsx --loader=jsx — no parse errors

Closes #15437
