### PR TITLE
fix: bound analytics periods parameter

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
@@ -45,7 +45,8 @@ public class AnalyticsController {
             @RequestParam(required = false) String organizationId,
             @RequestParam(defaultValue = "monthly") String granularity,
             @RequestParam(defaultValue = "6") int periods) {
-        return ResponseEntity.ok(analyticsService.getRegistrationTrend(granularity, periods));
+        int safePeriods = Math.min(Math.max(periods, 1), 100);
+        return ResponseEntity.ok(analyticsService.getRegistrationTrend(granularity, safePeriods));
     }
 
     @GetMapping("/feedback")


### PR DESCRIPTION
## Summary

Fixes #16668

- Validate and constrain the `periods` analytics parameter.
- Prevent excessively large or invalid period values from reaching the analytics service.
- Apply a safe supported range for registration trend queries.

## Root Cause

The `periods` query parameter was accepted directly from the client without
an upper or lower bound.

This allowed extremely large or negative values to reach the analytics
service and potentially cause excessive CPU, database, or memory usage.

## Fix

The controller now constrains the requested period count to a safe range:

- Minimum: 1
- Maximum: 100

Values outside this range are clamped before being passed to the analytics
service.

## Affected Endpoint

`GET /registrations/trends`

## Testing

- Ran `git diff --check`.
- Verified the analytics period value is bounded before service invocation.
- Ensured only `AnalyticsController.java` is included in the commit.