### PR TITLE
fix(kit): import gcdOf helper in lcmOf (#17744)

### DIFF
--- a/src/eventra-kit/lcm-of.js
+++ b/src/eventra-kit/lcm-of.js
@@ -2,6 +2,8 @@
 /**
  * adds an lcm helper.
  */
+import { gcdOf } from './gcd-of.js';
+
 export function lcmOf(a, b) {
   return a === 0 || b === 0 ? 0 : Math.abs(a * b) / gcdOf(a, b);
 }


### PR DESCRIPTION
## Description

`lcmOf` in `src/eventra-kit/lcm-of.js` called `gcdOf()` but never imported it, throwing `ReferenceError: gcdOf is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/gcd-of.js`.

### Before

```js
lcmOf(4, 6)
// ReferenceError: gcdOf is not defined
```

### After

```js
lcmOf(4, 6) // 12
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17744

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.