### PR TITLE
Check-in succeeds for unpaid/PENDING registrations; QrCodeValidationService is never invoked

### DIFF
--- a/Backend/src/main/java/com/eventra/service/QrCodeValidationService.java
+++ b/Backend/src/main/java/com/eventra/service/QrCodeValidationService.java
@@ -48,18 +48,9 @@ public class QrCodeValidationService {
                     paymentPlanRepository.findByRegistration_Id(registrationId);
             
             if (paymentPlanOptional.isPresent()) {
-                com.sandeep.eventrabackend.model.PaymentPlan paymentPlan = paymentPlanOptional.get();
-                
-                // If payment plan exists and is not completed, QR code is not activated
-                if (!paymentPlan.isQRCodeActivated() && paymentPlan.isActive()) {
-                    return new QrValidationResult(false, QrValidationStatus.PAYMENT_PENDING, 
-                            "❌ QR code not activated. Payment installments must be completed before QR code activation.");
-                }
-                
-                // Check if there are pending payments
-                if (paymentPlan.isActive() && !paymentPlan.isCompleted()) {
-                    return new QrValidationResult(false, QrValidationStatus.PAYMENT_INCOMPLETE, 
-                            "❌ Payment is incomplete. QR code activates after final installment is paid.");
+                QrValidationResult paymentResult = paymentGate(paymentPlanOptional.get());
+                if (paymentResult != null) {
+                    return paymentResult;
                 }
             }
         }
@@ -85,22 +76,32 @@ public class QrCodeValidationService {
                 paymentPlanRepository.findByRegistration_Id(registrationId);
         
         if (paymentPlanOptional.isPresent()) {
-            com.sandeep.eventrabackend.model.PaymentPlan paymentPlan = paymentPlanOptional.get();
-            
-            // If payment plan exists and is not completed, QR code is not activated
-            if (!paymentPlan.isQRCodeActivated()) {
-                return new QrValidationResult(false, QrValidationStatus.PAYMENT_PENDING, 
-                        "❌ QR code not activated. Payment installments must be completed before QR code activation.");
-            }
-            
-            // Check if there are pending payments
-            if (paymentPlan.isActive() && !paymentPlan.isCompleted()) {
-                return new QrValidationResult(false, QrValidationStatus.PAYMENT_INCOMPLETE, 
-                        "❌ Payment is incomplete. QR code activates after final installment is paid.");
+            QrValidationResult paymentResult = paymentGate(paymentPlanOptional.get());
+            if (paymentResult != null) {
+                return paymentResult;
             }
         }
 
         return new QrValidationResult(true, QrValidationStatus.VALID, "✅ QR Code verified successfully.");
+    }
+
+    private QrValidationResult paymentGate(com.sandeep.eventrabackend.model.PaymentPlan paymentPlan) {
+        if (paymentPlan.isCancelled() || paymentPlan.isFailed()) {
+            return new QrValidationResult(false, QrValidationStatus.CANCELLED_REGISTRATION,
+                    "❌ Payment plan was cancelled. Registration is no longer valid.");
+        }
+
+        if (!paymentPlan.isQRCodeActivated() && paymentPlan.isActive()) {
+            return new QrValidationResult(false, QrValidationStatus.PAYMENT_PENDING,
+                    "❌ QR code not activated. Payment installments must be completed before QR code activation.");
+        }
+
+        if (paymentPlan.isActive() && !paymentPlan.isCompleted()) {
+            return new QrValidationResult(false, QrValidationStatus.PAYMENT_INCOMPLETE,
+                    "❌ Payment is incomplete. QR code activates after final installment is paid.");
+        }
+
+        return null;
     }
 
     public boolean isQRCodeActivatedForRegistration(Long registrationId) {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.eventra.service.QrCodeValidationService;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
 import com.sandeep.eventrabackend.model.TicketCheckIn;
@@ -44,6 +45,7 @@ public class TicketController {
     private final EventRegistrationRepository eventRegistrationRepository;
     private final EventRepository eventRepository;
     private final TicketCheckInRepository ticketCheckInRepository;
+    private final QrCodeValidationService qrCodeValidationService;
 
     @PostMapping("/validate")
     @Operation(summary = "Validate a ticket",
@@ -88,6 +90,12 @@ public class TicketController {
         boolean alreadyCheckedIn =
                 ticketCheckInRepository.existsByEventIdAndRegistrationId(eventId, registrationId);
 
+        QrCodeValidationService.QrValidationResult qrResult = qrCodeValidationService
+                .validateQrCodeWithRegistrationId(registrationId, reg.getStatus(), event.getStatus(), null);
+        if (!qrResult.isValid()) {
+            return ResponseEntity.ok(result(false, displayName(reg), registrationId, alreadyCheckedIn, qrResult.message()));
+        }
+
         return ResponseEntity.ok(result(true, displayName(reg), registrationId, alreadyCheckedIn,
                 alreadyCheckedIn ? "This ticket has already been checked in." : "Ticket is valid"));
     }
@@ -131,6 +139,14 @@ public class TicketController {
         if ("CANCELLED".equals(event.getStatus()) || "COMPLETED".equals(event.getStatus())) {
             return ResponseEntity.ok(result(false, null, registrationId, false,
                     "Event status does not allow check-in."));
+        }
+
+        QrCodeValidationService.QrValidationResult qrResult = qrCodeValidationService
+                .validateQrCodeWithRegistrationId(registrationId, reg.getStatus(), event.getStatus(), null);
+        if (!qrResult.isValid()) {
+            return ResponseEntity.ok(result(false, displayName(reg), registrationId,
+                    ticketCheckInRepository.existsByEventIdAndRegistrationId(eventId, registrationId),
+                    qrResult.message()));
         }
 
         if (ticketCheckInRepository.existsByEventIdAndRegistrationId(eventId, registrationId)) {

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -487,6 +487,7 @@ public class PaymentPlanService {
         
         // Update registration
         registration.setPaymentStatus("COMPLETED");
+        registration.setStatus("CONFIRMED");
         registration.setQrActivated(true);
         registration.setQrActivationDate(LocalDateTime.now());
         eventRegistrationRepository.save(registration);
@@ -552,6 +553,7 @@ public class PaymentPlanService {
         
         // Update registration
         registration.setPaymentStatus("CANCELLED");
+        registration.setStatus("CANCELLED");
         registration.setQrActivated(false);
         eventRegistrationRepository.save(registration);
         


### PR DESCRIPTION
## Problem

The ticket check-in gate only validates `reg.getStatus() == "CONFIRMED"` and the event status. It never verifies payment completion or QR activation, so registrations that are `PARTIAL`/`PENDING`/`CANCELLED` on payment are still admitted at the venue. The elaborate `QrCodeValidationService` (which enforces payment completion and QR activation) has zero call sites, so the payment-to-ticket gating is entirely bypassed. Additionally, a cancelled/failed payment plan fell through both validation overloads and returned `VALID`.

## Fix

- Wired `QrCodeValidationService` into `TicketController.validateTicket` and `TicketController.checkIn`; both endpoints now run `validateQrCodeWithRegistrationId` and reject the ticket when payment is not completed or the QR is not activated.
- Unified the payment-gate logic in `QrCodeValidationService`: both overloads now share a single `paymentGate` helper that explicitly rejects `CANCELLED`/`FAILED` payment plans (previously they fell through to `VALID`) and apply the same `PAYMENT_PENDING`/`PAYMENT_INCOMPLETE` rules.
- Reflected payment state into `registration.status` so the existing `CONFIRMED` check is also correct: `PaymentPlanService.cancelPaymentPlan` now sets `registration.status = "CANCELLED"`, and `markPaymentPlanAsCompleted` sets `registration.status = "CONFIRMED"`.

## Files changed

- Backend/src/main/java/com/eventra/service/QrCodeValidationService.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
- Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java

## Testing

- Applied the temporary EmailSender.java string patch and ran `mvn -q compile` from `Backend`. `QrCodeValidationService.java`, `PaymentPlanService.java`, and `TicketController.java` compile with no errors.
- Temporary EmailSender patch reverted before committing.

Closes #16510
