### PR TITLE
[HIGH] advancedFilterUtils: max:Infinity price range breaks the + filter after a URL round-trip

### DIFF
--- a/src/utils/advancedFilterUtils.js
+++ b/src/utils/advancedFilterUtils.js
@@ -406,7 +406,10 @@ export const normalizeAdvancedFilters = (filters = {}) => ({
   priceRange: filters.priceRange
     ? {
         min: Number(filters.priceRange.min) || 0,
-        max: filters.priceRange.max === Infinity ? Infinity : Number(filters.priceRange.max) || 0,
+        max:
+          filters.priceRange.max === Infinity || filters.priceRange.max == null
+            ? Infinity
+            : Number(filters.priceRange.max) || 0,
       }
     : null,
   dateRange: filters.dateRange
@@ -428,7 +431,11 @@ export const serializeAdvancedFilters = (filters = {}) => {
   if (normalized.skillLevels.length) payload.skillLevels = normalized.skillLevels;
   if (normalized.tags.length) payload.tags = normalized.tags;
   if (normalized.location.trim()) payload.location = normalized.location.trim();
-  if (normalized.priceRange) payload.priceRange = normalized.priceRange;
+  if (normalized.priceRange) {
+    const pr = { min: normalized.priceRange.min };
+    if (Number.isFinite(normalized.priceRange.max)) pr.max = normalized.priceRange.max;
+    payload.priceRange = pr;
+  }
   if (normalized.dateRange && (normalized.dateRange.startDate || normalized.dateRange.endDate)) {
     payload.dateRange = normalized.dateRange;
   }


### PR DESCRIPTION
## Problem

The `"$1000+"` price range uses `max: Infinity`, but `serializeAdvancedFilters` emits the whole `priceRange` object. `JSON.stringify({ max: Infinity })` turns `Infinity` into `null`, and on decode `normalizeAdvancedFilters` maps `Number(null) || 0` → `0`. The range becomes `{ min: 1000, max: 0 }` after a share/reload URL round-trip, and `filterByPrice` requires `price >= 1000 && price <= 0`, which never matches — the "$1000+" filter returns zero events.

## Fix

- `normalizeAdvancedFilters` now treats `max === Infinity` **or** `max == null` (the JSON round-trip form of a non-finite max) as "no upper bound" (`Infinity`).
- `serializeAdvancedFilters` no longer emits a non-finite `max`: it builds `{ min }` and only adds `max` when `Number.isFinite`. This keeps `Infinity` out of the serialized JSON entirely.

## Files changed

- `src/utils/advancedFilterUtils.js`

## Testing

- `node --check src/utils/advancedFilterUtils.js` passed.
- Inline `node -e` round-trip check:
  - `serializeAdvancedFilters({ priceRange: { min: 1000, max: Infinity } })` → `{"priceRange":{"min":1000}}` (no `Infinity`/`null` emitted).
  - `decodeAdvancedFilters(encode(...))` for that payload → `priceRange.max === Infinity`.
  - Decoding a payload with no `max` → `priceRange.max === Infinity`.
- `tests/advancedFilterUtils.test.mjs` and `tests/advancedFilterUtils.edge.test.mjs` were run; the same 3 failures (unrelated null-event/mode/date-boundary assertions) reproduce on the unmodified base commit, and the price-related test "respects inclusive price boundaries" passes.

Closes #16494
