### PR TITLE
fix(events): remove invalid jsx attribute from VirtualConciergeChatbot style tag (#11831)

### DIFF
--- a/src/components/events/VirtualConciergeChatbot.jsx
+++ b/src/components/events/VirtualConciergeChatbot.jsx
@@ -167,7 +167,7 @@ const VirtualConciergeChatbot = () => {
         </form>
       </div>
 
-      <style jsx>{`
+      <style>{`
         .hide-scrollbar::-webkit-scrollbar {
           display: none;
         }


### PR DESCRIPTION
## Description

Removed the unsupported `jsx` property from the `<style>` tag in `VirtualConciergeChatbot.jsx`. Standard React DOM style elements do not accept `jsx` as a property, which was triggering an ESLint `react/no-unknown-property` error.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #11831

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

None
