### PR TITLE
fix(kit): normalizePercent handles negative values by magnitude

### DIFF
--- a/src/eventra-kit/normalize-percent.js
+++ b/src/eventra-kit/normalize-percent.js
@@ -3,7 +3,7 @@
  * adds a percent normalizer.
  */
 export function normalizePercent(value) {
-  if (value > 1) return value / 100;
+  if (Math.abs(value) > 1) return value / 100;
   return value;
 }
 


### PR DESCRIPTION
## Problem

`normalizePercent` only normalizes values strictly greater than `1`, so negative percentages are left untouched: `normalizePercent(-50)` returns `-50` instead of `-0.5`. That breaks any UI/math that expects a `0..1` (or `-1..1`) normalized range.

## Fix

Normalize by the absolute value so inputs are divided by 100 regardless of sign.

## Files changed

- `src/eventra-kit/normalize-percent.js`

## Testing

Verified manually:
- `normalizePercent(-50)` returns `-0.5`.
- `normalizePercent(50)` returns `0.5`.
- `normalizePercent(0.5)` returns `0.5` (unchanged).

Closes #16887
