### PR TITLE
fix: handle localStorage errors in session sync

### DIFF
--- a/src/utils/multiSessionRecovery.js
+++ b/src/utils/multiSessionRecovery.js
@@ -236,6 +236,10 @@ export const writeMultiSessions = (
   key = MULTI_SESSION_RECOVERY_KEY,
 ) => {
   const normalized = normalizeMultiSessions(sessions);
-  storage?.setItem?.(key, JSON.stringify(normalized));
+  try {
+    storage?.setItem?.(key, JSON.stringify(normalized));
+  } catch (err) {
+    console.warn("[MultiSessionRecovery] Failed to write sessions to storage:", err.message);
+  }
   return normalized;
 };


### PR DESCRIPTION
## Description

Fixes #17302

### What changed
- Wrapped localStorage session-state writes in a try/catch block.
- Prevented storage and quota errors from interrupting multi-tab session synchronization.
- Added a warning when session state cannot be persisted.

### Impact
The synchronization flow now fails gracefully when localStorage is unavailable or its quota is exceeded.

### Testing
- Verified normal session state writes continue to work.
- Verified localStorage write failures are caught without propagating exceptions.