### PR TITLE
fix(events): escape unescaped double quotes in TopicConflictEngine.jsx-#11828

### DIFF
--- a/src/components/events/TopicConflictEngine.jsx
+++ b/src/components/events/TopicConflictEngine.jsx
@@ -174,7 +174,7 @@ const TopicConflictEngine = () => {
                               {speaker.status}
                             </span>
                           </div>
-                          <p className="text-xs text-slate-400 italic">"{speaker.talk}"</p>
+                          <p className="text-xs text-slate-400 italic">&quot;{speaker.talk}&quot;</p>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Description

Escaped the raw double quotes (`"`) surrounding `{speaker.talk}` in `src/components/events/TopicConflictEngine.jsx` using HTML entity `&quot;`. This resolves the `react/no-unescaped-entities` ESLint rule error.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #11828

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [ ] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A

## Additional Notes

Verified clean execution with `npx eslint src/components/events/TopicConflictEngine.jsx` (0 errors).
