### PR TITLE
feat: add clamp gap helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/chunk-tree.test.js
+++ b/src/eventra-kit/__tests__/chunk-tree.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkTree from '../chunk-tree.js';
+
+describe('chunk-tree', () => {
+  it('exports a module', () => {
+    expect(ChunkTree).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-triple.test.js
+++ b/src/eventra-kit/__tests__/chunk-triple.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkTriple from '../chunk-triple.js';
+
+describe('chunk-triple', () => {
+  it('exports a module', () => {
+    expect(ChunkTriple).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-uri.test.js
+++ b/src/eventra-kit/__tests__/chunk-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkUri from '../chunk-uri.js';
+
+describe('chunk-uri', () => {
+  it('exports a module', () => {
+    expect(ChunkUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-url.test.js
+++ b/src/eventra-kit/__tests__/chunk-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkUrl from '../chunk-url.js';
+
+describe('chunk-url', () => {
+  it('exports a module', () => {
+    expect(ChunkUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-value.test.js
+++ b/src/eventra-kit/__tests__/chunk-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkValue from '../chunk-value.js';
+
+describe('chunk-value', () => {
+  it('exports a module', () => {
+    expect(ChunkValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-vector.test.js
+++ b/src/eventra-kit/__tests__/chunk-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkVector from '../chunk-vector.js';
+
+describe('chunk-vector', () => {
+  it('exports a module', () => {
+    expect(ChunkVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-vertex.test.js
+++ b/src/eventra-kit/__tests__/chunk-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkVertex from '../chunk-vertex.js';
+
+describe('chunk-vertex', () => {
+  it('exports a module', () => {
+    expect(ChunkVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-weight.test.js
+++ b/src/eventra-kit/__tests__/chunk-weight.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkWeight from '../chunk-weight.js';
+
+describe('chunk-weight', () => {
+  it('exports a module', () => {
+    expect(ChunkWeight).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-word.test.js
+++ b/src/eventra-kit/__tests__/chunk-word.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkWord from '../chunk-word.js';
+
+describe('chunk-word', () => {
+  it('exports a module', () => {
+    expect(ChunkWord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/chunk-xml.test.js
+++ b/src/eventra-kit/__tests__/chunk-xml.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ChunkXml from '../chunk-xml.js';
+
+describe('chunk-xml', () => {
+  it('exports a module', () => {
+    expect(ChunkXml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-block.test.js
+++ b/src/eventra-kit/__tests__/clamp-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampBlock from '../clamp-block.js';
+
+describe('clamp-block', () => {
+  it('exports a module', () => {
+    expect(ClampBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-box.test.js
+++ b/src/eventra-kit/__tests__/clamp-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampBox from '../clamp-box.js';
+
+describe('clamp-box', () => {
+  it('exports a module', () => {
+    expect(ClampBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-byte.test.js
+++ b/src/eventra-kit/__tests__/clamp-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampByte from '../clamp-byte.js';
+
+describe('clamp-byte', () => {
+  it('exports a module', () => {
+    expect(ClampByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-char.test.js
+++ b/src/eventra-kit/__tests__/clamp-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampChar from '../clamp-char.js';
+
+describe('clamp-char', () => {
+  it('exports a module', () => {
+    expect(ClampChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-chunk.test.js
+++ b/src/eventra-kit/__tests__/clamp-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampChunk from '../clamp-chunk.js';
+
+describe('clamp-chunk', () => {
+  it('exports a module', () => {
+    expect(ClampChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-circle.test.js
+++ b/src/eventra-kit/__tests__/clamp-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampCircle from '../clamp-circle.js';
+
+describe('clamp-circle', () => {
+  it('exports a module', () => {
+    expect(ClampCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-count.test.js
+++ b/src/eventra-kit/__tests__/clamp-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampCount from '../clamp-count.js';
+
+describe('clamp-count', () => {
+  it('exports a module', () => {
+    expect(ClampCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-delta.test.js
+++ b/src/eventra-kit/__tests__/clamp-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampDelta from '../clamp-delta.js';
+
+describe('clamp-delta', () => {
+  it('exports a module', () => {
+    expect(ClampDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-dict.test.js
+++ b/src/eventra-kit/__tests__/clamp-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampDict from '../clamp-dict.js';
+
+describe('clamp-dict', () => {
+  it('exports a module', () => {
+    expect(ClampDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-dir.test.js
+++ b/src/eventra-kit/__tests__/clamp-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampDir from '../clamp-dir.js';
+
+describe('clamp-dir', () => {
+  it('exports a module', () => {
+    expect(ClampDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-edge.test.js
+++ b/src/eventra-kit/__tests__/clamp-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampEdge from '../clamp-edge.js';
+
+describe('clamp-edge', () => {
+  it('exports a module', () => {
+    expect(ClampEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-element.test.js
+++ b/src/eventra-kit/__tests__/clamp-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampElement from '../clamp-element.js';
+
+describe('clamp-element', () => {
+  it('exports a module', () => {
+    expect(ClampElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-entry.test.js
+++ b/src/eventra-kit/__tests__/clamp-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampEntry from '../clamp-entry.js';
+
+describe('clamp-entry', () => {
+  it('exports a module', () => {
+    expect(ClampEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-field.test.js
+++ b/src/eventra-kit/__tests__/clamp-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampField from '../clamp-field.js';
+
+describe('clamp-field', () => {
+  it('exports a module', () => {
+    expect(ClampField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-file.test.js
+++ b/src/eventra-kit/__tests__/clamp-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampFile from '../clamp-file.js';
+
+describe('clamp-file', () => {
+  it('exports a module', () => {
+    expect(ClampFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-fraction.test.js
+++ b/src/eventra-kit/__tests__/clamp-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampFraction from '../clamp-fraction.js';
+
+describe('clamp-fraction', () => {
+  it('exports a module', () => {
+    expect(ClampFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-frame.test.js
+++ b/src/eventra-kit/__tests__/clamp-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampFrame from '../clamp-frame.js';
+
+describe('clamp-frame', () => {
+  it('exports a module', () => {
+    expect(ClampFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-gap.test.js
+++ b/src/eventra-kit/__tests__/clamp-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampGap from '../clamp-gap.js';
+
+describe('clamp-gap', () => {
+  it('exports a module', () => {
+    expect(ClampGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/chunk-tree.js
+++ b/src/eventra-kit/chunk-tree.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-tree helper.
+ */
+export function chunkTree(value, fallback = 0) {
+  return value == null ? fallback : value;
+}
+

--- a/src/eventra-kit/chunk-triple.js
+++ b/src/eventra-kit/chunk-triple.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-triple helper.
+ */
+export function chunkTriple(value) {
+  return Array.isArray(value) ? value.length : String(value).length;
+}
+

--- a/src/eventra-kit/chunk-uri.js
+++ b/src/eventra-kit/chunk-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-uri helper.
+ */
+export function chunkUri(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/chunk-url.js
+++ b/src/eventra-kit/chunk-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-url helper.
+ */
+export function chunkUrl(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/chunk-value.js
+++ b/src/eventra-kit/chunk-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-value helper.
+ */
+export function chunkValue(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/chunk-vector.js
+++ b/src/eventra-kit/chunk-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-vector helper.
+ */
+export function chunkVector(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/chunk-vertex.js
+++ b/src/eventra-kit/chunk-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-vertex helper.
+ */
+export function chunkVertex(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/chunk-weight.js
+++ b/src/eventra-kit/chunk-weight.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-weight helper.
+ */
+export function chunkWeight(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/chunk-word.js
+++ b/src/eventra-kit/chunk-word.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-word helper.
+ */
+export function chunkWord(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/chunk-xml.js
+++ b/src/eventra-kit/chunk-xml.js
@@ -1,0 +1,7 @@
+/**
+ * adds a chunk-xml helper.
+ */
+export function chunkXml(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/clamp-block.js
+++ b/src/eventra-kit/clamp-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-block helper.
+ */
+export function clampBlock(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/clamp-box.js
+++ b/src/eventra-kit/clamp-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-box helper.
+ */
+export function clampBox(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/clamp-byte.js
+++ b/src/eventra-kit/clamp-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-byte helper.
+ */
+export function clampByte(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/clamp-char.js
+++ b/src/eventra-kit/clamp-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-char helper.
+ */
+export function clampChar(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/clamp-chunk.js
+++ b/src/eventra-kit/clamp-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-chunk helper.
+ */
+export function clampChunk(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/clamp-circle.js
+++ b/src/eventra-kit/clamp-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-circle helper.
+ */
+export function clampCircle(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/clamp-count.js
+++ b/src/eventra-kit/clamp-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-count helper.
+ */
+export function clampCount(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/clamp-delta.js
+++ b/src/eventra-kit/clamp-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-delta helper.
+ */
+export function clampDelta(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/clamp-dict.js
+++ b/src/eventra-kit/clamp-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-dict helper.
+ */
+export function clampDict(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/clamp-dir.js
+++ b/src/eventra-kit/clamp-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-dir helper.
+ */
+export function clampDir(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/clamp-edge.js
+++ b/src/eventra-kit/clamp-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-edge helper.
+ */
+export function clampEdge(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/clamp-element.js
+++ b/src/eventra-kit/clamp-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-element helper.
+ */
+export function clampElement(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/clamp-entry.js
+++ b/src/eventra-kit/clamp-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-entry helper.
+ */
+export function clampEntry(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/clamp-field.js
+++ b/src/eventra-kit/clamp-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-field helper.
+ */
+export function clampField(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/clamp-file.js
+++ b/src/eventra-kit/clamp-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-file helper.
+ */
+export function clampFile(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/clamp-fraction.js
+++ b/src/eventra-kit/clamp-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-fraction helper.
+ */
+export function clampFraction(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/clamp-frame.js
+++ b/src/eventra-kit/clamp-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-frame helper.
+ */
+export function clampFrame(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/clamp-gap.js
+++ b/src/eventra-kit/clamp-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-gap helper.
+ */
+export function clampGap(value) {
+  return Math.round(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/clamp-gap.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change