### PR TITLE
feat: add estimate span helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/estimate-length.test.js
+++ b/src/eventra-kit/__tests__/estimate-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateLength from '../estimate-length.js';
+
+describe('estimate-length', () => {
+  it('exports a module', () => {
+    expect(EstimateLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-line.test.js
+++ b/src/eventra-kit/__tests__/estimate-line.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateLine from '../estimate-line.js';
+
+describe('estimate-line', () => {
+  it('exports a module', () => {
+    expect(EstimateLine).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-list.test.js
+++ b/src/eventra-kit/__tests__/estimate-list.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateList from '../estimate-list.js';
+
+describe('estimate-list', () => {
+  it('exports a module', () => {
+    expect(EstimateList).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-map.test.js
+++ b/src/eventra-kit/__tests__/estimate-map.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateMap from '../estimate-map.js';
+
+describe('estimate-map', () => {
+  it('exports a module', () => {
+    expect(EstimateMap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-matrix.test.js
+++ b/src/eventra-kit/__tests__/estimate-matrix.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateMatrix from '../estimate-matrix.js';
+
+describe('estimate-matrix', () => {
+  it('exports a module', () => {
+    expect(EstimateMatrix).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-name.test.js
+++ b/src/eventra-kit/__tests__/estimate-name.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateName from '../estimate-name.js';
+
+describe('estimate-name', () => {
+  it('exports a module', () => {
+    expect(EstimateName).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-node.test.js
+++ b/src/eventra-kit/__tests__/estimate-node.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateNode from '../estimate-node.js';
+
+describe('estimate-node', () => {
+  it('exports a module', () => {
+    expect(EstimateNode).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-number.test.js
+++ b/src/eventra-kit/__tests__/estimate-number.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateNumber from '../estimate-number.js';
+
+describe('estimate-number', () => {
+  it('exports a module', () => {
+    expect(EstimateNumber).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-object.test.js
+++ b/src/eventra-kit/__tests__/estimate-object.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateObject from '../estimate-object.js';
+
+describe('estimate-object', () => {
+  it('exports a module', () => {
+    expect(EstimateObject).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-order.test.js
+++ b/src/eventra-kit/__tests__/estimate-order.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateOrder from '../estimate-order.js';
+
+describe('estimate-order', () => {
+  it('exports a module', () => {
+    expect(EstimateOrder).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-page.test.js
+++ b/src/eventra-kit/__tests__/estimate-page.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimatePage from '../estimate-page.js';
+
+describe('estimate-page', () => {
+  it('exports a module', () => {
+    expect(EstimatePage).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-pair.test.js
+++ b/src/eventra-kit/__tests__/estimate-pair.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimatePair from '../estimate-pair.js';
+
+describe('estimate-pair', () => {
+  it('exports a module', () => {
+    expect(EstimatePair).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-path.test.js
+++ b/src/eventra-kit/__tests__/estimate-path.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimatePath from '../estimate-path.js';
+
+describe('estimate-path', () => {
+  it('exports a module', () => {
+    expect(EstimatePath).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-point.test.js
+++ b/src/eventra-kit/__tests__/estimate-point.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimatePoint from '../estimate-point.js';
+
+describe('estimate-point', () => {
+  it('exports a module', () => {
+    expect(EstimatePoint).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-portion.test.js
+++ b/src/eventra-kit/__tests__/estimate-portion.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimatePortion from '../estimate-portion.js';
+
+describe('estimate-portion', () => {
+  it('exports a module', () => {
+    expect(EstimatePortion).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-prop.test.js
+++ b/src/eventra-kit/__tests__/estimate-prop.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateProp from '../estimate-prop.js';
+
+describe('estimate-prop', () => {
+  it('exports a module', () => {
+    expect(EstimateProp).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-queue.test.js
+++ b/src/eventra-kit/__tests__/estimate-queue.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateQueue from '../estimate-queue.js';
+
+describe('estimate-queue', () => {
+  it('exports a module', () => {
+    expect(EstimateQueue).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-range.test.js
+++ b/src/eventra-kit/__tests__/estimate-range.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateRange from '../estimate-range.js';
+
+describe('estimate-range', () => {
+  it('exports a module', () => {
+    expect(EstimateRange).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-rank.test.js
+++ b/src/eventra-kit/__tests__/estimate-rank.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateRank from '../estimate-rank.js';
+
+describe('estimate-rank', () => {
+  it('exports a module', () => {
+    expect(EstimateRank).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-record.test.js
+++ b/src/eventra-kit/__tests__/estimate-record.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateRecord from '../estimate-record.js';
+
+describe('estimate-record', () => {
+  it('exports a module', () => {
+    expect(EstimateRecord).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-rect.test.js
+++ b/src/eventra-kit/__tests__/estimate-rect.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateRect from '../estimate-rect.js';
+
+describe('estimate-rect', () => {
+  it('exports a module', () => {
+    expect(EstimateRect).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-score.test.js
+++ b/src/eventra-kit/__tests__/estimate-score.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateScore from '../estimate-score.js';
+
+describe('estimate-score', () => {
+  it('exports a module', () => {
+    expect(EstimateScore).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-segment.test.js
+++ b/src/eventra-kit/__tests__/estimate-segment.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateSegment from '../estimate-segment.js';
+
+describe('estimate-segment', () => {
+  it('exports a module', () => {
+    expect(EstimateSegment).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-set.test.js
+++ b/src/eventra-kit/__tests__/estimate-set.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateSet from '../estimate-set.js';
+
+describe('estimate-set', () => {
+  it('exports a module', () => {
+    expect(EstimateSet).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-size.test.js
+++ b/src/eventra-kit/__tests__/estimate-size.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateSize from '../estimate-size.js';
+
+describe('estimate-size', () => {
+  it('exports a module', () => {
+    expect(EstimateSize).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-slice.test.js
+++ b/src/eventra-kit/__tests__/estimate-slice.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateSlice from '../estimate-slice.js';
+
+describe('estimate-slice', () => {
+  it('exports a module', () => {
+    expect(EstimateSlice).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-space.test.js
+++ b/src/eventra-kit/__tests__/estimate-space.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateSpace from '../estimate-space.js';
+
+describe('estimate-space', () => {
+  it('exports a module', () => {
+    expect(EstimateSpace).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/estimate-span.test.js
+++ b/src/eventra-kit/__tests__/estimate-span.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as EstimateSpan from '../estimate-span.js';
+
+describe('estimate-span', () => {
+  it('exports a module', () => {
+    expect(EstimateSpan).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/estimate-length.js
+++ b/src/eventra-kit/estimate-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-length helper.
+ */
+export function estimateLength(value, target) {
+  return value.indexOf(target);
+}
+

--- a/src/eventra-kit/estimate-line.js
+++ b/src/eventra-kit/estimate-line.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-line helper.
+ */
+export function estimateLine(value) {
+  return value.toUpperCase();
+}
+

--- a/src/eventra-kit/estimate-list.js
+++ b/src/eventra-kit/estimate-list.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-list helper.
+ */
+export function estimateList(value) {
+  return value.toLowerCase();
+}
+

--- a/src/eventra-kit/estimate-map.js
+++ b/src/eventra-kit/estimate-map.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-map helper.
+ */
+export function estimateMap(value) {
+  return value.trim();
+}
+

--- a/src/eventra-kit/estimate-matrix.js
+++ b/src/eventra-kit/estimate-matrix.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-matrix helper.
+ */
+export function estimateMatrix(value, count) {
+  return value.repeat(count);
+}
+

--- a/src/eventra-kit/estimate-name.js
+++ b/src/eventra-kit/estimate-name.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-name helper.
+ */
+export function estimateName(value, start, end) {
+  return value.slice(start, end);
+}
+

--- a/src/eventra-kit/estimate-node.js
+++ b/src/eventra-kit/estimate-node.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-node helper.
+ */
+export function estimateNode(value) {
+  return value.reverse();
+}
+

--- a/src/eventra-kit/estimate-number.js
+++ b/src/eventra-kit/estimate-number.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-number helper.
+ */
+export function estimateNumber(value) {
+  return value.split(' ').filter(Boolean).length;
+}
+

--- a/src/eventra-kit/estimate-object.js
+++ b/src/eventra-kit/estimate-object.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-object helper.
+ */
+export function estimateObject(value) {
+  return String(value).split('').reverse().join('');
+}
+

--- a/src/eventra-kit/estimate-order.js
+++ b/src/eventra-kit/estimate-order.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-order helper.
+ */
+export function estimateOrder(value, size) {
+  return value.slice(0, size);
+}
+

--- a/src/eventra-kit/estimate-page.js
+++ b/src/eventra-kit/estimate-page.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-page helper.
+ */
+export function estimatePage(value) {
+  return value.reduce((sum, item) => sum + item, 0);
+}
+

--- a/src/eventra-kit/estimate-pair.js
+++ b/src/eventra-kit/estimate-pair.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-pair helper.
+ */
+export function estimatePair(value) {
+  return value.reduce((sum, item) => sum + item, 0) / Math.max(1, value.length);
+}
+

--- a/src/eventra-kit/estimate-path.js
+++ b/src/eventra-kit/estimate-path.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-path helper.
+ */
+export function estimatePath(value) {
+  return Math.min(...value);
+}
+

--- a/src/eventra-kit/estimate-point.js
+++ b/src/eventra-kit/estimate-point.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-point helper.
+ */
+export function estimatePoint(value) {
+  return Math.max(...value);
+}
+

--- a/src/eventra-kit/estimate-portion.js
+++ b/src/eventra-kit/estimate-portion.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-portion helper.
+ */
+export function estimatePortion(value, from, to) {
+  return value.replaceAll(from, to);
+}
+

--- a/src/eventra-kit/estimate-prop.js
+++ b/src/eventra-kit/estimate-prop.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-prop helper.
+ */
+export function estimateProp(value) {
+  return String(value).padStart(10, '0');
+}
+

--- a/src/eventra-kit/estimate-queue.js
+++ b/src/eventra-kit/estimate-queue.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-queue helper.
+ */
+export function estimateQueue(value) {
+  return String(value).padEnd(10, ' ');
+}
+

--- a/src/eventra-kit/estimate-range.js
+++ b/src/eventra-kit/estimate-range.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-range helper.
+ */
+export function estimateRange(value) {
+  return Number(value).toFixed(2);
+}
+

--- a/src/eventra-kit/estimate-rank.js
+++ b/src/eventra-kit/estimate-rank.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-rank helper.
+ */
+export function estimateRank(value) {
+  return Number.isInteger(value);
+}
+

--- a/src/eventra-kit/estimate-record.js
+++ b/src/eventra-kit/estimate-record.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-record helper.
+ */
+export function estimateRecord(value) {
+  return Math.abs(value);
+}
+

--- a/src/eventra-kit/estimate-rect.js
+++ b/src/eventra-kit/estimate-rect.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-rect helper.
+ */
+export function estimateRect(value) {
+  return Math.sqrt(value);
+}
+

--- a/src/eventra-kit/estimate-score.js
+++ b/src/eventra-kit/estimate-score.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-score helper.
+ */
+export function estimateScore(value) {
+  return Math.floor(value);
+}
+

--- a/src/eventra-kit/estimate-segment.js
+++ b/src/eventra-kit/estimate-segment.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-segment helper.
+ */
+export function estimateSegment(value) {
+  return Math.ceil(value);
+}
+

--- a/src/eventra-kit/estimate-set.js
+++ b/src/eventra-kit/estimate-set.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-set helper.
+ */
+export function estimateSet(value) {
+  return Math.round(value);
+}
+

--- a/src/eventra-kit/estimate-size.js
+++ b/src/eventra-kit/estimate-size.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-size helper.
+ */
+export function estimateSize(value) {
+  return Math.sign(value);
+}
+

--- a/src/eventra-kit/estimate-slice.js
+++ b/src/eventra-kit/estimate-slice.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-slice helper.
+ */
+export function estimateSlice(value) {
+  return Math.pow(value, 2);
+}
+

--- a/src/eventra-kit/estimate-space.js
+++ b/src/eventra-kit/estimate-space.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-space helper.
+ */
+export function estimateSpace(value) {
+  return Math.log(value);
+}
+

--- a/src/eventra-kit/estimate-span.js
+++ b/src/eventra-kit/estimate-span.js
@@ -1,0 +1,7 @@
+/**
+ * adds a estimate-span helper.
+ */
+export function estimateSpan(value) {
+  return Math.exp(value);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/estimate-span.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change