### PR TITLE
[Bug] tests/useScrollProgress*.test.mjs crash with ENOENT: src/hooks/useScrollProgress.js does not exist

### DIFF
--- a/src/hooks/useScrollProgress.js
+++ b/src/hooks/useScrollProgress.js
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview useScrollProgress - Scroll progress tracking hook
+ * @module hooks/useScrollProgress
+ */
+import { useState, useEffect, useRef } from "react";
+
+/**
+ * A custom React hook that tracks the user's vertical scroll progress
+ * as a percentage of the total scrollable page height.
+ *
+ * Uses requestAnimationFrame for performance-optimized scroll tracking,
+ * preventing excessive re-renders during rapid scrolling.
+ * Also updates on window resize to recalculate scroll boundaries.
+ *
+ * @returns {number} A number between 0 and 100 representing scroll
+ * progress percentage (0 = top, 100 = bottom)
+ *
+ * @example
+ * // Show a progress bar based on scroll position
+ * function ProgressBar() {
+ *   const progress = useScrollProgress();
+ *   return (
+ *     <div
+ *       style={{ width: `${progress}%` }}
+ *       className="h-1 bg-blue-500 fixed top-0"
+ *     />
+ *   );
+ * }
+ */
+export function useScrollProgress() {
+  const [progress, setProgress] = useState(0);
+  const rafRef = useRef(null);
+
+  useEffect(() => {
+    const update = () => {
+      if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+        const doc = document.documentElement;
+        const scrollTop = window.scrollY || doc.scrollTop || 0;
+        const height = doc.scrollHeight - window.innerHeight;
+        const pct = height > 0 ? Math.round((scrollTop / height) * 100) : 0;
+        setProgress(Math.max(0, Math.min(100, pct)));
+      }
+      rafRef.current = null;
+    };
+
+    const onScroll = () => {
+      if (rafRef.current) return;
+      rafRef.current = requestAnimationFrame(update);
+    };
+
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      update();
+      window.addEventListener("scroll", onScroll, { passive: true });
+      window.addEventListener("resize", onScroll);
+    }
+
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      if (typeof window !== 'undefined') {
+        window.removeEventListener("scroll", onScroll);
+        window.removeEventListener("resize", onScroll);
+      }
+    };
+  }, []);
+
+  return progress;
+}


### PR DESCRIPTION
﻿## Problem

[Bug] tests/useScrollProgress*.test.mjs crash with ENOENT: src/hooks/useScrollProgress.js does not exist

## Description

Both `tests/useScrollProgress.test.mjs` and `tests/useScrollProgress.edge.test.mjs` are source-contract suites that `readFileSync` the hook implementation at module load time:

```js
const src = readFileSync(
  path.resolve(__dirname, '../src/hooks/useScrollProgress.js'),
  'utf8',
);
```

`src/hooks/useScrollProgress.js` does not exist anywhere in the repository, so both suites crash before any test runs. The tests expect a hook that exports `useScrollProgress` as a named export and uses `useState`, `useEffect`, `useRef` and `requestAnimationFrame` — the implementation appears to have been removed (the `ScrollProgressBar`/`ScrollProgress` components still reference a scroll-progress hook), leaving the tests orphaned.

## Reproduction

```bash
npm run test:node tests/useScrollProgress.test.mjs
npm run test:node tests/useScrollProgress.edge.test.mjs
```

```
Error: ENOENT: no such file or directory, open '...\Eventra\src\hooks\useScrollProgress.js'
    at file:///.../Eventra/tests/useScrollProgress.test.mjs:15:13
```

## Files affected

- `tests/useScrollProgress.test.mjs`
- `tests/useScrollProgress.edge.test.mjs`
- `src/hooks/useScrollProgress.js` (missing)

## Suggested fix

Restore `src/hooks/useScrollProgress.js` matching the contract the tests describe (named export, `useState` + `useEffect` + `useRef` RAF scroll-progress tracking), or update/replace the tests. (Unrelated to the ScrollProgressBar render-thrashing issue #4944.)

## Fix

fix(14589): restore src/hooks/useScrollProgress.js

## Files changed

- src/hooks/useScrollProgress.js

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14589
