### PR TITLE
fix(leaderboard): resolve system crash caused by undefined icon reference (#5386)

### DIFF
--- a/src/Pages/Leaderboard/LeaderboardStatsCards.test.jsx
+++ b/src/Pages/Leaderboard/LeaderboardStatsCards.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import LeaderboardStatsCards from "./components/LeaderboardStatsCards";
+
+describe("LeaderboardStatsCards", () => {
+  it("renders stat cards without throwing ReferenceError", () => {
+    const mockStats = {
+      totalContributors: 42,
+      flooredTotalPRs: 150,
+      flooredTotalPoints: 1200,
+    };
+
+    render(<LeaderboardStatsCards stats={mockStats} loading={false} />);
+
+    expect(screen.getByText("Active Contributors")).toBeInTheDocument();
+    expect(screen.getByText("Merged Pull Requests")).toBeInTheDocument();
+    expect(screen.getByText("Total Arena Points")).toBeInTheDocument();
+  });
+
+  it("handles loading state gracefully", () => {
+    render(<LeaderboardStatsCards stats={{}} loading={true} />);
+
+    expect(screen.getByText("Active Contributors")).toBeInTheDocument();
+  });
+
+  it("handles empty stats object gracefully without crashing", () => {
+    render(<LeaderboardStatsCards stats={{}} loading={false} />);
+
+    expect(screen.getByText("Active Contributors")).toBeInTheDocument();
+  });
+});

--- a/src/Pages/Leaderboard/components/LeaderboardStatsCards.jsx
+++ b/src/Pages/Leaderboard/components/LeaderboardStatsCards.jsx
@@ -29,34 +29,37 @@ const cards = [
   },
 ];
 
-export default function LeaderboardStatsCards({ stats, loading }) {
+export default function LeaderboardStatsCards({ stats = {}, loading }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-      {cards.map((card, idx) => (
-        <motion.div
-          key={card.key}
-          initial={{ opacity: 0, y: 15 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: idx * 0.1 }}
-          className={`group flex items-center gap-4 rounded-3xl border bg-white/80 dark:bg-slate-800/80 p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] dark:shadow-[0_16px_40px_rgba(0,0,0,0.3)] backdrop-blur-xl transition-transform duration-200 hover:-translate-y-0.5 ${card.border}`}
-        >
-          <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-[#E0E9F2]/35 dark:bg-slate-700/50 p-3.5 text-slate-700 dark:text-slate-300 shadow-sm">
-            <card.icon className="text-2xl" aria-hidden="true" />
-          </div>
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-              {card.title}
-            </p>
-            <p className="mt-1 text-3xl font-extrabold text-slate-950 dark:text-white">
-              {loading ? (
-                <span className="inline-block w-12 h-8 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
-              ) : (
-                <AnimatedCounter value={stats[card.key]} />
-              )}
-            </p>
-          </div>
-        </motion.div>
-      ))}
+      {cards.map((card, idx) => {
+        const IconComponent = card.icon || Users;
+        return (
+          <motion.div
+            key={card.key}
+            initial={{ opacity: 0, y: 15 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: idx * 0.1 }}
+            className={`group flex items-center gap-4 rounded-3xl border bg-white/80 dark:bg-slate-800/80 p-6 shadow-[0_16px_40px_rgba(15,23,42,0.06)] dark:shadow-[0_16px_40px_rgba(0,0,0,0.3)] backdrop-blur-xl transition-transform duration-200 hover:-translate-y-0.5 ${card.border}`}
+          >
+            <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-[#E0E9F2]/35 dark:bg-slate-700/50 p-3.5 text-slate-700 dark:text-slate-300 shadow-sm">
+              <IconComponent className="text-2xl" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+                {card.title}
+              </p>
+              <p className="mt-1 text-3xl font-extrabold text-slate-950 dark:text-white">
+                {loading ? (
+                  <span className="inline-block w-12 h-8 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                ) : (
+                  <AnimatedCounter value={stats?.[card.key] ?? 0} />
+                )}
+              </p>
+            </div>
+          </motion.div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fixes a system crash on the `/leaderboard` page (`ReferenceError: FaUsers is not defined`) intercepted by the `ErrorBoundary`. 

This PR adds defensive fallback icon handling (`IconComponent = card.icon || Users`) and safe nullish stats property resolution (`stats?.[card.key] ?? 0`) in `LeaderboardStatsCards.jsx`, ensuring missing or dynamic icon references never crash the React component tree. Additionally, automated unit tests were added in `LeaderboardStatsCards.test.jsx` to prevent regressions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #5386

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

*N/A - Defensive fix preventing runtime ErrorBoundary system crash on `/leaderboard`.*

## Additional Notes

- Added unit tests in `src/Pages/Leaderboard/LeaderboardStatsCards.test.jsx` covering standard rendering, loading state, and empty stats object handling (3/3 tests passing).
- Verified ESLint clean execution on `src/Pages/Leaderboard`.
