### PR TITLE
fix(issue-15444): reject cancelled events in requirePublicEvent

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -208,6 +208,7 @@ public class EventService {
         private Event requirePublicEvent(Long id) {
                 return eventRepository.findById(id)
                                 .filter(Event::isPublic)
+                                .filter(event -> !"CANCELLED".equals(event.getStatus()))
                                 .orElseThrow(() -> new EventNotFoundException(
                                                 "Event not found with id: " + id));
         }


### PR DESCRIPTION
## Problem

`getPublicEventById` rejects cancelled events, but `requirePublicEvent` (the guard used by `getEventAvailability`, `getOccupiedSeats`, and `buildIcsFeed`) does not. So a cancelled event still returns live availability, occupied-seat counts, and an ICS calendar feed even though it is hidden from the public listing and rejected by `getPublicEventById`.

## Fix

Added the same cancelled-event exclusion to `requirePublicEvent` (`.filter(event -> !"CANCELLED".equals(event.getStatus()))`), so every public event read backed by this guard treats a cancelled event as unavailable, consistent with `getPublicEventById` and the `notCancelledUnlessRequested` listing rule.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

- `GET /api/events/{id}/availability`, `GET /api/events/{id}/seats`, and `GET /api/events/{id}/feed.ics` for a cancelled event now return 404/EventNotFound, matching `GET /api/events/{id}`.

Closes #15444