### PR TITLE
debounceUtils.throttleAsync: trailing-edge callers receive the leading result; trailing result is discarded

### DIFF
--- a/src/utils/debounceUtils.js
+++ b/src/utils/debounceUtils.js
@@ -182,9 +182,18 @@ export const throttleAsync = (asyncFn, limit = 500, options = {}) => {
   const { leading = true, trailing = true } = options;
 
   let inThrottle = false;
-  let lastResult = null;
+  let lastResult = undefined;
   let lastArgs = null;
   let timeoutId = null;
+  const pendingCallbacks = [];
+
+  const settlePending = (error, result) => {
+    while (pendingCallbacks.length > 0) {
+      const { resolve, reject } = pendingCallbacks.shift();
+      if (error) reject(error);
+      else resolve(result);
+    }
+  };
 
   const throttled = async (...args) => {
     if (!inThrottle) {
@@ -194,6 +203,7 @@ export const throttleAsync = (asyncFn, limit = 500, options = {}) => {
         lastResult = await asyncFn(...args);
       } else {
         lastArgs = args;
+        lastResult = undefined;
       }
 
       timeoutId = setTimeout(async () => {
@@ -201,7 +211,14 @@ export const throttleAsync = (asyncFn, limit = 500, options = {}) => {
         if (trailing && lastArgs) {
           const trailingArgs = lastArgs;
           lastArgs = null;
-          await throttled(...trailingArgs);
+          try {
+            lastResult = await asyncFn(...trailingArgs);
+            settlePending(null, lastResult);
+          } catch (error) {
+            settlePending(error, null);
+          }
+        } else {
+          settlePending(null, lastResult);
         }
       }, limit);
 
@@ -209,7 +226,9 @@ export const throttleAsync = (asyncFn, limit = 500, options = {}) => {
     }
 
     lastArgs = args;
-    return lastResult;
+    return new Promise((resolve, reject) => {
+      pendingCallbacks.push({ resolve, reject });
+    });
   };
 
   throttled.cancel = () => {
@@ -220,6 +239,7 @@ export const throttleAsync = (asyncFn, limit = 500, options = {}) => {
     inThrottle = false;
     lastArgs = null;
     lastResult = null;
+    settlePending(new DebounceCancelledError(), null);
   };
 
   return throttled;

--- a/tests/throttleAsync.test.mjs
+++ b/tests/throttleAsync.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { throttleAsync } from "../src/utils/debounceUtils.js";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Trailing-edge callers must resolve with the trailing (latest args) result,
+// not the leading result, and the trailing execution must not be discarded.
+const calls = [];
+const throttled = throttleAsync(async (value) => {
+  calls.push(value);
+  await delay(10);
+  return `result:${value}`;
+}, 50);
+
+const leading = throttled("first");
+const trailing = throttled("second");
+
+assert.equal(await leading, "result:first", "leading call returns its own result");
+await delay(80);
+assert.equal(
+  await trailing,
+  "result:second",
+  "trailing call should resolve with the trailing execution result",
+);
+assert.deepEqual(
+  calls,
+  ["first", "second"],
+  "asyncFn should run exactly once for the leading edge and once for the trailing edge",
+);
+
+// A trailing call that arrives later in the same window should also receive the
+// trailing result computed from the latest args.
+const throttled2 = throttleAsync(async (value) => {
+  await delay(5);
+  return `result:${value}`;
+}, 50);
+const t1 = throttled2("a");
+const t2 = throttled2("b");
+const t3 = throttled2("c");
+assert.equal(await t1, "result:a", "leading call of second throttle returns its own result");
+await delay(80);
+assert.equal(await t2, "result:c", "superseded trailing call resolves with the latest trailing result");
+assert.equal(await t3, "result:c", "latest trailing call resolves with the latest trailing result");
+
+console.log("throttleAsync tests passed ✓");


### PR DESCRIPTION
## Problem

`throttleAsync` (`src/utils/debounceUtils.js`) returns the **leading** call's result to every throttled (trailing) caller, and the actual trailing execution's resolved value was thrown away (`await throttled(...trailingArgs)` inside the timeout with nobody awaiting it). Late callers silently received the wrong data.

## Fix

- Rewrote the throttle window handling so trailing callers get a promise that is settled with the **trailing execution's** result (computed from the latest args).
- The trailing `asyncFn` call is awaited inside the timeout with a try/catch, and pending callers are resolved with its result (or rejected on error) via a small pending-callback queue.
- `cancel()` now clears state and rejects any still-pending trailing callers with `DebounceCancelledError` so they never hang unresolved.
- Added `tests/throttleAsync.test.mjs` asserting a trailing call receives the trailing (latest-args) output, that `asyncFn` runs exactly once per edge, and that superseded trailing calls also resolve with the latest trailing result.

## Files changed

- `src/utils/debounceUtils.js`
- `tests/throttleAsync.test.mjs`

## Testing

- `node --check src/utils/debounceUtils.js` — passes.
- `node --import ./tests/setup.js --test tests/throttleAsync.test.mjs` — passes.
- `node --import ./tests/setup.js --test tests/debounceAsync.test.mjs` — passes (no regressions).
- `node --import ./tests/setup.js --test tests/debounceUtils.test.mjs` — passes (no regressions).

Closes #16209
