### PR TITLE
[Bug] `npm test` is red: sseMultiplexer test fails — its MockEventSource does not implement `addEventListener` which `sseMultiplexer.js` now uses

### DIFF
--- a/tests/sseMultiplexer.test.mjs
+++ b/tests/sseMultiplexer.test.mjs
@@ -72,6 +72,7 @@ class MockEventSource {
     this.url = url;
     this.options = options;
     this.closed = false;
+    this._listeners = new Map();
     eventSources.push(this);
     // Simulate connection open immediately to keep test simple and fast
     setTimeout(() => {
@@ -81,11 +82,19 @@ class MockEventSource {
   close() {
     this.closed = true;
   }
+  addEventListener(type, handler) {
+    this._listeners.set(type, handler);
+  }
+  removeEventListener(type) {
+    this._listeners.delete(type);
+  }
   emitMessage(data, type = "message") {
-    this.onmessage?.({
+    const event = {
       data: typeof data === "string" ? data : JSON.stringify(data),
       type,
-    });
+    };
+    const handler = this._listeners.get(type) || this.onmessage;
+    handler?.(event);
   }
 }
 globalThis.EventSource = MockEventSource;
@@ -218,11 +227,16 @@ const runTests = async () => {
   await new Promise((resolve) => setTimeout(resolve, 15));
 
   // Emit a mock message
-  eventSources[0].emitMessage({ contributors: [{ name: "Alice" }] }, "update");
+  eventSources[0].emitMessage({ contributors: [{ name: "Alice" }] }, "message");
 
   // Validate message propagation
   assert.deepEqual(receivedData, { contributors: [{ name: "Alice" }] });
-  assert.equal(receivedType, "update");
+  assert.equal(receivedType, "message");
+
+  // Named SSE event dispatch through addEventListener (e.g. "leaderboard")
+  eventSources[0].emitMessage({ contributors: [{ name: "Bob" }] }, "leaderboard");
+  assert.deepEqual(receivedData, { contributors: [{ name: "Bob" }] });
+  assert.equal(receivedType, "leaderboard", "Named event type must propagate");
 
   // Test 2: Status reporting
   let currentStatus = null;


### PR DESCRIPTION
﻿## Problem

[Bug] `npm test` is red: sseMultiplexer test fails — its MockEventSource does not implement `addEventListener` which `sseMultiplexer.js` now uses

## Description

`npm test` / `npm run test:unit` fails `tests/sseMultiplexer.test.mjs`:

```
TypeError: source.addEventListener is not a function
```

`src/utils/sseMultiplexer.js:585` registers named event listeners on the EventSource:

```js
source.addEventListener(name, handleEvent(name));
// ["availability", "init", "notification", "leaderboard", "analytics"].forEach(...)
```

The test's `MockEventSource` (`tests/sseMultiplexer.test.mjs:70-91`) only implements `onopen`/`onmessage`/`close` — no `addEventListener`. The real browser `EventSource` supports both, so the source is correct; the mock is stale relative to the source's switch to named event listeners.

## Repro

```bash
npm test
```

```
✖ tests\sseMultiplexer.test.mjs
TypeError: source.addEventListener is not a function
```

## Files affected

- `tests/sseMultiplexer.test.mjs` (mock)
- `src/utils/sseMultiplexer.js`

## Suggested fix

Add an `addEventListener(type, handler)` method to `MockEventSource` (storing handlers so `emitMessage`/`emit` can dispatch named events), and update the emit helpers accordingly.

## Fix

fix(tests): add addEventListener support to MockEventSource (#14573)

## Files changed

- tests/sseMultiplexer.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14573
