### PR TITLE
fix(analytics): harden encrypted analytics endpoint (auth, validation, no false claim) (#16255)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/EncryptedAnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/EncryptedAnalyticsController.java
@@ -1,16 +1,35 @@
 package com.sandeep.eventrabackend.security;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Homomorphic aggregation helper (#14040). The endpoint performs a public-key
+ * multiplication of ciphertexts; it never decrypts and holds no private key, so
+ * it cannot verify anything about the plaintexts. That is reflected in the API
+ * (no {@code homomorphicPropertyVerified} field) rather than claiming a
+ * verification the server does not perform (#16255).
+ */
 @RestController
 @RequestMapping("/api/analytics/encrypted")
-@CrossOrigin(origins = "*")
+@Tag(name = "Encrypted Analytics", description = "Homomorphic aggregation of encrypted analytics values")
 public class EncryptedAnalyticsController {
+
+    private static final int MAX_CIPHERTEXTS = 10_000;
+    private static final int MAX_CIPHERTEXT_LENGTH = 4096;
+    private static final int MAX_MODULUS_LENGTH = 4096;
 
     private final PaillierCryptoService paillierCryptoService;
 
@@ -30,14 +49,69 @@ public class EncryptedAnalyticsController {
     }
 
     @PostMapping("/aggregate-sum")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "Aggregate encrypted sums (homomorphic)",
+            description = """
+                    Computes E(sum) as the product of the supplied ciphertexts modulo n^2.
+                    Requires authentication. Inputs are validated and bounded to prevent
+                    unbounded computation. The server does not decrypt and holds no private
+                    key, so no verification of the plaintexts is claimed.
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"))
     public ResponseEntity<Map<String, Object>> aggregateEncryptedSum(@RequestBody HomomorphicSumRequest request) {
-        String sumCiphertext = paillierCryptoService.aggregateEncryptedSum(request.getCiphertexts(), request.getModulusN());
-        
+        List<String> ciphertexts = request.getCiphertexts();
+        if (ciphertexts == null || ciphertexts.isEmpty()) {
+            throw new IllegalArgumentException("ciphertexts must not be empty");
+        }
+        if (ciphertexts.size() > MAX_CIPHERTEXTS) {
+            throw new IllegalArgumentException(
+                    "ciphertexts exceeds the maximum of " + MAX_CIPHERTEXTS + " entries");
+        }
+        for (String ciphertext : ciphertexts) {
+            if (!isBoundedInteger(ciphertext, MAX_CIPHERTEXT_LENGTH)) {
+                throw new IllegalArgumentException(
+                        "Each ciphertext must be a valid integer (at most "
+                                + MAX_CIPHERTEXT_LENGTH + " characters)");
+            }
+        }
+
+        String modulusN = request.getModulusN();
+        if (!isPositiveBoundedInteger(modulusN, MAX_MODULUS_LENGTH)) {
+            throw new IllegalArgumentException(
+                    "modulusN must be a valid positive integer (at most "
+                            + MAX_MODULUS_LENGTH + " characters)");
+        }
+
+        String sumCiphertext = paillierCryptoService.aggregateEncryptedSum(ciphertexts, modulusN);
+
         Map<String, Object> response = new HashMap<>();
         response.put("encryptedSum", sumCiphertext);
-        response.put("count", request.getCiphertexts() != null ? request.getCiphertexts().size() : 0);
-        response.put("homomorphicPropertyVerified", true);
+        response.put("count", ciphertexts.size());
 
         return ResponseEntity.ok(response);
+    }
+
+    private boolean isBoundedInteger(String value, int maxLength) {
+        if (value == null || value.isBlank() || value.length() > maxLength) {
+            return false;
+        }
+        try {
+            new BigInteger(value.trim());
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private boolean isPositiveBoundedInteger(String value, int maxLength) {
+        if (value == null || value.isBlank() || value.length() > maxLength) {
+            return false;
+        }
+        try {
+            return new BigInteger(value.trim()).signum() > 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/EncryptedAnalyticsControllerTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/EncryptedAnalyticsControllerTest.java
@@ -1,0 +1,129 @@
+package com.sandeep.eventrabackend.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for EncryptedAnalyticsController.
+ * Verifies input validation/bounding and that the response never claims a
+ * verification the server does not perform (#16255).
+ */
+@ExtendWith(MockitoExtension.class)
+class EncryptedAnalyticsControllerTest {
+
+    @Mock
+    private PaillierCryptoService paillierCryptoService;
+
+    @InjectMocks
+    private EncryptedAnalyticsController controller;
+
+    private static final String MODULUS_N = "1073741827";
+    private static final String VALID_CIPHERTEXT = "12345";
+
+    private EncryptedAnalyticsController.HomomorphicSumRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = new EncryptedAnalyticsController.HomomorphicSumRequest();
+        request.setCiphertexts(new ArrayList<>(List.of(VALID_CIPHERTEXT, "67890")));
+        request.setModulusN(MODULUS_N);
+    }
+
+    @Test
+    @DisplayName("Valid request returns encrypted sum and count, with no false verification claim")
+    void validRequestReturnsSumWithoutVerificationClaim() {
+        when(paillierCryptoService.aggregateEncryptedSum(List.of(VALID_CIPHERTEXT, "67890"), MODULUS_N))
+                .thenReturn("99");
+
+        ResponseEntity<Map<String, Object>> response = controller.aggregateEncryptedSum(request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("99", response.getBody().get("encryptedSum"));
+        assertEquals(2, response.getBody().get("count"));
+        assertFalse(response.getBody().containsKey("homomorphicPropertyVerified"),
+                "response must not claim verification the server does not perform");
+    }
+
+    @Test
+    @DisplayName("Empty ciphertext list is rejected")
+    void emptyCiphertextsAreRejected() {
+        request.setCiphertexts(Collections.emptyList());
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Null ciphertext list is rejected")
+    void nullCiphertextsAreRejected() {
+        request.setCiphertexts(null);
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Oversized ciphertext list is rejected to bound computation")
+    void oversizedCiphertextListIsRejected() {
+        List<String> many = new ArrayList<>();
+        for (int i = 0; i < 10_001; i++) {
+            many.add(VALID_CIPHERTEXT);
+        }
+        request.setCiphertexts(many);
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Non-integer ciphertext is rejected")
+    void nonIntegerCiphertextIsRejected() {
+        request.setCiphertexts(new ArrayList<>(List.of(VALID_CIPHERTEXT, "not-a-number")));
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Oversized ciphertext string is rejected")
+    void oversizedCiphertextStringIsRejected() {
+        request.setCiphertexts(new ArrayList<>(List.of("9".repeat(4097))));
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Blank modulusN is rejected")
+    void blankModulusIsRejected() {
+        request.setModulusN("   ");
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Non-numeric modulusN is rejected")
+    void nonNumericModulusIsRejected() {
+        request.setModulusN("modulus");
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Non-positive modulusN is rejected")
+    void nonPositiveModulusIsRejected() {
+        request.setModulusN("-17");
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+
+    @Test
+    @DisplayName("Oversized modulusN is rejected")
+    void oversizedModulusIsRejected() {
+        request.setModulusN("9".repeat(4097));
+        assertThrows(IllegalArgumentException.class, () -> controller.aggregateEncryptedSum(request));
+    }
+}


### PR DESCRIPTION
## Problem

`EncryptedAnalyticsController` (`/api/analytics/encrypted/aggregate-sum`) was exposed with:

- `@CrossOrigin(origins = "*")` — open to any origin.
- No explicit authorization (anyone who reached the endpoint could use it as a compute helper).
- Fully client-supplied `modulusN` and an unbounded `ciphertexts` list — a DoS vector (an attacker could push thousands of arbitrarily large BigIntegers through the homomorphic multiplication loop).
- A hard-coded `homomorphicPropertyVerified: true` — the server never decrypts and holds no private key, so it cannot actually verify anything. The flag was a false security claim.

## Fix

- Removed the wildcard `@CrossOrigin` (CORS is governed centrally by `SecurityConfig.corsConfigurationSource`).
- Added `@PreAuthorize("isAuthenticated()")` + `@SecurityRequirement(bearerAuth)` (method-level security is enabled via `@EnableMethodSecurity`; the path also falls under `.anyRequest().authenticated()` in the security chain).
- Validated and bounded all inputs, rejecting invalid payloads with 400:
  - `ciphertexts` must be non-empty, at most 10,000 entries, each a valid integer of at most 4,096 characters.
  - `modulusN` must be a positive integer of at most 4,096 characters.
- Removed `homomorphicPropertyVerified` from the response. The endpoint only aggregates ciphertexts with public-key math; it never verifies plaintexts, so the API no longer claims otherwise (documented in the `@Operation` description).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/security/EncryptedAnalyticsController.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/security/EncryptedAnalyticsControllerTest.java` (new)

## Testing

- Valid request returns `encryptedSum` + `count` and does not contain a `homomorphicPropertyVerified` key.
- Empty/null ciphertext lists, lists over 10,000 entries, non-integer or oversized ciphertexts, and blank/non-numeric/non-positive/oversized `modulusN` are all rejected with `IllegalArgumentException` → 400.

Closes #16255
