### PR TITLE
fix: waitlist EVENT_CANCELLED status + process refunds on cancel (Closes #15978)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/EventWaitlist.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/EventWaitlist.java
@@ -46,8 +46,12 @@ public class EventWaitlist {
     @Column(name = "joined_at", nullable = false, updatable = false)
     private LocalDateTime joinedAt;
 
+    public static final String STATUS_WAITING = "WAITING";
+    public static final String STATUS_CANCELLED = "CANCELLED";
+    public static final String STATUS_EVENT_CANCELLED = "EVENT_CANCELLED";
+
     @Column(nullable = false, length = 30)
-    private String status = "WAITING";
+    private String status = STATUS_WAITING;
 
     @Column(name = "promoted_at")
     private LocalDateTime promotedAt;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -112,6 +112,7 @@ public class EventService {
         private final UserRepository userRepository;
         private final EventRoleService eventRoleService;
         private final EventStreamService eventStreamService;
+        private final StripeService stripeService;
 
         public EventService(
                         EventRepository eventRepository,
@@ -123,7 +124,8 @@ public class EventService {
                         EventRoleAuditLogRepository eventRoleAuditLogRepository,
                         UserRepository userRepository,
                         EventRoleService eventRoleService,
-                        EventStreamService eventStreamService) {
+                        EventStreamService eventStreamService,
+                        StripeService stripeService) {
                 this.eventRepository = eventRepository;
                 this.eventRegistrationRepository = eventRegistrationRepository;
                 this.eventWaitlistRepository = eventWaitlistRepository;
@@ -134,6 +136,7 @@ public class EventService {
                 this.userRepository = userRepository;
                 this.eventRoleService = eventRoleService;
                 this.eventStreamService = eventStreamService;
+                this.stripeService = stripeService;
         }
 
         /**
@@ -644,7 +647,9 @@ public class EventService {
                 eventRoleService.requireRole(id, userEmail, EventRole.ORGANIZER);
 
                 if ("CANCELLED".equals(event.getStatus())) {
-                        throw new RegistrationConflictException("Event is already cancelled.");
+                        // Idempotency guard: calling cancel twice must not re-send
+                        // notifications or re-process refunds.
+                        return toEventResponse(event);
                 }
 
                 String refundPolicy = request.getRefundPolicy() == null
@@ -740,7 +745,8 @@ public class EventService {
                                 .map(registration -> registration.getUser().getEmail())
                                 .forEach(emails::add);
                 eventWaitlistRepository
-                                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId, "CANCELLED")
+                                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId,
+                                                EventWaitlist.STATUS_EVENT_CANCELLED)
                                 .stream()
                                 .map(entry -> entry.getUser().getEmail())
                                 .forEach(emails::add);
@@ -749,23 +755,47 @@ public class EventService {
 
         private void notifyCancellation(Event event, String reason) {
                 String message = event.getTitle() + " has been cancelled. Reason: " + reason;
+                String refundPolicy = event.getRefundPolicy();
+                Integer refundPercent = event.getRefundPercent();
+                boolean refundDue = refundPolicy != null
+                                && !"NONE".equalsIgnoreCase(refundPolicy);
 
                 eventRegistrationRepository.findByEvent_IdAndStatus(event.getId(), "CONFIRMED")
-                                .forEach(registration -> notificationRepository.save(Notification.builder()
-                                                .user(registration.getUser())
-                                                .title("Event cancelled")
-                                                .message(message)
-                                                .build()));
+                                .forEach(registration -> {
+                                        notificationRepository.save(Notification.builder()
+                                                        .user(registration.getUser())
+                                                        .title("Event cancelled")
+                                                        .message(message)
+                                                        .build());
+
+                                        if (refundDue
+                                                        && registration.isPaymentCompleted()
+                                                        && registration.getStripePaymentIntentId() != null) {
+                                                try {
+                                                        stripeService.refundPayment(
+                                                                        registration.getStripePaymentIntentId(),
+                                                                        refundPolicy,
+                                                                        refundPercent);
+                                                } catch (Exception e) {
+                                                        log.error(
+                                                                        "Failed to refund payment for registration {} on cancelled event {}: {}",
+                                                                        registration.getId(),
+                                                                        event.getId(),
+                                                                        e.getMessage());
+                                                }
+                                        }
+                                });
 
                 eventWaitlistRepository
-                                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(event.getId(), "WAITING")
+                                .findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(event.getId(),
+                                                EventWaitlist.STATUS_WAITING)
                                 .forEach(entry -> {
                                         notificationRepository.save(Notification.builder()
                                                         .user(entry.getUser())
                                                         .title("Event cancelled")
                                                         .message(message)
                                                         .build());
-                                        entry.setStatus("CANCELLED");
+                                        entry.setStatus(EventWaitlist.STATUS_EVENT_CANCELLED);
                                         eventWaitlistRepository.save(entry);
                                 });
         }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -464,4 +464,44 @@ public class StripeService {
         
         return Refund.create(params);
     }
+
+    /**
+     * Refund a confirmed paid registration based on the event's refund policy.
+     *
+     * <p>Retrieves the PaymentIntent associated with the registration, reads the
+     * captured charge and refunds either the full amount (FULL) or a percentage of
+     * it (PARTIAL using {@code refundPercent}). When the policy is NONE the method
+     * is a no-op and returns {@code null}.</p>
+     *
+     * @param stripePaymentIntentId the registration's Stripe Payment Intent id
+     * @param refundPolicy           FULL, PARTIAL or NONE (case-insensitive)
+     * @param refundPercent          percentage to refund when policy is PARTIAL (1-100)
+     * @return the created {@link Refund}, or {@code null} when no refund is due
+     * @throws StripeException if the Stripe API call fails
+     */
+    public Refund refundPayment(String stripePaymentIntentId, String refundPolicy, Integer refundPercent)
+            throws StripeException {
+        if (stripePaymentIntentId == null || refundPolicy == null) {
+            return null;
+        }
+        if (!"FULL".equalsIgnoreCase(refundPolicy) && !"PARTIAL".equalsIgnoreCase(refundPolicy)) {
+            return null;
+        }
+
+        PaymentIntent intent = PaymentIntent.retrieve(stripePaymentIntentId);
+        if (intent.getCharges() == null || intent.getCharges().getData().isEmpty()) {
+            return null;
+        }
+        Charge charge = intent.getCharges().getData().get(0);
+
+        long chargeAmount = charge.getAmount();
+        long refundAmount;
+        if ("PARTIAL".equalsIgnoreCase(refundPolicy) && refundPercent != null) {
+            refundAmount = (long) (chargeAmount * refundPercent / 100.0);
+        } else {
+            refundAmount = chargeAmount;
+        }
+
+        return createRefund(charge.getId(), refundAmount);
+    }
 }


### PR DESCRIPTION
﻿## Problem

cancelEvent() marked waitlist entries as CANCELLED (conflating with user-initiated cancellation) and never processed refunds, creating financial liability.

## Fix

Added a distinct EVENT_CANCELLED waitlist status; refunds are now processed via Stripe honoring the policy (FULL/PARTIAL/NONE) with an idempotency guard so cancellation is safe when invoked twice.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/model/EventWaitlist.java; Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java; Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java

## Testing

Cancelling a paid event issues refunds; waitlist entries show EVENT_CANCELLED; repeated cancellation does not double-refund.

Closes #15978
