### PR TITLE
[Bug] useDebouncedSearch API mismatch crashes Home search and dashboard filters (`debouncedTerm` is undefined)

### DIFF
--- a/src/hooks/useDebouncedSearch.js
+++ b/src/hooks/useDebouncedSearch.js
@@ -1,31 +1,47 @@
-import { useState, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export const useDebouncedSearch = (searchCallback, delay = 300) => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const callbackRef = useRef(searchCallback);
-  const latestTermRef = useRef(searchTerm);
-
-  useEffect(() => {
-    callbackRef.current = searchCallback;
-  }, [searchCallback]);
+export function useDebouncedSearch(initialValue = '', delay = 300) {
+  const [searchTerm, setSearchTerm] = useState(initialValue);
+  const [debouncedTerm, setDebouncedTerm] = useState(initialValue);
+  const [isDebouncing, setIsDebouncing] = useState(false);
+  const timerRef = useRef(null);
 
   useEffect(() => {
-    latestTermRef.current = searchTerm;
-    const handler = setTimeout(() => {
-      if (callbackRef.current) {
-        callbackRef.current(latestTermRef.current);
-      }
+    setIsDebouncing(true);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      setDebouncedTerm(searchTerm);
+      setIsDebouncing(false);
+      timerRef.current = null;
     }, delay);
 
     return () => {
-      clearTimeout(handler);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = null;
     };
   }, [searchTerm, delay]);
 
+  const clear = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = null;
+    setSearchTerm('');
+    setDebouncedTerm('');
+    setIsDebouncing(false);
+  }, []);
+
   return {
     searchTerm,
+    debouncedTerm,
     setSearchTerm,
+    isDebouncing,
+    clear,
   };
-};
+}
 
 export default useDebouncedSearch;

--- a/src/hooks/useDebouncedValue.js
+++ b/src/hooks/useDebouncedValue.js
@@ -85,34 +85,3 @@ export function useDebouncedCallback(callback, delayMs = 300) {
   );
 }
 
-/**
- * useDebouncedSearch
- *
- * Convenience hook that pairs a local input value with a debounced search
- * term. Returns three values:
- *   - `inputValue`   — the current (immediate) value, bind to `<input value>`
- *   - `searchTerm`   — the debounced value, pass to the search/filter pipeline
- *   - `setInputValue` — the setter, bind to `<input onChange>`
- *
- * Callers that were previously doing:
- *
- *   onChange={(e) => listing.setSearchQuery(e.target.value)}
- *
- * can now do:
- *
- *   const { inputValue, searchTerm, setInputValue } = useDebouncedSearch(
- *     listing.searchQuery, 300
- *   );
- *   // <input value={inputValue} onChange={(e) => setInputValue(e.target.value)} />
- *   // Use searchTerm as the prop passed to the filtering hook.
- *
- * @param {string} initialValue
- * @param {number} [delayMs=300]
- * @returns {{ inputValue: string, searchTerm: string, setInputValue: function }}
- */
-export function useDebouncedSearch(initialValue = "", delayMs = 300) {
-  const [inputValue, setInputValue] = useState(initialValue);
-  const searchTerm = useDebouncedValue(inputValue, delayMs);
-
-  return { inputValue, searchTerm, setInputValue };
-}

--- a/tests/useDebouncedValue.test.mjs
+++ b/tests/useDebouncedValue.test.mjs
@@ -2,7 +2,7 @@
  * Tests for src/hooks/useDebouncedValue.js
  *
  * Verifies the debounced value hook contract, including
- * useDebouncedValue, useDebouncedCallback, and useDebouncedSearch functions.
+ * useDebouncedValue and useDebouncedCallback functions.
  */
 
 import { strict as assert } from 'node:assert';
@@ -30,13 +30,6 @@ describe('useDebouncedValue — source contract', () => {
     assert.ok(
       src.includes('export function useDebouncedCallback'),
       'Must export useDebouncedCallback as named export',
-    );
-  });
-
-  it('exports useDebouncedSearch as named export', () => {
-    assert.ok(
-      src.includes('export function useDebouncedSearch'),
-      'Must export useDebouncedSearch as named export',
     );
   });
 
@@ -126,30 +119,6 @@ describe('useDebouncedCallback — contract', () => {
     assert.ok(
       src.includes('timerRef.current = null'),
       'Must reset timerRef.current after callback fires',
-    );
-  });
-});
-
-describe('useDebouncedSearch — contract', () => {
-  it('uses useDebouncedValue internally', () => {
-    assert.ok(
-      src.includes('useDebouncedValue(inputValue, delayMs)'),
-      'Must use useDebouncedValue internally',
-    );
-  });
-
-  it('returns inputValue, searchTerm, and setInputValue', () => {
-    assert.ok(
-      src.includes('return { inputValue, searchTerm, setInputValue }'),
-      'Must return inputValue, searchTerm, and setInputValue',
-    );
-  });
-
-  it('accepts initialValue and delayMs parameters', () => {
-    assert.ok(
-      src.includes('initialValue = ""') &&
-        src.includes('delayMs = 300'),
-      'Must accept initialValue and delayMs parameters',
     );
   });
 });


### PR DESCRIPTION
﻿## Problem

[Bug] useDebouncedSearch API mismatch crashes Home search and dashboard filters (`debouncedTerm` is undefined)

## Description

`src/hooks/useDebouncedSearch.js` implements the hook with the signature `(searchCallback, delay)` and returns only `{ searchTerm, setSearchTerm }`. Three consumers and the unit test all expect the richer API `(initialValue, delay)` returning `{ debouncedTerm, isDebouncing, clear, ... }`. The result:

- `HomeEventSearch.jsx` destructures `debouncedTerm` (always `undefined`) and calls `debouncedTerm.trim()` → TypeError on the Home page.
- `useDashboardFilters.js` destructures `debouncedTerm` and `isDebouncing` (both `undefined`) and calls `debouncedTerm.toLowerCase()` → TypeError.
- `EventsTab.js` passes `""` as the first argument (the callback slot), so the debounced callback is never invoked — search silently never fires.
- `tests/useDebouncedSearch.test.mjs` fails 8 tests (source contract, return contract, behavior contract).

A fuller implementation already exists in `src/hooks/useDebouncedValue.js` (`useDebouncedSearch(initialValue, delayMs)` → `{ inputValue, searchTerm, setInputValue }`), but it still does not expose `debouncedTerm`/`isDebouncing`/`clear` that the consumers and the test expect.

## Repro

```bash
npm run test:node tests/useDebouncedSearch.test.mjs
```

Fails: `exports useDebouncedSearch as named export`, `uses useCallback for clear function`, `accepts initialValue parameter with default empty string`, `returns debouncedTerm state`, `returns isDebouncing state`, `clears timer on searchTerm change`, `sets isDebouncing to true when debouncing`, `sets isDebouncing to false after debounce completes`, `clear function resets all state`.

Runtime crash (Home search):

```js
// src/Pages/Home/components/HomeEventSearch.jsx:53-56
const { searchTerm, debouncedTerm, setSearchTerm } = useDebouncedSearch("", 300);
...
const trimmed = debouncedTerm.trim(); // TypeError: Cannot read properties of undefined (reading 'trim')
```

## Files affected

- `src/hooks/useDebouncedSearch.js` (implementation)
- `src/hooks/useDebouncedValue.js` (duplicate `useDebouncedSearch` export)
- `src/Pages/Home/components/HomeEventSearch.jsx`
- `src/hooks/useDashboardFilters.js`
- `src/components/user/EventsTab.js`
- `tests/useDebouncedSearch.test.mjs`

## Suggested fix

Reimplement `useDebouncedSearch` to match the documented contract used by the consumers and the test (`initialValue` param, `debouncedTerm`, `isDebouncing`, `setSearchTerm`, `clear`), and remove the duplicate definition in `useDebouncedValue.js` so there is a single source of truth.

## Fix

fix(hooks): align useDebouncedSearch API with consumers and remove duplicate (#14567)

## Files changed

- src/hooks/useDebouncedSearch.js
- src/hooks/useDebouncedValue.js
- tests/useDebouncedValue.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14567
