### PR TITLE
feat: add convert count helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/compute-set.test.js
+++ b/src/eventra-kit/__tests__/compute-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeSet from '../compute-set.js';
+
+describe('compute-set', () => {
+  it('exports a module', () => {
+    expect(ComputeSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-size.test.js
+++ b/src/eventra-kit/__tests__/compute-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeSize from '../compute-size.js';
+
+describe('compute-size', () => {
+  it('exports a module', () => {
+    expect(ComputeSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-slice.test.js
+++ b/src/eventra-kit/__tests__/compute-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeSlice from '../compute-slice.js';
+
+describe('compute-slice', () => {
+  it('exports a module', () => {
+    expect(ComputeSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-space.test.js
+++ b/src/eventra-kit/__tests__/compute-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeSpace from '../compute-space.js';
+
+describe('compute-space', () => {
+  it('exports a module', () => {
+    expect(ComputeSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-span.test.js
+++ b/src/eventra-kit/__tests__/compute-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeSpan from '../compute-span.js';
+
+describe('compute-span', () => {
+  it('exports a module', () => {
+    expect(ComputeSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-stack.test.js
+++ b/src/eventra-kit/__tests__/compute-stack.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeStack from '../compute-stack.js';
+
+describe('compute-stack', () => {
+  it('exports a module', () => {
+    expect(ComputeStack).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-step.test.js
+++ b/src/eventra-kit/__tests__/compute-step.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeStep from '../compute-step.js';
+
+describe('compute-step', () => {
+  it('exports a module', () => {
+    expect(ComputeStep).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-string.test.js
+++ b/src/eventra-kit/__tests__/compute-string.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeString from '../compute-string.js';
+
+describe('compute-string', () => {
+  it('exports a module', () => {
+    expect(ComputeString).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-text.test.js
+++ b/src/eventra-kit/__tests__/compute-text.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeText from '../compute-text.js';
+
+describe('compute-text', () => {
+  it('exports a module', () => {
+    expect(ComputeText).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-time.test.js
+++ b/src/eventra-kit/__tests__/compute-time.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeTime from '../compute-time.js';
+
+describe('compute-time', () => {
+  it('exports a module', () => {
+    expect(ComputeTime).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-token.test.js
+++ b/src/eventra-kit/__tests__/compute-token.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeToken from '../compute-token.js';
+
+describe('compute-token', () => {
+  it('exports a module', () => {
+    expect(ComputeToken).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-tree.test.js
+++ b/src/eventra-kit/__tests__/compute-tree.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeTree from '../compute-tree.js';
+
+describe('compute-tree', () => {
+  it('exports a module', () => {
+    expect(ComputeTree).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-triple.test.js
+++ b/src/eventra-kit/__tests__/compute-triple.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeTriple from '../compute-triple.js';
+
+describe('compute-triple', () => {
+  it('exports a module', () => {
+    expect(ComputeTriple).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-uri.test.js
+++ b/src/eventra-kit/__tests__/compute-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeUri from '../compute-uri.js';
+
+describe('compute-uri', () => {
+  it('exports a module', () => {
+    expect(ComputeUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-url.test.js
+++ b/src/eventra-kit/__tests__/compute-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeUrl from '../compute-url.js';
+
+describe('compute-url', () => {
+  it('exports a module', () => {
+    expect(ComputeUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-value.test.js
+++ b/src/eventra-kit/__tests__/compute-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeValue from '../compute-value.js';
+
+describe('compute-value', () => {
+  it('exports a module', () => {
+    expect(ComputeValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-vector.test.js
+++ b/src/eventra-kit/__tests__/compute-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeVector from '../compute-vector.js';
+
+describe('compute-vector', () => {
+  it('exports a module', () => {
+    expect(ComputeVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-vertex.test.js
+++ b/src/eventra-kit/__tests__/compute-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeVertex from '../compute-vertex.js';
+
+describe('compute-vertex', () => {
+  it('exports a module', () => {
+    expect(ComputeVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-weight.test.js
+++ b/src/eventra-kit/__tests__/compute-weight.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeWeight from '../compute-weight.js';
+
+describe('compute-weight', () => {
+  it('exports a module', () => {
+    expect(ComputeWeight).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-word.test.js
+++ b/src/eventra-kit/__tests__/compute-word.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeWord from '../compute-word.js';
+
+describe('compute-word', () => {
+  it('exports a module', () => {
+    expect(ComputeWord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/compute-xml.test.js
+++ b/src/eventra-kit/__tests__/compute-xml.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ComputeXml from '../compute-xml.js';
+
+describe('compute-xml', () => {
+  it('exports a module', () => {
+    expect(ComputeXml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-array.test.js
+++ b/src/eventra-kit/__tests__/convert-array.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertArray from '../convert-array.js';
+
+describe('convert-array', () => {
+  it('exports a module', () => {
+    expect(ConvertArray).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-block.test.js
+++ b/src/eventra-kit/__tests__/convert-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertBlock from '../convert-block.js';
+
+describe('convert-block', () => {
+  it('exports a module', () => {
+    expect(ConvertBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-box.test.js
+++ b/src/eventra-kit/__tests__/convert-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertBox from '../convert-box.js';
+
+describe('convert-box', () => {
+  it('exports a module', () => {
+    expect(ConvertBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-byte.test.js
+++ b/src/eventra-kit/__tests__/convert-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertByte from '../convert-byte.js';
+
+describe('convert-byte', () => {
+  it('exports a module', () => {
+    expect(ConvertByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-char.test.js
+++ b/src/eventra-kit/__tests__/convert-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertChar from '../convert-char.js';
+
+describe('convert-char', () => {
+  it('exports a module', () => {
+    expect(ConvertChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-chunk.test.js
+++ b/src/eventra-kit/__tests__/convert-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertChunk from '../convert-chunk.js';
+
+describe('convert-chunk', () => {
+  it('exports a module', () => {
+    expect(ConvertChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-circle.test.js
+++ b/src/eventra-kit/__tests__/convert-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertCircle from '../convert-circle.js';
+
+describe('convert-circle', () => {
+  it('exports a module', () => {
+    expect(ConvertCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-count.test.js
+++ b/src/eventra-kit/__tests__/convert-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertCount from '../convert-count.js';
+
+describe('convert-count', () => {
+  it('exports a module', () => {
+    expect(ConvertCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/compute-set.js
+++ b/src/eventra-kit/compute-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-set helper.
+ */
+export function computeSet(value, index, item) {
+  return value.slice(0, index).concat([item], value.slice(index));
+}
+

--- a/src/eventra-kit/compute-size.js
+++ b/src/eventra-kit/compute-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-size helper.
+ */
+export function computeSize(value) {
+  return value.flat();
+}
+

--- a/src/eventra-kit/compute-slice.js
+++ b/src/eventra-kit/compute-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-slice helper.
+ */
+export function computeSlice(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/compute-space.js
+++ b/src/eventra-kit/compute-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-space helper.
+ */
+export function computeSpace(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/compute-span.js
+++ b/src/eventra-kit/compute-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-span helper.
+ */
+export function computeSpan(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/compute-stack.js
+++ b/src/eventra-kit/compute-stack.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-stack helper.
+ */
+export function computeStack(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/compute-step.js
+++ b/src/eventra-kit/compute-step.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-step helper.
+ */
+export function computeStep(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/compute-string.js
+++ b/src/eventra-kit/compute-string.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-string helper.
+ */
+export function computeString(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/compute-text.js
+++ b/src/eventra-kit/compute-text.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-text helper.
+ */
+export function computeText(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/compute-time.js
+++ b/src/eventra-kit/compute-time.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-time helper.
+ */
+export function computeTime(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/compute-token.js
+++ b/src/eventra-kit/compute-token.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-token helper.
+ */
+export function computeToken(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/compute-tree.js
+++ b/src/eventra-kit/compute-tree.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-tree helper.
+ */
+export function computeTree(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/compute-triple.js
+++ b/src/eventra-kit/compute-triple.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-triple helper.
+ */
+export function computeTriple(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/compute-uri.js
+++ b/src/eventra-kit/compute-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-uri helper.
+ */
+export function computeUri(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/compute-url.js
+++ b/src/eventra-kit/compute-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-url helper.
+ */
+export function computeUrl(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/compute-value.js
+++ b/src/eventra-kit/compute-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-value helper.
+ */
+export function computeValue(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/compute-vector.js
+++ b/src/eventra-kit/compute-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-vector helper.
+ */
+export function computeVector(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/compute-vertex.js
+++ b/src/eventra-kit/compute-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-vertex helper.
+ */
+export function computeVertex(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/compute-weight.js
+++ b/src/eventra-kit/compute-weight.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-weight helper.
+ */
+export function computeWeight(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/compute-word.js
+++ b/src/eventra-kit/compute-word.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-word helper.
+ */
+export function computeWord(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/compute-xml.js
+++ b/src/eventra-kit/compute-xml.js
@@ -1,0 +1,7 @@
+/**
+ * adds a compute-xml helper.
+ */
+export function computeXml(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/convert-array.js
+++ b/src/eventra-kit/convert-array.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-array helper.
+ */
+export function convertArray(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/convert-block.js
+++ b/src/eventra-kit/convert-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-block helper.
+ */
+export function convertBlock(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/convert-box.js
+++ b/src/eventra-kit/convert-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-box helper.
+ */
+export function convertBox(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/convert-byte.js
+++ b/src/eventra-kit/convert-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-byte helper.
+ */
+export function convertByte(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/convert-char.js
+++ b/src/eventra-kit/convert-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-char helper.
+ */
+export function convertChar(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/convert-chunk.js
+++ b/src/eventra-kit/convert-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-chunk helper.
+ */
+export function convertChunk(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/convert-circle.js
+++ b/src/eventra-kit/convert-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-circle helper.
+ */
+export function convertCircle(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/convert-count.js
+++ b/src/eventra-kit/convert-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-count helper.
+ */
+export function convertCount(value) {
+  return value.map((item, index) => [index, item]);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/convert-count.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change