### PR TITLE
[CRITICAL] eventra-kit padArray references undefined fillArray (ReferenceError whenever padding is needed)

### DIFF
--- a/src/eventra-kit/pad-array.js
+++ b/src/eventra-kit/pad-array.js
@@ -2,6 +2,8 @@
 /**
  * adds an array padding helper.
  */
+import { fillArray } from './fill-array.js';
+
 export function padArray(array, length, fill) {
   return array.length >= length ? array.slice(0, length) : array.concat(fillArray(length - array.length, fill));
 }


### PR DESCRIPTION
## Problem

`padArray` delegates to `fillArray` to build padding but never imports it. Whenever the input array needs padding (`array.length < length`), the function throws `ReferenceError: fillArray is not defined`. Only the no-padding branch (`array.length >= length`) works.

## Fix

Added the missing import `import { fillArray } from './fill-array.js';` so the padding branch works as intended.

## Files changed

- `src/eventra-kit/pad-array.js`

## Testing

- `node --check src/eventra-kit/pad-array.js` passed.
- Inline `node -e` sanity check importing the module:
  - `padArray([1, 2], 5, 0)` → `[1, 2, 0, 0, 0]`
  - `padArray([1, 2, 3, 4, 5], 3, 'x')` → `[1, 2, 3]`
  - `padArray([], 2, () => 9)` → `[9, 9]`

Closes #16475
