### PR TITLE
[Bug] tests/useValidationState.test.mjs has unbalanced delimiters — SyntaxError: Unexpected end of input, suite cannot parse

### DIFF
--- a/tests/useValidationState.test.mjs
+++ b/tests/useValidationState.test.mjs
@@ -210,6 +210,7 @@ describe('useValidationState — status messages & custom i18n support', () => {
       result.current.statusMessage,
       'Email Address: Invalid format'
     );
+  });
 
   it('falls back to default message copy when a custom message key is missing', () => {
     const { result } = renderHook(() =>
@@ -254,6 +255,7 @@ describe('useValidationState — field class names', () => {
       classes.includes('border-red-500'),
       'Must include border-red-500'
     );
+  });
 
   it('applies blue border class for validating state when touched', () => {
     const { result } = renderHook(() =>
@@ -284,6 +286,7 @@ describe('useValidationState — ARIA attributes', () => {
       result.current.ariaAttributes['aria-describedby'],
       'email-error'
     );
+  });
 
   it('sets aria-describedby for success state when valid', () => {
     const { result } = renderHook(() =>


### PR DESCRIPTION
﻿## Problem

[Bug] tests/useValidationState.test.mjs has unbalanced delimiters — SyntaxError: Unexpected end of input, suite cannot parse

## Description

`tests/useValidationState.test.mjs` cannot be parsed at all. The file has unmatched opening brackets: 193 `(` vs 190 `)`, and 78 `{` vs 75 `}` (3 unbalanced groups each). The Node parser reaches EOF and reports:

```
file:///.../Eventra/tests/useValidationState.test.mjs:317
});

SyntaxError: Unexpected end of input
    at compileSourceTextModule (node:internal/modules/esm/utils:318:16)
```

Because the module fails to parse, the entire suite is dead — every test in the file is unreachable, including the `fieldClassName` reference-stability assertion at line 311-315.

## Reproduction

```bash
npm run test:node tests/useValidationState.test.mjs
```

## Files affected

- `tests/useValidationState.test.mjs`

## Suggested fix

Balance the delimiters (likely a prematurely closed `describe`/`it` block near the end of the file) so the module parses, then re-run the suite.

## Fix

test(validation-state): balance delimiters so suite can parse

## Files changed

- tests/useValidationState.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14598
