### PR TITLE
[HIGH] i18n: escapeValue:false disables HTML escaping (XSS enabler) and pluralization keys are missing

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -19,7 +19,7 @@ i18n
     supportedLngs: ["en", "hi", "te", "es"],
     fallbackLng: "en",
     interpolation: {
-      escapeValue: false,
+      escapeValue: true,
     },
     detection: {
       order: ["localStorage", "navigator"],

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -65,6 +65,8 @@
     "hidePassword": "Hide password",
     "lockedOut": "Too many failed attempts. Try again in {{seconds}}s.",
     "attemptsRemaining": "{{count}} attempt(s) remaining before temporary lockout.",
+    "attemptsRemaining_one": "{{count}} attempt remaining before temporary lockout.",
+    "attemptsRemaining_other": "{{count}} attempts remaining before temporary lockout.",
     "lockedWait": "Locked — wait {{seconds}}s"
   },
   "validation": {
@@ -258,6 +260,8 @@
       "searchPlaceholder": "Search events, hackathons, projects...",
       "searchResults": "Search results",
       "resultsCount": "Results ({{count}})",
+      "resultsCount_one": "Result ({{count}})",
+      "resultsCount_other": "Results ({{count}})",
       "noDescription": "No description available",
       "noResults": "No results for",
       "scrollToExplore": "Scroll to explore",
@@ -425,6 +429,8 @@
     "statsShown": "shown on this page",
     "podiumHeading": "Top 3 Contributors",
     "showingContributors": "Showing {{count}} of {{total}} contributors",
+    "showingContributors_one": "Showing {{count}} of {{total}} contributor",
+    "showingContributors_other": "Showing {{count}} of {{total}} contributors",
     "pageOf": "Page {{current}} of {{total}}",
     "tableHeading": "Contributor Rankings",
     "tableHeaders": {


### PR DESCRIPTION
## Problem

`i18n.js` sets `interpolation.escapeValue: false`, disabling i18next's HTML escaping of interpolated values globally. Because several components render `t()` output through `dangerouslySetInnerHTML`, any interpolated value flowing into an `__html` sink becomes a stored/reflected XSS vector. Additionally, the `{{count}}` keys (`attemptsRemaining`, `resultsCount`, `showingContributors`) in `locales/en.json` lack i18next plural forms (`_one`/`_other`), so `count: 1` renders incorrect phrasing ("1 attempt(s)", "1 contributors").

## Fix

- Enabled `interpolation.escapeValue: true` in `src/i18n/i18n.js` so interpolated values are HTML-escaped by default.
- Added `_one`/`_other` plural keys for `attemptsRemaining`, `resultsCount`, and `showingContributors` in `locales/en.json` so counts pluralize correctly via i18next. The base keys remain as fallbacks for lookups without a `count`.

## Files changed

- `src/i18n/i18n.js`
- `src/i18n/locales/en.json`

## Testing

- `node --check src/i18n/i18n.js` passed.
- Verified `src/i18n/locales/en.json` parses as valid JSON via `node -e` `JSON.parse`.

Closes #16492
