### PR TITLE
Double charge: scheduleInstallmentPayments creates and confirms a duplicate upfront PaymentIntent

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -345,16 +345,16 @@ public class PaymentPlanService {
                     paymentPlan, paymentPlan.getStripeCustomerId(), paymentMethodId);
             
             // Persist installment PaymentIntent IDs onto the Payment records so webhooks
-            // for installments 2+ can locate them. installmentIntentIds[0] is the
-            // (already persisted) upfront intent; subsequent entries map to installments
-            // 2+ by index.
+            // for installments 2+ can locate them. installmentIntentIds contains only
+            // the intents for installments 2..N (the upfront intent is already persisted
+            // above), so entry i-1 maps to the Payment row at index i.
             List<Payment> installmentPayments = paymentRepository.findByRegistration_IdOrderByInstallmentNumberAsc(
                     registration.getId());
             String stripeCustomerId = paymentPlan.getStripeCustomerId();
             for (int i = 0; i < installmentPayments.size(); i++) {
                 Payment p = installmentPayments.get(i);
-                if (i > 0 && i < installmentIntentIds.size()) {
-                    p.setStripePaymentIntentId(installmentIntentIds.get(i));
+                if (i > 0 && (i - 1) < installmentIntentIds.size()) {
+                    p.setStripePaymentIntentId(installmentIntentIds.get(i - 1));
                 }
                 p.setStripeCustomerId(stripeCustomerId);
                 paymentRepository.save(p);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -172,26 +172,13 @@ public class StripeService {
         
         // Calculate installment amounts
         BigDecimal installmentAmount = paymentPlan.getInstallmentAmount();
-        BigDecimal upfrontAmount = paymentPlan.getUpfrontAmount();
         BigDecimal remainingAmount = paymentPlan.getRemainingAmount();
         
         // Convert to cents (Stripe uses smallest currency unit)
-        long upfrontAmountCents = upfrontAmount.multiply(new BigDecimal(100)).longValue();
         long installmentAmountCents = installmentAmount.multiply(new BigDecimal(100)).longValue();
         
-        // Create upfront payment (25%)
-        PaymentIntent upfrontIntent = createPaymentIntent(
-                customerId,
-                upfrontAmountCents,
-                paymentPlan.getCurrency().toLowerCase(),
-                paymentMethodId,
-                "Upfront payment for " + paymentPlan.getRegistration().getEvent().getTitle(),
-                createMetadata(paymentPlan, 1, paymentPlan.getTotalInstallments())
-        );
-        
-        paymentIntentIds.add(upfrontIntent.getId());
-        
-        // Create remaining installments (3 monthly payments)
+        // Create remaining installments (2..N); the upfront payment is created
+        // and confirmed separately by PaymentPlanService.
         LocalDateTime eventDate = paymentPlan.getRegistration().getEvent().getEventDate();
         LocalDateTime now = LocalDateTime.now();
         


### PR DESCRIPTION
## Problem

When a user confirms an installment plan, the upfront payment is charged twice. `PaymentPlanService.confirmUpfrontPaymentAndScheduleInstallments` first confirms the originally-created upfront `PaymentIntent` (a real charge), then calls `StripeService.scheduleInstallmentPayments`, which creates a brand-new upfront `PaymentIntent` with `setConfirm(true)` and charges it again. That second intent's ID is orphaned by the `i > 0` guard in `PaymentPlanService` and never attached to any `Payment` row, so the duplicate charge is untracked and never refunded.

## Fix

- `StripeService.scheduleInstallmentPayments` no longer creates/confirms an upfront `PaymentIntent`. It now only creates the remaining installments (2..N) without immediate confirmation; the upfront amount is charged exactly once by `PaymentPlanService`.
- `PaymentPlanService.confirmUpfrontPaymentAndScheduleInstallments` now maps `installmentIntentIds` 1:1 to the `Payment` rows for installments 2..N (`installmentIntentIds.get(i - 1)` for row index `i`), and the comment was updated to reflect that the list no longer contains the upfront intent.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java

## Testing

- Applied the temporary EmailSender.java string patch and ran `mvn -q compile` from `Backend`. `StripeService.java` and `PaymentPlanService.java` compile with no errors.
- Temporary EmailSender patch reverted before committing.

Closes #16509
