### PR TITLE
[HIGH] useMultiTrackSchedule: optimistic track/session ids never reconciled and failures not rolled back

### DIFF
--- a/src/hooks/useMultiTrackSchedule.js
+++ b/src/hooks/useMultiTrackSchedule.js
@@ -145,19 +145,25 @@ export const useMultiTrackSchedule = (eventId) => {
    * Add new track
    */
   const addTrack = useCallback(async (trackData) => {
+    const optimisticId = `track-${Date.now()}`;
     try {
       const newTrack = {
-        id: `track-${Date.now()}`,
+        id: optimisticId,
         ...trackData,
         createdAt: new Date().toISOString(),
       };
       dispatch({ type: 'ADD_TRACK', payload: newTrack });
       
       // Save to server
-      await scheduleService.addTrack(eventId, trackData);
+      const created = await scheduleService.addTrack(eventId, { ...trackData, id: optimisticId });
+      const saved = created?.data ?? created;
+      if (saved?.id && saved.id !== optimisticId) {
+        dispatch({ type: 'UPDATE_TRACK', payload: { id: optimisticId, updates: { id: saved.id } } });
+      }
       
-      return newTrack;
+      return saved || newTrack;
     } catch (error) {
+      dispatch({ type: 'REMOVE_TRACK', payload: optimisticId });
       dispatch({ type: 'SET_ERROR', payload: error.message });
       throw error;
     }
@@ -203,9 +209,10 @@ export const useMultiTrackSchedule = (eventId) => {
    * Add session to schedule
    */
   const addSession = useCallback(async (sessionData) => {
+    const optimisticId = `session-${Date.now()}`;
     try {
       const newSession = {
-        id: `session-${Date.now()}`,
+        id: optimisticId,
         ...sessionData,
         createdAt: new Date().toISOString(),
         attendeeIds: [],
@@ -217,10 +224,15 @@ export const useMultiTrackSchedule = (eventId) => {
       updateValidation([...state.tracks], [...state.sessions, newSession]);
       
       // Save to server
-      await scheduleService.addSession(eventId, sessionData);
+      const created = await scheduleService.addSession(eventId, { ...sessionData, id: optimisticId });
+      const saved = created?.data ?? created;
+      if (saved?.id && saved.id !== optimisticId) {
+        dispatch({ type: 'UPDATE_SESSION', payload: { id: optimisticId, updates: { id: saved.id } } });
+      }
       
-      return newSession;
+      return saved || newSession;
     } catch (error) {
+      dispatch({ type: 'REMOVE_SESSION', payload: optimisticId });
       dispatch({ type: 'SET_ERROR', payload: error.message });
       throw error;
     }


### PR DESCRIPTION
## Problem

`useMultiTrackSchedule` adds tracks/sessions optimistically with a client-generated id (`track-${Date.now()}`), dispatches to local state, then calls `scheduleService.addTrack(eventId, trackData)` passing the original `trackData` **without** the id and ignoring the server's response. The server assigns its own id, so the local store keeps a divergent id; after a `loadSchedule()` refresh the entries get different server ids, making later edits/deletes target non-existent entities. On network failure the optimistic entry stays in the list while missing server-side, and there was no rollback.

## Fix

Applied the same reconciliation pattern to both `addTrack` and `addSession`:

- Generates the optimistic id up front (`optimisticId`) so the catch block can reference it.
- Sends the client id to the server (`{ ...trackData, id: optimisticId }`).
- Reads the created record from the response (`created?.data ?? created`) and, if the server assigned a different id, dispatches an `UPDATE_TRACK`/`UPDATE_SESSION` to remap the optimistic entry to the canonical id.
- On failure, dispatches `REMOVE_TRACK`/`REMOVE_SESSION` to roll back the optimistic entry, sets the error, and rethrows.
- Returns the saved record (or the optimistic entry as a fallback).

Covers every point in the issue: id reconciliation after refresh, no orphaned entries, rollback on failure, and correct `SET_ERROR`.

## Files changed

- src/hooks/useMultiTrackSchedule.js

## Testing

- `node --check src/hooks/useMultiTrackSchedule.js`: passed (exit 0).
- No test file exists for useMultiTrackSchedule under `tests/`, so the targeted test was not available.

Closes #16484
