### PR TITLE
fix(issue-15442): fix trimCache no-op by updating map entries instead of reassigning lambda parameter

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleService.java
@@ -479,17 +479,17 @@ public class SubtitleService {
      * Trim cache to prevent memory issues
      */
     private void trimCache() {
-        // Trim event cache
-        eventSubtitleCache.values().forEach(subtitles -> {
+        // Trim event cache — must update map entries, not reassign local variable
+        eventSubtitleCache.forEach((key, subtitles) -> {
             if (subtitles.size() > maxHistorySize) {
-                subtitles = new ArrayList<>(subtitles.subList(Math.max(0, subtitles.size() - maxHistorySize), subtitles.size()));
+                eventSubtitleCache.put(key, new ArrayList<>(subtitles.subList(Math.max(0, subtitles.size() - maxHistorySize), subtitles.size())));
             }
         });
         
-        // Trim session cache
-        sessionSubtitleCache.values().forEach(subtitles -> {
+        // Trim session cache — must update map entries, not reassign local variable
+        sessionSubtitleCache.forEach((key, subtitles) -> {
             if (subtitles.size() > bufferSize) {
-                subtitles = new ArrayList<>(subtitles.subList(Math.max(0, subtitles.size() - bufferSize), subtitles.size()));
+                sessionSubtitleCache.put(key, new ArrayList<>(subtitles.subList(Math.max(0, subtitles.size() - bufferSize), subtitles.size())));
             }
         });
         


### PR DESCRIPTION
## Problem

`SubtitleService.trimCache` (lines 481–509) was a no-op. It used `forEach` on `values()` and reassigned the lambda parameter `subtitles`:

```java
eventSubtitleCache.values().forEach(subtitles -> {
    if (subtitles.size() > maxHistorySize) {
        subtitles = new ArrayList<>(subtitles.subList(...)); // reassigns local var — no map update
    }
});
```

Reassigning the lambda parameter doesn't update the map entry, so the eviction never happened. The cache grew unboundedly.

## Fix

Changed `values().forEach` to `forEach((key, value) -> ...)` and used `map.put(key, newList)` to actually update the map entries. This applies to both `eventSubtitleCache` and `sessionSubtitleCache`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleService.java`

## Testing

- Manual code review confirms `map.put(key, newList)` now updates the actual cache entries
- `trimCache` is called from `addToCache` on every subtitle creation, so eviction now runs correctly

Closes #15442