### PR TITLE
fix: use event timezone in conflict detection (#16241)

### DIFF
--- a/src/utils/conflictDetection.js
+++ b/src/utils/conflictDetection.js
@@ -101,7 +101,17 @@ const parseEventStartUTC = (event, tz) => {
 export const getEventUTCRange = (event, fallbackDuration = 60, timezone) => {
   if (!event) return null;
 
-  const tz = event.timezone || event.timeZone || timezone || getUserTimezone();
+  // Prefer the event's OWN timezone (explicit field, or ICS TZID) over any
+  // caller-supplied fallback and over the viewer's browser timezone. A
+  // wall-clock date+time pair must be interpreted in the event's timezone, not
+  // the viewer's, otherwise cross-timezone overlaps are computed incorrectly.
+  const tz =
+    event.timezone ||
+    event.timeZone ||
+    event.tzid ||
+    event.icsTimezone ||
+    timezone ||
+    getUserTimezone();
   const startMs = parseEventStartUTC(event, tz);
 
   if (startMs === null) return null;

--- a/tests/conflictDetection.timezone.test.mjs
+++ b/tests/conflictDetection.timezone.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+
+const { getEventUTCRange, doEventsOverlap } = await import(
+  "../src/utils/conflictDetection.js"
+);
+
+// --- Issue #16241: wall-clock date+time must be interpreted in the EVENT's
+// timezone, not the viewer's browser timezone. ---
+
+const nyEvent = {
+  date: "2026-08-13",
+  time: "10:00 AM",
+  durationMinutes: 60,
+  timezone: "America/New_York",
+};
+
+// 10:00 AM America/New_York on 2026-08-13 (EDT, UTC-4) is 14:00:00 UTC.
+const EXPECTED_START = Date.parse("2026-08-13T10:00:00-04:00");
+const EXPECTED_END = EXPECTED_START + 60 * 60 * 1000;
+
+// Resolving from an Asia/Kolkata viewer should still yield the New York instant.
+const fromViewerTz = getEventUTCRange(nyEvent, 60, "Asia/Kolkata");
+const fromOwnTz = getEventUTCRange(nyEvent, 60, "America/New_York");
+
+assert.equal(fromOwnTz.startMs, EXPECTED_START);
+assert.equal(fromOwnTz.endMs, EXPECTED_END);
+// The viewer's browser timezone must NOT shift the event's instant.
+assert.equal(fromViewerTz.startMs, EXPECTED_START);
+assert.equal(fromViewerTz.endMs, EXPECTED_END);
+
+// Two NY events separated in absolute time must NOT be reported as overlapping
+// just because their wall-clock times look adjacent when mis-shifted to IST.
+const nyMorning = {
+  date: "2026-08-13",
+  time: "09:00 AM",
+  durationMinutes: 60,
+  timezone: "America/New_York",
+};
+const nyEvening = {
+  date: "2026-08-13",
+  time: "06:00 PM",
+  durationMinutes: 60,
+  timezone: "America/New_York",
+};
+assert.equal(doEventsOverlap(nyMorning, nyEvening, 60, "Asia/Kolkata"), false);
+
+// ICS TZID should also be honored when an explicit timezone field is absent.
+const icsEvent = {
+  date: "2026-08-13",
+  time: "10:00 AM",
+  durationMinutes: 60,
+  tzid: "America/New_York",
+};
+const fromIcsTzid = getEventUTCRange(icsEvent, 60, "Asia/Kolkata");
+assert.equal(fromIcsTzid.startMs, EXPECTED_START);


### PR DESCRIPTION
## Problem
Conflict windows are computed in the viewer's timezone instead of the event's own timezone.

## Fix
Prefer event.timezone/tzid when resolving event UTC ranges.

## Files changed
src/utils/conflictDetection.js, + tests/conflictDetection.timezone.test.mjs

## Testing
Timezone-specific overlap tests pass.

Closes #16241