### PR TITLE
fix: close TOCTOU race in SSE leader election (#16171)

### DIFF
--- a/src/utils/sseMultiplexer.js
+++ b/src/utils/sseMultiplexer.js
@@ -5,6 +5,7 @@ import { SSE_BASE_URL } from "../config/backendConfig.js";
 const MULTIPLEX_CHANNEL_NAME = "eventra_sse_multiplexer";
 const LOCK_NAME = "eventra_sse_leader_lock";
 const HEARTBEAT_KEY = "eventra_sse_leader_heartbeat";
+const RESERVATION_KEY = "eventra_sse_leader_reservation";
 const LOCAL_STORAGE_CONFIRM_MIN_MS = 25;
 const LOCAL_STORAGE_CONFIRM_JITTER_MS = 75;
 const TAB_ID = Math.random().toString(36).substring(2, 9);
@@ -154,18 +155,58 @@ export class SseMultiplexer {
         return;
       }
 
-      localStorage.setItem(HEARTBEAT_KEY, JSON.stringify({ tabId: this.tabId, token, timestamp }));
+      // Phase 1 (RESERVATION): write a per-tab reservation BEFORE touching the
+      // real heartbeat. localStorage writes are serialized by the event loop, so
+      // of all contending tabs only the LAST writer retains its reservation.
+      // This makes the winner deterministic and removes the check-then-act
+      // TOCTOU window that previously let two tabs both become leader.
+      localStorage.setItem(
+        RESERVATION_KEY,
+        JSON.stringify({ tabId: this.tabId, token, timestamp })
+      );
     } catch {
       this.becomeLocalStorageLeader(token);
       return;
     }
 
+    // Phase 2 (COMMIT): wait a small window so every contending tab has a
+    // chance to write its reservation, then commit the real heartbeat ONLY if
+    // our reservation is still intact (nobody overwrote it) AND the slot is
+    // still free/expired. Otherwise abort.
     const confirmDelay =
       LOCAL_STORAGE_CONFIRM_MIN_MS + Math.floor(Math.random() * LOCAL_STORAGE_CONFIRM_JITTER_MS);
 
     this.localStorageClaimTimeout = setTimeout(() => {
       this.localStorageClaimTimeout = null;
 
+      try {
+        const reservation = JSON.parse(localStorage.getItem(RESERVATION_KEY) || "null");
+        if (reservation?.tabId !== this.tabId || reservation?.token !== token) {
+          // Lost the reservation race — another tab is claiming leadership.
+          return;
+        }
+
+        const now = Date.now();
+        const heartbeat = JSON.parse(localStorage.getItem(HEARTBEAT_KEY) || "null");
+        if (
+          heartbeat &&
+          heartbeat.tabId !== this.tabId &&
+          now - (heartbeat.timestamp || 0) < heartbeatTimeout
+        ) {
+          // Slot was taken by a valid leader during the reservation window.
+          return;
+        }
+
+        localStorage.setItem(
+          HEARTBEAT_KEY,
+          JSON.stringify({ tabId: this.tabId, token, timestamp: now })
+        );
+      } catch {
+        return;
+      }
+
+      // Final confirmation that the heartbeat we committed is still ours
+      // before becoming leader.
       try {
         const heartbeat = JSON.parse(localStorage.getItem(HEARTBEAT_KEY) || "null");
         if (heartbeat?.tabId !== this.tabId || heartbeat?.token !== token) return;


### PR DESCRIPTION
## Problem

The LocalStorage-based leader election in `src/utils/sseMultiplexer.js` has a Time-of-Check-Time-of-Use (TOCTOU) race. `claimLocalStorageLeadership` read the heartbeat (check), then wrote its claim (act), then confirmed. Between the check and the write, two tabs could both pass the check on the same stale/expired heartbeat and both write their own claim. The last write overwrites the first, but both tabs can pass their confirm step, so multiple tabs believe they are the leader. This causes duplicate SSE connections and duplicate messages delivered to followers.

## Fix

- Implemented a reservation-based two-phase commit: Phase 1 writes a per-tab `RESERVATION_KEY` before touching the real `HEARTBEAT_KEY`. Because `localStorage.setItem` is serialized by the event loop, only the last writer retains its reservation, making the winner deterministic.
- Phase 2 (commit) waits a short window, then writes the real heartbeat ONLY if the reservation is still intact (tabId/token match, i.e. nobody overwrote it) AND the slot is still free/expired. Otherwise the claim aborts.
- Added a final confirmation that the committed heartbeat is still ours before `becomeLocalStorageLeader` is called, so it only runs on a winning commit.
- The existing Web Locks API path remains the primary mechanism; the localStorage fix is strictly the fallback and its logic was not removed.

## Files changed

src/utils/sseMultiplexer.js

## Testing

No automated test was added. Verify manually by opening the app in two tabs simultaneously on a browser without Web Locks support (or forcing the localStorage fallback): observe that exactly one tab opens the physical SSE connection and followers receive messages without duplication. Also confirm normal single-tab and leader-failover behavior is unchanged.

Closes #16171
