### PR TITLE
fix: do not restore cached admin roles when profile fetch fails

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -244,26 +244,19 @@ export const AuthProvider = ({ children }) => {
         if (err?.status === 401 || err?.status === 403) {
           clearSession();
         } else {
-          // If network is offline, attempt to fall back to securely cached user details
+          // Network/server errors are not proof the session is still valid.
+          // Restore a display-only cached profile without roles so Gate cannot
+          // treat a stale ADMIN/ORGANIZER cache as an authenticated session.
           try {
             const cachedUser = await syncSecureStorage.getItemAsync("user");
             if (cachedUser) {
               const parsed = JSON.parse(cachedUser);
-              const resolvedRoles = normalizeRoles(
-                parsed.roles ?? (parsed.role ? [parsed.role] : [])
-              );
-              const rolePermissions = resolvedRoles.flatMap(
-                (role) => ROLE_PERMISSIONS[role] || []
-              );
               setUser({
                 ...parsed,
-                roles: resolvedRoles,
-                permissions: rolePermissions,
+                roles: [],
+                permissions: [],
+                profileValidated: false,
               });
-              // Never read a JS-readable token cookie (httpOnlyStorage policy).
-              // The active token is held in JS memory by setAuthToken or by
-              // the backend's HttpOnly Set-Cookie flow.
-              setToken("cookie-managed");
             } else {
               clearSession();
             }


### PR DESCRIPTION
## Description

A 503/timeout on `/users/profile` restored the encrypted cached user including ADMIN/ORGANIZER roles and set `token` to `cookie-managed`. Gate then treated that as a live session.

Cached profile is now display-only (roles/permissions cleared). Privileged routes stay closed until profile succeeds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15941

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)