### PR TITLE
fix: clear only Eventra keys in secureStorage (#16242)

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -699,6 +699,41 @@ const removedKeys = new Set();
 // though the disk wipe is serialized behind earlier queued writes.
 let pendingClear = false;
 
+// Registry of keys this module has actually written, so clear() can remove
+// only secureStorage-managed data instead of wiping the entire same-origin
+// localStorage (which would destroy unrelated keys owned by other apps/SDKs).
+const secureStorageKeys = new Set();
+
+// Keys internal to the crypto layer that must be removed on clear().
+const SECURE_INTERNAL_KEYS = [MATERIAL_STORAGE_KEY, SALT_STORAGE_KEY, KEY_METADATA_KEY];
+
+/**
+ * Remove only the data owned by secureStorage: the per-key ciphertext entries
+ * we have written, the internal crypto-layer keys, and any legacy plaintext
+ * fallback entries. Unrelated same-origin keys are left untouched.
+ * @private
+ */
+const clearSecureStorageData = () => {
+  try {
+    const toRemove = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (!k) continue;
+      if (
+        secureStorageKeys.has(k) ||
+        SECURE_INTERNAL_KEYS.includes(k) ||
+        k.endsWith(PLAINTEXT_SUFFIX)
+      ) {
+        toRemove.push(k);
+      }
+    }
+    toRemove.forEach((k) => localStorage.removeItem(k));
+    secureStorageKeys.clear();
+  } catch {
+    // localStorage unavailable — nothing to clean up
+  }
+};
+
 /**
  * Encrypts `value` and writes the ciphertext to localStorage under `key`.
  *
@@ -718,10 +753,12 @@ let pendingClear = false;
 const writeWithEncryption = async (key, value) => {
   if (!cryptoSupported) {
     localStorage.setItem(key, value);
+    secureStorageKeys.add(key);
     return;
   }
   const encrypted = await encryptValue(key, value);
   localStorage.setItem(key, encrypted);
+  secureStorageKeys.add(key);
 };
 
 export const syncSecureStorage = {
@@ -762,7 +799,7 @@ export const syncSecureStorage = {
         const { key, type, value, resolve, reject } = this._opQueue.shift();
         try {
           if (type === "clear") {
-            localStorage.clear();
+            clearSecureStorageData();
             pendingClear = false;
           } else if (type === "remove") {
             localStorage.removeItem(key);
@@ -907,10 +944,11 @@ export const syncSecureStorage = {
    *
    * @param {string} key
    */
-  removeItem: function (key) {
+   removeItem: function (key) {
     try {
       /* Removed destructive cleanup to prevent queued writes from being dropped silently */
       pendingWrites.delete(key);
+      secureStorageKeys.delete(key);
       removedKeys.add(key);
       // Enqueued after any prior setItem for this key, so the disk removal is
       // guaranteed to happen after that write (issue #14613). Reads already
@@ -923,8 +961,9 @@ export const syncSecureStorage = {
   },
 
   /**
-   * Clears all localStorage data for the current origin.
-   * Use with caution: this removes ALL keys, not just Eventra's.
+   * Clears only the data owned by secureStorage (per-key ciphertext, the
+   * internal crypto-layer keys, and legacy plaintext fallbacks). Unrelated
+   * same-origin localStorage keys belonging to other apps/SDKs are preserved.
    */
   clear: function () {
     try {

--- a/tests/secureStorage.clear.test.mjs
+++ b/tests/secureStorage.clear.test.mjs
@@ -1,0 +1,119 @@
+import { strict as assert } from "node:assert";
+import { describe, it, beforeEach, afterEach } from "node:test";
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+class LocalStorageMock {
+  constructor() {
+    this._store = {};
+  }
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this._store, key)
+      ? this._store[key]
+      : null;
+  }
+  setItem(key, value) {
+    this._store[key] = String(value);
+  }
+  removeItem(key) {
+    delete this._store[key];
+  }
+  clear() {
+    this._store = {};
+  }
+  get length() {
+    return Object.keys(this._store).length;
+  }
+  key(index) {
+    return Object.keys(this._store)[index] ?? null;
+  }
+}
+
+class CryptoStub {
+  getRandomValues(array) {
+    for (let i = 0; i < array.length; i++) {
+      array[i] = Math.floor(Math.random() * 256);
+    }
+    return array;
+  }
+  get subtle() {
+    return {
+      importKey: async () => ({ type: "raw" }),
+      deriveKey: async () => ({ type: "derived" }),
+      encrypt: async (_algo, _key, data) => {
+        const src = new Uint8Array(data.buffer ?? data);
+        const out = new Uint8Array(src.length);
+        for (let i = 0; i < src.length; i++) out[i] = src[i] ^ 0x42;
+        return out.buffer;
+      },
+      decrypt: async (_algo, _key, data) => {
+        const src = new Uint8Array(data.buffer ?? data);
+        const out = new Uint8Array(src.length);
+        for (let i = 0; i < src.length; i++) out[i] = src[i] ^ 0x42;
+        return out.buffer;
+      },
+    };
+  }
+}
+
+const mockStorage = new LocalStorageMock();
+global.localStorage = mockStorage;
+global.window = {
+  localStorage: mockStorage,
+  location: { origin: "http://localhost" },
+  isSecureContext: true,
+  crypto: new CryptoStub(),
+};
+Object.defineProperty(global, "crypto", {
+  value: new CryptoStub(),
+  writable: true,
+  configurable: true,
+});
+
+const { syncSecureStorage } = await import("../src/utils/secureStorage.js");
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+describe("secureStorage.clear() scope (issue #16242)", () => {
+  beforeEach(() => {
+    mockStorage.clear();
+  });
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("removes only secureStorage keys, leaving unrelated keys intact", async () => {
+    // Unrelated same-origin keys (analytics, other Eventra modules, SDKs)
+    mockStorage.setItem("analytics:session", "abc");
+    mockStorage.setItem("eventra:theme", "dark");
+    mockStorage.setItem("otherApp:pref", "x");
+
+    await syncSecureStorage.setItem("secure:token", "super-secret");
+    await syncSecureStorage.setItem("secure:profile", "pii");
+
+    assert.equal(mockStorage.getItem("secure:token") !== null, true);
+
+    syncSecureStorage.clear();
+    await flush();
+
+    // Secure keys are gone
+    assert.equal(mockStorage.getItem("secure:token"), null);
+    assert.equal(mockStorage.getItem("secure:profile"), null);
+
+    // Unrelated keys survive
+    assert.equal(mockStorage.getItem("analytics:session"), "abc");
+    assert.equal(mockStorage.getItem("eventra:theme"), "dark");
+    assert.equal(mockStorage.getItem("otherApp:pref"), "x");
+  });
+
+  it("removes internal crypto keys on clear", async () => {
+    await syncSecureStorage.setItem("secure:token", "secret");
+    syncSecureStorage.clear();
+    await flush();
+    // The crypto-layer material/salt/metadata keys must be wiped too.
+    assert.equal(mockStorage.getItem("eventra:key-material"), null);
+    assert.equal(mockStorage.getItem("eventra:key-salt"), null);
+    assert.equal(mockStorage.getItem("eventra:key-metadata"), null);
+  });
+});


### PR DESCRIPTION
## Problem
clear() wipes all of localStorage, not just Eventra's encrypted keys.

## Fix
Remove only keys tracked in the secureStorageKeys set via clearSecureStorageData().

## Files changed
src/utils/secureStorage.js, + tests/secureStorage.clear.test.mjs

## Testing
Test asserts foreign localStorage keys survive clear().

Closes #16242