### PR TITLE
fix(kit): import addDaysToDate helper in futureDate (#17750)

### DIFF
--- a/src/eventra-kit/future-date.js
+++ b/src/eventra-kit/future-date.js
@@ -2,6 +2,8 @@
 /**
  * adds a future date helper.
  */
+import { addDaysToDate } from './add-days-to-date.js';
+
 export function futureDate(daysAhead) {
   return addDaysToDate(new Date(), daysAhead);
 }


### PR DESCRIPTION
## Description

`futureDate` in `src/eventra-kit/future-date.js` called `addDaysToDate()` but never imported it, throwing `ReferenceError: addDaysToDate is not defined` on every call.

This PR adds the missing import. The helper already exists and is exported from `src/eventra-kit/add-days-to-date.js`.

### Before

```js
futureDate(7)
// ReferenceError: addDaysToDate is not defined
```

### After

```js
futureDate(7) // date 7 days from now
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17750

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.