### PR TITLE
[Bug] tests/aiMatchmaking.test.mjs fails 13 assertions — generateCompatibilityScore scoring contract drift

### DIFF
--- a/tests/aiMatchmaking.test.mjs
+++ b/tests/aiMatchmaking.test.mjs
@@ -14,27 +14,28 @@ const {
 } = await import("../src/utils/aiMatchmaking.js");
 
 // ─── generateCompatibilityScore ───────────────────────────────────────────────
-// Note: The base score is 50 + 15 (industry match when both undefined)
-// = 65. This is a pre-existing quirk: undefined === undefined is true in JS,
-// so the industry bonus fires even when both users have no industry set.
-// All test expectations are based on the actual current behavior.
+// Note: The base score is 50. The industry bonus (+15) only fires when BOTH
+// industries are truthy and equal, so empty/null/undefined users score a plain
+// 50. Skill bonuses are case-insensitive (skills are normalized via
+// toLowerCase().trim()). These expectations assert the guarded behavior that
+// landed with #7715.
 
 describe("generateCompatibilityScore — base score", () => {
-  it("returns 65 for empty users (50 base + 15 industry match from both undefined)", () => {
-    assert.equal(generateCompatibilityScore({}, {}), 65);
+  it("returns 50 for empty users (no industry bonus when undefined)", () => {
+    assert.equal(generateCompatibilityScore({}, {}), 50);
   });
 
-  it("returns 65 for users with null skills (no skill bonus)", () => {
+  it("returns 50 for users with null skills (no skill bonus)", () => {
     const score = generateCompatibilityScore({ skills: null }, { skills: null });
-    assert.equal(score, 65);
+    assert.equal(score, 50);
   });
 
-  it("returns 65 for users with undefined skills", () => {
+  it("returns 50 for users with undefined skills", () => {
     const score = generateCompatibilityScore(
       { skills: undefined },
       { skills: undefined },
     );
-    assert.equal(score, 65);
+    assert.equal(score, 50);
   });
 });
 
@@ -44,7 +45,7 @@ describe("generateCompatibilityScore — skill matching", () => {
       { skills: ["React", "TypeScript"] },
       { skills: ["React", "TypeScript", "Node"] },
     );
-    assert.equal(score, 85); // 65 + 10 + 10
+    assert.equal(score, 70); // 50 + 10 + 10
   });
 
   it("adds 10 points per common skill (single skill)", () => {
@@ -52,7 +53,7 @@ describe("generateCompatibilityScore — skill matching", () => {
       { skills: ["React"] },
       { skills: ["React"] },
     );
-    assert.equal(score, 75);
+    assert.equal(score, 60);
   });
 
   it("no skill bonus when skills are completely different", () => {
@@ -60,22 +61,22 @@ describe("generateCompatibilityScore — skill matching", () => {
       { skills: ["Python"] },
       { skills: ["React", "TypeScript"] },
     );
-    assert.equal(score, 65);
+    assert.equal(score, 50);
   });
 
-  it("skill matching is exact string comparison (case-sensitive)", () => {
+  it("skill matching is case-insensitive (normalized to lowercase)", () => {
     const score = generateCompatibilityScore(
       { skills: ["react"] },
       { skills: ["React"] },
     );
-    assert.equal(score, 65); // no match
+    assert.equal(score, 60); // "react" === "React" after normalization
   });
 
-  it("throws TypeError when skills is not an array (pre-existing bug — needs guard)", () => {
-    // generateCompatibilityScore calls skillsA.filter() without checking if skills is an array.
-    // This is a pre-existing bug.
-    assert.throws(() => generateCompatibilityScore({ skills: "React" }, { skills: ["React"] }), TypeError);
-    assert.throws(() => generateCompatibilityScore({ skills: 123 }, { skills: ["React"] }), TypeError);
+  it("does not throw when skills is not an array (guarded by normalizeSkills)", () => {
+    assert.doesNotThrow(() => generateCompatibilityScore({ skills: "React" }, { skills: ["React"] }));
+    assert.doesNotThrow(() => generateCompatibilityScore({ skills: 123 }, { skills: ["React"] }));
+    assert.equal(generateCompatibilityScore({ skills: "React" }, { skills: ["React"] }), 50);
+    assert.equal(generateCompatibilityScore({ skills: 123 }, { skills: ["React"] }), 50);
   });
 });
 
@@ -104,22 +105,22 @@ describe("generateCompatibilityScore — industry bonus", () => {
     assert.equal(score, 50); // no match
   });
 
-  it("null industry vs null industry still matches (undefined === undefined)", () => {
+  it("null industry vs null industry does not match (guarded)", () => {
     const score = generateCompatibilityScore(
       { industry: null },
       { industry: null },
     );
-    assert.equal(score, 65); // null === null → industry match
+    assert.equal(score, 50); // industry bonus requires both industries to be truthy
   });
 });
 
 describe("generateCompatibilityScore — role diversity bonus", () => {
-  it("adds 5 points when roles are different", () => {
+  it("adds 5 points when both roles are defined and different", () => {
     const score = generateCompatibilityScore(
       { role: "Developer" },
       { role: "Designer" },
     );
-    assert.equal(score, 70); // 50 + 15 (same industry) + 5
+    assert.equal(score, 55); // 50 + 5
   });
 
   it("no role bonus when roles are the same", () => {
@@ -127,24 +128,23 @@ describe("generateCompatibilityScore — role diversity bonus", () => {
       { role: "Developer" },
       { role: "Developer" },
     );
-    assert.equal(score, 65); // 50 + 15 (same industry) + 0
+    assert.equal(score, 50);
   });
 
-  it("undefined role is not considered 'different' from undefined role", () => {
-    // Both undefined → undefined !== undefined is false → no role bonus
+  it("undefined role vs undefined role is not 'different'", () => {
     const score = generateCompatibilityScore(
       { role: undefined },
       { role: undefined },
     );
-    assert.equal(score, 65); // 50 + 15 + 0
+    assert.equal(score, 50);
   });
 
-  it("defined role vs undefined role is considered 'different' → +5", () => {
+  it("defined role vs undefined role is not 'different' (both must be truthy)", () => {
     const score = generateCompatibilityScore(
       { role: "Developer" },
       { role: undefined },
     );
-    assert.equal(score, 70); // 50 + 15 + 5
+    assert.equal(score, 50);
   });
 });
 


### PR DESCRIPTION
﻿## Problem

[Bug] tests/aiMatchmaking.test.mjs fails 13 assertions — generateCompatibilityScore scoring contract drift

## Description

`tests/aiMatchmaking.test.mjs` fails 13 of its 39 assertions in the `generateCompatibilityScore` describe blocks. `src/utils/aiMatchmaking.js:36-47` was refactored into atomic score calculators with guards, but the tests still encode the older contract:

1. **Base score** — tests expect `generateCompatibilityScore({}, {})` to be `65` (50 base + 15 industry match for both undefined industries). The source's `calcIndustryScore` returns 0 when `userA.industry` is falsy, so empty/null/undefined users score `50`.
2. **Skill matching** — tests expect `assert.throws(..., TypeError)` when `skills` is not an array (documenting a pre-existing bug). The source now guards via `normalizeSkills` (`if (!Array.isArray(skills)) return []`), so no `TypeError` is thrown.
3. **Industry bonus** — `null industry vs null industry still matches` expects +15; source returns 0 because `userA.industry` is falsy.
4. **Role diversity bonus** — `defined role vs undefined role is considered 'different' → +5` expects +5; `calcRoleScore` requires both roles to be truthy, so undefined-vs-defined yields 0.

## Reproduction

```bash
npm run test:node tests/aiMatchmaking.test.mjs
```

```
✖ generateCompatibilityScore — base score (1.9249ms)
✖ generateCompatibilityScore — skill matching (1.4081ms)
✖ generateCompatibilityScore — industry bonus (0.6052ms)
✖ generateCompatibilityScore — role diversity bonus (0.4708ms)
ℹ tests 39
ℹ pass 26
ℹ fail 13
```

## Files affected

- `tests/aiMatchmaking.test.mjs`
- `src/utils/aiMatchmaking.js`

## Suggested fix

Decide the intended scoring contract and reconcile: either update `generateCompatibilityScore` so empty/null users score 65 and null industries match, or update the tests to match the current behavior. Note: #7715 (null guards) has partially landed here via `normalizeSkills`, which is why the `throws TypeError` expectation now fails — the tests need to be updated to assert the guarded behavior.

## Fix

test(matchmaking): reconcile scoring contract assertions

## Files changed

- tests/aiMatchmaking.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14597
