### PR TITLE
fix: archive events via API instead of local state

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -404,6 +404,22 @@ public class EventController {
                                 eventService.cancelEvent(id, authentication.getName(), request));
         }
 
+        @PostMapping("/{id}/archive")
+        @PreAuthorize("isAuthenticated()")
+        @Operation(summary = "Archive an event", description = "Allows an event ORGANIZER/OWNER (or platform ADMIN) to archive an event. Archived events are hidden from the public listing.", security = @SecurityRequirement(name = "bearerAuth"))
+        @ApiResponses({
+                        @ApiResponse(responseCode = "200", description = "Event archived successfully", content = @Content(schema = @Schema(implementation = EventResponse.class))),
+                        @ApiResponse(responseCode = "401", description = "Unauthorized - JWT token missing or invalid", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                        @ApiResponse(responseCode = "403", description = "Forbidden - Insufficient event role", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                        @ApiResponse(responseCode = "404", description = "Event not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                        @ApiResponse(responseCode = "409", description = "Event is already archived or cancelled", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        })
+        public ResponseEntity<EventResponse> archiveEvent(
+                        @Parameter(description = "ID of the event to archive") @PathVariable Long id,
+                        Authentication authentication) {
+                return ResponseEntity.ok(eventService.archiveEvent(id, authentication.getName()));
+        }
+
         @PostMapping("/{id}/resend-cancellation-notice")
         @PreAuthorize("isAuthenticated()")
         @Operation(summary = "Resend cancellation notice", description = "Resends the cancellation notification to a specific attendee.", security = @SecurityRequirement(name = "bearerAuth"))

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
@@ -26,19 +26,32 @@ public final class EventSpecifications {
     }
 
     /**
-     * Cancelled events are hidden from the public listing unless the caller
-     * explicitly filters for them via the {@code CANCELLED} status label
-     * (Issue #12081).
+     * Cancelled and archived events are hidden from the public listing unless
+     * the caller explicitly filters for those lifecycle labels.
      */
     public static Specification<Event> notCancelledUnlessRequested(List<String> statuses) {
-        boolean requestsCancelled = statuses != null && statuses.stream()
-                .filter(StringUtils::hasText)
-                .map(raw -> raw.trim().toUpperCase(Locale.ROOT))
-                .anyMatch(status -> status.equals("CANCELLED") || status.equals("CANCELED"));
-        if (requestsCancelled) {
-            return null;
-        }
-        return (root, query, cb) -> cb.notEqual(cb.upper(root.get("status")), "CANCELLED");
+        java.util.Set<String> requested = statuses == null
+                ? java.util.Set.of()
+                : statuses.stream()
+                        .filter(StringUtils::hasText)
+                        .map(raw -> raw.trim().toUpperCase(Locale.ROOT))
+                        .collect(java.util.stream.Collectors.toSet());
+        boolean requestsCancelled = requested.contains("CANCELLED") || requested.contains("CANCELED");
+        boolean requestsArchived = requested.contains("ARCHIVED");
+
+        return (root, query, cb) -> {
+            java.util.List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+            if (!requestsCancelled) {
+                predicates.add(cb.notEqual(cb.upper(root.get("status")), "CANCELLED"));
+            }
+            if (!requestsArchived) {
+                predicates.add(cb.notEqual(cb.upper(root.get("status")), "ARCHIVED"));
+            }
+            if (predicates.isEmpty()) {
+                return cb.conjunction();
+            }
+            return cb.and(predicates.toArray(jakarta.persistence.criteria.Predicate[]::new));
+        };
     }
 
     public static Specification<Event> isPublic() {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -683,6 +683,25 @@ public class EventService {
         }
 
         @Transactional
+        public EventResponse archiveEvent(Long id, String userEmail) {
+                Event event = eventRepository.findById(id)
+                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
+
+                eventRoleService.requireRole(id, userEmail, EventRole.ORGANIZER);
+
+                if ("CANCELLED".equals(event.getStatus())) {
+                        throw new RegistrationConflictException("Cancelled events cannot be archived.");
+                }
+                if ("ARCHIVED".equals(event.getStatus())) {
+                        throw new RegistrationConflictException("Event is already archived.");
+                }
+
+                event.setStatus("ARCHIVED");
+                Event saved = eventRepository.save(event);
+                return toEventResponse(saved);
+        }
+
+        @Transactional
         public void resendCancellationNotice(Long eventId, String actorEmail, String attendeeEmail) {
                 Event event = eventRepository.findById(eventId)
                                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -168,6 +168,7 @@ const EventDetails = () => {
   const [fetchLoading, setFetchLoading] = useState(true);
   const [fetchError, setFetchError] = useState(null);
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
 
   // Issue #11021 — organizer actions (cancel/archive/export) must be gated by
   // event ownership, not role alone. Without this, any ORGANIZER/ADMIN could
@@ -321,6 +322,29 @@ const EventDetails = () => {
       isActive = false;
     };
   }, [eventId, user]);
+
+  const handleArchive = useCallback(async () => {
+    if (!eventId || isArchiving) return;
+    setIsArchiving(true);
+    try {
+      const response = await apiUtils.post(API_ENDPOINTS.EVENTS.ARCHIVE(eventId));
+      const updated = response.data?.data ?? response.data ?? {};
+      setEvent((current) => ({
+        ...(current || {}),
+        ...updated,
+        status: "archived",
+      }));
+      toast.success("Event archived.");
+    } catch (error) {
+      const message =
+        error?.data?.message ||
+        error?.message ||
+        "Could not archive this event. Please try again.";
+      toast.error(message);
+    } finally {
+      setIsArchiving(false);
+    }
+  }, [eventId, isArchiving]);
 
   const handlePrint = () => {
     setIsPrinting(true);
@@ -600,13 +624,12 @@ ${window.location.href}
               )}
               {canManageEvent && event.status !== "cancelled" && event.status !== "archived" && (
                 <button
-                  onClick={() => {
-                    setEvent({ ...event, status: "archived" });
-                    toast.success("Event Archived!");
-                  }}
-                  className="inline-flex items-center justify-center gap-2 rounded-full border border-orange-500 px-6 py-3 text-sm font-semibold text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/20 transition"
+                  type="button"
+                  onClick={handleArchive}
+                  disabled={isArchiving}
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-orange-500 px-6 py-3 text-sm font-semibold text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/20 transition disabled:opacity-60"
                 >
-                  <Archive size={16} /> Archive Event
+                  <Archive size={16} /> {isArchiving ? "Archiving..." : "Archive Event"}
                 </button>
               )}
 

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -201,6 +201,7 @@ export const API_ENDPOINTS = {
     REGISTER: (id) => buildApiUrl(`/events/${id}/register`),
     CANCEL_REGISTRATION: (id) => buildApiUrl(`/events/${id}/registration`),
     CANCEL: (id) => buildApiUrl(`/events/${id}/cancel`),
+    ARCHIVE: (id) => buildApiUrl(`/events/${id}/archive`),
     AVAILABILITY: (id) => buildApiUrl(`/events/${id}/availability`),
     ATTENDEES: (id) => buildApiUrl(`/events/${id}/attendees`),
 

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -18,6 +18,9 @@ const mapStatusKey = (status = "") => {
     done: "past",
     ended: "ended",
     "event ended": "ended",
+    cancelled: "cancelled",
+    canceled: "cancelled",
+    archived: "archived",
   };
 
   // 🔥 FIX: Return null for unmapped values instead of echoing the input.
@@ -86,6 +89,10 @@ export const getEventStatus = (event) => {
     return "cancelled";
   }
 
+  if (explicitStatus === "archived") {
+    return "archived";
+  }
+
   if (explicitStatus && explicitStatus !== dateStatus) {
     return explicitStatus;
   }
@@ -112,7 +119,7 @@ export const isEventRegistrationClosed = (eventOrStatus) => {
       ? mapStatusKey(eventOrStatus)
       : getEventStatus(eventOrStatus);
 
-  return status === "past" || status === "ended" || status === "cancelled";
+  return status === "past" || status === "ended" || status === "cancelled" || status === "archived";
 };
 
 /**


### PR DESCRIPTION
## Description

Archive on event details only flipped React state and toasted success. Reload brought the event back live.

Added `POST /events/{id}/archive`, wired the button, and hid archived events from the public listing unless explicitly requested.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15940

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)