### PR TITLE
[Bug] eventRegistrationAdditionalInfo.test.mjs crashes with ENOENT: test opens `EventRegistration.jsx` but the file is `EventRegistration.js`

### DIFF
--- a/tests/eventRegistrationAdditionalInfo.test.mjs
+++ b/tests/eventRegistrationAdditionalInfo.test.mjs
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-const sourcePath = "src/Pages/Events/EventRegistration.jsx";
+const sourcePath = "src/Pages/Events/EventRegistration.js";
 const source = readFileSync(sourcePath, "utf8");
 
 // The label is now rendered via i18n key — match the translation call
 // instead of the English literal which was removed when the form migrated
 // to react-i18next.
 const additionalInfoLabelMatches =
-  source.match(/t\(["']eventRegistration\.formAdditionalInfo["']\)/g) || [];
+  source.match(/t\(\s*["']eventRegistration\.formAdditionalInfo["']\s*\)/g) || [];
 const additionalInfoTextareaMatches =
   source.match(/<textarea[\s\S]*?name="additionalInfo"[\s\S]*?>/g) || [];
 const additionalInfoIdMatches =


### PR DESCRIPTION
﻿## Problem

[Bug] eventRegistrationAdditionalInfo.test.mjs crashes with ENOENT: test opens `EventRegistration.jsx` but the file is `EventRegistration.js`

## Description

`tests/eventRegistrationAdditionalInfo.test.mjs` reads the source path `src/Pages/Events/EventRegistration.jsx`, but the only file in the repo is `src/Pages/Events/EventRegistration.js`. The suite crashes at load under `npm run test:node`:

```bash
npm run test:node tests/eventRegistrationAdditionalInfo.test.mjs
```

```
Error: ENOENT: no such file or directory, open '...\src\Pages\Events\EventRegistration.jsx'
```

## Repro

```bash
npm run test:node
```

```
✖ tests\eventRegistrationAdditionalInfo.test.mjs
Error: ENOENT: no such file or directory, open '...\src\Pages\Events\EventRegistration.jsx'
```

## Files affected

- `tests/eventRegistrationAdditionalInfo.test.mjs`
- `src/Pages/Events/EventRegistration.js`

## Suggested fix

Point the test at `EventRegistration.js` (and confirm the additional-info behavior it asserts still matches the current component).

## Fix

fix(tests): point eventRegistrationAdditionalInfo test at EventRegistration.js (#14565)

## Files changed

- tests/eventRegistrationAdditionalInfo.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14565
