### PR TITLE
feat: add compute map helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/compute-circle.test.js
+++ b/src/eventra-kit/__tests__/compute-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeCircle from '../compute-circle.js';
+
+describe('compute-circle', () => {
+  it('exports a module', () => {
+    expect(ComputeCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-count.test.js
+++ b/src/eventra-kit/__tests__/compute-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeCount from '../compute-count.js';
+
+describe('compute-count', () => {
+  it('exports a module', () => {
+    expect(ComputeCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-date.test.js
+++ b/src/eventra-kit/__tests__/compute-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeDate from '../compute-date.js';
+
+describe('compute-date', () => {
+  it('exports a module', () => {
+    expect(ComputeDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-delta.test.js
+++ b/src/eventra-kit/__tests__/compute-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeDelta from '../compute-delta.js';
+
+describe('compute-delta', () => {
+  it('exports a module', () => {
+    expect(ComputeDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-dict.test.js
+++ b/src/eventra-kit/__tests__/compute-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeDict from '../compute-dict.js';
+
+describe('compute-dict', () => {
+  it('exports a module', () => {
+    expect(ComputeDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-dir.test.js
+++ b/src/eventra-kit/__tests__/compute-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeDir from '../compute-dir.js';
+
+describe('compute-dir', () => {
+  it('exports a module', () => {
+    expect(ComputeDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-edge.test.js
+++ b/src/eventra-kit/__tests__/compute-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeEdge from '../compute-edge.js';
+
+describe('compute-edge', () => {
+  it('exports a module', () => {
+    expect(ComputeEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-element.test.js
+++ b/src/eventra-kit/__tests__/compute-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeElement from '../compute-element.js';
+
+describe('compute-element', () => {
+  it('exports a module', () => {
+    expect(ComputeElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-entry.test.js
+++ b/src/eventra-kit/__tests__/compute-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeEntry from '../compute-entry.js';
+
+describe('compute-entry', () => {
+  it('exports a module', () => {
+    expect(ComputeEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-field.test.js
+++ b/src/eventra-kit/__tests__/compute-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeField from '../compute-field.js';
+
+describe('compute-field', () => {
+  it('exports a module', () => {
+    expect(ComputeField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-file.test.js
+++ b/src/eventra-kit/__tests__/compute-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeFile from '../compute-file.js';
+
+describe('compute-file', () => {
+  it('exports a module', () => {
+    expect(ComputeFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-fraction.test.js
+++ b/src/eventra-kit/__tests__/compute-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeFraction from '../compute-fraction.js';
+
+describe('compute-fraction', () => {
+  it('exports a module', () => {
+    expect(ComputeFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-frame.test.js
+++ b/src/eventra-kit/__tests__/compute-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeFrame from '../compute-frame.js';
+
+describe('compute-frame', () => {
+  it('exports a module', () => {
+    expect(ComputeFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-gap.test.js
+++ b/src/eventra-kit/__tests__/compute-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeGap from '../compute-gap.js';
+
+describe('compute-gap', () => {
+  it('exports a module', () => {
+    expect(ComputeGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-graph.test.js
+++ b/src/eventra-kit/__tests__/compute-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeGraph from '../compute-graph.js';
+
+describe('compute-graph', () => {
+  it('exports a module', () => {
+    expect(ComputeGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-grid.test.js
+++ b/src/eventra-kit/__tests__/compute-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeGrid from '../compute-grid.js';
+
+describe('compute-grid', () => {
+  it('exports a module', () => {
+    expect(ComputeGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-group.test.js
+++ b/src/eventra-kit/__tests__/compute-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeGroup from '../compute-group.js';
+
+describe('compute-group', () => {
+  it('exports a module', () => {
+    expect(ComputeGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-hash.test.js
+++ b/src/eventra-kit/__tests__/compute-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeHash from '../compute-hash.js';
+
+describe('compute-hash', () => {
+  it('exports a module', () => {
+    expect(ComputeHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-heap.test.js
+++ b/src/eventra-kit/__tests__/compute-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeHeap from '../compute-heap.js';
+
+describe('compute-heap', () => {
+  it('exports a module', () => {
+    expect(ComputeHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-html.test.js
+++ b/src/eventra-kit/__tests__/compute-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeHtml from '../compute-html.js';
+
+describe('compute-html', () => {
+  it('exports a module', () => {
+    expect(ComputeHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-id.test.js
+++ b/src/eventra-kit/__tests__/compute-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeId from '../compute-id.js';
+
+describe('compute-id', () => {
+  it('exports a module', () => {
+    expect(ComputeId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-index.test.js
+++ b/src/eventra-kit/__tests__/compute-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeIndex from '../compute-index.js';
+
+describe('compute-index', () => {
+  it('exports a module', () => {
+    expect(ComputeIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-interval.test.js
+++ b/src/eventra-kit/__tests__/compute-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeInterval from '../compute-interval.js';
+
+describe('compute-interval', () => {
+  it('exports a module', () => {
+    expect(ComputeInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-item.test.js
+++ b/src/eventra-kit/__tests__/compute-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeItem from '../compute-item.js';
+
+describe('compute-item', () => {
+  it('exports a module', () => {
+    expect(ComputeItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-json.test.js
+++ b/src/eventra-kit/__tests__/compute-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeJson from '../compute-json.js';
+
+describe('compute-json', () => {
+  it('exports a module', () => {
+    expect(ComputeJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-key.test.js
+++ b/src/eventra-kit/__tests__/compute-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeKey from '../compute-key.js';
+
+describe('compute-key', () => {
+  it('exports a module', () => {
+    expect(ComputeKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-leaf.test.js
+++ b/src/eventra-kit/__tests__/compute-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeLeaf from '../compute-leaf.js';
+
+describe('compute-leaf', () => {
+  it('exports a module', () => {
+    expect(ComputeLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-length.test.js
+++ b/src/eventra-kit/__tests__/compute-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeLength from '../compute-length.js';
+
+describe('compute-length', () => {
+  it('exports a module', () => {
+    expect(ComputeLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-line.test.js
+++ b/src/eventra-kit/__tests__/compute-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeLine from '../compute-line.js';
+
+describe('compute-line', () => {
+  it('exports a module', () => {
+    expect(ComputeLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-list.test.js
+++ b/src/eventra-kit/__tests__/compute-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeList from '../compute-list.js';
+
+describe('compute-list', () => {
+  it('exports a module', () => {
+    expect(ComputeList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-map.test.js
+++ b/src/eventra-kit/__tests__/compute-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeMap from '../compute-map.js';
+
+describe('compute-map', () => {
+  it('exports a module', () => {
+    expect(ComputeMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/compute-circle.js
+++ b/src/eventra-kit/compute-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-circle helper.
+ */
+export function computeCircle(value) {
+  return Array.isArray(value) ? value.length : String(value).length;
+}
+

--- a/src/eventra-kit/compute-count.js
+++ b/src/eventra-kit/compute-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-count helper.
+ */
+export function computeCount(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/compute-date.js
+++ b/src/eventra-kit/compute-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-date helper.
+ */
+export function computeDate(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/compute-delta.js
+++ b/src/eventra-kit/compute-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-delta helper.
+ */
+export function computeDelta(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/compute-dict.js
+++ b/src/eventra-kit/compute-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-dict helper.
+ */
+export function computeDict(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/compute-dir.js
+++ b/src/eventra-kit/compute-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-dir helper.
+ */
+export function computeDir(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/compute-edge.js
+++ b/src/eventra-kit/compute-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-edge helper.
+ */
+export function computeEdge(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/compute-element.js
+++ b/src/eventra-kit/compute-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-element helper.
+ */
+export function computeElement(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/compute-entry.js
+++ b/src/eventra-kit/compute-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-entry helper.
+ */
+export function computeEntry(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/compute-field.js
+++ b/src/eventra-kit/compute-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-field helper.
+ */
+export function computeField(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/compute-file.js
+++ b/src/eventra-kit/compute-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-file helper.
+ */
+export function computeFile(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/compute-fraction.js
+++ b/src/eventra-kit/compute-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-fraction helper.
+ */
+export function computeFraction(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/compute-frame.js
+++ b/src/eventra-kit/compute-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-frame helper.
+ */
+export function computeFrame(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/compute-gap.js
+++ b/src/eventra-kit/compute-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-gap helper.
+ */
+export function computeGap(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/compute-graph.js
+++ b/src/eventra-kit/compute-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-graph helper.
+ */
+export function computeGraph(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/compute-grid.js
+++ b/src/eventra-kit/compute-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-grid helper.
+ */
+export function computeGrid(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/compute-group.js
+++ b/src/eventra-kit/compute-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-group helper.
+ */
+export function computeGroup(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/compute-hash.js
+++ b/src/eventra-kit/compute-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-hash helper.
+ */
+export function computeHash(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/compute-heap.js
+++ b/src/eventra-kit/compute-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-heap helper.
+ */
+export function computeHeap(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/compute-html.js
+++ b/src/eventra-kit/compute-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-html helper.
+ */
+export function computeHtml(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/compute-id.js
+++ b/src/eventra-kit/compute-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-id helper.
+ */
+export function computeId(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/compute-index.js
+++ b/src/eventra-kit/compute-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-index helper.
+ */
+export function computeIndex(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/compute-interval.js
+++ b/src/eventra-kit/compute-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-interval helper.
+ */
+export function computeInterval(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/compute-item.js
+++ b/src/eventra-kit/compute-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-item helper.
+ */
+export function computeItem(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/compute-json.js
+++ b/src/eventra-kit/compute-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-json helper.
+ */
+export function computeJson(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/compute-key.js
+++ b/src/eventra-kit/compute-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-key helper.
+ */
+export function computeKey(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/compute-leaf.js
+++ b/src/eventra-kit/compute-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-leaf helper.
+ */
+export function computeLeaf(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/compute-length.js
+++ b/src/eventra-kit/compute-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-length helper.
+ */
+export function computeLength(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/compute-line.js
+++ b/src/eventra-kit/compute-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-line helper.
+ */
+export function computeLine(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/compute-list.js
+++ b/src/eventra-kit/compute-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-list helper.
+ */
+export function computeList(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/compute-map.js
+++ b/src/eventra-kit/compute-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-map helper.
+ */
+export function computeMap(value) {
+  return Math.exp(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/compute-map.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change