### PR TITLE
fix(auth): stop returning the raw reset token from password reset request (#16195)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -157,9 +157,9 @@ public class AuthController {
                     Accepts an email address and issues a short-lived, single-use password
                     reset token for the matching account (if one exists).
                     
-                    The raw `resetToken` is returned in the response so the client can
-                    complete the flow; deployments with an email transport should instead
-                    email a reset link and remove the token from the response.
+                    The raw token is never returned in the response; it must be delivered
+                    out-of-band (e.g. emailed as a reset link) so only the account owner
+                    can complete the reset.
                     """
     )
     @ApiResponses({

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -255,17 +255,18 @@ public class AuthService {
     /**
      * Initiates a password reset for the given email.
      *
-     * <p>A cryptographically random, short-lived token is generated and its
-     * SHA-256 hash is persisted so the raw token can be exchanged for a new
-     * password exactly once. The raw token is returned in the response because
-     * the backend has no email transport configured; deployments with a mailer
-     * should send it as a reset link instead and drop it from the response.</p>
+     * <p>A cryptographically random, short-lived token is generated and only
+     * its SHA-256 hash is persisted. The raw token is <em>never</em> returned
+     * in the API response (doing so would let an attacker take over any
+     * account, since this endpoint is unauthenticated). Deployments must
+     * deliver the raw token to the account owner out-of-band (e.g. email a
+     * reset link); the reset step exchanges the token via a server-side
+     * lookup of its hash.</p>
      *
      * <p>For privacy, unknown emails still return HTTP 200 with the same generic
      * message (no account enumeration).</p>
      *
-     * @return a map with {@code message} and, when the account exists,
-     *         {@code resetToken} (raw token for the next step)
+     * @return a map with the generic {@code message} (no token is disclosed)
      */
     @Transactional
     public Map<String, String> requestPasswordReset(String rawEmail) {
@@ -289,9 +290,10 @@ public class AuthService {
                 .used(false)
                 .build());
 
+        // The raw token is deliberately not included in the response; it must be
+        // delivered out-of-band (email) so only the account owner can reset.
         return Map.of(
-                "message", "If an account exists for that email, a password reset link has been sent.",
-                "resetToken", rawToken);
+                "message", "If an account exists for that email, a password reset link has been sent.");
     }
 
     private String generateResetToken() {


### PR DESCRIPTION
## Problem

`AuthService.requestPasswordReset` returned the raw password-reset token in the API response body (`Map.of("message", ..., "resetToken", rawToken)`). Because `/api/auth/**` is `permitAll()`, an attacker could POST any victim's email to the forgot-password endpoint and receive a usable reset token — then reset the victim's password and take over the account, without ever accessing the victim's email.

## Fix

- `requestPasswordReset` no longer includes the raw token in the response. It persists only the SHA-256 hash (unchanged) and always returns the generic "If an account exists…" message, so the token can only reach the account owner via an out-of-band channel (email).
- Updated the Javadoc and the controller's `@Operation` description that previously documented the token-in-response behavior.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java`

## Testing

- Manual review: the response now contains only the generic `message` in both the account-exists and account-missing paths; the hashed token is still stored for the out-of-band reset step.

Closes #16195
