### PR TITLE
fix(kit): return undefined for empty arrays or invalid percentile (#17735)

### DIFF
--- a/src/eventra-kit/percentile.js
+++ b/src/eventra-kit/percentile.js
@@ -4,6 +4,8 @@
  */
 export function percentile(values, p) {
   const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 0) return undefined;
+  if (!Number.isFinite(Number(p))) return undefined;
   const index = (p / 100) * (sorted.length - 1);
   const lower = Math.floor(index);
   const upper = Math.ceil(index);


### PR DESCRIPTION
## Description

`percentile` in `src/eventra-kit/percentile.js` returned `NaN` for an empty array (index arithmetic on `-1`), and for a non-finite `p` the interpolation produced `NaN`. `NaN` silently corrupts downstream JSON payloads (serialized as `null`) and math.

This PR returns `undefined` for an empty array or a non-finite percentile, leaving normal behavior unchanged.

### Before

```js
percentile([], 50)   // NaN
percentile([1, 2, 3], NaN) // NaN
```

### After

```js
percentile([], 50)   // undefined
percentile([1, 2, 3], NaN) // undefined
percentile([1, 2, 3, 4, 5], 50) // 3 (unchanged)
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17735

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
