### PR TITLE
fix: handle malformed JWT payloads safely

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -25,12 +25,17 @@ export function decodeJwtPayload(token) {
 
     const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
 
-    const jsonPayload = decodeURIComponent(
-      atob(padded)
-        .split("")
-        .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
-        .join("")
-    );
+    let jsonPayload;
+    try {
+      jsonPayload = decodeURIComponent(
+        atob(padded)
+          .split("")
+          .map((c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+          .join("")
+      );
+    } catch {
+      return null;
+    }
 
     return safeJsonParse(jsonPayload, {});
   } catch {


### PR DESCRIPTION
## Summary

Fixes #16896

- Prevent malformed JWT payloads from throwing an uncaught URIError.
- Safely handle invalid UTF-8 sequences during payload decoding.
- Return `null` when the JWT payload cannot be decoded.

## Problem

`decodeJwtPayload()` passes decoded Base64URL data directly to
`decodeURIComponent()`.

Malformed or non-standard JWT payloads can cause `decodeURIComponent()`
to throw a `URIError`, which can propagate to authentication-related
callers.

## Fix

Wrapped the UTF-8 decoding operation in a `try/catch`.

If decoding fails, the function now returns `null` instead of allowing
the exception to propagate.

## Expected Behavior

Malformed JWT payloads should be handled safely and return `null`
without throwing an uncaught exception.

## Testing

- Ran `git diff --check`.
- Verified malformed UTF-8 decoding is caught.
- Verified valid payloads continue through `safeJsonParse()`.