### PR TITLE
fix(issue-16259): escape HTML in chat markdown parser

### DIFF
--- a/src/components/chat/LiveChatMarkdownParser.js
+++ b/src/components/chat/LiveChatMarkdownParser.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Sparkles, MessageSquare, Cpu } from "lucide-react";
-import { createMarkdownParserWorkerCode } from "./markdownParserWorker";
+import { createMarkdownParserWorkerCode, parseMarkdownToSafeHtml } from "./markdownParserWorker";
 
 export default function LiveChatMarkdownParser({ rawMarkdown = "**Welcome to Eventra Live Chat!** Type `hello` below." }) {
   const [parsedHtml, setParsedHtml] = useState("");
@@ -8,7 +8,7 @@ export default function LiveChatMarkdownParser({ rawMarkdown = "**Welcome to Eve
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof Worker === "undefined") {
-      setParsedHtml(rawMarkdown);
+      setParsedHtml(parseMarkdownToSafeHtml(rawMarkdown));
       setLoading(false);
       return;
     }
@@ -36,7 +36,7 @@ export default function LiveChatMarkdownParser({ rawMarkdown = "**Welcome to Eve
       };
     } catch (err) {
       console.warn("[Markdown Parser] Fallback to sync parsing active:", err);
-      setParsedHtml(rawMarkdown);
+      setParsedHtml(parseMarkdownToSafeHtml(rawMarkdown));
       setLoading(false);
     }
   }, [rawMarkdown]);

--- a/src/components/chat/markdownParserWorker.js
+++ b/src/components/chat/markdownParserWorker.js
@@ -2,6 +2,32 @@
  * Markdown Parser Web Worker Background thread handler (#14088)
  */
 
+/**
+ * Escape HTML-sensitive characters so raw user input is rendered as text
+ * rather than markup (stored XSS guard, issue #16259).
+ */
+export function escapeHtml(value = "") {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Render a small safe subset of markdown (bold, italic, inline code) to HTML.
+ * Input is HTML-escaped first, so any HTML in the source text is displayed
+ * literally instead of being injected into the DOM.
+ */
+export function parseMarkdownToSafeHtml(text = "") {
+  const escaped = escapeHtml(text);
+  return escaped
+    .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.*?)\*/g, "<em>$1</em>")
+    .replace(/`(.*?)`/g, "<code>$1</code>");
+}
+
 export function createMarkdownParserWorkerCode() {
   return `
     self.onmessage = function(e) {
@@ -10,14 +36,12 @@ export function createMarkdownParserWorkerCode() {
         self.postMessage({ html: "" });
         return;
       }
-      
-      // Basic markdown parser mock for worker thread
-      let html = text
-        .replace(/\\*\\*(.*?)\\*\\*/g, '<strong>$1</strong>')
-        .replace(/\\*(.*?)\\*/g, '<em>$1</em>')
-        .replace(/\`(.*?)\`/g, '<code>$1</code>');
 
-      self.postMessage({ html });
+      const parseMarkdownToSafeHtml = ${parseMarkdownToSafeHtml.toString()};
+      const escapeHtml = ${escapeHtml.toString()};
+
+      self.postMessage({ html: parseMarkdownToSafeHtml(text) });
     };
   `;
 }
+


### PR DESCRIPTION
## Problem
`LiveChatMarkdownParser` renders chat messages through `dangerouslySetInnerHTML` with HTML built by naive regex string replacement in `markdownParserWorker.js`. Raw user content is never HTML-escaped, so a message such as `<img src=x onerror=alert(1)>` or `<script>...</script>` is injected verbatim into the DOM (stored XSS). The same flaw exists in the synchronous fallback paths in `LiveChatMarkdownParser.js`, which set `parsedHtml` directly to the raw input.

## Fix
- Added `escapeHtml()` and `parseMarkdownToSafeHtml()` to `markdownParserWorker.js`.
- `parseMarkdownToSafeHtml` HTML-escapes the source text before applying the bold/italic/inline-code markdown replacements, so HTML entered by users is displayed literally instead of executed. The worker thread embeds both helpers (via `.toString()`) so worker-rendered output is equally sanitized.
- The no-`Worker` and catch-block fallback paths in `LiveChatMarkdownParser.js` now route through `parseMarkdownToSafeHtml()` instead of dumping the raw string into the DOM.

## Files changed
- `src/components/chat/markdownParserWorker.js`
- `src/components/chat/LiveChatMarkdownParser.js`

## Testing
- `node --test tests/markdownParser.test.mjs` — 2/2 passing.
- `node --check` on `markdownParserWorker.js` — clean.
- Verified `parseMarkdownToSafeHtml` output: `**Hi <script>alert(1)</script>**` → `<strong>Hi &lt;script&gt;alert(1)&lt;/script&gt;</strong>`; `<img src=x onerror=alert(1)>` → escaped text; bold/italic/code markdown still render.

Closes #16259
