### PR TITLE
fix(kit): return 0 for empty array in rangeOf (#17751)

### DIFF
--- a/src/eventra-kit/range-of.js
+++ b/src/eventra-kit/range-of.js
@@ -3,6 +3,7 @@
  * adds a range helper.
  */
 export function rangeOf(values) {
+  if (!values || !values.length) return 0;
   return Math.max(...values) - Math.min(...values);
 }
 


### PR DESCRIPTION
## Description

`rangeOf` in `src/eventra-kit/range-of.js` computed `Math.max(...values) - Math.min(...values)` without guarding empty input, returning `-Infinity` for an empty array (`Math.max(...[]) = -Infinity`, `Math.min(...[]) = Infinity`). Its sibling `get-range.js` already returns `0` for empty input.

This PR guards empty input so `rangeOf([])` returns `0`, consistent with `get-range.js`.

### Before

```js
rangeOf([])      // -Infinity
```

### After

```js
rangeOf([])      // 0
rangeOf([1, 5])  // 4 (unchanged)
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17751

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.