### PR TITLE
[MEDIUM] multiTrackScheduleUtils: averageUtilization is missing the *100 scale factor (100x mismatch with overallUtilization)

### DIFF
--- a/src/utils/multiTrackScheduleUtils.js
+++ b/src/utils/multiTrackScheduleUtils.js
@@ -324,11 +324,12 @@ export const calculateTrackUtilization = (sessions, tracks, eventStart, eventEnd
     totalUsedMinutes += usedMinutes;
   });
 
+  const ratio = totalUsedMinutes / (totalEventMinutes * tracks.length);
   return {
     trackUtilization,
-    overallUtilization: ((totalUsedMinutes / (totalEventMinutes * tracks.length)) * 100).toFixed(2) + '%',
+    overallUtilization: (ratio * 100).toFixed(2) + '%',
     totalSessionMinutes: totalUsedMinutes,
-    averageUtilization: (totalUsedMinutes / (totalEventMinutes * tracks.length)).toFixed(2),
+    averageUtilization: Number((ratio * 100).toFixed(2)),
   };
 };
 


### PR DESCRIPTION
## Problem

`calculateTrackUtilization` (referred to in the issue as `calculateScheduleUtilization`) returns `overallUtilization` as a percentage string (`"42.00%"`) but `averageUtilization` as a raw fraction (`0.42`) — a 100× mismatch on a field labeled as a percentage.

## Fix

Computed the shared ratio once and applied the `* 100` scale factor to both outputs: `overallUtilization` keeps its `"X.XX%"` string form while `averageUtilization` now returns `Number((ratio * 100).toFixed(2))`, putting both on the same percentage scale.

## Files changed

- `src/utils/multiTrackScheduleUtils.js`

## Testing

- `node --check src/utils/multiTrackScheduleUtils.js` passed.
- Inline `node -e` check: with 1 track-hour used across 2 tracks over a 4-hour window, result was `overall: "12.50%"`, `avg: 12.5` (consistent percentage scale).

Closes #16496
