### PR TITLE
fix: use event timezone in ICS calendar feed (#16162)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -23,6 +23,12 @@ public class Event {
      * chosen by the organizer survives reload (issue #14603).
      */
     private LocalDateTime endDate;
+
+    /**
+     * IANA timezone (e.g. "America/New_York") or short alias (e.g. "EST") the
+     * event times are expressed in. Falls back to UTC when not set.
+     */
+    private String timezone;
     private boolean isPublic = true;
 
     /**
@@ -170,6 +176,14 @@ public class Event {
 
     public void setEndDate(LocalDateTime endDate) {
         this.endDate = endDate;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
     }
 
     public boolean isPublic() {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1540,16 +1540,19 @@ public class EventService {
         public String buildIcsFeed(Long eventId) {
                 Event event = requirePublicEvent(eventId);
 
-                java.time.Instant start = event.getEventDate() != null
-                                ? event.getEventDate().atZone(java.time.ZoneId.systemDefault()).toInstant()
-                                : java.time.Instant.now();
+                java.time.ZoneId eventZone = resolveEventZone(event.getTimezone());
+                java.time.ZonedDateTime start = event.getEventDate() != null
+                                ? event.getEventDate().atZone(eventZone)
+                                : java.time.ZonedDateTime.now(eventZone);
                 // Default duration is 2 hours when no end date was persisted.
-                java.time.Instant end = (event.getEndDate() != null
-                                ? event.getEndDate().atZone(java.time.ZoneId.systemDefault()).toInstant()
+                java.time.ZonedDateTime end = (event.getEndDate() != null
+                                ? event.getEndDate().atZone(eventZone)
                                 : start.plus(java.time.Duration.ofHours(2)));
                 java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter
                                 .ofPattern("yyyyMMdd'T'HHmmss'Z'")
                                 .withZone(java.time.ZoneOffset.UTC);
+                java.time.format.DateTimeFormatter zonedFmt = java.time.format.DateTimeFormatter
+                                .ofPattern("yyyyMMdd'T'HHmmss");
 
                 String summary = escapeIcs(event.getTitle() != null ? event.getTitle() : "Eventra Event");
                 String description = escapeIcs(event.getDescription() != null ? event.getDescription() : "");
@@ -1564,13 +1567,24 @@ public class EventService {
                                 + "BEGIN:VEVENT\r\n"
                                 + "UID:" + uid + "\r\n"
                                 + "DTSTAMP:" + fmt.format(java.time.Instant.now()) + "\r\n"
-                                + "DTSTART:" + fmt.format(start) + "\r\n"
-                                + "DTEND:" + fmt.format(end) + "\r\n"
+                                + "DTSTART;TZID=" + eventZone.getId() + ":" + zonedFmt.format(start) + "\r\n"
+                                + "DTEND;TZID=" + eventZone.getId() + ":" + zonedFmt.format(end) + "\r\n"
                                 + "SUMMARY:" + summary + "\r\n"
                                 + "DESCRIPTION:" + description + "\r\n"
                                 + "LOCATION:" + location + "\r\n"
                                 + "END:VEVENT\r\n"
                                 + "END:VCALENDAR\r\n";
+        }
+
+        private static java.time.ZoneId resolveEventZone(String timezone) {
+                if (timezone != null && !timezone.isBlank()) {
+                        try {
+                                return java.time.ZoneId.of(timezone, java.time.ZoneId.SHORT_IDS);
+                        } catch (java.time.DateTimeException ignored) {
+                                // fall through to UTC
+                        }
+                }
+                return java.time.ZoneId.of("UTC");
         }
 
         private static String escapeIcs(String value) {


### PR DESCRIPTION
## Problem

The `buildIcsFeed` method in `EventService.java` converted the event's `LocalDateTime` start/end times using `ZoneId.systemDefault()`, ignoring the event's own timezone. This produced incorrect UTC times for users in other timezones — e.g. an event at "14:00" in New York was exported as 14:00 UTC rather than 14:00 EST, so it appeared at 9:00 AM in the user's calendar.

## Fix

- Added a `timezone` field (with getter/setter) to the `Event` model so the event's timezone is persisted and available to the exporter.
- In `buildIcsFeed`, resolve the event timezone via `Event.getTimezone()` and fall back to `UTC`; use `ZoneId.of(timezone, ZoneId.SHORT_IDS)` so short aliases like "EST" are accepted.
- Convert `eventDate`/`endDate` with `.atZone(eventZone)` instead of `ZoneId.systemDefault()`.
- Emit `DTSTART`/`DTEND` using `TZID=<eventZone.getId()>` with the zoned date-time formatted as `yyyyMMdd'T'HHmmss` (e.g. `DTSTART;TZID=America/New_York:20240115T140000`).
- Keep `DTSTAMP` in UTC.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
Backend/src/main/java/com/sandeep/eventrabackend/model/Event.java

## Testing

Manual verification: export an event with `timezone="America/New_York"` and confirm the ICS contains `DTSTART;TZID=America/New_York:20240115T140000` (local wall-clock time), with `DTSTAMP` in UTC. No automated test was added in this change.

Closes #16162
