### PR TITLE
[HIGH] ThemeContext: OS theme change ignored when theme is 'system' (no-op setState)

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -62,6 +62,7 @@ export const ThemeProvider = ({ children }) => {
 
   const [theme, setThemeState] = useState(() => getInitialTheme());
 
+  const [systemTheme, setSystemTheme] = useState(() => getSystemTheme());
   // States to preserve existing codebase drawer flow without breaking
   const [activeThemeId, setActiveThemeId] = useState(() => {
     return safeStorage.getItem("activeThemeId", "default");
@@ -90,7 +91,7 @@ export const ThemeProvider = ({ children }) => {
     return saved !== null ? saved === "true" : prefersReduced;
   });
 
-  const resolvedTheme = theme === "system" ? getSystemTheme() : theme;
+  const resolvedTheme = theme === "system" ? systemTheme : theme;
   const isDarkMode = resolvedTheme === "dark";
 
   // Track whether we have already applied the profile theme for this session
@@ -234,13 +235,11 @@ export const ThemeProvider = ({ children }) => {
 
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = () => {
-      if (!safeStorage.getItem(THEME_STORAGE_KEY)) {
-        setTheme("system");
-      }
+      setSystemTheme(getSystemTheme());
     };
     mediaQuery.addEventListener("change", handleChange);
     return () => mediaQuery.removeEventListener("change", handleChange);
-  }, [setTheme]);
+  }, []);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
## Problem

`ThemeContext` advertises a "follow system" theme, but when `theme === "system"`, an OS appearance change is silently ignored. The media-query listener called `setTheme("system")`, which is a no-op because `theme` is already `"system"` — React bails out of the same-value state update and performs no re-render, so `resolvedTheme` (computed during render from `getSystemTheme()`) stays stale.

## Fix

- Added `systemTheme` state initialized from `getSystemTheme()`.
- `resolvedTheme` now derives from `systemTheme` when `theme === "system"`: `const resolvedTheme = theme === "system" ? systemTheme : theme;`.
- Replaced the redundant `setTheme("system")` media-query listener with one that calls `setSystemTheme(getSystemTheme())` on OS change, forcing a real state update and re-render.
- The existing render effect that applies `resolvedTheme` to `root.classList` and CSS variables runs as before, now picking up OS changes live.

## Files changed

- src/context/ThemeContext.js

## Testing

- `node --check` cannot parse this file (it is `.js` but contains JSX — `SyntaxError: Unexpected token '<'`), so syntax was verified by careful review.
- Ran `node --import ./tests/setup.js --test tests/themeConsistency.test.mjs`: 1 test passed, 0 failed (covers CSS theme contract, unaffected by this change).

Closes #16481
