### PR TITLE
fix: validate sponsor website URL scheme

### DIFF
--- a/src/components/events/VirtualBoothModal.jsx
+++ b/src/components/events/VirtualBoothModal.jsx
@@ -23,6 +23,16 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
   const chatLeadCapturedRef = useRef(false);
   const isMountedRef = useRef(true);
 
+  const isSafeUrl = (url) => {
+    if (!url || typeof url !== "string") return false;
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  };
+
   /* ---------------- Lead Capture ---------------- */
   const captureLead = (action) => {
     try {
@@ -195,16 +205,16 @@ const VirtualBoothModal = ({ isOpen, onClose, booth }) => {
                 </p>
 
                 <div className="flex gap-3 text-gray-400">
-                  {booth.sponsorWebsite && (
+                  {isSafeUrl(booth.sponsorWebsite) && (
                     <a href={booth.sponsorWebsite} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} website`}><Globe size={16} /></a>
                   )}
-                  {booth.sponsorLinkedin && (
+                  {isSafeUrl(booth.sponsorLinkedin) && (
                     <a href={booth.sponsorLinkedin} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} LinkedIn`}><Linkedin size={16} /></a>
                   )}
-                  {booth.sponsorTwitter && (
+                  {isSafeUrl(booth.sponsorTwitter) && (
                     <a href={booth.sponsorTwitter} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} Twitter`}><Twitter size={16} /></a>
                   )}
-                  {booth.sponsorGithub && (
+                  {isSafeUrl(booth.sponsorGithub) && (
                     <a href={booth.sponsorGithub} target="_blank" rel="noopener noreferrer" aria-label={`${booth.label} GitHub`}><Github size={16} /></a>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

Fixes #16680

- Validate sponsor website URLs before rendering them as links.
- Allow only HTTP and HTTPS URL schemes.
- Prevent unsafe schemes such as `javascript:`, `data:`, and `file:` from being rendered as clickable links.

## Root Cause

`VirtualBoothModal.jsx` renders `booth.sponsorWebsite` directly as an
anchor `href` without validating the URL scheme.

An attacker-controlled value using an unsafe scheme could therefore cause
unexpected browser behavior when the sponsor link is clicked.

## Fix

Validate the sponsor website URL before using it as an `href`, allowing
only HTTP and HTTPS URLs.

## Expected Behavior

Valid `http://` and `https://` sponsor URLs remain clickable.

Unsafe schemes such as:

- `javascript:`
- `data:`
- `file:`

are rejected.

## Testing

- Tested valid HTTP sponsor URLs.
- Tested valid HTTPS sponsor URLs.
- Tested unsafe URL schemes.
- Ran `git diff --check`.
- Verified only the intended file is staged.