### PR TITLE
debounceUtils: maxWait fires with the first call's args but resolves the latest caller's promise

### DIFF
--- a/src/utils/debounceUtils.js
+++ b/src/utils/debounceUtils.js
@@ -62,6 +62,7 @@ export const debounceAsync = (asyncFn, delay = 500, options = {}) => {
   let pendingResolve = null;
   let activeAbortController = null;
   let lastCallTime = null;
+  let latestArgs = null;
 
   const cancelPending = () => {
     if (timeoutId) {
@@ -123,6 +124,7 @@ export const debounceAsync = (asyncFn, delay = 500, options = {}) => {
   const debounced = (...args) => {
     const isFirstCall = timeoutId === null;
     cancelPending();
+    latestArgs = args;
 
     return new Promise((resolve, reject) => {
       pendingResolve = resolve;
@@ -130,13 +132,13 @@ export const debounceAsync = (asyncFn, delay = 500, options = {}) => {
       lastCallTime = Date.now();
 
       if (leading && isFirstCall) {
-        execute(args, resolve, reject);
+        execute(latestArgs, resolve, reject);
         return;
       }
 
       timeoutId = setTimeout(() => {
         timeoutId = null;
-        execute(args, resolve, reject);
+        execute(latestArgs, resolve, reject);
       }, delay);
 
       if (maxWait && !maxWaitTimeoutId) {
@@ -145,7 +147,7 @@ export const debounceAsync = (asyncFn, delay = 500, options = {}) => {
           if (timeoutId) {
             clearTimeout(timeoutId);
             timeoutId = null;
-            execute(args, pendingResolve, pendingReject);
+            execute(latestArgs, pendingResolve, pendingReject);
           }
         }, maxWait);
       }

--- a/tests/debounceAsync.test.mjs
+++ b/tests/debounceAsync.test.mjs
@@ -59,6 +59,28 @@ try {
 }
 assert.strictEqual(errorThrown, true, "Error should propagate");
 
+// Test maxWait executes with the latest arguments and resolves the latest caller's promise
+const maxWaitCalls = [];
+const maxWaitDebounced = debounceAsync(async (value) => {
+  maxWaitCalls.push(value);
+  await delay(5);
+  return `maxwait:${value}`;
+}, 500, { maxWait: 40 });
+
+const supersededMaxWait = maxWaitDebounced("first");
+supersededMaxWait.catch(() => {});
+const maxWaitResult = await maxWaitDebounced("second");
+assert.strictEqual(
+  maxWaitResult,
+  "maxwait:second",
+  "maxWait execution should use the latest args and resolve the latest caller",
+);
+assert.deepEqual(
+  maxWaitCalls,
+  ["second"],
+  "maxWait should execute exactly once with the latest args",
+);
+
 // Test createDebouncedValidator returns cancelled flag for superseded calls
 const validator = createDebouncedValidator(async (value) => {
   await delay(10);


### PR DESCRIPTION
## Problem

In `debounceAsync` (`src/utils/debounceUtils.js`), the `maxWait` timeout callback executed `asyncFn` with the `args` captured by the invocation that started `maxWaitTimeoutId` (the first call of the window) while resolving/rejecting the **latest** caller's `pendingResolve`/`pendingReject`. When rapid calls updated the pending promises but the executed request still used the first call's args, the executed input and the resolved output disagreed.

## Fix

- Introduced a `latestArgs` reference that is updated on every `debounced(...)` call and is used by the `maxWait` execution (as well as the regular timeout and leading paths), so `maxWait` always executes with the most recent arguments and settles the latest caller's promise consistently.
- Added a test to `tests/debounceAsync.test.mjs` that calls the debounced fn twice within `maxWait` with different args and asserts the executed fn received the second args and the resolved value corresponds to the latest call.

## Files changed

- `src/utils/debounceUtils.js`
- `tests/debounceAsync.test.mjs`

## Testing

- `node --check src/utils/debounceUtils.js` — passes.
- `node --import ./tests/setup.js --test tests/debounceAsync.test.mjs` — passes, including the new maxWait regression test.
- `node --import ./tests/setup.js --test tests/debounceUtils.test.mjs` — passes (no regressions).

Closes #16210
