### PR TITLE
[Bug] EventParticipationStatistics.js imports ../../utils/eventParticipationStatsUtils at wrong depth — module cannot resolve

### DIFF
--- a/src/components/events/profile/EventParticipationStatistics.js
+++ b/src/components/events/profile/EventParticipationStatistics.js
@@ -14,7 +14,7 @@ import {
   getEventParticipationStatistics,
   getParticipationActivityLabel,
   getParticipationStatCards,
-} from "../../utils/eventParticipationStatsUtils";
+} from "../../../utils/eventParticipationStatsUtils";
 
 const EventParticipationStatistics = ({
   user = {},


### PR DESCRIPTION
﻿## Problem

[Bug] EventParticipationStatistics.js imports ../../utils/eventParticipationStatsUtils at wrong depth — module cannot resolve

## Description

`src/components/events/profile/EventParticipationStatistics.js:17` imports three helpers from the wrong depth:

```js
import {
  getEventParticipationStatistics,
  getParticipationActivityLabel,
  getParticipationStatCards,
} from "../../utils/eventParticipationStatsUtils";
```

From `src/components/events/profile/`, `../../utils/eventParticipationStatsUtils` resolves to `src/components/utils/eventParticipationStatsUtils`, which does not exist. The canonical module `src/utils/eventParticipationStatsUtils.js` exists and exports all three names, so the correct relative path is `../../../utils/eventParticipationStatsUtils`. Any module resolution of this component fails to link.

## Reproduction

```
src/components/utils/eventParticipationStatsUtils.js  →  does not exist
src/utils/eventParticipationStatsUtils.js             →  exists (exports all three imported names)
```

## Files affected

- `src/components/events/profile/EventParticipationStatistics.js` (line 17)

## Suggested fix

Change the import to `"../../../utils/eventParticipationStatsUtils"` (one directory level deeper).

## Fix

fix(components): correct eventParticipationStatsUtils import depth (#14595)

## Files changed

- src/components/events/profile/EventParticipationStatistics.js

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14595
