### PR TITLE
fix: avoid duplicate schema-upgrade toasts in offlineQueue (#16163)

### DIFF
--- a/src/utils/offlineQueue.js
+++ b/src/utils/offlineQueue.js
@@ -76,7 +76,14 @@ const _rescueFromLocalStorage = () => {
 // ---------------------------------------------------------------------------
 // Internal: notify the UI that a schema upgrade occurred
 // ---------------------------------------------------------------------------
+let _upgradeEventDispatched = false;
+
 const _dispatchUpgradeEvent = (rescuedCount) => {
+  // Guard against double-dispatch (defense-in-depth for #16163): the
+  // onupgradeneeded handler must surface at most one migration toast.
+  if (_upgradeEventDispatched) return;
+  _upgradeEventDispatched = true;
+
   const message =
     rescuedCount > 0
       ? `IndexedDB schema upgraded. ${rescuedCount} queued action(s) were safely migrated.`
@@ -109,6 +116,10 @@ const openDB = () => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
 
     request.onupgradeneeded = (e) => {
+      // Reset the dispatch guard so each distinct schema upgrade can emit
+      // exactly one migration notification.
+      _upgradeEventDispatched = false;
+
       const db = e.target.result;
       const oldVersion = e.oldVersion;
       const transaction = e.target.transaction;
@@ -198,9 +209,6 @@ const openDB = () => {
         newStore.createIndex("by_userId", "userId", { unique: false });
         newStore.createIndex("by_priority", "priority", { unique: false });
       }
-
-      // Step 4: Dispatch upgrade event
-      _dispatchUpgradeEvent(rescuedItems.length);
     };
 
     request.onsuccess = (e) => resolve(e.target.result);


### PR DESCRIPTION
## Problem

In `src/utils/offlineQueue.js`, the `openDB` `onupgradeneeded` handler called `_dispatchUpgradeEvent` twice during a schema migration: once prematurely at the end of the handler with the still-empty `rescuedItems` array, and again inside the async `getAll` `onsuccess` (and `onerror`) callback with the actual rescued count. This produced two contradictory toasts ("IndexedDB schema upgraded. No queued actions were affected." followed by "...N queued action(s) were safely migrated.") for a single migration.

## Fix

- Removed the premature `_dispatchUpgradeEvent(rescuedItems.length)` call at the end of the `onupgradeneeded` handler (which used the still-empty `rescuedItems`).
- Ensured `_dispatchUpgradeEvent` is now invoked exactly once per migration, using the actual rescued count, only inside the `getAll` `onsuccess` and `onerror` callbacks — no triple/duplicate dispatch.
- Added a module-level `_upgradeEventDispatched` guard so `_dispatchUpgradeEvent` is idempotent and can never double-fire, with the guard reset at the start of each `onupgradeneeded` so distinct future upgrades still emit one notification.

## Files changed

src/utils/offlineQueue.js

## Testing

No automated test was added. To verify, run the app against a browser whose IndexedDB `eventra_offline_db` is at an older schema version (e.g. clear the DB or force `DB_VERSION` down, then reload): exactly one migration toast should appear, reporting the real migrated item count. Manual verification recommended given the IndexedDB/browser-runtime dependency.

Closes #16163
