### PR TITLE
[CRITICAL] RealTimeSubtitleContext: processSubtitleQueue silently drops all but the first queued subtitle

### DIFF
--- a/src/context/RealTimeSubtitleContext.jsx
+++ b/src/context/RealTimeSubtitleContext.jsx
@@ -284,11 +284,9 @@ export function RealTimeSubtitleProvider({ children }) {
   const processSubtitleQueue = useCallback(() => {
     if (subtitleQueue.current.length === 0) return;
     
-    const queue = [...subtitleQueue.current];
-    subtitleQueue.current = [];
-    
-    // Get the first subtitle from queue
-    const nextSubtitle = queue[0];
+    // Get the next subtitle from queue
+    const nextSubtitle = subtitleQueue.current.shift();
+    if (!nextSubtitle) return;
     
     // Update active subtitle
     setActiveSubtitle(nextSubtitle);
@@ -324,7 +322,7 @@ export function RealTimeSubtitleProvider({ children }) {
     }));
     
     // Process remaining queue
-    if (queue.length > 1) {
+    if (subtitleQueue.current.length > 0) {
       // Delay processing to maintain order
       setTimeout(processSubtitleQueue, 100);
     }


### PR DESCRIPTION
## Problem

In `RealTimeSubtitleContext`, `processSubtitleQueue` copies the queue into a local array, immediately empties the ref, and then only consumes `queue[0]`. When multiple subtitles are queued in a burst, the recursive `setTimeout` re-enters with an already-empty ref and returns early, so all subtitles after the first are silently dropped and `displayedSubtitles` undercounts.

## Fix

Reworked `processSubtitleQueue` to drain the queue with `subtitleQueue.current.shift()`, removing one item per tick while the ref still holds the remaining items, and rescheduling only while `subtitleQueue.current` still has items. This covers every point in the issue:

- `subtitleQueue.current` is no longer cleared before the siblings are processed.
- Every queued subtitle is displayed in order across ticks.
- `displayedSubtitles` now reflects the true count.
- `SUBTITLE_BUFFER_SIZE` and `HISTORY_SIZE` caps still apply unchanged.

## Files changed

- src/context/RealTimeSubtitleContext.jsx

## Testing

- `node --check` on the `.jsx` file is not supported by Node (ERR_UNKNOWN_FILE_EXTENSION), so syntax was verified by careful review.
- Ran `node --import ./tests/setup.js --test tests/realTimeSubtitleContext.test.mjs`: 9 tests passed, 0 failed.

Closes #16473
