### PR TITLE
fix(issue-15454): rate-limit anonymous account-availability checks

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
@@ -17,6 +17,7 @@ public class RateLimitProperties {
     private EndpointLimit githubProxy = new EndpointLimit(30, Duration.ofMinutes(1));
     private EndpointLimit google = new EndpointLimit(10, Duration.ofMinutes(1));
     private EndpointLimit refresh = new EndpointLimit(30, Duration.ofMinutes(1));
+    private EndpointLimit validate = new EndpointLimit(20, Duration.ofMinutes(1));
 
     public boolean isEnabled() {
         return enabled;
@@ -80,6 +81,14 @@ public class RateLimitProperties {
 
     public void setRefresh(EndpointLimit refresh) {
         this.refresh = refresh;
+    }
+
+    public EndpointLimit getValidate() {
+        return validate;
+    }
+
+    public void setValidate(EndpointLimit validate) {
+        this.validate = validate;
     }
 
     public static class EndpointLimit {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -38,7 +38,10 @@ public class RateLimitingFilter extends OncePerRequestFilter {
             new EndpointRule("contact", POST, "/api/contact/"),
             new EndpointRule("contact", POST, "/api/contacts"),
             new EndpointRule("contact", POST, "/api/contacts/"),
-            new EndpointRule("githubProxy", GET, "/api/github-proxy")
+            new EndpointRule("githubProxy", GET, "/api/github-proxy"),
+            new EndpointRule("validate", GET, "/api/validate/email"),
+            new EndpointRule("validate", GET, "/api/validate/username"),
+            new EndpointRule("validate", GET, "/api/validate/phone")
     );
 
     private final RateLimitProperties properties;
@@ -121,6 +124,7 @@ public class RateLimitingFilter extends OncePerRequestFilter {
             case "forgotPassword" -> properties.getForgotPassword();
             case "contact" -> properties.getContact();
             case "githubProxy" -> properties.getGithubProxy();
+            case "validate" -> properties.getValidate();
             default -> throw new IllegalArgumentException("Unknown rate limit endpoint: " + endpointName);
         };
     }

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -36,6 +36,9 @@ app:
     refresh:
       capacity: ${RATE_LIMIT_REFRESH_CAPACITY:30}
       window: ${RATE_LIMIT_REFRESH_WINDOW:1m}
+    validate:
+      capacity: ${RATE_LIMIT_VALIDATE_CAPACITY:20}
+      window: ${RATE_LIMIT_VALIDATE_WINDOW:1m}
 
 google:
   client:


### PR DESCRIPTION
## Problem

`GET /api/validate/email/<candidate>` and `GET /api/validate/username/<candidate>` are anonymous and unratelimited, so they act as an account-existence oracle: anyone can enumerate registered emails/usernames by probing without authentication, enabling targeted phishing and credential stuffing.

## Fix

Added server-side rate limiting to the anonymous availability checks (retaining the pre-JWT signup UX):

- Added a `validate` endpoint limit (default 20 req/min per client, configurable via `RATE_LIMIT_VALIDATE_CAPACITY`/`RATE_LIMIT_VALIDATE_WINDOW`) to `RateLimitProperties` and `application.yml`.
- Registered `GET /api/validate/email`, `/api/validate/username`, and `/api/validate/phone` as rate-limited routes in `RateLimitingFilter` (reuses the existing bucket4j infrastructure that already protects login/signup/refresh).

A client exceeding the cap now gets `429 Too Many Requests`, throttling bulk account enumeration while leaving the per-request checks intact.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java`
- `Backend/src/main/resources/application.yml`

## Testing

- More than 20 anonymous `GET /api/validate/...` requests from the same client within a minute now return `429` with `X-RateLimit-*` headers, matching login/signup behavior.

Closes #15454