### PR TITLE
fix(subtitles): scope SSE stream and stats endpoints to the event organizer

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleStreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleStreamController.java
@@ -69,7 +69,9 @@ public class SubtitleStreamController {
      * @return SseEmitter for streaming subtitles
      */
     @GetMapping("/event/{eventId}")
-    public SseEmitter streamEventSubtitles(@PathVariable Long eventId) {
+    public SseEmitter streamEventSubtitles(@PathVariable Long eventId, Authentication authentication) {
+        requireOrganizer(eventId, authentication);
+
         SseEmitter emitter = createEmitter();
         
         // Register emitter
@@ -98,7 +100,9 @@ public class SubtitleStreamController {
      * @return SseEmitter for streaming subtitles
      */
     @GetMapping("/session/{sessionId}")
-    public SseEmitter streamSessionSubtitles(@PathVariable String sessionId) {
+    public SseEmitter streamSessionSubtitles(@PathVariable String sessionId, Authentication authentication) {
+        requireSessionOrganizer(sessionId, authentication);
+
         SseEmitter emitter = createEmitter();
         
         // Register emitter
@@ -126,7 +130,10 @@ public class SubtitleStreamController {
     @GetMapping("/event/{eventId}/language/{language}")
     public SseEmitter streamEventSubtitlesByLanguage(
             @PathVariable Long eventId,
-            @PathVariable String language) {
+            @PathVariable String language,
+            Authentication authentication) {
+        requireOrganizer(eventId, authentication);
+
         SseEmitter emitter = createEmitter();
         
         // Register emitter with language filter
@@ -328,25 +335,38 @@ public class SubtitleStreamController {
      * Get statistics about active connections
      */
     @GetMapping("/stats")
-    public ResponseEntity<Map<String, Object>> getConnectionStats() {
+    public ResponseEntity<Map<String, Object>> getConnectionStats(
+            @RequestParam Long eventId,
+            Authentication authentication) {
+        requireOrganizer(eventId, authentication);
+
         Map<String, Object> stats = new HashMap<>();
-        
-        // Count active emitters by event
+
+        // Count active emitters for the requested event only
         Map<Long, Integer> eventCounts = new HashMap<>();
-        eventEmitters.forEach((eventId, emitters) -> 
-            eventCounts.put(eventId, emitters.size()));
-        
-        // Count active emitters by session
+        Map<SseEmitter, String> emitters = eventEmitters.get(eventId);
+        if (emitters != null) {
+            eventCounts.put(eventId, emitters.size());
+        }
+
+        // Count active emitters per session, scoped to sessions of the requested event
         Map<String, Integer> sessionCounts = new HashMap<>();
-        sessionEmitters.forEach((sessionId, emitters) -> 
-            sessionCounts.put(sessionId, emitters.size()));
-        
-        stats.put("totalEventConnections", eventEmitters.values().stream().mapToInt(Map::size).sum());
-        stats.put("totalSessionConnections", sessionEmitters.values().stream().mapToInt(List::size).sum());
+        sessionEmitters.forEach((sessionId, emittersForSession) -> {
+            boolean belongsToEvent = subtitleService.getSession(sessionId)
+                    .map(SubtitleSession::getEventId)
+                    .map(eventId::equals)
+                    .orElse(false);
+            if (belongsToEvent) {
+                sessionCounts.put(sessionId, emittersForSession.size());
+            }
+        });
+
+        stats.put("totalEventConnections", eventCounts.values().stream().mapToInt(Integer::intValue).sum());
+        stats.put("totalSessionConnections", sessionCounts.values().stream().mapToInt(Integer::intValue).sum());
         stats.put("activeEvents", eventCounts);
         stats.put("activeSessions", sessionCounts);
         stats.put("timestamp", new Date());
-        
+
         return ResponseEntity.ok(stats);
     }
     


### PR DESCRIPTION
## Problem

The subtitle SSE read/stream endpoints (`/event/{eventId}`, `/session/{sessionId}`, `/event/{eventId}/language/{language}`) and `/stats` only required a valid JWT (global `anyRequest().authenticated()`). Any authenticated user could open the live caption stream for any event and read global connection statistics, leaking private live-event content and connection metadata across events. This was inconsistent with `disconnectEventClients`, which already enforced `requireOrganizer`.

## Fix

All three stream endpoints and the `/stats` endpoint now take the `Authentication` and enforce event-scoping via the existing `requireOrganizer` / `requireSessionOrganizer` helpers:

- `streamEventSubtitles` / `streamEventSubtitlesByLanguage` require `ORGANIZER` (or higher, incl. platform admins) on `eventId`.
- `streamSessionSubtitles` requires `ORGANIZER` on the event the session belongs to.
- `/stats` now requires an `eventId` parameter, enforces `requireOrganizer`, and returns connection counts scoped to that event and its sessions instead of the whole platform.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleStreamController.java`

## Testing

- Manual review: each endpoint now fails closed with `AccessDeniedException` (→ 403 via the global handler) before any emitter is registered or data is streamed.

Closes #16190
