### PR TITLE
feat: add deduplicate score helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/deduplicate-key.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateKey from '../deduplicate-key.js';
+
+describe('deduplicate-key', () => {
+  it('exports a module', () => {
+    expect(DeduplicateKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-leaf.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateLeaf from '../deduplicate-leaf.js';
+
+describe('deduplicate-leaf', () => {
+  it('exports a module', () => {
+    expect(DeduplicateLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-length.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateLength from '../deduplicate-length.js';
+
+describe('deduplicate-length', () => {
+  it('exports a module', () => {
+    expect(DeduplicateLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-line.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateLine from '../deduplicate-line.js';
+
+describe('deduplicate-line', () => {
+  it('exports a module', () => {
+    expect(DeduplicateLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-list.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateList from '../deduplicate-list.js';
+
+describe('deduplicate-list', () => {
+  it('exports a module', () => {
+    expect(DeduplicateList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-map.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateMap from '../deduplicate-map.js';
+
+describe('deduplicate-map', () => {
+  it('exports a module', () => {
+    expect(DeduplicateMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-matrix.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateMatrix from '../deduplicate-matrix.js';
+
+describe('deduplicate-matrix', () => {
+  it('exports a module', () => {
+    expect(DeduplicateMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-name.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateName from '../deduplicate-name.js';
+
+describe('deduplicate-name', () => {
+  it('exports a module', () => {
+    expect(DeduplicateName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-node.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateNode from '../deduplicate-node.js';
+
+describe('deduplicate-node', () => {
+  it('exports a module', () => {
+    expect(DeduplicateNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-number.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateNumber from '../deduplicate-number.js';
+
+describe('deduplicate-number', () => {
+  it('exports a module', () => {
+    expect(DeduplicateNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-object.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateObject from '../deduplicate-object.js';
+
+describe('deduplicate-object', () => {
+  it('exports a module', () => {
+    expect(DeduplicateObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-order.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateOrder from '../deduplicate-order.js';
+
+describe('deduplicate-order', () => {
+  it('exports a module', () => {
+    expect(DeduplicateOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-page.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicatePage from '../deduplicate-page.js';
+
+describe('deduplicate-page', () => {
+  it('exports a module', () => {
+    expect(DeduplicatePage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-pair.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicatePair from '../deduplicate-pair.js';
+
+describe('deduplicate-pair', () => {
+  it('exports a module', () => {
+    expect(DeduplicatePair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-path.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicatePath from '../deduplicate-path.js';
+
+describe('deduplicate-path', () => {
+  it('exports a module', () => {
+    expect(DeduplicatePath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-point.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicatePoint from '../deduplicate-point.js';
+
+describe('deduplicate-point', () => {
+  it('exports a module', () => {
+    expect(DeduplicatePoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-portion.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicatePortion from '../deduplicate-portion.js';
+
+describe('deduplicate-portion', () => {
+  it('exports a module', () => {
+    expect(DeduplicatePortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-prop.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateProp from '../deduplicate-prop.js';
+
+describe('deduplicate-prop', () => {
+  it('exports a module', () => {
+    expect(DeduplicateProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-queue.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateQueue from '../deduplicate-queue.js';
+
+describe('deduplicate-queue', () => {
+  it('exports a module', () => {
+    expect(DeduplicateQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-range.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateRange from '../deduplicate-range.js';
+
+describe('deduplicate-range', () => {
+  it('exports a module', () => {
+    expect(DeduplicateRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-rank.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateRank from '../deduplicate-rank.js';
+
+describe('deduplicate-rank', () => {
+  it('exports a module', () => {
+    expect(DeduplicateRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-record.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateRecord from '../deduplicate-record.js';
+
+describe('deduplicate-record', () => {
+  it('exports a module', () => {
+    expect(DeduplicateRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-rect.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateRect from '../deduplicate-rect.js';
+
+describe('deduplicate-rect', () => {
+  it('exports a module', () => {
+    expect(DeduplicateRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/deduplicate-score.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DeduplicateScore from '../deduplicate-score.js';
+
+describe('deduplicate-score', () => {
+  it('exports a module', () => {
+    expect(DeduplicateScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/deduplicate-key.js
+++ b/src/eventra-kit/deduplicate-key.js
@@ -1,0 +1,8 @@
+/**
+ * adds a deduplicate-key helper.
+ */
+export function deduplicateKey(value, index) {
+  if (index < 0 || index >= value.length) return value;
+  return value.slice(0, index).concat(value.slice(index + 1));
+}
+

--- a/src/eventra-kit/deduplicate-leaf.js
+++ b/src/eventra-kit/deduplicate-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-leaf helper.
+ */
+export function deduplicateLeaf(value, index, item) {
+  return value.slice(0, index).concat([item], value.slice(index));
+}
+

--- a/src/eventra-kit/deduplicate-length.js
+++ b/src/eventra-kit/deduplicate-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-length helper.
+ */
+export function deduplicateLength(value) {
+  return value.flat();
+}
+

--- a/src/eventra-kit/deduplicate-line.js
+++ b/src/eventra-kit/deduplicate-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-line helper.
+ */
+export function deduplicateLine(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/deduplicate-list.js
+++ b/src/eventra-kit/deduplicate-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-list helper.
+ */
+export function deduplicateList(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/deduplicate-map.js
+++ b/src/eventra-kit/deduplicate-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-map helper.
+ */
+export function deduplicateMap(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/deduplicate-matrix.js
+++ b/src/eventra-kit/deduplicate-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-matrix helper.
+ */
+export function deduplicateMatrix(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/deduplicate-name.js
+++ b/src/eventra-kit/deduplicate-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-name helper.
+ */
+export function deduplicateName(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/deduplicate-node.js
+++ b/src/eventra-kit/deduplicate-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-node helper.
+ */
+export function deduplicateNode(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/deduplicate-number.js
+++ b/src/eventra-kit/deduplicate-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-number helper.
+ */
+export function deduplicateNumber(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/deduplicate-object.js
+++ b/src/eventra-kit/deduplicate-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-object helper.
+ */
+export function deduplicateObject(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/deduplicate-order.js
+++ b/src/eventra-kit/deduplicate-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-order helper.
+ */
+export function deduplicateOrder(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/deduplicate-page.js
+++ b/src/eventra-kit/deduplicate-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-page helper.
+ */
+export function deduplicatePage(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/deduplicate-pair.js
+++ b/src/eventra-kit/deduplicate-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-pair helper.
+ */
+export function deduplicatePair(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/deduplicate-path.js
+++ b/src/eventra-kit/deduplicate-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-path helper.
+ */
+export function deduplicatePath(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/deduplicate-point.js
+++ b/src/eventra-kit/deduplicate-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-point helper.
+ */
+export function deduplicatePoint(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/deduplicate-portion.js
+++ b/src/eventra-kit/deduplicate-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-portion helper.
+ */
+export function deduplicatePortion(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/deduplicate-prop.js
+++ b/src/eventra-kit/deduplicate-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-prop helper.
+ */
+export function deduplicateProp(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/deduplicate-queue.js
+++ b/src/eventra-kit/deduplicate-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-queue helper.
+ */
+export function deduplicateQueue(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/deduplicate-range.js
+++ b/src/eventra-kit/deduplicate-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-range helper.
+ */
+export function deduplicateRange(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/deduplicate-rank.js
+++ b/src/eventra-kit/deduplicate-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-rank helper.
+ */
+export function deduplicateRank(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/deduplicate-record.js
+++ b/src/eventra-kit/deduplicate-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-record helper.
+ */
+export function deduplicateRecord(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/deduplicate-rect.js
+++ b/src/eventra-kit/deduplicate-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-rect helper.
+ */
+export function deduplicateRect(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/deduplicate-score.js
+++ b/src/eventra-kit/deduplicate-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a deduplicate-score helper.
+ */
+export function deduplicateScore(value, length) {
+  return value.length === length;
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/deduplicate-score.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change