### PR TITLE
fix(kit): escape CSV header cells in toCsvString

### DIFF
--- a/src/eventra-kit/to-csv-string.js
+++ b/src/eventra-kit/to-csv-string.js
@@ -5,12 +5,12 @@
 export function toCsvString(rows, columns) {
   if (!rows.length) return '';
   const cols = columns || Object.keys(rows[0]);
-  const header = cols.join(',');
-  const body = rows.map(row => cols.map(c => {
-    const value = row[c];
-    const str = value == null ? '' : String(value);
+  const escapeCell = (v) => {
+    const str = v == null ? '' : String(v);
     return /[",\n]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
-  }).join(','));
+  };
+  const header = cols.map(escapeCell).join(',');
+  const body = rows.map(row => cols.map(c => escapeCell(row[c])).join(','));
   return [header, ...body].join('\n');
 }
 


### PR DESCRIPTION
## Problem

`toCsvString` escapes body cells containing `,`, `"`, or newline, but the header row is built with `cols.join(',')` and never quoted/escaped. A column name containing a comma, quote, or newline produces a malformed CSV header that misaligns with the data (problematic for attendee/export reports).

## Fix

Extracted the escaping logic into a shared `escapeCell` helper and applied it to both the header cells and the body cells, so headers are quoted/escaped exactly like the data.

## Files changed

- src/eventra-kit/to-csv-string.js


## Testing

Ran `node --check src/eventra-kit/to-csv-string.js` — parses without errors. Manually verified the logic: a column named `Full, Name` is now emitted as `"Full, Name"` in the header, aligning with the escaped body rows.


Closes #16888
