### PR TITLE
fix: validate share URLs against unsafe schemes

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -2,6 +2,17 @@ import { ENV } from "../config/env.js";
 
 const DEFAULT_EVENT_SHARE_HOST = "sandeepvashishtha.tech";
 
+const isSafeUrl = (url) => {
+  if (!url || typeof url !== "string") return false;
+  if (url.startsWith("/")) return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Sharing utility functions for Eventra
  * These functions generate URLs for sharing content across various platforms
@@ -111,10 +122,10 @@ export const generateSharingUrl = (shareData, platform) => {
       return `https://telegram.me/share/url?url=${encodedUrl}&text=${encodedTitle}`;
 
     case "copy":
-      return url;
+      return isSafeUrl(url) ? url : "";
 
     default:
-      return url;
+      return isSafeUrl(url) ? url : "";
   }
 };
 


### PR DESCRIPTION
## Description

Fixes #17298

### What changed
- Added URL validation for generated share URLs.
- Restricted external URLs to `http:` and `https:` schemes.
- Rejected unsafe schemes such as `javascript:`, `data:`, and `file:`.
- Prevented invalid URLs from being returned for unsupported sharing platforms.

### Security Impact
This prevents attacker-controlled URLs from being returned as navigable links and reduces the risk of XSS through unsafe URL schemes.

### Testing
- Verified valid HTTP/HTTPS URLs are accepted.
- Verified unsafe URL schemes are rejected.
- Verified invalid URLs safely return an empty value.