### PR TITLE
fix(plagiarism): sanitize CSV export against formula injection

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PlagiarismDetectionService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PlagiarismDetectionService.java
@@ -61,8 +61,25 @@ public class PlagiarismDetectionService {
         csv.append("Team A,Team B,Similarity Score (%),Risk Level\n");
         for (SubmissionComparison c : comparisons) {
             csv.append(String.format("\"%s\",\"%s\",%.2f,%s\n",
-                    c.getTeamNameA(), c.getTeamNameB(), c.getSimilarityPercentage(), c.getRiskLevel()));
+                    sanitizeCsvCell(c.getTeamNameA()), sanitizeCsvCell(c.getTeamNameB()),
+                    c.getSimilarityPercentage(), c.getRiskLevel()));
         }
         return csv.toString();
+    }
+
+    /**
+     * Neutralize CSV formula injection by prefixing cells that start with a
+     * spreadsheet formula metacharacter (=, +, -, @) with a single quote, and
+     * escape any embedded double quotes so the CSV cell stays well-formed.
+     */
+    private String sanitizeCsvCell(String value) {
+        if (value == null) {
+            return "";
+        }
+        String cleaned = value.replace("\"", "\"\"");
+        if (!cleaned.isEmpty() && "=+-@".indexOf(cleaned.charAt(0)) >= 0) {
+            cleaned = "'" + cleaned;
+        }
+        return cleaned;
     }
 }


### PR DESCRIPTION
## Problem

`PlagiarismDetectionService.generateCsvAuditReport` wrote team names verbatim into the CSV export. A team name starting with `=`, `+`, `-`, or `@` would be interpreted as a formula when an organizer opens the export in Excel/Google Sheets, enabling CSV formula injection against the organizer's machine.

## Fix

Added a `sanitizeCsvCell` helper that:
- prefixes any cell starting with `=`, `+`, `-`, or `@` with a single quote (neutralizing it as a formula), and
- escapes embedded double quotes (`"` -> `""`) so the quoted CSV cell stays well-formed.

Both `teamNameA` and `teamNameB` are sanitized before being written to the report.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/PlagiarismDetectionService.java`

## Testing

- Manually verified cell escaping logic against `=SUM(A1:A2)`, `+cmd`, `-2`, `@x`, embedded-quote, and null inputs.

Closes #16256
