### PR TITLE
[HIGH] CarbonFootprintGamification: leaderboard uses hardcoded index + stale closure, corrupting 'You' row

### DIFF
--- a/src/components/events/CarbonFootprintGamification.jsx
+++ b/src/components/events/CarbonFootprintGamification.jsx
@@ -50,8 +50,15 @@ const CarbonFootprintGamification = () => {
       // Update leaderboard
       setLeaderboard(prev => {
         const newLb = [...prev];
-        newLb[2] = { ...newLb[2], points: ecoPoints + 150, saved: carbonSaved + 12.5 };
-        return newLb.sort((a, b) => b.points - a.points).map((item, index) => ({...item, rank: index + 1}));
+        const myIndex = newLb.findIndex(item => item.name === 'You');
+        if (myIndex === -1) return prev;
+        newLb[myIndex] = {
+          ...newLb[myIndex],
+          points: newLb[myIndex].points + 150,
+          saved: (newLb[myIndex].saved ?? 0) + 12.5,
+        };
+        return newLb.sort((a, b) => b.points - a.points)
+                  .map((item, index) => ({...item, rank: index + 1}));
       });
     }, 2000);
     


### PR DESCRIPTION
## Problem

`CarbonFootprintGamification`'s transit action updated the leaderboard "You" row by hardcoding index `2` and reading `ecoPoints`/`carbonSaved` from the render closure instead of locating the row by identity and accumulating relative to the true current value. Once "You" accumulates enough points to move out of slot 3, the +150 was granted to a different person, and a preceding recycling scan's progress was overwritten rather than added to.

## Fix

Reworked the leaderboard update in `simulateTransit` to mirror the correct pattern used by `simulateScan`:

- Locates the "You" row via `findIndex(item => item.name === 'You')` and bails out (returns `prev`) if it isn't present.
- Accumulates `+150` points and `+12.5` saved relative to the row's current values (`newLb[myIndex].points + 150`, `(newLb[myIndex].saved ?? 0) + 12.5`), so no preceding progress is lost.
- Still sorts and re-ranks afterwards.

## Files changed

- src/components/events/CarbonFootprintGamification.jsx

## Testing

- `node --check` cannot parse this file (it is `.jsx` — `ERR_UNKNOWN_FILE_EXTENSION`), so syntax was verified by careful review.
- No test file exists for CarbonFootprintGamification under `tests/`, so the targeted test was not available.

Closes #16483
