### PR TITLE
fix: reject non-access JWTs with 401

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -65,7 +65,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
                 if (!jwtTokenProvider.isAccessToken(token)) {
                     logger.warn("Rejected non-access JWT on API request");
-                    filterChain.doFilter(request, response);
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.getWriter().write("Access token required");
                     return;
                 }
                 String username = jwtTokenProvider.getUsernameFromToken(token);


### PR DESCRIPTION
## Summary

Fixes #15512

- Reject non-access JWTs, such as refresh tokens, when presented to protected API endpoints.
- Return HTTP 401 Unauthorized instead of continuing the request through the filter chain.
- Prevents non-access tokens from reaching downstream protected application logic without an authenticated principal.

## Root Cause

`JwtAuthenticationFilter` previously detected non-access JWTs but called `filterChain.doFilter()` and allowed the request to continue.

## Fix

The authentication filter now:

1. Detects when a JWT is not an access token.
2. Sets the response status to `401 Unauthorized`.
3. Returns immediately without continuing the filter chain.

## Expected Behavior

Non-access JWTs are rejected immediately with:

`HTTP 401 Unauthorized`

## Testing

- Verified the modified authentication filter.
- Ran `git diff --check` to verify the patch has no whitespace errors.