### PR TITLE
fix(jsx): escape unescaped apostrophes in UnifiedLoyaltyProgram.jsx

### DIFF
--- a/src/components/events/UnifiedLoyaltyProgram.jsx
+++ b/src/components/events/UnifiedLoyaltyProgram.jsx
@@ -155,10 +155,10 @@ const UnifiedLoyaltyProgram = () => {
                   <p className="text-xs text-slate-500 font-bold uppercase tracking-wider mb-2">THEN Action (Execution)</p>
                   <div className="space-y-2">
                     <p className="font-mono text-sm text-emerald-700 font-bold bg-emerald-50 p-2 rounded">
-                      Email.SendTemplate('VIP_Discount_25')
+                      Email.SendTemplate(&apos;VIP_Discount_25&apos;)
                     </p>
                     <p className="font-mono text-sm text-emerald-700 font-bold bg-emerald-50 p-2 rounded">
-                      Attendee.Tags.Add('VIP')
+                      Attendee.Tags.Add(&apos;VIP&apos;)
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Description

This PR resolves ESLint `react/no-unescaped-entities` errors in `src/components/events/UnifiedLoyaltyProgram.jsx` by replacing unescaped single quotes (`'`) in JSX text nodes with HTML entities (`&apos;`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Fixes #11829

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

None.
