### PR TITLE
fix: reject unauthenticated attendee directory requests

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -260,7 +260,9 @@ public class EventController {
         public ResponseEntity<List<AttendeeDirectoryResponse>> getAttendeeDirectory(
                         @Parameter(description = "ID of the event") @PathVariable Long id,
                         Authentication authentication) {
-
+                if (authentication == null || !authentication.isAuthenticated()) {
+                        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+                }
                 return ResponseEntity.ok(eventService.getAttendeeDirectory(id, authentication.getName()));
         }
 


### PR DESCRIPTION
## Summary

Fixes #15513

- Validate the authentication principal before accessing `authentication.getName()`.
- Return HTTP 401 Unauthorized for unauthenticated attendee directory requests.
- Prevent NullPointerException and HTTP 500 responses caused by missing authentication.

## Root Cause

`getAttendeeDirectory()` accessed `authentication.getName()` without first checking whether the authentication principal was available and authenticated.

For unauthenticated requests, this could result in a `NullPointerException`.

## Fix

Added an authentication guard before accessing the authenticated user's identity.

Unauthenticated requests now receive:

`HTTP 401 Unauthorized`

instead of reaching the service layer and producing an HTTP 500 error.

## Testing

- Verified the authentication guard in `EventController`.
- Ran `git diff --check`.
- Kept unrelated changes out of this PR.