### PR TITLE
fix(kit): import percentile helper in interquartileRange (#17745)

### DIFF
--- a/src/eventra-kit/interquartile-range.js
+++ b/src/eventra-kit/interquartile-range.js
@@ -2,6 +2,8 @@
 /**
  * adds an IQR helper.
  */
+import { percentile } from './percentile.js';
+
 export function interquartileRange(array) {
   const sorted = [...array].sort((a, b) => a - b);
   const q1 = percentile(sorted, 25);


### PR DESCRIPTION
## Description

`interquartileRange` in `src/eventra-kit/interquartile-range.js` called `percentile()` but never imported it, throwing `ReferenceError: percentile is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/percentile.js`.

### Before

```js
interquartileRange([1, 2, 3, 4, 5, 6, 7, 8])
// ReferenceError: percentile is not defined
```

### After

```js
interquartileRange([1, 2, 3, 4, 5, 6, 7, 8]) // 3.5
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17745

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.