### PR TITLE
feat: add count span helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/count-leaf.test.js
+++ b/src/eventra-kit/__tests__/count-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountLeaf from '../count-leaf.js';
+
+describe('count-leaf', () => {
+  it('exports a module', () => {
+    expect(CountLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-length.test.js
+++ b/src/eventra-kit/__tests__/count-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountLength from '../count-length.js';
+
+describe('count-length', () => {
+  it('exports a module', () => {
+    expect(CountLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-line.test.js
+++ b/src/eventra-kit/__tests__/count-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountLine from '../count-line.js';
+
+describe('count-line', () => {
+  it('exports a module', () => {
+    expect(CountLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-list.test.js
+++ b/src/eventra-kit/__tests__/count-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountList from '../count-list.js';
+
+describe('count-list', () => {
+  it('exports a module', () => {
+    expect(CountList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-map.test.js
+++ b/src/eventra-kit/__tests__/count-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountMap from '../count-map.js';
+
+describe('count-map', () => {
+  it('exports a module', () => {
+    expect(CountMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-matrix.test.js
+++ b/src/eventra-kit/__tests__/count-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountMatrix from '../count-matrix.js';
+
+describe('count-matrix', () => {
+  it('exports a module', () => {
+    expect(CountMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-name.test.js
+++ b/src/eventra-kit/__tests__/count-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountName from '../count-name.js';
+
+describe('count-name', () => {
+  it('exports a module', () => {
+    expect(CountName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-node.test.js
+++ b/src/eventra-kit/__tests__/count-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountNode from '../count-node.js';
+
+describe('count-node', () => {
+  it('exports a module', () => {
+    expect(CountNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-number.test.js
+++ b/src/eventra-kit/__tests__/count-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountNumber from '../count-number.js';
+
+describe('count-number', () => {
+  it('exports a module', () => {
+    expect(CountNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-object.test.js
+++ b/src/eventra-kit/__tests__/count-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountObject from '../count-object.js';
+
+describe('count-object', () => {
+  it('exports a module', () => {
+    expect(CountObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-order.test.js
+++ b/src/eventra-kit/__tests__/count-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountOrder from '../count-order.js';
+
+describe('count-order', () => {
+  it('exports a module', () => {
+    expect(CountOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-page.test.js
+++ b/src/eventra-kit/__tests__/count-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountPage from '../count-page.js';
+
+describe('count-page', () => {
+  it('exports a module', () => {
+    expect(CountPage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-pair.test.js
+++ b/src/eventra-kit/__tests__/count-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountPair from '../count-pair.js';
+
+describe('count-pair', () => {
+  it('exports a module', () => {
+    expect(CountPair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-path.test.js
+++ b/src/eventra-kit/__tests__/count-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountPath from '../count-path.js';
+
+describe('count-path', () => {
+  it('exports a module', () => {
+    expect(CountPath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-point.test.js
+++ b/src/eventra-kit/__tests__/count-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountPoint from '../count-point.js';
+
+describe('count-point', () => {
+  it('exports a module', () => {
+    expect(CountPoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-portion.test.js
+++ b/src/eventra-kit/__tests__/count-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountPortion from '../count-portion.js';
+
+describe('count-portion', () => {
+  it('exports a module', () => {
+    expect(CountPortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-prop.test.js
+++ b/src/eventra-kit/__tests__/count-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountProp from '../count-prop.js';
+
+describe('count-prop', () => {
+  it('exports a module', () => {
+    expect(CountProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-queue.test.js
+++ b/src/eventra-kit/__tests__/count-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountQueue from '../count-queue.js';
+
+describe('count-queue', () => {
+  it('exports a module', () => {
+    expect(CountQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-range.test.js
+++ b/src/eventra-kit/__tests__/count-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountRange from '../count-range.js';
+
+describe('count-range', () => {
+  it('exports a module', () => {
+    expect(CountRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-rank.test.js
+++ b/src/eventra-kit/__tests__/count-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountRank from '../count-rank.js';
+
+describe('count-rank', () => {
+  it('exports a module', () => {
+    expect(CountRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-record.test.js
+++ b/src/eventra-kit/__tests__/count-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountRecord from '../count-record.js';
+
+describe('count-record', () => {
+  it('exports a module', () => {
+    expect(CountRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-rect.test.js
+++ b/src/eventra-kit/__tests__/count-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountRect from '../count-rect.js';
+
+describe('count-rect', () => {
+  it('exports a module', () => {
+    expect(CountRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-score.test.js
+++ b/src/eventra-kit/__tests__/count-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountScore from '../count-score.js';
+
+describe('count-score', () => {
+  it('exports a module', () => {
+    expect(CountScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-segment.test.js
+++ b/src/eventra-kit/__tests__/count-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountSegment from '../count-segment.js';
+
+describe('count-segment', () => {
+  it('exports a module', () => {
+    expect(CountSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-set.test.js
+++ b/src/eventra-kit/__tests__/count-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountSet from '../count-set.js';
+
+describe('count-set', () => {
+  it('exports a module', () => {
+    expect(CountSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-size.test.js
+++ b/src/eventra-kit/__tests__/count-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountSize from '../count-size.js';
+
+describe('count-size', () => {
+  it('exports a module', () => {
+    expect(CountSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-slice.test.js
+++ b/src/eventra-kit/__tests__/count-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountSlice from '../count-slice.js';
+
+describe('count-slice', () => {
+  it('exports a module', () => {
+    expect(CountSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-space.test.js
+++ b/src/eventra-kit/__tests__/count-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountSpace from '../count-space.js';
+
+describe('count-space', () => {
+  it('exports a module', () => {
+    expect(CountSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/count-span.test.js
+++ b/src/eventra-kit/__tests__/count-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CountSpan from '../count-span.js';
+
+describe('count-span', () => {
+  it('exports a module', () => {
+    expect(CountSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/count-leaf.js
+++ b/src/eventra-kit/count-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-leaf helper.
+ */
+export function countLeaf(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/count-length.js
+++ b/src/eventra-kit/count-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-length helper.
+ */
+export function countLength(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/count-line.js
+++ b/src/eventra-kit/count-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-line helper.
+ */
+export function countLine(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/count-list.js
+++ b/src/eventra-kit/count-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-list helper.
+ */
+export function countList(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/count-map.js
+++ b/src/eventra-kit/count-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-map helper.
+ */
+export function countMap(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/count-matrix.js
+++ b/src/eventra-kit/count-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-matrix helper.
+ */
+export function countMatrix(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/count-name.js
+++ b/src/eventra-kit/count-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-name helper.
+ */
+export function countName(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/count-node.js
+++ b/src/eventra-kit/count-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-node helper.
+ */
+export function countNode(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/count-number.js
+++ b/src/eventra-kit/count-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-number helper.
+ */
+export function countNumber(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/count-object.js
+++ b/src/eventra-kit/count-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-object helper.
+ */
+export function countObject(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/count-order.js
+++ b/src/eventra-kit/count-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-order helper.
+ */
+export function countOrder(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/count-page.js
+++ b/src/eventra-kit/count-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-page helper.
+ */
+export function countPage(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/count-pair.js
+++ b/src/eventra-kit/count-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-pair helper.
+ */
+export function countPair(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/count-path.js
+++ b/src/eventra-kit/count-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-path helper.
+ */
+export function countPath(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/count-point.js
+++ b/src/eventra-kit/count-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-point helper.
+ */
+export function countPoint(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/count-portion.js
+++ b/src/eventra-kit/count-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-portion helper.
+ */
+export function countPortion(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/count-prop.js
+++ b/src/eventra-kit/count-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-prop helper.
+ */
+export function countProp(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/count-queue.js
+++ b/src/eventra-kit/count-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-queue helper.
+ */
+export function countQueue(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/count-range.js
+++ b/src/eventra-kit/count-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-range helper.
+ */
+export function countRange(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/count-rank.js
+++ b/src/eventra-kit/count-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-rank helper.
+ */
+export function countRank(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/count-record.js
+++ b/src/eventra-kit/count-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-record helper.
+ */
+export function countRecord(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/count-rect.js
+++ b/src/eventra-kit/count-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-rect helper.
+ */
+export function countRect(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/count-score.js
+++ b/src/eventra-kit/count-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-score helper.
+ */
+export function countScore(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/count-segment.js
+++ b/src/eventra-kit/count-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-segment helper.
+ */
+export function countSegment(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/count-set.js
+++ b/src/eventra-kit/count-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-set helper.
+ */
+export function countSet(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/count-size.js
+++ b/src/eventra-kit/count-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-size helper.
+ */
+export function countSize(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/count-slice.js
+++ b/src/eventra-kit/count-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-slice helper.
+ */
+export function countSlice(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/count-space.js
+++ b/src/eventra-kit/count-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-space helper.
+ */
+export function countSpace(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/count-span.js
+++ b/src/eventra-kit/count-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a count-span helper.
+ */
+export function countSpan(value) {
+  return Math.exp(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/count-span.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change