### PR TITLE
[HIGH] eventVisibilityFilter: organiserId (British) vs organizerId breaks owner visibility and cancellation emails

### DIFF
--- a/src/utils/eventCancellationNotifications.js
+++ b/src/utils/eventCancellationNotifications.js
@@ -21,7 +21,7 @@ class EventCancellationNotificationService {
    * Validate that event has essential data for notifications
    */
   validateEventData(event) {
-    const requiredFields = ['id', 'title', 'organiserId'];
+    const requiredFields = ['id', 'title', 'organizerId'];
     const missingFields = requiredFields.filter(field => !event[field]);
 
     if (missingFields.length > 0) {

--- a/src/utils/eventVisibilityFilter.js
+++ b/src/utils/eventVisibilityFilter.js
@@ -48,12 +48,12 @@ class EventVisibilityFilter {
 
     // Organizer-only events visible only to creator
     if (ORGANIZER_STATUSES.includes(event.status)) {
-      return isAuthenticated && currentUserId === event.organiserId;
+      return isAuthenticated && currentUserId === event.organizerId;
     }
 
     // Cancelled events visible only to organizer
     if (event.status === EVENT_STATUS.CANCELLED) {
-      return isAuthenticated && currentUserId === event.organiserId;
+      return isAuthenticated && currentUserId === event.organizerId;
     }
 
     return false;
@@ -113,7 +113,7 @@ class EventVisibilityFilter {
     if (!isAuthenticated) {
       return `${status} - hidden from unauthenticated users`;
     }
-    if (currentUserId === event.organiserId) {
+    if (currentUserId === event.organizerId) {
       return `${status} - visible to organizer`;
     }
     return `${status} - hidden from other users`;


### PR DESCRIPTION
## Problem

`eventVisibilityFilter.js` compared the current user id against `event.organiserId` (British spelling) at three sites, while the rest of the codebase uses `organizerId` (American spelling). The data model uses `organizerId`, so `event.organiserId` was always `undefined`. Result:

- `canViewEvent()` returned `false` for every DRAFT/ARCHIVED/CANCELLED event, so organizers could never see their own non-public events.
- `validateEventData` always threw `"Event missing required fields: organiserId"`, so `handleEventCancellation`/`notifyAllAttendees` threw before any cancellation email was sent — no cancellation emails ever went out.

## Fix

Corrected the property name to `organizerId` at all four sites:

- `src/utils/eventVisibilityFilter.js:51` — `canViewEvent` DRAFT/ARCHIVED check
- `src/utils/eventVisibilityFilter.js:56` — `canViewEvent` CANCELLED check
- `src/utils/eventVisibilityFilter.js:116` — `describeOrganizerOnlyVisibility`
- `src/utils/eventCancellationNotifications.js:24` — `requiredFields` array

A repo-wide grep confirms no `organiserId` occurrences remain in `src/`.

## Files changed

- src/utils/eventVisibilityFilter.js
- src/utils/eventCancellationNotifications.js

## Testing

- `node --check` on both files: passed (exit 0).
- Ran `node --import ./tests/setup.js --test tests/eventVisibilityFilter.test.mjs tests/eventCancellationNotifications.test.mjs`: 2 tests passed, 0 failed (these suites use self-contained mocks that mirror the implementations).
- Grep for `organiserId` in `src/`: no matches.

Closes #16487
