### PR TITLE
feat: add estimate graph helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/ensure-url.test.js
+++ b/src/eventra-kit/__tests__/ensure-url.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureUrl from '../ensure-url.js';
+
+describe('ensure-url', () => {
+  it('exports a module', () => {
+    expect(EnsureUrl).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ensure-value.test.js
+++ b/src/eventra-kit/__tests__/ensure-value.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureValue from '../ensure-value.js';
+
+describe('ensure-value', () => {
+  it('exports a module', () => {
+    expect(EnsureValue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ensure-vector.test.js
+++ b/src/eventra-kit/__tests__/ensure-vector.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureVector from '../ensure-vector.js';
+
+describe('ensure-vector', () => {
+  it('exports a module', () => {
+    expect(EnsureVector).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ensure-vertex.test.js
+++ b/src/eventra-kit/__tests__/ensure-vertex.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureVertex from '../ensure-vertex.js';
+
+describe('ensure-vertex', () => {
+  it('exports a module', () => {
+    expect(EnsureVertex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ensure-weight.test.js
+++ b/src/eventra-kit/__tests__/ensure-weight.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureWeight from '../ensure-weight.js';
+
+describe('ensure-weight', () => {
+  it('exports a module', () => {
+    expect(EnsureWeight).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ensure-word.test.js
+++ b/src/eventra-kit/__tests__/ensure-word.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureWord from '../ensure-word.js';
+
+describe('ensure-word', () => {
+  it('exports a module', () => {
+    expect(EnsureWord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/ensure-xml.test.js
+++ b/src/eventra-kit/__tests__/ensure-xml.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EnsureXml from '../ensure-xml.js';
+
+describe('ensure-xml', () => {
+  it('exports a module', () => {
+    expect(EnsureXml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-array.test.js
+++ b/src/eventra-kit/__tests__/estimate-array.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateArray from '../estimate-array.js';
+
+describe('estimate-array', () => {
+  it('exports a module', () => {
+    expect(EstimateArray).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-block.test.js
+++ b/src/eventra-kit/__tests__/estimate-block.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateBlock from '../estimate-block.js';
+
+describe('estimate-block', () => {
+  it('exports a module', () => {
+    expect(EstimateBlock).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-box.test.js
+++ b/src/eventra-kit/__tests__/estimate-box.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateBox from '../estimate-box.js';
+
+describe('estimate-box', () => {
+  it('exports a module', () => {
+    expect(EstimateBox).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-byte.test.js
+++ b/src/eventra-kit/__tests__/estimate-byte.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateByte from '../estimate-byte.js';
+
+describe('estimate-byte', () => {
+  it('exports a module', () => {
+    expect(EstimateByte).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-char.test.js
+++ b/src/eventra-kit/__tests__/estimate-char.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateChar from '../estimate-char.js';
+
+describe('estimate-char', () => {
+  it('exports a module', () => {
+    expect(EstimateChar).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-chunk.test.js
+++ b/src/eventra-kit/__tests__/estimate-chunk.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateChunk from '../estimate-chunk.js';
+
+describe('estimate-chunk', () => {
+  it('exports a module', () => {
+    expect(EstimateChunk).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-circle.test.js
+++ b/src/eventra-kit/__tests__/estimate-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateCircle from '../estimate-circle.js';
+
+describe('estimate-circle', () => {
+  it('exports a module', () => {
+    expect(EstimateCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-count.test.js
+++ b/src/eventra-kit/__tests__/estimate-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateCount from '../estimate-count.js';
+
+describe('estimate-count', () => {
+  it('exports a module', () => {
+    expect(EstimateCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-date.test.js
+++ b/src/eventra-kit/__tests__/estimate-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateDate from '../estimate-date.js';
+
+describe('estimate-date', () => {
+  it('exports a module', () => {
+    expect(EstimateDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-delta.test.js
+++ b/src/eventra-kit/__tests__/estimate-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateDelta from '../estimate-delta.js';
+
+describe('estimate-delta', () => {
+  it('exports a module', () => {
+    expect(EstimateDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-dict.test.js
+++ b/src/eventra-kit/__tests__/estimate-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateDict from '../estimate-dict.js';
+
+describe('estimate-dict', () => {
+  it('exports a module', () => {
+    expect(EstimateDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-dir.test.js
+++ b/src/eventra-kit/__tests__/estimate-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateDir from '../estimate-dir.js';
+
+describe('estimate-dir', () => {
+  it('exports a module', () => {
+    expect(EstimateDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-edge.test.js
+++ b/src/eventra-kit/__tests__/estimate-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateEdge from '../estimate-edge.js';
+
+describe('estimate-edge', () => {
+  it('exports a module', () => {
+    expect(EstimateEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-element.test.js
+++ b/src/eventra-kit/__tests__/estimate-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateElement from '../estimate-element.js';
+
+describe('estimate-element', () => {
+  it('exports a module', () => {
+    expect(EstimateElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-entry.test.js
+++ b/src/eventra-kit/__tests__/estimate-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateEntry from '../estimate-entry.js';
+
+describe('estimate-entry', () => {
+  it('exports a module', () => {
+    expect(EstimateEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-field.test.js
+++ b/src/eventra-kit/__tests__/estimate-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateField from '../estimate-field.js';
+
+describe('estimate-field', () => {
+  it('exports a module', () => {
+    expect(EstimateField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-file.test.js
+++ b/src/eventra-kit/__tests__/estimate-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateFile from '../estimate-file.js';
+
+describe('estimate-file', () => {
+  it('exports a module', () => {
+    expect(EstimateFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-fraction.test.js
+++ b/src/eventra-kit/__tests__/estimate-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateFraction from '../estimate-fraction.js';
+
+describe('estimate-fraction', () => {
+  it('exports a module', () => {
+    expect(EstimateFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-frame.test.js
+++ b/src/eventra-kit/__tests__/estimate-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateFrame from '../estimate-frame.js';
+
+describe('estimate-frame', () => {
+  it('exports a module', () => {
+    expect(EstimateFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-gap.test.js
+++ b/src/eventra-kit/__tests__/estimate-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateGap from '../estimate-gap.js';
+
+describe('estimate-gap', () => {
+  it('exports a module', () => {
+    expect(EstimateGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-graph.test.js
+++ b/src/eventra-kit/__tests__/estimate-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateGraph from '../estimate-graph.js';
+
+describe('estimate-graph', () => {
+  it('exports a module', () => {
+    expect(EstimateGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/ensure-url.js
+++ b/src/eventra-kit/ensure-url.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-url helper.
+ */
+export function ensureUrl(value) {
+  return value.flat(Infinity);
+}
+

--- a/src/eventra-kit/ensure-value.js
+++ b/src/eventra-kit/ensure-value.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-value helper.
+ */
+export function ensureValue(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/ensure-vector.js
+++ b/src/eventra-kit/ensure-vector.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-vector helper.
+ */
+export function ensureVector(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/ensure-vertex.js
+++ b/src/eventra-kit/ensure-vertex.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-vertex helper.
+ */
+export function ensureVertex(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/ensure-weight.js
+++ b/src/eventra-kit/ensure-weight.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-weight helper.
+ */
+export function ensureWeight(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/ensure-word.js
+++ b/src/eventra-kit/ensure-word.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-word helper.
+ */
+export function ensureWord(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/ensure-xml.js
+++ b/src/eventra-kit/ensure-xml.js
@@ -1,0 +1,7 @@
+/**
+ * adds a ensure-xml helper.
+ */
+export function ensureXml(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/estimate-array.js
+++ b/src/eventra-kit/estimate-array.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-array helper.
+ */
+export function estimateArray(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/estimate-block.js
+++ b/src/eventra-kit/estimate-block.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-block helper.
+ */
+export function estimateBlock(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/estimate-box.js
+++ b/src/eventra-kit/estimate-box.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-box helper.
+ */
+export function estimateBox(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/estimate-byte.js
+++ b/src/eventra-kit/estimate-byte.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-byte helper.
+ */
+export function estimateByte(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/estimate-char.js
+++ b/src/eventra-kit/estimate-char.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-char helper.
+ */
+export function estimateChar(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/estimate-chunk.js
+++ b/src/eventra-kit/estimate-chunk.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-chunk helper.
+ */
+export function estimateChunk(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/estimate-circle.js
+++ b/src/eventra-kit/estimate-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-circle helper.
+ */
+export function estimateCircle(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/estimate-count.js
+++ b/src/eventra-kit/estimate-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-count helper.
+ */
+export function estimateCount(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/estimate-date.js
+++ b/src/eventra-kit/estimate-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-date helper.
+ */
+export function estimateDate(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/estimate-delta.js
+++ b/src/eventra-kit/estimate-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-delta helper.
+ */
+export function estimateDelta(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/estimate-dict.js
+++ b/src/eventra-kit/estimate-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-dict helper.
+ */
+export function estimateDict(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/estimate-dir.js
+++ b/src/eventra-kit/estimate-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-dir helper.
+ */
+export function estimateDir(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/estimate-edge.js
+++ b/src/eventra-kit/estimate-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-edge helper.
+ */
+export function estimateEdge(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/estimate-element.js
+++ b/src/eventra-kit/estimate-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-element helper.
+ */
+export function estimateElement(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/estimate-entry.js
+++ b/src/eventra-kit/estimate-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-entry helper.
+ */
+export function estimateEntry(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/estimate-field.js
+++ b/src/eventra-kit/estimate-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-field helper.
+ */
+export function estimateField(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/estimate-file.js
+++ b/src/eventra-kit/estimate-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-file helper.
+ */
+export function estimateFile(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/estimate-fraction.js
+++ b/src/eventra-kit/estimate-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-fraction helper.
+ */
+export function estimateFraction(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/estimate-frame.js
+++ b/src/eventra-kit/estimate-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-frame helper.
+ */
+export function estimateFrame(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/estimate-gap.js
+++ b/src/eventra-kit/estimate-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-gap helper.
+ */
+export function estimateGap(value) {
+  return value.map((item, index) => [index, item]);
+}
+

--- a/src/eventra-kit/estimate-graph.js
+++ b/src/eventra-kit/estimate-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-graph helper.
+ */
+export function estimateGraph(value) {
+  return String(value).split(/\r?\n/);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/estimate-graph.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change