### PR TITLE
fix: return fallback rate limit state

### DIFF
--- a/src/components/utils/rateLimitUtils.js
+++ b/src/components/utils/rateLimitUtils.js
@@ -46,6 +46,7 @@ export function readPersistedRateLimit() {
     return { attempts, lockoutUntil: validLockout };
   } catch (err) {
       console.warn("[rateLimitUtils] Rate limit operation failed:", err);
+      return { attempts: 0, lockoutUntil: 0 };
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #16894

- Return a safe fallback rate-limit state when sessionStorage is unavailable.
- Prevent `readPersistedRateLimit()` from returning `undefined`.
- Keep callers safe when browser storage access fails.

## Problem

`readPersistedRateLimit()` catches sessionStorage access errors but previously
returned `undefined` from the catch block.

Callers expecting `attempts` and `lockoutUntil` could therefore fail with a
TypeError when sessionStorage was unavailable.

## Fix

Return the default rate-limit state:

- `attempts: 0`
- `lockoutUntil: 0`

when sessionStorage cannot be accessed.

## Expected Behavior

The rate-limit logic should continue safely using default values even when
browser storage is unavailable.

## Testing

- Ran `git diff --check`
- Verified the fallback state is returned when storage access fails.