### PR TITLE
fix: make addon allocation atomic

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/UpgradeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/UpgradeService.java
@@ -32,12 +32,16 @@ public class UpgradeService {
 
     @Transactional
     public boolean allocateAddon(String addonId) {
-        int count = addonInventory.getOrDefault(addonId, 0);
-        if (count > 0) {
-            addonInventory.put(addonId, count - 1);
-            return true;
-        }
-        return false;
+        final boolean[] allocated = { false };
+        addonInventory.compute(addonId, (key, current) -> {
+            int count = current == null ? 0 : current;
+            if (count > 0) {
+                allocated[0] = true;
+                return count - 1;
+            }
+            return current;
+        });
+        return allocated[0];
     }
 
     public String getTicketTier(String ticketId) {


### PR DESCRIPTION
## Summary

Fixes #16891

- Make addon inventory allocation atomic.
- Prevent concurrent requests from allocating the same inventory unit.
- Use `ConcurrentHashMap.compute()` to combine inventory checking and decrementing into a single atomic operation.

## Problem

Addon allocation previously performed inventory reads and writes separately.
Under concurrent requests, multiple requests could observe the same available
inventory and successfully allocate the same inventory slot.

## Fix

Use an atomic `ConcurrentHashMap.compute()` operation so the availability
check and inventory decrement happen together for the addon key.

## Expected Behavior

Each available addon inventory unit can be allocated only once, even when
multiple allocation requests arrive concurrently.

## Testing

- Verified the allocation logic.
- Ran `git diff --check`.
- Verified the working tree contains only the intended changes.