### PR TITLE
fix: reject mismatched header/cookie JWT tokens (Closes #15842)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -49,7 +49,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
         try {
-            String token = extractTokenFromRequest(request);
+            String headerToken = extractHeaderToken(request);
+            String cookieToken = authCookieHelper.extractToken(request);
+
+            // Token confusion protection: when a token is supplied via BOTH the
+            // Authorization header and the auth cookie, they must resolve to the
+            // same principal. A mismatch means the request is ambiguous/forged.
+            if (StringUtils.hasText(headerToken) && StringUtils.hasText(cookieToken)
+                    && !tokensResolveToSameUser(headerToken, cookieToken)) {
+                logger.warn("Rejected request with mismatched header/cookie JWT identities");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Conflicting token identities");
+                return;
+            }
+
+            String token = StringUtils.hasText(headerToken) ? headerToken : cookieToken;
 
             if (StringUtils.hasText(token) && tokenBlacklistService.isBlacklisted(token)) {
                 if (tokenRefreshQueueHandler != null && tokenRefreshQueueHandler.isWithinGracePeriod(token)) {
@@ -105,12 +119,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String extractTokenFromRequest(HttpServletRequest request) {
+    private String extractHeaderToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
-        return authCookieHelper.extractToken(request);
+        return null;
+    }
+
+    private boolean tokensResolveToSameUser(String token1, String token2) {
+        if (!jwtTokenProvider.validateToken(token1) || !jwtTokenProvider.validateToken(token2)) {
+            return false;
+        }
+        if (!jwtTokenProvider.isAccessToken(token1) || !jwtTokenProvider.isAccessToken(token2)) {
+            return false;
+        }
+        String username1 = jwtTokenProvider.getUsernameFromToken(token1);
+        String username2 = jwtTokenProvider.getUsernameFromToken(token2);
+        return username1 != null && username1.equals(username2);
     }
 
     public boolean isTokenIssuedBeforePasswordUpdate(Date tokenIssuedAt, Date passwordUpdatedAt) {


### PR DESCRIPTION
﻿## Problem

JwtAuthenticationFilter accepted a token from both the Authorization header and the HttpOnly cookie without verifying they represent the same user, enabling token confusion in proxy/CDN setups.

## Fix

When both a header token and a cookie token are present, the filter validates that both resolve to the same username and rejects the request (401) otherwise. Single-source behavior is unchanged (header preferred, then cookie).

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java

## Testing

Request with mismatched header + cookie token returns 401; matching tokens or a single source succeed.

Closes #15842
