### PR TITLE
fix(issue-15455): remove dead API_ENDPOINTS keys (AUTH.GITHUB, WAITLIST.*)

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -191,7 +191,6 @@ export const API_ENDPOINTS = {
     REFRESH: buildApiUrl("/auth/refresh"),
     GOOGLE: buildApiUrl("/auth/google"),
     REAUTH: buildApiUrl("/auth/reauth"),
-    GITHUB: buildApiUrl("/auth/github"),
   },
   EVENTS: {
     CREATE: buildApiUrl("/events/create"),
@@ -275,12 +274,6 @@ export const API_ENDPOINTS = {
     SESSION: (id) => buildApiUrl(`/session-recovery/${id}`),
     RESTORE: (id) => buildApiUrl(`/session-recovery/${id}/restore`),
     CLEANUP_EXPIRED: buildApiUrl("/session-recovery/cleanup"),
-  },
-  WAITLIST: {
-    BASE: buildApiUrl("/waitlist"),
-    JOIN: buildApiUrl("/waitlist/join"),
-    LEAVE: (id) => buildApiUrl(`/waitlist/${id}/leave`),
-    STATUS: (id) => buildApiUrl(`/waitlist/${id}/status`),
   },
   FEEDBACK: {
     BASE: buildApiUrl("/feedback"),


### PR DESCRIPTION
## Problem

Three dead keys in `src/config/api.js` that are defined but never used anywhere in the codebase:

1. `API_ENDPOINTS.AUTH.GITHUB` (line 194) — `/auth/github` endpoint not implemented on backend
2. `API_ENDPOINTS.WAITLIST.*` (lines 279–284) — top-level `WAITLIST` object with `BASE`, `JOIN`, `LEAVE`, `STATUS` pointing to `/waitlist/*` routes; the codebase only uses the per-event waitlist endpoints under `API_ENDPOINTS.EVENTS.WAITLIST(id)` (`/events/{id}/waitlist`)
3. `API_ENDPOINTS.VALIDATION.PHONE` was listed as dead but is now used by the phone validation endpoint added in #15435 — this key is kept

## Fix

Removed the unused `AUTH.GITHUB` and the entire top-level `WAITLIST` object from `API_ENDPOINTS`. The per-event waitlist endpoints under `EVENTS.WAITLIST` remain.

## Files changed

- `src/config/api.js`

## Testing

- `node --check src/config/api.js` — clean parse
- Searched codebase for `API_ENDPOINTS.AUTH.GITHUB` and `API_ENDPOINTS.WAITLIST.*` — no usages found

Closes #15455