### PR TITLE
fix(issue-15440,15452): harden QA stream endpoints with auth, role checks, and upvote dedupe

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java
@@ -1,7 +1,11 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.model.SessionQuestion;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -10,7 +14,6 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/stream/qa")
-@CrossOrigin(origins = "*")
 public class QAStreamController {
 
     private final Map<String, SessionQuestion> questionsDatabase = new ConcurrentHashMap<>();
@@ -28,7 +31,15 @@ public class QAStreamController {
     }
 
     @PostMapping("/submit")
-    public ResponseEntity<SessionQuestion> submitQuestion(@RequestBody SessionQuestion payload) {
+    public ResponseEntity<SessionQuestion> submitQuestion(@RequestBody SessionQuestion payload,
+            Authentication authentication) {
+        if (authentication == null || !StringUtils.hasText(authentication.getName())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if (payload.getSessionId() == null || payload.getSessionId().isBlank()
+                || payload.getQuestionText() == null || payload.getQuestionText().isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
         String id = "q-" + UUID.randomUUID().toString().substring(0, 8);
         SessionQuestion q = new SessionQuestion(id, payload.getSessionId(), payload.getAuthorName(), payload.getQuestionText());
         questionsDatabase.put(id, q);
@@ -36,16 +47,24 @@ public class QAStreamController {
     }
 
     @PostMapping("/{id}/upvote")
-    public ResponseEntity<SessionQuestion> upvoteQuestion(@PathVariable String id) {
+    public ResponseEntity<SessionQuestion> upvoteQuestion(@PathVariable String id, Authentication authentication) {
         SessionQuestion q = questionsDatabase.get(id);
-        if (q != null) {
-            q.setUpvotes(q.getUpvotes() + 1);
-            return ResponseEntity.ok(q);
+        if (q == null) {
+            return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.notFound().build();
+        if (authentication == null || !StringUtils.hasText(authentication.getName())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if (!q.addVoter(authentication.getName())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .build();
+        }
+        q.setUpvotes(q.getUpvotes() + 1);
+        return ResponseEntity.ok(q);
     }
 
     @PostMapping("/{id}/pin")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<SessionQuestion> pinQuestion(@PathVariable String id) {
         SessionQuestion q = questionsDatabase.get(id);
         if (q != null) {
@@ -56,6 +75,7 @@ public class QAStreamController {
     }
 
     @PostMapping("/{id}/answer")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<SessionQuestion> markAnswered(@PathVariable String id) {
         SessionQuestion q = questionsDatabase.get(id);
         if (q != null) {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/SessionQuestion.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/SessionQuestion.java
@@ -1,6 +1,8 @@
 package com.sandeep.eventrabackend.model;
 
 import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SessionQuestion {
     private String id;
@@ -11,6 +13,7 @@ public class SessionQuestion {
     private boolean isPinned;
     private boolean isAnswered;
     private LocalDateTime createdAt;
+    private final Set<String> voterKeys = ConcurrentHashMap.newKeySet();
 
     public SessionQuestion() {
         this.createdAt = LocalDateTime.now();
@@ -25,6 +28,14 @@ public class SessionQuestion {
         this.isPinned = false;
         this.isAnswered = false;
         this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean hasVoted(String voterKey) {
+        return voterKeys.contains(voterKey);
+    }
+
+    public boolean addVoter(String voterKey) {
+        return voterKeys.add(voterKey);
     }
 
     // Getters and Setters


### PR DESCRIPTION
## Problem

`QAStreamController` (`/api/stream/qa`) exposed four mutating endpoints with no explicit authorization, no ownership/session checks, and `@CrossOrigin(origins = "*")`:

- `POST /submit` — any caller can post a question into any `sessionId`.
- `POST /{id}/upvote` — `q.setUpvotes(q.getUpvotes() + 1)` with no per-user dedupe: one client can upvote the same question unlimited times and drive it to the top of the sort (by `isPinned`, then `upvotes`).
- `POST /{id}/pin` — any caller can pin/unpin (moderator action).
- `POST /{id}/answer` — any caller can mark any question as answered.

This contrasts with the hardened sibling `LiveAudienceController`, where upvotes are deduped per user (issue #14509).

## Fix

- Removed `@CrossOrigin(origins = "*")` (CORS is handled by the global `corsConfigurationSource` in `SecurityConfig`).
- `submit` now requires an authenticated user and rejects blank `sessionId`/`questionText`.
- `upvote` is now idempotent per user: the first upvote by a given authenticated user is counted; repeat upvotes from the same user return `400`.
- `pin` and `answer` now require an `ORGANIZER`, `ADMIN`, or `SUPER_ADMIN` authority via `@PreAuthorize` (method security is enabled via `@EnableMethodSecurity`).

The shared `SessionQuestion` model gained a `voterKeys` set (per-question, concurrency-safe) plus `hasVoted`/`addVoter` helpers for the dedupe. It is used only by this controller.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/model/SessionQuestion.java`

## Testing

- Repeating `POST /api/stream/qa/{id}/upvote` with the same authenticated user returns `400` after the first call; a different user can still upvote.
- `POST /api/stream/qa/{id}/pin` and `/answer` by an attendee now return `403`; organizer/admin succeeds.
- `/api/stream/qa/**` remains behind the security filter chain's `anyRequest().authenticated()`.

Note: question data is still stored in-memory in this legacy controller; the DB-backed `LiveAudienceController`/`LiveAudienceService` flow remains the persistent Q&A path.

Closes #15440
Closes #15452