### PR TITLE
fix(sponsorAnalytics): count QR scans by action, not total lead count (#17543)

### DIFF
--- a/src/utils/sponsorAnalyticsUtils.js
+++ b/src/utils/sponsorAnalyticsUtils.js
@@ -20,6 +20,7 @@ export function computeSponsorBoothMetrics(leads = []) {
   let boothVisits = 0;
   let jobClicks = 0;
   let chatInitiations = 0;
+  let qrScans = 0;
 
   for (const lead of list) {
     const action = String(lead?.action || "").trim();
@@ -29,11 +30,12 @@ export function computeSponsorBoothMetrics(leads = []) {
       chatInitiations += 1;
     } else if (/^Applied:/i.test(action)) {
       jobClicks += 1;
+    } else if (/^QR/i.test(action)) {
+      qrScans += 1;
     }
   }
 
-  const qrScans = list.length;
-  const engagementBase = boothVisits > 0 ? boothVisits : 0;
+  const engagementBase = boothVisits + qrScans;
   const engagementRate =
     engagementBase > 0
       ? Number((((jobClicks + chatInitiations) / engagementBase) * 100).toFixed(1))

--- a/tests/sponsorAnalyticsUtils.test.mjs
+++ b/tests/sponsorAnalyticsUtils.test.mjs
@@ -27,9 +27,27 @@ import { computeSponsorBoothMetrics } from "../src/utils/sponsorAnalyticsUtils.j
   assert.equal(metrics.footfall, 3);
   assert.equal(metrics.jobClicks, 2);
   assert.equal(metrics.chatInitiations, 1);
-  assert.equal(metrics.qrScans, 6);
-  // (2 applies + 1 chat) / 3 visits = 100%
+  // No QR-scan actions were recorded, so qrScans must be 0 — not the total
+  // lead count (previously list.length == 6, see #17543).
+  assert.equal(metrics.qrScans, 0);
+  // (2 applies + 1 chat) / (3 visits + 0 scans) = 100%
   assert.equal(metrics.engagementRate, 100);
+}
+
+{
+  // QR scans are counted by action, not fabricated from the total lead count.
+  const metrics = computeSponsorBoothMetrics([
+    { action: "QR Scan" },
+    { action: "QR Scan" },
+    { action: "QR Scan: Booth A" },
+    { action: "Booth Visit" },
+    { action: "Chat Initiated" },
+  ]);
+  assert.equal(metrics.qrScans, 3);
+  assert.equal(metrics.boothVisits, 1);
+  assert.equal(metrics.chatInitiations, 1);
+  // (0 applies + 1 chat) / (1 visit + 3 scans) = 25%
+  assert.equal(metrics.engagementRate, 25);
 }
 
 {
@@ -41,9 +59,27 @@ import { computeSponsorBoothMetrics } from "../src/utils/sponsorAnalyticsUtils.j
   assert.equal(metrics.boothVisits, 0);
   assert.equal(metrics.footfall, 0);
   assert.equal(metrics.jobClicks, 2);
-  assert.equal(metrics.qrScans, 2);
+  assert.equal(metrics.qrScans, 0);
   assert.equal(metrics.engagementRate, 0);
-  assert.notEqual(metrics.boothVisits, metrics.qrScans * 3);
+  // boothVisits is not fabricated from the lead count (no Booth Visit actions
+  // were recorded, so it must stay 0 rather than tracking list.length).
+  assert.equal(metrics.boothVisits, 0);
+}
+
+{
+  // engagementRate should reflect the actual interaction mix (booth visits +
+  // QR scans as the base), so QR-only traffic still contributes a base.
+  const metrics = computeSponsorBoothMetrics([
+    { action: "QR Scan" },
+    { action: "QR Scan" },
+    { action: "Chat Initiated" },
+    { action: "Chat Initiated" },
+  ]);
+  assert.equal(metrics.qrScans, 2);
+  assert.equal(metrics.boothVisits, 0);
+  assert.equal(metrics.chatInitiations, 2);
+  // (0 applies + 2 chats) / (0 visits + 2 scans) = 100%
+  assert.equal(metrics.engagementRate, 100);
 }
 
 {


### PR DESCRIPTION
## Description

`src/utils/sponsorAnalyticsUtils.js` `computeSponsorBoothMetrics` tallied `boothVisits`, `jobClicks`, and `chatInitiations` by inspecting each lead's `action`, but then set `qrScans = list.length` — counting **every** lead record (booth visits, chats, job applications, and everything else) as a QR scan. The module's own doc comment says it "does not invent counts — only tallies recorded actions," yet `qrScans` was fabricated from the total list size, massively over-reporting scans. It also derived `engagementRate` from `boothVisits` alone, ignoring QR scans entirely, so the engagement base/rate did not reflect the actual interaction mix.

For example, with 3 booth visits + 2 job applications + 1 chat (and zero QR-scan actions), the function reported `qrScans: 6` — the full lead count.

## Fix

Two changes in `src/utils/sponsorAnalyticsUtils.js`:

1. **Count QR scans by action**: added a `qrScans` counter incremented when an action matches `/^QR/i` (matching the existing `/^Applied:/i` convention used for job clicks), instead of `list.length`. Now `qrScans` only reflects leads whose action is actually a QR scan.
2. **Include QR scans in the engagement base**: changed `engagementBase` from `boothVisits` to `boothVisits + qrScans`, so the engagement rate is `(jobClicks + chatInitiations) / (boothVisits + qrScans) * 100`. QR-only traffic now contributes a real base instead of being silently dropped, and the rate no longer misattributes every lead as a scan.

This matches the proposed fix in the issue.

## Verification

Updated `tests/sponsorAnalyticsUtils.test.mjs` to reflect the corrected behavior and added regression cases:

1. The original 6-lead case (3 visits + 2 applies + 1 chat, **no QR actions**) now asserts `qrScans: 0` (was `6`) and `engagementRate: 100` — `(2+1)/(3+0) = 100%`.
2. New: QR scans counted by action — 3 `QR Scan`/`QR Scan: Booth A` actions + 1 visit + 1 chat → `qrScans: 3`, `engagementRate: 25` — `(0+1)/(1+3) = 25%`.
3. The "must not invent multipliers" case (2 applies, no visits/scans) now asserts `qrScans: 0` (was `2`) and that `boothVisits` stays `0` rather than tracking the lead count.
4. New: QR-only traffic contributes a base — 2 scans + 2 chats → `engagementRate: 100` — `(0+2)/(0+2) = 100%`.
5. The empty-array and `null`-input cases remain unchanged (all zeros).

All assertions pass:
```
sponsorAnalyticsUtils tests passed
```

Note: the prior tests encoded the *buggy* behavior (`qrScans === list.length`), so they necessarily changed. The new assertions assert the correct, action-based counts.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

Closes #17543
