### PR TITLE
fix(kit): guard rangeNumbers against zero/negative step infinite loop

### DIFF
--- a/src/eventra-kit/range-numbers.js
+++ b/src/eventra-kit/range-numbers.js
@@ -4,7 +4,16 @@
  */
 export function rangeNumbers(start, end, step = 1) {
   const out = [];
-  for (let i = start; i < end; i += step) out.push(i);
+  if (step === 0) return out;
+  const forward = end >= start;
+  const inc = step > 0 ? step : -step;
+  if (forward) {
+    if (step < 0) return out;
+    for (let i = start; i < end; i += inc) out.push(i);
+  } else {
+    if (step > 0) return out;
+    for (let i = start; i > end; i -= inc) out.push(i);
+  }
   return out;
 }
 


### PR DESCRIPTION
## Problem

`rangeNumbers` in the Eventra Kit has no guard for a zero or negative `step`, so it can enter an infinite loop that hangs the process:
- `step = 0` never advances `i` (infinite loop).
- `step < 0` with `start < end` decreases `i` while always satisfying `i < end` (infinite loop).
- `step < 0` with `start > end` silently returns `[]` instead of counting down.

## Fix

Guard against `step === 0` and the mismatched direction cases. Descending ranges (`start > end`) now count down when given a negative step, and any `[]` empty range returns immediately with no unbounded loop.

## Files changed

- `src/eventra-kit/range-numbers.js`

## Testing

Verified manually:
- `rangeNumbers(1, 5, 0)` returns `[]` (no hang).
- `rangeNumbers(1, 10, -1)` returns `[]` (no hang).
- `rangeNumbers(10, 1, -1)` returns `[10, 9, 8, 7, 6, 5, 4, 3, 2]`.
- `rangeNumbers(1, 5)` returns `[1, 2, 3, 4]` (unchanged behavior).

Closes #16878
