### PR TITLE
fix(issue-15443): hide cancelled events from event search

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -449,6 +449,7 @@ public class EventService {
 
                 return events.stream()
                                 .filter(Event::isPublic)
+                                .filter(event -> !"CANCELLED".equals(event.getStatus()))
                                 .map(this::toPublicEventResponse)
                                 .collect(Collectors.toList());
         }


### PR DESCRIPTION
## Problem

The public listing endpoint hides cancelled events (Issue #12081), but `EventService.searchEvents` does not. A cancelled event returned by the full-text query is served as a normal public result, so `GET /api/events/search` behaves inconsistently with the main list.

## Fix

Added the same cancelled-event exclusion to the final stream in `searchEvents` (`.filter(event -> !"CANCELLED".equals(event.getStatus()))`), mirroring the `notCancelledUnlessRequested` rule. `searchEvents` accepts no status parameter, so cancelled events are always hidden from search.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

- Search for a cancelled event's title via `GET /api/events/search?search=<title>` no longer returns it.

Closes #15443