### PR TITLE
fix(live-audience): enforce event-scoped access on all audience endpoints (#16198)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java
@@ -47,8 +47,10 @@ public class LiveAudienceController {
             @ApiResponse(responseCode = "404", description = "Event not found",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<LiveAudienceDataResponse> getInitialData(@PathVariable Long eventId) {
-        return ResponseEntity.ok(liveAudienceService.getInitialData(eventId));
+    public ResponseEntity<LiveAudienceDataResponse> getInitialData(
+            @PathVariable Long eventId,
+            Authentication authentication) {
+        return ResponseEntity.ok(liveAudienceService.getInitialData(eventId, authentication.getName()));
     }
 
     @GetMapping("/questions")
@@ -62,8 +64,9 @@ public class LiveAudienceController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<java.util.List<LiveAudienceQuestionResponse>> getQuestions(
-            @PathVariable Long eventId) {
-        return ResponseEntity.ok(liveAudienceService.getQuestions(eventId));
+            @PathVariable Long eventId,
+            Authentication authentication) {
+        return ResponseEntity.ok(liveAudienceService.getQuestions(eventId, authentication.getName()));
     }
 
     @PostMapping("/questions")

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
@@ -13,6 +13,7 @@ import com.sandeep.eventrabackend.model.LiveAudiencePollVote;
 import com.sandeep.eventrabackend.model.LiveAudienceQuestion;
 import com.sandeep.eventrabackend.model.LiveAudienceQuestionUpvote;
 import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
 import com.sandeep.eventrabackend.repository.LiveAudiencePollRepository;
 import com.sandeep.eventrabackend.repository.LiveAudiencePollVoteRepository;
@@ -21,6 +22,7 @@ import com.sandeep.eventrabackend.repository.LiveAudienceQuestionUpvoteRepositor
 import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +45,7 @@ public class LiveAudienceService {
     private static final List<String> POLL_TYPES = List.of("single", "multiple");
 
     private final EventRepository eventRepository;
+    private final EventRegistrationRepository eventRegistrationRepository;
     private final UserRepository userRepository;
     private final EventRoleService eventRoleService;
     private final LiveAudienceQuestionRepository questionRepository;
@@ -52,9 +55,9 @@ public class LiveAudienceService {
     private final EventStreamService eventStreamService;
 
     @Transactional(readOnly = true)
-    public LiveAudienceDataResponse getInitialData(Long eventId) {
-        requireEvent(eventId);
-        List<LiveAudienceQuestionResponse> questions = getQuestions(eventId);
+    public LiveAudienceDataResponse getInitialData(Long eventId, String email) {
+        requireEventAccess(eventId, email);
+        List<LiveAudienceQuestionResponse> questions = getQuestions(eventId, email);
         LiveAudiencePollResponse activePoll = pollRepository
                 .findByEventIdOrderByCreatedAtDesc(eventId)
                 .stream()
@@ -68,8 +71,8 @@ public class LiveAudienceService {
     }
 
     @Transactional(readOnly = true)
-    public List<LiveAudienceQuestionResponse> getQuestions(Long eventId) {
-        requireEvent(eventId);
+    public List<LiveAudienceQuestionResponse> getQuestions(Long eventId, String email) {
+        requireEventAccess(eventId, email);
         return questionRepository
                 .findByEventIdOrderByUpvotesDescCreatedAtDesc(eventId)
                 .stream()
@@ -78,7 +81,7 @@ public class LiveAudienceService {
     }
     @Transactional
     public LiveAudienceQuestionResponse createQuestion(Long eventId, String text, String email) {
-        requireEvent(eventId);
+        requireEventAccess(eventId, email);
         if (text == null || text.isBlank()) {
             throw new IllegalArgumentException("Question text is required");
         }
@@ -104,7 +107,7 @@ public class LiveAudienceService {
 
     @Transactional
     public LiveAudienceQuestionResponse upvoteQuestion(Long eventId, Long questionId, String email) {
-        requireEvent(eventId);
+        requireEventAccess(eventId, email);
         requireQuestion(eventId, questionId);
         User user = getUser(email);
         if (questionUpvoteRepository.existsByQuestionIdAndUserId(questionId, user.getId())) {
@@ -216,7 +219,7 @@ public class LiveAudienceService {
 
     @Transactional
     public LiveAudiencePollResponse submitVote(Long eventId, Long pollId, String option, String email) {
-        requireEvent(eventId);
+        requireEventAccess(eventId, email);
         LiveAudiencePoll poll = requirePollForUpdate(eventId, pollId);
         if ("closed".equals(poll.getStatus())) {
             throw new IllegalArgumentException("Voting is closed for this poll");
@@ -266,6 +269,24 @@ public class LiveAudienceService {
     private Event requireEvent(Long eventId) {
         return eventRepository.findById(eventId)
                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+    }
+
+    /**
+     * Gates live-audience reads/writes on event visibility (#16198). Public events
+     * are open to any authenticated user; private events require the caller to be
+     * an event organizer (or platform admin/legacy owner) or a registered
+     * participant.
+     */
+    private void requireEventAccess(Long eventId, String email) {
+        Event event = requireEvent(eventId);
+        if (event.isPublic()) {
+            return;
+        }
+        boolean organizer = eventRoleService.hasRole(eventId, email, EventRole.ORGANIZER);
+        boolean participant = eventRegistrationRepository.existsByEvent_IdAndUser_Email(eventId, email);
+        if (!organizer && !participant) {
+            throw new AccessDeniedException("You do not have access to this event's live audience.");
+        }
     }
 
     private LiveAudienceQuestion requireQuestion(Long eventId, Long questionId) {

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
@@ -2,8 +2,10 @@ package com.sandeep.eventrabackend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
 import com.sandeep.eventrabackend.repository.LiveAudiencePollRepository;
 import com.sandeep.eventrabackend.repository.LiveAudiencePollVoteRepository;
@@ -57,6 +59,9 @@ public class LiveAudienceControllerTests {
     private LiveAudienceQuestionUpvoteRepository questionUpvoteRepository;
 
     @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
     private LiveAudiencePollRepository pollRepository;
 
     @Autowired
@@ -75,6 +80,7 @@ public class LiveAudienceControllerTests {
         pollRepository.deleteAll();
         questionUpvoteRepository.deleteAll();
         questionRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
         eventRepository.deleteAll();
         userRepository.deleteAll();
 
@@ -389,5 +395,103 @@ public class LiveAudienceControllerTests {
                 .andExpect(jsonPath("$.questions", hasSize(1)))
                 .andExpect(jsonPath("$.questions[0].text").value("Question one"))
                 .andExpect(jsonPath("$.activePoll.question").value("Poll question"));
+    }
+
+    @Test
+    @DisplayName("Private event — unregistered users are denied on all read/write paths (#16198)")
+    void testPrivateEventDeniesUnregisteredUser() throws Exception {
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Live Audience Event");
+        privateEvent.setCapacity(20);
+        privateEvent.setEventDate(LocalDateTime.now().plusDays(1));
+        privateEvent.setOwnerId(userRepository.findByEmail(organizerEmail).orElseThrow().getId());
+        privateEvent.setPublic(false);
+        privateEvent = eventRepository.save(privateEvent);
+        Long privateEventId = privateEvent.getId();
+
+        String intruderEmail = "intruder@example.com";
+        userRepository.save(User.builder()
+                .firstName("Intruder")
+                .lastName("User")
+                .email(intruderEmail)
+                .username("intruder")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        mockMvc.perform(get("/api/events/{id}/live-audience", privateEventId)
+                        .with(user(intruderEmail)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/events/{id}/live-audience/questions", privateEventId)
+                        .with(user(intruderEmail)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions", privateEventId)
+                        .with(user(intruderEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("text", "Sneaky question"))))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls", privateEventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("question", "Vote?", "options", List.of("A", "B")))))
+                .andExpect(status().isCreated());
+
+        long pollId = objectMapper.readTree(
+                        mockMvc.perform(post("/api/events/{id}/live-audience/polls", privateEventId)
+                                        .with(user(organizerEmail))
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(
+                                                java.util.Map.of("question", "Vote?", "options", List.of("A", "B")))))
+                                .andExpect(status().isCreated())
+                                .andReturn().getResponse().getContentAsString())
+                .get("id").asLong();
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/vote", privateEventId, pollId)
+                        .with(user(intruderEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("option", "A"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Private event — organizer and registered participant are allowed (#16198)")
+    void testPrivateEventAllowsOrganizerAndParticipant() throws Exception {
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Live Audience Event");
+        privateEvent.setCapacity(20);
+        privateEvent.setEventDate(LocalDateTime.now().plusDays(1));
+        privateEvent.setOwnerId(userRepository.findByEmail(organizerEmail).orElseThrow().getId());
+        privateEvent.setPublic(false);
+        privateEvent = eventRepository.save(privateEvent);
+        Long privateEventId = privateEvent.getId();
+
+        User attendee = userRepository.findByEmail(attendeeEmail).orElseThrow();
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(privateEvent);
+        registration.setUser(attendee);
+        registration.setStatus("CONFIRMED");
+        eventRegistrationRepository.save(registration);
+
+        // Registered participant can read and post.
+        mockMvc.perform(get("/api/events/{id}/live-audience", privateEventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/events/{id}/live-audience/questions", privateEventId)
+                        .with(user(attendeeEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("text", "Registered question"))))
+                .andExpect(status().isCreated());
+
+        // Organizer (owner) can read too.
+        mockMvc.perform(get("/api/events/{id}/live-audience/questions", privateEventId)
+                        .with(user(organizerEmail)))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## Problem

The live-audience REST endpoints (`getInitialData`, `getQuestions`, `createQuestion`, `submitVote`, and `upvoteQuestion`) only verified the event existed — they performed no visibility or participant check. Any authenticated user could read the Q&A and poll results of a private event and inject questions/votes into it, polluting the moderator's live view and skewing poll outcomes.

## Fix

- Added `LiveAudienceService.requireEventAccess(eventId, email)`:
  - Public events: open to any authenticated user (unchanged).
  - Private events: caller must be an event organizer (or platform admin / legacy owner via `EventRoleService.hasRole`) **or** a registered participant (`EventRegistrationRepository.existsByEvent_IdAndUser_Email`). Otherwise an `AccessDeniedException` → **403** is returned.
- Applied the check consistently across all participant-facing read/write paths: `getInitialData`, `getQuestions`, `createQuestion`, `upvoteQuestion`, `submitVote`. (Moderator-only endpoints already enforced `requireModerator`.)
- `getInitialData` and `getQuestions` now receive the authenticated principal from `LiveAudienceController` so the check can be evaluated.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java`

## Testing

- Added `testPrivateEventDeniesUnregisteredUser`: unregistered user gets 403 on GET board, GET questions, POST question, and POST vote for a private event.
- Added `testPrivateEventAllowsOrganizerAndParticipant`: a registered participant and the organizer can read/post on a private event.
- Existing public-event tests still pass (public events remain open to any authenticated user).

Closes #16198
