### PR TITLE
fix(kit): import rangeNumbers helper in stepRange (#17742)

### DIFF
--- a/src/eventra-kit/step-range.js
+++ b/src/eventra-kit/step-range.js
@@ -2,6 +2,8 @@
 /**
  * adds a step range helper.
  */
+import { rangeNumbers } from './range-numbers.js';
+
 export function stepRange(start, end, step = 1) {
   return rangeNumbers(start, end, step);
 }


### PR DESCRIPTION
## Description

`stepRange` in `src/eventra-kit/step-range.js` called `rangeNumbers()` but never imported it, throwing `ReferenceError: rangeNumbers is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/range-numbers.js`.

### Before

```js
stepRange(0, 5, 1)
// ReferenceError: rangeNumbers is not defined
```

### After

```js
stepRange(0, 5, 1) // [0, 1, 2, 3, 4]
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17742

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.