### PR TITLE
fix: HTML-escape user data in EmailTemplateService (#16236)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
@@ -169,27 +169,85 @@ public class EmailTemplateService {
         
         // Replace event placeholders
         if (event != null) {
-            content = content.replace("{eventTitle}", String.valueOf(event.getOrDefault("title", "Event")));
-            content = content.replace("{eventDate}", String.valueOf(event.getOrDefault("eventDate", "N/A")));
-            content = content.replace("{eventTime}", String.valueOf(event.getOrDefault("eventTime", "N/A")));
-            content = content.replace("{location}", String.valueOf(event.getOrDefault("location", "TBD")));
-            content = content.replace("{refundDeadline}", String.valueOf(event.getOrDefault("refundDeadline", "N/A")));
-            content = content.replace("{organizerEmail}", String.valueOf(event.getOrDefault("organizerEmail", "support@eventra.com")));
+            content = content.replace("{eventTitle}", escapeHtml(String.valueOf(event.getOrDefault("title", "Event"))));
+            content = content.replace("{eventDate}", escapeHtml(String.valueOf(event.getOrDefault("eventDate", "N/A"))));
+            content = content.replace("{eventTime}", escapeHtml(String.valueOf(event.getOrDefault("eventTime", "N/A"))));
+            content = content.replace("{location}", escapeHtml(String.valueOf(event.getOrDefault("location", "TBD"))));
+            content = content.replace("{refundDeadline}", escapeHtml(String.valueOf(event.getOrDefault("refundDeadline", "N/A"))));
+            content = content.replace("{organizerEmail}", sanitizeUrl(String.valueOf(event.getOrDefault("organizerEmail", "support@eventra.com"))));
         }
 
         // Replace attendee placeholders
         if (attendee != null) {
-            String firstName = String.valueOf(attendee.getOrDefault("firstName", "Attendee"));
-            String lastName = String.valueOf(attendee.getOrDefault("lastName", ""));
+            String firstName = escapeHtml(String.valueOf(attendee.getOrDefault("firstName", "Attendee")));
+            String lastName = escapeHtml(String.valueOf(attendee.getOrDefault("lastName", "")));
             String fullName = (firstName + " " + lastName).trim();
             
             content = content.replace("{attendeeName}", fullName.isEmpty() ? "Attendee" : fullName);
             content = content.replace("{firstName}", firstName);
             content = content.replace("{lastName}", lastName);
-            content = content.replace("{attendeeEmail}", String.valueOf(attendee.getOrDefault("email", "")));
+            content = content.replace("{attendeeEmail}", sanitizeUrl(String.valueOf(attendee.getOrDefault("email", ""))));
         }
 
         return content;
+    }
+
+    /**
+     * Escape HTML special characters to prevent stored XSS when interpolating
+     * user-controlled values into an HTML email body. Handles null safely.
+     */
+    private String escapeHtml(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '&':
+                    out.append("&amp;");
+                    break;
+                case '<':
+                    out.append("&lt;");
+                    break;
+                case '>':
+                    out.append("&gt;");
+                    break;
+                case '"':
+                    out.append("&quot;");
+                    break;
+                case '\'':
+                    out.append("&#x27;");
+                    break;
+                default:
+                    out.append(c);
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * Sanitize a URL before placing it into an href/src attribute. Only http(s)
+     * and mailto schemes are allowed; any other scheme (e.g. javascript:) is
+     * replaced with a safe fallback ("#") to prevent URL-based XSS. The result
+     * is also HTML-escaped.
+     */
+    private String sanitizeUrl(String url) {
+        if (url == null) {
+            return "#";
+        }
+        String trimmed = url.trim();
+        if (trimmed.isEmpty()) {
+            return "#";
+        }
+        int colon = trimmed.indexOf(':');
+        if (colon > 0 && colon < 32) {
+            String scheme = trimmed.substring(0, colon).toLowerCase();
+            if (!scheme.equals("http") && !scheme.equals("https") && !scheme.equals("mailto")) {
+                return "#";
+            }
+        }
+        return escapeHtml(trimmed);
     }
 
     /**

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/EmailTemplateServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/EmailTemplateServiceTest.java
@@ -258,6 +258,42 @@ class EmailTemplateServiceTest {
     }
 
     @Test
+    @DisplayName("renderTemplate HTML-escapes user data and neutralizes javascript: URLs (Closes #16236)")
+    void sendTestEmail_HtmlEscaping() {
+        Map<String, Object> event = new HashMap<>();
+        event.put("title", "<script>alert(1)</script>");
+        event.put("location", "<img src=x onerror=alert(1)>");
+        event.put("organizerEmail", "javascript:alert(1)");
+
+        Map<String, Object> attendee = new HashMap<>();
+        attendee.put("firstName", "<b>x</b>");
+        attendee.put("lastName", "\"><script>evil()</script>");
+
+        TestEmailRequest request = new TestEmailRequest(
+                "789",
+                "cancellation",
+                event,
+                attendee,
+                "Event {eventTitle} at {location} by {attendeeName} contact {organizerEmail}",
+                organizerEmail
+        );
+
+        when(emailSender.sendEmail(any(), any(), any(), anyBoolean()))
+                .thenAnswer(invocation -> {
+                    String body = invocation.getArgument(2);
+                    assertFalse(body.contains("<script>"), "raw <script> must be escaped");
+                    assertFalse(body.contains("onerror="), "raw HTML attributes must be escaped");
+                    assertFalse(body.contains("javascript:alert(1)"), "javascript: URL must be neutralized");
+                    assertTrue(body.contains("&lt;script&gt;"), "script payload must be escaped to entities");
+                    assertTrue(body.contains("#"), "unsafe URL should fall back to safe value");
+                    return "msg-xss";
+                });
+
+        TestEmailResponse response = emailTemplateService.sendTestEmail(request, organizerEmail);
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
     @DisplayName("Get default template for cancellation")
     void getDefaultTemplate_Cancellation() {
         String template = emailTemplateService.getDefaultTemplate("cancellation");


### PR DESCRIPTION
## Problem
User-controlled values are interpolated into email HTML/URLs without escaping, enabling XSS/injection.

## Fix
HTML-escape and URL-sanitize all dynamic values in renderTemplate before interpolation.

## Files changed
Backend/.../service/EmailTemplateService.java, + EmailTemplateServiceTest.java

## Testing
EmailTemplateServiceTest asserts <script> payloads are escaped in output.

Closes #16236