### PR TITLE
fix(issue-15447): enforce public visibility for event schedule endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -561,8 +561,7 @@ public class EventService {
 
         @Transactional(readOnly = true)
         public EventScheduleResponse getEventSchedule(Long id) {
-                Event event = eventRepository.findById(id)
-                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
+                Event event = requirePublicEvent(id);
                 return toEventScheduleResponse(event);
         }
 


### PR DESCRIPTION
## Problem

`EventService.getEventSchedule` performed a bare `findById` with no `isPublic` check and no cancelled check. The unauthenticated `GET /api/events/{id}/schedule` route therefore disclosed `{ eventId, startDate, endDate }` for private/draft/cancelled events by ID — unlike every other public event read path (`getPublicEventById`, `requirePublicEvent`, `publicListing`).

## Fix

`getEventSchedule` now resolves the event through the existing `requirePublicEvent` guard, which enforces `isPublic` and rejects `CANCELLED` — the same visibility rule as `getPublicEventById`. Non-public or cancelled events produce 404.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java`

## Testing

- `GET /api/events/{id}/schedule` for a private/draft or cancelled event now returns 404, matching `GET /api/events/{id}`.

Closes #15447