### PR TITLE
fix: dedupe emails within same CSV waitlist import (Closes #15988)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -60,6 +60,7 @@ import java.time.LocalDateTime;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -954,14 +955,31 @@ public class EventService {
                 
                 CsvWaitlistImportResponse response = new CsvWaitlistImportResponse();
                 response.setTotalProcessed(entries.size());
-                
+
                 int successfulImports = 0;
                 int failedImports = 0;
-                
-                // Sort entries by timestamp to maintain fair queuing (oldest first)
-                List<CsvWaitlistImportRequest.CsvWaitlistEntry> sortedEntries = entries.stream()
-                        .sorted((a, b) -> a.getTimestamp().compareTo(b.getTimestamp()))
-                        .toList();
+
+                // Deduplicate entries by email (case-insensitive) within the same
+                // CSV so a repeated email doesn't cause a unique-constraint
+                // violation. Keep the first occurrence (preserving original order)
+                // and record each duplicate as a failure.
+                LinkedHashMap<String, CsvWaitlistImportRequest.CsvWaitlistEntry> uniqueEntries = new LinkedHashMap<>();
+                for (int idx = 0; idx < entries.size(); idx++) {
+                        CsvWaitlistImportRequest.CsvWaitlistEntry entry = entries.get(idx);
+                        String key = entry.getEmail() == null ? "" : entry.getEmail().toLowerCase().trim();
+                        if (uniqueEntries.containsKey(key)) {
+                                response.addFailure(new CsvWaitlistImportResponse.ImportFailure(
+                                                idx, entry.getEmail(), "Duplicate email within CSV import"));
+                                failedImports++;
+                        } else {
+                                uniqueEntries.put(key, entry);
+                        }
+                }
+
+                // Sort unique entries by timestamp to maintain fair queuing (oldest first)
+                List<CsvWaitlistImportRequest.CsvWaitlistEntry> sortedEntries = uniqueEntries.values().stream()
+                                .sorted((a, b) -> a.getTimestamp().compareTo(b.getTimestamp()))
+                                .toList();
                 
                 // Get current max position for this event
                 int currentMaxPosition = eventWaitlistRepository.findMaxPositionByEventId(eventId);

--- a/src/utils/waitlistUtils.js
+++ b/src/utils/waitlistUtils.js
@@ -80,7 +80,19 @@ export const parseCsvWaitlistData = (csvText) => {
       entries.push(entry);
     }
 
-    return entries;
+    // Deduplicate rows by email (case-insensitive) so the same email isn't
+    // sent twice within a single CSV import. Keep the first occurrence.
+    const seenEmails = new Set();
+    const dedupedEntries = [];
+    for (const entry of entries) {
+      const emailKey = (entry.email || '').toLowerCase().trim();
+      if (!seenEmails.has(emailKey)) {
+        seenEmails.add(emailKey);
+        dedupedEntries.push(entry);
+      }
+    }
+
+    return dedupedEntries;
   } catch (error) {
     logger.error('[WaitlistUtils] Failed to parse CSV waitlist data:', error);
     throw new Error(`Failed to parse CSV: ${error.message}`);


### PR DESCRIPTION
﻿## Problem

Duplicate emails within a single CSV import caused unique-constraint violations and partial import failures.

## Fix

Deduplicated entries by email (case-insensitive) in importLegacyWaitlist and in parseCsvWaitlistData, recording duplicates as failures while preserving fair timestamp ordering for unique entries.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java; src/utils/waitlistUtils.js

## Testing

A CSV with a repeated email imports once with one failure recorded; positions remain consistent.

Closes #15988
