### PR TITLE
fix: handle all-day/date-only events in conflict detection (#16240)

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -90,13 +90,69 @@ const parseEventStartUTC = (event, tz) => {
 };
 
 /**
+ * Given a "YYYY-MM-DD" date string, return the next calendar day as
+ * "YYYY-MM-DD" using UTC date arithmetic so month/year rollovers are correct.
+ *
+ * @param {string} dateStr
+ * @returns {string|null}
+ */
+const getNextDayString = (dateStr) => {
+  const parts = dateStr.split("-").map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) return null;
+  const [year, month, day] = parts;
+  const d = new Date(Date.UTC(year, month - 1, day));
+  d.setUTCDate(d.getUTCDate() + 1);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dayNum = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${dayNum}`;
+};
+
+/**
+ * Resolve an all-day / date-only event to a UTC range spanning the local day
+ * [dayStart, dayEnd) in the event's timezone.
+ *
+ * An event is treated as date-only when it has a parseable date but no time
+ * component. The range covers local midnight of `dateStr` through local
+ * midnight of the following day, converted via parseEventToUTC so DST
+ * transitions inside the day are honoured. This makes an all-day event
+ * overlap any timed event that falls on the same local day.
+ *
+ * @param {object} event
+ * @param {string} tz
+ * @returns {{ startMs: number, endMs: number, allDay: boolean }|null}
+ */
+const getDateOnlyUTCRange = (event, tz) => {
+  const dateStr = event?.date || event?.eventDate || event?.startDate;
+  const normalizedDate = normalizeDateString(dateStr);
+  if (!normalizedDate) return null;
+
+  // If a time component is present the event is timed, not all-day.
+  if (event?.time && parseTimeString(event.time)) return null;
+
+  const dayStartMs = parseEventToUTC(normalizedDate, "00:00", tz);
+  if (dayStartMs === null) return null;
+
+  const nextDay = getNextDayString(normalizedDate);
+  const dayEndMs =
+    nextDay !== null ? parseEventToUTC(nextDay, "00:00", tz) : dayStartMs + 24 * 60 * 60 * 1000;
+  if (dayEndMs === null) return null;
+
+  return { startMs: dayStartMs, endMs: dayEndMs, allDay: true };
+};
+
+/**
  * Convert an event to a UTC time-range { startMs, endMs }.
  * Returns null when the event lacks enough date/time data to parse.
+ *
+ * For all-day / date-only events (a date with no time component) the range
+ * spans the local day [dayStart, dayEnd) in the event timezone so that
+ * conflicts with other same-day events are detected.
  *
  * @param {object} event  - Event object with a .date/.time pair or an ISO timestamp
  * @param {number} fallbackDuration  - Minutes to use when event.durationMinutes is absent
  * @param {string} [timezone]  - IANA tz string; defaults to browser's tz
- * @returns {{ startMs: number, endMs: number }|null}
+ * @returns {{ startMs: number, endMs: number, allDay?: boolean }|null}
  */
 export const getEventUTCRange = (event, fallbackDuration = 60, timezone) => {
   if (!event) return null;
@@ -104,10 +160,13 @@ export const getEventUTCRange = (event, fallbackDuration = 60, timezone) => {
   const tz = event.timezone || event.timeZone || timezone || getUserTimezone();
   const startMs = parseEventStartUTC(event, tz);
 
-  if (startMs === null) return null;
+  if (startMs !== null) {
+    const durationMs = getEffectiveDuration(event, fallbackDuration) * 60 * 1000;
+    return { startMs, endMs: startMs + durationMs };
+  }
 
-  const durationMs = getEffectiveDuration(event, fallbackDuration) * 60 * 1000;
-  return { startMs, endMs: startMs + durationMs };
+  // All-day / date-only event: span the local day [dayStart, dayEnd).
+  return getDateOnlyUTCRange(event, tz);
 };
 
 // ---------------------------------------------------------------------------

--- a/src/utils/conflictDetection.test.js
+++ b/src/utils/conflictDetection.test.js
@@ -374,6 +374,59 @@ describe("getEventUTCRange", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 10b. All-day / date-only events (issue #16240)
+// ---------------------------------------------------------------------------
+describe("all-day / date-only events — issue #16240", () => {
+  test("getEventUTCRange builds a full-day range for a date-only event", () => {
+    const range = getEventUTCRange({ id: 1, date: "2026-08-13" }, 60, "UTC");
+    expect(range).not.toBeNull();
+    // A full UTC day is 24h (UTC has no DST, so exactly 24h).
+    expect(range.endMs - range.startMs).toBe(24 * 60 * 60 * 1000);
+    expect(range.allDay).toBe(true);
+  });
+
+  test("two overlapping all-day events on the same day conflict", () => {
+    const e1 = { id: 1, date: "2026-08-13" };
+    const e2 = { id: 2, date: "2026-08-13" };
+    expect(doEventsOverlap(e1, e2, 60)).toBe(true);
+  });
+
+  test("two all-day events on different days do not conflict", () => {
+    const e1 = { id: 1, date: "2026-08-13" };
+    const e2 = { id: 2, date: "2026-08-14" };
+    expect(doEventsOverlap(e1, e2, 60)).toBe(false);
+  });
+
+  test("an all-day event conflicts with a timed event on the same day", () => {
+    const allDay = { id: 1, date: "2026-08-13" };
+    const timed = mkEvent(2, "2026-08-13", "2:00 PM", 60);
+    expect(doEventsOverlap(allDay, timed, 60)).toBe(true);
+  });
+
+  test("an all-day event does NOT conflict with a timed event on a different day", () => {
+    const allDay = { id: 1, date: "2026-08-13" };
+    const timed = mkEvent(2, "2026-08-14", "2:00 PM", 60);
+    expect(doEventsOverlap(allDay, timed, 60)).toBe(false);
+  });
+
+  test("checkRegistrationConflict detects overlap for an all-day event", () => {
+    const newEvent = { id: 99, date: "2026-08-13" };
+    const registered = [mkEvent(10, "2026-08-13", "10:00 AM", 60)];
+    const result = checkRegistrationConflict(newEvent, registered);
+    expect(result.hasConflict).toBe(true);
+    expect(result.conflicts).toHaveLength(1);
+  });
+
+  test("checkRegistrationConflict detects two overlapping all-day registrations", () => {
+    const newEvent = { id: 99, date: "2026-08-13" };
+    const registered = [{ id: 10, date: "2026-08-13" }];
+    const result = checkRegistrationConflict(newEvent, registered);
+    expect(result.hasConflict).toBe(true);
+    expect(result.conflicts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 11. doEventsOverlap — null/undefined event arguments
 // ---------------------------------------------------------------------------
 describe("doEventsOverlap — null/undefined event arguments", () => {


### PR DESCRIPTION
## Problem
All-day/date-only events are treated as zero-duration, missing or mis-timing conflicts.

## Fix
Resolve date-only events to a full-day UTC window via getDateOnlyUTCRange.

## Files changed
src/utils/conflictDetection.js, + src/utils/conflictDetection.test.js

## Testing
Conflict tests cover all-day event overlap.

Closes #16240