### PR TITLE
[Bug] tests/backToTopButtonIntegrity.test.mjs fails: BackToTopButton uses prefers-reduced-motion in scroll-behavior

### DIFF
--- a/tests/backToTopButtonIntegrity.test.mjs
+++ b/tests/backToTopButtonIntegrity.test.mjs
@@ -30,8 +30,14 @@ assert.match(
 
 assert.match(
   source,
-  /window\.scrollTo\(\{[\s\S]*top: 0,[\s\S]*behavior: "smooth"[\s\S]*\}\)/,
-  "BackToTopButton click behavior must still smooth-scroll to the top"
+  /window\.matchMedia\(\s*"\(prefers-reduced-motion: reduce\)"\s*\)/,
+  "BackToTopButton must respect the prefers-reduced-motion media query"
+);
+
+assert.match(
+  source,
+  /window\.scrollTo\(\{[\s\S]*top: 0,[\s\S]*behavior: prefersReducedMotion \? "auto" : "smooth"[\s\S]*\}\)/,
+  "BackToTopButton click behavior must smooth-scroll to the top unless prefers-reduced-motion"
 );
 
 assert.match(


### PR DESCRIPTION
﻿## Problem

[Bug] tests/backToTopButtonIntegrity.test.mjs fails: BackToTopButton uses prefers-reduced-motion in scroll-behavior

## Description

`tests/backToTopButtonIntegrity.test.mjs` is a source-contract test that fails because `src/components/common/BackToTopButton.jsx` now chooses its scroll behavior dynamically, but the test still expects the literal string `behavior: "smooth"`.

`src/components/common/BackToTopButton.jsx` uses:

```js
window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" });
```

The test only accepts the plain `behavior: "smooth"` form, so the suite cannot pass.

## Reproduction

```bash
npm run test:node tests/backToTopButtonIntegrity.test.mjs
```

```
AssertionError [ERR_ASSERTION]: BackToTopButton click behavior must still smooth-scroll to the top
    at file:///.../Eventra/tests/backToTopButtonIntegrity.test.mjs:31:8
```

## Files affected

- `tests/backToTopButtonIntegrity.test.mjs`
- `src/components/common/BackToTopButton.jsx`

## Suggested fix

Update the test to accept the reduced-motion-aware expression (e.g. match `behavior: prefersReducedMotion ? "auto" : "smooth"`), or assert that both the reduced-motion and non-reduced-motion behaviors are present.

## Fix

fix(tests): accept reduced-motion-aware scroll behavior in BackToTopButton integrity test (#14586)

## Files changed

- tests/backToTopButtonIntegrity.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14586
