### PR TITLE
[HIGH] QuestCenter: claim guard ref never reset, permanently blocks quest claiming after daily/weekly reset

### DIFF
--- a/src/components/gamification/QuestCenter.jsx
+++ b/src/components/gamification/QuestCenter.jsx
@@ -220,6 +220,18 @@ export default function QuestCenter({ totalEvents = 0, currentStreak = 0, gssocE
       if (now >= state.dailyResetAt || now >= state.weeklyResetAt) {
         setState(initState());
       }
+
+      // Clear stale claim guards for expired periods so claims aren't blocked
+      if (now >= state.dailyResetAt) {
+        claimedGuardRef.current = Object.fromEntries(
+          Object.entries(claimedGuardRef.current).filter(([k]) => !k.startsWith('dailyClaimed:'))
+        );
+      }
+      if (now >= state.weeklyResetAt) {
+        claimedGuardRef.current = Object.fromEntries(
+          Object.entries(claimedGuardRef.current).filter(([k]) => !k.startsWith('weeklyClaimed:'))
+        );
+      }
     }
     tick();
     const id = setInterval(tick, 30000); // update every 30s


### PR DESCRIPTION
## Problem

`QuestCenter`'s `claimXP` uses a `useRef` guard (`claimedGuardRef`) to prevent double-clicks. The guard is set to `true` on the first claim and never reset. When a daily/weekly reset boundary passes, `initState()` wipes `dailyClaimed`/`weeklyClaimed` to `{}`, but the stale ref guard stays `true`, so the next "Claim" click on a reset, unclaimed quest hits the guard and returns early — permanently blocking quest claiming until a full page reload.

## Fix

In the countdown timer's reset handling, clear the claim guards for each expired period alongside the state reset:

- If `now >= state.dailyResetAt`, remove every guard key starting with `dailyClaimed:` from `claimedGuardRef.current`.
- If `now >= state.weeklyResetAt`, remove every guard key starting with `weeklyClaimed:` from `claimedGuardRef.current`.

This keeps the double-click protection intact while allowing claims to work again after a rollover. Covers both points in the issue: the guard is now cleared exactly when the corresponding claimed map is reset.

## Files changed

- src/components/gamification/QuestCenter.jsx

## Testing

- `node --check` cannot parse this file (it is `.jsx` — `ERR_UNKNOWN_FILE_EXTENSION`), so syntax was verified by careful review.
- No test file exists for QuestCenter under `tests/`, so the targeted test was not available; the change is limited to the reset path described in the issue.

Closes #16482
