### PR TITLE
fix: validate recommendation half-life

### DIFF
--- a/src/utils/recommendationEngine.js
+++ b/src/utils/recommendationEngine.js
@@ -139,8 +139,11 @@ export const applyTimeDecay = (timestamp, halfLifeDays = DEFAULT_HALF_LIFE_DAYS)
   const timeMs = new Date(timestamp).getTime();
   if (Number.isNaN(timeMs)) return 1.0;
 
+  const safeHalfLife = Number.isFinite(halfLifeDays) && halfLifeDays > 0
+    ? halfLifeDays
+    : DEFAULT_HALF_LIFE_DAYS;
   const ageInDays = Math.max(0, (Date.now() - timeMs) / (1000 * 60 * 60 * 24));
-  const lambda = Math.LN2 / halfLifeDays;
+  const lambda = Math.LN2 / safeHalfLife;
   return Math.exp(-lambda * ageInDays);
 };
 


### PR DESCRIPTION
## Summary

Fixes #16682

- Validate `halfLifeDays` before calculating recommendation decay.
- Prevent zero, negative, non-finite, or otherwise invalid values from producing invalid decay constants.
- Fall back to a safe positive default when the supplied half-life is invalid.

## Root Cause

`applyTimeDecay()` calculates the decay constant using `Math.LN2 / halfLifeDays`.

When `halfLifeDays` is zero or invalid, this can produce `Infinity`,
`NaN`, or other invalid values that propagate into recommendation
scoring.

## Fix

Validate `halfLifeDays` before performing the decay calculation and use a
safe positive default when the supplied value is invalid or non-positive.

## Expected Behavior

Valid positive half-life values continue to work normally.

Invalid or non-positive values should result in a safe decay calculation
instead of corrupting recommendation scores.

## Testing

- Tested positive half-life values.
- Tested zero half-life.
- Tested negative half-life.
- Tested invalid/non-numeric values.
- Ran `git diff --check`.
- Verified only the intended file is staged.