### PR TITLE
feat: add create vertex helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/create-path.test.js
+++ b/src/eventra-kit/__tests__/create-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreatePath from '../create-path.js';
+
+describe('create-path', () => {
+  it('exports a module', () => {
+    expect(CreatePath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-point.test.js
+++ b/src/eventra-kit/__tests__/create-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreatePoint from '../create-point.js';
+
+describe('create-point', () => {
+  it('exports a module', () => {
+    expect(CreatePoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-portion.test.js
+++ b/src/eventra-kit/__tests__/create-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreatePortion from '../create-portion.js';
+
+describe('create-portion', () => {
+  it('exports a module', () => {
+    expect(CreatePortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-prop.test.js
+++ b/src/eventra-kit/__tests__/create-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateProp from '../create-prop.js';
+
+describe('create-prop', () => {
+  it('exports a module', () => {
+    expect(CreateProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-queue.test.js
+++ b/src/eventra-kit/__tests__/create-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateQueue from '../create-queue.js';
+
+describe('create-queue', () => {
+  it('exports a module', () => {
+    expect(CreateQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-range.test.js
+++ b/src/eventra-kit/__tests__/create-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateRange from '../create-range.js';
+
+describe('create-range', () => {
+  it('exports a module', () => {
+    expect(CreateRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-rank.test.js
+++ b/src/eventra-kit/__tests__/create-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateRank from '../create-rank.js';
+
+describe('create-rank', () => {
+  it('exports a module', () => {
+    expect(CreateRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-record.test.js
+++ b/src/eventra-kit/__tests__/create-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateRecord from '../create-record.js';
+
+describe('create-record', () => {
+  it('exports a module', () => {
+    expect(CreateRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-rect.test.js
+++ b/src/eventra-kit/__tests__/create-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateRect from '../create-rect.js';
+
+describe('create-rect', () => {
+  it('exports a module', () => {
+    expect(CreateRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-score.test.js
+++ b/src/eventra-kit/__tests__/create-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateScore from '../create-score.js';
+
+describe('create-score', () => {
+  it('exports a module', () => {
+    expect(CreateScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-segment.test.js
+++ b/src/eventra-kit/__tests__/create-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateSegment from '../create-segment.js';
+
+describe('create-segment', () => {
+  it('exports a module', () => {
+    expect(CreateSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-set.test.js
+++ b/src/eventra-kit/__tests__/create-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateSet from '../create-set.js';
+
+describe('create-set', () => {
+  it('exports a module', () => {
+    expect(CreateSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-size.test.js
+++ b/src/eventra-kit/__tests__/create-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateSize from '../create-size.js';
+
+describe('create-size', () => {
+  it('exports a module', () => {
+    expect(CreateSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-slice.test.js
+++ b/src/eventra-kit/__tests__/create-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateSlice from '../create-slice.js';
+
+describe('create-slice', () => {
+  it('exports a module', () => {
+    expect(CreateSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-space.test.js
+++ b/src/eventra-kit/__tests__/create-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateSpace from '../create-space.js';
+
+describe('create-space', () => {
+  it('exports a module', () => {
+    expect(CreateSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-span.test.js
+++ b/src/eventra-kit/__tests__/create-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateSpan from '../create-span.js';
+
+describe('create-span', () => {
+  it('exports a module', () => {
+    expect(CreateSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-stack.test.js
+++ b/src/eventra-kit/__tests__/create-stack.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateStack from '../create-stack.js';
+
+describe('create-stack', () => {
+  it('exports a module', () => {
+    expect(CreateStack).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-step.test.js
+++ b/src/eventra-kit/__tests__/create-step.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateStep from '../create-step.js';
+
+describe('create-step', () => {
+  it('exports a module', () => {
+    expect(CreateStep).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-string.test.js
+++ b/src/eventra-kit/__tests__/create-string.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateString from '../create-string.js';
+
+describe('create-string', () => {
+  it('exports a module', () => {
+    expect(CreateString).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-text.test.js
+++ b/src/eventra-kit/__tests__/create-text.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateText from '../create-text.js';
+
+describe('create-text', () => {
+  it('exports a module', () => {
+    expect(CreateText).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-time.test.js
+++ b/src/eventra-kit/__tests__/create-time.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateTime from '../create-time.js';
+
+describe('create-time', () => {
+  it('exports a module', () => {
+    expect(CreateTime).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-token.test.js
+++ b/src/eventra-kit/__tests__/create-token.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateToken from '../create-token.js';
+
+describe('create-token', () => {
+  it('exports a module', () => {
+    expect(CreateToken).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-tree.test.js
+++ b/src/eventra-kit/__tests__/create-tree.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateTree from '../create-tree.js';
+
+describe('create-tree', () => {
+  it('exports a module', () => {
+    expect(CreateTree).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-triple.test.js
+++ b/src/eventra-kit/__tests__/create-triple.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateTriple from '../create-triple.js';
+
+describe('create-triple', () => {
+  it('exports a module', () => {
+    expect(CreateTriple).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-uri.test.js
+++ b/src/eventra-kit/__tests__/create-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateUri from '../create-uri.js';
+
+describe('create-uri', () => {
+  it('exports a module', () => {
+    expect(CreateUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-url.test.js
+++ b/src/eventra-kit/__tests__/create-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateUrl from '../create-url.js';
+
+describe('create-url', () => {
+  it('exports a module', () => {
+    expect(CreateUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-value.test.js
+++ b/src/eventra-kit/__tests__/create-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateValue from '../create-value.js';
+
+describe('create-value', () => {
+  it('exports a module', () => {
+    expect(CreateValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-vector.test.js
+++ b/src/eventra-kit/__tests__/create-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateVector from '../create-vector.js';
+
+describe('create-vector', () => {
+  it('exports a module', () => {
+    expect(CreateVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/create-vertex.test.js
+++ b/src/eventra-kit/__tests__/create-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as CreateVertex from '../create-vertex.js';
+
+describe('create-vertex', () => {
+  it('exports a module', () => {
+    expect(CreateVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/create-path.js
+++ b/src/eventra-kit/create-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-path helper.
+ */
+export function createPath(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/create-point.js
+++ b/src/eventra-kit/create-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-point helper.
+ */
+export function createPoint(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/create-portion.js
+++ b/src/eventra-kit/create-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-portion helper.
+ */
+export function createPortion(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/create-prop.js
+++ b/src/eventra-kit/create-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-prop helper.
+ */
+export function createProp(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/create-queue.js
+++ b/src/eventra-kit/create-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-queue helper.
+ */
+export function createQueue(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/create-range.js
+++ b/src/eventra-kit/create-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-range helper.
+ */
+export function createRange(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/create-rank.js
+++ b/src/eventra-kit/create-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-rank helper.
+ */
+export function createRank(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/create-record.js
+++ b/src/eventra-kit/create-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-record helper.
+ */
+export function createRecord(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/create-rect.js
+++ b/src/eventra-kit/create-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-rect helper.
+ */
+export function createRect(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/create-score.js
+++ b/src/eventra-kit/create-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-score helper.
+ */
+export function createScore(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/create-segment.js
+++ b/src/eventra-kit/create-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-segment helper.
+ */
+export function createSegment(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/create-set.js
+++ b/src/eventra-kit/create-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-set helper.
+ */
+export function createSet(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/create-size.js
+++ b/src/eventra-kit/create-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-size helper.
+ */
+export function createSize(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/create-slice.js
+++ b/src/eventra-kit/create-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-slice helper.
+ */
+export function createSlice(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/create-space.js
+++ b/src/eventra-kit/create-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-space helper.
+ */
+export function createSpace(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/create-span.js
+++ b/src/eventra-kit/create-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-span helper.
+ */
+export function createSpan(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/create-stack.js
+++ b/src/eventra-kit/create-stack.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-stack helper.
+ */
+export function createStack(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/create-step.js
+++ b/src/eventra-kit/create-step.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-step helper.
+ */
+export function createStep(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/create-string.js
+++ b/src/eventra-kit/create-string.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-string helper.
+ */
+export function createString(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/create-text.js
+++ b/src/eventra-kit/create-text.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-text helper.
+ */
+export function createText(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/create-time.js
+++ b/src/eventra-kit/create-time.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-time helper.
+ */
+export function createTime(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/create-token.js
+++ b/src/eventra-kit/create-token.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-token helper.
+ */
+export function createToken(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/create-tree.js
+++ b/src/eventra-kit/create-tree.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-tree helper.
+ */
+export function createTree(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/create-triple.js
+++ b/src/eventra-kit/create-triple.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-triple helper.
+ */
+export function createTriple(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/create-uri.js
+++ b/src/eventra-kit/create-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-uri helper.
+ */
+export function createUri(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/create-url.js
+++ b/src/eventra-kit/create-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-url helper.
+ */
+export function createUrl(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/create-value.js
+++ b/src/eventra-kit/create-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-value helper.
+ */
+export function createValue(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/create-vector.js
+++ b/src/eventra-kit/create-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-vector helper.
+ */
+export function createVector(value) {
+  return Math.exp(value);
+}
+

--- a/src/eventra-kit/create-vertex.js
+++ b/src/eventra-kit/create-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a create-vertex helper.
+ */
+export function createVertex(value) {
+  return value == null ? '' : String(value).trim();
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/create-vertex.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change