### PR TITLE
fix(tickets): map duplicate check-in race to 409 conflict

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -154,12 +156,21 @@ public class TicketController {
                     "This ticket has already been checked in."));
         }
 
-        ticketCheckInRepository.save(TicketCheckIn.builder()
-                .eventId(eventId)
-                .registrationId(registrationId)
-                .attendeeName(displayName(reg))
-                .checkedInBy(payload.get("checkedInBy") != null ? String.valueOf(payload.get("checkedInBy")) : null)
-                .build());
+        // Two concurrent scans can both pass the exists() check above and race to insert
+        // the same (event, registration) row; the unique constraint then rejects the loser.
+        // Flush eagerly so the violation surfaces here and is mapped to a friendly 409.
+        try {
+            ticketCheckInRepository.saveAndFlush(TicketCheckIn.builder()
+                    .eventId(eventId)
+                    .registrationId(registrationId)
+                    .attendeeName(displayName(reg))
+                    .checkedInBy(payload.get("checkedInBy") != null ? String.valueOf(payload.get("checkedInBy")) : null)
+                    .build());
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                    result(true, displayName(reg), registrationId, true,
+                            "This ticket has already been checked in."));
+        }
 
         Map<String, Object> response = result(true, displayName(reg), registrationId, false,
                 "Check-in recorded successfully.");


### PR DESCRIPTION
## Problem

`TicketController.checkIn` first checked `existsByEventIdAndRegistrationId` and then inserted a check-in row. Two concurrent scans (or a retry from a flaky network) for the same ticket could both pass the existence check and race to insert, so the loser hit the `uk_ticket_checkin_event_registration` unique constraint. That surfaced as an unhandled `DataIntegrityViolationException` → HTTP 500 instead of a friendly conflict.

## Fix

The insert now uses `saveAndFlush` so the constraint violation surfaces at the insert point, and a `catch (DataIntegrityViolationException)` maps it to `409 Conflict` with a "This ticket has already been checked in." message — mirroring the pattern already used for upvote concurrency (#14509).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java`

## Testing

- Manual review: duplicate inserts now resolve to a 409 instead of bubbling up as a 500; the happy path is unchanged.

Closes #16189
