### PR TITLE
fix: append UTC Z to Outlook calendar timestamps (#16250)

### DIFF
--- a/src/utils/calendarUrlUtils.js
+++ b/src/utils/calendarUrlUtils.js
@@ -40,9 +40,11 @@ const formatUTCtoCalendarString = (utcMs, mode = 'compact') => {
   const second = pad(d.getUTCSeconds());
 
   if (mode === 'iso') {
-    // "YYYY-MM-DDTHH:mm:ss" — no trailing Z; Outlook interprets it as UTC
-    // when passed alongside the timezone-neutral startdt param.
-    return `${year}-${month}-${day}T${hour}:${minute}:${second}`;
+    // "YYYY-MM-DDTHH:mm:ssZ" — the trailing Z marks the instant as UTC.
+    // Without it Outlook treats the bare timestamp as the viewer's local
+    // time, shifting the event. The Z makes the UTC instant explicit so
+    // Outlook (and other RFC5545 consumers) interpret it correctly.
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
   }
 
   // Compact: "YYYYMMDDTHHmmssZ"

--- a/tests/calendarUrlUtils.outlook.test.mjs
+++ b/tests/calendarUrlUtils.outlook.test.mjs
@@ -1,0 +1,25 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+import { getOutlookCalendarUrl } from "../src/utils/calendarUrlUtils.js";
+
+describe("calendarUrlUtils outlook timezone #16250", () => {
+  it("emits a trailing Z on startdt/enddt so Outlook reads UTC", () => {
+    const url = getOutlookCalendarUrl(
+      { title: "T", date: "2026-06-01", time: "10:00 AM", durationMinutes: 60 },
+      "America/New_York"
+    );
+
+    const start = url.match(/[?&]startdt=([^&]+)/)[1];
+    const end = url.match(/[?&]enddt=([^&]+)/)[1];
+
+    assert.ok(start.endsWith("Z"), `startdt should end with Z, got ${start}`);
+    assert.ok(end.endsWith("Z"), `enddt should end with Z, got ${end}`);
+  });
+
+  it("does not append Z in the date-only fallback path", () => {
+    const url = getOutlookCalendarUrl({ title: "T", date: "2026-06-01" });
+    const start = url.match(/[?&]startdt=([^&]+)/)[1];
+    assert.ok(!start.endsWith("Z"), `date-only fallback should not carry Z, got ${start}`);
+  });
+});


### PR DESCRIPTION
## Problem
Outlook timestamps omit the timezone indicator, so Outlook shifts the event to the viewer's local time.

## Fix
Append a trailing Z to the UTC timestamp so Outlook reads it as UTC.

## Files changed
src/utils/calendarUrlUtils.js, + tests/calendarUrlUtils.outlook.test.mjs

## Testing
Test asserts startdt/enddt end with Z.

Closes #16250