### PR TITLE
fix: validate time slot step minutes

### DIFF
--- a/src/utils/eventSchedulingUtils.js
+++ b/src/utils/eventSchedulingUtils.js
@@ -318,8 +318,11 @@ export const buildTimeSlots = ({
   endHour = DEFAULT_DAY_END_HOUR,
   stepMinutes = 60,
 } = {}) => {
+  const safeStep = Number.isFinite(stepMinutes) && stepMinutes > 0 ? stepMinutes : DEFAULT_DURATION_MINUTES;
+  const start = startHour * 60;
+  const end = endHour * 60;
   const slots = [];
-  for (let minutes = startHour * 60; minutes < endHour * 60; minutes += stepMinutes) {
+  for (let minutes = start; minutes < end; minutes += safeStep) {
     slots.push({
       minutes,
       label: formatDisplayTime(new Date(2026, 0, 1, Math.floor(minutes / 60), minutes % 60)),


### PR DESCRIPTION
## Summary

Fixes #16673

- Validate `stepMinutes` before generating event time slots.
- Prevent zero or negative step values from causing an infinite loop.
- Ensure time-slot generation always makes forward progress.

## Root Cause

`buildTimeSlots()` uses `stepMinutes` to advance the loop that generates
event time slots.

When `stepMinutes` is zero or negative, the loop cannot progress toward
the end time, potentially causing an infinite JavaScript loop and freezing
the browser.

## Fix

Validate `stepMinutes` before starting the time-slot generation loop and
reject or replace non-positive values with a safe positive interval.

## Expected Behavior

Invalid `stepMinutes` values should not cause an infinite loop or make the
browser unresponsive.

## Testing

- Tested valid positive time-slot intervals.
- Tested zero and negative `stepMinutes` values.
- Ran `git diff --check`.
- Verified only `src/utils/eventSchedulingUtils.js` is included.