### PR TITLE
fix: make registration capacity increment atomic with save (#16175)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1146,6 +1146,14 @@ public class EventService {
                                                 eventId,
                                                 attempt,
                                                 MAX_REGISTRATION_RETRIES);
+                        } catch (org.springframework.dao.PessimisticLockingFailureException ex) {
+                                lastConflict = ex;
+
+                                log.warn(
+                                                "Pessimistic lock conflict on event {} (attempt {}/{})",
+                                                eventId,
+                                                attempt,
+                                                MAX_REGISTRATION_RETRIES);
                         }
                 }
 
@@ -1205,12 +1213,12 @@ public class EventService {
                         }
                 }
 
-                // FIX (#13914): atomic capacity guard. The single UPDATE
-                // increments registeredCount only while a seat is free (row
-                // count 1), so two concurrent registrations cannot both pass an
-                // in-memory check and overshoot capacity. Row count 0 => full.
+                // Capacity guard. The event row is held under a pessimistic write
+                // lock (findByIdWithLock) for the whole transaction, so this
+                // in-memory check is safe against concurrent registrations and
+                // keeps the increment atomic with the registration save below.
                 if (event.getCapacity() != null
-                                && eventRepository.incrementRegisteredCountAtomically(eventId) == 0) {
+                                && event.getRegisteredCount() >= event.getCapacity()) {
 
                         throw new EventFullException(
                                         "Event is already full. Capacity: " + event.getCapacity());
@@ -1230,8 +1238,10 @@ public class EventService {
                         throw mapRegistrationIntegrityViolation(ex, seatId);
                 }
 
-                event.setRegisteredCount((int) eventRegistrationRepository
-                                .countByEvent_IdAndStatus(eventId, "CONFIRMED"));
+                // Increment in memory and persist within the same transaction as
+                // the registration so the two either both commit or both roll
+                // back (no orphaned capacity increment, #16175).
+                event.setRegisteredCount(event.getRegisteredCount() + 1);
                 Event saved = eventRepository.save(event);
 
                 broadcastAvailability(saved);


### PR DESCRIPTION
## Problem

`EventService.registerUserForEvent` increments `registeredCount` via the atomic `@Modifying` query `incrementRegisteredCountAtomically`, which commits immediately (`flushAutomatically = true`). The subsequent `eventRegistrationRepository.saveAndFlush(registration)` can fail (e.g. `DataIntegrityViolationException` from a unique/seat constraint, deadlock, validation). When it does, the transaction rolls back the registration but the capacity increment was already flushed and committed, leaving `registeredCount = N+1` with only `N` actual registrations. A seat is permanently lost and `registeredCount` no longer equals the count of confirmed registrations. The retry loop also only caught `ObjectOptimisticLockingFailureException`, not these failures.

## Fix

- Chose **Option 1** (single transaction with explicit pessimistic lock).
- The event is already loaded under a pessimistic write lock (`findByIdWithLock`, `PESSIMISTIC_WRITE`) for the whole transaction, so the standalone atomic increment query was redundant and the source of the gap.
- Replaced the atomic increment with an **in-memory capacity check**: throw `EventFullException` when `registeredCount >= capacity`.
- After the registration is saved, increment `event.setRegisteredCount(event.getRegisteredCount() + 1)` and `eventRepository.save(event)` in the same transaction — capacity increment and registration creation now commit or roll back together (no orphaned increment).
- Kept `broadcastAvailability(saved)` on the freshly saved event (correct `spotsRemaining`).
- Added a retry handler for `PessimisticLockingFailureException` so the existing retry loop also covers pessimistic lock contention, preserving the optimistic/pessimistic lock retry behavior.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java

## Testing

- Manual verification: register until capacity is reached; confirm a failed registration (e.g. duplicate seat/constraint) no longer leaves `registeredCount` incremented without a registration, and that `registeredCount` always equals the number of confirmed registrations.
- No automated test was added as part of this scoped fix.

Closes #16175
