### PR TITLE
fix(kit): import formatLargeNumber helper in abbreviateNumber (#17743)

### DIFF
--- a/src/eventra-kit/abbreviate-number.js
+++ b/src/eventra-kit/abbreviate-number.js
@@ -2,6 +2,8 @@
 /**
  * adds a number abbreviation helper.
  */
+import { formatLargeNumber } from './format-large-number.js';
+
 export function abbreviateNumber(value) {
   return formatLargeNumber(value);
 }


### PR DESCRIPTION
## Description

`abbreviateNumber` in `src/eventra-kit/abbreviate-number.js` called `formatLargeNumber()` but never imported it, throwing `ReferenceError: formatLargeNumber is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/format-large-number.js`.

### Before

```js
abbreviateNumber(1500)
// ReferenceError: formatLargeNumber is not defined
```

### After

```js
abbreviateNumber(1500) // '1.5K'
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17743

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.