### PR TITLE
fix: hide soft-deleted events from public schedule

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -221,6 +221,7 @@ public class EventService {
                 return eventRepository.findById(id)
                                 .filter(Event::isPublic)
                                 .filter(event -> !"CANCELLED".equals(event.getStatus()))
+                                .filter(event -> !"DELETED".equals(event.getStatus()))
                                 .orElseThrow(() -> new EventNotFoundException(
                                                 "Event not found with id: " + id));
         }


### PR DESCRIPTION
## Summary

Fixes #16898

- Prevent soft-deleted events from being returned by the public event schedule endpoint.
- Filter out cancelled and deleted events before returning the schedule.
- Return `EventNotFoundException` when the requested event is no longer publicly available.

## Problem

The public event schedule service retrieves events using `findById()`
without checking their soft-deleted status.

As a result, events marked as deleted can still be exposed through the
public schedule endpoint.

## Fix

Updated `getEventSchedule()` to exclude events with `CANCELLED` or
`DELETED` status before returning the schedule.

## Expected Behavior

Soft-deleted or cancelled events should not be accessible through the
public event schedule endpoint.

## Testing

- Ran `git diff --check`.
- Verified the event status filtering logic.
- Verified that unavailable events result in `EventNotFoundException`.