### PR TITLE
fix(utils): skip extension check when filename has no extension (#17731)

### DIFF
--- a/src/utils/fileValidator.js
+++ b/src/utils/fileValidator.js
@@ -21,6 +21,19 @@ const DANGEROUS_EXTENSIONS = [
 const DEFAULT_MAX_SIZE_MB = 5;
 
 /**
+ * Extract a normalized lowercase extension (with a leading dot) from a filename.
+ * Returns "" when the filename has no extension, so extension checks can be
+ * skipped instead of treating the whole filename as an extension.
+ * @param {string} filename
+ * @returns {string}
+ */
+const getFileExtension = (filename) => {
+  const cleanName = filename.trim().replace(/\.+$/, "");
+  if (!cleanName.includes(".")) return "";
+  return "." + cleanName.split(".").pop().toLowerCase();
+};
+
+/**
  * Magic byte signatures for file type verification.
  * Each entry maps a MIME type to its expected byte pattern.
  */
@@ -115,17 +128,16 @@ export async function validateImageFile(file, options = {}) {
   }
 
   // Check file extension
-  const cleanName = file.name.trim().replace(/\.+$/, "");
-  const ext = "." + cleanName.split(".").pop().toLowerCase();
+  const ext = getFileExtension(file.name);
 
-  if (DANGEROUS_EXTENSIONS.includes(ext)) {
+  if (ext && DANGEROUS_EXTENSIONS.includes(ext)) {
     return {
       valid: false,
       error: `File extension "${ext}" is not allowed for security reasons`,
     };
   }
 
-  if (!allowedExtensions.includes(ext)) {
+  if (ext && !allowedExtensions.includes(ext)) {
     return {
       valid: false,
       error: `File extension "${ext}" is not a recognized or allowed image format`,
@@ -164,17 +176,16 @@ export function validateFile(file, options = {}) {
     return { valid: false, error: "File is empty" };
   }
 
-  const cleanName = file.name.trim().replace(/\.+$/, "");
-  const ext = "." + cleanName.split(".").pop().toLowerCase();
+  const ext = getFileExtension(file.name);
 
-  if (DANGEROUS_EXTENSIONS.includes(ext)) {
+  if (ext && DANGEROUS_EXTENSIONS.includes(ext)) {
     return {
       valid: false,
       error: `File extension "${ext}" is blocked for security`,
     };
   }
 
-  if (options.allowedExtensions && !options.allowedExtensions.includes(ext)) {
+  if (ext && options.allowedExtensions && !options.allowedExtensions.includes(ext)) {
     return {
       valid: false,
       error: `Extension "${ext}" not allowed. Accepted: ${options.allowedExtensions.join(", ")}`,


### PR DESCRIPTION
## Description

`validateImageFile` and `validateFile` in `src/utils/fileValidator.js` derived the extension as `"." + cleanName.split(".").pop().toLowerCase()`. For filenames without a dot (e.g. `"photo"`), the whole name became the extension (`.photo`), so valid files were rejected with `File extension ".photo" is not a recognized or allowed image format`.

This PR adds a `getFileExtension` helper that returns `""` when a filename has no dot, and skips the extension checks in that case — MIME type, magic bytes, and size still govern validity.

### Before

```js
await validateImageFile({ name: "photo", size: 1024, type: "image/png" })
// { valid: false, error: 'File extension ".photo" is not a recognized or allowed image format' }
```

### After

```js
await validateImageFile({ name: "photo", size: 1024, type: "image/png" })
// { valid: true }
```

Dangerous extensions (`.exe`, `.html`, etc.) are still rejected, and `validateFile` still enforces `allowedExtensions` when the file actually has an extension.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17731

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
