### PR TITLE
fix: block signup submit when email uniqueness check fails open

### DIFF
--- a/src/components/auth/SignupForm.js
+++ b/src/components/auth/SignupForm.js
@@ -99,8 +99,10 @@ const SignupForm = () => {
         setFieldState("email", "error");
       } else {
         const emailAvailability = await validateEmailAvailability(emailValue);
-        if (!emailAvailability?.isValid && !emailAvailability?.skippedDueToError) {
-          nextErrors.email = getResultMessage(
+        if (!emailAvailability?.isValid) {
+          nextErrors.email = emailAvailability?.skippedDueToError
+            ? "Could not verify this email right now. Please try again."
+            : getResultMessage(
             emailAvailability,
             "This email is already registered. Please log in."
           );


### PR DESCRIPTION
## Description

`validateEmailAvailability` returns `skippedDueToError: true` when the uniqueness API is down. Signup submit treated that as success.

Submit now fails closed and asks the user to retry.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #15953

## Checklist

- [x] I have read and followed the CONTRIBUTING.md guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [ ] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

Made with [Cursor](https://cursor.com)