### PR TITLE
fix(notifications): pin test email recipient to the authenticated organizer (#16253)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -6,6 +6,8 @@ import com.sandeep.eventrabackend.dto.request.TestEmailRequest;
 import com.sandeep.eventrabackend.dto.request.SaveTemplateRequest;
 import com.sandeep.eventrabackend.dto.response.TestEmailResponse;
 import com.sandeep.eventrabackend.dto.response.TemplateResponse;
+import com.sandeep.eventrabackend.model.EventRole;
+import com.sandeep.eventrabackend.service.EventRoleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -39,13 +41,16 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final PushSubscriptionService pushSubscriptionService;
     private final EmailTemplateService emailTemplateService;
+    private final EventRoleService eventRoleService;
 
     public NotificationController(NotificationService notificationService,
                                   PushSubscriptionService pushSubscriptionService,
-                                  EmailTemplateService emailTemplateService) {
+                                  EmailTemplateService emailTemplateService,
+                                  EventRoleService eventRoleService) {
         this.notificationService = notificationService;
         this.pushSubscriptionService = pushSubscriptionService;
         this.emailTemplateService = emailTemplateService;
+        this.eventRoleService = eventRoleService;
     }
 
     @GetMapping
@@ -201,10 +206,26 @@ public class NotificationController {
                     description = "Forbidden - User does not have organizer or admin privileges"
             )
     })
-    public ResponseEntity<TestEmailResponse> sendTestEmail(
+    public ResponseEntity<?> sendTestEmail(
             @Valid @RequestBody TestEmailRequest request,
             Authentication authentication) {
         String organizerEmail = authentication.getName();
+
+        long eventId;
+        try {
+            eventId = Long.parseLong(request.getEventId());
+        } catch (NumberFormatException ex) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "error", "Invalid event id"
+            ));
+        }
+
+        // The caller must be an organizer of the specific event (or a platform
+        // admin / legacy owner). Platform ORGANIZER/ADMIN authority alone must
+        // not grant the ability to mail for arbitrary events (#16253).
+        eventRoleService.requireRole(eventId, organizerEmail, EventRole.ORGANIZER);
+
         return ResponseEntity.ok(emailTemplateService.sendTestEmail(request, organizerEmail));
     }
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
@@ -33,7 +33,11 @@ public class EmailTemplateService {
     }
 
     /**
-     * Send a test email to the organizer with the provided template
+     * Send a test email to the organizer with the provided template.
+     *
+     * <p>The recipient is always the authenticated organizer's own email; any
+     * caller-supplied recipient is ignored so the endpoint can never be used as
+     * an open relay to arbitrary addresses (#16253).</p>
      */
     public TestEmailResponse sendTestEmail(TestEmailRequest request, String organizerEmail) {
         try {
@@ -45,9 +49,11 @@ public class EmailTemplateService {
             // Generate a test subject
             String subject = generateSubject(request.getTemplateType(), request.getEvent());
 
-            // Send the email using the email sender
+            // Send the email using the email sender. The recipient is pinned to
+            // the authenticated organizer — request.getRecipientEmail() is never
+            // trusted, preventing arbitrary-recipient phishing relays.
             String messageId = emailSender.sendEmail(
-                    request.getRecipientEmail(),
+                    organizerEmail,
                     subject,
                     renderedContent,
                     true // isHtml
@@ -56,7 +62,7 @@ public class EmailTemplateService {
             return new TestEmailResponse(
                     true,
                     messageId,
-                    request.getRecipientEmail(),
+                    organizerEmail,
                     request.getTemplateType(),
                     request.getEventId(),
                     "Test email sent successfully"
@@ -65,7 +71,7 @@ public class EmailTemplateService {
             return new TestEmailResponse(
                     false,
                     null,
-                    request.getRecipientEmail(),
+                    organizerEmail,
                     request.getTemplateType(),
                     request.getEventId(),
                     "Failed to send test email: " + e.getMessage()

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/EmailTemplateServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/EmailTemplateServiceTest.java
@@ -152,6 +152,32 @@ class EmailTemplateServiceTest {
     }
 
     @Test
+    @DisplayName("Test email recipient is pinned to the authenticated organizer (#16253)")
+    void sendTestEmail_IgnoresCallerSuppliedRecipient() {
+        when(emailSender.sendEmail(any(), any(), any(), anyBoolean()))
+                .thenAnswer(invocation -> {
+                    String to = invocation.getArgument(0);
+                    assertEquals(organizerEmail, to, "recipient must be the organizer's own email");
+                    return "msg-16253";
+                });
+
+        // Caller supplies a victim address; it must be ignored.
+        TestEmailRequest request = new TestEmailRequest(
+                "123",
+                "cancellation",
+                testEmailRequest.getEvent(),
+                testEmailRequest.getAttendee(),
+                "Dear {attendeeName}",
+                "victim@evil.example"
+        );
+
+        TestEmailResponse response = emailTemplateService.sendTestEmail(request, organizerEmail);
+
+        assertTrue(response.isSuccess());
+        assertEquals(organizerEmail, response.getRecipient());
+    }
+
+    @Test
     @DisplayName("Save new template successfully")
     void saveTemplate_NewTemplate() {
         // Mock repository to return null (no existing template)


### PR DESCRIPTION
## Problem

`POST /api/notifications/send-test-email` only checked `isAuthenticated()`/platform role, and `EmailTemplateService.sendTestEmail` ignored the authenticated `organizerEmail`, sending instead to the fully caller-controlled `request.getRecipientEmail()` with a fully caller-controlled HTML body. Any authorized user could relay arbitrary HTML email to arbitrary recipients (phishing/spam vector), and the design would become directly exploitable with a real mail transport.

## Fix

- **Recipient pinned**: `sendTestEmail` now always sends to the authenticated organizer's own email and never trusts `request.getRecipientEmail()` (response also reflects the organizer). The template is only ever rendered to the organizer's own inbox for preview.
- **Event-scoped authorization**: `NotificationController.sendTestEmail` now parses `request.getEventId()` and calls `EventRoleService.requireRole(eventId, email, ORGANIZER)` — the caller must organize the specific event (or be a platform admin / legacy owner). A platform `ORGANIZER`/`ADMIN` authority alone no longer grants mailing for arbitrary events. Invalid event ids return 400; non-organizers get 403 via `GlobalExceptionHandler`.
- The frontend already sends to the organizer's own email (`useEmailTemplates.js`, `EmailTemplateConfig.jsx`), so the pinned server-side behaviour matches the client.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java`
- `Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/EmailTemplateServiceTest.java`

## Testing

- Added `sendTestEmail_IgnoresCallerSuppliedRecipient`: a request carrying `victim@evil.example` still sends to — and reports — the organizer's email.
- Existing `EmailTemplateServiceTest` cases (which pass the organizer as recipient) remain valid.

Closes #16253
