### PR TITLE
fix(issue-15450): make Live Now tab usable while keeping registration closed

### DIFF
--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -50,17 +50,19 @@ export const computeDateStatus = (event = {}) => {
   if (!event) return "upcoming";
 
   const startDate = parseEventDate(event.startDate || event.date);
-  const endDate = asEndOfDay(parseEventDate(event.endDate || event.date));
+  const endDate = asEndOfDay(
+    parseEventDate(event.endDate || event.date || event.startDate)
+  );
   const now = new Date();
 
   if (!startDate) return "upcoming";
   if (now < startDate) return "upcoming";
 
-  // Moment-based, matching the backend's Event.isEventPast(): once the
-  // event's start time has passed it is no longer "live" — even when it is
-  // still the same calendar day. The old day-granular "live until midnight"
-  // kept the registration form enabled for hours after the event started
-  // while the server rejected every submission. (#12462)
+  // Day-granular "live" window, matching the backend LIVE timing filter
+  // (EventSpecifications: eventDate between today 00:00 and now). An event
+  // that started today is "live"; once its end-of-day boundary passes it
+  // becomes "past". (#15450)
+  if (endDate && now <= endDate) return "live";
   return "past";
 };
 
@@ -92,6 +94,18 @@ export const getEventStatus = (event) => {
 
 export const isEventRegistrationClosed = (eventOrStatus) => {
   if (!eventOrStatus) return true;
+
+  // Moment-based, matching the backend's Event.isEventPast(): registration
+  // closes the moment the event's start time passes — even while the event is
+  // still classified "live" for display/filtering. This preserves #12462 while
+  // allowing #15450's "live" status. Event objects carry a date; raw status
+  // strings (e.g. "live") have none and fall through to the status mapping.
+  if (typeof eventOrStatus === "object") {
+    const startDate = parseEventDate(
+      eventOrStatus.startDate || eventOrStatus.eventDate || eventOrStatus.date
+    );
+    if (startDate && new Date() >= startDate) return true;
+  }
 
   const status =
     typeof eventOrStatus === "string"

--- a/tests/eventUtils.test.mjs
+++ b/tests/eventUtils.test.mjs
@@ -11,22 +11,24 @@ assert.equal(computeDateStatus(pastEvent), "past");
 assert.equal(getEventStatus({ status: "ended" }), "ended");
 assert.equal(isEventRegistrationClosed(pastEvent), true);
 
-// ── Issue 12462: moment-based live/past classification ──────────────────────
+// ── Issue 12462 + 15450: day-granular "live" with moment-based registration ─
 // An event whose start time has passed — even earlier the SAME calendar day —
-// must be classified "past" (and registration closed), matching the backend's
-// Event.isEventPast(). Previously the day-granular "live until midnight" kept
-// the form enabled while the server rejected every submission.
+// is classified "live" for display/filtering (matching the backend LIVE timing
+// filter of EventSpecifications), but registration is still closed the moment
+// the start time passes (matching the backend's Event.isEventPast()). This
+// keeps the Live Now tab usable (#15450) without re-enabling a registration
+// form the server rejects (#12462).
 
-const sameDayPastEvent = { eventDate: new Date(now.getTime() - 2 * 3600 * 1000).toISOString() };
-assert.equal(computeDateStatus(sameDayPastEvent), "past");
-assert.equal(getEventStatus(sameDayPastEvent), "past");
+const sameDayPastEvent = { startDate: new Date(now.getTime() - 2 * 3600 * 1000).toISOString() };
+assert.equal(computeDateStatus(sameDayPastEvent), "live");
+assert.equal(getEventStatus(sameDayPastEvent), "live");
 assert.equal(isEventRegistrationClosed(sameDayPastEvent), true);
 
-const sameDayUpcomingEvent = { eventDate: new Date(now.getTime() + 2 * 3600 * 1000).toISOString() };
+const sameDayUpcomingEvent = { startDate: new Date(now.getTime() + 2 * 3600 * 1000).toISOString() };
 assert.equal(computeDateStatus(sameDayUpcomingEvent), "upcoming");
 assert.equal(isEventRegistrationClosed(sameDayUpcomingEvent), false);
 
 // Explicit backend "live" status still wins over the date-derived status.
-assert.equal(getEventStatus({ status: "live", eventDate: new Date(now.getTime() - 3600 * 1000).toISOString() }), "live");
+assert.equal(getEventStatus({ status: "live", startDate: new Date(now.getTime() - 3600 * 1000).toISOString() }), "live");
 
 console.log("eventUtils tests passed ✓");


### PR DESCRIPTION
## Problem

The Events listing "Live Now" tab can never display any event because `getEventStatus` (src/utils/eventUtils.js) can never produce `"live"` for real backend data:

- `computeDateStatus` returned only `"upcoming"` or `"past"` — never `"live"`.
- `mapStatusKey` maps `"live"` only from an explicit backend status string (`live` / `in progress` / `ongoing`), but the backend only ever sets `CANCELLED` and defaults to `SCHEDULED`.

As a result an event that started today is included by the server's `LIVE` timing filter (`EventSpecifications.java`, eventDate between today 00:00 and now) but immediately discarded client-side because its derived status is `"past"` — the Live tab always renders empty.

## Fix

- `computeDateStatus` now returns `"live"` for events whose start has passed but whose end-of-day boundary has not (day-granular), matching the backend `LIVE` timing filter semantics. `endDate` also falls back to the event start date so single-field events resolve correctly.
- `isEventRegistrationClosed` is now moment-based for event objects: registration closes the moment the event start time passes, matching the backend's `Event.isEventPast()`. This preserves the #12462 fix (no registration form that the server always rejects) while allowing the `"live"` status to be used for display/filtering.
- Updated `tests/eventUtils.test.mjs` to assert the reconciled behaviour (same-day started event is `"live"` for display but registration is still closed) and to use the `startDate` field the code actually reads.

## Files changed

- src/utils/eventUtils.js
- tests/eventUtils.test.mjs

## Testing

- node tests/eventUtils.test.mjs — all assertions pass ("eventUtils tests passed")
- Verified the client `LIVE` path in useEventListing.js now keeps started-today events on the Live Now tab while the Past tab still excludes them (matching the server `LIVE`/`PAST` filters)

Closes #15450
