### PR TITLE
fix: block mutating requests until step-up reauth succeeds

### DIFF
--- a/src/components/auth/ReAuthModal.jsx
+++ b/src/components/auth/ReAuthModal.jsx
@@ -3,11 +3,15 @@ import { motion } from "framer-motion";
 import { AlertCircle, Lock } from "lucide-react";
 import { apiUtils, API_ENDPOINTS } from "config/api.js";
 import { toast } from "react-toastify";
+import { useFocusTrap } from "hooks/useFocusTrap";
+import useScrollLock from "hooks/useScrollLock";
 
 const ReAuthModal = ({ onSuccess }) => {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { containerRef } = useFocusTrap(true);
+  useScrollLock(true);
 
 
   const handleSubmit = async (e) => {
@@ -43,6 +47,10 @@ const ReAuthModal = ({ onSuccess }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
       <motion.div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="reauth-title"
         initial={{ opacity: 0, scale: 0.95, y: 20 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         className="bg-white dark:bg-gray-800 rounded-2xl p-6 sm:p-8 max-w-md w-full shadow-2xl relative overflow-hidden"
@@ -53,7 +61,7 @@ const ReAuthModal = ({ onSuccess }) => {
           <div className="mx-auto bg-red-100 dark:bg-red-900/30 w-16 h-16 rounded-full flex items-center justify-center mb-4">
             <Lock className="w-8 h-8 text-red-600 dark:text-red-400" />
           </div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+          <h2 id="reauth-title" className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
             Verify Your Session
           </h2>
           <p className="text-gray-500 dark:text-gray-200 text-sm">

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -3,7 +3,7 @@ import { ENV } from "./env";
 import { syncServerTimeFromHeader } from "../utils/timeSync";
 import { createIntegrityHeader } from "../utils/security/requestIntegrity";
 import { ApiError, RateLimitError } from "./api/errors.js";
-import { setupRequestInterceptor, setupResponseInterceptor, setOnRequiresReauthHandler, setAuthToken as setInterceptorAuthToken, setRefreshToken as setInterceptorRefreshToken } from "./api/interceptors.js";
+import { setupRequestInterceptor, setupResponseInterceptor, setOnRequiresReauthHandler, setReauthRequired, setAuthToken as setInterceptorAuthToken, setRefreshToken as setInterceptorRefreshToken } from "./api/interceptors.js";
 import { API_BASE_URL, validateBackendConfig } from "./backendConfig.js";
 
 // ---------------------------------------------------------------------------
@@ -51,6 +51,7 @@ export const setRequiresReauthHandler = (handler) => {
   onRequiresReauth = handler;
   setOnRequiresReauthHandler(handler);
 };
+export { setReauthRequired };
 export const setAuthToken = (token) => {
   _authToken = token;
   setInterceptorAuthToken(token);

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -52,17 +52,34 @@ const signRequestConfig = async (config) => {
 
 let onUnauthorized = null;
 let _onRequiresReauth = null;
+let _reauthRequired = false;
 
 let _authToken = null;
 let _refreshToken = null;
 
 export const setOnUnauthorizedHandler = (handler) => { onUnauthorized = handler; };
 export const setOnRequiresReauthHandler = (handler) => { _onRequiresReauth = handler; };
+export const setReauthRequired = (value) => { _reauthRequired = Boolean(value); };
+export const isReauthRequired = () => _reauthRequired;
 export const setAuthToken = (token) => { _authToken = token; };
 export const setRefreshToken = (token) => { _refreshToken = token; };
 export const getRefreshToken = () => _refreshToken;
 
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const isReauthUrl = (url) => typeof url === "string" && url.includes("/auth/reauth");
+
+const assertReauthAllowsRequest = (config) => {
+  const method = config.method?.toUpperCase();
+  if (_reauthRequired && MUTATING_METHODS.has(method) && !isReauthUrl(config.url)) {
+    throw new ApiError("Re-authentication required before this action can continue.", {
+      status: 401,
+      data: { code: "REQUIRES_REAUTH" },
+    });
+  }
+};
+
 export const createRequestInterceptor = (isDev) => async (config) => {
+  assertReauthAllowsRequest(config);
   if (isDev) {
     logger.info(`[API ${config.method?.toUpperCase()}]`, config.url || "");
   }
@@ -107,6 +124,7 @@ export const createResponseInterceptor = (API) => {
 
     if (status === 401) {
       if (errorCode === "REQUIRES_REAUTH" && _onRequiresReauth) {
+        _reauthRequired = true;
         _onRequiresReauth();
       } else if (onUnauthorized) {
         onUnauthorized();
@@ -183,6 +201,7 @@ const normalizeApiErrorWithTimeout = (error, timeoutMs) => {
 
 export function setupRequestInterceptor(api, { isDev, buildApiUrl, getAuthToken,   }) {
   api.interceptors.request.use(async (config) => {
+    assertReauthAllowsRequest(config);
     if (isDev) {
       logger.info(`[API ${config.method?.toUpperCase()}]`, buildApiUrl(config.url || ""));
     }
@@ -253,6 +272,7 @@ export function setupResponseInterceptor(api, { isDev, timeoutMs, getOnUnauthori
 
       if (status === 401) {
         if (errorCode === "REQUIRES_REAUTH") {
+          _reauthRequired = true;
           if (onRequiresReauth) onRequiresReauth();
           throw normalizeApiErrorWithTimeout(error, timeoutMs);
         }

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useMemo, useCallback, useRef, useState } from "react";
-import { setOnUnauthorizedHandler, setRequiresReauthHandler, setAuthToken, setRefreshToken, apiUtils } from "../config/api.js";
+import { setOnUnauthorizedHandler, setRequiresReauthHandler, setReauthRequired, setAuthToken, setRefreshToken, apiUtils } from "../config/api.js";
 import { getRefreshToken } from "../config/api/interceptors.js";
 import { authService } from "../services/authService.js";
 import { syncSecureStorage } from "../utils/secureStorage.js";
@@ -291,6 +291,7 @@ export const AuthProvider = ({ children }) => {
     // Intercept 401 errors globally at Axios layer to auto-logout user
     setOnUnauthorizedHandler(() => clearExpiredSessionRef.current());
     setRequiresReauthHandler(() => {
+      setReauthRequired(true);
       setRequiresReauth(true);
     });
     return () => {
@@ -502,7 +503,14 @@ export const AuthProvider = ({ children }) => {
   return (
     <AuthContext.Provider value={value}>
       {children}
-      {requiresReauth && <ReAuthModal onSuccess={() => setRequiresReauth(false)} />}
+      {requiresReauth && (
+        <ReAuthModal
+          onSuccess={() => {
+            setReauthRequired(false);
+            setRequiresReauth(false);
+          }}
+        />
+      )}
     </AuthContext.Provider>
   );
 };


### PR DESCRIPTION
## Description

`REQUIRES_REAUTH` opened a modal but did not stop later POSTs/PATCHes. The overlay was also not a dialog.

Mutating axios calls (except `/auth/reauth`) now throw until reauth succeeds. Modal uses a focus trap and `role="dialog"`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15945

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)