### PR TITLE
[Bug] P2PVideoPlayer.jsx imports ../../utils/p2p/webtorrentMesh at wrong depth — module cannot resolve

### DIFF
--- a/src/components/events/p2pstream/P2PVideoPlayer.jsx
+++ b/src/components/events/p2pstream/P2PVideoPlayer.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Play, Pause, Settings, Volume2, ShieldCheck } from "lucide-react";
 import SwarmStatsOverlay from "./SwarmStatsOverlay";
-import { WebTorrentMeshManager } from "../../utils/p2p/webtorrentMesh";
+import { WebTorrentMeshManager } from "../../../utils/p2p/webtorrentMesh";
 
 export default function P2PVideoPlayer({
   streamUrl = "https://cdn.example.com/hls/keynote.m3u8",


### PR DESCRIPTION
﻿## Problem

[Bug] P2PVideoPlayer.jsx imports ../../utils/p2p/webtorrentMesh at wrong depth — module cannot resolve

## Description

`src/components/events/p2pstream/P2PVideoPlayer.jsx:4` imports the WebTorrent mesh manager from the wrong depth:

```js
import { WebTorrentMeshManager } from "../../utils/p2p/webtorrentMesh";
```

From `src/components/events/p2pstream/`, `../../utils/p2p/webtorrentMesh` resolves to `src/components/utils/p2p/webtorrentMesh`, which does not exist. The canonical module is `src/utils/p2p/webtorrentMesh.js` (it exists and exports `WebTorrentMeshManager`), so the correct relative path is `../../../utils/p2p/webtorrentMesh`. Any bundler or runner that resolves this component's imports will fail to link the module.

## Reproduction

The import target is absent:

```
src/components/utils/p2p/webtorrentMesh.js  →  does not exist
src/utils/p2p/webtorrentMesh.js            →  exists (exports WebTorrentMeshManager)
```

## Files affected

- `src/components/events/p2pstream/P2PVideoPlayer.jsx` (line 4)

## Suggested fix

Change the import to `"../../../utils/p2p/webtorrentMesh"` (one directory level deeper).

## Fix

fix(components): correct webtorrentMesh import depth in P2PVideoPlayer (#14594)

## Files changed

- src/components/events/p2pstream/P2PVideoPlayer.jsx

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14594
