### PR TITLE
fix: make Q&A upvote updates atomic

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java
@@ -56,10 +56,8 @@ public class QAStreamController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         if (!q.addVoter(authentication.getName())) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .build();
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
-        q.setUpvotes(q.getUpvotes() + 1);
         return ResponseEntity.ok(q);
     }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/SessionQuestion.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/SessionQuestion.java
@@ -3,15 +3,16 @@ package com.sandeep.eventrabackend.model;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SessionQuestion {
     private String id;
     private String sessionId;
     private String authorName;
     private String questionText;
-    private int upvotes;
-    private boolean isPinned;
-    private boolean isAnswered;
+    private final AtomicInteger upvotes = new AtomicInteger(0);
+    private volatile boolean isPinned;
+    private volatile boolean isAnswered;
     private LocalDateTime createdAt;
     private final Set<String> voterKeys = ConcurrentHashMap.newKeySet();
 
@@ -24,7 +25,7 @@ public class SessionQuestion {
         this.sessionId = sessionId;
         this.authorName = authorName;
         this.questionText = questionText;
-        this.upvotes = 1;
+        this.upvotes.set(1);
         this.isPinned = false;
         this.isAnswered = false;
         this.createdAt = LocalDateTime.now();
@@ -35,7 +36,19 @@ public class SessionQuestion {
     }
 
     public boolean addVoter(String voterKey) {
-        return voterKeys.add(voterKey);
+        boolean added = voterKeys.add(voterKey);
+        if (added) {
+            upvotes.incrementAndGet();
+        }
+        return added;
+    }
+
+    public int removeVoter(String voterKey) {
+        boolean removed = voterKeys.remove(voterKey);
+        if (removed) {
+            return upvotes.decrementAndGet();
+        }
+        return upvotes.get();
     }
 
     // Getters and Setters
@@ -51,8 +64,8 @@ public class SessionQuestion {
     public String getQuestionText() { return questionText; }
     public void setQuestionText(String questionText) { this.questionText = questionText; }
 
-    public int getUpvotes() { return upvotes; }
-    public void setUpvotes(int upvotes) { this.upvotes = upvotes; }
+    public int getUpvotes() { return upvotes.get(); }
+    public void setUpvotes(int upvotes) { this.upvotes.set(upvotes); }
 
     public boolean isPinned() { return isPinned; }
     public void setPinned(boolean pinned) { isPinned = pinned; }


### PR DESCRIPTION
## Summary

Fixes #16665

- Make Q&A upvote counting safe under concurrent requests.
- Use an atomic counter for upvote updates.
- Increment the counter only when a new voter is successfully recorded.
- Prevent lost upvote counts caused by concurrent read-modify-write operations.

## Root Cause

The previous implementation updated the upvote count using a non-atomic read-modify-write operation:

`getUpvotes() + 1`

When multiple requests arrived concurrently, they could read the same previous value and overwrite each other's updates.

## Fix

The upvote count now uses `AtomicInteger`.

`addVoter()` also checks whether the voter was actually added before incrementing the counter.

This ensures that:

- Each unique voter increments the count exactly once.
- Concurrent upvotes do not overwrite each other.
- Duplicate votes do not increase the counter.

## Expected Behavior

Each successful unique voter should increase the Q&A upvote count exactly once, including when multiple users vote concurrently.

## Testing

- Reviewed the atomic upvote update logic.
- Ran `git diff --check`.
- Kept unrelated changes out of the PR.