### PR TITLE
feat: add diff length helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/diff-count.test.js
+++ b/src/eventra-kit/__tests__/diff-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffCount from '../diff-count.js';
+
+describe('diff-count', () => {
+  it('exports a module', () => {
+    expect(DiffCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-date.test.js
+++ b/src/eventra-kit/__tests__/diff-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffDate from '../diff-date.js';
+
+describe('diff-date', () => {
+  it('exports a module', () => {
+    expect(DiffDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-delta.test.js
+++ b/src/eventra-kit/__tests__/diff-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffDelta from '../diff-delta.js';
+
+describe('diff-delta', () => {
+  it('exports a module', () => {
+    expect(DiffDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-dict.test.js
+++ b/src/eventra-kit/__tests__/diff-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffDict from '../diff-dict.js';
+
+describe('diff-dict', () => {
+  it('exports a module', () => {
+    expect(DiffDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-dir.test.js
+++ b/src/eventra-kit/__tests__/diff-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffDir from '../diff-dir.js';
+
+describe('diff-dir', () => {
+  it('exports a module', () => {
+    expect(DiffDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-edge.test.js
+++ b/src/eventra-kit/__tests__/diff-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffEdge from '../diff-edge.js';
+
+describe('diff-edge', () => {
+  it('exports a module', () => {
+    expect(DiffEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-element.test.js
+++ b/src/eventra-kit/__tests__/diff-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffElement from '../diff-element.js';
+
+describe('diff-element', () => {
+  it('exports a module', () => {
+    expect(DiffElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-entry.test.js
+++ b/src/eventra-kit/__tests__/diff-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffEntry from '../diff-entry.js';
+
+describe('diff-entry', () => {
+  it('exports a module', () => {
+    expect(DiffEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-field.test.js
+++ b/src/eventra-kit/__tests__/diff-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffField from '../diff-field.js';
+
+describe('diff-field', () => {
+  it('exports a module', () => {
+    expect(DiffField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-file.test.js
+++ b/src/eventra-kit/__tests__/diff-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffFile from '../diff-file.js';
+
+describe('diff-file', () => {
+  it('exports a module', () => {
+    expect(DiffFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-fraction.test.js
+++ b/src/eventra-kit/__tests__/diff-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffFraction from '../diff-fraction.js';
+
+describe('diff-fraction', () => {
+  it('exports a module', () => {
+    expect(DiffFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-frame.test.js
+++ b/src/eventra-kit/__tests__/diff-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffFrame from '../diff-frame.js';
+
+describe('diff-frame', () => {
+  it('exports a module', () => {
+    expect(DiffFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-gap.test.js
+++ b/src/eventra-kit/__tests__/diff-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffGap from '../diff-gap.js';
+
+describe('diff-gap', () => {
+  it('exports a module', () => {
+    expect(DiffGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-graph.test.js
+++ b/src/eventra-kit/__tests__/diff-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffGraph from '../diff-graph.js';
+
+describe('diff-graph', () => {
+  it('exports a module', () => {
+    expect(DiffGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-grid.test.js
+++ b/src/eventra-kit/__tests__/diff-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffGrid from '../diff-grid.js';
+
+describe('diff-grid', () => {
+  it('exports a module', () => {
+    expect(DiffGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-group.test.js
+++ b/src/eventra-kit/__tests__/diff-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffGroup from '../diff-group.js';
+
+describe('diff-group', () => {
+  it('exports a module', () => {
+    expect(DiffGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-hash.test.js
+++ b/src/eventra-kit/__tests__/diff-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffHash from '../diff-hash.js';
+
+describe('diff-hash', () => {
+  it('exports a module', () => {
+    expect(DiffHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-heap.test.js
+++ b/src/eventra-kit/__tests__/diff-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffHeap from '../diff-heap.js';
+
+describe('diff-heap', () => {
+  it('exports a module', () => {
+    expect(DiffHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-html.test.js
+++ b/src/eventra-kit/__tests__/diff-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffHtml from '../diff-html.js';
+
+describe('diff-html', () => {
+  it('exports a module', () => {
+    expect(DiffHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-id.test.js
+++ b/src/eventra-kit/__tests__/diff-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffId from '../diff-id.js';
+
+describe('diff-id', () => {
+  it('exports a module', () => {
+    expect(DiffId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-index.test.js
+++ b/src/eventra-kit/__tests__/diff-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffIndex from '../diff-index.js';
+
+describe('diff-index', () => {
+  it('exports a module', () => {
+    expect(DiffIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-interval.test.js
+++ b/src/eventra-kit/__tests__/diff-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffInterval from '../diff-interval.js';
+
+describe('diff-interval', () => {
+  it('exports a module', () => {
+    expect(DiffInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-item.test.js
+++ b/src/eventra-kit/__tests__/diff-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffItem from '../diff-item.js';
+
+describe('diff-item', () => {
+  it('exports a module', () => {
+    expect(DiffItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-json.test.js
+++ b/src/eventra-kit/__tests__/diff-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffJson from '../diff-json.js';
+
+describe('diff-json', () => {
+  it('exports a module', () => {
+    expect(DiffJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-key.test.js
+++ b/src/eventra-kit/__tests__/diff-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffKey from '../diff-key.js';
+
+describe('diff-key', () => {
+  it('exports a module', () => {
+    expect(DiffKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-leaf.test.js
+++ b/src/eventra-kit/__tests__/diff-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffLeaf from '../diff-leaf.js';
+
+describe('diff-leaf', () => {
+  it('exports a module', () => {
+    expect(DiffLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/diff-length.test.js
+++ b/src/eventra-kit/__tests__/diff-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as DiffLength from '../diff-length.js';
+
+describe('diff-length', () => {
+  it('exports a module', () => {
+    expect(DiffLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/diff-count.js
+++ b/src/eventra-kit/diff-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-count helper.
+ */
+export function diffCount(value, predicate = Boolean) {
+  return value.filter(predicate);
+}
+

--- a/src/eventra-kit/diff-date.js
+++ b/src/eventra-kit/diff-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-date helper.
+ */
+export function diffDate(value) {
+  return value.map((item) => item).join(', ');
+}
+

--- a/src/eventra-kit/diff-delta.js
+++ b/src/eventra-kit/diff-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-delta helper.
+ */
+export function diffDelta(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/diff-dict.js
+++ b/src/eventra-kit/diff-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-dict helper.
+ */
+export function diffDict(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/diff-dir.js
+++ b/src/eventra-kit/diff-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-dir helper.
+ */
+export function diffDir(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/diff-edge.js
+++ b/src/eventra-kit/diff-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-edge helper.
+ */
+export function diffEdge(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/diff-element.js
+++ b/src/eventra-kit/diff-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-element helper.
+ */
+export function diffElement(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/diff-entry.js
+++ b/src/eventra-kit/diff-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-entry helper.
+ */
+export function diffEntry(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/diff-field.js
+++ b/src/eventra-kit/diff-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-field helper.
+ */
+export function diffField(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/diff-file.js
+++ b/src/eventra-kit/diff-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-file helper.
+ */
+export function diffFile(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/diff-fraction.js
+++ b/src/eventra-kit/diff-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-fraction helper.
+ */
+export function diffFraction(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/diff-frame.js
+++ b/src/eventra-kit/diff-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-frame helper.
+ */
+export function diffFrame(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/diff-gap.js
+++ b/src/eventra-kit/diff-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-gap helper.
+ */
+export function diffGap(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/diff-graph.js
+++ b/src/eventra-kit/diff-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-graph helper.
+ */
+export function diffGraph(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/diff-grid.js
+++ b/src/eventra-kit/diff-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-grid helper.
+ */
+export function diffGrid(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/diff-group.js
+++ b/src/eventra-kit/diff-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-group helper.
+ */
+export function diffGroup(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/diff-hash.js
+++ b/src/eventra-kit/diff-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-hash helper.
+ */
+export function diffHash(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/diff-heap.js
+++ b/src/eventra-kit/diff-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-heap helper.
+ */
+export function diffHeap(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/diff-html.js
+++ b/src/eventra-kit/diff-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-html helper.
+ */
+export function diffHtml(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/diff-id.js
+++ b/src/eventra-kit/diff-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-id helper.
+ */
+export function diffId(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/diff-index.js
+++ b/src/eventra-kit/diff-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-index helper.
+ */
+export function diffIndex(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/diff-interval.js
+++ b/src/eventra-kit/diff-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-interval helper.
+ */
+export function diffInterval(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/diff-item.js
+++ b/src/eventra-kit/diff-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-item helper.
+ */
+export function diffItem(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/diff-json.js
+++ b/src/eventra-kit/diff-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-json helper.
+ */
+export function diffJson(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/diff-key.js
+++ b/src/eventra-kit/diff-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-key helper.
+ */
+export function diffKey(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/diff-leaf.js
+++ b/src/eventra-kit/diff-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-leaf helper.
+ */
+export function diffLeaf(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/diff-length.js
+++ b/src/eventra-kit/diff-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a diff-length helper.
+ */
+export function diffLength(value) {
+  return Math.sign(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/diff-length.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change