### PR TITLE
fix(analytics): make registration trend queries portable across dialects (#12612)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/RegistrationAnalyticsRepository.java
@@ -15,11 +15,14 @@ public interface RegistrationAnalyticsRepository
         extends JpaRepository<EventRegistration, Long> {
 
     // ── Trends — note: field is registeredAt, NOT createdAt ──────────────────
-    // All queries accept a nullable collection of event IDs: null = global,
-    // non-null = restrict to those events (e.g. a caller's accessible events).
+    // Only Hibernate HQL built-ins (YEAR/MONTH/HOUR and CAST to date) are used
+    // below so the same queries run on the default H2 database and on
+    // MySQL/Postgres (#12612). All queries accept a nullable collection of event
+    // IDs: null = global, non-null = restrict to those events (e.g. a caller's
+    // accessible events).
 
     @Query("""
-        SELECT FUNCTION('FORMATDATETIME', r.registeredAt, 'yyyy-MM') AS period,
+        SELECT YEAR(r.registeredAt) * 100 + MONTH(r.registeredAt) AS period,
                COUNT(r) AS regCount
         FROM EventRegistration r
         WHERE r.registeredAt >= :from
@@ -29,19 +32,6 @@ public interface RegistrationAnalyticsRepository
         ORDER BY period ASC
         """)
     List<Object[]> findMonthlyTrend(@Param("from") LocalDateTime from, @Param("eventIds") Collection<Long> eventIds);
-
-    @Query("""
-        SELECT CAST(FUNCTION('YEAR', r.registeredAt) AS int) * 100
-             + CAST(FUNCTION('WEEK', r.registeredAt) AS int) AS period,
-               COUNT(r) AS regCount
-        FROM EventRegistration r
-        WHERE r.registeredAt >= :from
-          AND r.status = 'CONFIRMED'
-          AND (:eventIds IS NULL OR r.event.id IN :eventIds)
-        GROUP BY period
-        ORDER BY period ASC
-        """)
-    List<Object[]> findWeeklyTrend(@Param("from") LocalDateTime from, @Param("eventIds") Collection<Long> eventIds);
 
     @Query("""
         SELECT CAST(r.registeredAt AS date) AS period,
@@ -55,15 +45,16 @@ public interface RegistrationAnalyticsRepository
         """)
     List<Object[]> findDailyTrend(@Param("from") LocalDateTime from, @Param("eventIds") Collection<Long> eventIds);
 
-    // ── Peak registration periods ─────────────────────────────────────────────
+    // ── Peak registration periods — day and hour extracted portably; the
+    //    service derives the weekday (no portable SQL WEEKDAY exists) ─────────
     @Query("""
-        SELECT FUNCTION('DAY_OF_WEEK', r.registeredAt) AS dow,
-               FUNCTION('HOUR', r.registeredAt)      AS hr,
-               COUNT(r)                              AS cnt
+        SELECT CAST(r.registeredAt AS date) AS day,
+               HOUR(r.registeredAt) AS hr,
+               COUNT(r) AS cnt
         FROM EventRegistration r
         WHERE r.status = 'CONFIRMED'
           AND (:eventIds IS NULL OR r.event.id IN :eventIds)
-        GROUP BY dow, hr
+        GROUP BY day, hr
         ORDER BY cnt DESC
         """)
     List<Object[]> findPeakPeriods(@Param("eventIds") Collection<Long> eventIds);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AnalyticsService.java
@@ -21,14 +21,17 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Duration;
+import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,6 +41,9 @@ public class AnalyticsService {
     private static final String[] BREAKDOWN_COLORS = {
             "#6366f1", "#ec4899", "#10b981", "#f59e0b", "#06b6d4"
     };
+
+    // Index 1 = Sunday .. 7 = Saturday, matching the ISO-derived weekday index.
+    private static final String[] DAYS = {"", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
     private final EventAnalyticsRepository eventRepo;
     private final RegistrationAnalyticsRepository regRepo;
@@ -115,22 +121,62 @@ public class AnalyticsService {
             default       -> LocalDateTime.now().minusMonths(safePeriods);
         };
 
-        List<Object[]> raw = switch (granularity.toLowerCase()) {
-            case "daily"  -> regRepo.findDailyTrend(from, eventIds);
-            case "weekly" -> regRepo.findWeeklyTrend(from, eventIds);
-            default       -> regRepo.findMonthlyTrend(from, eventIds);
+        List<TrendBucket> buckets = switch (granularity.toLowerCase()) {
+            case "daily"  -> dailyBuckets(regRepo.findDailyTrend(from, eventIds));
+            case "weekly" -> weeklyBuckets(regRepo.findDailyTrend(from, eventIds));
+            default       -> monthlyBuckets(regRepo.findMonthlyTrend(from, eventIds));
         };
 
         final long[] cumulative = {0};
-        return raw.stream().map(row -> {
-            long count = ((Number) row[1]).longValue();
-            cumulative[0] += count;
-            return RegistrationTrendDTO.builder()
-                .period(row[0].toString())
-                .registrationCount(count)
-                .cumulativeTotal(cumulative[0])
-                .build();
-        }).collect(Collectors.toList());
+        return buckets.stream()
+            .map(b -> RegistrationTrendDTO.builder()
+                .period(b.period())
+                .registrationCount(b.count())
+                .cumulativeTotal(cumulative[0] += b.count())
+                .build())
+            .collect(Collectors.toList());
+    }
+
+    private List<TrendBucket> dailyBuckets(List<Object[]> rows) {
+        return rows.stream()
+                .map(row -> new TrendBucket(row[0].toString(), ((Number) row[1]).longValue()))
+                .collect(Collectors.toList());
+    }
+
+    private List<TrendBucket> weeklyBuckets(List<Object[]> dailyRows) {
+        Map<Long, Long> weekly = new TreeMap<>();
+        for (Object[] row : dailyRows) {
+            LocalDate day = toLocalDate(row[0]);
+            long yearWeek = day.get(WeekFields.ISO.weekBasedYear()) * 100L
+                    + day.get(WeekFields.ISO.weekOfWeekBasedYear());
+            weekly.merge(yearWeek, ((Number) row[1]).longValue(), Long::sum);
+        }
+        return weekly.entrySet().stream()
+                .map(e -> new TrendBucket(String.valueOf(e.getKey()), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private List<TrendBucket> monthlyBuckets(List<Object[]> rows) {
+        return rows.stream()
+                .map(row -> {
+                    int yyyyMm = ((Number) row[0]).intValue();
+                    String period = (yyyyMm / 100) + "-" + String.format("%02d", yyyyMm % 100);
+                    return new TrendBucket(period, ((Number) row[1]).longValue());
+                })
+                .collect(Collectors.toList());
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof LocalDate localDate) {
+            return localDate;
+        }
+        if (value instanceof java.sql.Date sqlDate) {
+            return sqlDate.toLocalDate();
+        }
+        return LocalDate.parse(value.toString());
+    }
+
+    private record TrendBucket(String period, long count) {
     }
 
     // ── 3. Most popular events ────────────────────────────────────────────────
@@ -190,19 +236,27 @@ public class AnalyticsService {
 
     // ── 5. Peak registration periods ─────────────────────────────────────────
     public List<Map<String, Object>> getPeakPeriods() {
-        String[] days = {"", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-        return regRepo.findPeakPeriods(resolveEventScope()).stream()
-            .limit(10)
-            .map(row -> {
-                Map<String, Object> m = new LinkedHashMap<>();
-                int dow = ((Number) row[0]).intValue();
-                int hr  = ((Number) row[1]).intValue();
-                m.put("dayOfWeek",  days[dow]);
-                m.put("hour",       String.format("%02d:00", hr));
-                m.put("count",      ((Number) row[2]).longValue());
-                return m;
-            })
-            .collect(Collectors.toList());
+        Map<String, Long> aggregated = new LinkedHashMap<>();
+        for (Object[] row : regRepo.findPeakPeriods(resolveEventScope())) {
+            LocalDate day = toLocalDate(row[0]);
+            int hour = ((Number) row[1]).intValue();
+            int dowIndex = (day.getDayOfWeek().getValue() % 7) + 1;
+            String key = dowIndex + "|" + hour;
+            aggregated.merge(key, ((Number) row[2]).longValue(), Long::sum);
+        }
+
+        return aggregated.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(10)
+                .map(e -> {
+                    String[] parts = e.getKey().split("\\|");
+                    Map<String, Object> m = new LinkedHashMap<>();
+                    m.put("dayOfWeek", DAYS[Integer.parseInt(parts[0])]);
+                    m.put("hour", String.format("%02d:00", Integer.parseInt(parts[1])));
+                    m.put("count", e.getValue());
+                    return m;
+                })
+                .collect(Collectors.toList());
     }
 
     // ── 6. Organizer insights ────────────────────────────────────────────────

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AnalyticsTrendsTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AnalyticsTrendsTests.java
@@ -1,0 +1,230 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import com.sandeep.eventrabackend.service.AnalyticsService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Regression tests for the analytics trend and peak-period queries running on
+ * the default H2 database. The queries must only rely on Hibernate HQL
+ * built-ins (YEAR/MONTH/HOUR, CAST to date) that Hibernate translates for any
+ * dialect, so they no longer call H2-only SQL functions via FUNCTION(...)
+ * (#12612).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AnalyticsTrendsTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private AnalyticsService analyticsService;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private LocalDateTime monthA;
+    private LocalDateTime monthB;
+    private LocalDateTime recentDay;
+
+    @BeforeEach
+    void setUp() {
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User admin = User.builder()
+                .firstName("Ada")
+                .lastName("Admin")
+                .email("admin@example.com")
+                .username("adaadmin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.SUPER_ADMIN)
+                .build();
+        userRepository.save(admin);
+
+        User attendee = User.builder()
+                .firstName("Sam")
+                .lastName("Attendee")
+                .email("sam@example.com")
+                .username("samattendee")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(attendee);
+
+        Event event = new Event();
+        event.setTitle("Tech Conference 2026");
+        event.setDescription("A deep dive into AI and Cloud computing.");
+        event.setLocation("San Francisco, CA");
+        event.setEventDate(LocalDateTime.now().plusDays(10));
+        eventRepository.save(event);
+
+        // Registrations whose timestamps are planted directly in the DB because
+        // @CreationTimestamp would otherwise overwrite any value set on the entity.
+        // Each registration gets its own attendee: the (event, user) pair is
+        // unique per the DB constraint UK_EVENT_REGISTRATION_EVENT_USER_INDEX_3.
+        LocalDateTime now = LocalDateTime.now();
+        monthA = now.minusMonths(2).withDayOfMonth(1).withHour(10).withMinute(5).withSecond(0).withNano(0);
+        monthB = now.minusMonths(1).withDayOfMonth(1).withHour(9).withMinute(15).withSecond(0).withNano(0);
+        recentDay = now.minusDays(3).withHour(11).withMinute(30).withSecond(0).withNano(0);
+
+        saveRegistration(event, monthA);                    // pair A (hour 10)
+        saveRegistration(event, monthA.plusHours(2));       // pair A (hour 12)
+        saveRegistration(event, monthB);                    // pair B (hour 9)
+        saveRegistration(event, monthB.plusMinutes(30));    // pair B (hour 9)
+        saveRegistration(event, recentDay);                 // single (hour 11)
+    }
+
+    private int attendeeSeq = 0;
+
+    private void saveRegistration(Event event, LocalDateTime registeredAt) {
+        User attendee = User.builder()
+                .firstName("Sam")
+                .lastName("Attendee")
+                .email("sam" + attendeeSeq + "@example.com")
+                .username("samattendee" + attendeeSeq)
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        attendeeSeq++;
+        userRepository.save(attendee);
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(event);
+        registration.setUser(attendee);
+        registration.setStatus("CONFIRMED");
+        eventRegistrationRepository.save(registration);
+
+        plantRegisteredAt(registration, registeredAt);
+    }
+
+    private void plantRegisteredAt(EventRegistration registration, LocalDateTime registeredAt) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+                entityManager.createNativeQuery(
+                                "UPDATE event_registrations SET registered_at = :ts WHERE id = :id")
+                        .setParameter("ts", registeredAt)
+                        .setParameter("id", registration.getId())
+                        .executeUpdate());
+    }
+
+    @Test
+    @DisplayName("GET /api/analytics/registrations/trends?granularity=monthly - buckets by month on H2")
+    void testMonthlyTrend() throws Exception {
+        mockMvc.perform(get("/api/analytics/registrations/trends")
+                        .param("granularity", "monthly")
+                        .param("periods", "12")
+                        .with(user("admin@example.com").authorities(() -> "SUPER_ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].period").value(
+                        monthA.getYear() + "-" + String.format("%02d", monthA.getMonthValue())))
+                .andExpect(jsonPath("$[0].registrationCount").value(2))
+                .andExpect(jsonPath("$[1].period").value(
+                        monthB.getYear() + "-" + String.format("%02d", monthB.getMonthValue())))
+                .andExpect(jsonPath("$[1].registrationCount").value(2))
+                .andExpect(jsonPath("$[2].registrationCount").value(1))
+                .andExpect(jsonPath("$[2].cumulativeTotal").value(5));
+    }
+
+    @Test
+    @DisplayName("GET /api/analytics/registrations/trends?granularity=weekly - buckets by ISO week on H2")
+    void testWeeklyTrend() throws Exception {
+        mockMvc.perform(get("/api/analytics/registrations/trends")
+                        .param("granularity", "weekly")
+                        .param("periods", "12")
+                        .with(user("admin@example.com").authorities(() -> "SUPER_ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].registrationCount").value(2))
+                .andExpect(jsonPath("$[1].registrationCount").value(2))
+                .andExpect(jsonPath("$[2].registrationCount").value(1))
+                .andExpect(jsonPath("$[2].cumulativeTotal").value(5));
+    }
+
+    @Test
+    @DisplayName("GET /api/analytics/registrations/trends?granularity=daily - buckets by date on H2")
+    void testDailyTrend() throws Exception {
+        mockMvc.perform(get("/api/analytics/registrations/trends")
+                        .param("granularity", "daily")
+                        .param("periods", "365")
+                        .with(user("admin@example.com").authorities(() -> "SUPER_ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].registrationCount").value(2))
+                .andExpect(jsonPath("$[1].registrationCount").value(2))
+                .andExpect(jsonPath("$[2].registrationCount").value(1))
+                .andExpect(jsonPath("$[2].cumulativeTotal").value(5));
+    }
+
+    @Test
+    @DisplayName("Peak registration periods - derived from day+hour on H2, sorted descending")
+    @WithMockUser("admin@example.com")
+    void testPeakPeriods() {
+        List<Map<String, Object>> peaks = analyticsService.getPeakPeriods();
+
+        assertTrue(!peaks.isEmpty(), "expected at least one peak bucket");
+        assertTrue(peaks.size() <= 10, "at most ten peak buckets");
+        assertEquals(2L, ((Number) peaks.get(0).get("count")).longValue(),
+                "the two same-hour registrations must form the top bucket");
+
+        long previous = Long.MAX_VALUE;
+        for (Map<String, Object> peak : peaks) {
+            String day = (String) peak.get("dayOfWeek");
+            assertTrue(List.of("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat").contains(day),
+                    "dayOfWeek must be a valid weekday but was " + day);
+            assertTrue(((String) peak.get("hour")).matches("\\d{2}:00"),
+                    "hour must be formatted HH:00 but was " + peak.get("hour"));
+            long count = ((Number) peak.get("count")).longValue();
+            assertTrue(count <= previous, "buckets must be sorted by count descending");
+            previous = count;
+        }
+    }
+}


### PR DESCRIPTION
## What

Makes the analytics registration-trend queries portable across databases.

The monthly / weekly / peak-period queries in `RegistrationAnalyticsRepository` called H2-only SQL functions through `FUNCTION(...)`:
- `FORMATDATETIME(..., 'yyyy-MM')` for monthly buckets
- `WEEK(...)` for weekly buckets
- `DAY_OF_WEEK(...)` for peak periods

These compile and run only on H2 and fail on MySQL/Postgres (#12612).

**Changes**
- Queries now rely only on HQL built-ins Hibernate translates for any dialect: `YEAR(...)`, `MONTH(...)`, `HOUR(...)` and `CAST(... AS date)`.
- `findWeeklyTrend` removed; weekly bucketing is now derived in `AnalyticsService` from the portable daily rows using `WeekFields.ISO` (`weekBasedYear * 100 + weekOfWeekBasedYear`), matching the previous `YEAR*100 + WEEK` key format.
- Peak periods now select the registration day + hour and derive the weekday in the service (`LocalDate.getDayOfWeek`), aggregated/sorted/limited there. The `eventIds` scope filter added to these queries on master is preserved.
- Month labels are formatted `yyyy-MM` in the service from the numeric `yyyy*100 + MM` key, so the API response shape is unchanged.

## Regression test

`AnalyticsTrendsTests` (new): `@SpringBootTest` integration test that plants registrations with known `registered_at` timestamps and asserts:
- monthly / weekly / daily trend bucket counts and cumulative totals via the `GET /api/analytics/registrations/trends` endpoint,
- peak-period buckets are valid weekdays, formatted `HH:00`, sorted descending by count.

## Verification

- `mvn -Dtest=AnalyticsTrendsTests test` → 4/4 green.
- Full suite on this change rebased onto the compile-fix base (PR #17697): **347 tests, 0 errors, 29 failures** — identical to that base's 29 pre-existing failures, no regressions. This PR is based directly on `master`, which still does not compile until #17697 lands.
