### PR TITLE
fix: stop sending Authorization Bearer cookie-managed

### DIFF
--- a/src/Pages/Hackathons/HostHackathon.js
+++ b/src/Pages/Hackathons/HostHackathon.js
@@ -14,7 +14,7 @@ import { REQUIRED_FIELDS, validateHostHackathonForm } from "utils/hostHackathonV
 const HostHackathon = () => {
   const prefersReducedMotion = useReducedMotion();
   const navigate = useNavigate();
-  const { token, isAuthenticated } = useAuth();
+  const { isAuthenticated } = useAuth();
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -111,24 +111,17 @@ const HostHackathon = () => {
       const registrationDeadline =
         formData.registrationDeadline?.trim() || formData.startDate;
 
-      await hostHackathon(
-        {
-          title: sanitizeInputText(formData.hackathonName),
-          organizer: sanitizeInputText(formData.organizerName),
-          prizePool: sanitizeInputText(formData.prizeDetails),
-          description: sanitizeInputText(formData.description),
-          location: sanitizeInputText(formData.location),
-          startDate: formData.startDate,
-          endDate: formData.endDate,
-          mode: formData.mode,
-          registrationDeadline,
-        },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`
-          }
-        }
-      );
+      await hostHackathon({
+        title: sanitizeInputText(formData.hackathonName),
+        organizer: sanitizeInputText(formData.organizerName),
+        prizePool: sanitizeInputText(formData.prizeDetails),
+        description: sanitizeInputText(formData.description),
+        location: sanitizeInputText(formData.location),
+        startDate: formData.startDate,
+        endDate: formData.endDate,
+        mode: formData.mode,
+        registrationDeadline,
+      });
 
       toast.success("Hackathon submitted successfully! It will be reviewed before going live.");
 

--- a/src/components/admin/CSPViolationDashboard.jsx
+++ b/src/components/admin/CSPViolationDashboard.jsx
@@ -7,8 +7,13 @@ const CSPViolationDashboard = () => {
   const { token } = useAuth();
 
   useEffect(() => {
+    const headers = {};
+    if (token && token !== "cookie-managed") {
+      headers.Authorization = `Bearer ${token}`;
+    }
     fetch('/api/admin/csp-reports', {
-      headers: { Authorization: `Bearer ${token}` }
+      credentials: 'include',
+      headers,
     }).then(res => res.json()).then(setViolations).catch(err => console.error("[CSP] Failed to fetch violations:", err));
   }, [token]);
 

--- a/src/hooks/usePublicEvents.js
+++ b/src/hooks/usePublicEvents.js
@@ -26,7 +26,10 @@ export function usePublicEvents(options = {}) {
 
     try {
       // Add user context header for backend to filter appropriately
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const headers =
+        token && token !== "cookie-managed"
+          ? { Authorization: `Bearer ${token}` }
+          : {};
 
       const params = new URLSearchParams({
         page: String(page),


### PR DESCRIPTION
## Description

HttpOnly sessions store `token === "cookie-managed"`. The interceptor skips Bearer for that, but HostHackathon, `usePublicEvents`, and the CSP dashboard set the header themselves, so the backend got `Bearer cookie-managed`.

Those callers now rely on `withCredentials` unless the token is a real JWT.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15948

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)