### PR TITLE
fix(issue-15435): restore RETRYABLE_STATUS_CODES and add phone validation endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,6 +37,8 @@ public class ValidationController {
             Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
     private static final Pattern USERNAME_PATTERN =
             Pattern.compile("^[a-zA-Z0-9_-]{3,50}$");
+    private static final Pattern PHONE_PATTERN =
+            Pattern.compile("^\\+?[\\d\\s\\-()]+$");
 
     private final UserRepository userRepository;
 
@@ -86,6 +90,27 @@ public class ValidationController {
                 .build());
     }
 
+    @PostMapping("/phone")
+    @Operation(
+            summary = "Validate phone number format",
+            description = "Validates phone number format. Returns 400 for malformed numbers."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Phone format is valid",
+                    content = @Content(schema = @Schema(implementation = ValidationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid phone format",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<?> validatePhone(@RequestBody PhoneRequest request) {
+        String phone = request != null ? request.phone() : null;
+        if (phone == null || !PHONE_PATTERN.matcher(phone).matches()) {
+            return ResponseEntity.badRequest().body(buildError("Invalid phone format", "/api/validate/phone"));
+        }
+        return ResponseEntity.ok(ValidationResponse.builder()
+                .available(true)
+                .build());
+    }
+
     private ErrorResponse buildError(String message, String path) {
         return ErrorResponse.builder()
                 .status(400)
@@ -95,4 +120,6 @@ public class ValidationController {
                 .timestamp(LocalDateTime.now())
                 .build();
     }
+
+    public record PhoneRequest(String phone) {}
 }

--- a/src/utils/validationApi.js
+++ b/src/utils/validationApi.js
@@ -2,7 +2,7 @@ import { apiUtils } from "../config/api.js";
 
 const DEFAULT_TIMEOUT_MS = 8000;
 const DEFAULT_RETRIES = 1;
-// const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
 // In-memory response cache for validation results
 const validationCache = new Map();
@@ -251,7 +251,7 @@ export const checkPhoneValidation = (phone, options = {}) =>
   requestValidation(options.endpoint || "/api/validate/phone", {
     method: "POST",
     body: { phone },
-    availabilityField: "valid",
+    availabilityField: "available",
     invalidMessage: "Phone number is invalid",
     validMessage: "",
     ...options,


### PR DESCRIPTION
## Problem

Two defects in the phone-validation path:

1. **`POST /api/validate/phone` has no backend route (always 404)** — `checkPhoneValidation` in `src/utils/validationApi.js:250-258` calls this endpoint, and `validatePhoneNumber` in `src/validation.js:405` calls it by default. Since no backend route exists, every call 404s and the API-level phone verification can never succeed.

2. **`RETRYABLE_STATUS_CODES` is commented out but still referenced** — `validationApi.js:5` had `// const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];` but lines 156 and 197 still reference `RETRYABLE_STATUS_CODES.includes(status)`. On any non-2xx response (e.g. the 404 from `/validate/phone`, or a 400 from malformed email/username), `requestValidation` hits a `ReferenceError: RETRYABLE_STATUS_CODES is not defined`. The error is swallowed by the outer catch and retried, so the caller gets the generic "Unable to validate right now" message instead of the real validation failure.

## Fix

- Restored the `RETRYABLE_STATUS_CODES` constant in `validationApi.js`.
- Added `POST /api/validate/phone` endpoint in `ValidationController.java` that validates phone number format against the same regex used by the frontend (`^\+?[\d\s\-()]+$`). Since there is no phone column in the User table, it only validates format and returns `{ available: true }` for well-formed numbers.
- Updated `checkPhoneValidation` to use `availabilityField: "available"` for consistency with email/username endpoints (the backend `ValidationResponse` uses the `available` field).

## Files changed

- `src/utils/validationApi.js`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java`

## Testing

- `node --check src/utils/validationApi.js` — clean parse
- Manual test: `checkPhoneValidation('+1 555 111 2222')` now hits the new endpoint and returns `{ isValid: true, ... }` for well-formed numbers
- Non-2xx responses from email/username/phone endpoints no longer throw `ReferenceError` internally

Closes #15435