### PR TITLE
fix: preserve zkp nullifier on feedback persistence failure

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ZkpFeedbackController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ZkpFeedbackController.java
@@ -37,15 +37,11 @@ public class ZkpFeedbackController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
         }
 
-        boolean nullifierRecorded = zkpVerifierService.markNullifierUsed(payload.getEventId(), payload.getNullifierHash());
-        if (!nullifierRecorded) {
-            response.put("success", false);
-            response.put("message", "This proof has already been used. Each nullifier can only be submitted once.");
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
-        }
-
+        // Save feedback first, then mark nullifier as used to prevent nullifier
+        // consumption on failed feedback persistence.
+        ZkpFeedback savedFeedback = null;
         try {
-            zkpFeedbackRepository.save(new ZkpFeedback(
+            savedFeedback = zkpFeedbackRepository.save(new ZkpFeedback(
                     Long.valueOf(payload.getEventId()),
                     payload.getNullifierHash(),
                     payload.getFeedbackCategory(),
@@ -55,6 +51,17 @@ public class ZkpFeedbackController {
             response.put("success", false);
             response.put("message", "Failed to persist anonymous feedback. Please try again.");
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        }
+
+        boolean nullifierRecorded = zkpVerifierService.markNullifierUsed(payload.getEventId(), payload.getNullifierHash());
+        if (!nullifierRecorded) {
+            // Nullifier was already consumed (race condition) - roll back the saved feedback
+            if (savedFeedback != null) {
+                zkpFeedbackRepository.delete(savedFeedback);
+            }
+            response.put("success", false);
+            response.put("message", "This proof has already been used. Each nullifier can only be submitted once.");
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
         }
 
         response.put("success", true);


### PR DESCRIPTION
## Summary

Fixes #16670

- Persist anonymous feedback before permanently consuming the ZKP nullifier.
- Prevent a failed feedback save from leaving the nullifier consumed.
- Handle feedback persistence failures without permanently blocking valid retries.

## Root Cause

The anonymous feedback flow marked the ZKP nullifier as used before
successfully persisting the corresponding feedback record.

If the database save failed after the nullifier was consumed, the same
valid anonymous feedback submission could not be retried because the
nullifier was already considered used.

## Fix

- Save the feedback record before completing nullifier consumption.
- If persistence fails after the feedback record is created, remove the
  saved feedback record so the operation does not leave inconsistent state.
- Return an appropriate error response when persistence fails.

## Expected Behavior

A valid anonymous feedback submission should not permanently consume its
ZKP nullifier when the corresponding feedback cannot be persisted.

## Testing

- Verified the changed controller logic.
- Ran `git diff --check`.
- Ensured unrelated changes are not included in the commit.