### PR TITLE
[HIGH] Backend EventService.importLegacyWaitlist: NPE on null timestamp and string-based fair-queue sort

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -60,6 +60,7 @@ import java.time.LocalDateTime;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -989,7 +990,11 @@ public class EventService {
 
                 // Sort unique entries by timestamp to maintain fair queuing (oldest first)
                 List<CsvWaitlistImportRequest.CsvWaitlistEntry> sortedEntries = uniqueEntries.values().stream()
-                                .sorted((a, b) -> a.getTimestamp().compareTo(b.getTimestamp()))
+                                .sorted(Comparator.comparing(
+                                                e -> e.getTimestamp() == null
+                                                                ? LocalDateTime.now()
+                                                                : parseTimestamp(e.getTimestamp()),
+                                                LocalDateTime::compareTo))
                                 .toList();
                 
                 // Get current max position for this event


### PR DESCRIPTION
## Problem

`EventService.importLegacyWaitlist` sorts unique CSV entries by timestamp using `a.getTimestamp().compareTo(b.getTimestamp())`:
1. It throws `NullPointerException` when a row omits the timestamp — even though `parseTimestamp` (used when persisting `joinedAt`) treats null/blank timestamps as "now", so a missing timestamp is valid input.
2. It compares raw `String` timestamps lexicographically, while persistence uses the parsed `LocalDateTime` (ISO, space-separated, and date-only formats), mis-ordering mixed-format rows and corrupting the fair-queue ordering.

## Fix

Replaced the sort with a null-safe chronological comparator:

```java
.sorted(Comparator.comparing(
        e -> e.getTimestamp() == null
                ? LocalDateTime.now()
                : parseTimestamp(e.getTimestamp()),
        LocalDateTime::compareTo))
```

Entries with a missing timestamp are treated as "now" (consistent with `parseTimestamp`), and ordering is now by the parsed `LocalDateTime` (oldest first) rather than the raw string, restoring correct fair-queue ordering.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java

## Testing

- Applied the temporary EmailSender.java string patch and ran `mvn -q compile` from `Backend`. `EventService.java` compiles with no errors.
- Temporary EmailSender patch reverted before committing.

Closes #16477
