### PR TITLE
feat: add dedupe pair helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-frame.test.js
+++ b/src/eventra-kit/__tests__/dedupe-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeFrame from '../dedupe-frame.js';
+
+describe('dedupe-frame', () => {
+  it('exports a module', () => {
+    expect(DedupeFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-gap.test.js
+++ b/src/eventra-kit/__tests__/dedupe-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeGap from '../dedupe-gap.js';
+
+describe('dedupe-gap', () => {
+  it('exports a module', () => {
+    expect(DedupeGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-graph.test.js
+++ b/src/eventra-kit/__tests__/dedupe-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeGraph from '../dedupe-graph.js';
+
+describe('dedupe-graph', () => {
+  it('exports a module', () => {
+    expect(DedupeGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-grid.test.js
+++ b/src/eventra-kit/__tests__/dedupe-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeGrid from '../dedupe-grid.js';
+
+describe('dedupe-grid', () => {
+  it('exports a module', () => {
+    expect(DedupeGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-group.test.js
+++ b/src/eventra-kit/__tests__/dedupe-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeGroup from '../dedupe-group.js';
+
+describe('dedupe-group', () => {
+  it('exports a module', () => {
+    expect(DedupeGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-hash.test.js
+++ b/src/eventra-kit/__tests__/dedupe-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeHash from '../dedupe-hash.js';
+
+describe('dedupe-hash', () => {
+  it('exports a module', () => {
+    expect(DedupeHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-heap.test.js
+++ b/src/eventra-kit/__tests__/dedupe-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeHeap from '../dedupe-heap.js';
+
+describe('dedupe-heap', () => {
+  it('exports a module', () => {
+    expect(DedupeHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-html.test.js
+++ b/src/eventra-kit/__tests__/dedupe-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeHtml from '../dedupe-html.js';
+
+describe('dedupe-html', () => {
+  it('exports a module', () => {
+    expect(DedupeHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-id.test.js
+++ b/src/eventra-kit/__tests__/dedupe-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeId from '../dedupe-id.js';
+
+describe('dedupe-id', () => {
+  it('exports a module', () => {
+    expect(DedupeId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-index.test.js
+++ b/src/eventra-kit/__tests__/dedupe-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeIndex from '../dedupe-index.js';
+
+describe('dedupe-index', () => {
+  it('exports a module', () => {
+    expect(DedupeIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-interval.test.js
+++ b/src/eventra-kit/__tests__/dedupe-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeInterval from '../dedupe-interval.js';
+
+describe('dedupe-interval', () => {
+  it('exports a module', () => {
+    expect(DedupeInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-item.test.js
+++ b/src/eventra-kit/__tests__/dedupe-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeItem from '../dedupe-item.js';
+
+describe('dedupe-item', () => {
+  it('exports a module', () => {
+    expect(DedupeItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-json.test.js
+++ b/src/eventra-kit/__tests__/dedupe-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeJson from '../dedupe-json.js';
+
+describe('dedupe-json', () => {
+  it('exports a module', () => {
+    expect(DedupeJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-key.test.js
+++ b/src/eventra-kit/__tests__/dedupe-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeKey from '../dedupe-key.js';
+
+describe('dedupe-key', () => {
+  it('exports a module', () => {
+    expect(DedupeKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-leaf.test.js
+++ b/src/eventra-kit/__tests__/dedupe-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeLeaf from '../dedupe-leaf.js';
+
+describe('dedupe-leaf', () => {
+  it('exports a module', () => {
+    expect(DedupeLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-length.test.js
+++ b/src/eventra-kit/__tests__/dedupe-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeLength from '../dedupe-length.js';
+
+describe('dedupe-length', () => {
+  it('exports a module', () => {
+    expect(DedupeLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-line.test.js
+++ b/src/eventra-kit/__tests__/dedupe-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeLine from '../dedupe-line.js';
+
+describe('dedupe-line', () => {
+  it('exports a module', () => {
+    expect(DedupeLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-list.test.js
+++ b/src/eventra-kit/__tests__/dedupe-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeList from '../dedupe-list.js';
+
+describe('dedupe-list', () => {
+  it('exports a module', () => {
+    expect(DedupeList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-map.test.js
+++ b/src/eventra-kit/__tests__/dedupe-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeMap from '../dedupe-map.js';
+
+describe('dedupe-map', () => {
+  it('exports a module', () => {
+    expect(DedupeMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-matrix.test.js
+++ b/src/eventra-kit/__tests__/dedupe-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeMatrix from '../dedupe-matrix.js';
+
+describe('dedupe-matrix', () => {
+  it('exports a module', () => {
+    expect(DedupeMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-name.test.js
+++ b/src/eventra-kit/__tests__/dedupe-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeName from '../dedupe-name.js';
+
+describe('dedupe-name', () => {
+  it('exports a module', () => {
+    expect(DedupeName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-node.test.js
+++ b/src/eventra-kit/__tests__/dedupe-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeNode from '../dedupe-node.js';
+
+describe('dedupe-node', () => {
+  it('exports a module', () => {
+    expect(DedupeNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-number.test.js
+++ b/src/eventra-kit/__tests__/dedupe-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeNumber from '../dedupe-number.js';
+
+describe('dedupe-number', () => {
+  it('exports a module', () => {
+    expect(DedupeNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-object.test.js
+++ b/src/eventra-kit/__tests__/dedupe-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeObject from '../dedupe-object.js';
+
+describe('dedupe-object', () => {
+  it('exports a module', () => {
+    expect(DedupeObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-order.test.js
+++ b/src/eventra-kit/__tests__/dedupe-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeOrder from '../dedupe-order.js';
+
+describe('dedupe-order', () => {
+  it('exports a module', () => {
+    expect(DedupeOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-page.test.js
+++ b/src/eventra-kit/__tests__/dedupe-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupePage from '../dedupe-page.js';
+
+describe('dedupe-page', () => {
+  it('exports a module', () => {
+    expect(DedupePage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-pair.test.js
+++ b/src/eventra-kit/__tests__/dedupe-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupePair from '../dedupe-pair.js';
+
+describe('dedupe-pair', () => {
+  it('exports a module', () => {
+    expect(DedupePair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/dedupe-frame.js
+++ b/src/eventra-kit/dedupe-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-frame helper.
+ */
+export function dedupeFrame(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/dedupe-gap.js
+++ b/src/eventra-kit/dedupe-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-gap helper.
+ */
+export function dedupeGap(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/dedupe-graph.js
+++ b/src/eventra-kit/dedupe-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-graph helper.
+ */
+export function dedupeGraph(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/dedupe-grid.js
+++ b/src/eventra-kit/dedupe-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-grid helper.
+ */
+export function dedupeGrid(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/dedupe-group.js
+++ b/src/eventra-kit/dedupe-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-group helper.
+ */
+export function dedupeGroup(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/dedupe-hash.js
+++ b/src/eventra-kit/dedupe-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-hash helper.
+ */
+export function dedupeHash(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/dedupe-heap.js
+++ b/src/eventra-kit/dedupe-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-heap helper.
+ */
+export function dedupeHeap(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/dedupe-html.js
+++ b/src/eventra-kit/dedupe-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-html helper.
+ */
+export function dedupeHtml(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/dedupe-id.js
+++ b/src/eventra-kit/dedupe-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-id helper.
+ */
+export function dedupeId(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/dedupe-index.js
+++ b/src/eventra-kit/dedupe-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-index helper.
+ */
+export function dedupeIndex(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/dedupe-interval.js
+++ b/src/eventra-kit/dedupe-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-interval helper.
+ */
+export function dedupeInterval(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/dedupe-item.js
+++ b/src/eventra-kit/dedupe-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-item helper.
+ */
+export function dedupeItem(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/dedupe-json.js
+++ b/src/eventra-kit/dedupe-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-json helper.
+ */
+export function dedupeJson(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/dedupe-key.js
+++ b/src/eventra-kit/dedupe-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-key helper.
+ */
+export function dedupeKey(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/dedupe-leaf.js
+++ b/src/eventra-kit/dedupe-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-leaf helper.
+ */
+export function dedupeLeaf(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/dedupe-length.js
+++ b/src/eventra-kit/dedupe-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-length helper.
+ */
+export function dedupeLength(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/dedupe-line.js
+++ b/src/eventra-kit/dedupe-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-line helper.
+ */
+export function dedupeLine(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/dedupe-list.js
+++ b/src/eventra-kit/dedupe-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-list helper.
+ */
+export function dedupeList(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/dedupe-map.js
+++ b/src/eventra-kit/dedupe-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-map helper.
+ */
+export function dedupeMap(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/dedupe-matrix.js
+++ b/src/eventra-kit/dedupe-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-matrix helper.
+ */
+export function dedupeMatrix(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/dedupe-name.js
+++ b/src/eventra-kit/dedupe-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-name helper.
+ */
+export function dedupeName(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/dedupe-node.js
+++ b/src/eventra-kit/dedupe-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-node helper.
+ */
+export function dedupeNode(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/dedupe-number.js
+++ b/src/eventra-kit/dedupe-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-number helper.
+ */
+export function dedupeNumber(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/dedupe-object.js
+++ b/src/eventra-kit/dedupe-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-object helper.
+ */
+export function dedupeObject(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/dedupe-order.js
+++ b/src/eventra-kit/dedupe-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-order helper.
+ */
+export function dedupeOrder(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/dedupe-page.js
+++ b/src/eventra-kit/dedupe-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-page helper.
+ */
+export function dedupePage(value) {
+  return value.map((item, index) => [index, item]);
+}
+

--- a/src/eventra-kit/dedupe-pair.js
+++ b/src/eventra-kit/dedupe-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-pair helper.
+ */
+export function dedupePair(value) {
+  return String(value).split(/\r?\n/);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/dedupe-pair.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change