### PR TITLE
fix(kit): import fileExtension helper in extensionUpper (#17749)

### DIFF
--- a/src/eventra-kit/extension-upper.js
+++ b/src/eventra-kit/extension-upper.js
@@ -2,6 +2,8 @@
 /**
  * adds an ext upper helper.
  */
+import { fileExtension } from './file-extension.js';
+
 export function extensionUpper(filename) {
   return fileExtension(filename).toUpperCase();
 }


### PR DESCRIPTION
## Description

`extensionUpper` in `src/eventra-kit/extension-upper.js` called `fileExtension()` but never imported it, throwing `ReferenceError: fileExtension is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/file-extension.js`.

### Before

```js
extensionUpper('report.pdf')
// ReferenceError: fileExtension is not defined
```

### After

```js
extensionUpper('report.pdf') // 'PDF'
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17749

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.