### PR TITLE
fix: prevent cancelled reminders from rescheduling

### DIFF
--- a/src/utils/eventReminder.js
+++ b/src/utils/eventReminder.js
@@ -218,7 +218,10 @@ export const scheduleReminder = (title, delay, options = {}) => {
     const currentDelay = Math.min(remainingDelay, MAX_TIMEOUT_DELAY);
     const timeoutId = setTimeout(() => {
       if (remainingDelay > MAX_TIMEOUT_DELAY) {
-        scheduleTimeout(remainingDelay - MAX_TIMEOUT_DELAY);
+        // Guard: skip scheduling the next chunk if the reminder was cancelled
+        if (activeReminders.has(reminderId)) {
+          scheduleTimeout(remainingDelay - MAX_TIMEOUT_DELAY);
+        }
       } else {
         sendNotification("⏰ Event Reminder", {
           body,


### PR DESCRIPTION
## Summary

Fixes #16677

- Prevent cancelled long-delay reminders from scheduling additional timeouts.
- Ensure timeout callbacks verify that the reminder is still active before rescheduling.
- Prevent notifications from being delivered after a reminder has been cancelled.

## Root Cause

Long-delay reminders use multiple `setTimeout()` calls when the delay
exceeds the maximum timeout duration.

A pending timeout could still execute after `cancelReminder()` was called
and schedule another timeout, causing the cancelled reminder to remain
active.

## Fix

Ensure the timeout callback checks the reminder's active/cancelled state
before scheduling the next timeout.

## Expected Behavior

Once a reminder is cancelled, no additional timeout should be scheduled
and no notification should be delivered.

## Testing

- Tested long-delay reminder scheduling.
- Tested cancellation before the first timeout expires.
- Verified that cancelled reminders do not schedule another timeout.
- Ran `git diff --check`.