### PR TITLE
fix(issue-15446): exclude soft-deleted hackathons from public list and admin stats

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,6 +19,10 @@ public interface HackathonRepository extends JpaRepository<Hackathon, Long> {
     Optional<Hackathon> findByIdAndIsDeletedFalse(Long id);
 
     Page<Hackathon> findByIsDeletedFalse(Pageable pageable);
+
+    List<Hackathon> findByIsDeletedFalse();
+
+    long countByIsDeletedFalse();
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT h FROM Hackathon h WHERE h.id = :id AND h.isDeleted = false")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -291,7 +291,7 @@ public class AdminService {
     public PagedResponse<HackathonResponse> getHackathons(int page, int size) {
         int safePage = Math.max(page, 0);
         Pageable pageable = PageRequest.of(safePage, size, Sort.by("startDate").descending());
-        return PagedResponse.from(hackathonRepository.findAll(pageable).map(this::toHackathonResponse));
+        return PagedResponse.from(hackathonRepository.findByIsDeletedFalse(pageable).map(this::toHackathonResponse));
     }
 
     /**
@@ -337,7 +337,7 @@ public class AdminService {
                 .averageCapacityUtilization(
                         Optional.ofNullable(eventAnalyticsRepo.findAverageCapacityUtilization()).orElse(0.0))
                 // Hackathons
-                .totalHackathons(hackathonRepository.count())
+                .totalHackathons(hackathonRepository.countByIsDeletedFalse())
                 // Feedback
                 .totalFeedbackSubmissions(feedbackRepository.countTotalFeedback())
                 .overallAverageRating(

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -55,7 +55,7 @@ public class HackathonService {
     }
 
     public List<HackathonResponse> getAllHackathons() {
-        return hackathonRepository.findAll().stream()
+        return hackathonRepository.findByIsDeletedFalse().stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Problem

Soft-deleted hackathons leak through two paths:

- `HackathonService.getAllHackathons()` (no-arg) used the unfiltered `hackathonRepository.findAll()`, so deleted hackathons appear in the public `GET /api/hackathons` list.
- `AdminService.getHackathons` used `hackathonRepository.findAll(pageable)` and `AdminService.getAdminDashboard` used `hackathonRepository.count()`, so the admin list mixed deleted rows and `totalHackathons` was inflated.

## Fix

- Added `findByIsDeletedFalse()` (List) and `countByIsDeletedFalse()` to `HackathonRepository`.
- `HackathonService.getAllHackathons()` now uses `findByIsDeletedFalse()`, matching the pageable overload (`findByIsDeletedFalse(pageable)`) and `getHackathonById` (`findByIdAndIsDeletedFalse`).
- `AdminService.getHackathons` now uses `findByIsDeletedFalse(pageable)`.
- `AdminService.getAdminDashboard` now counts with `countByIsDeletedFalse()`.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java`

## Testing

- Soft-deleted hackathons no longer appear in `GET /api/hackathons`, `GET /api/admin/hackathons`, or the admin dashboard `totalHackathons`.

Closes #15446