### PR TITLE
[Bug] `npm test` is red: eventRecommendationsResponsive test still expects manual `setVisibleCount` + window resize listener that the component intentionally replaced with `useWindowSize`

### DIFF
--- a/tests/eventRecommendationsResponsive.test.mjs
+++ b/tests/eventRecommendationsResponsive.test.mjs
@@ -68,15 +68,18 @@ describe("EventRecommendations Responsive Carousel Logic", () => {
 });
 
 describe("EventRecommendations Code Structure Integrity", () => {
-  it("should use dynamic visibleCount state and window resize listener", () => {
+  it("should derive visibleCount from useWindowSize breakpoints", () => {
     assert.ok(
-      componentSrc.includes("setVisibleCount"),
-      "Component source must declare and use visibleCount state"
+      componentSrc.includes("useWindowSize"),
+      "Component source must use the useWindowSize hook"
     );
     assert.ok(
-      componentSrc.includes('addEventListener("resize"') ||
-        componentSrc.includes("addEventListener('resize'"),
-      "Component source must attach window resize event listener"
+      componentSrc.includes("const { width } = useWindowSize()"),
+      "Component source must destructure width from useWindowSize"
+    );
+    assert.ok(
+      componentSrc.includes("width < 640 ? 1 : width < 1024 ? 2 : 3"),
+      "Component source must map width breakpoints to 1/2/3 visible cards"
     );
   });
 


### PR DESCRIPTION
﻿## Problem

[Bug] `npm test` is red: eventRecommendationsResponsive test still expects manual `setVisibleCount` + window resize listener that the component intentionally replaced with `useWindowSize`

## Description

`npm test` / `npm run test:unit` currently fails 1 test in `tests/eventRecommendationsResponsive.test.mjs`:

```
✖ should use dynamic visibleCount state and window resize listener (1.0855ms)
```

The test statically asserts that `src/components/events/EventRecommendations.jsx` declares `visibleCount` state via `setVisibleCount` and attaches a window `resize` listener. The component was deliberately refactored (comment at line 126: `// Fix: useWindowSize replaces manual resize listener — debounced, SSR-safe`) to derive `visibleCount` from the `useWindowSize()` hook:

```js
const visibleCount = width < 640 ? 1 : width < 1024 ? 2 : 3; // EventRecommendations.jsx:128
```

All the other structure sub-tests (clamp, skeletons, nav buttons, card width/translate formulas) pass — the functionality is intact and responsive; only the "declares setVisibleCount + manual resize listener" assertion is stale.

## Repro

```bash
npm test
```

```
ℹ tests 162
ℹ pass 158
ℹ fail 4
✖ should use dynamic visibleCount state and window resize listener
```

## Files affected

- `tests/eventRecommendationsResponsive.test.mjs`
- `src/components/events/EventRecommendations.jsx`

## Suggested fix

Update the test to assert the current implementation (e.g. that `visibleCount` is derived from `useWindowSize()` and matches the breakpoint rules) instead of requiring the removed manual `setVisibleCount`/resize-listener pattern.

## Fix

fix(tests): assert useWindowSize-derived visibleCount in recommendations test (#14571)

## Files changed

- tests/eventRecommendationsResponsive.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14571
