### PR TITLE
perf(backend): database-level aggregate grouping for category statistics (#16693)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -192,6 +192,17 @@ public class EventController {
                 return ResponseEntity.ok(events);
         }
 
+        // ── Issue #16693 — GET /api/events/categories/summary ───────────────────
+
+        @GetMapping("/categories/summary")
+        @Operation(summary = "Get event count by category", description = "Returns total event counts per category computed using database-level GROUP BY aggregation.")
+        @ApiResponses({
+                        @ApiResponse(responseCode = "200", description = "Category statistics fetched successfully")
+        })
+        public ResponseEntity<java.util.Map<String, Long>> getEventCountByCategory() {
+                return ResponseEntity.ok(eventService.getEventCountByCategory());
+        }
+
         // ── Issue #2101 — GET /api/events/{id} ──────────────────────────────────
 
         @GetMapping("/{id}")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -41,4 +41,11 @@ public interface EventRepository extends JpaRepository<Event, Long>, JpaSpecific
      */
     List<Event> findByTitleContainingIgnoreCaseOrDescriptionContainingIgnoreCase(
             String title, String description);
+
+    /**
+     * Grouped aggregate query for category statistics (Issue #16693).
+     * Calculates event count per category directly in the database to avoid loading all entities into JVM heap.
+     */
+    @Query("SELECT e.category, COUNT(e) FROM Event e WHERE e.category IS NOT NULL AND e.category <> '' GROUP BY e.category")
+    List<Object[]> countEventsByCategory();
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -444,6 +444,24 @@ public class EventService {
         }
 
         /**
+         * Calculates total event count per category directly in the database (Issue #16693).
+         * Uses database GROUP BY aggregation to avoid loading all Event entities into memory.
+         *
+         * @return Map of category names to event counts
+         */
+        @Transactional(readOnly = true)
+        public Map<String, Long> getEventCountByCategory() {
+                List<Object[]> results = eventRepository.countEventsByCategory();
+                Map<String, Long> categoryCounts = new LinkedHashMap<>();
+                for (Object[] row : results) {
+                        if (row[0] != null) {
+                                categoryCounts.put((String) row[0], ((Number) row[1]).longValue());
+                        }
+                }
+                return categoryCounts;
+        }
+
+        /**
          * Creates a new event.
          *
          * @param request event creation details

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventCategoryStatisticsTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventCategoryStatisticsTests.java
@@ -1,0 +1,100 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
+import com.sandeep.eventrabackend.service.EventService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class EventCategoryStatisticsTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private HackathonRegistrationRepository hackathonRegistrationRepository;
+
+    @Autowired
+    private EventService eventService;
+
+    @BeforeEach
+    void setUp() {
+        hackathonRegistrationRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+
+        // 3 Tech events
+        createEvent("Tech Conf 1", "Tech");
+        createEvent("Tech Conf 2", "Tech");
+        createEvent("Tech Hackathon", "Tech");
+
+        // 2 Music events
+        createEvent("Music Festival 1", "Music");
+        createEvent("Music Festival 2", "Music");
+
+        // 1 Sports event
+        createEvent("Sports Meet", "Sports");
+
+        // 1 Event with null category (should be ignored in counts)
+        createEvent("Uncategorized Event", null);
+    }
+
+    private void createEvent(String title, String category) {
+        Event event = new Event();
+        event.setTitle(title);
+        event.setCategory(category);
+        event.setPublic(true);
+        event.setEventDate(LocalDateTime.now().plusDays(1));
+        eventRepository.save(event);
+    }
+
+    @Test
+    @DisplayName("Service method getEventCountByCategory returns grouped counts directly from DB")
+    void testServiceGetEventCountByCategory() {
+        Map<String, Long> categoryCounts = eventService.getEventCountByCategory();
+
+        assertEquals(3, categoryCounts.size());
+        assertEquals(3L, categoryCounts.get("Tech"));
+        assertEquals(2L, categoryCounts.get("Music"));
+        assertEquals(1L, categoryCounts.get("Sports"));
+        assertFalse(categoryCounts.containsKey(null));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("GET /api/events/categories/summary returns 200 with category count map")
+    void testGetEventCategorySummaryEndpoint() throws Exception {
+        mockMvc.perform(get("/api/events/categories/summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.Tech").value(3))
+                .andExpect(jsonPath("$.Music").value(2))
+                .andExpect(jsonPath("$.Sports").value(1));
+    }
+}


### PR DESCRIPTION
## Description

This PR optimizes event category statistics calculation by delegating category grouping and counting directly to the database via a JPQL `GROUP BY` query. Previously, retrieving category counts loaded all `Event` entities into memory via `eventRepository.findAll()` and grouped them in the JVM, causing high heap consumption, increased garbage collection overhead, and potential `OutOfMemoryError` risks on large datasets.

Key changes:
- Added `countEventsByCategory()` JPQL query in `EventRepository` to perform database-level `GROUP BY` aggregation.
- Implemented `getEventCountByCategory()` in `EventService` returning a map of category names to counts directly from DB results.
- Added REST endpoint `GET /api/events/categories/summary` in `EventController`.
- Added unit and MockMvc integration tests in `EventCategoryStatisticsTests` to verify database aggregation and API responses.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #16693

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

*N/A - Backend performance optimization*

## Additional Notes

- The database query safely ignores `null` or blank category entries.
- The service method is annotated with `@Transactional(readOnly = true)` for query optimization.
