### PR TITLE
fix(issue-15439): break infinite re-render loop in useRecentlyViewed

### DIFF
--- a/src/hooks/useRecentlyViewed.js
+++ b/src/hooks/useRecentlyViewed.js
@@ -81,13 +81,19 @@ const loadInitialHistory = () => {
 
 /**
  * Top-level helper to save the history array.
+ * Skips the write/dispatch when the serialized content is unchanged so the
+ * same-tab 'local-storage-recently-viewed-update' listener cannot trigger a
+ * re-render loop (fresh array reference from loadInitialHistory → save → dispatch → …).
  */
 const saveHistory = (items) => {
   try {
+    const serialized = JSON.stringify(items);
+    if (serialized === localStorage.getItem(STORAGE_KEY)) return;
+
     if (items.length === 0) {
       localStorage.removeItem(STORAGE_KEY);
     } else {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+      localStorage.setItem(STORAGE_KEY, serialized);
     }
     window.dispatchEvent(new Event('local-storage-recently-viewed-update'));
   } catch (err) {


### PR DESCRIPTION
## Problem

src/hooks/useRecentlyViewed.js has a self-sustaining state loop once history is non-empty:

- saveHistory (line 85) writes to localStorage, then dispatches the custom window event `local-storage-recently-viewed-update` (line 92).
- The hook registers a same-tab listener for that event: `handleLocalUpdate = () => setRecentlyViewed(loadInitialHistory())`.
- `loadInitialHistory()` re-parses localStorage and returns a fresh array reference on every call.
- The effect at lines 129–131 runs on every `recentlyViewed` change and calls `saveHistory` again → dispatch → `setRecentlyViewed(newRef)` → new render → effect → repeats forever.

Because React only bails out on Object.is equality (not content equality), the new array reference always triggers a re-render, flooding the main thread and making pages unresponsive.

## Fix

Added a content-equality guard at the top of `saveHistory`: if `JSON.stringify(items)` is identical to the value already stored in localStorage, it returns early without writing or dispatching the window event. The same-tab listener can then re-set state to a fresh reference with identical content without re-triggering `saveHistory` → no dispatch → the loop terminates.

## Files changed

- src/hooks/useRecentlyViewed.js

## Testing

- node --check src/hooks/useRecentlyViewed.js — clean parse
- Trace of the loop: add → save+dispatch → listener re-sets identical content → saveHistory early-returns → no dispatch → stable render

Closes #15439
