### PR TITLE
[MEDIUM] eventDefaults: initialFormData is a shared singleton and todayString is stale (contrary to comments)

### DIFF
--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -46,7 +46,7 @@ const EventCreation = () => {
   const location = useLocation();
 
   const [currentStep, setCurrentStep] = useState(CREATION_STEPS.FORM);
-  const [formData, setFormData] = useState(initialFormData);
+  const [formData, setFormData] = useState(initialFormData());
   const [errors, setErrors] = useState({});
   const [newTag, setNewTag] = useState("");
   const [isDraftLoaded, setIsDraftLoaded] = useState(false);
@@ -341,7 +341,7 @@ const EventCreation = () => {
   }, [formData]);
 
   const resetForm = () => {
-    setFormData(initialFormData);
+    setFormData(initialFormData());
     setErrors({});
     localStorage.removeItem(DRAFT_KEY);
     setNewTag("");
@@ -504,7 +504,7 @@ const EventCreation = () => {
                 handleInputChange={handleInputChange}
                 errors={errors}
                 prefersReducedMotion={prefersReducedMotion}
-                todayString={todayString}
+                todayString={todayString()}
               />
               {/* Event Duration Type */}
               <motion.div
@@ -587,7 +587,7 @@ const EventCreation = () => {
                       name="startDate"
                       value={formData.startDate}
                       onChange={handleInputChange}
-                      min={todayString}
+                      min={todayString()}
                       className={`w-full border ${
                         errors.startDate ? "border-red-500" : "border-gray-300 dark:border-gray-600"
                       } rounded-lg p-3 text-gray-700 dark:text-white bg-white dark:bg-gray-700`}
@@ -607,7 +607,7 @@ const EventCreation = () => {
                       name="endDate"
                       value={formData.endDate}
                       onChange={handleInputChange}
-                      min={formData.startDate || todayString}
+                      min={formData.startDate || todayString()}
                       className={`w-full border ${
                         errors.endDate ? "border-red-500" : "border-gray-300 dark:border-gray-600"
                       } rounded-lg p-3 text-gray-700 dark:text-white bg-white dark:bg-gray-700`}
@@ -677,7 +677,7 @@ const EventCreation = () => {
                       name="date"
                       value={formData.date}
                       onChange={handleInputChange}
-                      min={todayString}
+                      min={todayString()}
                       className={`w-full border ${
                         errors.date ? "border-red-500" : "border-gray-300 dark:border-gray-600"
                       } rounded-lg p-3 text-gray-700 dark:text-white bg-white dark:bg-gray-700`}

--- a/src/constants/eventDefaults.js
+++ b/src/constants/eventDefaults.js
@@ -90,12 +90,15 @@ export const getInitialFormData = () => ({
   bannerPreview: null,
 });
 
-// Backward-compatible alias for existing callers - each access returns a new copy
-export const initialFormData = getInitialFormData();
+// Backward-compatible factory - each call returns a fresh copy
+export const getInitialFormDataSnapshot = () => getInitialFormData();
+
+// Backward-compatible alias - callers use initialFormData()
+export const initialFormData = () => getInitialFormData();
 
 // Computed on every call so date validations stay accurate across midnight
 // on long-running sessions without a page refresh.
 export const getTodayString = () => new Date().toISOString().split("T")[0];
 
-// Backward-compatible alias - evaluates fresh on access via getter
-export const todayString = getTodayString();
+// Backward-compatible alias - callers use todayString()
+export const todayString = () => getTodayString();

--- a/src/hooks/useEventForm.js
+++ b/src/hooks/useEventForm.js
@@ -668,14 +668,15 @@ export const useEventForm = () => {
   }, [discardDraft]);
 
   const hasUnsavedChanges = useMemo(() => {
+    const baseline = initialFormData();
     return Object.entries(formData).some(([key, value]) => {
       if (["banner", "bannerPreview"].includes(key)) return false;
-      if (typeof value === "string") return value.trim() !== (initialFormData[key] || "");
+      if (typeof value === "string") return value.trim() !== (baseline[key] || "");
       if (Array.isArray(value)) return value.length > 0;
       if (typeof value === "object" && value !== null) {
-        return JSON.stringify(value) !== JSON.stringify(initialFormData[key] || {});
+        return JSON.stringify(value) !== JSON.stringify(baseline[key] || {});
       }
-      return Boolean(value) !== Boolean(initialFormData[key]);
+      return Boolean(value) !== Boolean(baseline[key]);
     });
   }, [formData]);
 


### PR DESCRIPTION
## Problem

`eventDefaults.js` exports `initialFormData` and `todayString` as values computed once at module load, contradicting their comments. `initialFormData` is a shared mutable singleton: a caller that mutates the returned object corrupts the template for every subsequent form session (used as the pristine dirty-check baseline in `useEventForm`). `todayString` is frozen at the module-evaluation date, so date-min/comparison logic can use a stale "today".

## Fix

- `initialFormData` and `todayString` are now factories (`initialFormData()`, `todayString()`) so each access returns a fresh value; added `getInitialFormDataSnapshot()` alias.
- Updated all consumers to call them:
  - `src/components/common/EventCreation/EventCreation.jsx`: `useState(initialFormData())`, `setFormData(initialFormData())`, `todayString={todayString()}`, `min={todayString()}`.
  - `src/hooks/useEventForm.js`: dirty-check baseline now built from `initialFormData()`.

## Files changed

- `src/constants/eventDefaults.js`
- `src/hooks/useEventForm.js`
- `src/components/common/EventCreation/EventCreation.jsx`

## Testing

- `node --check` on `eventDefaults.js` and `useEventForm.js` passed.
- Parsed all changed files with esbuild (`transformSync`) — all OK.
- Inline `node -e` check importing `eventDefaults.js`:
  - Two `initialFormData()` calls return different references; mutating one does not affect the other.
  - `getInitialFormDataSnapshot()` returns a fresh object per call.
  - `todayString()` returns a string for the current date.

Closes #16495
