### PR TITLE
fix: restrict test email endpoint access

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -177,9 +177,10 @@ public class NotificationController {
     }
 
     @PostMapping("/send-test-email")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     @Operation(
             summary = "Send a test email to organizer",
-            description = "Sends a test email with the provided template to the organizer's email address for preview purposes.",
+            description = "Sends a test email with the provided template to the organizer's email address for preview purposes. Only organizers and administrators can use this endpoint.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
@@ -197,7 +198,7 @@ public class NotificationController {
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "Forbidden - User does not have permission"
+                    description = "Forbidden - User does not have organizer or admin privileges"
             )
     })
     public ResponseEntity<TestEmailResponse> sendTestEmail(


### PR DESCRIPTION
## Summary

Fixes #16669

- Restrict the test email endpoint to authorized roles.
- Prevent regular or unauthorized users from sending arbitrary test emails.
- Protect the application's configured mail infrastructure from unauthorized use.

## Root Cause

The `/test-email` endpoint accepted a `TestEmailRequest` containing a recipient
address without enforcing an explicit authorization requirement.

This could allow unauthorized users to specify arbitrary recipient addresses.

## Fix

Added method-level authorization using `@PreAuthorize` to restrict the
endpoint to:

- ORGANIZER
- ADMIN
- SUPER_ADMIN

Unauthorized users will be rejected before the endpoint executes.

## Expected Behavior

Only authorized organizer and administrator roles can access the test email
functionality.

Regular users cannot specify arbitrary recipient addresses.

## Testing

- Verified the authorization annotation on the test email endpoint.
- Ran `git diff --check`.
- Kept unrelated changes out of this PR.