### PR TITLE
fix(utils): guard zero-length or NaN event window in calculateTrackUtilization (#17730)

### DIFF
--- a/src/utils/multiTrackScheduleUtils.js
+++ b/src/utils/multiTrackScheduleUtils.js
@@ -302,6 +302,7 @@ export const getAvailableTimeSlots = (
 export const calculateTrackUtilization = (sessions, tracks, eventStart, eventEnd) => {
   const trackUtilization = {};
   const totalEventMinutes = (new Date(eventEnd) - new Date(eventStart)) / (1000 * 60);
+  const safeTotalEventMinutes = Number.isFinite(totalEventMinutes) && totalEventMinutes > 0 ? totalEventMinutes : 0;
   let totalUsedMinutes = 0;
 
   tracks.forEach(track => {
@@ -310,21 +311,27 @@ export const calculateTrackUtilization = (sessions, tracks, eventStart, eventEnd
 
     trackSessions.forEach(session => {
       const duration = (new Date(session.endTime) - new Date(session.startTime)) / (1000 * 60);
-      usedMinutes += duration;
+      if (Number.isFinite(duration) && duration > 0) {
+        usedMinutes += duration;
+      }
     });
+
+    const utilization = safeTotalEventMinutes > 0 ? (usedMinutes / safeTotalEventMinutes) * 100 : 0;
 
     trackUtilization[track.id] = {
       trackName: track.name,
       usedMinutes,
-      totalMinutes: totalEventMinutes,
-      utilization: ((usedMinutes / totalEventMinutes) * 100).toFixed(2) + '%',
+      totalMinutes: safeTotalEventMinutes,
+      utilization: utilization.toFixed(2) + '%',
       sessionCount: trackSessions.length,
     };
 
     totalUsedMinutes += usedMinutes;
   });
 
-  const ratio = totalUsedMinutes / (totalEventMinutes * tracks.length);
+  const denominator = safeTotalEventMinutes * tracks.length;
+  const ratio = denominator > 0 ? totalUsedMinutes / denominator : 0;
+
   return {
     trackUtilization,
     overallUtilization: (ratio * 100).toFixed(2) + '%',


### PR DESCRIPTION
## Description

`calculateTrackUtilization` in `src/utils/multiTrackScheduleUtils.js` divided by the event time window and by `tracks.length` without guarding against zero or non-finite denominators, producing `"NaN%"` / `"Infinity%"` utilization strings in the schedule UI (`MultiTrackScheduleBuilder.jsx`).

This PR guards the denominator so that a zero-length, NaN, or invalid event window (and an empty `tracks` array) falls back to `0.00%`, while leaving normal calculation behavior unchanged.

### Repro before fix

```js
calculateTrackUtilization([], [], start, end) // overallUtilization "NaN%"
calculateTrackUtilization(sessions, tracks, start, start) // "NaN%"
```

### After fix

```js
calculateTrackUtilization([], [], start, end) // overallUtilization "0.00%"
calculateTrackUtilization(sessions, tracks, start, start) // "0.00%"
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17730

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
