### PR TITLE
fix: prevent duplicate active payment plans per registration (Closes #15839)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -46,7 +46,15 @@ public class PaymentPlanService {
         // Get registration
         EventRegistration registration = eventRegistrationRepository.findById(registrationId)
                 .orElseThrow(() -> new IllegalArgumentException("Registration not found"));
-        
+
+        // Idempotency: return the existing active plan for this registration if present
+        // to prevent duplicate Payment records and potential double-charging.
+        Optional<PaymentPlan> existingActivePlan =
+                paymentPlanRepository.findActivePaymentPlanByRegistrationId(registrationId);
+        if (existingActivePlan.isPresent()) {
+            return existingActivePlan.get();
+        }
+
         // Validate input
         if (ticketPrice == null || ticketPrice.compareTo(BigDecimal.ZERO) <= 0) {
             throw new IllegalArgumentException("Ticket price must be greater than zero");


### PR DESCRIPTION
﻿## Problem

createPaymentPlan() allowed multiple active payment plans for the same registration, creating duplicate Payment records and a double-charging risk if called more than once.

## Fix

Before creating a plan, the service checks for an existing active plan (findActivePaymentPlanByRegistrationId) and returns it instead of creating a duplicate.

## Files changed

Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java

## Testing

Calling createPaymentPlan twice returns the same plan; no duplicate Payment rows are created.

Closes #15839
