### PR TITLE
fix(payments): authorize access on all payment endpoints (IDOR) (#16252)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
@@ -41,12 +41,15 @@ public class PaymentController {
     @PostMapping("/plans")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> createPaymentPlan(
+            Authentication authentication,
             @RequestParam Long registrationId,
             @RequestParam(required = false, defaultValue = "1000.00") BigDecimal ticketPrice,
             @RequestParam(required = false, defaultValue = "USD") String currency,
             @RequestParam(required = false, defaultValue = "25") Integer upfrontPercentage,
             @RequestParam(required = false, defaultValue = "4") Integer totalInstallments) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             PaymentPlan paymentPlan = paymentPlanService.createPaymentPlan(
                     registrationId, ticketPrice, currency, upfrontPercentage, totalInstallments);
@@ -85,6 +88,8 @@ public class PaymentController {
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String phone) {
 
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             Map<String, String> result = paymentPlanService.initializeStripePayment(
                     registrationId, authentication.getName(), email, name, phone);
@@ -110,9 +115,12 @@ public class PaymentController {
     @PostMapping("/setup-method/{paymentPlanId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> setupPaymentMethodAndCreateUpfrontPayment(
+            Authentication authentication,
             @PathVariable Long paymentPlanId,
             @RequestBody Map<String, String> request) {
-        
+
+        paymentPlanService.requirePaymentAccessByPlan(paymentPlanId, authentication.getName());
+
         String paymentMethodId = request.get("paymentMethodId");
         
         if (paymentMethodId == null || paymentMethodId.isEmpty()) {
@@ -147,9 +155,12 @@ public class PaymentController {
     @PostMapping("/confirm-upfront/{paymentPlanId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> confirmUpfrontPaymentAndScheduleInstallments(
+            Authentication authentication,
             @PathVariable Long paymentPlanId,
             @RequestBody Map<String, String> request) {
-        
+
+        paymentPlanService.requirePaymentAccessByPlan(paymentPlanId, authentication.getName());
+
         String paymentMethodId = request.get("paymentMethodId");
         
         if (paymentMethodId == null || paymentMethodId.isEmpty()) {
@@ -184,8 +195,11 @@ public class PaymentController {
     @GetMapping("/plans/{registrationId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getPaymentPlanByRegistrationId(
+            Authentication authentication,
             @PathVariable Long registrationId) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             Map<String, Object> status = paymentPlanService.getPaymentPlanStatus(registrationId);
             
@@ -223,8 +237,11 @@ public class PaymentController {
     @GetMapping("/registrations/{registrationId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getPaymentsByRegistrationId(
+            Authentication authentication,
             @PathVariable Long registrationId) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             List<Payment> payments = paymentPlanService.getPaymentsByRegistrationId(registrationId);
             
@@ -248,8 +265,11 @@ public class PaymentController {
     @GetMapping("/schedule/{registrationId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getInstallmentSchedule(
+            Authentication authentication,
             @PathVariable Long registrationId) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             List<Map<String, Object>> schedule = paymentPlanService.getInstallmentSchedule(registrationId);
             
@@ -273,9 +293,12 @@ public class PaymentController {
     @PostMapping("/retry/{paymentId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> retryFailedPayment(
+            Authentication authentication,
             @PathVariable Long paymentId,
             @RequestParam(required = false) String paymentMethodId) {
-        
+
+        paymentPlanService.requirePaymentAccessByPayment(paymentId, authentication.getName());
+
         try {
             Map<String, Object> result = paymentPlanService.retryFailedPayment(paymentId, paymentMethodId);
             
@@ -300,8 +323,11 @@ public class PaymentController {
     @GetMapping("/methods/{registrationId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getCustomerPaymentMethods(
+            Authentication authentication,
             @PathVariable Long registrationId) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             List<Map<String, Object>> methods = paymentPlanService.getCustomerPaymentMethods(registrationId);
             
@@ -330,8 +356,11 @@ public class PaymentController {
     @GetMapping("/qr-status/{registrationId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> isQRCodeActivated(
+            Authentication authentication,
             @PathVariable Long registrationId) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             boolean activated = paymentPlanService.isQRCodeActivated(registrationId);
             boolean completed = paymentPlanService.isPaymentCompleted(registrationId);
@@ -356,9 +385,12 @@ public class PaymentController {
     @DeleteMapping("/plans/{paymentPlanId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> cancelPaymentPlan(
+            Authentication authentication,
             @PathVariable Long paymentPlanId,
             @RequestParam(required = false, defaultValue = "User request") String reason) {
-        
+
+        paymentPlanService.requirePaymentAccessByPlan(paymentPlanId, authentication.getName());
+
         try {
             paymentPlanService.cancelPaymentPlan(paymentPlanId, reason);
             
@@ -381,8 +413,11 @@ public class PaymentController {
     @GetMapping("/active/{registrationId}")
     @PreAuthorize("hasAnyRole('USER', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> hasActivePaymentPlan(
+            Authentication authentication,
             @PathVariable Long registrationId) {
-        
+
+        paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
+
         try {
             boolean hasActive = paymentPlanService.hasActivePaymentPlan(registrationId);
             

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -26,17 +26,20 @@ public class PaymentPlanService {
     private final EventRegistrationRepository eventRegistrationRepository;
     private final StripeService stripeService;
     private final UserRepository userRepository;
+    private final EventRoleService eventRoleService;
 
     public PaymentPlanService(PaymentPlanRepository paymentPlanRepository,
                               PaymentRepository paymentRepository,
                               EventRegistrationRepository eventRegistrationRepository,
                               StripeService stripeService,
-                              UserRepository userRepository) {
+                              UserRepository userRepository,
+                              EventRoleService eventRoleService) {
         this.paymentPlanRepository = paymentPlanRepository;
         this.paymentRepository = paymentRepository;
         this.eventRegistrationRepository = eventRegistrationRepository;
         this.stripeService = stripeService;
         this.userRepository = userRepository;
+        this.eventRoleService = eventRoleService;
     }
 
     // Create a new payment plan for installment payments
@@ -664,5 +667,50 @@ public class PaymentPlanService {
         }
         
         return paymentPlanOptional.get().isCompleted();
+    }
+
+    /**
+     * Object-level authorization (#16252): resolves a registration and asserts the
+     * authenticated caller either owns it (registration.user) or is an ORGANIZER
+     * (incl. platform admin / legacy event owner) of its event.
+     */
+    @Transactional(readOnly = true)
+    public void requirePaymentAccessByRegistration(Long registrationId, String email) {
+        EventRegistration registration = eventRegistrationRepository.findById(registrationId)
+                .orElseThrow(() -> new IllegalArgumentException("Registration not found"));
+        requirePaymentAccess(registration, email);
+    }
+
+    /** Resolves the plan's registration and runs the shared ownership check. */
+    @Transactional(readOnly = true)
+    public void requirePaymentAccessByPlan(Long paymentPlanId, String email) {
+        PaymentPlan plan = paymentPlanRepository.findById(paymentPlanId)
+                .orElseThrow(() -> new IllegalArgumentException("Payment plan not found"));
+        requirePaymentAccess(plan.getRegistration(), email);
+    }
+
+    /** Resolves the payment's registration and runs the shared ownership check. */
+    @Transactional(readOnly = true)
+    public void requirePaymentAccessByPayment(Long paymentId, String email) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new IllegalArgumentException("Payment not found"));
+        requirePaymentAccess(payment.getRegistration(), email);
+    }
+
+    private void requirePaymentAccess(EventRegistration registration, String email) {
+        if (isOwnerOrOrganizer(registration, email)) {
+            return;
+        }
+        throw new AccessDeniedException("You are not authorized to access this payment data");
+    }
+
+    private boolean isOwnerOrOrganizer(EventRegistration registration, String email) {
+        if (registration.getUser() != null && registration.getUser().getEmail() != null
+                && registration.getUser().getEmail().equalsIgnoreCase(email)) {
+            return true;
+        }
+        Event event = registration.getEvent();
+        return event != null && event.getId() != null
+                && eventRoleService.hasRole(event.getId(), email, EventRole.ORGANIZER);
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java
@@ -1,0 +1,195 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.PaymentPlanRepository;
+import com.sandeep.eventrabackend.repository.PaymentRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import com.sandeep.eventrabackend.service.PaymentPlanService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #16252 — payment endpoints must enforce object-level authorization.
+ * A caller may only access payment data for a registration they own or whose
+ * event they organize; any other authenticated user gets 403.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PaymentAccessControlTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PaymentPlanRepository paymentPlanRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private PaymentPlanService paymentPlanService;
+
+    private Long registrationId;
+    private Long planId;
+    private Long paymentId;
+    private final String organizerEmail = "payorganizer@example.com";
+    private final String attendeeEmail = "payattendee@example.com";
+    private final String attackerEmail = "payattacker@example.com";
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        paymentPlanRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User organizer = userRepository.save(User.builder()
+                .firstName("Pay")
+                .lastName("Organizer")
+                .email(organizerEmail)
+                .username("payorganizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        User attendee = userRepository.save(User.builder()
+                .firstName("Pay")
+                .lastName("Attendee")
+                .email(attendeeEmail)
+                .username("payattendee")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        userRepository.save(User.builder()
+                .firstName("Pay")
+                .lastName("Attacker")
+                .email(attackerEmail)
+                .username("payattacker")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        Event event = new Event();
+        event.setTitle("Payment Access Test Event");
+        event.setCapacity(50);
+        event.setEventDate(LocalDateTime.now().plusDays(10));
+        event.setOwnerId(organizer.getId());
+        event.setPublic(true);
+        event = eventRepository.save(event);
+
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(event);
+        registration.setUser(attendee);
+        registration.setStatus("CONFIRMED");
+        registration = eventRegistrationRepository.save(registration);
+        registrationId = registration.getId();
+
+        planId = paymentPlanService.createPaymentPlan(
+                registrationId, new BigDecimal("1000.00"), "USD", 25, 4).getId();
+        paymentId = paymentRepository.findByRegistration_IdOrderByInstallmentNumberAsc(registrationId)
+                .get(0)
+                .getId();
+    }
+
+    @Test
+    @DisplayName("Registration owner can read plan, schedule, QR and active-plan state")
+    void ownerCanReadOwnPaymentData() throws Exception {
+        mockMvc.perform(get("/api/payments/plans/{id}", registrationId).with(user(attendeeEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/payments/registrations/{id}", registrationId).with(user(attendeeEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/payments/schedule/{id}", registrationId).with(user(attendeeEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/payments/qr-status/{id}", registrationId).with(user(attendeeEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/payments/active/{id}", registrationId).with(user(attendeeEmail)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Event organizer can access a participant's payment data")
+    void organizerCanReadParticipantPaymentData() throws Exception {
+        mockMvc.perform(get("/api/payments/plans/{id}", registrationId).with(user(organizerEmail)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Unrelated user is denied on every payment endpoint (403)")
+    void attackerIsDeniedEverywhere() throws Exception {
+        mockMvc.perform(get("/api/payments/plans/{id}", registrationId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/payments/registrations/{id}", registrationId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/payments/schedule/{id}", registrationId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/payments/methods/{id}", registrationId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/payments/qr-status/{id}", registrationId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/payments/active/{id}", registrationId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Unrelated user cannot create or cancel another user's payment plan (403)")
+    void attackerCannotCreateOrCancelPlans() throws Exception {
+        mockMvc.perform(post("/api/payments/plans")
+                        .with(user(attackerEmail))
+                        .param("registrationId", String.valueOf(registrationId)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(delete("/api/payments/plans/{id}", planId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/payments/setup-method/{planId}", planId)
+                        .with(user(attackerEmail))
+                        .contentType("application/json")
+                        .content("{\"paymentMethodId\":\"pm_123\"}"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/payments/confirm-upfront/{planId}", planId)
+                        .with(user(attackerEmail))
+                        .contentType("application/json")
+                        .content("{\"paymentMethodId\":\"pm_123\"}"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/payments/retry/{paymentId}", paymentId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Problem

`PaymentController` endpoints only enforced a role check; none verified that the authenticated caller owns the referenced `registrationId`, `paymentPlanId`, or `paymentId`. Any authenticated user could read another user's payment records (amounts, payment-method metadata, schedules) and cancel/retry/modify another user's payment plan.

## Fix

- Added transactional object-level authorization helpers on `PaymentPlanService`:
  - `requirePaymentAccessByRegistration(registrationId, email)`
  - `requirePaymentAccessByPlan(paymentPlanId, email)`
  - `requirePaymentAccessByPayment(paymentId, email)`
- Each resolves the referenced entity's registration and asserts the caller either owns it (`registration.user.email` matches the principal) or is an ORGANIZER of its event (via `EventRoleService.hasRole`, which also covers platform admins and legacy event owners). Otherwise `AccessDeniedException` → **403**.
- Wired the check (with `Authentication` now passed in) into all 12 affected endpoints: `POST /plans`, `POST /initialize/{id}`, `POST /setup-method/{planId}`, `POST /confirm-upfront/{planId}`, `POST /retry/{paymentId}`, `GET /plans/{registrationId}`, `GET /registrations/{registrationId}`, `GET /schedule/{registrationId}`, `GET /methods/{registrationId}`, `GET /qr-status/{registrationId}`, `GET /active/{registrationId}`, `DELETE /plans/{paymentPlanId}`.
- Checks run outside the endpoints' `try/catch` so 403/400 surface through `GlobalExceptionHandler` instead of being swallowed as generic errors.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java` (new)

## Testing

- Added `PaymentAccessControlTests`:
  - Registration owner gets 200 on plan/schedule/QR/active reads.
  - Event organizer gets 200 on a participant's payment data.
  - An unrelated user gets **403** on every read/write endpoint (GET plan/registrations/schedule/methods/QR/active, POST plans/setup-method/confirm-upfront/retry, DELETE plan).

Closes #16252
