### PR TITLE
fix: do not put the auth token on EventSource query strings

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -528,17 +528,10 @@ export class SseMultiplexer {
     let url = `${sseBaseUrl}${path}`;
     const urlParams = new URLSearchParams();
 
-    // 1. Dynamic Auth Token Injection
-    if (typeof this.getAuthToken === "function") {
-      try {
-        const token = await this.getAuthToken();
-        if (token) urlParams.append("token", token);
-      } catch (err) {
-        logger.error("[SSE Multiplexer] Failed to retrieve auth token:", err);
-      }
-    }
+    // Auth is the HttpOnly session cookie (EventSource withCredentials).
+    // Do not put JWTs on the query string — they leak via logs, Referer, and history.
 
-    // 2. Last-Event-ID Failover Recovery
+    // Last-Event-ID Failover Recovery
     const lastEventId = this.lastEventIds.get(path);
     if (lastEventId) {
       urlParams.append("lastEventId", lastEventId);


### PR DESCRIPTION
## Description

`sseMultiplexer` appended `?token=` to EventSource URLs (and logged them). Query tokens leak via proxy logs, Referer, and history.

Stream auth already uses `withCredentials: true`. Token query param is gone.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15949

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)