### PR TITLE
fix: use server authoritative isFull in EventRegistration (#16246)

### DIFF
--- a/src/Pages/Events/EventRegistration.isfull.test.jsx
+++ b/src/Pages/Events/EventRegistration.isfull.test.jsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import EventRegistration from './EventRegistration';
+
+const mockUser = {
+  id: 'u1',
+  email: 'john@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  fullName: 'John Doe',
+  username: 'john',
+};
+
+vi.mock('context/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser, token: 'tok', isAuthenticated: () => true }),
+  AuthProvider: ({ children }) => children,
+}));
+
+vi.mock('context/MyEventsContext', () => ({
+  useMyEvents: () => ({ myEvents: [], addRegistration: vi.fn() }),
+  MyEventsProvider: ({ children }) => children,
+}));
+
+vi.mock('context/SessionRecoveryContext', () => ({
+  useSessionRecovery: () => ({ clearSession: vi.fn() }),
+  SessionRecoveryProvider: ({ children }) => children,
+}));
+
+let availabilityData = { isFull: false, capacity: 30, registeredCount: 5 };
+let eventData = {
+  id: 'test-event',
+  title: 'Test Event',
+  maxAttendees: 30,
+  attendees: 5,
+  date: '2030-01-01',
+  time: '10:00 AM',
+  durationMinutes: 60,
+};
+
+vi.mock('config/api', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    apiUtils: {
+      get: vi.fn(async (url) => {
+        const u = String(url);
+        if (u.includes('availability')) return { status: 200, data: availabilityData };
+        if (u.includes('email')) return { status: 200, data: { available: true } };
+        return { status: 200, data: eventData };
+      }),
+      post: vi.fn(async () => ({ status: 200, data: { registrationId: 'r1', qrToken: 'q1' } })),
+    },
+  };
+});
+
+vi.mock('utils/waitlistUtils', () => ({
+  joinWaitlist: vi.fn(async () => ({})),
+  getQueuePosition: vi.fn(async () => 1),
+  getGlobalWaitlist: vi.fn(async () => []),
+}));
+
+function renderRegistration() {
+  return render(
+    <MemoryRouter initialEntries={['/events/test-event/register']}>
+      <Routes>
+        <Route path="/events/:id/register" element={<EventRegistration />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+async function fillAndSubmit(user) {
+  await user.type(screen.getByLabelText(/full name/i), 'John Doe');
+  await user.type(screen.getByLabelText(/email/i), 'john@example.com');
+  await user.type(screen.getByLabelText(/phone/i), '1234567890');
+  const submit = screen.getByRole('button', { name: /register/i });
+  await user.click(submit);
+}
+
+describe('EventRegistration isFull (server authoritative) #16246', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    availabilityData = { isFull: false, capacity: 30, registeredCount: 5 };
+    eventData = {
+      id: 'test-event',
+      title: 'Test Event',
+      maxAttendees: 30,
+      attendees: 5,
+      date: '2030-01-01',
+      time: '10:00 AM',
+      durationMinutes: 60,
+    };
+  });
+
+  it('shows "Register" label when event is not full', async () => {
+    renderRegistration();
+    await waitFor(() => expect(screen.getByRole('button', { name: /register/i })).toBeTruthy());
+    expect(screen.queryByRole('button', { name: /join waitlist/i })).toBeNull();
+  });
+
+  it('shows "Join Waitlist" label when event is full (local capacity)', async () => {
+    eventData = { ...eventData, attendees: 30, maxAttendees: 30 };
+    renderRegistration();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /join waitlist/i })).toBeTruthy()
+    );
+    expect(screen.queryByRole('button', { name: /^register$/i })).toBeNull();
+  });
+
+  it('shows confirmed success message when server says not full', async () => {
+    const user = userEvent.setup();
+    renderRegistration();
+    await fillAndSubmit(user);
+    await waitFor(() => expect(screen.queryByText(/waitlist/i)).toBeNull());
+    expect(screen.getByText(/registration/i)).toBeTruthy();
+  });
+
+  it('shows waitlist success message when server says full', async () => {
+    availabilityData = { isFull: true, capacity: 30, registeredCount: 30 };
+    eventData = { ...eventData, attendees: 30, maxAttendees: 30 };
+    const user = userEvent.setup();
+    renderRegistration();
+    await fillAndSubmit(user);
+    await waitFor(() => expect(screen.getByText(/waitlist/i)).toBeTruthy());
+  });
+});

--- a/src/Pages/Events/EventRegistration.js
+++ b/src/Pages/Events/EventRegistration.js
@@ -355,7 +355,7 @@ const EventRegistration = () => {
         const pos = await getQueuePosition(eventId, user.id);
         toast.success(t("eventRegistration.toastWaitlistSuccess"));
         clearSession();
-        return { success: true, error: null, waitlistPosition: pos };
+        return { success: true, error: null, waitlistPosition: pos, onWaitlist: true };
       } catch (err) {
         toast.error(err.message || t("eventRegistration.toastRegistrationError"));
         return { success: false, error: err.message, waitlistPosition: -1 };
@@ -395,7 +395,7 @@ const EventRegistration = () => {
       toast.success(t("eventRegistration.toastRegistrationSuccess"));
       addRegistration(event, formData, registrationId, qrToken);
       clearSession();
-      return { success: true, error: null, waitlistPosition: -1 };
+      return { success: true, error: null, waitlistPosition: -1, onWaitlist: false };
     } catch (error) {
       const failureMessage = getRegistrationFailureMessage(error);
 
@@ -448,7 +448,7 @@ const EventRegistration = () => {
           toast.warning(t("eventRegistration.toastNetworkQueued"), {
             autoClose: 4000,
           });
-          return { success: true, error: null, waitlistPosition: -1 };
+          return { success: true, error: null, waitlistPosition: -1, onWaitlist: isFreshlyFull };
         } else {
           toast.error(t("eventRegistration.toastOfflineQueueFull"));
           return {
@@ -472,7 +472,7 @@ const EventRegistration = () => {
         addRegistration(event, formData);
         clearSession();
         toast.info(failureMessage);
-        return { success: true, error: null, waitlistPosition: -1 };
+        return { success: true, error: null, waitlistPosition: -1, onWaitlist: isFreshlyFull };
       }
 
       toast.error(failureMessage);
@@ -566,7 +566,11 @@ const EventRegistration = () => {
     [navigate]
   );
 
-  const isEventFull = event ? event.attendees >= event.maxAttendees : false;
+  const isEventFull = event
+    ? typeof event.isFull === "boolean"
+      ? event.isFull
+      : event.attendees >= event.maxAttendees
+    : false;
   const status = getEventStatus(event);
   // const isPastEvent = status === "past" || status === "ended";
   const isCancelledEvent = status === "cancelled";
@@ -703,14 +707,14 @@ const EventRegistration = () => {
           </motion.div>
 
           <h2 className="text-3xl font-extrabold text-transparent bg-clip-text bg-linear-to-t from-indigo-600 to-pink-600 dark:from-indigo-400 dark:to-pink-400 mb-2">
-            {isEventFull
-              ? t("eventRegistration.successWaitlistTitle")
-              : t("eventRegistration.successConfirmedTitle")}
-          </h2>
-          <p className="text-gray-500 dark:text-gray-200 text-sm mb-6 max-w-md mx-auto leading-relaxed">
-            {isEventFull
-              ? t("eventRegistration.successWaitlistDesc", { position: waitlistPosition })
-              : t("eventRegistration.successConfirmedDesc")}
+         {actionState?.onWaitlist
+           ? t("eventRegistration.successWaitlistTitle")
+           : t("eventRegistration.successConfirmedTitle")}
+         </Typography>
+       </Stack>
+       {actionState?.onWaitlist
+         ? t("eventRegistration.successWaitlistDesc", { position: waitlistPosition })
+         : t("eventRegistration.successConfirmedDesc")}
           </p>
 
           <div className="bg-slate-50/80 dark:bg-slate-950/40 border border-slate-200/40 dark:border-slate-800/50 rounded-3xl p-5 mb-8 text-left">


### PR DESCRIPTION
## Problem
The register button label and success message use a locally recomputed isEventFull instead of the server's isFull.

## Fix
Derive the label from the server-normalized event.isFull and branch the success message on the actual server outcome (actionState.onWaitlist).

## Files changed
src/Pages/Events/EventRegistration.js, + src/Pages/Events/EventRegistration.isfull.test.jsx

## Testing
Integration test asserts label and post-submit message match server isFull.

Closes #16246