### PR TITLE
fix(auth): stop Google login from auto-claiming unverified local accounts (#16197)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/AccountNotVerifiedException.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/AccountNotVerifiedException.java
@@ -1,0 +1,11 @@
+package com.sandeep.eventrabackend.exception;
+
+public class AccountNotVerifiedException extends RuntimeException {
+    public AccountNotVerifiedException(String message) {
+        super(message);
+    }
+
+    public AccountNotVerifiedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -145,6 +145,13 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.FORBIDDEN, "Forbidden", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(AccountNotVerifiedException.class)
+    public ResponseEntity<ErrorResponse> handleAccountNotVerified(
+            AccountNotVerifiedException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(
             AccessDeniedException ex,

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -6,6 +6,7 @@ import com.sandeep.eventrabackend.dto.response.AuthResponse;
 import com.sandeep.eventrabackend.exception.PasswordMismatchException;
 import com.sandeep.eventrabackend.exception.UserAlreadyExistsException;
 import com.sandeep.eventrabackend.exception.InvalidGoogleTokenException;
+import com.sandeep.eventrabackend.exception.AccountNotVerifiedException;
 import com.sandeep.eventrabackend.model.PasswordResetToken;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
@@ -176,23 +177,12 @@ public class AuthService {
                 user = createOrGetGoogleUser(email, firstName, lastName, baseUsername);
             } else if (!user.isEmailVerified()
                     && (user.getAuthProvider() == null || "LOCAL".equalsIgnoreCase(user.getAuthProvider()))) {
-                // Unverified LOCAL accounts can be claimed by a verified Google identity
-                // for the same email. Verified LOCAL accounts are left untouched below.
-                SecureRandom secureRandom = new SecureRandom();
-                byte[] randomBytes = new byte[32];
-                secureRandom.nextBytes(randomBytes);
-                String securePassword = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
-
-                user.setAuthProvider("GOOGLE");
-                user.setEmailVerified(true);
-                user.setPassword(passwordEncoder.encode(securePassword));
-                if (firstName != null && !firstName.isBlank()) {
-                    user.setFirstName(firstName);
-                }
-                if (lastName != null && !lastName.isBlank()) {
-                    user.setLastName(lastName);
-                }
-                user = userRepository.save(user);
+                // Never auto-claim an unverified LOCAL account. The Google identity may
+                // only be linked after the LOCAL account has proven email ownership; the
+                // caller must route to a verify-email / explicit link flow instead.
+                throw new AccountNotVerifiedException(
+                        "An account already exists for this email but has not been verified. "
+                        + "Please verify your email before linking your Google account.");
             } else if (!user.isEmailVerified()) {
                 user.setEmailVerified(true);
                 if (user.getAuthProvider() == null || user.getAuthProvider().isBlank()) {
@@ -206,6 +196,8 @@ public class AuthService {
             return buildAuthResponse(user, token);
 
         } catch (InvalidGoogleTokenException e) {
+            throw e;
+        } catch (AccountNotVerifiedException e) {
             throw e;
         } catch (DataIntegrityViolationException e) {
             // A unique-constraint race could not be resolved within the bounded

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthGoogleLoginTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthGoogleLoginTests.java
@@ -104,8 +104,8 @@ class AuthGoogleLoginTests {
     }
 
     @Test
-    @DisplayName("Verified Google identity claims an unverified LOCAL account for the same email")
-    void googleLogin_UnverifiedLocal_LinksToGoogle() throws Exception {
+    @DisplayName("Verified Google identity must NOT claim an unverified LOCAL account for the same email")
+    void googleLogin_UnverifiedLocal_IsRejected() throws Exception {
         String originalPasswordHash = passwordEncoder.encode("attacker-password");
         userRepository.save(User.builder()
                 .firstName("Squatter")
@@ -124,14 +124,15 @@ class AuthGoogleLoginTests {
         mockMvc.perform(post("/api/auth/google")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("token", "google-id-token"))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.email").value("claim@example.com"))
-                .andExpect(jsonPath("$.username").value("squatter"));
+                .andExpect(status().isConflict());
 
-        User linked = userRepository.findByEmail("claim@example.com").orElseThrow();
-        assertEquals("GOOGLE", linked.getAuthProvider());
-        assertTrue(linked.isEmailVerified());
-        assertFalse(passwordEncoder.matches("attacker-password", linked.getPassword()));
+        // The account must be left fully intact: no provider swap, no verification,
+        // no password/profile overwrite, no login issued.
+        User untouched = userRepository.findByEmail("claim@example.com").orElseThrow();
+        assertEquals("LOCAL", untouched.getAuthProvider());
+        assertFalse(untouched.isEmailVerified());
+        assertTrue(passwordEncoder.matches("attacker-password", untouched.getPassword()));
+        assertEquals("Squatter", untouched.getFirstName());
         assertEquals(1, userRepository.count());
     }
 


### PR DESCRIPTION
## Problem

`AuthService.googleLogin` auto-claimed an existing **unverified LOCAL** account whenever a verified Google identity for the same email logged in. It overwrote the account's password with a random value, flipped `authProvider` to `GOOGLE`, marked it verified, and replaced the profile names from the token — so a Google account holder could take over any unverified LOCAL account sharing that email.

## Fix

- Removed the auto-claim/overwrite branch entirely. When an unverified LOCAL (or provider-less) account exists for the Google email, login is now rejected with a new `AccountNotVerifiedException` → **409 Conflict** telling the caller to complete email verification / use the explicit link flow before linking Google.
- The account is left fully intact: provider, password, profile, and verification state are untouched; no token is issued.
- Verified LOCAL accounts remain linkable on Google login (unchanged behaviour).
- Added `AccountNotVerifiedException` + a `GlobalExceptionHandler` mapping.
- Rewrote the existing `AuthGoogleLoginTests` test that previously pinned the vulnerable "claim" behaviour to instead assert the rejection and that the account is not modified.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/AuthService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/exception/AccountNotVerifiedException.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthGoogleLoginTests.java`

## Testing

- Updated `googleLogin_UnverifiedLocal_IsRejected`: asserts 409, provider still `LOCAL`, email still unverified, original password still valid, profile names unchanged, no duplicate account.

Closes #16197
