### PR TITLE
fix(issue-15441): make email availability check case-insensitive

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
@@ -58,7 +58,7 @@ public class ValidationController {
         if (email == null || !EMAIL_PATTERN.matcher(email).matches()) {
             return ResponseEntity.badRequest().body(buildError("Invalid email format", "/api/validate/email/" + email));
         }
-        boolean available = !userRepository.existsByEmail(email);
+        boolean available = !userRepository.existsByEmailIgnoreCase(email);
         return ResponseEntity.ok(ValidationResponse.builder()
                 .available(available)
                 .build());

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
@@ -24,6 +24,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByEmailIgnoreCase(String email);
+
     boolean existsByUsername(String username);
 
     // ── Admin panel queries ────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`ValidationController.validateEmail` used `userRepository.existsByEmail(email)` which performs a case-sensitive database lookup. However, `AuthService.signup` normalizes emails to lowercase before persisting (`request.getEmail().toLowerCase()`). This caused false positives: if a user registered as `Test@Site.com` (stored as `test@site.com`), then `GET /api/validate/email/TEST@SITE.COM` would return "available" (200), but the subsequent signup would fail with `UserAlreadyExistsException` (409).

## Fix

Added `existsByEmailIgnoreCase(String email)` to `UserRepository` (Spring Data JPA derives the case-insensitive query automatically). Updated `ValidationController.validateEmail` to use `existsByEmailIgnoreCase(email)` so the availability check matches the signup normalization.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java`

## Testing

- `existsByEmailIgnoreCase` is derived by Spring Data JPA — no manual query needed
- Manual test: register `Test@Site.com`, then `GET /api/validate/email/TEST@SITE.COM` now returns `"available": false` correctly

Closes #15441