### PR TITLE
[Bug] tests/copyLinkButtonIntegrity.test.mjs fails: CopyLinkButton aria-label is dynamic, test expects static aria-label=Copy event link

### DIFF
--- a/tests/copyLinkButtonIntegrity.test.mjs
+++ b/tests/copyLinkButtonIntegrity.test.mjs
@@ -12,8 +12,20 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label="Copy event link"/,
-  "CopyLinkButton must have accessiblity aria-label"
+  /aria-label/,
+  "CopyLinkButton must have an accessibility aria-label"
+);
+
+assert.match(
+  source,
+  /"Share event invite"/,
+  "CopyLinkButton must expose the native-share aria-label branch"
+);
+
+assert.match(
+  source,
+  /"Copy event link"/,
+  "CopyLinkButton must expose the copy-invite aria-label branch"
 );
 
 console.log("CopyLinkButton integrity tests passed");


### PR DESCRIPTION
﻿## Problem

[Bug] tests/copyLinkButtonIntegrity.test.mjs fails: CopyLinkButton aria-label is dynamic, test expects static aria-label="Copy event link"

## Description

`tests/copyLinkButtonIntegrity.test.mjs` expects `src/components/common/CopyLinkButton.jsx` to contain the literal attribute `aria-label="Copy event link"`, but the source now computes the label dynamically based on native share support:

```jsx
<button
  aria-label={canNativeShare ? "Share event invite" : "Copy event link"}
  ...
/>
```

Because the aria-label is an expression, the static string check in the test fails and the whole suite errors.

## Reproduction

```bash
npm run test:node tests/copyLinkButtonIntegrity.test.mjs
```

```
AssertionError [ERR_ASSERTION]: CopyLinkButton must have accessiblity aria-label
    at file:///.../Eventra/tests/copyLinkButtonIntegrity.test.mjs:13:8
```

## Files affected

- `tests/copyLinkButtonIntegrity.test.mjs`
- `src/components/common/CopyLinkButton.jsx`

## Suggested fix

Make the test aware of the dynamic label (e.g. assert that the source references `aria-label` and that both branch strings `"Share event invite"` and `"Copy event link"` are present), so the accessibility contract is still verified.

## Fix

fix(tests): accept dynamic aria-label in CopyLinkButton integrity test (#14600)

## Files changed

- tests/copyLinkButtonIntegrity.test.mjs

## Testing

Verified the change with the project's relevant test and lint commands for the modified files.

Closes #14600
