### PR TITLE
[Bug] `npm run test:node` crashes 7+ suites: source uses Vite-only module resolution (extension-less relative imports and bare `utils/*` aliases) that Node's ESM resolver cannot handle

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
-import { ENV } from "./env";
-import { syncServerTimeFromHeader } from "../utils/timeSync";
-import { createIntegrityHeader } from "../utils/security/requestIntegrity";
+import { ENV } from "./env.js";
+import { syncServerTimeFromHeader } from "../utils/timeSync.js";
+import { createIntegrityHeader } from "../utils/security/requestIntegrity.js";
 import { ApiError, RateLimitError } from "./api/errors.js";
 import { setupRequestInterceptor, setupResponseInterceptor, setOnRequiresReauthHandler, setAuthToken as setInterceptorAuthToken, setRefreshToken as setInterceptorRefreshToken } from "./api/interceptors.js";
 import { API_BASE_URL, validateBackendConfig } from "./backendConfig.js";

--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -1,9 +1,9 @@
-import { syncServerTimeFromHeader } from "utils/timeSync.js";
-import { getCSRFToken, requiresCSRF, getCSRFEnforcementMode } from "utils/csrfToken.js";
-import { signRequest } from "utils/requestSigner.js";
-import { logger } from "utils/logger.js";
+import { syncServerTimeFromHeader } from "../../utils/timeSync.js";
+import { getCSRFToken, requiresCSRF, getCSRFEnforcementMode } from "../../utils/csrfToken.js";
+import { signRequest } from "../../utils/requestSigner.js";
+import { logger } from "../../utils/logger.js";
 import { ApiError, RateLimitError, CSRFError } from "./errors.js";
-import { logCategorizedError } from "utils/errorRecovery.js";
+import { logCategorizedError } from "../../utils/errorRecovery.js";
 
 const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 const RETRYABLE_METHODS = new Set(["GET", "HEAD", "OPTIONS", "TRACE"]);

--- a/src/hooks/useOfflineSync.js
+++ b/src/hooks/useOfflineSync.js
@@ -8,9 +8,9 @@
  * and session validation, and persists the resulting queue state.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useAuth } from "../context/AuthContext";
-import { processQueue } from "../utils/offlineQueue";
-import { logger } from "../utils/logger";
+import { useAuth } from "../context/AuthContext.js";
+import { processQueue } from "../utils/offlineQueue.js";
+import { logger } from "../utils/logger.js";
 
 // Message types the service worker may post to request an offline queue sync.
 // EVENTRA_BACKGROUND_SYNC is posted by public/service-worker.js when the

--- a/src/hooks/useTokenExpiry.js
+++ b/src/hooks/useTokenExpiry.js
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useCallback } from "react";
 import { toast } from "react-toastify";
-import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils";
-import { syncSecureStorage } from "../utils/secureStorage";
-import { logger } from "../utils/logger";
+import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils.js";
+import { syncSecureStorage } from "../utils/secureStorage.js";
+import { logger } from "../utils/logger.js";
 export const MAX_TOKEN_EXPIRY_TIMEOUT_MS = 2_147_483_647;
 const TOKEN_EXPIRY_BUFFER_MS = 1_000;
 

--- a/src/utils/storage/storageManager.js
+++ b/src/utils/storage/storageManager.js
@@ -1,6 +1,6 @@
 import { STORAGE_KEYS } from "./storageKeys.js";
 import { validators } from "./storageValidators.js";
-import { safeJsonParse } from "utils/safeJsonParse.js";
+import { safeJsonParse } from "../safeJsonParse.js";
 import { logger } from "../logger.js";
 
 const DEFAULT_EXPIRY = 1000 * 60 * 60; // 1 hour


### PR DESCRIPTION
﻿## Problem

[Bug] `npm run test:node` crashes 7+ suites: source uses Vite-only module resolution (extension-less relative imports and bare `utils/*` aliases) that Node's ESM resolver cannot handle

## Description

Several `src/` modules use import specifiers that Vite resolves but the native Node ESM resolver does not:

- Extension-less relative imports (Node ESM requires explicit `.js` extensions):
  - `src/config/api.js:2` → `import { ENV } from "./env";` (should be `./env.js`)
  - `src/hooks/useOfflineSync.js:2` → `import { OfflineStorageQueue } from "../utils/offlineStorage";`
  - `src/hooks/useTokenExpiry.js:3` → `import { isTokenValid, decodeTokenPayload } from "../utils/tokenUtils";`
- Bare `utils/*` aliases (Vite alias only):
  - `src/utils/storage/storageManager.js:3` → `import { safeJsonParse } from "utils/safeJsonParse.js";`

Consequences when running the Node test runner:

```
node --test tests/waitlist.test.mjs
```

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../src/config/env' imported from .../src/config/api.js
```

Suites that crash on this family of errors (from `npm run test:node`):

- `tests/waitlist.test.mjs`, `tests/multiSessionRecovery.test.mjs`, `tests/notificationSync.test.mjs`, `tests/passwordValidation.test.mjs`, `tests/sessionExportImport.test.mjs` (via `api.js` → `./env`)
- `tests/useOfflineSync.test.mjs` (via `useOfflineSync.js` → `../utils/offlineStorage`)
- `tests/useNetworkStatus.test.mjs`, `tests/useToast.test.mjs` (via `useTokenExpiry.js` → `../utils/tokenUtils`)
- `tests/storageManager.test.mjs` (`Cannot find package 'utils' imported from .../storageManager.js`)

## Repro

```bash
npm run test:node tests/waitlist.test.mjs tests/useOfflineSync.test.mjs tests/storageManager.test.mjs
```

All three fail with `ERR_MODULE_NOT_FOUND` as above.

## Files affected

- `src/config/api.js`, `src/config/env.js`
- `src/hooks/useOfflineSync.js`, `src/hooks/useTokenExpiry.js`
- `src/utils/storage/storageManager.js`
- The listed `tests/*.test.mjs`

## Suggested fix

Add explicit `.js` extensions to relative imports (both in these files and repo-wide) and/or register a small specifier-resolution hook in `tests/setup.js` that expands extension-less relative imports and maps `utils/*`/`hooks/*`/`config/*` to their `src/` directories, so the Node runner resolves source the same way Vite does.

## Fix

fix(14574): use Node-resolvable import specifiers in src modules

## Files changed

- src/config/api.js
- src/config/api/interceptors.js
- src/hooks/useOfflineSync.js
- src/hooks/useTokenExpiry.js
- src/utils/storage/storageManager.js

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14574
