### PR TITLE
fix(issue-15445): give RateLimitingFilter beans explicit names to avoid collision

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilter.java
@@ -13,7 +13,7 @@ import java.time.Duration;
 /**
  * Differentiates SSE Heartbeat Reconnect Streams from REST API Rate Limit Buckets.
  */
-@Component
+@Component("sseRateLimitingFilter")
 public class RateLimitingFilter extends OncePerRequestFilter {
 
     private final RateLimitService rateLimitService;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Component
+@Component("authRateLimitingFilter")
 public class RateLimitingFilter extends OncePerRequestFilter {
 
     private static final String POST = "POST";


### PR DESCRIPTION
## Problem

Two `@Component` classes named `RateLimitingFilter` exist in the component scan root:
- `com.sandeep.eventrabackend.security.RateLimitingFilter` — registered via `FilterRegistrationBean` in `SecurityConfig` for auth endpoints
- `com.sandeep.eventrabackend.ratelimit.RateLimitingFilter` — guards SSE stream `/api/stream/` reconnects and a generic `rest-api` bucket

Neither specified a bean name, so both defaulted to `rateLimitingFilter`, causing `ConflictingBeanDefinitionException` at Spring context startup.

## Fix

Added explicit bean names via `@Component("...")`:
- `security.RateLimitingFilter` → `@Component("authRateLimitingFilter")`
- `ratelimit.RateLimitingFilter` → `@Component("sseRateLimitingFilter")`

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilter.java`

## Testing

- Spring context startup no longer throws `ConflictingBeanDefinitionException`
- Both filters retain their distinct path registrations (auth endpoints vs SSE stream)

Closes #15445