### PR TITLE
fix: installment total equals ticket price and due-date drift (#16173)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -84,7 +84,7 @@ public class PaymentPlanService {
         
         if (eventDate != null && now.isBefore(eventDate)) {
             long totalDays = java.time.temporal.ChronoUnit.DAYS.between(now.toLocalDate(), eventDate.toLocalDate());
-            long daysUntilFirstInstallment = totalDays / totalInstallments;
+            long daysUntilFirstInstallment = totalDays / (totalInstallments - 1);
             paymentPlan.setNextPaymentDate(now.plusDays(daysUntilFirstInstallment));
         }
         
@@ -127,26 +127,34 @@ public class PaymentPlanService {
         
         // Remaining installments
         long totalDays = java.time.temporal.ChronoUnit.DAYS.between(now.toLocalDate(), eventDate.toLocalDate());
-        long intervalDays = totalDays / (paymentPlan.getTotalInstallments() - 1);
-        
+        int numInstallments = paymentPlan.getTotalInstallments() - 1;
+
+        // Ensure installments + upfront sum exactly to ticketPrice: the last
+        // installment absorbs the rounding difference from the base amount.
+        BigDecimal remainingAmount = paymentPlan.getTotalAmount().subtract(upfrontAmount);
+        BigDecimal lastInstallmentAmount = remainingAmount.subtract(
+                installmentAmount.multiply(new BigDecimal(numInstallments - 1)));
+
         for (int i = 2; i <= paymentPlan.getTotalInstallments(); i++) {
             Payment payment = new Payment();
             payment.setRegistration(registration);
-            payment.setAmount(installmentAmount);
+            payment.setAmount(i == paymentPlan.getTotalInstallments() ? lastInstallmentAmount : installmentAmount);
             payment.setCurrency(paymentPlan.getCurrency());
             payment.setPaymentMethod("CARD");
             payment.setPaymentProvider("STRIPE");
             payment.setStatus("PENDING");
             payment.setInstallmentNumber(i);
             payment.setTotalInstallments(paymentPlan.getTotalInstallments());
-            
-            // Calculate due date
-            LocalDateTime dueDate = now.plusDays(intervalDays * (i - 1));
+
+            // Calculate due date: spread total days evenly so the schedule spans
+            // the full period without dropping remainder days (proportional spacing).
+            long dueDayOffset = (totalDays * (i - 1)) / numInstallments;
+            LocalDateTime dueDate = now.plusDays(dueDayOffset);
             if (dueDate.isAfter(eventDate)) {
                 dueDate = eventDate;
             }
             payment.setDueDate(dueDate);
-            
+
             paymentRepository.save(payment);
         }
     }


### PR DESCRIPTION
## Problem

`PaymentPlanService` computes installment amounts and due dates with rounding/integer-division bugs:
- The two-step `HALF_UP` rounding of the upfront amount and the per-installment base amount can leave `sum(upfront + installments)` off from `ticketPrice` by a cent (e.g. 99.99 ticket, 25% upfront, 4 installments produced a total of 100.00 instead of 99.99).
- Due-date scheduling used integer division (`totalDays / installments`) which dropped the remainder days, so the installment schedule finished before the event date (scheduling drift).

## Fix

- Compute the base installment amount with `HALF_UP`, then set the **last** installment to `remainingAmount - baseAmount * (numInstallments - 1)` so `upfront + all installments == ticketPrice` exactly to the cent.
- Spread the total day span across due dates using proportional spacing (`totalDays * (i - 1) / numInstallments`) so the remainder days are distributed and the schedule spans the full period without drift.
- `nextPaymentDate` now divides by `totalInstallments - 1` to stay consistent with the installment schedule.
- Only the payment-plan calculation paths were changed; no other payment logic was touched. `BigDecimal` is used throughout.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java

## Testing

Verified the rounding math manually for the reported case (99.99 ticket, 25% upfront, 4 installments → installments 25.00, 25.00, 24.99 + 25.00 upfront = 99.99). No automated test was added as part of this scoped fix.

Closes #16173
