### PR TITLE
recommendationEngine: interaction time-decay falls back to event.date, corrupting user affinity weights

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -288,7 +288,9 @@ export const buildInteractionProfile = ({
     const eventLocation = normalizeText(event.location);
 
     // Apply time-decay multiplier based on interaction timestamp
-    const decayFactor = applyTimeDecay(entry.createdAt || entry.timestamp || event.date);
+    // (never fall back to the event date, which is not a recency signal)
+    const interactionTime = entry?.createdAt || entry?.timestamp;
+    const decayFactor = interactionTime ? applyTimeDecay(interactionTime) : 1.0;
     const weight = baseWeight * decayFactor;
 
     if (id) interactedIds.add(id);

--- a/tests/recommendationEngine.test.mjs
+++ b/tests/recommendationEngine.test.mjs
@@ -119,6 +119,27 @@ assert(
   "decay factor should scale interaction weights",
 );
 
+// Interactions without a timestamp must default to full recency, never the event date
+const pastEvent = { ...events[2], date: new Date(NOW - 30 * DAY_MS).toISOString() };
+const noTimestampProfile = buildInteractionProfile({
+  viewedEvents: [{ ...pastEvent }],
+});
+assert.equal(
+  noTimestampProfile.categories["devops and cloud"],
+  1,
+  "interaction without its own timestamp should keep full weight instead of decaying against the event date",
+);
+
+// A freshly-viewed future event keeps a high category weight
+const futureEvent = { ...events[2], date: new Date(NOW + 30 * DAY_MS).toISOString() };
+const freshProfile = buildInteractionProfile({
+  viewedEvents: [{ ...futureEvent, createdAt: new Date(NOW - 1000).toISOString() }],
+});
+assert(
+  Math.abs(freshProfile.categories["devops and cloud"] - 1) < 0.01,
+  "freshly-viewed event should keep full category weight",
+);
+
 // ===========================================================================
 // Temporal urgency & expiration filtering
 // ===========================================================================


### PR DESCRIPTION
## Problem

In `buildInteractionProfile` (`src/utils/recommendationEngine.js`), the time-decay multiplier was computed as `applyTimeDecay(entry.createdAt || entry.timestamp || event.date)`. When an interaction record has no timestamp of its own, it fell back to the **event start date**, which is not a recency signal: future events produced `decayFactor = 1.0` (inflating old views) and past events produced `decayFactor ≈ 0` (erasing affinity), corrupting all downstream affinity weights.

## Fix

- `src/utils/recommendationEngine.js`: decay now uses only the interaction's own timestamp (`entry?.createdAt || entry?.timestamp`); a missing/invalid timestamp defaults to `1.0` (fully recent) instead of falling back to the event date.
- `tests/recommendationEngine.test.mjs`: added regression tests asserting that an old interaction with no timestamp keeps full category weight even when the event date is in the past, and that a freshly-viewed future event keeps full category weight.

## Files changed

- `src/utils/recommendationEngine.js`
- `tests/recommendationEngine.test.mjs`

## Testing

- `node --check src/utils/recommendationEngine.js` — passes.
- `node --import ./tests/setup.js --test tests/recommendationEngine.test.mjs` — all existing assertions plus the new regression assertions pass.

Closes #16207
