### PR TITLE
fix(issue-15453): persist anonymous zkp feedback instead of discarding it

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ZkpFeedbackController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ZkpFeedbackController.java
@@ -1,5 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.model.ZkpFeedback;
+import com.sandeep.eventrabackend.repository.ZkpFeedbackRepository;
 import com.sandeep.eventrabackend.service.ZkpVerifierService;
 import com.sandeep.eventrabackend.service.ZkpVerifierService.ZkpProofPayload;
 import jakarta.validation.Valid;
@@ -21,6 +23,9 @@ public class ZkpFeedbackController {
     @Autowired
     private ZkpVerifierService zkpVerifierService;
 
+    @Autowired
+    private ZkpFeedbackRepository zkpFeedbackRepository;
+
     @PostMapping("/submit")
     public ResponseEntity<Map<String, Object>> submitAnonymousFeedback(@Valid @RequestBody ZkpProofPayload payload) {
         Map<String, Object> response = new HashMap<>();
@@ -37,6 +42,19 @@ public class ZkpFeedbackController {
             response.put("success", false);
             response.put("message", "This proof has already been used. Each nullifier can only be submitted once.");
             return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+        }
+
+        try {
+            zkpFeedbackRepository.save(new ZkpFeedback(
+                    Long.valueOf(payload.getEventId()),
+                    payload.getNullifierHash(),
+                    payload.getFeedbackCategory(),
+                    payload.getFeedbackContent(),
+                    payload.getSeverity()));
+        } catch (RuntimeException e) {
+            response.put("success", false);
+            response.put("message", "Failed to persist anonymous feedback. Please try again.");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
         }
 
         response.put("success", true);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/ZkpFeedback.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/ZkpFeedback.java
@@ -1,0 +1,81 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Persisted anonymous feedback submitted through the ZKP proof channel
+ * (feature #13898). No link to a user identity is stored.
+ */
+@Entity
+@Table(name = "zkp_feedback",
+        indexes = {
+                @Index(name = "idx_zkp_feedback_event", columnList = "event_id")
+        })
+public class ZkpFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+    @Column(name = "nullifier_hash", nullable = false, unique = true, length = 128)
+    private String nullifierHash;
+
+    @Column(name = "feedback_category", length = 64)
+    private String feedbackCategory;
+
+    @Column(length = 2000)
+    private String feedbackContent;
+
+    @Column(length = 16)
+    private String severity;
+
+    @CreationTimestamp
+    @Column(name = "submitted_at", nullable = false, updatable = false)
+    private LocalDateTime submittedAt;
+
+    public ZkpFeedback() {
+    }
+
+    public ZkpFeedback(Long eventId, String nullifierHash, String feedbackCategory,
+            String feedbackContent, String severity) {
+        this.eventId = eventId;
+        this.nullifierHash = nullifierHash;
+        this.feedbackCategory = feedbackCategory;
+        this.feedbackContent = feedbackContent;
+        this.severity = severity;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public String getNullifierHash() {
+        return nullifierHash;
+    }
+
+    public String getFeedbackCategory() {
+        return feedbackCategory;
+    }
+
+    public String getFeedbackContent() {
+        return feedbackContent;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public LocalDateTime getSubmittedAt() {
+        return submittedAt;
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/ZkpFeedbackRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/ZkpFeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.ZkpFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ZkpFeedbackRepository extends JpaRepository<ZkpFeedback, Long> {
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java
@@ -34,6 +34,7 @@ public class ZkpVerifierService {
         @NotBlank(message = "nullifierHash is required")
         private String nullifierHash;
         private String feedbackCategory;
+        @NotBlank(message = "feedbackContent is required")
         private String feedbackContent;
         private String severity; // LOW, MEDIUM, CRITICAL
 


### PR DESCRIPTION
## Problem

`POST /api/feedback/zkp/submit` verified the ZKP proof, recorded the nullifier for replay protection, and returned `success: true` — but never persisted the submitted `feedbackContent`/`feedbackCategory`/`severity`. Every submission was silently lost: the user saw "submitted successfully", the nullifier was burned (blocking resubmission), but no organizer ever received the message. No entity/repository existed for ZKP feedback content.

## Fix

- Added a `ZkpFeedback` entity (`eventId`, `nullifierHash` unique, `feedbackCategory`, `feedbackContent`, `severity`, `submittedAt`) and `ZkpFeedbackRepository`.
- `submitAnonymousFeedback` now persists the feedback after proof verification and nullifier recording. If persistence fails, it returns `500 INTERNAL_SERVER_ERROR` instead of falsely reporting success.
- Added `@NotBlank` validation on `feedbackContent` so empty submissions are rejected.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/model/ZkpFeedback.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/ZkpFeedbackRepository.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/ZkpFeedbackController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java`

## Testing

- A valid submission now inserts a `zkp_feedback` row containing the feedback content; the dev profile's Hibernate `ddl-auto: update` creates the table automatically.
- If persistence throws, the response is `500` rather than a misleading success.

Closes #15453