### PR TITLE
[HIGH] Backend AdminService.deleteUser/deleteEvent: missing @Transactional causes non-atomic deletions

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -269,6 +269,7 @@ public class AdminService {
         return toEventResponse(saved);
     }
 
+    @Transactional
     public void deleteEvent(Long id) {
         if (!eventRepository.existsById(id)) {
             throw new EntityNotFoundException("Event not found with id: " + id);


### PR DESCRIPTION
## Problem

`AdminService.deleteUser` and `AdminService.deleteEvent` perform multiple dependent writes (cascading deletes, count recomputation, waitlist promotion) without `@Transactional`. Without it, Spring commits each repository call independently, so a mid-deletion failure leaves partially-deleted data, stale counts, and skipped waitlist promotions — permanent data inconsistency. Sibling delete paths (`EventService.deleteEvent`, `HackathonService.deleteHackathon`) are already `@Transactional`.

## Fix

Added `@Transactional` to `AdminService.deleteEvent`. (`deleteUser` was already annotated with `@Transactional` in the current `master`.) Now all dependent writes in each deletion path commit atomically: either everything succeeds or everything rolls back.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java

## Testing

- Applied the temporary EmailSender.java string patch and ran `mvn -q compile` from `Backend`. `AdminService.java` compiles with no errors.
- Temporary EmailSender patch reverted before committing.

Closes #16479
