### PR TITLE
recommendationEngine: module-global _tagCache is never invalidated and is shared across users/sessions

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -69,6 +69,7 @@ const getPopularityScore = (event) => {
 const _tagCache = new Map();
 const _cacheOrder = [];
 const MAX_CACHE_SIZE = 100;
+const TAG_CACHE_TTL_MS = 5 * 60 * 1000;
 
 const _getCachedTags = (event) => {
   // 🔥 FIX: Skip the cache entirely when the event has no real id.
@@ -79,21 +80,30 @@ const _getCachedTags = (event) => {
   // events we expect to be re-encountered, and id-less events are not.
   const id = getEventId(event);
   if (!id) return getEventTags(event);
-  if (_tagCache.has(id)) {
-    const tags = _tagCache.get(id);
+  const cached = _tagCache.get(id);
+  if (cached && Date.now() - cached.cachedAt <= TAG_CACHE_TTL_MS) {
     const idx = _cacheOrder.indexOf(id);
     if (idx > -1) _cacheOrder.splice(idx, 1);
     _cacheOrder.push(id);
-    return tags;
+    return cached.tags;
   }
   if (_cacheOrder.length >= MAX_CACHE_SIZE) {
     const oldest = _cacheOrder.shift();
     _tagCache.delete(oldest);
   }
   const tags = getEventTags(event);
-  _tagCache.set(id, tags);
+  _tagCache.set(id, { tags, cachedAt: Date.now() });
   _cacheOrder.push(id);
   return tags;
+};
+
+/**
+ * Clears the in-memory tag cache. Exported for tests and SSR resets so stale,
+ * session-lifetime tag vectors are never served across users/requests.
+ */
+export const clearTagCache = () => {
+  _tagCache.clear();
+  _cacheOrder.length = 0;
 };
 
 const getSimilarityScore = (candidate, interactedEvents) => {

--- a/tests/recommendationEngine.test.mjs
+++ b/tests/recommendationEngine.test.mjs
@@ -7,6 +7,7 @@ import {
   calculateDiversitySimilarity,
   calculateRecommendationScore,
   calculateTemporalUrgencyScore,
+  clearTagCache,
   getTrendingEventsForArea,
 } from "../src/utils/recommendationEngine.js";
 
@@ -220,6 +221,54 @@ assert(coldStart.length > 0, "cold-start users should still receive recommendati
 assert(
   coldStart.every((event) => event.recommendationScore > 0),
   "cold-start recommendations should all be positively scored",
+);
+
+// ===========================================================================
+// Tag cache TTL & invalidation
+// ===========================================================================
+
+const mutableEvent = {
+  id: 777,
+  title: "Mutable Event",
+  category: "Web Development",
+  type: "conference",
+  tags: ["React", "Frontend"],
+};
+const candidateEvent = {
+  id: 888,
+  title: "React Meetup",
+  category: "Web Development",
+  type: "conference",
+  tags: ["React"],
+};
+
+const similarityScore = (profile) =>
+  calculateRecommendationScore(candidateEvent, {}, profile).breakdown.find(
+    (b) => b.label === "Collaborative item similarity",
+  )?.score ?? 0;
+
+const cachedSimilarity = similarityScore(
+  buildInteractionProfile({ registeredEvents: [{ ...mutableEvent }] }),
+);
+
+mutableEvent.tags = ["Python", "Data"];
+
+const staleSimilarity = similarityScore(
+  buildInteractionProfile({ registeredEvents: [{ ...mutableEvent }] }),
+);
+assert.equal(
+  staleSimilarity,
+  cachedSimilarity,
+  "tag cache should serve the original tags within TTL",
+);
+
+clearTagCache();
+const freshSimilarity = similarityScore(
+  buildInteractionProfile({ registeredEvents: [{ ...mutableEvent }] }),
+);
+assert(
+  freshSimilarity < staleSimilarity,
+  "tag edits should be reflected once the cache is invalidated",
 );
 
 console.log("recommendationEngine tests passed ✓");


### PR DESCRIPTION
## Problem

`src/utils/recommendationEngine.js` keeps a module-global `_tagCache`/`_cacheOrder` used by `_getCachedTags`. It is a singleton shared across every user/session/recommendation call, is never invalidated, and only ever gets evicted by LRU after 100 distinct events — so an event whose tags/techStack/title change on the server keeps serving the first cached tag vector for the rest of the session.

## Fix

- Added a TTL window (`TAG_CACHE_TTL_MS = 5 * 60 * 1000`); cache entries now store `{ tags, cachedAt }` and are recomputed once the entry is older than the TTL, so recommendation inputs reflect current data within a bounded window.
- Added a `clearTagCache()` export for tests/SSR reset, so stale tag vectors are never served across requests.
- `tests/recommendationEngine.test.mjs`: added a regression test that mutates an event's tags and asserts the cache serves the original tags within TTL but the next computation reflects the change once the cache is invalidated.

## Files changed

- `src/utils/recommendationEngine.js`
- `tests/recommendationEngine.test.mjs`

## Testing

- `node --check src/utils/recommendationEngine.js` — passes.
- `node --import ./tests/setup.js --test tests/recommendationEngine.test.mjs` — all existing assertions plus the new TTL/invalidation regression test pass.

Closes #16208
