### PR TITLE
[Bug] sseMultiplexerMemoryLeak test is flaky/broken: it asserts watchdog state before `acquireLock()` resolves

### DIFF
--- a/tests/sseMultiplexerMemoryLeak.test.mjs
+++ b/tests/sseMultiplexerMemoryLeak.test.mjs
@@ -57,12 +57,12 @@ describe("SSE Multiplexer Memory Leak & Lock Acquisition Tests", () => {
     followerManager.release();
   });
 
-  it("should clear watchdog timers and release abort controllers on release", () => {
+  it("should clear watchdog timers and release abort controllers on release", async () => {
     const manager = new SseLockManager({
       tabId: "cleanup-tab-303",
     });
 
-    manager.acquireLock();
+    await manager.acquireLock();
     assert.ok(manager.watchdogTimer !== null || manager.isLeader === true);
 
     manager.release();


### PR DESCRIPTION
﻿## Problem

[Bug] sseMultiplexerMemoryLeak test is flaky/broken: it asserts watchdog state before `acquireLock()` resolves

## Description

`tests/sseMultiplexerMemoryLeak.test.mjs` (part of `npm run test:node`) asserts that the watchdog timer is set and then that `watchdogTimer` is null after `release()`, but it never awaits the async `acquireLock()` that triggers the manager to arm the watchdog — so the leak/cleanup assertions run against an un-initialized manager and the test fails:

```bash
npm run test:node tests/sseMultiplexerMemoryLeak.test.mjs
```

```
AssertionError [ERR_ASSERTION]: watchdogTimer should be null after release
```

The watchdog implementation in `src/utils/sseLockManager.js` (default `watchdogMs = 45_000`, a `setInterval` that fires `forceRelease` + `releaseAll`) is fine on its own; the memory-leak test that guards it is not waiting for the promise that sets the timer, so it cannot observe the cleanup. The result is a red test on `main` that gives false confidence about the leak it is meant to protect.

## Repro

```bash
npm run test:node
```

```
✖ tests\sseMultiplexerMemoryLeak.test.mjs
AssertionError [ERR_ASSERTION]: watchdogTimer should be null after release
```

## Files affected

- `tests/sseMultiplexerMemoryLeak.test.mjs`
- `src/utils/sseLockManager.js`
- `src/utils/sseMultiplexer.js`

## Suggested fix

`await manager.acquireLock(...)` (and use the returned handle to `release()`) before asserting watchdog timer state; add a `fake.timers`-driven case that advances past `watchdogMs` and asserts `forceRelease`/`releaseAll` fire.

## Fix

fix(tests): await acquireLock before watchdog assertions in sseMultiplexerMemoryLeak test (#14566)

## Files changed

- tests/sseMultiplexerMemoryLeak.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14566
