### PR TITLE
[MEDIUM] budgetCalculatorUtils: validateBudgetInput accepts garbage/non-numeric input (coerced to 0)

### DIFF
--- a/src/utils/budgetCalculatorUtils.js
+++ b/src/utils/budgetCalculatorUtils.js
@@ -119,9 +119,12 @@ export const validateBudgetInput = (budget = {}) => {
     "participants",
   ];
 
-  return fields.every(
-    (field) => toNumber(budget[field]) >= 0
-  );
+  return fields.every((field) => {
+    const raw = budget[field];
+    if (raw === "" || raw === null || raw === undefined) return false;
+    const num = Number(raw);
+    return Number.isFinite(num) && num >= 0;
+  });
 };
 
 /**


### PR DESCRIPTION
## Problem

`validateBudgetInput`'s predicate `toNumber(budget[field]) >= 0` coerces any non-finite value (`"abc"`, `"100x"`, `NaN`, `null`) to `0`, so garbage input passes validation and gets recorded as `0`. Verified: `validateBudgetInput({ venue: "abc", participants: "xyz" })` returns `true`.

## Fix

Rewrote the predicate to validate the raw value instead of the coerced number: empty/null/undefined fields are rejected as required, and any field is accepted only when `Number(raw)` is finite and `>= 0`. Non-numeric strings are now rejected.

## Files changed

- `src/utils/budgetCalculatorUtils.js`

## Testing

- `node --check src/utils/budgetCalculatorUtils.js` passed.
- Inline `node -e` checks:
  - `validateBudgetInput({ venue: "abc", ...rest 0 })` → `false`
  - fully numeric valid budget → `true`
  - `-100` in any field → `false`
  - `{}` → `false`

Closes #16497
