### PR TITLE
fix: single waitlist promotion + safety bound on capacity increase (Closes #15992)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -577,10 +577,7 @@ public class EventService {
                                 && previousCapacity != null
                                 && request.getCapacity() > previousCapacity;
                 if (capacityIncreased) {
-                        int freedSeats = request.getCapacity() - previousCapacity;
-                        for (int i = 0; i < freedSeats; i++) {
-                                promoteWaitlistAfterVacancy(saved.getId());
-                        }
+                        promoteWaitlistAfterVacancy(saved.getId());
                         saved = eventRepository.findById(saved.getId()).orElse(saved);
                 }
 
@@ -1306,7 +1303,11 @@ public class EventService {
                 Event event = eventRepository.findByIdWithLock(eventId)
                                 .orElseThrow(() -> new EventNotFoundException(
                                                 "Event not found with id: " + eventId));
+                int safetyCounter = 0;
                 while (event.getCapacity() == null || event.getRegisteredCount() < event.getCapacity()) {
+                        if (safetyCounter++ >= 1000) {
+                                break;
+                        }
                         RegistrationResponse promoted = promoteFirstWaitingUser(event);
                         if (promoted == null) {
                                 break;


### PR DESCRIPTION
﻿## Problem

updateEvent() called promoteWaitlistAfterVacancy() in a loop freedSeats times (redundant), and promoteWaitlistAfterVacancy()'s while loop could run forever on stale counts, risking DB overload / hang.

## Fix

Capacity increase now triggers promotion exactly once and the while loop has a 1000-iteration safety bound.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java

## Testing

Capacity increase promotes eligible users once; no infinite loop under stale count.

Closes #15992
