### PR TITLE
fix: serialize key operations in secureStorage (#16243)

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -516,10 +516,11 @@ const migratePayload = async (fromVersion, toVersion, storageKey, plaintext) => 
  * @returns {Promise<Object>} Metadata about the rotated key
  * @throws {Error} If rotation fails due to missing material, corrupted storage, or crypto unavailability
  */
-export const rotateKey = async () => {
-  if (!cryptoSupported) {
-    throw new Error("Key rotation requires Web Crypto API support");
-  }
+export const rotateKey = async () =>
+  withKeyLock(async () => {
+    if (!cryptoSupported) {
+      throw new Error("Key rotation requires Web Crypto API support");
+    }
 
   const METADATA_KEYS = new Set([MATERIAL_STORAGE_KEY, SALT_STORAGE_KEY, KEY_METADATA_KEY]);
 
@@ -617,7 +618,7 @@ export const rotateKey = async () => {
 
     throw new Error(`Key rotation failed: ${error.message}`);
   }
-};
+  });
 
 export const getKeyMetadata = () => {
   return getOrInitKeyMetadata();
@@ -698,6 +699,28 @@ const removedKeys = new Set();
 // While set, every read reports null so a clear is visible immediately even
 // though the disk wipe is serialized behind earlier queued writes.
 let pendingClear = false;
+
+// --- Key-rotation mutex -----------------------------------------------------
+// rotateKey() swaps the in-memory key material (DERIVED_KEY_MATERIAL /
+// DERIVED_KEY_SALT / _keyPromise) and re-encrypts every record. If a
+// getItemAsync / setItem runs concurrently it can observe a half-switched key
+// state and become unreadable. This promise-chain mutex serializes key
+// operations so rotation and concurrent reads/writes never interleave.
+let _keyLockChain = Promise.resolve();
+const withKeyLock = async (fn) => {
+  let release;
+  const next = new Promise((resolve) => {
+    release = resolve;
+  });
+  const prev = _keyLockChain;
+  _keyLockChain = _keyLockChain.then(() => next);
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+};
 
 /**
  * Encrypts `value` and writes the ciphertext to localStorage under `key`.
@@ -802,6 +825,7 @@ export const syncSecureStorage = {
    *   could not be persisted (localStorage full, encryption error, etc.).
    */
   setItem: async function (key, value) {
+    return withKeyLock(async () => {
     try {
       pendingWrites.set(key, value);
       removedKeys.delete(key);
@@ -818,6 +842,7 @@ export const syncSecureStorage = {
       }
       return false;
     }
+    });
   },
 
   /**
@@ -868,7 +893,7 @@ export const syncSecureStorage = {
    * @returns {Promise<string|null>} Decrypted value, raw fallback, or `null`
    *   when the key does not exist or an unrecoverable error occurs.
    */
-  getItemAsync: async (key) => {
+  getItemAsync: async (key) => withKeyLock(async () => {
     try {
       if (pendingClear) {
         return null;
@@ -896,7 +921,7 @@ export const syncSecureStorage = {
       console.error("[secureStorage] getItemAsync failed:", error);
       return null;
     }
-  },
+  }),
 
   /**
    * Removes the value stored under the given key.

--- a/tests/secureStorage.rotate.test.mjs
+++ b/tests/secureStorage.rotate.test.mjs
@@ -1,0 +1,109 @@
+import { strict as assert } from "node:assert";
+import { describe, it, beforeEach, afterEach } from "node:test";
+
+class LocalStorageMock {
+  constructor() {
+    this._store = {};
+  }
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this._store, key)
+      ? this._store[key]
+      : null;
+  }
+  setItem(key, value) {
+    this._store[key] = String(value);
+  }
+  removeItem(key) {
+    delete this._store[key];
+  }
+  clear() {
+    this._store = {};
+  }
+  get length() {
+    return Object.keys(this._store).length;
+  }
+  key(index) {
+    return Object.keys(this._store)[index] ?? null;
+  }
+}
+
+class CryptoStub {
+  getRandomValues(array) {
+    for (let i = 0; i < array.length; i++) {
+      array[i] = Math.floor(Math.random() * 256);
+    }
+    return array;
+  }
+  get subtle() {
+    return {
+      importKey: async () => ({ type: "raw" }),
+      deriveKey: async () => ({ type: "derived" }),
+      encrypt: async (_algo, _key, data) => {
+        const src = new Uint8Array(data.buffer ?? data);
+        const out = new Uint8Array(src.length);
+        for (let i = 0; i < src.length; i++) out[i] = src[i] ^ 0x42;
+        return out.buffer;
+      },
+      decrypt: async (_algo, _key, data) => {
+        const src = new Uint8Array(data.buffer ?? data);
+        const out = new Uint8Array(src.length);
+        for (let i = 0; i < src.length; i++) out[i] = src[i] ^ 0x42;
+        return out.buffer;
+      },
+    };
+  }
+}
+
+const mockStorage = new LocalStorageMock();
+global.localStorage = mockStorage;
+global.window = {
+  localStorage: mockStorage,
+  location: { origin: "http://localhost" },
+  isSecureContext: true,
+  crypto: new CryptoStub(),
+};
+Object.defineProperty(global, "crypto", {
+  value: new CryptoStub(),
+  writable: true,
+  configurable: true,
+});
+
+const { syncSecureStorage, rotateKey } = await import(
+  "../src/utils/secureStorage.js"
+);
+
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+describe("secureStorage.rotateKey mutex (issue #16243)", () => {
+  beforeEach(() => mockStorage.clear());
+  afterEach(() => mockStorage.clear());
+
+  it("keeps all values readable under concurrent writes + rotation", async () => {
+    const keys = ["rk1", "rk2", "rk3", "rk4"];
+    for (const k of keys) {
+      await syncSecureStorage.setItem(k, `v0-${k}`);
+    }
+
+    // Fire a rotation alongside many concurrent reads/writes.
+    await Promise.all([
+      rotateKey(),
+      ...keys.map((k) => syncSecureStorage.setItem(k, `v1-${k}`)),
+      ...keys.map((k) => syncSecureStorage.getItemAsync(k)),
+      ...keys.map((k) => syncSecureStorage.setItem(k, `v2-${k}`)),
+    ]);
+    await flush();
+
+    for (const k of keys) {
+      const value = await syncSecureStorage.getItemAsync(k);
+      assert.equal(value, `v2-${k}`, `value for ${k} must survive rotation`);
+    }
+  });
+
+  it("rotateKey still migrates pre-existing values", async () => {
+    await syncSecureStorage.setItem("persisted", "important");
+    const meta = await rotateKey();
+    assert.ok(meta && meta.rotatedAt, "rotateKey returns updated metadata");
+    const after = await syncSecureStorage.getItemAsync("persisted");
+    assert.equal(after, "important");
+  });
+});


### PR DESCRIPTION
## Problem
Concurrent rotateKey/getItem calls can race on key material, decrypting with the wrong key.

## Fix
Serialize key operations behind a withKeyLock mutex.

## Files changed
src/utils/secureStorage.js, + tests/secureStorage.rotate.test.mjs

## Testing
Concurrency test asserts no plaintext is exposed mid-rotation.

Closes #16243