### PR TITLE
[Bug] `npm test` is red: hostHackathonValidation test fails because `mode` became a required field but the test's `validData` doesn't include it

### DIFF
--- a/tests/hostHackathonValidation.test.mjs
+++ b/tests/hostHackathonValidation.test.mjs
@@ -11,6 +11,7 @@ const validData = {
   organizerName: "My Org",
   email: "me@example.com",
   location: "Online",
+  mode: "Online",
   startDate: TOMORROW,
   endDate: DAY_AFTER,
   description: "A description that is long enough to pass validation.",
@@ -83,6 +84,14 @@ assert.equal(
   validateHostHackathonForm({ ...validData, startDate: TOMORROW, endDate: TOMORROW }, TODAY).endDate,
   undefined
 );
+
+// Mode is required and must be one of Online / Offline / Hybrid
+assert.equal(
+  validateHostHackathonForm({ ...validData, mode: "Invalid" }, TODAY).mode,
+  "Mode must be Online, Offline, or Hybrid!"
+);
+assert.equal(validateHostHackathonForm({ ...validData, mode: "Offline" }, TODAY).mode, undefined);
+assert.equal(validateHostHackathonForm({ ...validData, mode: "Hybrid" }, TODAY).mode, undefined);
 
 // Participant limit is optional but must be >= 1 when present
 assert.equal(validateHostHackathonForm({ ...validData, participantLimit: "" }, TODAY).participantLimit, undefined);


### PR DESCRIPTION
﻿## Problem

[Bug] `npm test` is red: hostHackathonValidation test fails because `mode` became a required field but the test's `validData` doesn't include it

## Description

`npm test` / `npm run test:unit` fails `tests/hostHackathonValidation.test.mjs`:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  actual:   { mode: 'mode is required!' }
  expected: {}
```

`src/utils/hostHackathonValidation.js` now requires `mode` (added to `REQUIRED_FIELDS`, with `VALID_MODES = ["Online", "Offline", "Hybrid"]`), and the Host Hackathon form renders a required Mode field (`src/Pages/Hackathons/HostHackathon.js:345-352`, `mode: modeRef`). The test file's `validData` fixture (line 9-17) predates the field and omits `mode`, so the "fully valid submission has no errors" assertion at line 20 fails.

The validation logic itself is correct — the fixture is stale.

## Repro

```bash
npm test
```

```
✖ tests\hostHackathonValidation.test.mjs
```

## Files affected

- `tests/hostHackathonValidation.test.mjs`
- `src/utils/hostHackathonValidation.js`

## Suggested fix

Add `mode: "Online"` (and a mode-validation case) to the test fixture so it matches the current form contract.

## Fix

fix(tests): add required mode field to host hackathon validation fixture (#14572)

## Files changed

- tests/hostHackathonValidation.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14572
