### PR TITLE
fix(ratelimit): ignore spoofable client-supplied leftmost X-Forwarded-For (#16254)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilter.java
@@ -4,7 +4,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -17,9 +19,12 @@ import java.time.Duration;
 public class RateLimitingFilter extends OncePerRequestFilter {
 
     private final RateLimitService rateLimitService;
+    private final int trustedProxyHops;
 
-    public RateLimitingFilter(RateLimitService rateLimitService) {
+    public RateLimitingFilter(RateLimitService rateLimitService,
+            @Value("${app.rate-limit.trusted-proxy-hops:1}") int trustedProxyHops) {
         this.rateLimitService = rateLimitService;
+        this.trustedProxyHops = Math.max(0, trustedProxyHops);
     }
 
     @Override
@@ -56,11 +61,31 @@ public class RateLimitingFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * Resolve the originating client IP using {@code X-Forwarded-For} with a
+     * known trusted hop count, falling back to {@code X-Real-IP} then
+     * {@code getRemoteAddr()} (#16254). Proxies append the connecting peer on
+     * the right; the client is the leftmost of the trusted suffix, so a
+     * client-supplied left-hand spoof is ignored instead of being used as the
+     * rate-limit bucket key.
+     */
     private String getClientIp(HttpServletRequest request) {
-        String xf = request.getHeader("X-Forwarded-For");
-        if (xf != null && !xf.isEmpty()) {
-            return xf.split(",")[0].trim();
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(forwarded)) {
+            String[] parts = forwarded.split(",");
+            int clientIndex = Math.min(parts.length - 1,
+                    Math.max(0, parts.length - trustedProxyHops));
+            String candidate = parts[clientIndex].trim();
+            if (StringUtils.hasText(candidate) && !"unknown".equalsIgnoreCase(candidate)) {
+                return candidate;
+            }
         }
+
+        String realIp = request.getHeader("X-Real-IP");
+        if (StringUtils.hasText(realIp)) {
+            return realIp.trim();
+        }
+
         return request.getRemoteAddr();
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilterUnitTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilterUnitTests.java
@@ -1,0 +1,102 @@
+package com.sandeep.eventrabackend.ratelimit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Issue #16254 — the sse/rest {@link RateLimitingFilter} must not trust a
+ * client-supplied leftmost {@code X-Forwarded-For} value as the rate-limit
+ * bucket key, otherwise an attacker can rotate it to bypass per-IP limits.
+ */
+class RateLimitingFilterUnitTests {
+
+    private RateLimitResult allowed() {
+        return new RateLimitResult(true, 100, 99, 0);
+    }
+
+    @Test
+    @DisplayName("Spoofed leftmost XFF is ignored; trusted rightmost hop keys the bucket")
+    void usesRightmostTrustedHopNotSpoofedLeftmost() throws Exception {
+        RateLimitService service = mock(RateLimitService.class);
+        org.mockito.Mockito.when(service.consume(anyString(), anyString(), anyInt(), any(Duration.class)))
+                .thenReturn(allowed());
+        RateLimitingFilter filter = new RateLimitingFilter(service, 1);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/some-endpoint");
+        request.addHeader("X-Forwarded-For", "198.51.100.1, 203.0.113.50");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        verify(service).consume(eq("rest-api"), eq("203.0.113.50"), anyInt(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("Different spoofed leftmost values map to the same bucket (no bypass)")
+    void rotatingSpoofedLeftmostKeepsSameBucket() throws Exception {
+        RateLimitService service = mock(RateLimitService.class);
+        org.mockito.Mockito.when(service.consume(anyString(), anyString(), anyInt(), any(Duration.class)))
+                .thenReturn(allowed());
+        RateLimitingFilter filter = new RateLimitingFilter(service, 1);
+
+        for (String spoof : new String[]{"198.51.100.1, 203.0.113.50", "198.51.100.99, 203.0.113.50"}) {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setRequestURI("/api/some-endpoint");
+            request.addHeader("X-Forwarded-For", spoof);
+            filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+        }
+
+        // Both requests keyed on the same trusted hop.
+        verify(service, org.mockito.Mockito.times(2))
+                .consume(eq("rest-api"), eq("203.0.113.50"), anyInt(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("Falls back to remoteAddr when no forwarding headers are present")
+    void fallsBackToRemoteAddr() throws Exception {
+        RateLimitService service = mock(RateLimitService.class);
+        org.mockito.Mockito.when(service.consume(anyString(), anyString(), anyInt(), any(Duration.class)))
+                .thenReturn(allowed());
+        RateLimitingFilter filter = new RateLimitingFilter(service, 1);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/some-endpoint");
+        request.setRemoteAddr("203.0.113.77");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        verify(service).consume(eq("rest-api"), eq("203.0.113.77"), anyInt(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("Assert bucket key is a valid non-blank value")
+    void bucketKeyIsNeverBlank() throws Exception {
+        RateLimitService service = mock(RateLimitService.class);
+        org.mockito.Mockito.when(service.consume(anyString(), anyString(), anyInt(), any(Duration.class)))
+                .thenReturn(allowed());
+        RateLimitingFilter filter = new RateLimitingFilter(service, 1);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/some-endpoint");
+        request.setRemoteAddr("");
+
+        filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+        org.mockito.ArgumentCaptor<String> captor = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(service).consume(eq("rest-api"), captor.capture(), anyInt(), any(Duration.class));
+        String ip = captor.getValue();
+        assertEquals(false, ip == null || ip.isBlank());
+    }
+}


### PR DESCRIPTION
## Problem

`RateLimitingFilter` (the sse/rest filter, `ratelimit/RateLimitingFilter.java`) derived the rate-limit bucket key from the **leftmost** `X-Forwarded-For` entry, which is fully client-controlled. An attacker could rotate the header per request to evade the per-IP limits (100/min REST, 1000/min SSE), defeating brute-force and abuse protections.

## Fix

- Replaced the naive `xf.split(",")[0]` logic with the same trusted-proxy-hop resolution already used by the auth `RateLimitingFilter`:
  - `X-Forwarded-For` entries are read from the **leftmost trusted hop** (proxies append the connecting peer on the right), so a client-supplied left-hand spoof is ignored.
  - Falls back to `X-Real-IP`, then `request.getRemoteAddr()`.
- The filter now reads the existing `app.rate-limit.trusted-proxy-hops` config (default 1), matching the auth filter's behavior.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilter.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/ratelimit/RateLimitingFilterUnitTests.java` (new)

## Testing

- `usesRightmostTrustedHopNotSpoofedLeftmost`: `X-Forwarded-For: 198.51.100.1, 203.0.113.50` keys the bucket on `203.0.113.50`.
- `rotatingSpoofedLeftmostKeepsSameBucket`: varying the spoofed leftmost value still hits the same bucket (no bypass).
- `fallsBackToRemoteAddr`: no forwarding headers → `getRemoteAddr()` is used.
- `bucketKeyIsNeverBlank`: the bucket key is never blank.

Closes #16254
