### PR TITLE
[HIGH] validationApi: module-level cache is never invalidated/aliased and catch branch masks the server 4xx message

### DIFF
--- a/src/utils/validationApi.js
+++ b/src/utils/validationApi.js
@@ -7,6 +7,10 @@ const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 // In-memory response cache for validation results
 const validationCache = new Map();
 
+export const clearValidationCache = () => {
+  validationCache.clear();
+};
+
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const createValidationResponse = (
@@ -77,7 +81,7 @@ export const requestValidation = async (endpoint, options = {}) => {
   // Cache Lookup Key
   const cacheKey = `${method}:${endpoint}:${JSON.stringify(body || {})}`;
   if (useCache && validationCache.has(cacheKey)) {
-    return validationCache.get(cacheKey);
+    return { ...validationCache.get(cacheKey) };
   }
 
   let lastError = null;
@@ -159,7 +163,6 @@ export const requestValidation = async (endpoint, options = {}) => {
             errData?.message || invalidMessage,
             { status, data: errData },
           );
-          if (useCache) validationCache.set(cacheKey, failureResponse);
           return failureResponse;
         }
 
@@ -197,10 +200,9 @@ export const requestValidation = async (endpoint, options = {}) => {
       if (status && !RETRYABLE_STATUS_CODES.includes(status) && status < 500) {
         const failureResponse = createValidationResponse(
           false,
-          networkMessage,
+          data?.message || networkMessage,
           { status, data }
         );
-        if (useCache) validationCache.set(cacheKey, failureResponse);
         return failureResponse;
       }
 
@@ -261,6 +263,7 @@ const validationApi = {
   checkEmailAvailability,
   checkUsernameAvailability,
   checkPhoneValidation,
+  clearValidationCache,
   createValidationResponse,
   normalizeValidationApiResponse,
   requestValidation,


### PR DESCRIPTION
## Problem

`src/utils/validationApi.js` has a module-level cache that:
1. Returns cached entries **by reference**, letting a caller mutate and poison the shared entry.
2. Caches **negative/failure** results forever (with no TTL/clear mechanism), so availability checks can serve permanently stale "taken"/"available" answers.
3. Masks the server's real validation message: the catch branch uses the generic `networkMessage` for non-retryable 4xx responses even though the axios interceptor throws an error carrying `data` with the server's message.

## Fix

- Read path now returns a defensive shallow clone (`{ ...validationCache.get(cacheKey) }`).
- Removed both `validationCache.set(...)` calls in failure branches (the non-OK status path and the catch path), so only affirmative results are ever cached (the success path already cached only `normalized.isValid`).
- Catch branch now reports `data?.message || networkMessage` so users see the server's actionable reason.
- Added and exported `clearValidationCache()` so the cache can be invalidated explicitly.

## Files changed

- `src/utils/validationApi.js`

## Testing

- `node --check src/utils/validationApi.js` passed.
- `node --import ./tests/setup.js --test tests/validationApiStripping.test.mjs` passed.
- Note: `tests/validationApiErrorHandling.test.mjs` fails on master too (it asserts no empty `catch {}` blocks, but `} catch {}` at the JSON-parse site exists on the base commit and is untouched by this PR).

Closes #16493
