### PR TITLE
fix(tickets): scope ticket validate/check-in to the ticket's event organizer

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
@@ -3,10 +3,12 @@ package com.sandeep.eventrabackend.controller;
 import com.eventra.service.QrCodeValidationService;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.EventRole;
 import com.sandeep.eventrabackend.model.TicketCheckIn;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
 import com.sandeep.eventrabackend.repository.TicketCheckInRepository;
+import com.sandeep.eventrabackend.service.EventRoleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,7 +18,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,6 +50,7 @@ public class TicketController {
     private final EventRepository eventRepository;
     private final TicketCheckInRepository ticketCheckInRepository;
     private final QrCodeValidationService qrCodeValidationService;
+    private final EventRoleService eventRoleService;
 
     @PostMapping("/validate")
     @Operation(summary = "Validate a ticket",
@@ -58,7 +63,8 @@ public class TicketController {
                              "alreadyCheckedIn": false, "message": "Ticket is valid"}"""))),
             @ApiResponse(responseCode = "403", description = "Forbidden - organizer/admin access required")
     })
-    public ResponseEntity<Map<String, Object>> validateTicket(@RequestBody Map<String, Object> payload) {
+    public ResponseEntity<Map<String, Object>> validateTicket(Authentication authentication,
+            @RequestBody Map<String, Object> payload) {
         Long eventId = asLong(payload.get("eventId"));
         Long registrationId = asLong(payload.get("ticketId"));
 
@@ -73,6 +79,11 @@ public class TicketController {
                 || !registration.get().getEvent().getId().equals(eventId)) {
             return ResponseEntity.ok(result(false, null, registrationId, false,
                     "This ticket does not match the selected event."));
+        }
+
+        // Object-level authorization: the caller must organize the event the ticket belongs to.
+        if (!isAuthorizedForEvent(eventId, authentication)) {
+            return forbidden();
         }
 
         EventRegistration reg = registration.get();
@@ -112,7 +123,8 @@ public class TicketController {
                              "message": "Check-in recorded"}"""))),
             @ApiResponse(responseCode = "403", description = "Forbidden - organizer/admin access required")
     })
-    public ResponseEntity<Map<String, Object>> checkIn(@RequestBody Map<String, Object> payload) {
+    public ResponseEntity<Map<String, Object>> checkIn(Authentication authentication,
+            @RequestBody Map<String, Object> payload) {
         Long eventId = asLong(payload.get("eventId"));
         Long registrationId = asLong(payload.get("ticketId"));
 
@@ -127,6 +139,11 @@ public class TicketController {
                 || !registration.get().getEvent().getId().equals(eventId)) {
             return ResponseEntity.ok(result(false, null, registrationId, false,
                     "This ticket does not match the selected event."));
+        }
+
+        // Object-level authorization: the caller must organize the event the ticket belongs to.
+        if (!isAuthorizedForEvent(eventId, authentication)) {
+            return forbidden();
         }
 
         EventRegistration reg = registration.get();
@@ -249,6 +266,25 @@ public class TicketController {
         stats.put("remainingAttendees", 0L);
         stats.put("attendancePercentage", 0);
         return stats;
+    }
+
+    private boolean isAuthorizedForEvent(Long eventId, Authentication authentication) {
+        if (authentication == null) {
+            return false;
+        }
+        try {
+            eventRoleService.requireRole(eventId, authentication.getName(), EventRole.ORGANIZER);
+            return true;
+        } catch (AccessDeniedException e) {
+            return false;
+        }
+    }
+
+    private ResponseEntity<Map<String, Object>> forbidden() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("valid", false);
+        response.put("message", "You are not authorized to manage this event.");
+        return ResponseEntity.status(403).body(response);
     }
 
     private String displayName(EventRegistration reg) {


### PR DESCRIPTION
## Problem

`TicketController.validateTicket` and `checkIn` never verified that the authenticated organizer actually belongs to the event the ticket is for. Any user holding the `ORGANIZER` authority could validate and check in tickets for any event on the platform, not just events they organize — a cross-event privilege escalation and a broken object-level authorization gap.

## Fix

After resolving the ticket and confirming it belongs to the requested event, both endpoints now call `eventRoleService.requireRole(eventId, callerEmail, EventRole.ORGANIZER)` (the same helper used elsewhere in the app, which also grants platform admins access). When the caller is not authorized for that specific event, the endpoint returns `403 Forbidden` instead of proceeding.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java`

## Testing

- Manual review: authorization is checked after ticket/event resolution and before any state change, and `EventRoleService.hasRole` already short-circuits platform `ADMIN`/`SUPER_ADMIN`.

Closes #16188
