### PR TITLE
[HIGH] MyEventsContext: async IndexedDB hydration overwrites a registration added before it resolves

### DIFF
--- a/src/context/MyEventsContext.js
+++ b/src/context/MyEventsContext.js
@@ -134,14 +134,20 @@ export const MyEventsProvider = ({ children }) => {
     
     setLoading(true);
     loadFromIDB(userId).then(data => {
-      if (mounted) {
-        setMyEvents(data);
-        setLoading(false);
-        // Important: allow saves *after* initial load resolves
-        setTimeout(() => {
-          isInitialLoad.current = false;
-        }, 50);
-      }
+      if (!mounted) return;
+      setMyEvents(prev => {
+        const byId = new Map();
+        [...(data || []), ...prev].forEach(r => {
+          const key = String(r.eventId);
+          if (!byId.has(key)) byId.set(key, r);
+        });
+        return Array.from(byId.values());
+      });
+      setLoading(false);
+      // Important: allow saves *after* initial load resolves
+      setTimeout(() => {
+        isInitialLoad.current = false;
+      }, 50);
     });
 
     return () => { mounted = false; };


### PR DESCRIPTION
## Problem

`MyEventsContext` hydrates "My Events" from IndexedDB asynchronously with an unconditional `setMyEvents(data)` full replacement when the read resolves. If a registration is added via `addRegistration` before the async read finishes, the freshly-added registration is overwritten and lost, and the persist effect later writes the stale snapshot back. The `isInitialLoad` 50 ms guard only prevents saving too early; it does nothing to stop the overwrite.

## Fix

Changed the hydration callback to merge the IndexedDB records with anything already captured in memory instead of replacing state:

- Uses a functional `setMyEvents(prev => ...)` updater that combines `data` and `prev`, deduplicating by `String(r.eventId)`.
- Registrations added before the read resolves are retained (their `eventId` is absent from the hydrated data).
- `setLoading(false)` and the `isInitialLoad` guard timing are unchanged.

## Files changed

- src/context/MyEventsContext.js

## Testing

- `node --check` cannot parse this file (it is `.js` but contains JSX — `SyntaxError: Unexpected token '<'`), so syntax was verified by careful review.
- No test file exists for MyEventsContext under `tests/`, so the targeted contract test was not available; change is limited to the hydration merge logic described in the issue.

Closes #16480
