### PR TITLE
fix: record failed password attempts on the login false path

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -103,6 +103,7 @@ const Login = () => {
       }
       else {
         incrementFailures("login");
+        recordAttempt();
 
         const delay =
           getBackoffDelay("login") / 1000;


### PR DESCRIPTION
## Description

`login()` returns `false` on 401 instead of throwing. The else branch called `incrementFailures` (in-memory toast) but never `recordAttempt()`, so persisted lockout never counted wrong passwords.

`recordAttempt()` now runs on that path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15952

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)