### PR TITLE
[Bug] isValidCspReport accepts reports whose blocked-uri is a `javascript:`/data URI (sanitization test fails)

### DIFF
--- a/src/utils/cspReportValidator.js
+++ b/src/utils/cspReportValidator.js
@@ -2,12 +2,31 @@
  * CSP Report Validator & Endpoint Domain Filtering (#13909)
  */
 
+const isNonHttpScheme = (uri) => {
+  if (!uri) return false;
+  if (typeof uri !== "string") return true;
+  try {
+    const scheme = new URL(uri).protocol.replace(":", "");
+    return scheme !== "http" && scheme !== "https";
+  } catch {
+    return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(uri);
+  }
+};
+
 export function isValidCspReport(report) {
   if (!report || typeof report !== "object" || !report["csp-report"]) {
     return false;
   }
   const body = report["csp-report"];
-  return Boolean(body["violated-directive"] || body["effective-directive"]);
+  if (!(body["violated-directive"] || body["effective-directive"])) {
+    return false;
+  }
+  // Reject reports that carry scriptable/non-http(s) URIs so that
+  // blocked-uri and source-file can never be rendered or forwarded unsanitized.
+  if (isNonHttpScheme(body["blocked-uri"]) || isNonHttpScheme(body["source-file"])) {
+    return false;
+  }
+  return true;
 }
 
 export function isSelfOriginatingCspReport(blockedUri, reportUri) {


### PR DESCRIPTION
﻿## Problem

[Bug] isValidCspReport accepts reports whose blocked-uri is a `javascript:`/data URI (sanitization test fails)

## Description

`src/utils/cspReportValidator.js` implements `isValidCspReport(report)` as:

```js
export function isValidCspReport(report) {
  if (!report || typeof report !== "object" || !report["csp-report"]) {
    return false;
  }
  const body = report["csp-report"];
  return Boolean(body["violated-directive"] || body["effective-directive"]);
}
```

It only checks that a directive name is present — it never inspects `blocked-uri`. A report carrying `"blocked-uri": "javascript:alert(1)"` (or another `javascript:`/`data:` URI) is therefore accepted, even though such a value must never be rendered or forwarded unsanitized.

`tests/cspReportValidatorSanitization.test.mjs` codifies the expected behavior and fails:

```bash
npm run test:node tests/cspReportValidatorSanitization.test.mjs
```

```
AssertionError [ERR_ASSERTION]: Should reject malicious scripts
  actual: true
  expected: false
```

## Repro

```js
import { isValidCspReport } from "../src/utils/cspReportValidator.js";
isValidCspReport({
  "csp-report": {
    "violated-directive": "script-src",
    "blocked-uri": "javascript:alert(1)",
  },
}); // returns true, expected false
```

## Files affected

- `src/utils/cspReportValidator.js`
- `tests/cspReportValidatorSanitization.test.mjs`

## Suggested fix

Reject reports whose `blocked-uri` (and `source-file`, where present) use a non-http(s) scheme (e.g. `javascript:`, `data:`, `about:`), before returning `true` for an otherwise well-formed report.

## Fix

fix(utils): reject csp reports with non-http blocked-uri scheme (#14570)

## Files changed

- src/utils/cspReportValidator.js

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14570
