### PR TITLE
fix(issue-15448): fail closed at startup when zkp verification secret unset or default

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.model.ZkpNullifier;
 import com.sandeep.eventrabackend.repository.ZkpNullifierRepository;
+import jakarta.annotation.PostConstruct;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,11 +20,27 @@ import java.util.HexFormat;
 @Service
 public class ZkpVerifierService {
 
-    @Value("${zkp.proof.verification-secret:eventra-zkp-verification-secret}")
+    private static final String DEFAULT_VERIFICATION_SECRET = "eventra-zkp-verification-secret";
+
+    /**
+     * Externally provisioned secret. Fails closed at startup when unset or still
+     * equal to the documented default, so instances never run with a publicly
+     * known key.
+     */
+    @Value("${zkp.proof.verification-secret:}")
     private String verificationSecret;
 
     @Autowired
     private ZkpNullifierRepository zkpNullifierRepository;
+
+    @PostConstruct
+    public void validateConfiguration() {
+        if (verificationSecret == null || verificationSecret.isBlank()
+                || DEFAULT_VERIFICATION_SECRET.equals(verificationSecret)) {
+            throw new IllegalStateException(
+                    "zkp.proof.verification-secret must be set to a non-default, externally provisioned secret");
+        }
+    }
 
     public static class ZkpProofPayload {
         @NotBlank(message = "eventId is required")

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -11,7 +11,7 @@ app:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173,https://eventra-psi.vercel.app,https://eventra.sandeepvashishtha.in}
   zkp:
     proof:
-      verification-secret: ${ZKP_PROOF_VERIFICATION_SECRET:eventra-zkp-verification-secret}
+      verification-secret: ${ZKP_PROOF_VERIFICATION_SECRET:}
   rate-limit:
     enabled: ${RATE_LIMIT_ENABLED:true}
     trusted-proxy-hops: ${RATE_LIMIT_TRUSTED_PROXY_HOPS:1}


### PR DESCRIPTION
## Problem

`ZkpVerifierService` shipped a hardcoded default verification secret (`eventra-zkp-verification-secret`, publicly known from the source). Unless a deployer explicitly set `zkp.proof.verification-secret`, every instance ran with the same known key, so anyone could forge `proofHash = SHA-256(secret:eventId:nullifierHash)` and get `VERIFIED` with no event membership.

## Fix

Fails closed at startup instead of running with a weak/known key:

- Removed the public default from `@Value("${zkp.proof.verification-secret:}")` and from `application.yml` (`${ZKP_PROOF_VERIFICATION_SECRET:}`).
- Added a `@PostConstruct` validation that throws `IllegalStateException` when the secret is unset/blank or still equal to the documented default `eventra-zkp-verification-secret`, so the application refuses to boot without an externally provisioned secret.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java`
- `Backend/src/main/resources/application.yml`

## Testing

- Starting the app without `ZKP_PROOF_VERIFICATION_SECRET` (or with it set to the old default) now aborts at startup with a clear `IllegalStateException`. Setting a distinct value boots normally.

Closes #15448