### PR TITLE
fix: stop leaking waitlist position in public availability + SSE (Closes #15838)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -213,12 +213,9 @@ public class EventController {
                         @ApiResponse(responseCode = "404", description = "Event not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
         })
         public ResponseEntity<EventAvailabilityResponse> getEventAvailability(
-                        @Parameter(description = "ID of the event") @PathVariable Long id,
-                        Authentication authentication) {
+                        @Parameter(description = "ID of the event") @PathVariable Long id) {
 
-                EventAvailabilityResponse response = eventService.getEventAvailability(
-                                id,
-                                authentication == null ? null : authentication.getName());
+                EventAvailabilityResponse response = eventService.getEventAvailability(id);
 
                 return ResponseEntity.ok(response);
         }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java
@@ -54,12 +54,6 @@ public class EventAvailabilityResponse {
     )
     private boolean eventPassed;
 
-    @Schema(description = "Authenticated user's active waitlist position, if queued.")
-    private Integer waitlistPosition;
-
-    @Schema(description = "True when the authenticated user is currently queued for this event.")
-    private boolean waitlisted;
-
     // ── Alias fields (issue #2101 spec names) ────────────────────────────────
 
     /**

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -145,10 +145,6 @@ public class EventService {
          * @throws EventNotFoundException if no event with {@code id} exists
          */
         public EventAvailabilityResponse getEventAvailability(Long id) {
-                return getEventAvailability(id, null);
-        }
-
-        public EventAvailabilityResponse getEventAvailability(Long id, String userEmail) {
                 Event event = requirePublicEvent(id);
 
                 Integer capacity = event.getCapacity();
@@ -160,22 +156,12 @@ public class EventService {
 
                 boolean isFull = (capacity != null) && (registeredCount >= capacity);
 
-                Integer waitlistPosition = null;
-                if (userEmail != null) {
-                        waitlistPosition = eventWaitlistRepository
-                                        .findByEvent_IdAndUser_EmailAndStatus(id, userEmail, "WAITING")
-                                        .map(EventWaitlist::getPosition)
-                                        .orElse(null);
-                }
-
                 return EventAvailabilityResponse.builder()
                                 .capacity(capacity)
                                 .registeredCount(registeredCount)
                                 .spotsLeft(spotsLeft)
                                 .isFull(isFull)
                                 .eventPassed(event.isEventPast())
-                                .waitlistPosition(waitlistPosition)
-                                .waitlisted(waitlistPosition != null)
                                 .build();
         }
 
@@ -1452,8 +1438,6 @@ public class EventService {
                                 .spotsLeft(spotsLeft)
                                 .isFull(isFull)
                                 .eventPassed(event.isEventPast())
-                                .waitlistPosition(null)
-                                .waitlisted(false)
                                 .build();
         }
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
@@ -489,9 +489,7 @@ public class EventRegistrationTests {
         mockMvc.perform(get("/api/events/" + eventId + "/availability")
                         .with(user("user6@example.com")))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.full").value(true))
-                .andExpect(jsonPath("$.waitlisted").value(true))
-                .andExpect(jsonPath("$.waitlistPosition").value(1));
+                .andExpect(jsonPath("$.full").value(true));
     }
 
     @Test
@@ -542,9 +540,7 @@ public class EventRegistrationTests {
 
         mockMvc.perform(get("/api/events/" + eventId + "/availability")
                         .with(user("user6@example.com")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.waitlisted").value(false))
-                .andExpect(jsonPath("$.waitlistPosition", nullValue()));
+                .andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
﻿## Problem

The public availability endpoint and the SSE availability stream exposed waitlistPosition and a waitlisted flag for any authenticated user, enabling user enumeration and disclosing sensitive queue positions.

## Fix

Removed waitlistPosition/waitlisted from the public EventAvailabilityResponse and from the SSE broadcast. Users can still fetch their own position via the authenticated /api/events/{id}/waitlist/me endpoint. Related tests updated.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java; Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java; Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java; Backend/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java

## Testing

Availability endpoint no longer returns waitlist fields; authenticated /waitlist/me still returns the caller's position.

Closes #15838
