### PR TITLE
[Bug] tests/shareUtils.test.mjs fails: generateEventSharingData default base URL is ENV.PUBLIC_URL, not sandeepvashishtha.tech

### DIFF
--- a/tests/shareUtils.test.mjs
+++ b/tests/shareUtils.test.mjs
@@ -5,6 +5,7 @@
 import assert from "node:assert/strict";
 
 const { generateSharingUrl, generateEventSharingData } = await import("../src/utils/shareUtils.js");
+const { ENV } = await import("../src/config/env.js");
 
 const shareData = {
   title: "Tech Summit 2024",
@@ -74,6 +75,10 @@ assert.ok(sharingData.description.includes("Berlin"));
 assert.equal(sharingData.hashtags, "eventra,event,tech");
 
 const sharingDataNoBase = generateEventSharingData(mockEvent);
-assert.ok(sharingDataNoBase.url.includes("sandeepvashishtha.tech"));
+const expectedShareOrigin = (ENV.PUBLIC_URL || "https://eventra.sandeepvashishtha.in").replace(/\/$/, "");
+assert.ok(
+  sharingDataNoBase.url.startsWith(`${expectedShareOrigin}/events/evt-42`),
+  "Default share base URL must be the configured ENV.PUBLIC_URL origin"
+);
 
 console.log("All shareUtils tests passed");


### PR DESCRIPTION
﻿## Problem

[Bug] tests/shareUtils.test.mjs fails: generateEventSharingData default base URL is ENV.PUBLIC_URL, not sandeepvashishtha.tech

## Description

`tests/shareUtils.test.mjs:77` asserts that when no `baseUrl` is passed, `generateEventSharingData` builds the share URL on the legacy default host `sandeepvashishtha.tech`:

```js
const sharingDataNoBase = generateEventSharingData(mockEvent);
assert.ok(sharingDataNoBase.url.includes("sandeepvashishtha.tech"));
```

But in `src/utils/shareUtils.js` the fallback chain puts `DEFAULT_EVENT_SHARE_HOST` (`sandeepvashishtha.tech`) *after* `ENV.PUBLIC_URL`:

```js
const effectiveBase = baseUrl || currentOrigin || ENV.PUBLIC_URL || `https://${DEFAULT_EVENT_SHARE_HOST}`;
```

`ENV.PUBLIC_URL` always resolves (default `https://eventra.sandeepvashishtha.in` per `src/config/env.js`), so the legacy host is unreachable and the produced URL is `https://eventra.sandeepvashishtha.in/events/evt-42`.

## Reproduction

```bash
npm run test:node tests/shareUtils.test.mjs
```

```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  assert.ok(sharingDataNoBase.url.includes("sandeepvashishtha.tech"))

    at file:///.../Eventra/tests/shareUtils.test.mjs:77:8
```

## Files affected

- `tests/shareUtils.test.mjs`
- `src/utils/shareUtils.js`
- `src/config/env.js`

## Suggested fix

Reconcile the contract: either restore `DEFAULT_EVENT_SHARE_HOST` as the default when `baseUrl` is omitted (moving it ahead of `ENV.PUBLIC_URL`), or update the test to expect the `ENV.PUBLIC_URL`-based origin. (Note: unrelated to the open `isValidShareUrl` origin-validation issues #14551 / #14459.)

## Fix

fix(tests): assert ENV.PUBLIC_URL default share base origin (#14587)

## Files changed

- tests/shareUtils.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14587
