### PR TITLE
[CRITICAL] Backend TeamWorkspaceSyncService: orphaned code block breaks compilation

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
@@ -24,12 +24,6 @@ public class TeamWorkspaceSyncService {
     private static final Pattern HACKATHON_ROOM_KEY =
             Pattern.compile("^hackathon:(\\d+)(?::team:.*)?$");
 
-    private final HackathonRegistrationRepository hackathonRegistrationRepository;
-
-    public TeamWorkspaceSyncService(HackathonRegistrationRepository hackathonRegistrationRepository) {
-        this.hackathonRegistrationRepository = hackathonRegistrationRepository;
-    }
-
     private static final class WorkspaceState {
         private final Object lock = new Object();
         private List<Map<String, Object>> tasks = new ArrayList<>();
@@ -163,14 +157,6 @@ public class TeamWorkspaceSyncService {
         } catch (NumberFormatException ex) {
             return null;
         }
-    }
-        if (StringUtils.hasText(hackathonId) && StringUtils.hasText(teamId)) {
-            return "hackathon:" + hackathonId.trim() + ":team:" + teamId.trim();
-        }
-        if (StringUtils.hasText(hackathonId)) {
-            return "hackathon:" + hackathonId.trim();
-        }
-        return "user:" + authenticatedEmail().trim().toLowerCase();
     }
 
     /**


### PR DESCRIPTION
## Problem

`TeamWorkspaceSyncService.java` contains an orphaned block of bare statements (previously lines 167-174) immediately after the closing brace of `extractHackathonId()`. Java class bodies may only contain declarations, so these statements referencing `hackathonId`, `teamId`, and `authenticatedEmail()` at class scope are illegal and duplicate the fallback tail of `resolveRoomKey`. This is a hard compile error (`illegal start of type / not a statement`) that prevents the entire backend module from building.

## Fix

- Deleted the orphaned duplicate block after `extractHackathonId()`; it was redundant with the room-key resolution already implemented in `resolveRoomKey`.
- Removed a duplicate `hackathonRegistrationRepository` field declaration and its single-argument constructor left over from the same broken merge (the canonical three-argument constructor used by the application and the existing `TeamWorkspaceSyncServiceTest` remains).

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java

## Testing

- Applied the temporary EmailSender.java string patch and ran `mvn -q compile` from `Backend`. `TeamWorkspaceSyncService.java` compiles with no errors (remaining errors are confined to pre-existing unrelated files: `SvgSanitizationService.java`, `RegistrationResponse.java`, `TeamWorkspaceSyncController.java`).
- Temporary EmailSender patch reverted before committing.

Closes #16476
