### PR TITLE
fix(navbar): remove duplicate role prop in NavbarLinks (#11832)

### DIFF
--- a/src/components/navbar/NavbarLinks.jsx
+++ b/src/components/navbar/NavbarLinks.jsx
@@ -181,11 +181,10 @@ useEffect(() => {
               {/* Dropdown / Submenu */}
               {(vertical || isOpen) && (
                 <div
-                ref={(el) => (menuRefs.current[item.nameKey] = el)}
+                  ref={(el) => (menuRefs.current[item.nameKey] = el)}
                   id={menuId}
                   role="menu"
                   aria-labelledby={`${menuId}-button`}
-                  role="menu"
                   className={
                     vertical
                       ? "mt-1 ml-6 space-y-1"


### PR DESCRIPTION
## Description

This PR fixes a JSX error caused by duplicate `role="menu"` attributes on the submenu container `div` element inside `src/components/navbar/NavbarLinks.jsx`. The redundant attribute has been removed to resolve linter/compiler errors while keeping all dropdown keyboard navigation and accessibility attributes intact.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #11832

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

*N/A - Non-visual code fix.*

## Additional Notes

- Verified with `node tests/navbar.keyboard.test.mjs` (4/4 passed).
