### PR TITLE
[Bug] tests/globalErrorHandler.test.mjs crashes: initializeGlobalErrorHandling() calls window.addEventListener with no SSR guard

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,7 +1,7 @@
 /* eslint-disable-next-line no-console */
 
 // Cross-environment development check (Vite, Webpack, Node.js)
-const isDevelopment = (() => {
+export const isDevelopment = (() => {
   if (typeof import.meta !== "undefined" && import.meta?.env) {
     return import.meta.env.DEV ?? import.meta.env.MODE !== "production";
   }

--- a/tests/globalErrorHandler.test.mjs
+++ b/tests/globalErrorHandler.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-globalThis.window = {};
+globalThis.window = { addEventListener: () => {} };
 globalThis.process = { env: { NODE_ENV: "production" } };
 
 import { initializeGlobalErrorHandling } from "../src/utils/globalErrorHandler.js";


### PR DESCRIPTION
﻿## Problem

[Bug] tests/globalErrorHandler.test.mjs crashes: initializeGlobalErrorHandling() calls window.addEventListener with no SSR guard

## Description

`src/utils/globalErrorHandler.js:39` calls `window.addEventListener(...)` unconditionally inside `initializeGlobalErrorHandling()`. Under Node (no `window`), the call throws. `tests/globalErrorHandler.test.mjs:8` invokes the initializer at module top level, so the whole suite crashes before any assertion runs.

```
TypeError: window.addEventListener is not a function
    at initializeGlobalErrorHandling (src/utils/globalErrorHandler.js:39:10)
    at file:///.../Eventra/tests/globalErrorHandler.test.mjs:8:1
```

## Reproduction

```bash
npm run test:node tests/globalErrorHandler.test.mjs
```

## Files affected

- `src/utils/globalErrorHandler.js` (line 39)
- `tests/globalErrorHandler.test.mjs`

## Suggested fix

Add a `typeof window === "undefined"` guard in `initializeGlobalErrorHandling()` (mirroring the SSR guards already applied to `errorLogger`/`abuseLogger` in #8949/#7705), or stub `window` in the test. Distinct from #6460 (circular JSON / silent data loss), which is about the handler's payload serialization.

## Fix

fix(utils): export isDevelopment from logger and stub window in globalErrorHandler test (#14596)

## Files changed

- src/utils/logger.js
- tests/globalErrorHandler.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14596
