### PR TITLE
fix: reject access tokens on refresh endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -117,12 +117,6 @@ public class AuthController {
             HttpServletRequest request) {
         try {
             String refreshToken = body != null ? body.getRefreshToken() : null;
-            if (refreshToken == null || refreshToken.isBlank()) {
-                String auth = request.getHeader("Authorization");
-                if (auth != null && auth.startsWith("Bearer ")) {
-                    refreshToken = auth.substring(7).trim();
-                }
-            }
             AuthResponse response = authService.refresh(refreshToken);
             return withAuthCookie(ResponseEntity.ok(), response);
         } catch (Exception ex) {


### PR DESCRIPTION
## Summary

Fixes #15514

- Remove the Authorization header fallback from the refresh endpoint.
- Ensure refresh operations use the intended refresh-token source.
- Prevent access tokens from being incorrectly accepted as refresh tokens.

## Root Cause

The refresh endpoint falls back to the `Authorization: Bearer` header when no
`refreshToken` is supplied in the request body.

The Authorization header normally contains an access token, so accepting it
as a refresh token creates an ambiguous token contract.

## Fix

The refresh endpoint no longer extracts a token from the Authorization header.

Refresh requests must provide the refresh token through the intended
refresh-token source.

## Expected Behavior

An access token supplied through the Authorization header must not be treated
as a refresh token.

## Testing

- Verified the AuthController diff.
- Ran `git diff --check`.
- Kept unrelated changes out of this PR.