### PR TITLE
feat: add convert prop helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/convert-gap.test.js
+++ b/src/eventra-kit/__tests__/convert-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertGap from '../convert-gap.js';
+
+describe('convert-gap', () => {
+  it('exports a module', () => {
+    expect(ConvertGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-graph.test.js
+++ b/src/eventra-kit/__tests__/convert-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertGraph from '../convert-graph.js';
+
+describe('convert-graph', () => {
+  it('exports a module', () => {
+    expect(ConvertGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-grid.test.js
+++ b/src/eventra-kit/__tests__/convert-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertGrid from '../convert-grid.js';
+
+describe('convert-grid', () => {
+  it('exports a module', () => {
+    expect(ConvertGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-group.test.js
+++ b/src/eventra-kit/__tests__/convert-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertGroup from '../convert-group.js';
+
+describe('convert-group', () => {
+  it('exports a module', () => {
+    expect(ConvertGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-hash.test.js
+++ b/src/eventra-kit/__tests__/convert-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertHash from '../convert-hash.js';
+
+describe('convert-hash', () => {
+  it('exports a module', () => {
+    expect(ConvertHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-heap.test.js
+++ b/src/eventra-kit/__tests__/convert-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertHeap from '../convert-heap.js';
+
+describe('convert-heap', () => {
+  it('exports a module', () => {
+    expect(ConvertHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-html.test.js
+++ b/src/eventra-kit/__tests__/convert-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertHtml from '../convert-html.js';
+
+describe('convert-html', () => {
+  it('exports a module', () => {
+    expect(ConvertHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-id.test.js
+++ b/src/eventra-kit/__tests__/convert-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertId from '../convert-id.js';
+
+describe('convert-id', () => {
+  it('exports a module', () => {
+    expect(ConvertId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-index.test.js
+++ b/src/eventra-kit/__tests__/convert-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertIndex from '../convert-index.js';
+
+describe('convert-index', () => {
+  it('exports a module', () => {
+    expect(ConvertIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-interval.test.js
+++ b/src/eventra-kit/__tests__/convert-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertInterval from '../convert-interval.js';
+
+describe('convert-interval', () => {
+  it('exports a module', () => {
+    expect(ConvertInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-item.test.js
+++ b/src/eventra-kit/__tests__/convert-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertItem from '../convert-item.js';
+
+describe('convert-item', () => {
+  it('exports a module', () => {
+    expect(ConvertItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-json.test.js
+++ b/src/eventra-kit/__tests__/convert-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertJson from '../convert-json.js';
+
+describe('convert-json', () => {
+  it('exports a module', () => {
+    expect(ConvertJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-key.test.js
+++ b/src/eventra-kit/__tests__/convert-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertKey from '../convert-key.js';
+
+describe('convert-key', () => {
+  it('exports a module', () => {
+    expect(ConvertKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-leaf.test.js
+++ b/src/eventra-kit/__tests__/convert-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertLeaf from '../convert-leaf.js';
+
+describe('convert-leaf', () => {
+  it('exports a module', () => {
+    expect(ConvertLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-length.test.js
+++ b/src/eventra-kit/__tests__/convert-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertLength from '../convert-length.js';
+
+describe('convert-length', () => {
+  it('exports a module', () => {
+    expect(ConvertLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-line.test.js
+++ b/src/eventra-kit/__tests__/convert-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertLine from '../convert-line.js';
+
+describe('convert-line', () => {
+  it('exports a module', () => {
+    expect(ConvertLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-list.test.js
+++ b/src/eventra-kit/__tests__/convert-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertList from '../convert-list.js';
+
+describe('convert-list', () => {
+  it('exports a module', () => {
+    expect(ConvertList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-map.test.js
+++ b/src/eventra-kit/__tests__/convert-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertMap from '../convert-map.js';
+
+describe('convert-map', () => {
+  it('exports a module', () => {
+    expect(ConvertMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-matrix.test.js
+++ b/src/eventra-kit/__tests__/convert-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertMatrix from '../convert-matrix.js';
+
+describe('convert-matrix', () => {
+  it('exports a module', () => {
+    expect(ConvertMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-name.test.js
+++ b/src/eventra-kit/__tests__/convert-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertName from '../convert-name.js';
+
+describe('convert-name', () => {
+  it('exports a module', () => {
+    expect(ConvertName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-node.test.js
+++ b/src/eventra-kit/__tests__/convert-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertNode from '../convert-node.js';
+
+describe('convert-node', () => {
+  it('exports a module', () => {
+    expect(ConvertNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-number.test.js
+++ b/src/eventra-kit/__tests__/convert-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertNumber from '../convert-number.js';
+
+describe('convert-number', () => {
+  it('exports a module', () => {
+    expect(ConvertNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-object.test.js
+++ b/src/eventra-kit/__tests__/convert-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertObject from '../convert-object.js';
+
+describe('convert-object', () => {
+  it('exports a module', () => {
+    expect(ConvertObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-order.test.js
+++ b/src/eventra-kit/__tests__/convert-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertOrder from '../convert-order.js';
+
+describe('convert-order', () => {
+  it('exports a module', () => {
+    expect(ConvertOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-page.test.js
+++ b/src/eventra-kit/__tests__/convert-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertPage from '../convert-page.js';
+
+describe('convert-page', () => {
+  it('exports a module', () => {
+    expect(ConvertPage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-pair.test.js
+++ b/src/eventra-kit/__tests__/convert-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertPair from '../convert-pair.js';
+
+describe('convert-pair', () => {
+  it('exports a module', () => {
+    expect(ConvertPair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-path.test.js
+++ b/src/eventra-kit/__tests__/convert-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertPath from '../convert-path.js';
+
+describe('convert-path', () => {
+  it('exports a module', () => {
+    expect(ConvertPath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-point.test.js
+++ b/src/eventra-kit/__tests__/convert-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertPoint from '../convert-point.js';
+
+describe('convert-point', () => {
+  it('exports a module', () => {
+    expect(ConvertPoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-portion.test.js
+++ b/src/eventra-kit/__tests__/convert-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertPortion from '../convert-portion.js';
+
+describe('convert-portion', () => {
+  it('exports a module', () => {
+    expect(ConvertPortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-prop.test.js
+++ b/src/eventra-kit/__tests__/convert-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertProp from '../convert-prop.js';
+
+describe('convert-prop', () => {
+  it('exports a module', () => {
+    expect(ConvertProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/convert-gap.js
+++ b/src/eventra-kit/convert-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-gap helper.
+ */
+export function convertGap(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/convert-graph.js
+++ b/src/eventra-kit/convert-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-graph helper.
+ */
+export function convertGraph(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/convert-grid.js
+++ b/src/eventra-kit/convert-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-grid helper.
+ */
+export function convertGrid(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/convert-group.js
+++ b/src/eventra-kit/convert-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-group helper.
+ */
+export function convertGroup(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/convert-hash.js
+++ b/src/eventra-kit/convert-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-hash helper.
+ */
+export function convertHash(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/convert-heap.js
+++ b/src/eventra-kit/convert-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-heap helper.
+ */
+export function convertHeap(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/convert-html.js
+++ b/src/eventra-kit/convert-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-html helper.
+ */
+export function convertHtml(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/convert-id.js
+++ b/src/eventra-kit/convert-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-id helper.
+ */
+export function convertId(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/convert-index.js
+++ b/src/eventra-kit/convert-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-index helper.
+ */
+export function convertIndex(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/convert-interval.js
+++ b/src/eventra-kit/convert-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-interval helper.
+ */
+export function convertInterval(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/convert-item.js
+++ b/src/eventra-kit/convert-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-item helper.
+ */
+export function convertItem(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/convert-json.js
+++ b/src/eventra-kit/convert-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-json helper.
+ */
+export function convertJson(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/convert-key.js
+++ b/src/eventra-kit/convert-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-key helper.
+ */
+export function convertKey(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/convert-leaf.js
+++ b/src/eventra-kit/convert-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-leaf helper.
+ */
+export function convertLeaf(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/convert-length.js
+++ b/src/eventra-kit/convert-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-length helper.
+ */
+export function convertLength(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/convert-line.js
+++ b/src/eventra-kit/convert-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-line helper.
+ */
+export function convertLine(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/convert-list.js
+++ b/src/eventra-kit/convert-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-list helper.
+ */
+export function convertList(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/convert-map.js
+++ b/src/eventra-kit/convert-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-map helper.
+ */
+export function convertMap(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/convert-matrix.js
+++ b/src/eventra-kit/convert-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-matrix helper.
+ */
+export function convertMatrix(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/convert-name.js
+++ b/src/eventra-kit/convert-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-name helper.
+ */
+export function convertName(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/convert-node.js
+++ b/src/eventra-kit/convert-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-node helper.
+ */
+export function convertNode(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/convert-number.js
+++ b/src/eventra-kit/convert-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-number helper.
+ */
+export function convertNumber(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/convert-object.js
+++ b/src/eventra-kit/convert-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-object helper.
+ */
+export function convertObject(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/convert-order.js
+++ b/src/eventra-kit/convert-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-order helper.
+ */
+export function convertOrder(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/convert-page.js
+++ b/src/eventra-kit/convert-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-page helper.
+ */
+export function convertPage(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/convert-pair.js
+++ b/src/eventra-kit/convert-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-pair helper.
+ */
+export function convertPair(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/convert-path.js
+++ b/src/eventra-kit/convert-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-path helper.
+ */
+export function convertPath(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/convert-point.js
+++ b/src/eventra-kit/convert-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-point helper.
+ */
+export function convertPoint(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/convert-portion.js
+++ b/src/eventra-kit/convert-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-portion helper.
+ */
+export function convertPortion(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/convert-prop.js
+++ b/src/eventra-kit/convert-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-prop helper.
+ */
+export function convertProp(value) {
+  return Math.exp(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/convert-prop.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change