### PR TITLE
fix(issue-15430): export resolveEventInstant from timezoneUtils

### DIFF
--- a/src/utils/timezoneUtils.js
+++ b/src/utils/timezoneUtils.js
@@ -151,6 +151,24 @@ export const parseEventToUTC = (dateStr, timeStr, timezone) => {
   }
 };
 
+/**
+ * Resolve an event's local wall-clock date/time to a Date instant anchored to
+ * the event's own timezone.
+ *
+ * Uses parseEventToUTC so the returned instant is identical regardless of the
+ * viewer's location. Returns null when either input is invalid.
+ *
+ * @param {string} dateStr - Date string
+ * @param {string} timeStr - Time string
+ * @param {string} [timezone] - IANA timezone the event time is expressed in
+ * @returns {Date|null}
+ */
+export const resolveEventInstant = (dateStr, timeStr, timezone) => {
+  const utcMs = parseEventToUTC(dateStr, timeStr, timezone);
+  if (utcMs === null) return null;
+  return new Date(utcMs);
+};
+
 export const parseEventDateTimeLocal = (dateStr, timeStr) => {
   const normalizedDate = normalizeDateString(dateStr);
   const parsedTime = parseTimeString(timeStr || "12:00 AM");


### PR DESCRIPTION
## Problem

src/utils/timezoneUtils.js never exported `resolveEventInstant`, but three consumers already depend on it:
- src/utils/eventCreationUtils.js imports it at line 1 and calls it in buildEventPayload (lines 66, 71)
- src/components/common/CountdownTimer.jsx imports it from "utils/timezoneUtils" (line 4) and calls it in resolveDeadline (line 18)
- tests/resolveEventInstant.test.mjs imports it and fails with `SyntaxError: The requested module './timezoneUtils.js' does not provide an export named 'resolveEventInstant'`

This breaks event creation (buildEventPayload throws at runtime) and the countdown timer.

## Fix

Added a `resolveEventInstant(dateStr, timeStr, timezone)` export to src/utils/timezoneUtils.js. It resolves the event's local wall-clock time in the event's own timezone to a Date instant via the existing `parseEventToUTC` helper, and returns null for invalid inputs. This makes the instant viewer-independent, matching the behaviour already required by the test suite.

## Files changed

- src/utils/timezoneUtils.js

## Testing

- node tests/resolveEventInstant.test.mjs — all assertions pass ("resolveEventInstant timezone tests passed")
- Confirmed consumers (eventCreationUtils.js, CountdownTimer.jsx) now import a defined export

Closes #15430
