### PR TITLE
fix: ticket QR payload matches opaque scanner contract

### DIFF
--- a/src/utils/ticketQrPayload.js
+++ b/src/utils/ticketQrPayload.js
@@ -38,11 +38,19 @@ export const buildTicketQrPayload = ({ registration, serialNumber, stepSeconds =
   };
 };
 
+export const buildOpaqueTicketQrPayload = ({ registration, serialNumber }) => {
+  const ticketId = registration?.qrToken || registration?.registrationId || serialNumber || null;
+  if (!ticketId) return null;
+  return { ticketId };
+};
+
 export const buildTicketQrValue = (ticketData) => {
   if (!ticketData || typeof ticketData !== "object" || !ticketData.ticketId) {
     return "";
   }
-  return JSON.stringify(ticketData);
+  // Scanner (TicketScanner.jsx) only accepts opaque { ticketId }. Extra keys
+  // are treated as forgeable claims and rejected.
+  return JSON.stringify({ ticketId: ticketData.ticketId });
 };
 
 /**

--- a/tests/ticketQrPayload.test.mjs
+++ b/tests/ticketQrPayload.test.mjs
@@ -28,7 +28,8 @@ describe("Dynamic Ticket QR Payload & TOTP Rotating Protocol Tests", () => {
     assert.ok(payload.timeWindow);
 
     const jsonStr = buildTicketQrValue(payload);
-    assert.ok(jsonStr.includes("REG-101"));
+    assert.equal(jsonStr, JSON.stringify({ ticketId: "REG-101" }));
+    assert.equal(Object.keys(JSON.parse(jsonStr)).length, 1);
   });
 
   it("should validate current TOTP time window and reject expired windows", () => {


### PR DESCRIPTION
## Description

Tickets encoded `{ ticketId, totpToken, timeWindow, timestamp }`. The scanner only accepts `{ ticketId }`, so real attendee QRs were flagged invalid.

`buildTicketQrValue` now stringifies only `{ ticketId }`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15936

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)