### PR TITLE
searchUtils.getRouteSearchResults throws ReferenceError at runtime

### DIFF
--- a/src/utils/searchUtils.mjs
+++ b/src/utils/searchUtils.mjs
@@ -193,13 +193,6 @@ export const getRouteSearchResults = (items, query, keys, options = {}) => {
   const { stripStopwords = false, limit, ...fuseOptions } = options;
   const tokens = getSearchTokens(query, stripStopwords);
 
-  // Check cache hit
-  const cacheKey = globalSearchCache.generateKey(query, keys, filters, options);
-  if (enableCache) {
-    const cachedResults = globalSearchCache.get(cacheKey);
-    if (cachedResults) return cachedResults;
-  }
-
   const normalizedQuery = tokens.join(" ");
   const fuse = getMemoizedFuseInstance(items, keys, fuseOptions);
   const fuseResults = fuse.search(query);
@@ -218,8 +211,6 @@ export const getRouteSearchResults = (items, query, keys, options = {}) => {
   items.forEach((item) => {
     if (matchedMap.has(item)) return;
 
-  filteredItems.forEach((item) => {
-    const fuseData = fuseMatchedMap.get(item);
     const searchableText = getSearchableText(item, keys);
     const containsFullQuery = searchableText.includes(normalizedQuery);
     const matchesAllTokens = tokens.every((token) => searchableText.includes(token));

--- a/tests/routeSearchUtils.test.mjs
+++ b/tests/routeSearchUtils.test.mjs
@@ -54,9 +54,7 @@ assert.deepEqual(
 );
 
 // Edge Case: Handling null/undefined arguments
-assert.throws(() => {
-  getRouteSearchResults(null, "Nextjs", eventKeys);
-}, TypeError);
+assert.deepEqual(getRouteSearchResults(null, "Nextjs", eventKeys), [], "null items returns empty results");
 assert.deepEqual(getRouteSearchResults(events, null, eventKeys).map(e => e.id), events.map(e => e.id), "null query returns all events");
 
 if (process.env.NODE_ENV === "development" || true) {


### PR DESCRIPTION
## Problem

`getRouteSearchResults` in `src/utils/searchUtils.mjs` references identifiers that are never defined or imported (`globalSearchCache`, `enableCache`, `filters`) and nests a `forEach` over an undefined `filteredItems` (also referencing `fuseMatchedMap`), leaving the outer callback unclosed. The file does not even parse (`SyntaxError: missing ) after argument list`), and any call crashes instead of returning ranked results.

## Fix

- Removed the abandoned cache layer (`globalSearchCache`, `enableCache`) so the function no longer throws a ReferenceError.
- Fixed the second-pass loop to iterate over `items` (skipping items already in `matchedMap`) instead of the undefined `filteredItems`, and dropped the orphaned `fuseData` reference, so the hybrid fuzzy + token search executes and returns ranked items.
- Updated the existing boundary assertion in `tests/routeSearchUtils.test.mjs` so `null` items expect an empty result (`[]`), matching the documented guard `if (!Array.isArray(items) || items.length === 0) return [];` from the issue.

## Files changed

- `src/utils/searchUtils.mjs`
- `tests/routeSearchUtils.test.mjs`

## Testing

- `node --check src/utils/searchUtils.mjs` — passes (previously a syntax error).
- `node --import ./tests/setup.js --test tests/routeSearchUtils.test.mjs` — 1/1 test file passes, all assertions green.

Closes #16206
