### PR TITLE
fix(issue-15438): unescape template literals in events components

### DIFF
--- a/src/components/events/ADARouteGenerator.jsx
+++ b/src/components/events/ADARouteGenerator.jsx
@@ -177,10 +177,10 @@ const ADARouteGenerator = () => {
               {/* Waypoints */}
               <div className="absolute z-10 w-full h-full pointer-events-none">
                  {/* Origin */}
-                 <div className="absolute w-4 h-4 bg-white rounded-full border-2 border-blue-500 shadow-[0_0_10px_rgba(59,130,246,0.8)]" style={{ left: \`\${path.origin.x}%\`, top: \`\${path.origin.y}%\`, transform: 'translate(-50%, -50%)' }}></div>
+                 <div className="absolute w-4 h-4 bg-white rounded-full border-2 border-blue-500 shadow-[0_0_10px_rgba(59,130,246,0.8)]" style={{ left: `${path.origin.x}%`, top: `${path.origin.y}%`, transform: 'translate(-50%, -50%)' }}></div>
                  
                  {/* Destination */}
-                 <div className="absolute w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center border-2 border-white shadow-[0_0_15px_rgba(59,130,246,1)]" style={{ left: \`\${path.destination.x}%\`, top: \`\${path.destination.y}%\`, transform: 'translate(-50%, -50%)' }}>
+                 <div className="absolute w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center border-2 border-white shadow-[0_0_15px_rgba(59,130,246,1)]" style={{ left: `${path.destination.x}%`, top: `${path.destination.y}%`, transform: 'translate(-50%, -50%)' }}>
                    <span className="text-[10px] text-white">📍</span>
                  </div>
 
@@ -198,7 +198,7 @@ const ADARouteGenerator = () => {
               <svg className="absolute inset-0 w-full h-full z-0 pointer-events-none">
                 {routeState === 'recalculating' ? (
                   <path 
-                    d={\`M \${path.nodes.map(n => \`\${n.x}% \${n.y}%\`).join(' L ')}\`} 
+                    d={`M ${path.nodes.map(n => `${n.x}% ${n.y}%`).join(' L ')}`} 
                     fill="none" 
                     stroke="rgba(59,130,246,0.3)" 
                     strokeWidth="6" 
@@ -211,7 +211,7 @@ const ADARouteGenerator = () => {
                   <>
                     {/* Shadow/Glow */}
                     <path 
-                      d={\`M \${path.nodes.map(n => \`\${n.x}% \${n.y}%\`).join(' L ')}\`} 
+                      d={`M ${path.nodes.map(n => `${n.x}% ${n.y}%`).join(' L ')}`} 
                       fill="none" 
                       stroke="rgba(59,130,246,0.4)" 
                       strokeWidth="12" 
@@ -221,7 +221,7 @@ const ADARouteGenerator = () => {
                     />
                     {/* Main Line */}
                     <path 
-                      d={\`M \${path.nodes.map(n => \`\${n.x}% \${n.y}%\`).join(' L ')}\`} 
+                      d={`M ${path.nodes.map(n => `${n.x}% ${n.y}%`).join(' L ')}`} 
                       fill="none" 
                       stroke="#3b82f6" 
                       strokeWidth="4" 

--- a/src/components/events/AIDirectorStream.jsx
+++ b/src/components/events/AIDirectorStream.jsx
@@ -152,7 +152,7 @@ const AIDirectorStream = () => {
                        <span>{audioLevels.host}%</span>
                      </div>
                      <div className="h-1.5 w-full bg-black rounded-full overflow-hidden">
-                       <div className="h-full bg-emerald-500 transition-all duration-300" style={{ width: \`\${audioLevels.host}%\` }}></div>
+                       <div className="h-full bg-emerald-500 transition-all duration-300" style={{ width: `${audioLevels.host}%` }}></div>
                      </div>
                    </div>
                    
@@ -162,7 +162,7 @@ const AIDirectorStream = () => {
                        <span>{audioLevels.guest}%</span>
                      </div>
                      <div className="h-1.5 w-full bg-black rounded-full overflow-hidden">
-                       <div className="h-full bg-emerald-500 transition-all duration-300" style={{ width: \`\${audioLevels.guest}%\` }}></div>
+                       <div className="h-full bg-emerald-500 transition-all duration-300" style={{ width: `${audioLevels.guest}%` }}></div>
                      </div>
                    </div>
 
@@ -172,7 +172,7 @@ const AIDirectorStream = () => {
                        <span>{audioLevels.crowd}%</span>
                      </div>
                      <div className="h-1.5 w-full bg-black rounded-full overflow-hidden">
-                       <div className="h-full bg-sky-500 transition-all duration-300" style={{ width: \`\${audioLevels.crowd}%\` }}></div>
+                       <div className="h-full bg-sky-500 transition-all duration-300" style={{ width: `${audioLevels.crowd}%` }}></div>
                      </div>
                    </div>
                  </div>

--- a/src/components/events/AcousticsOptimizationEngine.jsx
+++ b/src/components/events/AcousticsOptimizationEngine.jsx
@@ -99,14 +99,14 @@ const AcousticsOptimizationEngine = () => {
                              band.gain > 0 ? 'bg-emerald-900 border-emerald-500 shadow-[0_0_15px_rgba(16,185,129,0.3)]' : 
                              'bg-rose-900 border-rose-500 shadow-[0_0_15px_rgba(225,29,72,0.3)]'
                            }`}
-                           style={{ bottom: \`calc(\${heightPercent}% - 12px)\` }}
+                           style={{ bottom: `calc(${heightPercent}% - 12px)` }}
                          >
                            <div className="w-1.5 h-1.5 rounded-full bg-white/50"></div>
                          </div>
                        </div>
                        
                        <div className="absolute -bottom-6 text-center">
-                         <span className="block text-[10px] text-sky-400 font-bold font-mono">{band.freq >= 1000 ? \`\${band.freq/1000}k\` : band.freq}Hz</span>
+                         <span className="block text-[10px] text-sky-400 font-bold font-mono">{band.freq >= 1000 ? `${band.freq/1000}k` : band.freq}Hz</span>
                          <span className="block text-[9px] text-neutral-500 font-mono mt-0.5">{band.gain > 0 ? '+' : ''}{band.gain.toFixed(1)} dB</span>
                        </div>
                      </div>
@@ -173,7 +173,7 @@ const AcousticsOptimizationEngine = () => {
                     <p className="text-slate-400 text-sm font-mono">Listening for room reflections...</p>
                     
                     <div className="w-full bg-slate-900 h-2 rounded-full mt-8 overflow-hidden">
-                      <div className="h-full bg-sky-500 transition-all duration-200" style={{ width: \`\${(frequency / 20000) * 100}%\` }}></div>
+                      <div className="h-full bg-sky-500 transition-all duration-200" style={{ width: `${(frequency / 20000) * 100}%` }}></div>
                     </div>
                   </div>
                 ) : engineState === 'processing' ? (

--- a/src/components/events/AlgorithmicLightingControl.jsx
+++ b/src/components/events/AlgorithmicLightingControl.jsx
@@ -145,7 +145,7 @@ const AlgorithmicLightingControl = () => {
                          {[...Array(5)].map((_, i) => (
                            <div key={i} className={`w-1.5 rounded-t transition-all duration-500 ${
                              i < (zone.crowdLevel / 20) ? (zone.crowdLevel > 70 ? 'bg-rose-500' : 'bg-emerald-500') : 'bg-neutral-800'
-                           }`} style={{ height: \`\${(i+1)*20}%\` }}></div>
+                           }`} style={{ height: `${(i+1)*20}%` }}></div>
                          ))}
                        </div>
                      </div>
@@ -224,8 +224,8 @@ const AlgorithmicLightingControl = () => {
                           key={i} 
                           className="absolute w-1 h-1 bg-white rounded-full shadow-[0_0_3px_white] transition-all duration-1000"
                           style={{
-                            left: \`\${20 + Math.random() * 60}%\`,
-                            top: \`\${20 + Math.random() * 60}%\`,
+                            left: `${20 + Math.random() * 60}%`,
+                            top: `${20 + Math.random() * 60}%`,
                           }}
                         ></div>
                       ))}

--- a/src/components/events/AnalyticsDossierAI.jsx
+++ b/src/components/events/AnalyticsDossierAI.jsx
@@ -110,7 +110,7 @@ const AnalyticsDossierAI = () => {
                <div className="w-full h-3 bg-slate-100 rounded-full overflow-hidden border border-slate-200">
                  <div 
                    className="h-full bg-gradient-to-r from-violet-500 to-fuchsia-500 transition-all duration-1000 ease-out"
-                   style={{ width: \`\${progress}%\` }}
+                   style={{ width: `${progress}%` }}
                  ></div>
                </div>
              </div>

--- a/src/components/events/AudienceSentimentAnalytics.jsx
+++ b/src/components/events/AudienceSentimentAnalytics.jsx
@@ -187,7 +187,7 @@ const AudienceSentimentAnalytics = () => {
                 {/* Playhead indicator */}
                 <div 
                   className="absolute left-[-5px] w-2.5 h-2.5 rounded-full bg-white shadow-[0_0_10px_white] transition-all duration-300 z-20"
-                  style={{ top: \`\${(currentTime / duration) * 100}%\` }}
+                  style={{ top: `${(currentTime / duration) * 100}%` }}
                 ></div>
 
                 {timelineData.map((node, i) => (

--- a/src/components/events/BiometricPyroSync.jsx
+++ b/src/components/events/BiometricPyroSync.jsx
@@ -134,7 +134,7 @@ const BiometricPyroSync = () => {
                <div className="flex-1 relative flex items-end">
                  
                  {/* Threshold Line */}
-                 <div className="absolute inset-x-0 border-t border-dashed border-rose-500/50 z-10" style={{ bottom: \`\${((excitementThreshold - 60) / (160 - 60)) * 100}%\` }}>
+                 <div className="absolute inset-x-0 border-t border-dashed border-rose-500/50 z-10" style={{ bottom: `${((excitementThreshold - 60) / (160 - 60)) * 100}%` }}>
                    <span className="absolute right-0 -top-4 text-[8px] text-rose-500 font-mono pr-1">Trigger</span>
                  </div>
 
@@ -146,7 +146,7 @@ const BiometricPyroSync = () => {
                        <div 
                          key={i} 
                          className={`flex-1 rounded-t-sm transition-all duration-300 ${bpm >= excitementThreshold ? 'bg-rose-500' : bpm > 110 ? 'bg-fuchsia-400' : 'bg-neutral-600'}`}
-                         style={{ height: \`\${heightPercent}%\` }}
+                         style={{ height: `${heightPercent}%` }}
                        ></div>
                      )
                    })}

--- a/src/components/events/CVPerimeterSecurity.jsx
+++ b/src/components/events/CVPerimeterSecurity.jsx
@@ -234,8 +234,8 @@ const CVPerimeterSecurity = () => {
                     className="absolute border-2 border-red-500 bg-red-500/20 shadow-[0_0_15px_rgba(220,38,38,0.8)] flex flex-col justify-end transition-all duration-300 ease-linear"
                     style={{ 
                       width: '40px', height: '80px',
-                      left: \`\${targetPos.x}%\`, 
-                      top: \`\${targetPos.y}%\`,
+                      left: `${targetPos.x}%`, 
+                      top: `${targetPos.y}%`,
                       transform: 'translate(-50%, -50%)'
                     }}
                   >
@@ -253,8 +253,8 @@ const CVPerimeterSecurity = () => {
                   {/* Trajectory Prediction Line */}
                   <svg className="absolute inset-0 w-full h-full pointer-events-none opacity-50">
                     <line 
-                      x1={\`\${targetPos.x}%\`} y1={\`\${targetPos.y}%\`} 
-                      x2={\`\${targetPos.x + 20}%\`} y2={\`\${targetPos.y + 20}%\`} 
+                      x1={`${targetPos.x}%`} y1={`${targetPos.y}%`} 
+                      x2={`${targetPos.x + 20}%`} y2={`${targetPos.y + 20}%`} 
                       stroke="red" strokeWidth="1" strokeDasharray="4 2" 
                     />
                   </svg>

--- a/src/components/events/CarbonFootprintGamification.jsx
+++ b/src/components/events/CarbonFootprintGamification.jsx
@@ -204,7 +204,7 @@ const CarbonFootprintGamification = () => {
                     <span>{tier === 'Green' ? '250 (Gold)' : '500 (VIP)'}</span>
                   </div>
                   <div className="w-full h-1.5 bg-black/20 rounded-full overflow-hidden">
-                    <div className="h-full bg-white transition-all duration-1000" style={{ width: \`\${Math.min(100, (ecoPoints / (tier === 'Green' ? 250 : 500)) * 100)}%\` }}></div>
+                    <div className="h-full bg-white transition-all duration-1000" style={{ width: `${Math.min(100, (ecoPoints / (tier === 'Green' ? 250 : 500)) * 100)}%` }}></div>
                   </div>
                 </div>
               )}

--- a/src/components/events/DroneLostAndFound.jsx
+++ b/src/components/events/DroneLostAndFound.jsx
@@ -98,7 +98,7 @@ const DroneLostAndFound = () => {
                      {[...Array(5)].map((_, i) => (
                        <div key={i} className={`w-3 rounded-t transition-all duration-300 ${
                          i < (signalStrength / 20) ? 'bg-amber-500' : 'bg-neutral-800'
-                       }`} style={{ height: \`\${(i+1)*20}%\` }}></div>
+                       }`} style={{ height: `${(i+1)*20}%` }}></div>
                      ))}
                    </div>
                    <span className="text-2xl font-black text-amber-400 font-mono">{Math.floor(signalStrength)}%</span>
@@ -108,7 +108,7 @@ const DroneLostAndFound = () => {
                <div className="bg-neutral-900 border border-neutral-800 rounded-xl p-4 flex flex-col justify-between">
                  <span className="text-[10px] font-bold text-neutral-500 uppercase tracking-widest block mb-2">Drone Coordinates</span>
                  <span className="text-xl font-black text-white font-mono">
-                   {systemState === 'standby' ? 'HOME BASE' : \`\${dronePos.x.toFixed(4)}N, \${dronePos.y.toFixed(4)}W\`}
+                   {systemState === 'standby' ? 'HOME BASE' : `${dronePos.x.toFixed(4)}N, ${dronePos.y.toFixed(4)}W`}
                  </span>
                  <span className="text-[10px] text-neutral-500 font-mono mt-1">ALT: {systemState === 'searching' ? '45m' : systemState === 'found' ? '5m' : '0m'}</span>
                </div>
@@ -192,8 +192,8 @@ const DroneLostAndFound = () => {
                 <div 
                   className="absolute w-8 h-8 z-30 transition-all duration-100 ease-linear flex items-center justify-center"
                   style={{ 
-                    left: \`\${dronePos.x}%\`, 
-                    top: \`\${dronePos.y}%\`,
+                    left: `${dronePos.x}%`, 
+                    top: `${dronePos.y}%`,
                     transform: 'translate(-50%, -50%)'
                   }}
                 >
@@ -217,8 +217,8 @@ const DroneLostAndFound = () => {
                 <div 
                   className="absolute w-4 h-4 bg-emerald-500 rounded-full z-20 flex items-center justify-center shadow-[0_0_15px_rgba(16,185,129,1)] animate-bounce"
                   style={{ 
-                    left: \`\${targetPos.x}%\`, 
-                    top: \`\${targetPos.y}%\`,
+                    left: `${targetPos.x}%`, 
+                    top: `${targetPos.y}%`,
                     transform: 'translate(-50%, -50%)'
                   }}
                 >

--- a/src/components/events/FoodSpoilageTracker.jsx
+++ b/src/components/events/FoodSpoilageTracker.jsx
@@ -168,7 +168,7 @@ const FoodSpoilageTracker = () => {
                    <div className="absolute bottom-0 inset-x-0 h-1.5 bg-slate-100">
                      <div className={`h-full transition-all duration-1000 ${
                        platter.risk === 'critical' ? 'bg-rose-500' : platter.risk === 'warning' ? 'bg-amber-500' : 'bg-emerald-500'
-                     }`} style={{ width: \`\${(platter.remainingMinutes / platter.safetyMinutes) * 100}%\` }}></div>
+                     }`} style={{ width: `${(platter.remainingMinutes / platter.safetyMinutes) * 100}%` }}></div>
                    </div>
 
                  </div>

--- a/src/components/events/GamifiedExitDispersal.jsx
+++ b/src/components/events/GamifiedExitDispersal.jsx
@@ -157,7 +157,7 @@ const GamifiedExitDispersal = () => {
                        <div className={`h-full transition-all duration-1000 ${
                          gate.status === 'critical' ? 'bg-rose-500' :
                          gate.status === 'warning' ? 'bg-amber-400' : 'bg-emerald-400'
-                       }`} style={{ width: \`\${gate.density}%\` }}></div>
+                       }`} style={{ width: `${gate.density}%` }}></div>
                      </div>
                    </div>
 

--- a/src/components/events/GenAITrailerSynthesis.jsx
+++ b/src/components/events/GenAITrailerSynthesis.jsx
@@ -121,7 +121,7 @@ const GenAITrailerSynthesis = () => {
                    {generationState === 'analyzing' ? 'Analyzing Raw Footage...' : 'Synthesizing Trailer...'}
                  </span>
                  <div className="w-full bg-neutral-200 h-1.5 rounded-full mt-2 overflow-hidden">
-                   <div className="h-full bg-gradient-to-r from-fuchsia-500 to-indigo-500 transition-all duration-300" style={{ width: \`\${progress}%\` }}></div>
+                   <div className="h-full bg-gradient-to-r from-fuchsia-500 to-indigo-500 transition-all duration-300" style={{ width: `${progress}%` }}></div>
                  </div>
                </div>
              )}

--- a/src/components/events/MeshNetworkChat.jsx
+++ b/src/components/events/MeshNetworkChat.jsx
@@ -175,7 +175,7 @@ const MeshNetworkChat = () => {
                    <div className="mt-2 space-y-1 text-emerald-400 font-bold">
                      <p>&gt; Routing payload via peer nodes...</p>
                      {messageHops.map((hop, i) => (
-                       <p key={i} className="animate-fade-in-up" style={{ animationDelay: \`\${hop.time}ms\` }}>
+                       <p key={i} className="animate-fade-in-up" style={{ animationDelay: `${hop.time}ms` }}>
                          &gt; Hop {i+1}: Handshake with {hop.id}... OK.
                        </p>
                      ))}

--- a/src/components/events/NeuralTTSAnnouncement.jsx
+++ b/src/components/events/NeuralTTSAnnouncement.jsx
@@ -173,7 +173,7 @@ const NeuralTTSAnnouncement = () => {
                     key={i} 
                     className={`w-3 rounded-full transition-all duration-150 ${systemState === 'broadcasting' ? 'bg-rose-500' : 'bg-slate-800 h-2'}`}
                     style={{ 
-                      height: systemState === 'broadcasting' ? \`\${Math.max(10, Math.random() * 100)}%\` : '8px',
+                      height: systemState === 'broadcasting' ? `${Math.max(10, Math.random() * 100)}%` : '8px',
                       boxShadow: systemState === 'broadcasting' ? '0 0 15px rgba(225,29,72,0.5)' : 'none'
                     }}
                   ></div>

--- a/src/components/events/NoiseComplianceMonitor.jsx
+++ b/src/components/events/NoiseComplianceMonitor.jsx
@@ -26,7 +26,7 @@ const NoiseComplianceMonitor = () => {
         const hrs = 21 + Math.floor(seconds / 3600);
         const mins = Math.floor((seconds % 3600) / 60);
         const secs = seconds % 60;
-        setTime(\`\${hrs.toString().padStart(2, '0')}:\${mins.toString().padStart(2, '0')}:\${secs.toString().padStart(2, '0')}\`);
+        setTime(`${hrs.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`);
         
         setDecibels(prev => {
           let newDb = prev + (Math.random() * 3 - 1);
@@ -253,7 +253,7 @@ const NoiseComplianceMonitor = () => {
                      className={`absolute w-12 h-6 rounded shadow-lg flex items-center justify-center transition-all duration-1000 ease-out z-10 ${
                        compressionActive ? 'bg-red-600 border-b-4 border-red-800 shadow-[0_0_15px_rgba(220,38,38,0.5)]' : 'bg-yellow-600 border-b-4 border-yellow-800'
                      }`} 
-                     style={{ bottom: \`\${subBassLevel}%\` }}
+                     style={{ bottom: `${subBassLevel}%` }}
                    >
                      <div className="w-8 h-1 bg-white/50"></div>
                    </div>

--- a/src/components/events/RideshareSurgeMitigation.jsx
+++ b/src/components/events/RideshareSurgeMitigation.jsx
@@ -196,8 +196,8 @@ const RideshareSurgeMitigation = () => {
             <div className="absolute inset-0 z-10 pointer-events-none">
                {Array.from({ length: activeDrivers > 100 ? 15 : 3 }).map((_, i) => (
                  <div key={i} className="absolute w-2 h-2 bg-indigo-500 rounded-full shadow-[0_0_10px_rgba(79,70,229,1)] transition-all duration-1000" style={{
-                   left: \`\${20 + Math.random() * 60}%\`,
-                   top: \`\${20 + Math.random() * 60}%\`,
+                   left: `${20 + Math.random() * 60}%`,
+                   top: `${20 + Math.random() * 60}%`,
                  }}></div>
                ))}
             </div>

--- a/src/components/events/ThermalImagingScanner.jsx
+++ b/src/components/events/ThermalImagingScanner.jsx
@@ -189,8 +189,8 @@ const ThermalImagingScanner = () => {
                         p.isFever ? 'border-rose-500 w-16 h-16 shadow-[0_0_15px_rgba(225,29,72,0.8)] z-20' : 'border-emerald-500/50 w-12 h-12 z-10'
                       }`}
                       style={{ 
-                        left: \`\${p.x}%\`, 
-                        top: \`\${p.y}%\`,
+                        left: `${p.x}%`, 
+                        top: `${p.y}%`,
                         transform: 'translate(-50%, -50%)',
                         opacity: p.age > 2 ? 0 : 1 // fade out
                       }}


### PR DESCRIPTION
## Problem

Template literals in 18 event component files under src/components/events/ were corrupted with escaped backticks (`\``) and escaped interpolation markers (`\${`), e.g. `\`\${hop.time}ms\`` instead of `` `${hop.time}ms` ``. This causes esbuild/Vite to fail while parsing these files and would throw at runtime.

## Fix

Replaced every escaped backtick `` \` `` with `` ` `` and every `` \${ `` with `` ${ `` across the 18 affected JSX files, restoring proper template literal interpolation.

## Files changed

- src/components/events/ADARouteGenerator.jsx
- src/components/events/AIDirectorStream.jsx
- src/components/events/AcousticsOptimizationEngine.jsx
- src/components/events/AlgorithmicLightingControl.jsx
- src/components/events/AnalyticsDossierAI.jsx
- src/components/events/AudienceSentimentAnalytics.jsx
- src/components/events/BiometricPyroSync.jsx
- src/components/events/CVPerimeterSecurity.jsx
- src/components/events/CarbonFootprintGamification.jsx
- src/components/events/DroneLostAndFound.jsx
- src/components/events/FoodSpoilageTracker.jsx
- src/components/events/GamifiedExitDispersal.jsx
- src/components/events/GenAITrailerSynthesis.jsx
- src/components/events/MeshNetworkChat.jsx
- src/components/events/NeuralTTSAnnouncement.jsx
- src/components/events/NoiseComplianceMonitor.jsx
- src/components/events/RideshareSurgeMitigation.jsx
- src/components/events/ThermalImagingScanner.jsx

## Testing

- npx esbuild on affected files — clean transform, no parse errors
- Confirmed no remaining escaped backticks or escaped interpolation markers under src/components/events/

Closes #15438
