### PR TITLE
fix: return null on getItemAsync decrypt failure (#16248)

### DIFF
--- a/src/utils/secureStorage.js
+++ b/src/utils/secureStorage.js
@@ -859,8 +859,9 @@ export const syncSecureStorage = {
    *    a `setItem` for this key is still running.
    * 2. localStorage ciphertext — decrypted with the derived AES-GCM key.
    *    If decryption fails (e.g. key material was lost between sessions) the
-   *    raw stored string is returned as a best-effort fallback so callers
-   *    can surface an error rather than silently returning `null`.
+   *    value is treated as unreadable and `null` is returned rather than
+   *    handing back raw ciphertext, so callers are not misled into treating
+   *    encrypted bytes as the intended plaintext (issue #16248).
    * 3. When Web Crypto is unavailable the raw stored value is returned
    *    directly (plaintext was written by `setItem` in degraded mode).
    *
@@ -887,7 +888,12 @@ export const syncSecureStorage = {
         try {
           return await decryptValue(key, stored);
         } catch {
-          return stored;
+          // Decryption failed: `stored` is ciphertext (or corrupt data), not the
+          // intended plaintext. Returning it would mask data loss and silently
+          // hand ciphertext to callers, so we surface the failure as `null`
+          // instead (issue #16248).
+          console.error("[secureStorage] getItemAsync decryption failed for", key);
+          return null;
         }
       }
 

--- a/tests/secureStorage.getitem.test.mjs
+++ b/tests/secureStorage.getitem.test.mjs
@@ -1,0 +1,65 @@
+import { strict as assert } from "node:assert";
+import { describe, it, beforeEach, afterEach } from "node:test";
+
+// Minimal localStorage mock (mirrors existing secureStorage tests).
+class LocalStorageMock {
+  constructor() {
+    this._store = {};
+  }
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this._store, key) ? this._store[key] : null;
+  }
+  setItem(key, value) {
+    this._store[key] = String(value);
+  }
+  removeItem(key) {
+    delete this._store[key];
+  }
+  clear() {
+    this._store = {};
+  }
+  get length() {
+    return Object.keys(this._store).length;
+  }
+  key(index) {
+    return Object.keys(this._store)[index] ?? null;
+  }
+}
+
+describe("secureStorage getItemAsync #16248", () => {
+  let prevLocalStorage;
+  let prevWindow;
+
+  beforeEach(() => {
+    prevLocalStorage = global.localStorage;
+    prevWindow = global.window;
+    global.localStorage = new LocalStorageMock();
+    // Enable the Web Crypto path inside the module (isCryptoAvailable checks window.isSecureContext).
+    global.window = { isSecureContext: true };
+  });
+
+  afterEach(() => {
+    global.localStorage = prevLocalStorage;
+    global.window = prevWindow;
+  });
+
+  it("returns null on decrypt failure instead of raw ciphertext", async () => {
+    const { syncSecureStorage } = await import("../src/utils/secureStorage.js");
+
+    // Seed a value that is NOT valid ciphertext/JSON so decryption throws.
+    global.localStorage.setItem("eventra:broken", "not-a-valid-ciphertext");
+
+    const result = await syncSecureStorage.getItemAsync("eventra:broken");
+    assert.strictEqual(result, null, "decrypt failure must surface as null, not ciphertext");
+  });
+
+  it("returns null (not raw ciphertext) for corrupt encrypted JSON", async () => {
+    const { syncSecureStorage } = await import("../src/utils/secureStorage.js");
+
+    // Valid JSON but missing the fields decryptValue expects → decryption throws.
+    global.localStorage.setItem("eventra:corrupt", JSON.stringify({ foo: "bar" }));
+
+    const result = await syncSecureStorage.getItemAsync("eventra:corrupt");
+    assert.strictEqual(result, null, "corrupt payload must surface as null, not ciphertext");
+  });
+});


### PR DESCRIPTION
## Problem
On decryption failure getItemAsync returns the raw ciphertext, masking data loss.

## Fix
Return null on decrypt failure instead of the ciphertext.

## Files changed
src/utils/secureStorage.js, + tests/secureStorage.getitem.test.mjs

## Testing
Test asserts corrupt ciphertext yields null, not the raw bytes.

Closes #16248