### PR TITLE
fix: validate public status filter + clamp pagination on getAllEvents (Closes #15981)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
@@ -38,6 +38,7 @@ public final class EventSpecifications {
                         .collect(java.util.stream.Collectors.toSet());
         boolean requestsCancelled = requested.contains("CANCELLED") || requested.contains("CANCELED");
         boolean requestsArchived = requested.contains("ARCHIVED");
+        boolean requestsDraft = requested.contains("DRAFT");
 
         return (root, query, cb) -> {
             java.util.List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
@@ -46,6 +47,9 @@ public final class EventSpecifications {
             }
             if (!requestsArchived) {
                 predicates.add(cb.notEqual(cb.upper(root.get("status")), "ARCHIVED"));
+            }
+            if (!requestsDraft) {
+                predicates.add(cb.notEqual(cb.upper(root.get("status")), "DRAFT"));
             }
             if (predicates.isEmpty()) {
                 return cb.conjunction();

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -102,6 +102,22 @@ public class EventService {
                         "title", "title",
                         "id", "id");
 
+        /**
+         * Allowlist for the public listing {@code status} filter. Restricts the
+         * public endpoint to timing/lifecycle labels that are safe to expose so
+         * callers cannot request internal states (e.g. DRAFT, ARCHIVED, INTERNAL)
+         * via the filter.
+         */
+        private static final Set<String> ALLOWED_PUBLIC_STATUSES = Set.of(
+                        "PUBLISHED", "UPCOMING", "ONGOING", "COMPLETED",
+                        "LIVE", "PAST", "ENDED", "CANCELLED", "CANCELED", "SCHEDULED");
+
+        /** Maximum page index accepted by the public listing (DoS guard). */
+        private static final int MAX_EVENTS_PAGE = 1000;
+
+        /** Maximum length (chars) of the public listing search term. */
+        private static final int MAX_EVENTS_SEARCH_LENGTH = 200;
+
         private final EventRepository eventRepository;
         private final EventRegistrationRepository eventRegistrationRepository;
         private final EventWaitlistRepository eventWaitlistRepository;
@@ -221,7 +237,24 @@ public class EventService {
                         String search,
                         List<String> statuses,
                         String sort) {
-                int safePage = Math.max(0, page);
+                if (statuses != null) {
+                        for (String raw : statuses) {
+                                if (raw == null) {
+                                        continue;
+                                }
+                                String status = raw.trim().toUpperCase(Locale.ROOT);
+                                if (!status.isEmpty() && !ALLOWED_PUBLIC_STATUSES.contains(status)) {
+                                        throw new IllegalArgumentException(
+                                                        "Invalid status filter '" + raw + "'. Allowed values: "
+                                                                        + String.join(", ", ALLOWED_PUBLIC_STATUSES));
+                                }
+                        }
+                }
+                if (search != null && search.length() > MAX_EVENTS_SEARCH_LENGTH) {
+                        throw new IllegalArgumentException(
+                                        "Search term must not exceed " + MAX_EVENTS_SEARCH_LENGTH + " characters");
+                }
+                int safePage = Math.min(Math.max(0, page), MAX_EVENTS_PAGE);
                 int safeSize = (size <= 0) ? 20 : Math.min(size, 100);
                 Pageable pageable = PageRequest.of(safePage, safeSize, resolveSort(sort));
                 Specification<Event> spec = EventSpecifications.publicListing(search, statuses);


### PR DESCRIPTION
﻿## Problem

The public getAllEvents endpoint accepted arbitrary status values (e.g. DRAFT/ARCHIVED/INTERNAL) bypassing the public-listing intent, and allowed unbounded deep pagination (DoS + information disclosure).

## Fix

Validated the status list against an allowlist (400 on invalid), clamped the maximum page (1000), validated search length, and ensured publicListing excludes drafts/archived events.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java; Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java

## Testing

Request with status=DRAFT returns 400; deep page numbers are clamped.

Closes #15981
