### PR TITLE
fix(security): guard against inlining the request-signing secret in the client bundle (#16263)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -36,6 +36,9 @@ REACT_APP_PUBLIC_URL=https://eventra.sandeepvashishtha.tech
 
 # ── Security ─────────────────────────────────
 # VITE_CSRF_ENFORCEMENT_MODE=strict
+# NOTE: NEVER prefix REQUEST_SIGNING_SECRET with VITE_ — Vite inlines VITE_*
+# vars into the browser bundle, making HMAC signatures forgeable by anyone.
+# Only server-side Node processes may use it (e.g. when proxying requests).
 # REQUEST_SIGNING_SECRET=shared-hmac-secret-for-tamper-evidence
 # BLOCKED_COUNTRIES=CU,IR,KP,SY,RU
 # ALLOWED_ORIGINS=https://your-domain.com,https://www.your-domain.com

--- a/tests/interceptorRequestSigning.test.mjs
+++ b/tests/interceptorRequestSigning.test.mjs
@@ -17,8 +17,13 @@ import { signRequest } from "../src/utils/requestSigner.js";
 import { validateSignature } from "../src/utils/signatureValidator.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
 const interceptorCode = fs.readFileSync(
-  path.resolve(__dirname, "../src/config/api/interceptors.js"),
+  path.resolve(repoRoot, "src/config/api/interceptors.js"),
+  "utf8",
+);
+const signerCode = fs.readFileSync(
+  path.resolve(repoRoot, "src/utils/requestSigner.js"),
   "utf8",
 );
 
@@ -28,7 +33,7 @@ describe("request signing wiring", () => {
   it("the live interceptor imports signRequest", () => {
     assert.match(
       interceptorCode,
-      /import\s*\{\s*signRequest\s*\}\s*from\s*["']utils\/requestSigner\.js["']/,
+      /import\s*\{\s*signRequest\s*\}\s*from\s*["'][^"']*requestSigner\.js["']/,
       "setupRequestInterceptor must import signRequest",
     );
   });
@@ -69,6 +74,46 @@ describe("request signing wiring", () => {
       interceptorCode,
       /["']REQUEST_SIGNING_SECRET["']/,
       "interceptor may only read a non-VITE REQUEST_SIGNING_SECRET",
+    );
+  });
+
+  it("no file under src/ references the VITE_ signing secret anywhere", () => {
+    const walk = (dir) =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = path.join(dir, entry.name);
+        return entry.isDirectory() ? walk(full) : full;
+      });
+    const offenders = [];
+    for (const file of walk(path.join(repoRoot, "src"))) {
+      if (!/\.(js|jsx|ts|tsx|mjs)$/.test(file)) {
+        continue;
+      }
+      if (fs.readFileSync(file, "utf8").includes("VITE_REQUEST_SIGNING_SECRET")) {
+        offenders.push(path.relative(repoRoot, file));
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `VITE_REQUEST_SIGNING_SECRET must never appear under src/ (it is inlined into the client bundle): ${offenders.join(", ")}`,
+    );
+  });
+
+  it("requestSigner never reads a signing secret from the environment", () => {
+    assert.doesNotMatch(
+      signerCode,
+      /VITE_REQUEST_SIGNING_SECRET/,
+      "requestSigner must not read VITE_REQUEST_SIGNING_SECRET",
+    );
+    assert.doesNotMatch(
+      signerCode,
+      /import\.meta\.env/,
+      "requestSigner must not read import.meta.env (bundle-inlined)",
+    );
+    assert.doesNotMatch(
+      signerCode,
+      /process\.env/,
+      "requestSigner must not read process.env for a signing secret",
     );
   });
 


### PR DESCRIPTION
## Problem

`VITE_REQUEST_SIGNING_SECRET` was documented for HMAC request signing. Vite inlines every `VITE_*` var into the client bundle at build time, so such a secret would be readable by anyone with DevTools — making every `x-signature` forgeable and the signing mechanism meaningless.

The interceptor already stopped reading a `VITE_` secret (`1233b5f35`), but there was no guard preventing a regression, and the production env example did not warn against the `VITE_` prefix.

## Fix

- Added an automated static guard in `tests/interceptorRequestSigning.test.mjs` that fails the suite if:
  - `VITE_REQUEST_SIGNING_SECRET` appears **anywhere** under `src/` (recursive scan of all `*.js/jsx/ts/tsx/mjs`), or
  - `requestSigner.js` ever reads a signing secret from `import.meta.env` or `process.env`.
- Fixed a stale import-path regex in the existing test that no longer matched the current `../../utils/requestSigner.js` import (it was failing on master).
- Documented in `.env.production.example` that `REQUEST_SIGNING_SECRET` must never be `VITE_`-prefixed (only server-side Node processes may use it).

The backend performs authorization via JWT only and does not verify `x-signature`, so nothing server-side trusts a client-embeddable secret.

## Files changed

- `tests/interceptorRequestSigning.test.mjs`
- `.env.production.example`

## Testing

- `node --test tests/interceptorRequestSigning.test.mjs` → 8/8 pass, including the new tree-wide scan and `requestSigner.js` guards.

Closes #16263
