### PR TITLE
fix: persist installment PaymentIntent IDs for webhook tracking (Closes #15848)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -307,6 +307,22 @@ public class PaymentPlanService {
             List<String> installmentIntentIds = stripeService.scheduleInstallmentPayments(
                     paymentPlan, paymentPlan.getStripeCustomerId(), paymentMethodId);
             
+            // Persist installment PaymentIntent IDs onto the Payment records so webhooks
+            // for installments 2+ can locate them. installmentIntentIds[0] is the
+            // (already persisted) upfront intent; subsequent entries map to installments
+            // 2+ by index.
+            List<Payment> installmentPayments = paymentRepository.findByRegistration_IdOrderByInstallmentNumberAsc(
+                    registration.getId());
+            String stripeCustomerId = paymentPlan.getStripeCustomerId();
+            for (int i = 0; i < installmentPayments.size(); i++) {
+                Payment p = installmentPayments.get(i);
+                if (i > 0 && i < installmentIntentIds.size()) {
+                    p.setStripePaymentIntentId(installmentIntentIds.get(i));
+                }
+                p.setStripeCustomerId(stripeCustomerId);
+                paymentRepository.save(p);
+            }
+            
             // Update payment plan status
             paymentPlan.setStatus("ACTIVE");
             paymentPlanRepository.save(paymentPlan);


### PR DESCRIPTION
﻿## Problem

confirmUpfrontPaymentAndScheduleInstallments() did not persist the installment PaymentIntent IDs onto the Payment records, so Stripe webhooks for installments 2+ could not find them and created orphaned records.

## Fix

After scheduling, the returned installment intent IDs and Stripe customer id are persisted onto the existing Payment records ordered by installment number.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java

## Testing

Webhook for installment 2+ now locates the existing Payment record by stripePaymentIntentId.

Closes #15848
