### PR TITLE
fix: do not HMAC-sign API requests with a VITE_ secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,15 +124,13 @@ REACT_APP_SENTRY_DSN=
 VITE_CSRF_ENFORCEMENT_MODE=warning
 
 # Optional: HMAC-SHA256 request-signing secret shared with the backend.
-# When set, the API request interceptor attaches x-timestamp / x-nonce /
-# x-signature headers to every POST/PUT/PATCH/DELETE request with a JSON body,
-# which the backend verifies (see src/middleware/requestSignature.js).
+# This MUST NOT use a VITE_ prefix — Vite inlines VITE_* into the browser
+# bundle, which would make signatures forgeable. Client builds leave this
+# unset (signing disabled). Server-side Node processes may set
+# REQUEST_SIGNING_SECRET if they proxy mutating requests.
 #
-# NOTE: a secret shipped in the frontend bundle is NOT a real authentication
-# boundary — it is defence-in-depth / tamper-evidence only. The backend must
-# treat request signatures as advisory on top of session + CSRF validation.
-# Leave empty to disable request signing.
-VITE_REQUEST_SIGNING_SECRET=
+# Leave empty to disable request signing. Auth remains cookie + CSRF.
+REQUEST_SIGNING_SECRET=
 
 # ============================================
 # Server-side Secrets (set in Vercel Dashboard / .env.local)

--- a/.env.production.example
+++ b/.env.production.example
@@ -36,7 +36,7 @@ REACT_APP_PUBLIC_URL=https://eventra.sandeepvashishtha.tech
 
 # ── Security ─────────────────────────────────
 # VITE_CSRF_ENFORCEMENT_MODE=strict
-# VITE_REQUEST_SIGNING_SECRET=shared-hmac-secret-for-tamper-evidence
+# REQUEST_SIGNING_SECRET=shared-hmac-secret-for-tamper-evidence
 # BLOCKED_COUNTRIES=CU,IR,KP,SY,RU
 # ALLOWED_ORIGINS=https://your-domain.com,https://www.your-domain.com
 

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -11,12 +11,11 @@ const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 1_000;
 
 const SIGNED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
-const REQUEST_SIGNING_SECRET_KEY = "VITE_REQUEST_SIGNING_SECRET";
+// Never read VITE_* here. Vite inlines those into the browser bundle, which
+// would make HMAC request signing forgeable by anyone who opens DevTools.
+const REQUEST_SIGNING_SECRET_KEY = "REQUEST_SIGNING_SECRET";
 
 const getRequestSigningSecret = () => {
-  if (typeof import.meta !== "undefined" && import.meta.env) {
-    return import.meta.env[REQUEST_SIGNING_SECRET_KEY] || "";
-  }
   if (typeof process !== "undefined" && process.env) {
     return process.env[REQUEST_SIGNING_SECRET_KEY] || "";
   }

--- a/tests/interceptorRequestSigning.test.mjs
+++ b/tests/interceptorRequestSigning.test.mjs
@@ -59,11 +59,16 @@ describe("request signing wiring", () => {
     );
   });
 
-  it("keys the secret off VITE_REQUEST_SIGNING_SECRET", () => {
+  it("does not read a VITE_ signing secret (those are public in the bundle)", () => {
+    assert.doesNotMatch(
+      interceptorCode,
+      /VITE_REQUEST_SIGNING_SECRET/,
+      "interceptor must not read VITE_REQUEST_SIGNING_SECRET",
+    );
     assert.match(
       interceptorCode,
-      /["']VITE_REQUEST_SIGNING_SECRET["']/,
-      "interceptor must read VITE_REQUEST_SIGNING_SECRET",
+      /["']REQUEST_SIGNING_SECRET["']/,
+      "interceptor may only read a non-VITE REQUEST_SIGNING_SECRET",
     );
   });
 


### PR DESCRIPTION
## Description

The interceptor signed mutating requests with `VITE_REQUEST_SIGNING_SECRET`. Vite inlines that into the client bundle, so anyone can forge `x-signature`.

Signing now only reads `REQUEST_SIGNING_SECRET` (not inlined). Browser builds leave it unset.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15942

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)