### PR TITLE
feat: add clamp vector helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/clamp-page.test.js
+++ b/src/eventra-kit/__tests__/clamp-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampPage from '../clamp-page.js';
+
+describe('clamp-page', () => {
+  it('exports a module', () => {
+    expect(ClampPage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-pair.test.js
+++ b/src/eventra-kit/__tests__/clamp-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampPair from '../clamp-pair.js';
+
+describe('clamp-pair', () => {
+  it('exports a module', () => {
+    expect(ClampPair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-path.test.js
+++ b/src/eventra-kit/__tests__/clamp-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampPath from '../clamp-path.js';
+
+describe('clamp-path', () => {
+  it('exports a module', () => {
+    expect(ClampPath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-point.test.js
+++ b/src/eventra-kit/__tests__/clamp-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampPoint from '../clamp-point.js';
+
+describe('clamp-point', () => {
+  it('exports a module', () => {
+    expect(ClampPoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-portion.test.js
+++ b/src/eventra-kit/__tests__/clamp-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampPortion from '../clamp-portion.js';
+
+describe('clamp-portion', () => {
+  it('exports a module', () => {
+    expect(ClampPortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-prop.test.js
+++ b/src/eventra-kit/__tests__/clamp-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampProp from '../clamp-prop.js';
+
+describe('clamp-prop', () => {
+  it('exports a module', () => {
+    expect(ClampProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-queue.test.js
+++ b/src/eventra-kit/__tests__/clamp-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampQueue from '../clamp-queue.js';
+
+describe('clamp-queue', () => {
+  it('exports a module', () => {
+    expect(ClampQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-range.test.js
+++ b/src/eventra-kit/__tests__/clamp-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampRange from '../clamp-range.js';
+
+describe('clamp-range', () => {
+  it('exports a module', () => {
+    expect(ClampRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-rank.test.js
+++ b/src/eventra-kit/__tests__/clamp-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampRank from '../clamp-rank.js';
+
+describe('clamp-rank', () => {
+  it('exports a module', () => {
+    expect(ClampRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-record.test.js
+++ b/src/eventra-kit/__tests__/clamp-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampRecord from '../clamp-record.js';
+
+describe('clamp-record', () => {
+  it('exports a module', () => {
+    expect(ClampRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-rect.test.js
+++ b/src/eventra-kit/__tests__/clamp-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampRect from '../clamp-rect.js';
+
+describe('clamp-rect', () => {
+  it('exports a module', () => {
+    expect(ClampRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-score.test.js
+++ b/src/eventra-kit/__tests__/clamp-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampScore from '../clamp-score.js';
+
+describe('clamp-score', () => {
+  it('exports a module', () => {
+    expect(ClampScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-segment.test.js
+++ b/src/eventra-kit/__tests__/clamp-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampSegment from '../clamp-segment.js';
+
+describe('clamp-segment', () => {
+  it('exports a module', () => {
+    expect(ClampSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-set.test.js
+++ b/src/eventra-kit/__tests__/clamp-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampSet from '../clamp-set.js';
+
+describe('clamp-set', () => {
+  it('exports a module', () => {
+    expect(ClampSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-size.test.js
+++ b/src/eventra-kit/__tests__/clamp-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampSize from '../clamp-size.js';
+
+describe('clamp-size', () => {
+  it('exports a module', () => {
+    expect(ClampSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-slice.test.js
+++ b/src/eventra-kit/__tests__/clamp-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampSlice from '../clamp-slice.js';
+
+describe('clamp-slice', () => {
+  it('exports a module', () => {
+    expect(ClampSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-space.test.js
+++ b/src/eventra-kit/__tests__/clamp-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampSpace from '../clamp-space.js';
+
+describe('clamp-space', () => {
+  it('exports a module', () => {
+    expect(ClampSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-span.test.js
+++ b/src/eventra-kit/__tests__/clamp-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampSpan from '../clamp-span.js';
+
+describe('clamp-span', () => {
+  it('exports a module', () => {
+    expect(ClampSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-stack.test.js
+++ b/src/eventra-kit/__tests__/clamp-stack.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampStack from '../clamp-stack.js';
+
+describe('clamp-stack', () => {
+  it('exports a module', () => {
+    expect(ClampStack).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-step.test.js
+++ b/src/eventra-kit/__tests__/clamp-step.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampStep from '../clamp-step.js';
+
+describe('clamp-step', () => {
+  it('exports a module', () => {
+    expect(ClampStep).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-string.test.js
+++ b/src/eventra-kit/__tests__/clamp-string.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampString from '../clamp-string.js';
+
+describe('clamp-string', () => {
+  it('exports a module', () => {
+    expect(ClampString).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-text.test.js
+++ b/src/eventra-kit/__tests__/clamp-text.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampText from '../clamp-text.js';
+
+describe('clamp-text', () => {
+  it('exports a module', () => {
+    expect(ClampText).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-time.test.js
+++ b/src/eventra-kit/__tests__/clamp-time.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampTime from '../clamp-time.js';
+
+describe('clamp-time', () => {
+  it('exports a module', () => {
+    expect(ClampTime).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-token.test.js
+++ b/src/eventra-kit/__tests__/clamp-token.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampToken from '../clamp-token.js';
+
+describe('clamp-token', () => {
+  it('exports a module', () => {
+    expect(ClampToken).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-tree.test.js
+++ b/src/eventra-kit/__tests__/clamp-tree.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampTree from '../clamp-tree.js';
+
+describe('clamp-tree', () => {
+  it('exports a module', () => {
+    expect(ClampTree).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-triple.test.js
+++ b/src/eventra-kit/__tests__/clamp-triple.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampTriple from '../clamp-triple.js';
+
+describe('clamp-triple', () => {
+  it('exports a module', () => {
+    expect(ClampTriple).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-uri.test.js
+++ b/src/eventra-kit/__tests__/clamp-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampUri from '../clamp-uri.js';
+
+describe('clamp-uri', () => {
+  it('exports a module', () => {
+    expect(ClampUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-url.test.js
+++ b/src/eventra-kit/__tests__/clamp-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampUrl from '../clamp-url.js';
+
+describe('clamp-url', () => {
+  it('exports a module', () => {
+    expect(ClampUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-value.test.js
+++ b/src/eventra-kit/__tests__/clamp-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampValue from '../clamp-value.js';
+
+describe('clamp-value', () => {
+  it('exports a module', () => {
+    expect(ClampValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/clamp-vector.test.js
+++ b/src/eventra-kit/__tests__/clamp-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ClampVector from '../clamp-vector.js';
+
+describe('clamp-vector', () => {
+  it('exports a module', () => {
+    expect(ClampVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/clamp-page.js
+++ b/src/eventra-kit/clamp-page.js
@@ -1,0 +1,8 @@
+/**
+ * adds a clamp-page helper.
+ */
+export function clampPage(value, index) {
+  if (index < 0 || index >= value.length) return value;
+  return value.slice(0, index).concat(value.slice(index + 1));
+}
+

--- a/src/eventra-kit/clamp-pair.js
+++ b/src/eventra-kit/clamp-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-pair helper.
+ */
+export function clampPair(value, index, item) {
+  return value.slice(0, index).concat([item], value.slice(index));
+}
+

--- a/src/eventra-kit/clamp-path.js
+++ b/src/eventra-kit/clamp-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-path helper.
+ */
+export function clampPath(value) {
+  return value.flat();
+}
+

--- a/src/eventra-kit/clamp-point.js
+++ b/src/eventra-kit/clamp-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-point helper.
+ */
+export function clampPoint(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/clamp-portion.js
+++ b/src/eventra-kit/clamp-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-portion helper.
+ */
+export function clampPortion(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/clamp-prop.js
+++ b/src/eventra-kit/clamp-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-prop helper.
+ */
+export function clampProp(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/clamp-queue.js
+++ b/src/eventra-kit/clamp-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-queue helper.
+ */
+export function clampQueue(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/clamp-range.js
+++ b/src/eventra-kit/clamp-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-range helper.
+ */
+export function clampRange(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/clamp-rank.js
+++ b/src/eventra-kit/clamp-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-rank helper.
+ */
+export function clampRank(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/clamp-record.js
+++ b/src/eventra-kit/clamp-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-record helper.
+ */
+export function clampRecord(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/clamp-rect.js
+++ b/src/eventra-kit/clamp-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-rect helper.
+ */
+export function clampRect(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/clamp-score.js
+++ b/src/eventra-kit/clamp-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-score helper.
+ */
+export function clampScore(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/clamp-segment.js
+++ b/src/eventra-kit/clamp-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-segment helper.
+ */
+export function clampSegment(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/clamp-set.js
+++ b/src/eventra-kit/clamp-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-set helper.
+ */
+export function clampSet(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/clamp-size.js
+++ b/src/eventra-kit/clamp-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-size helper.
+ */
+export function clampSize(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/clamp-slice.js
+++ b/src/eventra-kit/clamp-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-slice helper.
+ */
+export function clampSlice(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/clamp-space.js
+++ b/src/eventra-kit/clamp-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-space helper.
+ */
+export function clampSpace(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/clamp-span.js
+++ b/src/eventra-kit/clamp-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-span helper.
+ */
+export function clampSpan(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/clamp-stack.js
+++ b/src/eventra-kit/clamp-stack.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-stack helper.
+ */
+export function clampStack(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/clamp-step.js
+++ b/src/eventra-kit/clamp-step.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-step helper.
+ */
+export function clampStep(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/clamp-string.js
+++ b/src/eventra-kit/clamp-string.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-string helper.
+ */
+export function clampString(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/clamp-text.js
+++ b/src/eventra-kit/clamp-text.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-text helper.
+ */
+export function clampText(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/clamp-time.js
+++ b/src/eventra-kit/clamp-time.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-time helper.
+ */
+export function clampTime(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/clamp-token.js
+++ b/src/eventra-kit/clamp-token.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-token helper.
+ */
+export function clampToken(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/clamp-tree.js
+++ b/src/eventra-kit/clamp-tree.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-tree helper.
+ */
+export function clampTree(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/clamp-triple.js
+++ b/src/eventra-kit/clamp-triple.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-triple helper.
+ */
+export function clampTriple(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/clamp-uri.js
+++ b/src/eventra-kit/clamp-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-uri helper.
+ */
+export function clampUri(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/clamp-url.js
+++ b/src/eventra-kit/clamp-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-url helper.
+ */
+export function clampUrl(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/clamp-value.js
+++ b/src/eventra-kit/clamp-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-value helper.
+ */
+export function clampValue(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/clamp-vector.js
+++ b/src/eventra-kit/clamp-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a clamp-vector helper.
+ */
+export function clampVector(value) {
+  return value.map((item, index) => [index, item]);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/clamp-vector.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change