### PR TITLE
fix(kit): return empty string for invalid dates in dateFormatIso (#17734)

### DIFF
--- a/src/eventra-kit/date-format-iso.js
+++ b/src/eventra-kit/date-format-iso.js
@@ -4,6 +4,7 @@
  */
 export function dateFormatIso(date, withTime = false) {
   const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return '';
   const iso = d.toISOString();
   return withTime ? iso : iso.slice(0, 10);
 }


### PR DESCRIPTION
## Description

`dateFormatIso` in `src/eventra-kit/date-format-iso.js` called `d.toISOString()` unconditionally. For invalid inputs (`"garbage"`, `undefined`, `"2026-02-31"`, etc.), `new Date(...)` produces an invalid `Date` and `toISOString()` throws `RangeError: Invalid time value`, which can crash rendering when a malformed date reaches the formatter.

This PR returns `""` for invalid dates instead of throwing.

### Before

```js
dateFormatIso("garbage") // throws RangeError: Invalid time value
```

### After

```js
dateFormatIso("garbage") // ""
dateFormatIso("2026-08-14T10:30:00Z") // "2026-08-14" (unchanged)
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17734

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
