### PR TITLE
fix: reuse a single GoogleIdTokenVerifier (#16238)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/GoogleAuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/GoogleAuthService.java
@@ -17,25 +17,37 @@ public class GoogleAuthService {
     @Value("${google.client.id}")
     private String googleClientId;
 
+    private volatile GoogleIdTokenVerifier verifier;
+
     public GoogleIdToken.Payload verifyToken(String token)
             throws Exception {
 
-        GoogleIdTokenVerifier verifier =
-                new GoogleIdTokenVerifier.Builder(
-                        new NetHttpTransport(),
-                        new GsonFactory()
-                )
-                .setAudience(
-                        Collections.singletonList(googleClientId)
-                )
-                .build();
-
-        GoogleIdToken idToken = verifier.verify(token);
+        GoogleIdToken idToken = getVerifier().verify(token);
 
         if (idToken != null) {
             return idToken.getPayload();
         }
 
         throw new InvalidGoogleTokenException("Invalid Google token");
+    }
+
+    GoogleIdTokenVerifier getVerifier() {
+        GoogleIdTokenVerifier local = verifier;
+        if (local == null) {
+            synchronized (this) {
+                local = verifier;
+                if (local == null) {
+                    verifier = local = new GoogleIdTokenVerifier.Builder(
+                            new NetHttpTransport(),
+                            new GsonFactory()
+                    )
+                            .setAudience(
+                                    Collections.singletonList(googleClientId)
+                            )
+                            .build();
+                }
+            }
+        }
+        return local;
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/GoogleAuthServiceVerifierReuseTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/GoogleAuthServiceVerifierReuseTest.java
@@ -1,0 +1,32 @@
+package com.sandeep.eventrabackend.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class GoogleAuthServiceVerifierReuseTest {
+
+    @Test
+    @DisplayName("Reuses a single GoogleIdTokenVerifier instance across calls (#16238)")
+    void verifyToken_ReusesSingletonVerifier() throws Exception {
+        GoogleAuthService service = new GoogleAuthService();
+        setField(service, "googleClientId", "test-client-id.apps.googleusercontent.com");
+
+        GoogleIdTokenVerifier first = service.getVerifier();
+        GoogleIdTokenVerifier second = service.getVerifier();
+
+        assertNotNull(first);
+        assertSame(first, second, "Expected the same verifier instance to be reused across calls");
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## Problem
A new GoogleIdTokenVerifier is built on every token validation, wasting resources.

## Fix
Lazily build and reuse one verifier instance via double-checked getVerifier().

## Files changed
Backend/.../service/GoogleAuthService.java, + GoogleAuthServiceVerifierReuseTest.java

## Testing
Test asserts the same verifier instance is reused across validations.

Closes #16238