### PR TITLE
[Bug] FloorPlanDesigner.js imports ../../common/ConfirmationModal at wrong depth — module cannot resolve

### DIFF
--- a/src/components/events/FloorPlanDesigner.js
+++ b/src/components/events/FloorPlanDesigner.js
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Layout, Save, RotateCcw, Plus, Minus, Move, AlertTriangle, Undo2, Redo2, Users } from "lucide-react";
 import { LiveAudienceContext } from "context/RealTimeContext";
 import { toast } from "react-toastify";
-import ConfirmationModal from "../../common/ConfirmationModal";
+import ConfirmationModal from "../common/ConfirmationModal";
 import ElementPalette from "./FloorPlan/ElementPalette";
 import PropertiesPanel from "./FloorPlan/PropertiesPanel";
 import { PRESETS } from "constants/floorPlanPresets";


### PR DESCRIPTION
﻿## Problem

[Bug] FloorPlanDesigner.js imports ../../common/ConfirmationModal at wrong depth — module cannot resolve

## Description

`src/components/events/FloorPlanDesigner.js:6` imports the confirmation dialog from the wrong depth:

```js
import ConfirmationModal from "../../common/ConfirmationModal";
```

From `src/components/events/`, `../../common/ConfirmationModal` resolves to `src/common/ConfirmationModal`, which does not exist. The component lives at `src/components/common/ConfirmationModal.js`, so the correct relative path is `../common/ConfirmationModal` (one `..` instead of two). Any module resolution of `FloorPlanDesigner` fails to link this import.

## Reproduction

```
src/common/ConfirmationModal.js              →  does not exist
src/components/common/ConfirmationModal.js   →  exists
```

## Files affected

- `src/components/events/FloorPlanDesigner.js` (line 6)

## Suggested fix

Change the import to `"../common/ConfirmationModal"`. Note: this is a separate defect from #14569, which covers the `checkCollision`/`getSeatPositions` import at line 10 of the same file.

## Fix

fix(components): correct ConfirmationModal import depth in FloorPlanDesigner (#14599)

## Files changed

- src/components/events/FloorPlanDesigner.js

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14599
