### PR TITLE
fix: persist event archive via backend API (#16166)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
@@ -53,4 +53,7 @@ public class EventUpdateRequest {
 
     @Schema(description = "Optional tags for the event to enable granular filtering and search", example = "AI,Conference,2026")
     private Set<String> tags;
+
+    @Schema(description = "Optional lifecycle status for the event (e.g. archived). When omitted the previous status is preserved.", example = "archived")
+    private String status;
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -569,6 +569,9 @@ public class EventService {
                 if (request.getTags() != null) {
                         event.setTags(new HashSet<>(request.getTags()));
                 }
+                if (request.getStatus() != null) {
+                        event.setStatus(request.getStatus());
+                }
 
                 Event saved = eventRepository.save(event);
 

--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -600,9 +600,21 @@ ${window.location.href}
               )}
               {canManageEvent && event.status !== "cancelled" && event.status !== "archived" && (
                 <button
-                  onClick={() => {
-                    setEvent({ ...event, status: "archived" });
-                    toast.success("Event Archived!");
+                  onClick={async () => {
+                    try {
+                      const res = await apiUtils.put(
+                        API_ENDPOINTS.EVENTS.UPDATE(event.id),
+                        { status: "archived" },
+                        { requiresAuth: true }
+                      );
+                      const updated = res?.data ?? res;
+                      setEvent({ ...event, ...(updated || {}) });
+                      toast.success("Event Archived!");
+                    } catch (err) {
+                      toast.error(
+                        err?.message || "Failed to archive event. Please try again."
+                      );
+                    }
                   }}
                   className="inline-flex items-center justify-center gap-2 rounded-full border border-orange-500 px-6 py-3 text-sm font-semibold text-orange-600 hover:bg-orange-50 dark:hover:bg-orange-900/20 transition"
                 >

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -198,6 +198,7 @@ export const API_ENDPOINTS = {
     ALL: buildApiUrl("/events"),
     LIST: buildApiUrl("/events"),
     DETAIL: (id) => buildApiUrl(`/events/${id}`),
+    UPDATE: (id) => buildApiUrl(`/events/${id}`),
     REGISTER: (id) => buildApiUrl(`/events/${id}/register`),
     CANCEL_REGISTRATION: (id) => buildApiUrl(`/events/${id}/registration`),
     CANCEL: (id) => buildApiUrl(`/events/${id}/cancel`),


### PR DESCRIPTION
## Problem

The "Archive Event" button in `src/Pages/Events/EventDetails.js` updated only local React state (`setEvent({ ...event, status: "archived" })`) with no backend API call. As a result:

- The archived status was lost on page refresh because `loadEvent()` re-fetches from the backend, which still returned the original status.
- The `toast.success("Event Archived!")` fired immediately, prematurely claiming success even though nothing was persisted.
- The Cancel button (via `EventCancellationModal`) correctly calls the backend, so the two actions behaved inconsistently.

## Fix

- Made the Archive button `onClick` async and added an API call to persist the change:
  `apiUtils.put(API_ENDPOINTS.EVENTS.UPDATE(event.id), { status: "archived" }, { requiresAuth: true })`.
- On success, the local state is updated with the returned event (`setEvent({ ...event, ...updated })`) and a success toast is shown.
- On failure, an error toast is shown and the local state is **not** modified (no premature success / no rollback needed).
- Added the missing `private String status;` field (with getter/setter via Lombok `@Data`) to `EventUpdateRequest.java`.
- Ensured `EventService.updateEvent` sets `event.setStatus(request.getStatus())` when a status is provided (the existing `requireRole(ORGANIZER)` guard already restricts this to organizers/admins).
- Added the `API_ENDPOINTS.EVENTS.UPDATE` endpoint constant (maps to `PUT /events/{id}`) used by the call.

## Files changed

- src/Pages/Events/EventDetails.js
- src/config/api.js
- Backend/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java

## Testing

- Manual: as an organizer, open an event, click "Archive Event", confirm the success toast appears and the status remains "archived" after refreshing the page (persisted via `PUT /events/{id}`). On a simulated backend failure, confirm the error toast shows and the status is unchanged.
- No automated test was added for this change.

Closes #16166
