### PR TITLE
fix: sanitize registration metadata

### DIFF
--- a/src/utils/registrationGuard.js
+++ b/src/utils/registrationGuard.js
@@ -40,6 +40,19 @@ export const isAlreadyRegistered = (userId, eventId) => {
   return Boolean(registry[key]);
 };
 
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+const sanitizeMetadata = (metadata) => {
+  if (!metadata || typeof metadata !== "object") return {};
+  const clean = {};
+  for (const key of Object.keys(metadata)) {
+    if (!DANGEROUS_KEYS.has(key)) {
+      clean[key] = metadata[key];
+    }
+  }
+  return clean;
+};
+
 export const recordRegistration = (userId, eventId, metadata = {}) => {
   if (!userId || !eventId) return false;
   const registry = getRegistry();
@@ -49,7 +62,7 @@ export const recordRegistration = (userId, eventId, metadata = {}) => {
     userId,
     eventId,
     registeredAt: new Date().toISOString(),
-    ...metadata,
+    ...sanitizeMetadata(metadata),
   };
   const persisted = saveRegistry(registry);
   if (!persisted) {


### PR DESCRIPTION
## Summary

Fixes #16895

- Sanitize untrusted registration metadata before storing it.
- Reject prototype-related keys such as `__proto__`, `constructor`, and `prototype`.
- Prevent attacker-controlled metadata from affecting client-side object behavior.

## Problem

Registration metadata was spread directly into the registration record.

Untrusted metadata containing prototype-related properties could therefore
interfere with object behavior and potentially lead to prototype pollution.

## Fix

Added metadata sanitization that:

- Accepts object metadata only.
- Filters dangerous prototype-related keys.
- Preserves safe metadata fields.
- Uses the sanitized metadata when constructing the registration record.

## Expected Behavior

Untrusted metadata should be validated and restricted before being merged
into registration state.

## Testing

- Ran `git diff --check`.
- Verified the registration record uses sanitized metadata.
- Verified prototype-related keys are excluded.