### PR TITLE
fix(analytics): scope dashboard stats to the caller's tenant (no cross-tenant leakage) (#16193)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
@@ -6,7 +6,6 @@ import com.sandeep.eventrabackend.dto.FeedbackAnalyticsDTO;
 import com.sandeep.eventrabackend.dto.OrganizerInsightDTO;
 import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
 import com.sandeep.eventrabackend.service.AnalyticsService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -26,23 +25,19 @@ public class AnalyticsController {
 
     @GetMapping("/dashboard")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
-    public ResponseEntity<?> getDashboardStats(@RequestParam(required = false) String organizationId) {
-        if (organizationId != null && organizationId.startsWith("unauthorized")) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Access denied to organization analytics scope.");
-        }
+    public ResponseEntity<?> getDashboardStats() {
         return ResponseEntity.ok(analyticsService.getDashboardStats());
     }
 
     @GetMapping("/summary")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
-    public ResponseEntity<AnalyticsSummaryDTO> getSummary(@RequestParam(required = false) String organizationId) {
+    public ResponseEntity<AnalyticsSummaryDTO> getSummary() {
         return ResponseEntity.ok(analyticsService.getSummary());
     }
 
     @GetMapping("/registrations/trends")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
     public ResponseEntity<List<RegistrationTrendDTO>> getRegistrationTrends(
-            @RequestParam(required = false) String organizationId,
             @RequestParam(defaultValue = "monthly") String granularity,
             @RequestParam(defaultValue = "6") int periods) {
         int safePeriods = Math.min(Math.max(periods, 1), 100);
@@ -51,13 +46,13 @@ public class AnalyticsController {
 
     @GetMapping("/feedback")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
-    public ResponseEntity<List<FeedbackAnalyticsDTO>> getFeedbackAnalytics(@RequestParam(required = false) String organizationId) {
+    public ResponseEntity<List<FeedbackAnalyticsDTO>> getFeedbackAnalytics() {
         return ResponseEntity.ok(analyticsService.getFeedbackAnalytics());
     }
 
     @GetMapping("/organizers")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
-    public ResponseEntity<List<OrganizerInsightDTO>> getOrganizerInsights(@RequestParam(required = false) String organizationId) {
+    public ResponseEntity<List<OrganizerInsightDTO>> getOrganizerInsights() {
         return ResponseEntity.ok(analyticsService.getOrganizerInsights());
     }
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java
@@ -8,18 +8,25 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface EventAnalyticsRepository extends JpaRepository<Event, Long> {
 
+    // Scoped variants accept a nullable collection of event IDs: null = global,
+    // non-null = restrict to those events (e.g. a caller's accessible events).
+
+    @Query("SELECT COUNT(e) FROM Event e WHERE (:eventIds IS NULL OR e.id IN :eventIds)")
+    long countEvents(@Param("eventIds") Collection<Long> eventIds);
+
     // "Active" = public, non-cancelled event whose date is in the future
-    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate > :now AND e.isPublic = TRUE AND (e.status IS NULL OR e.status <> 'CANCELLED')")
-    long countActiveEvents(@Param("now") LocalDateTime now);
+    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate > :now AND e.isPublic = TRUE AND (e.status IS NULL OR e.status <> 'CANCELLED') AND (:eventIds IS NULL OR e.id IN :eventIds)")
+    long countActiveEvents(@Param("now") LocalDateTime now, @Param("eventIds") Collection<Long> eventIds);
 
     // "Completed" = public, non-cancelled event whose date is in the past
-    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate <= :now AND e.isPublic = TRUE AND (e.status IS NULL OR e.status <> 'CANCELLED')")
-    long countCompletedEvents(@Param("now") LocalDateTime now);
+    @Query("SELECT COUNT(e) FROM Event e WHERE e.eventDate <= :now AND e.isPublic = TRUE AND (e.status IS NULL OR e.status <> 'CANCELLED') AND (:eventIds IS NULL OR e.id IN :eventIds)")
+    long countCompletedEvents(@Param("now") LocalDateTime now, @Param("eventIds") Collection<Long> eventIds);
 
     // Uses registeredCount (denormalised counter already on Event — free query!)
     // Returns: [id, title, registeredCount, capacity, utilization]
@@ -30,31 +37,34 @@ public interface EventAnalyticsRepository extends JpaRepository<Event, Long> {
                e.capacity,
                (e.registeredCount * 1.0 / NULLIF(e.capacity, 0))
         FROM Event e
+        WHERE (:eventIds IS NULL OR e.id IN :eventIds)
         ORDER BY e.registeredCount DESC
         """)
-    List<Object[]> findMostPopularEvents(Pageable pageable);
+    List<Object[]> findMostPopularEvents(@Param("eventIds") Collection<Long> eventIds, Pageable pageable);
 
     // Per-category registration distribution. Returns: [category, count]
     @Query("""
         SELECT e.category, COUNT(e)
         FROM Event e
         WHERE e.category IS NOT NULL AND e.category <> ''
+          AND (:eventIds IS NULL OR e.id IN :eventIds)
         GROUP BY e.category
         ORDER BY COUNT(e) DESC
         """)
-    List<Object[]> findCategoryBreakdown(Pageable pageable);
+    List<Object[]> findCategoryBreakdown(@Param("eventIds") Collection<Long> eventIds, Pageable pageable);
 
     // Average utilization across events that have a capacity set
     @Query("""
         SELECT AVG(e.registeredCount * 1.0 / NULLIF(e.capacity, 0))
         FROM Event e
         WHERE e.capacity IS NOT NULL AND e.capacity > 0
+          AND (:eventIds IS NULL OR e.id IN :eventIds)
         """)
-    Double findAverageCapacityUtilization();
+    Double findAverageCapacityUtilization(@Param("eventIds") Collection<Long> eventIds);
 
     // Total unique participants via confirmed registrations
-    @Query("SELECT COUNT(DISTINCT r.user.id) FROM EventRegistration r WHERE r.status = 'CONFIRMED'")
-    long countUniqueParticipants();
+    @Query("SELECT COUNT(DISTINCT r.user.id) FROM EventRegistration r WHERE r.status = 'CONFIRMED' AND (:eventIds IS NULL OR r.event.id IN :eventIds)")
+    long countUniqueParticipants(@Param("eventIds") Collection<Long> eventIds);
 
     // Events a user owns or manages (owner or member of the event team)
     @Query("""

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
@@ -6,19 +6,23 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface FeedbackAnalyticsRepository extends JpaRepository<Feedback, Long> {
 
-    @Query("SELECT AVG(f.rating) FROM Feedback f")
-    Double findOverallAverageRating();
+    // Scoped variants accept a nullable collection of event IDs: null = global,
+    // non-null = restrict to those events (e.g. a caller's accessible events).
+
+    @Query("SELECT AVG(f.rating) FROM Feedback f WHERE (:eventIds IS NULL OR f.event.id IN :eventIds)")
+    Double findOverallAverageRating(@Param("eventIds") Collection<Long> eventIds);
 
     @Query("SELECT AVG(f.rating) FROM Feedback f WHERE f.event.id IN :eventIds")
     Double findAverageRatingForEvents(@Param("eventIds") java.util.Collection<Long> eventIds);
 
-    @Query("SELECT COUNT(f) FROM Feedback f")
-    long countTotalFeedback();
+    @Query("SELECT COUNT(f) FROM Feedback f WHERE (:eventIds IS NULL OR f.event.id IN :eventIds)")
+    long countTotalFeedback(@Param("eventIds") Collection<Long> eventIds);
 
     // Returns: [eventId, eventTitle, avgRating, feedbackCount]
     @Query("""
@@ -27,10 +31,11 @@ public interface FeedbackAnalyticsRepository extends JpaRepository<Feedback, Lon
                AVG(f.rating),
                COUNT(f)
         FROM Feedback f
+        WHERE (:eventIds IS NULL OR f.event.id IN :eventIds)
         GROUP BY f.event.id, f.event.title
         ORDER BY AVG(f.rating) DESC
         """)
-    List<Object[]> findPerEventSummary();
+    List<Object[]> findPerEventSummary(@Param("eventIds") Collection<Long> eventIds);
 
     // Returns: [rating(1–5), count]
     @Query("""

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -14,6 +15,8 @@ public interface RegistrationAnalyticsRepository
         extends JpaRepository<EventRegistration, Long> {
 
     // ── Trends — note: field is registeredAt, NOT createdAt ──────────────────
+    // All queries accept a nullable collection of event IDs: null = global,
+    // non-null = restrict to those events (e.g. a caller's accessible events).
 
     @Query("""
         SELECT FUNCTION('FORMATDATETIME', r.registeredAt, 'yyyy-MM') AS period,
@@ -21,10 +24,11 @@ public interface RegistrationAnalyticsRepository
         FROM EventRegistration r
         WHERE r.registeredAt >= :from
           AND r.status = 'CONFIRMED'
+          AND (:eventIds IS NULL OR r.event.id IN :eventIds)
         GROUP BY period
         ORDER BY period ASC
         """)
-    List<Object[]> findMonthlyTrend(@Param("from") LocalDateTime from);
+    List<Object[]> findMonthlyTrend(@Param("from") LocalDateTime from, @Param("eventIds") Collection<Long> eventIds);
 
     @Query("""
         SELECT CAST(FUNCTION('YEAR', r.registeredAt) AS int) * 100
@@ -33,10 +37,11 @@ public interface RegistrationAnalyticsRepository
         FROM EventRegistration r
         WHERE r.registeredAt >= :from
           AND r.status = 'CONFIRMED'
+          AND (:eventIds IS NULL OR r.event.id IN :eventIds)
         GROUP BY period
         ORDER BY period ASC
         """)
-    List<Object[]> findWeeklyTrend(@Param("from") LocalDateTime from);
+    List<Object[]> findWeeklyTrend(@Param("from") LocalDateTime from, @Param("eventIds") Collection<Long> eventIds);
 
     @Query("""
         SELECT CAST(r.registeredAt AS date) AS period,
@@ -44,10 +49,11 @@ public interface RegistrationAnalyticsRepository
         FROM EventRegistration r
         WHERE r.registeredAt >= :from
           AND r.status = 'CONFIRMED'
+          AND (:eventIds IS NULL OR r.event.id IN :eventIds)
         GROUP BY period
         ORDER BY period ASC
         """)
-    List<Object[]> findDailyTrend(@Param("from") LocalDateTime from);
+    List<Object[]> findDailyTrend(@Param("from") LocalDateTime from, @Param("eventIds") Collection<Long> eventIds);
 
     // ── Peak registration periods ─────────────────────────────────────────────
     @Query("""
@@ -56,16 +62,17 @@ public interface RegistrationAnalyticsRepository
                COUNT(r)                              AS cnt
         FROM EventRegistration r
         WHERE r.status = 'CONFIRMED'
+          AND (:eventIds IS NULL OR r.event.id IN :eventIds)
         GROUP BY dow, hr
         ORDER BY cnt DESC
         """)
-    List<Object[]> findPeakPeriods();
+    List<Object[]> findPeakPeriods(@Param("eventIds") Collection<Long> eventIds);
 
     // Total confirmed registrations
-    @Query("SELECT COUNT(r) FROM EventRegistration r WHERE r.status = 'CONFIRMED'")
-    long countConfirmedRegistrations();
+    @Query("SELECT COUNT(r) FROM EventRegistration r WHERE r.status = 'CONFIRMED' AND (:eventIds IS NULL OR r.event.id IN :eventIds)")
+    long countConfirmedRegistrations(@Param("eventIds") Collection<Long> eventIds);
 
     // Earliest confirmed registration — used to derive "hours active"
-    @Query("SELECT MIN(r.registeredAt) FROM EventRegistration r WHERE r.status = 'CONFIRMED'")
-    LocalDateTime findEarliestRegistration();
+    @Query("SELECT MIN(r.registeredAt) FROM EventRegistration r WHERE r.status = 'CONFIRMED' AND (:eventIds IS NULL OR r.event.id IN :eventIds)")
+    LocalDateTime findEarliestRegistration(@Param("eventIds") Collection<Long> eventIds);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
@@ -46,8 +46,12 @@ public class AnalyticsService {
 
     // ── 0. Summary (admin dashboard) ────────────────────────────────────────
     public AnalyticsSummaryDTO getSummary() {
+        return getSummary(resolveEventScope());
+    }
+
+    private AnalyticsSummaryDTO getSummary(List<Long> eventIds) {
         List<Object[]> rows = eventRepo.findCategoryBreakdown(
-                PageRequest.of(0, BREAKDOWN_COLORS.length));
+                eventIds, PageRequest.of(0, BREAKDOWN_COLORS.length));
 
         List<CategoryBreakdownDTO> breakdown = new ArrayList<>(rows.size());
         for (int i = 0; i < rows.size(); i++) {
@@ -60,16 +64,16 @@ public class AnalyticsService {
         }
 
         return AnalyticsSummaryDTO.builder()
-                .stats(getDashboardStats())
+                .stats(getDashboardStats(eventIds))
                 .categoryBreakdown(breakdown)
-                .hoursActive(computeHoursActive())
+                .hoursActive(computeHoursActive(eventIds))
                 .securityHealth(null)
                 .activeAlerts(0)
                 .build();
     }
 
-    private String computeHoursActive() {
-        LocalDateTime first = regRepo.findEarliestRegistration();
+    private String computeHoursActive(List<Long> eventIds) {
+        LocalDateTime first = regRepo.findEarliestRegistration(eventIds);
         if (first == null) {
             return "0h 0m";
         }
@@ -79,23 +83,31 @@ public class AnalyticsService {
 
     // ── 1. Dashboard ──────────────────────────────────────────────────────────
     public DashboardStatsDTO getDashboardStats() {
+        return getDashboardStats(resolveEventScope());
+    }
+
+    private DashboardStatsDTO getDashboardStats(List<Long> eventIds) {
         LocalDateTime now = LocalDateTime.now();
         return DashboardStatsDTO.builder()
-            .totalEvents(eventRepo.count())
-            .totalRegistrations(regRepo.countConfirmedRegistrations())
-            .activeEvents(eventRepo.countActiveEvents(now))
-            .completedEvents(eventRepo.countCompletedEvents(now))
-            .uniqueParticipants(eventRepo.countUniqueParticipants())
+            .totalEvents(eventRepo.countEvents(eventIds))
+            .totalRegistrations(regRepo.countConfirmedRegistrations(eventIds))
+            .activeEvents(eventRepo.countActiveEvents(now, eventIds))
+            .completedEvents(eventRepo.countCompletedEvents(now, eventIds))
+            .uniqueParticipants(eventRepo.countUniqueParticipants(eventIds))
             .averageCapacityUtilization(
-                Optional.ofNullable(eventRepo.findAverageCapacityUtilization()).orElse(0.0))
-            .totalFeedbackSubmissions(feedbackRepo.countTotalFeedback())
+                Optional.ofNullable(eventRepo.findAverageCapacityUtilization(eventIds)).orElse(0.0))
+            .totalFeedbackSubmissions(feedbackRepo.countTotalFeedback(eventIds))
             .overallAverageRating(
-                Optional.ofNullable(feedbackRepo.findOverallAverageRating()).orElse(0.0))
+                Optional.ofNullable(feedbackRepo.findOverallAverageRating(eventIds)).orElse(0.0))
             .build();
     }
 
     // ── 2. Registration trends ────────────────────────────────────────────────
     public List<RegistrationTrendDTO> getRegistrationTrend(String granularity, int periods) {
+        return getRegistrationTrend(granularity, periods, resolveEventScope());
+    }
+
+    private List<RegistrationTrendDTO> getRegistrationTrend(String granularity, int periods, List<Long> eventIds) {
         int safePeriods = Math.max(1, Math.min(periods, 365));
         LocalDateTime from = switch (granularity.toLowerCase()) {
             case "daily"  -> LocalDateTime.now().minusDays(safePeriods);
@@ -104,9 +116,9 @@ public class AnalyticsService {
         };
 
         List<Object[]> raw = switch (granularity.toLowerCase()) {
-            case "daily"  -> regRepo.findDailyTrend(from);
-            case "weekly" -> regRepo.findWeeklyTrend(from);
-            default       -> regRepo.findMonthlyTrend(from);
+            case "daily"  -> regRepo.findDailyTrend(from, eventIds);
+            case "weekly" -> regRepo.findWeeklyTrend(from, eventIds);
+            default       -> regRepo.findMonthlyTrend(from, eventIds);
         };
 
         final long[] cumulative = {0};
@@ -123,7 +135,7 @@ public class AnalyticsService {
 
     // ── 3. Most popular events ────────────────────────────────────────────────
     public List<Map<String, Object>> getMostPopularEvents(int limit) {
-        return eventRepo.findMostPopularEvents(PageRequest.of(0, limit))
+        return eventRepo.findMostPopularEvents(resolveEventScope(), PageRequest.of(0, limit))
             .stream()
             .map(row -> {
                 Map<String, Object> m = new LinkedHashMap<>();
@@ -143,7 +155,11 @@ public class AnalyticsService {
 
     // ── 4. Feedback analytics ─────────────────────────────────────────────────
     public List<FeedbackAnalyticsDTO> getFeedbackAnalytics() {
-        return feedbackRepo.findPerEventSummary().stream().map(row -> {
+        return getFeedbackAnalytics(resolveEventScope());
+    }
+
+    private List<FeedbackAnalyticsDTO> getFeedbackAnalytics(List<Long> eventIds) {
+        return feedbackRepo.findPerEventSummary(eventIds).stream().map(row -> {
             Long   eventId = ((Number) row[0]).longValue();
             double avg     = ((Number) row[2]).doubleValue();
             long   count   = ((Number) row[3]).longValue();
@@ -175,7 +191,7 @@ public class AnalyticsService {
     // ── 5. Peak registration periods ─────────────────────────────────────────
     public List<Map<String, Object>> getPeakPeriods() {
         String[] days = {"", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-        return regRepo.findPeakPeriods().stream()
+        return regRepo.findPeakPeriods(resolveEventScope()).stream()
             .limit(10)
             .map(row -> {
                 Map<String, Object> m = new LinkedHashMap<>();
@@ -196,14 +212,7 @@ public class AnalyticsService {
      * regular ORGANIZER only sees their own events (ownerId or event team).
      */
     public List<OrganizerInsightDTO> getOrganizerInsights() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new AccessDeniedException("Unable to determine the authenticated user");
-        }
-
-        User caller = userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new UsernameNotFoundException(
-                        "User not found with email: " + authentication.getName()));
+        User caller = currentUser();
 
         if (caller.getRole() == Role.ADMIN || caller.getRole() == Role.SUPER_ADMIN) {
             return eventRepo.findDistinctOwnerIds().stream()
@@ -223,6 +232,32 @@ public class AnalyticsService {
                 caller.getFirstName(),
                 caller.getLastName(),
                 eventRepo.findAccessibleToUser(caller.getId())));
+    }
+
+    /**
+     * Resolve the event scope for the caller: {@code null} (global) for
+     * ADMIN / SUPER_ADMIN, or the list of events the caller owns/manages
+     * for a regular ORGANIZER. This enforces tenant isolation on the
+     * dashboard/summary/trends/feedback analytics.
+     */
+    private List<Long> resolveEventScope() {
+        User caller = currentUser();
+        if (caller.getRole() == Role.ADMIN || caller.getRole() == Role.SUPER_ADMIN) {
+            return null;
+        }
+        return eventRepo.findAccessibleToUser(caller.getId()).stream()
+                .map(Event::getId)
+                .collect(Collectors.toList());
+    }
+
+    private User currentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AccessDeniedException("Unable to determine the authenticated user");
+        }
+        return userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new UsernameNotFoundException(
+                        "User not found with email: " + authentication.getName()));
     }
 
     private OrganizerInsightDTO buildOrganizerInsight(


### PR DESCRIPTION
## Problem

`AnalyticsController`'s `/dashboard`, `/summary`, `/registrations/trends` and `/feedback` endpoints were open to any `ORGANIZER` and returned global, platform-wide data. The `organizationId` request parameter was a no-op decoy (and contained a useless `startsWith("unauthorized")` check), so a regular organizer could read registrations, feedback ratings and trends for every organization on the platform — breaking tenant isolation.

## Fix

Scoped the analytics to the caller's organization:

- `AnalyticsService` now resolves the caller's event scope — `null` (global) for `ADMIN`/`SUPER_ADMIN`, and the events the caller owns/manages (via the existing `findAccessibleToUser`) for a regular `ORGANIZER` — and passes it through every dashboard/summary/trend/feedback query.
- All analytics repository queries accept a nullable `eventIds` collection and filter with `(:eventIds IS NULL OR ... IN :eventIds)`, so admins keep the global view while organizers only see their own events.
- Removed the decoy `organizationId` parameter (and the dead `"unauthorized"` check) from the controller; tenant scoping is now derived from the authenticated principal.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/EventAnalyticsRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java`

## Testing

- Manual review: organizer callers are restricted to `findAccessibleToUser` event ids in every query; admin behavior is unchanged (null scope = global).
- No Maven toolchain available locally, so the test suite could not be executed.

Closes #16193
