### PR TITLE
fix: sanitize imported session data

### DIFF
--- a/src/utils/sessionExportImport.js
+++ b/src/utils/sessionExportImport.js
@@ -75,6 +75,21 @@ export const downloadSessionBackup = ({
   return { filename, count: normalizeMultiSessions(sessions).length };
 };
 
+const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+const sanitizeObject = (obj) => {
+  if (!obj || typeof obj !== "object") return obj;
+  if (Array.isArray(obj)) return obj.map(sanitizeObject);
+
+  const clean = {};
+  for (const key of Object.keys(obj)) {
+    if (!DANGEROUS_KEYS.has(key)) {
+      clean[key] = typeof obj[key] === "object" ? sanitizeObject(obj[key]) : obj[key];
+    }
+  }
+  return clean;
+};
+
 const getStringByteSize = (value) => {
   if (typeof Blob !== "undefined") {
     return new Blob([value]).size;
@@ -92,7 +107,8 @@ export const parseSessionBackupJson = (rawJson) => {
   }
 
   try {
-    return validateSessionBackup(JSON.parse(rawJson));
+    const parsed = JSON.parse(rawJson);
+    return validateSessionBackup(sanitizeObject(parsed));
   } catch {
     return { ok: false, error: "Backup file is not valid JSON." };
   }


### PR DESCRIPTION
## Description

Fixes #17311

### What changed

- Added sanitization for imported session JSON.
- Rejected dangerous prototype-related keys such as `__proto__`, `constructor`, and `prototype`.
- Recursively sanitized nested objects and arrays before session validation.

### Security Impact

Prevents prototype-related properties from being introduced through user-controlled session import data.

### Testing

- Verified valid session data continues to be imported.
- Verified dangerous prototype-related keys are removed.
- Verified nested objects and arrays are sanitized recursively.