### PR TITLE
feat: add count frame helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/convert-uri.test.js
+++ b/src/eventra-kit/__tests__/convert-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertUri from '../convert-uri.js';
+
+describe('convert-uri', () => {
+  it('exports a module', () => {
+    expect(ConvertUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-url.test.js
+++ b/src/eventra-kit/__tests__/convert-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertUrl from '../convert-url.js';
+
+describe('convert-url', () => {
+  it('exports a module', () => {
+    expect(ConvertUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-value.test.js
+++ b/src/eventra-kit/__tests__/convert-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertValue from '../convert-value.js';
+
+describe('convert-value', () => {
+  it('exports a module', () => {
+    expect(ConvertValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-vector.test.js
+++ b/src/eventra-kit/__tests__/convert-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertVector from '../convert-vector.js';
+
+describe('convert-vector', () => {
+  it('exports a module', () => {
+    expect(ConvertVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-vertex.test.js
+++ b/src/eventra-kit/__tests__/convert-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertVertex from '../convert-vertex.js';
+
+describe('convert-vertex', () => {
+  it('exports a module', () => {
+    expect(ConvertVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-weight.test.js
+++ b/src/eventra-kit/__tests__/convert-weight.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertWeight from '../convert-weight.js';
+
+describe('convert-weight', () => {
+  it('exports a module', () => {
+    expect(ConvertWeight).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-word.test.js
+++ b/src/eventra-kit/__tests__/convert-word.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertWord from '../convert-word.js';
+
+describe('convert-word', () => {
+  it('exports a module', () => {
+    expect(ConvertWord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/convert-xml.test.js
+++ b/src/eventra-kit/__tests__/convert-xml.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ConvertXml from '../convert-xml.js';
+
+describe('convert-xml', () => {
+  it('exports a module', () => {
+    expect(ConvertXml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-array.test.js
+++ b/src/eventra-kit/__tests__/count-array.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountArray from '../count-array.js';
+
+describe('count-array', () => {
+  it('exports a module', () => {
+    expect(CountArray).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-block.test.js
+++ b/src/eventra-kit/__tests__/count-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountBlock from '../count-block.js';
+
+describe('count-block', () => {
+  it('exports a module', () => {
+    expect(CountBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-box.test.js
+++ b/src/eventra-kit/__tests__/count-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountBox from '../count-box.js';
+
+describe('count-box', () => {
+  it('exports a module', () => {
+    expect(CountBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-byte.test.js
+++ b/src/eventra-kit/__tests__/count-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountByte from '../count-byte.js';
+
+describe('count-byte', () => {
+  it('exports a module', () => {
+    expect(CountByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-char.test.js
+++ b/src/eventra-kit/__tests__/count-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountChar from '../count-char.js';
+
+describe('count-char', () => {
+  it('exports a module', () => {
+    expect(CountChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-chunk.test.js
+++ b/src/eventra-kit/__tests__/count-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountChunk from '../count-chunk.js';
+
+describe('count-chunk', () => {
+  it('exports a module', () => {
+    expect(CountChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-circle.test.js
+++ b/src/eventra-kit/__tests__/count-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountCircle from '../count-circle.js';
+
+describe('count-circle', () => {
+  it('exports a module', () => {
+    expect(CountCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-count.test.js
+++ b/src/eventra-kit/__tests__/count-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountCount from '../count-count.js';
+
+describe('count-count', () => {
+  it('exports a module', () => {
+    expect(CountCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-date.test.js
+++ b/src/eventra-kit/__tests__/count-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountDate from '../count-date.js';
+
+describe('count-date', () => {
+  it('exports a module', () => {
+    expect(CountDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-delta.test.js
+++ b/src/eventra-kit/__tests__/count-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountDelta from '../count-delta.js';
+
+describe('count-delta', () => {
+  it('exports a module', () => {
+    expect(CountDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-dict.test.js
+++ b/src/eventra-kit/__tests__/count-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountDict from '../count-dict.js';
+
+describe('count-dict', () => {
+  it('exports a module', () => {
+    expect(CountDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-dir.test.js
+++ b/src/eventra-kit/__tests__/count-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountDir from '../count-dir.js';
+
+describe('count-dir', () => {
+  it('exports a module', () => {
+    expect(CountDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-edge.test.js
+++ b/src/eventra-kit/__tests__/count-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountEdge from '../count-edge.js';
+
+describe('count-edge', () => {
+  it('exports a module', () => {
+    expect(CountEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-element.test.js
+++ b/src/eventra-kit/__tests__/count-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountElement from '../count-element.js';
+
+describe('count-element', () => {
+  it('exports a module', () => {
+    expect(CountElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-entry.test.js
+++ b/src/eventra-kit/__tests__/count-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountEntry from '../count-entry.js';
+
+describe('count-entry', () => {
+  it('exports a module', () => {
+    expect(CountEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-field.test.js
+++ b/src/eventra-kit/__tests__/count-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountField from '../count-field.js';
+
+describe('count-field', () => {
+  it('exports a module', () => {
+    expect(CountField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-file.test.js
+++ b/src/eventra-kit/__tests__/count-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountFile from '../count-file.js';
+
+describe('count-file', () => {
+  it('exports a module', () => {
+    expect(CountFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-fraction.test.js
+++ b/src/eventra-kit/__tests__/count-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountFraction from '../count-fraction.js';
+
+describe('count-fraction', () => {
+  it('exports a module', () => {
+    expect(CountFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-frame.test.js
+++ b/src/eventra-kit/__tests__/count-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountFrame from '../count-frame.js';
+
+describe('count-frame', () => {
+  it('exports a module', () => {
+    expect(CountFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/convert-uri.js
+++ b/src/eventra-kit/convert-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-uri helper.
+ */
+export function convertUri(value) {
+  return value.flat();
+}
+

--- a/src/eventra-kit/convert-url.js
+++ b/src/eventra-kit/convert-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-url helper.
+ */
+export function convertUrl(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/convert-value.js
+++ b/src/eventra-kit/convert-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-value helper.
+ */
+export function convertValue(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/convert-vector.js
+++ b/src/eventra-kit/convert-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-vector helper.
+ */
+export function convertVector(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/convert-vertex.js
+++ b/src/eventra-kit/convert-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-vertex helper.
+ */
+export function convertVertex(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/convert-weight.js
+++ b/src/eventra-kit/convert-weight.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-weight helper.
+ */
+export function convertWeight(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/convert-word.js
+++ b/src/eventra-kit/convert-word.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-word helper.
+ */
+export function convertWord(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/convert-xml.js
+++ b/src/eventra-kit/convert-xml.js
@@ -1,0 +1,7 @@
+/**
+ * adds a convert-xml helper.
+ */
+export function convertXml(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/count-array.js
+++ b/src/eventra-kit/count-array.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-array helper.
+ */
+export function countArray(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/count-block.js
+++ b/src/eventra-kit/count-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-block helper.
+ */
+export function countBlock(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/count-box.js
+++ b/src/eventra-kit/count-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-box helper.
+ */
+export function countBox(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/count-byte.js
+++ b/src/eventra-kit/count-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-byte helper.
+ */
+export function countByte(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/count-char.js
+++ b/src/eventra-kit/count-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-char helper.
+ */
+export function countChar(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/count-chunk.js
+++ b/src/eventra-kit/count-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-chunk helper.
+ */
+export function countChunk(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/count-circle.js
+++ b/src/eventra-kit/count-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-circle helper.
+ */
+export function countCircle(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/count-count.js
+++ b/src/eventra-kit/count-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-count helper.
+ */
+export function countCount(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/count-date.js
+++ b/src/eventra-kit/count-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-date helper.
+ */
+export function countDate(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/count-delta.js
+++ b/src/eventra-kit/count-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-delta helper.
+ */
+export function countDelta(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/count-dict.js
+++ b/src/eventra-kit/count-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-dict helper.
+ */
+export function countDict(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/count-dir.js
+++ b/src/eventra-kit/count-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-dir helper.
+ */
+export function countDir(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/count-edge.js
+++ b/src/eventra-kit/count-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-edge helper.
+ */
+export function countEdge(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/count-element.js
+++ b/src/eventra-kit/count-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-element helper.
+ */
+export function countElement(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/count-entry.js
+++ b/src/eventra-kit/count-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-entry helper.
+ */
+export function countEntry(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/count-field.js
+++ b/src/eventra-kit/count-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-field helper.
+ */
+export function countField(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/count-file.js
+++ b/src/eventra-kit/count-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-file helper.
+ */
+export function countFile(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/count-fraction.js
+++ b/src/eventra-kit/count-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-fraction helper.
+ */
+export function countFraction(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/count-frame.js
+++ b/src/eventra-kit/count-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-frame helper.
+ */
+export function countFrame(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/count-frame.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change