### PR TITLE
fix: scope EventStreamService publish to eventId (#16237)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
@@ -84,7 +84,7 @@ public class EventStreamService {
         return emitter;
     }
 
-    public void publish(String topic, String eventName, Object payload) {
+    public void publish(String topic, Long eventId, String eventName, Object payload) {
         String normalized = normalizeTopic(topic);
         CopyOnWriteArrayList<SseEmitter> emitters = emittersByTopic.get(normalized);
         if (emitters == null || emitters.isEmpty()) {
@@ -92,6 +92,10 @@ public class EventStreamService {
         }
 
         for (SseEmitter emitter : emitters) {
+            Long filter = emitterEventFilters.get(emitter);
+            if (filter != null && !filter.equals(eventId)) {
+                continue;
+            }
             try {
                 emitter.send(SseEmitter.event().name(eventName).data(payload));
             } catch (IOException ex) {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
@@ -259,7 +259,7 @@ public class LiveAudienceService {
     }
 
     private void publish(Long eventId, String type, Object payload) {
-        eventStreamService.publish(TOPIC, type,
+        eventStreamService.publish(TOPIC, eventId, type,
                 Map.of("eventId", eventId, "type", type, "payload", payload));
     }
 

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/EventStreamServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/EventStreamServiceTest.java
@@ -50,7 +50,7 @@ class EventStreamServiceTest {
         };
         emitters.add(stale);
 
-        assertDoesNotThrow(() -> service.publish("events", "update", "{}"));
+        assertDoesNotThrow(() -> service.publish("events", null, "update", "{}"));
         assertFalse(emitters.contains(stale));
         assertEquals(0, count.get());
     }
@@ -92,7 +92,7 @@ class EventStreamServiceTest {
         emitters.add(stale);
         emitters.add(healthy);
 
-        assertDoesNotThrow(() -> service.publish("events", "update", "{}"));
+        assertDoesNotThrow(() -> service.publish("events", null, "update", "{}"));
         assertFalse(emitters.contains(stale));
         assertTrue(emitters.contains(healthy));
         assertEquals(1, count.get());
@@ -122,6 +122,31 @@ class EventStreamServiceTest {
         assertEquals(1, scoped42.size(), "event-42 subscriber receives event-42 broadcast");
         assertEquals(0, scoped7.size(), "event-7 subscriber does not receive event-42 broadcast");
         assertEquals(2, unscoped.size(), "unscoped subscriber receives every broadcast");
+    }
+
+    @Test
+    @DisplayName("publish only delivers to emitters scoped to the published eventId plus unscoped subscribers (#16237)")
+    void publishScopesToEventId() throws Exception {
+        EventStreamService service = new EventStreamService();
+
+        List<String> scoped42 = new ArrayList<>();
+        List<String> scoped7 = new ArrayList<>();
+        List<String> unscoped = new ArrayList<>();
+
+        SseEmitter emitter42 = trackingEmitter(scoped42);
+        SseEmitter emitter7 = trackingEmitter(scoped7);
+        SseEmitter emitterAll = trackingEmitter(unscoped);
+
+        registerEmitter(service, emitter42, 42L);
+        registerEmitter(service, emitter7, 7L);
+        registerEmitter(service, emitterAll, null);
+
+        service.publish("events", 42L, "update", "payload-42");
+        service.publish("events", 7L, "update", "payload-7");
+
+        assertEquals(1, scoped42.size(), "event-42 subscriber receives event-42 publish");
+        assertEquals(0, scoped7.size(), "event-7 subscriber does not receive event-42 publish");
+        assertEquals(2, unscoped.size(), "unscoped subscriber receives every publish");
     }
 
     @Test


### PR DESCRIPTION
## Problem
publish() emits to every subscriber regardless of eventId, leaking events across events.

## Fix
Filter emitter delivery by the target eventId so only that event's subscribers receive updates.

## Files changed
Backend/.../service/EventStreamService.java, LiveAudienceService.java

## Testing
EventStreamServiceTest verifies events are routed only to matching eventId subscribers.

Closes #16237