### PR TITLE
fix: push event search filtering to DB with pagination (Closes #15843)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -30,8 +30,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
-
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -176,14 +177,18 @@ public class EventController {
         @ApiResponses({
                         @ApiResponse(responseCode = "200", description = "Events fetched successfully", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EventResponse.class))))
         })
-        public ResponseEntity<List<EventResponse>> searchEvents(
+        public ResponseEntity<Page<EventResponse>> searchEvents(
                         @Parameter(description = "Search term for full-text search on title and description") @RequestParam(required = false) String search,
                         @Parameter(description = "Event category for filtering") @RequestParam(required = false) String category,
                         @Parameter(description = "Start date for filtering (ISO format)") @RequestParam(required = false) String startDate,
                         @Parameter(description = "End date for filtering (ISO format)") @RequestParam(required = false) String endDate,
-                        @Parameter(description = "Filter for free events only") @RequestParam(required = false) Boolean free) {
+                        @Parameter(description = "Filter for free events only") @RequestParam(required = false) Boolean free,
+                        @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+                        @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
 
-                List<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free);
+                Pageable pageable = PageRequest.of(page, size);
+                Page<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free,
+                                pageable);
                 return ResponseEntity.ok(events);
         }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
@@ -58,6 +58,45 @@ public final class EventSpecifications {
         return (root, query, cb) -> cb.isTrue(root.get("isPublic"));
     }
 
+    public static Specification<Event> notCancelled() {
+        return (root, query, cb) -> cb.notEqual(cb.upper(root.get("status")), "CANCELLED");
+    }
+
+    public static Specification<Event> categoryEquals(String category) {
+        if (!StringUtils.hasText(category)) {
+            return null;
+        }
+        return (root, query, cb) -> cb.equal(
+                cb.upper(root.get("category")),
+                category.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public static Specification<Event> eventDateAfter(String startDate) {
+        if (!StringUtils.hasText(startDate)) {
+            return null;
+        }
+        LocalDateTime startDateTime;
+        try {
+            startDateTime = LocalDateTime.parse(startDate.trim());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid startDate parameter: " + startDate);
+        }
+        return (root, query, cb) -> cb.greaterThanOrEqualTo(root.get("eventDate"), startDateTime);
+    }
+
+    public static Specification<Event> eventDateBefore(String endDate) {
+        if (!StringUtils.hasText(endDate)) {
+            return null;
+        }
+        LocalDateTime endDateTime;
+        try {
+            endDateTime = LocalDateTime.parse(endDate.trim());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid endDate parameter: " + endDate);
+        }
+        return (root, query, cb) -> cb.lessThanOrEqualTo(root.get("eventDate"), endDateTime);
+    }
+
     public static Specification<Event> searchContains(String search) {
         if (!StringUtils.hasText(search)) {
             return null;

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -395,54 +395,16 @@ public class EventService {
          * @return List of events matching the search criteria
          */
         @Transactional(readOnly = true)
-        public List<EventResponse> searchEvents(String search, String category, String startDate, String endDate,
-                        Boolean free) {
-                List<Event> events;
-
-                // Build query based on search criteria
-                if (search != null && !search.trim().isEmpty()) {
-                        // Full-text search on title and description
-                        events = eventRepository.findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
-                                        search, search);
-                } else {
-                        events = eventRepository.findAll();
-                }
-
-                // Apply additional filters
-                if (category != null && !category.trim().isEmpty()) {
-                        List<Event> filteredEvents = events.stream()
-                                        .filter(event -> category.equals(event.getCategory()))
-                                        .collect(Collectors.toList());
-                        events = filteredEvents;
-                }
-
-                if (startDate != null && !startDate.trim().isEmpty()) {
-                        LocalDateTime startDateTime;
-                        try {
-                                startDateTime = LocalDateTime.parse(startDate);
-                        } catch (Exception e) {
-                                throw new IllegalArgumentException("Invalid startDate parameter: " + startDate);
-                        }
-                        List<Event> filteredEvents = events.stream()
-                                        .filter(event -> event.getEventDate() != null &&
-                                                        !event.getEventDate().isBefore(startDateTime))
-                                        .collect(Collectors.toList());
-                        events = filteredEvents;
-                }
-
-                if (endDate != null && !endDate.trim().isEmpty()) {
-                        LocalDateTime endDateTime;
-                        try {
-                                endDateTime = LocalDateTime.parse(endDate);
-                        } catch (Exception e) {
-                                throw new IllegalArgumentException("Invalid endDate parameter: " + endDate);
-                        }
-                        List<Event> filteredEvents = events.stream()
-                                        .filter(event -> event.getEventDate() != null &&
-                                                        !event.getEventDate().isAfter(endDateTime))
-                                        .collect(Collectors.toList());
-                        events = filteredEvents;
-                }
+        public Page<EventResponse> searchEvents(String search, String category, String startDate, String endDate,
+                        Boolean free, Pageable pageable) {
+                // Push all filtering down to the database via a dynamic Specification.
+                Specification<Event> spec = Specification
+                                .where(EventSpecifications.isPublic())
+                                .and(EventSpecifications.notCancelled())
+                                .and(EventSpecifications.searchContains(search))
+                                .and(EventSpecifications.categoryEquals(category))
+                                .and(EventSpecifications.eventDateAfter(startDate))
+                                .and(EventSpecifications.eventDateBefore(endDate));
 
                 // Events do not currently model price, so a free filter cannot be applied.
                 // Do not use capacity as a proxy for price.
@@ -450,11 +412,8 @@ public class EventService {
                         // Intentionally no-op until pricing data is available.
                 }
 
-                return events.stream()
-                                .filter(Event::isPublic)
-                                .filter(event -> !"CANCELLED".equals(event.getStatus()))
-                                .map(this::toPublicEventResponse)
-                                .collect(Collectors.toList());
+                Page<Event> page = eventRepository.findAll(spec, pageable);
+                return page.map(this::toPublicEventResponse);
         }
 
         /**


### PR DESCRIPTION
﻿## Problem

searchEvents() loaded all events into memory and filtered them in Java streams with no pagination, causing OOM risk and poor performance at scale.

## Fix

Rewrote searchEvents to build a dynamic Specification (public, not cancelled, search, category, date range) and query with a Pageable. Added missing specs and exposed page/size on the controller search endpoint.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java; Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java; Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java

## Testing

Search against a large dataset returns paginated results without loading all events into memory.

Closes #15843
