### PR TITLE
fix(kit): import frequencyMap helper in getMode (#17746)

### DIFF
--- a/src/eventra-kit/get-mode.js
+++ b/src/eventra-kit/get-mode.js
@@ -2,6 +2,8 @@
 /**
  * adds a mode helper.
  */
+import { frequencyMap } from './frequency-map.js';
+
 export function getMode(array) {
   const freq = frequencyMap(array);
   let best;


### PR DESCRIPTION
## Description

`getMode` in `src/eventra-kit/get-mode.js` called `frequencyMap()` but never imported it, throwing `ReferenceError: frequencyMap is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/frequency-map.js`.

### Before

```js
getMode([1, 2, 2, 3])
// ReferenceError: frequencyMap is not defined
```

### After

```js
getMode([1, 2, 2, 3]) // 2
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17746

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.