### PR TITLE
[HIGH] eventra-kit slugify: regex-special separator strips the entire string

### DIFF
--- a/src/eventra-kit/slugify.js
+++ b/src/eventra-kit/slugify.js
@@ -3,11 +3,12 @@
  */
 export function slugify(input, separator = '-') {
   if (typeof input !== 'string') return '';
+  const escaped = separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return input
     .toLowerCase()
     .trim()
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^a-z0-9]+/g, separator)
-    .replace(new RegExp(`^${separator}+|${separator}+$`, 'g'), '');
+    .replace(new RegExp(`^${escaped}+|${escaped}+$`, 'g'), '');
 }


### PR DESCRIPTION
## Problem

`slugify` in the Eventra Kit builds a trailing-trim regex by interpolating `separator` directly into a `RegExp` without escaping. When the separator is a regex metacharacter (e.g. `.`), the trim regex becomes `/^.+|.+$/g`, where `.` matches any character — so the entire string is consumed and replaced with `''` (`slugify("a.b.c", ".")` returned `""` instead of `"a.b.c"`).

## Fix

Escaped the separator with the standard regex-escape pattern (`separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`) before building the trim regex. The leading/trailing trim now only removes the literal separator, so `slugify("a.b.c", ".")` returns `"a.b.c"` and `slugify("v1.2.3", ".")` returns `"v1.2.3"`, while default behavior is unchanged.

## Files changed

- src/eventra-kit/slugify.js

## Testing

- Ran `node --check` (via `node -e` import) and direct functional checks:
  - `slugify("a.b.c", ".")` → `"a.b.c"` (previously `""`)
  - `slugify("v1.2.3", ".")` → `"v1.2.3"`
  - `slugify("Hello World")` → `"hello-world"` (default separator unchanged)
  - `slugify("-foo-")` → `"foo"` (trim still works)
- No test file exists for slugify under `tests/`, so the targeted test was not available.

Closes #16485
