### PR TITLE
fix: remove mock hackathon fallback from event registration

### DIFF
--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -11,7 +11,6 @@ import {
   getWebcalSubscriptionUrl,
 } from "utils/calendarUrlUtils";
 import { useParams, useNavigate, Link, useLocation } from "react-router-dom";
-import hackathonsData from "../Hackathons/hackathonMockData.json";
 import { motion } from "framer-motion";
 import { toast } from "react-toastify";
 import {
@@ -177,26 +176,6 @@ const EventRegistration = () => {
     const loadEvent = async () => {
       setLoading(true);
 
-      const isHackathonPath = location.pathname.startsWith("/register");
-      if (isHackathonPath) {
-        const foundMock = hackathonsData.find((item) => String(item.id) === String(eventId));
-        if (foundMock) {
-          applyLoadedEvent({
-            ...foundMock,
-            date: foundMock.startDate,
-            time: "10:00 AM",
-            image:
-              "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&q=80&w=800",
-            attendees: foundMock.participants,
-            maxAttendees: 1500,
-            status: foundMock.status,
-          });
-          if (!isCancelled) setLoading(false);
-          prefillAuthenticatedUser();
-          return;
-        }
-      }
-
       try {
         const response = await apiUtils.get(API_ENDPOINTS.EVENTS.DETAIL(eventId));
 
@@ -232,20 +211,6 @@ const EventRegistration = () => {
             t("eventRegistration.toastShowingCached", { label: getCacheAgeLabel(cached.cachedAt) })
           );
           return;
-        }
-
-        const foundMock = hackathonsData.find((item) => String(item.id) === String(eventId));
-        if (foundMock) {
-          applyLoadedEvent({
-            ...foundMock,
-            date: foundMock.startDate,
-            time: "10:00 AM",
-            image:
-              "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&q=80&w=800",
-            attendees: foundMock.participants,
-            maxAttendees: 1500,
-            status: foundMock.status,
-          });
         }
       } finally {
         if (!isCancelled) setLoading(false);


### PR DESCRIPTION
## Description

If event detail fetch failed and cache missed, registration loaded `hackathonMockData.json` and let the user submit against a fake event.

Removed that fallback. Cached events still show; otherwise the existing error path stands.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15946

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)