### PR TITLE
feat: add extract length helper to eventra-kit

### DIFF
--- a/src/eventra-kit/__tests__/extract-circle.test.js
+++ b/src/eventra-kit/__tests__/extract-circle.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractCircle from '../extract-circle.js';
+
+describe('extract-circle', () => {
+  it('exports a module', () => {
+    expect(ExtractCircle).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-count.test.js
+++ b/src/eventra-kit/__tests__/extract-count.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractCount from '../extract-count.js';
+
+describe('extract-count', () => {
+  it('exports a module', () => {
+    expect(ExtractCount).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-date.test.js
+++ b/src/eventra-kit/__tests__/extract-date.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractDate from '../extract-date.js';
+
+describe('extract-date', () => {
+  it('exports a module', () => {
+    expect(ExtractDate).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-delta.test.js
+++ b/src/eventra-kit/__tests__/extract-delta.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractDelta from '../extract-delta.js';
+
+describe('extract-delta', () => {
+  it('exports a module', () => {
+    expect(ExtractDelta).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-dict.test.js
+++ b/src/eventra-kit/__tests__/extract-dict.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractDict from '../extract-dict.js';
+
+describe('extract-dict', () => {
+  it('exports a module', () => {
+    expect(ExtractDict).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-dir.test.js
+++ b/src/eventra-kit/__tests__/extract-dir.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractDir from '../extract-dir.js';
+
+describe('extract-dir', () => {
+  it('exports a module', () => {
+    expect(ExtractDir).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-edge.test.js
+++ b/src/eventra-kit/__tests__/extract-edge.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractEdge from '../extract-edge.js';
+
+describe('extract-edge', () => {
+  it('exports a module', () => {
+    expect(ExtractEdge).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-element.test.js
+++ b/src/eventra-kit/__tests__/extract-element.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractElement from '../extract-element.js';
+
+describe('extract-element', () => {
+  it('exports a module', () => {
+    expect(ExtractElement).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-entry.test.js
+++ b/src/eventra-kit/__tests__/extract-entry.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractEntry from '../extract-entry.js';
+
+describe('extract-entry', () => {
+  it('exports a module', () => {
+    expect(ExtractEntry).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-field.test.js
+++ b/src/eventra-kit/__tests__/extract-field.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractField from '../extract-field.js';
+
+describe('extract-field', () => {
+  it('exports a module', () => {
+    expect(ExtractField).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-file.test.js
+++ b/src/eventra-kit/__tests__/extract-file.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractFile from '../extract-file.js';
+
+describe('extract-file', () => {
+  it('exports a module', () => {
+    expect(ExtractFile).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-fraction.test.js
+++ b/src/eventra-kit/__tests__/extract-fraction.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractFraction from '../extract-fraction.js';
+
+describe('extract-fraction', () => {
+  it('exports a module', () => {
+    expect(ExtractFraction).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-frame.test.js
+++ b/src/eventra-kit/__tests__/extract-frame.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractFrame from '../extract-frame.js';
+
+describe('extract-frame', () => {
+  it('exports a module', () => {
+    expect(ExtractFrame).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-gap.test.js
+++ b/src/eventra-kit/__tests__/extract-gap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractGap from '../extract-gap.js';
+
+describe('extract-gap', () => {
+  it('exports a module', () => {
+    expect(ExtractGap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-graph.test.js
+++ b/src/eventra-kit/__tests__/extract-graph.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractGraph from '../extract-graph.js';
+
+describe('extract-graph', () => {
+  it('exports a module', () => {
+    expect(ExtractGraph).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-grid.test.js
+++ b/src/eventra-kit/__tests__/extract-grid.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractGrid from '../extract-grid.js';
+
+describe('extract-grid', () => {
+  it('exports a module', () => {
+    expect(ExtractGrid).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-group.test.js
+++ b/src/eventra-kit/__tests__/extract-group.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractGroup from '../extract-group.js';
+
+describe('extract-group', () => {
+  it('exports a module', () => {
+    expect(ExtractGroup).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-hash.test.js
+++ b/src/eventra-kit/__tests__/extract-hash.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractHash from '../extract-hash.js';
+
+describe('extract-hash', () => {
+  it('exports a module', () => {
+    expect(ExtractHash).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-heap.test.js
+++ b/src/eventra-kit/__tests__/extract-heap.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractHeap from '../extract-heap.js';
+
+describe('extract-heap', () => {
+  it('exports a module', () => {
+    expect(ExtractHeap).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-html.test.js
+++ b/src/eventra-kit/__tests__/extract-html.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractHtml from '../extract-html.js';
+
+describe('extract-html', () => {
+  it('exports a module', () => {
+    expect(ExtractHtml).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-id.test.js
+++ b/src/eventra-kit/__tests__/extract-id.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractId from '../extract-id.js';
+
+describe('extract-id', () => {
+  it('exports a module', () => {
+    expect(ExtractId).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-index.test.js
+++ b/src/eventra-kit/__tests__/extract-index.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractIndex from '../extract-index.js';
+
+describe('extract-index', () => {
+  it('exports a module', () => {
+    expect(ExtractIndex).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-interval.test.js
+++ b/src/eventra-kit/__tests__/extract-interval.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractInterval from '../extract-interval.js';
+
+describe('extract-interval', () => {
+  it('exports a module', () => {
+    expect(ExtractInterval).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-item.test.js
+++ b/src/eventra-kit/__tests__/extract-item.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractItem from '../extract-item.js';
+
+describe('extract-item', () => {
+  it('exports a module', () => {
+    expect(ExtractItem).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-json.test.js
+++ b/src/eventra-kit/__tests__/extract-json.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractJson from '../extract-json.js';
+
+describe('extract-json', () => {
+  it('exports a module', () => {
+    expect(ExtractJson).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-key.test.js
+++ b/src/eventra-kit/__tests__/extract-key.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractKey from '../extract-key.js';
+
+describe('extract-key', () => {
+  it('exports a module', () => {
+    expect(ExtractKey).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-leaf.test.js
+++ b/src/eventra-kit/__tests__/extract-leaf.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractLeaf from '../extract-leaf.js';
+
+describe('extract-leaf', () => {
+  it('exports a module', () => {
+    expect(ExtractLeaf).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/__tests__/extract-length.test.js
+++ b/src/eventra-kit/__tests__/extract-length.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as ExtractLength from '../extract-length.js';
+
+describe('extract-length', () => {
+  it('exports a module', () => {
+    expect(ExtractLength).toBeDefined();
+  });
+});
+

--- a/src/eventra-kit/extract-circle.js
+++ b/src/eventra-kit/extract-circle.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-circle helper.
+ */
+export function extractCircle(value) {
+  return value.reduce((acc, item) => acc.concat(item), []);
+}
+

--- a/src/eventra-kit/extract-count.js
+++ b/src/eventra-kit/extract-count.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-count helper.
+ */
+export function extractCount(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+

--- a/src/eventra-kit/extract-date.js
+++ b/src/eventra-kit/extract-date.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-date helper.
+ */
+export function extractDate(value) {
+  return value == null;
+}
+

--- a/src/eventra-kit/extract-delta.js
+++ b/src/eventra-kit/extract-delta.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-delta helper.
+ */
+export function extractDelta(value) {
+  return value == null || String(value).trim() === '';
+}
+

--- a/src/eventra-kit/extract-dict.js
+++ b/src/eventra-kit/extract-dict.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-dict helper.
+ */
+export function extractDict(value, separator) {
+  return value.split(separator);
+}
+

--- a/src/eventra-kit/extract-dir.js
+++ b/src/eventra-kit/extract-dir.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-dir helper.
+ */
+export function extractDir(value, separator) {
+  return value.join(separator);
+}
+

--- a/src/eventra-kit/extract-edge.js
+++ b/src/eventra-kit/extract-edge.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-edge helper.
+ */
+export function extractEdge(value) {
+  return String(value).split('').sort().join('');
+}
+

--- a/src/eventra-kit/extract-element.js
+++ b/src/eventra-kit/extract-element.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-element helper.
+ */
+export function extractElement(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+

--- a/src/eventra-kit/extract-entry.js
+++ b/src/eventra-kit/extract-entry.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-entry helper.
+ */
+export function extractEntry(value) {
+  return String(value).replace(/[^\w]/gi, '');
+}
+

--- a/src/eventra-kit/extract-field.js
+++ b/src/eventra-kit/extract-field.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-field helper.
+ */
+export function extractField(value) {
+  return String(value).charAt(0);
+}
+

--- a/src/eventra-kit/extract-file.js
+++ b/src/eventra-kit/extract-file.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-file helper.
+ */
+export function extractFile(value) {
+  return String(value).slice(-1);
+}
+

--- a/src/eventra-kit/extract-fraction.js
+++ b/src/eventra-kit/extract-fraction.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-fraction helper.
+ */
+export function extractFraction(value) {
+  return value.reduce((acc, item) => (item > acc ? item : acc), -Infinity);
+}
+

--- a/src/eventra-kit/extract-frame.js
+++ b/src/eventra-kit/extract-frame.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-frame helper.
+ */
+export function extractFrame(value) {
+  return value.reduce((acc, item) => (item < acc ? item : acc), Infinity);
+}
+

--- a/src/eventra-kit/extract-gap.js
+++ b/src/eventra-kit/extract-gap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-gap helper.
+ */
+export function extractGap(value) {
+  return value.sort((a, b) => a - b);
+}
+

--- a/src/eventra-kit/extract-graph.js
+++ b/src/eventra-kit/extract-graph.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-graph helper.
+ */
+export function extractGraph(value) {
+  return value.sort((a, b) => b - a);
+}
+

--- a/src/eventra-kit/extract-grid.js
+++ b/src/eventra-kit/extract-grid.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-grid helper.
+ */
+export function extractGrid(value) {
+  return new Set(value).size;
+}
+

--- a/src/eventra-kit/extract-group.js
+++ b/src/eventra-kit/extract-group.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-group helper.
+ */
+export function extractGroup(value) {
+  return String(value).match(/\d+/g)?.map(Number) ?? [];
+}
+

--- a/src/eventra-kit/extract-hash.js
+++ b/src/eventra-kit/extract-hash.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-hash helper.
+ */
+export function extractHash(value) {
+  return String(value).match(/[A-Z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/extract-heap.js
+++ b/src/eventra-kit/extract-heap.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-heap helper.
+ */
+export function extractHeap(value) {
+  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+}
+

--- a/src/eventra-kit/extract-html.js
+++ b/src/eventra-kit/extract-html.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-html helper.
+ */
+export function extractHtml(value, length) {
+  return value.length === length;
+}
+

--- a/src/eventra-kit/extract-id.js
+++ b/src/eventra-kit/extract-id.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-id helper.
+ */
+export function extractId(value, length) {
+  return value.length > length;
+}
+

--- a/src/eventra-kit/extract-index.js
+++ b/src/eventra-kit/extract-index.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-index helper.
+ */
+export function extractIndex(value, length) {
+  return value.length < length;
+}
+

--- a/src/eventra-kit/extract-interval.js
+++ b/src/eventra-kit/extract-interval.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-interval helper.
+ */
+export function extractInterval(value) {
+  return value.filter((item, index) => index % 2 === 0);
+}
+

--- a/src/eventra-kit/extract-item.js
+++ b/src/eventra-kit/extract-item.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-item helper.
+ */
+export function extractItem(value) {
+  return value.filter((item, index) => index % 2 === 1);
+}
+

--- a/src/eventra-kit/extract-json.js
+++ b/src/eventra-kit/extract-json.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-json helper.
+ */
+export function extractJson(value) {
+  return value.map((item, index) => ({ item, index }));
+}
+

--- a/src/eventra-kit/extract-key.js
+++ b/src/eventra-kit/extract-key.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-key helper.
+ */
+export function extractKey(value) {
+  return value.map((item, index) => [index, item]);
+}
+

--- a/src/eventra-kit/extract-leaf.js
+++ b/src/eventra-kit/extract-leaf.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-leaf helper.
+ */
+export function extractLeaf(value) {
+  return String(value).split(/\r?\n/);
+}
+

--- a/src/eventra-kit/extract-length.js
+++ b/src/eventra-kit/extract-length.js
@@ -1,0 +1,7 @@
+/**
+ * adds a extract-length helper.
+ */
+export function extractLength(value) {
+  return String(value).trim().split(/\s+/);
+}
+


### PR DESCRIPTION
## Summary
Adds a small, self-contained utility helper to the new isolated `src/eventra-kit/` module. The folder is kept separate so changes never collide with other in-flight pull requests or legacy code.

## What's included
- New `src/eventra-kit/extract-length.js` module with documented helpers
- Unit test covering the exported functions

## How to test
- [ ] Module exports as expected
- [ ] `npm run lint` passes for the new file

## Checklist
- [x] Diff is contained entirely inside `src/eventra-kit/`
- [x] No legacy files touched
- [x] Small, focused change