### PR TITLE
fix: make TeamWorkspaceSync service and controller compile (#16476)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
@@ -54,29 +54,3 @@ public class TeamWorkspaceSyncController {
         return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
     }
 }
-
-    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(
-            @RequestParam(required = false) String roomKey,
-            @RequestParam(required = false) String hackathonId,
-            @RequestParam(required = false) String teamId) {
-        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
-        teamWorkspaceSyncService.requireReadAccess(resolved);
-        return teamWorkspaceSyncService.subscribe(resolved);
-    }
-
-    @PostMapping
-    public ResponseEntity<Map<String, Object>> pollOrUpdate(
-            @RequestParam(required = false) String roomKey,
-            @RequestParam(required = false) String hackathonId,
-            @RequestParam(required = false) String teamId,
-            @RequestBody(required = false) Map<String, Object> body) {
-        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
-        if (body == null || body.isEmpty()) {
-            teamWorkspaceSyncService.requireReadAccess(resolved);
-            return ResponseEntity.ok(teamWorkspaceSyncService.snapshot(resolved));
-        }
-        teamWorkspaceSyncService.requireWriteAccess(resolved);
-        return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
-    }
-}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
@@ -29,6 +29,9 @@ public class TeamWorkspaceSyncService {
     private static final Pattern HACKATHON_ROOM_KEY =
             Pattern.compile("^hackathon:(\\d+)(?::team:.*)?$");
 
+    private static final String HACKATHON_ROOM_PREFIX = "hackathon:";
+    private static final String USER_ROOM_PREFIX = "user:";
+
     private static final class WorkspaceState {
         private final Object lock = new Object();
         private List<Map<String, Object>> tasks = new ArrayList<>();

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
@@ -1,10 +1,15 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
+import com.sandeep.eventrabackend.repository.HackathonRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -23,12 +28,6 @@ public class TeamWorkspaceSyncService {
 
     private static final Pattern HACKATHON_ROOM_KEY =
             Pattern.compile("^hackathon:(\\d+)(?::team:.*)?$");
-
-    private final HackathonRegistrationRepository hackathonRegistrationRepository;
-
-    public TeamWorkspaceSyncService(HackathonRegistrationRepository hackathonRegistrationRepository) {
-        this.hackathonRegistrationRepository = hackathonRegistrationRepository;
-    }
 
     private static final class WorkspaceState {
         private final Object lock = new Object();
@@ -163,14 +162,6 @@ public class TeamWorkspaceSyncService {
         } catch (NumberFormatException ex) {
             return null;
         }
-    }
-        if (StringUtils.hasText(hackathonId) && StringUtils.hasText(teamId)) {
-            return "hackathon:" + hackathonId.trim() + ":team:" + teamId.trim();
-        }
-        if (StringUtils.hasText(hackathonId)) {
-            return "hackathon:" + hackathonId.trim();
-        }
-        return "user:" + authenticatedEmail().trim().toLowerCase();
     }
 
     /**


### PR DESCRIPTION
﻿## Problem

Issue #16476: the Team Workspace sync files shipped to the Backend module did not compile. TeamWorkspaceSyncService contained an orphaned duplicate of the esolveRoomKey tail block dangling after extractHackathonId, a second (old) constructor/field pair for HackathonRegistrationRepository, references to HACKATHON_ROOM_PREFIX/USER_ROOM_PREFIX that were never declared, and missing imports for User, Role, UserRepository, HackathonRepository and UsernameNotFoundException. TeamWorkspaceSyncController contained orphaned duplicate esolveRoomKeyForMember endpoint methods that referenced the same missing pieces.

## Fix

- Removed the orphaned duplicate esolveRoomKey tail block and the obsolete duplicate constructor/field.
- Re-declared the two room-key prefix constants (hackathon:, user:) used by the authorization helpers (equireReadAccess, equireWriteAccess, equireOwnUserRoom, parseHackathonId).
- Added the missing imports required by the retained authz methods.
- Removed the orphaned duplicate esolveRoomKeyForMember methods from TeamWorkspaceSyncController.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
- Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java

## Testing

The changed service and controller (with their transitive source dependencies) compile cleanly with javac on JDK 17 + Lombok (exit 0, no errors).

Closes #16476
