### PR TITLE
fix(push): validate WebPush endpoints to prevent SSRF (#16257)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
@@ -10,11 +10,16 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class PushSubscriptionService {
+
+    private static final int MAX_ENDPOINT_LENGTH = 2048;
 
     private final PushSubscriptionRepository pushSubscriptionRepository;
     private final UserRepository userRepository;
@@ -30,6 +35,11 @@ public class PushSubscriptionService {
         if (p256dh == null || p256dh.isBlank() || auth == null || auth.isBlank()) {
             throw new IllegalArgumentException("Push subscription keys.p256dh and keys.auth are required");
         }
+
+        // Reject endpoints that could be used as an SSRF vector when the server
+        // later dispatches pushes: only https to a public hostname on the default
+        // port is accepted (#16257).
+        validateEndpoint(request.getEndpoint());
 
         PushSubscription subscription = pushSubscriptionRepository
                 .findByUser_IdAndEndpoint(user.getId(), request.getEndpoint())
@@ -52,4 +62,104 @@ public class PushSubscriptionService {
         }
         pushSubscriptionRepository.deleteByUser_Id(user.getId());
     }
-}
+
+    private void validateEndpoint(String endpoint) {
+        if (endpoint == null || endpoint.isBlank()) {
+            throw new IllegalArgumentException("Push subscription endpoint is required");
+        }
+        if (endpoint.length() > MAX_ENDPOINT_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Push subscription endpoint exceeds " + MAX_ENDPOINT_LENGTH + " characters");
+        }
+
+        URI uri;
+        try {
+            uri = new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Push subscription endpoint is not a valid URL");
+        }
+        if (!"https".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("Push subscription endpoint must use the https scheme");
+        }
+        if (uri.getUserInfo() != null) {
+            throw new IllegalArgumentException("Push subscription endpoint must not contain user information");
+        }
+        int port = uri.getPort();
+        if (port != -1 && port != 443) {
+            throw new IllegalArgumentException("Push subscription endpoint must use the default https port (443)");
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("Push subscription endpoint must include a host");
+        }
+        rejectNonPublicHost(host);
+    }
+
+    /**
+     * Rejects loopback/link-local/private/multicast IP literals and bare or
+     * reserved hostnames, so a stored endpoint can never point at internal
+     * infrastructure (metadata endpoints, admin ports, etc.).
+     */
+    private void rejectNonPublicHost(String host) {
+        String h = host.toLowerCase(Locale.ROOT);
+        if ("localhost".equals(h) || h.endsWith(".localhost")) {
+            throw new IllegalArgumentException("Push subscription endpoint must not point at localhost");
+        }
+        if (h.endsWith(".local") || h.endsWith(".internal")
+                || h.endsWith(".home") || h.endsWith(".lan") || h.endsWith(".localdomain")) {
+            throw new IllegalArgumentException("Push subscription endpoint must use a public hostname");
+        }
+        // IPv6 literals and bare hostnames never contain a dot and are never
+        // valid WebPush endpoints.
+        if (!h.contains(".")) {
+            throw new IllegalArgumentException("Push subscription endpoint must use a public hostname");
+        }
+        if (isIpv4Literal(h) && isNonPublicIpv4(h)) {
+            throw new IllegalArgumentException("Push subscription endpoint must not point at a private IP address");
+        }
+    }
+
+    private boolean isIpv4Literal(String host) {
+        if (host.startsWith(".") || host.endsWith(".")) {
+            return false;
+        }
+        String[] parts = host.split("\\.");
+        if (parts.length != 4) {
+            return false;
+        }
+        for (String part : parts) {
+            if (part.isEmpty() || part.length() > 3) {
+                return false;
+            }
+            for (int i = 0; i < part.length(); i++) {
+                if (!Character.isDigit(part.charAt(i))) {
+                    return false;
+                }
+            }
+            int value = Integer.parseInt(part);
+            if (value > 255) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isNonPublicIpv4(String host) {
+        int[] octets = new int[4];
+        String[] parts = host.split("\\.");
+        for (int i = 0; i < 4; i++) {
+            octets[i] = Integer.parseInt(parts[i]);
+        }
+        int a = octets[0], b = octets[1], c = octets[2], d = octets[3];
+        if (a == 0 || a == 10) return true;                       // 0.0.0.0/8, 10.0.0.0/8
+        if (a == 127) return true;                                 // 127.0.0.0/8 loopback
+        if (a == 169 && b == 254) return true;                     // 169.254.0.0/16 incl. metadata
+        if (a == 172 && b >= 16 && b <= 31) return true;           // 172.16.0.0/12
+        if (a == 192 && b == 168) return true;                     // 192.168.0.0/16
+        if (a == 192 && b == 0 && c == 0) return true;             // 192.0.0.0/24 incl. 192.0.0.9/10
+        if (a == 198 && (b == 18 || b == 19)) return true;         // 198.18.0.0/15 benchmark
+        if (a >= 224) return true;                                 // multicast + reserved
+        if (a == 255) return true;                                 // broadcast
+        return d == 0 && c == 0 && b == 0;                         // x.x.x.0 reserved only if a was public
+    }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/PushSubscriptionServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/PushSubscriptionServiceTest.java
@@ -1,0 +1,162 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.request.PushSubscriptionRequest;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.PushSubscriptionRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for PushSubscriptionService endpoint validation.
+ * Stored endpoints are later dispatched to by the server, so they must never
+ * be usable as an SSRF vector (#16257).
+ */
+@ExtendWith(MockitoExtension.class)
+class PushSubscriptionServiceTest {
+
+    @Mock
+    private PushSubscriptionRepository pushSubscriptionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PushSubscriptionService pushSubscriptionService;
+
+    private User user;
+    private PushSubscriptionRequest request;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setEmail("user@example.com");
+        request = new PushSubscriptionRequest();
+        request.setKeys(Map.of("p256dh", "base64p256", "auth", "base64auth"));
+    }
+
+    @Test
+    @DisplayName("Valid public https WebPush endpoint is accepted")
+    void validPublicHttpsEndpointIsAccepted() {
+        request.setEndpoint("https://fcm.googleapis.com/fcm/send/abc123");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        when(pushSubscriptionRepository.findByUser_IdAndEndpoint(any(), any())).thenReturn(Optional.empty());
+
+        assertDoesNotThrow(() -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("http endpoint is rejected")
+    void httpEndpointIsRejected() {
+        request.setEndpoint("http://push.example.com/endpoint");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Non-443 https port is rejected")
+    void nonStandardPortIsRejected() {
+        request.setEndpoint("https://push.example.com:8080/endpoint");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Loopback endpoint is rejected")
+    void localhostEndpointIsRejected() {
+        request.setEndpoint("https://localhost:443/endpoint");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Cloud metadata IP literal is rejected")
+    void metadataIpLiteralIsRejected() {
+        request.setEndpoint("https://169.254.169.254/latest/meta-data/");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Private IP literal is rejected")
+    void privateIpLiteralIsRejected() {
+        request.setEndpoint("https://192.168.1.5/admin");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("IPv6 loopback literal is rejected")
+    void ipv6LoopbackIsRejected() {
+        request.setEndpoint("https://[::1]/endpoint");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Bare internal hostname without a dot is rejected")
+    void bareHostnameIsRejected() {
+        request.setEndpoint("https://internal-service/endpoint");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Hostname pointing at an internal domain suffix is rejected")
+    void internalDomainSuffixIsRejected() {
+        request.setEndpoint("https://admin.internal/api");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Endpoint with userinfo is rejected")
+    void userInfoIsRejected() {
+        request.setEndpoint("https://evil@push.example.com/endpoint");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+
+    @Test
+    @DisplayName("Missing push keys are rejected before endpoint validation")
+    void missingKeysAreRejected() {
+        request.setEndpoint("https://fcm.googleapis.com/fcm/send/abc123");
+        request.setKeys(null);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> pushSubscriptionService.subscribe("user@example.com", request));
+    }
+}


### PR DESCRIPTION
## Problem

`PushSubscriptionService.subscribe()` persisted the WebPush `endpoint` straight from the request with no validation. Endpoints are stored and later dispatched to by the server, so a malicious client could store an endpoint pointing at internal services (`http://169.254.169.254/...`, `https://127.0.0.1:admin-port`, internal hostnames) and turn push dispatch into an SSRF primitive.

## Fix

`subscribe()` now validates the endpoint before persisting it (#16257):

- Must be a valid `https` URL.
- No user-info component, no non-443 port.
- Host must be a public hostname — rejects `localhost`, `.local`/`.internal`/`.home`/`.lan`/`.localdomain` suffixes, bare hostnames (no dot, which also excludes all IPv6 literals), and private/loopback/link-local/metadata IPv4 literals (`0.0.0.0/8`, `10/8`, `127/8`, `169.254/16`, `172.16/12`, `192.168/16`, `192.0.0.0/24`, `198.18/15`, multicast/reserved).
- Length capped at the 2048-char DB column.

Endpoints remain tied to the authenticated user (stored from the caller's `Authentication`, not from request-supplied identity).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/PushSubscriptionServiceTest.java` (new)

## Testing

- Valid public endpoint (`https://fcm.googleapis.com/fcm/send/abc123`) is accepted.
- `http`, non-443 ports, `localhost`, `https://169.254.169.254/...`, `192.168.1.5`, `[::1]`, bare hostnames (`internal-service`), `.internal` suffix, and user-info URLs are all rejected with `IllegalArgumentException`.
- Missing push keys still rejected before endpoint validation.

Closes #16257
