### PR TITLE
fix(median-low): return lower-middle value for even-length arrays (#17542)

### DIFF
--- a/src/eventra-kit/__tests__/median-low.test.js
+++ b/src/eventra-kit/__tests__/median-low.test.js
@@ -1,9 +1,44 @@
 import { describe, it, expect } from 'vitest';
 import * as MedianLow from '../median-low.js';
+import { medianLow } from '../median-low.js';
+import { medianHigh } from '../median-high.js';
 
 describe('median-low', () => {
   it('exports a module', () => {
     expect(MedianLow).toBeDefined();
+  });
+
+  it('returns the exact middle element for an odd-length array', () => {
+    expect(medianLow([5, 1, 3, 2, 4])).toBe(3);
+  });
+
+  it('returns the lower-middle value for an even-length array (#17542)', () => {
+    expect(medianLow([1, 2, 3, 4])).toBe(2);
+    expect(medianLow([10, 20])).toBe(10);
+    expect(medianLow([1, 2, 3, 4, 5, 6])).toBe(3);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [3, 1, 2];
+    const snapshot = [...input];
+    medianLow(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it('sorts numerically (not lexicographically)', () => {
+    expect(medianLow([10, 2, 8, 4, 6])).toBe(6);
+    expect(medianLow([10, 2, 8, 4])).toBe(4);
+  });
+
+  it('returns undefined for an empty array', () => {
+    expect(medianLow([])).toBeUndefined();
+  });
+
+  it('returns a different value than medianHigh for even-length arrays', () => {
+    const data = [1, 2, 3, 4];
+    expect(medianLow(data)).toBe(2);
+    expect(medianHigh(data)).toBe(3);
+    expect(medianLow(data)).not.toBe(medianHigh(data));
   });
 });
 

--- a/src/eventra-kit/median-low.js
+++ b/src/eventra-kit/median-low.js
@@ -1,10 +1,17 @@
 
 /**
  * adds a low median helper.
+ *
+ * For an odd-length array this is the middle element. For an even-length
+ * array the low median is the lower of the two middle values (the element
+ * before the upper-middle). The index Math.floor((n - 1) / 2) lands on the
+ * lower-middle for even n (e.g. n=4 -> index 1) and the exact middle for
+ * odd n (e.g. n=5 -> index 2), so medianLow and medianHigh no longer collide.
  */
 export function medianLow(array) {
+  if (!array.length) return undefined;
   const sorted = [...array].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
+  const mid = Math.floor((sorted.length - 1) / 2);
   return sorted[mid];
 }
 


### PR DESCRIPTION
## Description

`src/eventra-kit/median-low.js` is supposed to compute the **low median** — for an odd-length array, the middle element; for an even-length array, the **lower** of the two middle values (the element before the upper-middle). The implementation instead used `Math.floor(sorted.length / 2)` as the index, which for an even-length array lands on the **upper-middle** element — exactly the same index `median-high.js` reaches with `Math.ceil(sorted.length / 2)`. As a result `medianLow` and `medianHigh` returned the **same value for every even-length array**, defeating the purpose of having a low-median helper.

For example:
- `medianLow([1, 2, 3, 4])` returned `3` (index 2, the upper-middle) instead of the correct `2` (index 1, the lower-middle).
- `medianLow([10, 20])` returned `20` (index 1) instead of the correct `10` (index 0).

## Fix

Change the middle index to `Math.floor((sorted.length - 1) / 2)`. For even `n` this lands on the lower-middle (e.g. `n=4 → index 1`), and for odd `n` it lands on the exact middle (e.g. `n=5 → index 2`), so:
- odd-length arrays keep returning the single middle element (unchanged behavior), and
- even-length arrays now return the lower-middle value, diverging correctly from `medianHigh`.

This is the exact fix proposed in the issue. I also added an empty-array guard returning `undefined`, consistent with the sibling `median-value.js` helper (which already guards `!numbers.length`) — previously `medianLow([])` returned `undefined` via `sorted[Math.floor(0)]`, but making the guard explicit keeps the contract clear and avoids relying on `undefined`-from-empty-index.

## Verification

The existing `median-low.test.js` only asserted the module was exported (no behavioral coverage), which is why the bug was never caught. I added behavioral regression tests, **7 tests, all passing** (`src/eventra-kit/__tests__/median-low.test.js`):

1. exact middle element for an odd-length array (`[5,1,3,2,4] → 3`),
2. **the issue's regression** — lower-middle for even-length arrays: `[1,2,3,4] → 2`, `[10,20] → 10`, `[1..6] → 3`,
3. does not mutate the input array,
4. sorts numerically, not lexicographically (`[10,2,8,4] → 4`),
5. returns `undefined` for an empty array,
6. returns a **different** value than `medianHigh` for even-length arrays (the core of the bug: they previously collided),
7. the module is still exported.

The sibling suites stay green: `median-high`, `median`, and `median-value` all pass (10 tests total across the 4 files).

```
Test Files  4 passed (4)
     Tests  10 passed (10)
```

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Closes #17542
