### PR TITLE
[Bug] tests/useKeyboardShortcuts.test.mjs crashes: useKeyboardShortcuts calls useNavigate() outside a Router

### DIFF
--- a/tests/useKeyboardShortcuts.test.mjs
+++ b/tests/useKeyboardShortcuts.test.mjs
@@ -23,6 +23,14 @@ global.document = dom.window.document;
 global.KeyboardEvent = dom.window.KeyboardEvent;
 global.CustomEvent = dom.window.CustomEvent;
 
+// JSDOM (without pretendToBeVisual) has no requestAnimationFrame; the hook
+// defers element focus to a RAF callback, so provide a synchronous shim.
+global.requestAnimationFrame = (cb) => {
+  cb();
+  return 0;
+};
+global.cancelAnimationFrame = () => {};
+
 // Mock Navigate
 const navigatedPaths = [];
 globalThis.ReactRouterDomMock = {
@@ -50,6 +58,8 @@ global.React = {
 
 // ── Import Hook ──────────────────────────────────────────────────────────────
 const { useKeyboardShortcuts } = await import("../src/hooks/useKeyboardShortcuts.js");
+const { renderHook } = await import("@testing-library/react");
+const { MemoryRouter } = await import("react-router-dom");
 
 // ── Listen to Custom Events ──────────────────────────────────────────────────
 const commandPaletteEvents = [];
@@ -72,6 +82,11 @@ function fireKeydown(keyOptions) {
 }
 
 // Helper to reset test states
+const hookRenderer = renderHook(
+  ({ shortcuts, disabled }) => useKeyboardShortcuts(shortcuts, disabled),
+  { wrapper: MemoryRouter, initialProps: { shortcuts: {}, disabled: false } }
+);
+
 function setupTest(shortcuts = {}, disabled = false) {
   activeCleanups.forEach(c => {
     try { c(); } catch (e) {}
@@ -82,7 +97,7 @@ function setupTest(shortcuts = {}, disabled = false) {
   if (document.activeElement) {
     document.activeElement.blur();
   }
-  useKeyboardShortcuts(shortcuts, disabled);
+  hookRenderer.rerender({ shortcuts, disabled });
 }
 
 // ── Test Cases ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Problem

[Bug] tests/useKeyboardShortcuts.test.mjs crashes: useKeyboardShortcuts calls useNavigate() outside a Router

## Description

`tests/useKeyboardShortcuts.test.mjs` invokes `useKeyboardShortcuts(...)` directly (test helper at line 85, call site at line 94) without rendering it inside a `Router`/`RouterProvider`. The hook now calls `useNavigate()` from `react-router-dom` (`src/hooks/useKeyboardShortcuts.js:45`), which throws when there is no router context:

```
TypeError: Cannot read properties of null (reading 'useContext')
    at useNavigate (react-router/dist/...:5912:32)
    at useKeyboardShortcuts (src/hooks/useKeyboardShortcuts.js:45:23)
    at setupTest (tests/useKeyboardShortcuts.test.mjs:85:3)
    at tests/useKeyboardShortcuts.test.mjs:94:3
```

The suite then hangs for ~16s (19 pending assertions) before failing.

## Reproduction

```bash
npm run test:node tests/useKeyboardShortcuts.test.mjs
```

## Files affected

- `tests/useKeyboardShortcuts.test.mjs`
- `src/hooks/useKeyboardShortcuts.js`

## Suggested fix

Wrap the hook invocation in a router context (e.g. `MemoryRouter`/`RouterProvider`) in the test harness, or render the hook through `@testing-library/react`'s `renderHook` inside a router so `useNavigate` resolves. Note: distinct from #11838 (conditional hook usage), #6890 (listener recreation) and #4646 (feature request).

## Fix

fix(14590): render useKeyboardShortcuts under MemoryRouter in test

## Files changed

- tests/useKeyboardShortcuts.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14590
