### PR TITLE
fix(kit): import fileExtension helper in extensionLower (#17748)

### DIFF
--- a/src/eventra-kit/extension-lower.js
+++ b/src/eventra-kit/extension-lower.js
@@ -2,6 +2,8 @@
 /**
  * adds an ext lower helper.
  */
+import { fileExtension } from './file-extension.js';
+
 export function extensionLower(filename) {
   return fileExtension(filename).toLowerCase();
 }


### PR DESCRIPTION
## Description

`extensionLower` in `src/eventra-kit/extension-lower.js` called `fileExtension()` but never imported it, throwing `ReferenceError: fileExtension is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/file-extension.js`.

### Before

```js
extensionLower('report.PDF')
// ReferenceError: fileExtension is not defined
```

### After

```js
extensionLower('report.PDF') // 'pdf'
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17748

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.