### PR TITLE
fix: treat 423 as capacity conflict (#16244)

### DIFF
--- a/src/utils/eventAvailabilityUtils.mjs
+++ b/src/utils/eventAvailabilityUtils.mjs
@@ -63,13 +63,18 @@ export const mergeAvailabilityIntoEvent = (event = {}, availability = {}) => {
   };
 };
 
+// Status codes that the backend uses to signal a capacity / availability
+// conflict. Both isCapacityConflictError and getRegistrationFailureMessage
+// must agree on this set so capacity rejections are classified consistently.
+export const CAPACITY_CONFLICT_STATUSES = [409, 423];
+
 export const isCapacityConflictError = (error = {}) => {
   const message = String(
     error?.data?.message || error?.data?.error || error?.message || ""
   ).toLowerCase();
 
   return (
-    error?.status === 409 &&
+    CAPACITY_CONFLICT_STATUSES.includes(error?.status) &&
     /capacity|full|sold out|not enough|insufficient|no spots|unavailable/.test(
       message
     )

--- a/src/utils/registrationErrors.js
+++ b/src/utils/registrationErrors.js
@@ -1,6 +1,8 @@
 /**
  * Derives a user-facing error message from a failed registration API response.
  */
+import { CAPACITY_CONFLICT_STATUSES } from "./eventAvailabilityUtils.mjs";
+
 export const getRegistrationFailureMessage = (error) => {
   const message = error?.data?.message || error?.data?.error || error?.message || "";
   const normalizedMessage = message.toLowerCase();
@@ -18,8 +20,7 @@ export const getRegistrationFailureMessage = (error) => {
   }
 
   if (
-    error?.status === 409 ||
-    error?.status === 423 ||
+    CAPACITY_CONFLICT_STATUSES.includes(error?.status) ||
     /capacity|full|sold out|max(?:imum)? capacity/.test(normalizedMessage)
   ) {
     return "This event has reached maximum capacity. Please choose another event.";

--- a/tests/eventAvailabilityUtils.capacity.test.mjs
+++ b/tests/eventAvailabilityUtils.capacity.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+
+const { isCapacityConflictError, CAPACITY_CONFLICT_STATUSES } = await import(
+  "../src/utils/eventAvailabilityUtils.mjs"
+);
+const { getRegistrationFailureMessage } = await import(
+  "../src/utils/registrationErrors.js"
+);
+
+const capacityMessage =
+  "This event has reached maximum capacity. Please choose another event.";
+
+const makeError = (status) => ({
+  status,
+  data: { message: "Event is at full capacity, no spots left" },
+});
+
+// Issue #16244: isCapacityConflictError must recognize 423 (not just 409) and
+// must agree with getRegistrationFailureMessage on the set of statuses.
+
+for (const status of CAPACITY_CONFLICT_STATUSES) {
+  const err = makeError(status);
+  assert.equal(
+    isCapacityConflictError(err),
+    true,
+    `isCapacityConflictError should be true for status ${status}`
+  );
+  assert.equal(
+    getRegistrationFailureMessage(err),
+    capacityMessage,
+    `getRegistrationFailureMessage should show capacity message for status ${status}`
+  );
+}
+
+// A 409 that is NOT a capacity conflict (already-registered) is a conflict but
+// a different message; isCapacityConflictError must be false for non-capacity 409s.
+const dupError = {
+  status: 409,
+  data: { message: "You are already registered for this event" },
+};
+assert.equal(isCapacityConflictError(dupError), false);
+
+// Non-capacity statuses are not capacity conflicts.
+assert.equal(isCapacityConflictError({ status: 500, data: { message: "boom" } }), false);
+assert.equal(isCapacityConflictError(null), false);


### PR DESCRIPTION
## Problem
A 423 (locked) capacity response isn't treated as a capacity conflict, forcing a generic error.

## Fix
Include 423 in CAPACITY_CONFLICT_STATUSES and route through isCapacityConflictError/getRegistrationFailureMessage.

## Files changed
src/utils/eventAvailabilityUtils.mjs, src/utils/registrationErrors.js, + tests/eventAvailabilityUtils.capacity.test.mjs

## Testing
Capacity conflict tests cover 409 and 423.

Closes #16244