### PR TITLE
fix: handle Stripe payment retry failures

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -593,14 +593,28 @@ public class PaymentPlanService {
         metadata.put("total_installments", String.valueOf(payment.getTotalInstallments()));
         metadata.put("retry_attempt", "true");
         
-        PaymentIntent paymentIntent = stripeService.createPaymentIntentWithoutConfirmation(
-                paymentPlan.getStripeCustomerId(),
-                amountCents,
-                payment.getCurrency().toLowerCase(),
-                "Retry payment for installment " + payment.getInstallmentNumber() + 
-                        " of " + payment.getTotalInstallments(),
-                metadata
-        );
+        PaymentIntent paymentIntent;
+        try {
+            paymentIntent = stripeService.createPaymentIntentWithoutConfirmation(
+                    paymentPlan.getStripeCustomerId(),
+                    amountCents,
+                    payment.getCurrency().toLowerCase(),
+                    "Retry payment for installment " + payment.getInstallmentNumber() + 
+                            " of " + payment.getTotalInstallments(),
+                    metadata
+            );
+        } catch (StripeException e) {
+            payment.setStatus("FAILED");
+            payment.setFailedAt(LocalDateTime.now());
+            payment.setFailureReason("Retry failed: " + e.getMessage());
+            paymentRepository.save(payment);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("success", false);
+            response.put("error", "Payment retry failed: " + e.getMessage());
+            response.put("paymentId", payment.getId());
+            return response;
+        }
         
         // Update payment record
         payment.setStripePaymentIntentId(paymentIntent.getId());


### PR DESCRIPTION
## Summary

Fixes #16893

- Handle Stripe PaymentIntent creation failures during payment retry.
- Persist the payment failure state when Stripe returns an exception.
- Store the failure timestamp and reason.
- Return a structured failure response instead of allowing the exception to propagate.

## Problem

The payment retry flow creates a Stripe PaymentIntent before updating the
local payment record.

If Stripe fails during PaymentIntent creation, the exception can propagate
without updating the local payment state. This can leave the payment retry
state inconsistent and prevent the user from retrying correctly.

## Fix

Added explicit Stripe exception handling around PaymentIntent creation.

When Stripe fails:
- The payment is marked as failed.
- The failure timestamp is recorded.
- The failure reason is stored.
- The updated payment record is persisted.
- A failure response is returned to the caller.

## Expected Behavior

Stripe failures during payment retry should leave the local payment record
in a consistent retryable failure state.

## Testing

- Ran `git diff --check`
- Verified the affected payment retry flow.