### PR TITLE
fix(kit): import isWeekend helper in isWeekday (#17747)

### DIFF
--- a/src/eventra-kit/is-weekday.js
+++ b/src/eventra-kit/is-weekday.js
@@ -2,6 +2,8 @@
 /**
  * adds a weekday check.
  */
+import { isWeekend } from './is-weekend.js';
+
 export function isWeekday(date) {
   return !isWeekend(date);
 }


### PR DESCRIPTION
## Description

`isWeekday` in `src/eventra-kit/is-weekday.js` called `isWeekend()` but never imported it, throwing `ReferenceError: isWeekend is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/is-weekend.js`.

### Before

```js
isWeekday(new Date('2026-08-14'))
// ReferenceError: isWeekend is not defined
```

### After

```js
isWeekday(new Date('2026-08-14')) // true (Friday)
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17747

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.