### PR TITLE
fix(issue-15449): enforce eligibility range bound in zkp range verifier

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/zkp/ZkRangeVerifierService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/zkp/ZkRangeVerifierService.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.zkp;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigInteger;
@@ -13,8 +14,15 @@ import java.security.MessageDigest;
 @Service
 public class ZkRangeVerifierService {
 
+    @Value("${zkp.range.min:18}")
+    private int minBound;
+
+    @Value("${zkp.range.max:120}")
+    private int maxBound;
+
     /**
-     * Verify range proof: H(Age + Salt) matches the committed value.
+     * Verify range proof: H(Age + Salt) matches the committed value AND the
+     * plaintext value satisfies the configured eligibility range.
      */
     public boolean verifyRangeProof(String commitment, String proofValue, String salt) {
         if (commitment == null || proofValue == null || salt == null) {
@@ -33,7 +41,13 @@ public class ZkRangeVerifierService {
                 hexString.append(hex);
             }
 
-            return commitment.equalsIgnoreCase(hexString.toString());
+            if (!commitment.equalsIgnoreCase(hexString.toString())) {
+                return false;
+            }
+
+            BigInteger value = new BigInteger(proofValue.trim());
+            return value.compareTo(BigInteger.valueOf(minBound)) >= 0
+                    && value.compareTo(BigInteger.valueOf(maxBound)) <= 0;
         } catch (Exception e) {
             return false;
         }

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -12,6 +12,9 @@ app:
   zkp:
     proof:
       verification-secret: ${ZKP_PROOF_VERIFICATION_SECRET:eventra-zkp-verification-secret}
+    range:
+      min: ${ZKP_RANGE_MIN:18}
+      max: ${ZKP_RANGE_MAX:120}
   rate-limit:
     enabled: ${RATE_LIMIT_ENABLED:true}
     trusted-proxy-hops: ${RATE_LIMIT_TRUSTED_PROXY_HOPS:1}


### PR DESCRIPTION
## Problem

`POST /api/zkp/verify-range` claimed to enforce a "Zero-Knowledge Range Proof" for attendee eligibility, but `ZkRangeVerifierService.verifyRangeProof` only checked that `commitment == SHA-256(proofValue + salt)`. No range or eligibility bound was ever validated, so any client could submit an arbitrary value (e.g. `proofValue: "0"`) with a matching self-computed commitment and receive `VERIFIED_ELIGIBLE`.

## Fix

Enforced the eligibility range server-side in addition to the hash check:

- `verifyRangeProof` now parses `proofValue` as a number and requires it to fall within the configured `[min, max]` bound before returning `true`.
- Bounds are configurable via `zkp.range.min` (default 18) and `zkp.range.max` (default 120), sourced from `ZKP_RANGE_MIN`/`ZKP_RANGE_MAX` env vars.
- Non-numeric `proofValue` or any out-of-range value now fails verification even when the commitment hash matches.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/zkp/ZkRangeVerifierService.java`
- `Backend/src/main/resources/application.yml`

## Testing

- `POST /api/zkp/verify-range` with `proofValue: "17"` (or a non-integer) now returns `VERIFICATION_FAILED`; an in-range value with a correct commitment returns `VERIFIED_ELIGIBLE`.

Closes #15449