### PR TITLE
feat: add create leaf helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/create-chunk.test.js
+++ b/src/eventra-kit/__tests__/create-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateChunk from '../create-chunk.js';
+
+describe('create-chunk', () => {
+  it('exports a module', () => {
+    expect(CreateChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-circle.test.js
+++ b/src/eventra-kit/__tests__/create-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateCircle from '../create-circle.js';
+
+describe('create-circle', () => {
+  it('exports a module', () => {
+    expect(CreateCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-count.test.js
+++ b/src/eventra-kit/__tests__/create-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateCount from '../create-count.js';
+
+describe('create-count', () => {
+  it('exports a module', () => {
+    expect(CreateCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-date.test.js
+++ b/src/eventra-kit/__tests__/create-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateDate from '../create-date.js';
+
+describe('create-date', () => {
+  it('exports a module', () => {
+    expect(CreateDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-delta.test.js
+++ b/src/eventra-kit/__tests__/create-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateDelta from '../create-delta.js';
+
+describe('create-delta', () => {
+  it('exports a module', () => {
+    expect(CreateDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-dict.test.js
+++ b/src/eventra-kit/__tests__/create-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateDict from '../create-dict.js';
+
+describe('create-dict', () => {
+  it('exports a module', () => {
+    expect(CreateDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-dir.test.js
+++ b/src/eventra-kit/__tests__/create-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateDir from '../create-dir.js';
+
+describe('create-dir', () => {
+  it('exports a module', () => {
+    expect(CreateDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-edge.test.js
+++ b/src/eventra-kit/__tests__/create-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateEdge from '../create-edge.js';
+
+describe('create-edge', () => {
+  it('exports a module', () => {
+    expect(CreateEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-element.test.js
+++ b/src/eventra-kit/__tests__/create-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateElement from '../create-element.js';
+
+describe('create-element', () => {
+  it('exports a module', () => {
+    expect(CreateElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-entry.test.js
+++ b/src/eventra-kit/__tests__/create-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateEntry from '../create-entry.js';
+
+describe('create-entry', () => {
+  it('exports a module', () => {
+    expect(CreateEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-field.test.js
+++ b/src/eventra-kit/__tests__/create-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateField from '../create-field.js';
+
+describe('create-field', () => {
+  it('exports a module', () => {
+    expect(CreateField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-file.test.js
+++ b/src/eventra-kit/__tests__/create-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateFile from '../create-file.js';
+
+describe('create-file', () => {
+  it('exports a module', () => {
+    expect(CreateFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-fraction.test.js
+++ b/src/eventra-kit/__tests__/create-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateFraction from '../create-fraction.js';
+
+describe('create-fraction', () => {
+  it('exports a module', () => {
+    expect(CreateFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-frame.test.js
+++ b/src/eventra-kit/__tests__/create-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateFrame from '../create-frame.js';
+
+describe('create-frame', () => {
+  it('exports a module', () => {
+    expect(CreateFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-gap.test.js
+++ b/src/eventra-kit/__tests__/create-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateGap from '../create-gap.js';
+
+describe('create-gap', () => {
+  it('exports a module', () => {
+    expect(CreateGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-graph.test.js
+++ b/src/eventra-kit/__tests__/create-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateGraph from '../create-graph.js';
+
+describe('create-graph', () => {
+  it('exports a module', () => {
+    expect(CreateGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-grid.test.js
+++ b/src/eventra-kit/__tests__/create-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateGrid from '../create-grid.js';
+
+describe('create-grid', () => {
+  it('exports a module', () => {
+    expect(CreateGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-group.test.js
+++ b/src/eventra-kit/__tests__/create-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateGroup from '../create-group.js';
+
+describe('create-group', () => {
+  it('exports a module', () => {
+    expect(CreateGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-hash.test.js
+++ b/src/eventra-kit/__tests__/create-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateHash from '../create-hash.js';
+
+describe('create-hash', () => {
+  it('exports a module', () => {
+    expect(CreateHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-heap.test.js
+++ b/src/eventra-kit/__tests__/create-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateHeap from '../create-heap.js';
+
+describe('create-heap', () => {
+  it('exports a module', () => {
+    expect(CreateHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-html.test.js
+++ b/src/eventra-kit/__tests__/create-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateHtml from '../create-html.js';
+
+describe('create-html', () => {
+  it('exports a module', () => {
+    expect(CreateHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-id.test.js
+++ b/src/eventra-kit/__tests__/create-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateId from '../create-id.js';
+
+describe('create-id', () => {
+  it('exports a module', () => {
+    expect(CreateId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-index.test.js
+++ b/src/eventra-kit/__tests__/create-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateIndex from '../create-index.js';
+
+describe('create-index', () => {
+  it('exports a module', () => {
+    expect(CreateIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-interval.test.js
+++ b/src/eventra-kit/__tests__/create-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateInterval from '../create-interval.js';
+
+describe('create-interval', () => {
+  it('exports a module', () => {
+    expect(CreateInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-item.test.js
+++ b/src/eventra-kit/__tests__/create-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateItem from '../create-item.js';
+
+describe('create-item', () => {
+  it('exports a module', () => {
+    expect(CreateItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-json.test.js
+++ b/src/eventra-kit/__tests__/create-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateJson from '../create-json.js';
+
+describe('create-json', () => {
+  it('exports a module', () => {
+    expect(CreateJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-key.test.js
+++ b/src/eventra-kit/__tests__/create-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateKey from '../create-key.js';
+
+describe('create-key', () => {
+  it('exports a module', () => {
+    expect(CreateKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-leaf.test.js
+++ b/src/eventra-kit/__tests__/create-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateLeaf from '../create-leaf.js';
+
+describe('create-leaf', () => {
+  it('exports a module', () => {
+    expect(CreateLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/create-chunk.js
+++ b/src/eventra-kit/create-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-chunk helper.
+ */
+export function createChunk(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/create-circle.js
+++ b/src/eventra-kit/create-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-circle helper.
+ */
+export function createCircle(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/create-count.js
+++ b/src/eventra-kit/create-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-count helper.
+ */
+export function createCount(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/create-date.js
+++ b/src/eventra-kit/create-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-date helper.
+ */
+export function createDate(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/create-delta.js
+++ b/src/eventra-kit/create-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-delta helper.
+ */
+export function createDelta(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/create-dict.js
+++ b/src/eventra-kit/create-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-dict helper.
+ */
+export function createDict(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/create-dir.js
+++ b/src/eventra-kit/create-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-dir helper.
+ */
+export function createDir(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/create-edge.js
+++ b/src/eventra-kit/create-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-edge helper.
+ */
+export function createEdge(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/create-element.js
+++ b/src/eventra-kit/create-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-element helper.
+ */
+export function createElement(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/create-entry.js
+++ b/src/eventra-kit/create-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-entry helper.
+ */
+export function createEntry(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/create-field.js
+++ b/src/eventra-kit/create-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-field helper.
+ */
+export function createField(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/create-file.js
+++ b/src/eventra-kit/create-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-file helper.
+ */
+export function createFile(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/create-fraction.js
+++ b/src/eventra-kit/create-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-fraction helper.
+ */
+export function createFraction(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/create-frame.js
+++ b/src/eventra-kit/create-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-frame helper.
+ */
+export function createFrame(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/create-gap.js
+++ b/src/eventra-kit/create-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-gap helper.
+ */
+export function createGap(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/create-graph.js
+++ b/src/eventra-kit/create-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-graph helper.
+ */
+export function createGraph(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/create-grid.js
+++ b/src/eventra-kit/create-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-grid helper.
+ */
+export function createGrid(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/create-group.js
+++ b/src/eventra-kit/create-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-group helper.
+ */
+export function createGroup(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/create-hash.js
+++ b/src/eventra-kit/create-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-hash helper.
+ */
+export function createHash(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/create-heap.js
+++ b/src/eventra-kit/create-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-heap helper.
+ */
+export function createHeap(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/create-html.js
+++ b/src/eventra-kit/create-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-html helper.
+ */
+export function createHtml(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/create-id.js
+++ b/src/eventra-kit/create-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-id helper.
+ */
+export function createId(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/create-index.js
+++ b/src/eventra-kit/create-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-index helper.
+ */
+export function createIndex(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/create-interval.js
+++ b/src/eventra-kit/create-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-interval helper.
+ */
+export function createInterval(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/create-item.js
+++ b/src/eventra-kit/create-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-item helper.
+ */
+export function createItem(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/create-json.js
+++ b/src/eventra-kit/create-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-json helper.
+ */
+export function createJson(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/create-key.js
+++ b/src/eventra-kit/create-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-key helper.
+ */
+export function createKey(value) {
+  return value.map((item, index) => [index, item]);
+}
+

--- a/src/eventra-kit/create-leaf.js
+++ b/src/eventra-kit/create-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-leaf helper.
+ */
+export function createLeaf(value) {
+  return String(value).split(/\r?\n/);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/create-leaf.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change