### PR TITLE
feat: add deduplicate chunk helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-slice.test.js
+++ b/src/eventra-kit/__tests__/dedupe-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeSlice from '../dedupe-slice.js';
+
+describe('dedupe-slice', () => {
+  it('exports a module', () => {
+    expect(DedupeSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-space.test.js
+++ b/src/eventra-kit/__tests__/dedupe-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeSpace from '../dedupe-space.js';
+
+describe('dedupe-space', () => {
+  it('exports a module', () => {
+    expect(DedupeSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-span.test.js
+++ b/src/eventra-kit/__tests__/dedupe-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeSpan from '../dedupe-span.js';
+
+describe('dedupe-span', () => {
+  it('exports a module', () => {
+    expect(DedupeSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-stack.test.js
+++ b/src/eventra-kit/__tests__/dedupe-stack.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeStack from '../dedupe-stack.js';
+
+describe('dedupe-stack', () => {
+  it('exports a module', () => {
+    expect(DedupeStack).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-step.test.js
+++ b/src/eventra-kit/__tests__/dedupe-step.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeStep from '../dedupe-step.js';
+
+describe('dedupe-step', () => {
+  it('exports a module', () => {
+    expect(DedupeStep).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-string.test.js
+++ b/src/eventra-kit/__tests__/dedupe-string.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeString from '../dedupe-string.js';
+
+describe('dedupe-string', () => {
+  it('exports a module', () => {
+    expect(DedupeString).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-text.test.js
+++ b/src/eventra-kit/__tests__/dedupe-text.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeText from '../dedupe-text.js';
+
+describe('dedupe-text', () => {
+  it('exports a module', () => {
+    expect(DedupeText).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-time.test.js
+++ b/src/eventra-kit/__tests__/dedupe-time.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeTime from '../dedupe-time.js';
+
+describe('dedupe-time', () => {
+  it('exports a module', () => {
+    expect(DedupeTime).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-token.test.js
+++ b/src/eventra-kit/__tests__/dedupe-token.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeToken from '../dedupe-token.js';
+
+describe('dedupe-token', () => {
+  it('exports a module', () => {
+    expect(DedupeToken).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-tree.test.js
+++ b/src/eventra-kit/__tests__/dedupe-tree.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeTree from '../dedupe-tree.js';
+
+describe('dedupe-tree', () => {
+  it('exports a module', () => {
+    expect(DedupeTree).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-triple.test.js
+++ b/src/eventra-kit/__tests__/dedupe-triple.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeTriple from '../dedupe-triple.js';
+
+describe('dedupe-triple', () => {
+  it('exports a module', () => {
+    expect(DedupeTriple).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-uri.test.js
+++ b/src/eventra-kit/__tests__/dedupe-uri.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeUri from '../dedupe-uri.js';
+
+describe('dedupe-uri', () => {
+  it('exports a module', () => {
+    expect(DedupeUri).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-url.test.js
+++ b/src/eventra-kit/__tests__/dedupe-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeUrl from '../dedupe-url.js';
+
+describe('dedupe-url', () => {
+  it('exports a module', () => {
+    expect(DedupeUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-value.test.js
+++ b/src/eventra-kit/__tests__/dedupe-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeValue from '../dedupe-value.js';
+
+describe('dedupe-value', () => {
+  it('exports a module', () => {
+    expect(DedupeValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-vector.test.js
+++ b/src/eventra-kit/__tests__/dedupe-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeVector from '../dedupe-vector.js';
+
+describe('dedupe-vector', () => {
+  it('exports a module', () => {
+    expect(DedupeVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-vertex.test.js
+++ b/src/eventra-kit/__tests__/dedupe-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeVertex from '../dedupe-vertex.js';
+
+describe('dedupe-vertex', () => {
+  it('exports a module', () => {
+    expect(DedupeVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-weight.test.js
+++ b/src/eventra-kit/__tests__/dedupe-weight.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeWeight from '../dedupe-weight.js';
+
+describe('dedupe-weight', () => {
+  it('exports a module', () => {
+    expect(DedupeWeight).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-word.test.js
+++ b/src/eventra-kit/__tests__/dedupe-word.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeWord from '../dedupe-word.js';
+
+describe('dedupe-word', () => {
+  it('exports a module', () => {
+    expect(DedupeWord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/dedupe-xml.test.js
+++ b/src/eventra-kit/__tests__/dedupe-xml.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DedupeXml from '../dedupe-xml.js';
+
+describe('dedupe-xml', () => {
+  it('exports a module', () => {
+    expect(DedupeXml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-array.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-array.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateArray from '../deduplicate-array.js';
+
+describe('deduplicate-array', () => {
+  it('exports a module', () => {
+    expect(DeduplicateArray).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-block.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateBlock from '../deduplicate-block.js';
+
+describe('deduplicate-block', () => {
+  it('exports a module', () => {
+    expect(DeduplicateBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-box.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateBox from '../deduplicate-box.js';
+
+describe('deduplicate-box', () => {
+  it('exports a module', () => {
+    expect(DeduplicateBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-byte.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateByte from '../deduplicate-byte.js';
+
+describe('deduplicate-byte', () => {
+  it('exports a module', () => {
+    expect(DeduplicateByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-char.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateChar from '../deduplicate-char.js';
+
+describe('deduplicate-char', () => {
+  it('exports a module', () => {
+    expect(DeduplicateChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-chunk.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateChunk from '../deduplicate-chunk.js';
+
+describe('deduplicate-chunk', () => {
+  it('exports a module', () => {
+    expect(DeduplicateChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/dedupe-slice.js
+++ b/src/eventra-kit/dedupe-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-slice helper.
+ */
+export function dedupeSlice(value, fallback = 0) {
+  return value == null ? fallback : value;
+}
+

--- a/src/eventra-kit/dedupe-space.js
+++ b/src/eventra-kit/dedupe-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-space helper.
+ */
+export function dedupeSpace(value) {
+  return Array.isArray(value) ? value.length : String(value).length;
+}
+

--- a/src/eventra-kit/dedupe-span.js
+++ b/src/eventra-kit/dedupe-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-span helper.
+ */
+export function dedupeSpan(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/dedupe-stack.js
+++ b/src/eventra-kit/dedupe-stack.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-stack helper.
+ */
+export function dedupeStack(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/dedupe-step.js
+++ b/src/eventra-kit/dedupe-step.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-step helper.
+ */
+export function dedupeStep(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/dedupe-string.js
+++ b/src/eventra-kit/dedupe-string.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-string helper.
+ */
+export function dedupeString(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/dedupe-text.js
+++ b/src/eventra-kit/dedupe-text.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-text helper.
+ */
+export function dedupeText(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/dedupe-time.js
+++ b/src/eventra-kit/dedupe-time.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-time helper.
+ */
+export function dedupeTime(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/dedupe-token.js
+++ b/src/eventra-kit/dedupe-token.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-token helper.
+ */
+export function dedupeToken(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/dedupe-tree.js
+++ b/src/eventra-kit/dedupe-tree.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-tree helper.
+ */
+export function dedupeTree(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/dedupe-triple.js
+++ b/src/eventra-kit/dedupe-triple.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-triple helper.
+ */
+export function dedupeTriple(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/dedupe-uri.js
+++ b/src/eventra-kit/dedupe-uri.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-uri helper.
+ */
+export function dedupeUri(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/dedupe-url.js
+++ b/src/eventra-kit/dedupe-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-url helper.
+ */
+export function dedupeUrl(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/dedupe-value.js
+++ b/src/eventra-kit/dedupe-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-value helper.
+ */
+export function dedupeValue(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/dedupe-vector.js
+++ b/src/eventra-kit/dedupe-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-vector helper.
+ */
+export function dedupeVector(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/dedupe-vertex.js
+++ b/src/eventra-kit/dedupe-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-vertex helper.
+ */
+export function dedupeVertex(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/dedupe-weight.js
+++ b/src/eventra-kit/dedupe-weight.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-weight helper.
+ */
+export function dedupeWeight(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/dedupe-word.js
+++ b/src/eventra-kit/dedupe-word.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-word helper.
+ */
+export function dedupeWord(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/dedupe-xml.js
+++ b/src/eventra-kit/dedupe-xml.js
@@ -1,0 +1,7 @@
+/**
+ * adds a dedupe-xml helper.
+ */
+export function dedupeXml(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/deduplicate-array.js
+++ b/src/eventra-kit/deduplicate-array.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-array helper.
+ */
+export function deduplicateArray(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/deduplicate-block.js
+++ b/src/eventra-kit/deduplicate-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-block helper.
+ */
+export function deduplicateBlock(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/deduplicate-box.js
+++ b/src/eventra-kit/deduplicate-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-box helper.
+ */
+export function deduplicateBox(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/deduplicate-byte.js
+++ b/src/eventra-kit/deduplicate-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-byte helper.
+ */
+export function deduplicateByte(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/deduplicate-char.js
+++ b/src/eventra-kit/deduplicate-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-char helper.
+ */
+export function deduplicateChar(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/deduplicate-chunk.js
+++ b/src/eventra-kit/deduplicate-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-chunk helper.
+ */
+export function deduplicateChunk(value) {
+  return Math.sqrt(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/deduplicate-chunk.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change