### PR TITLE
[HIGH] eventra-kit formatLargeNumber: boundary values render as '1000.0' of the lower unit

### DIFF
--- a/src/eventra-kit/format-large-number.js
+++ b/src/eventra-kit/format-large-number.js
@@ -3,9 +3,18 @@
  * adds a large number helper.
  */
 export function formatLargeNumber(value) {
-  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
-  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
-  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  const tiers = [[1e9, 'B'], [1e6, 'M'], [1e3, 'K']];
+  for (let i = 0; i < tiers.length; i++) {
+    const [divisor, suffix] = tiers[i];
+    if (value >= divisor) {
+      const v = Math.round((value / divisor) * 10) / 10;
+      if (v >= 1000) {
+        if (i === 0) return String(value);
+        return `${(value / tiers[i - 1][0]).toFixed(1)}${tiers[i - 1][1]}`;
+      }
+      return `${v.toFixed(1)}${suffix}`;
+    }
+  }
   return String(value);
 }
 


### PR DESCRIPTION
## Problem

`formatLargeNumber` picked the largest matching tier and divided, but near a `1eN` boundary the lower-tier value rounds up to `1000.0` instead of promoting to the next (higher) tier. So `formatLargeNumber(999999999)` returned `"1000.0M"` instead of `"1.0B"`, misrepresenting magnitude for attendee counts, revenue, and other large metrics.

## Fix

Iterate the tiers and round the scaled value to one decimal before deciding. When the rounded scaled value reaches/exceeds `1000`, promote to the next (higher) tier instead of displaying `1000.0` of the lower unit:

- `999999999` → `1.0B` (was `1000.0M`)
- `999999` → `1.0M` (was `1000.0K`)
- Values that genuinely round below 1000 are untouched: `999949` → `999.9K`, `950000000` → `950.0M`, `1234` → `1.2K`, `1000` → `1.0K`
- Formatting stays `toFixed(1)`-style, matching the original output format and the issue's expected `"1.0B"`.

Note: the issue's exact proposed snippet would still return `"1000M"` for `999999999` (the `value >= 1e9` gate skips the B tier before the promote check), so this PR implements the promotion semantics the issue describes rather than that snippet verbatim.

## Files changed

- src/eventra-kit/format-large-number.js

## Testing

- Direct functional checks via `node --input-type=module`:
  - `formatLargeNumber(999999999)` → `1.0B` (issue's expected value)
  - `formatLargeNumber(999999)` → `1.0M`
  - `formatLargeNumber(999949)` → `999.9K`, `formatLargeNumber(950000000)` → `950.0M`, `formatLargeNumber(1000)` → `1.0K`, `formatLargeNumber(1234)` → `1.2K`
- No test file exists for format-large-number under `tests/`, so the targeted test was not available.

Closes #16486
