### PR TITLE
fix(components): initialize formData before useFormDirty reads it in EventCreation (#17762)

### DIFF
--- a/src/components/common/EventCreation/EventCreation.jsx
+++ b/src/components/common/EventCreation/EventCreation.jsx
@@ -40,14 +40,13 @@ import { safeJsonParse } from "../../../utils/safeJsonParse";
 
 
 const EventCreation = () => {
-  // Fix: useFormDirty replaces manual hasUnsavedChanges + beforeunload
-  const { isDirty: hasUnsavedChanges } = useFormDirty(formData);
-
   const prefersReducedMotion = useReducedMotion();
   const location = useLocation();
 
   const [currentStep, setCurrentStep] = useState(CREATION_STEPS.FORM);
   const [formData, setFormData] = useState(initialFormData());
+  // Fix: useFormDirty replaces manual hasUnsavedChanges + beforeunload
+  const { isDirty: hasUnsavedChanges } = useFormDirty(formData);
   const [errors, setErrors] = useState({});
   const [newTag, setNewTag] = useState("");
   const [isDraftLoaded, setIsDraftLoaded] = useState(false);


### PR DESCRIPTION
## Description

`EventCreation` read `formData` in `useFormDirty(formData)` before its `useState` declaration on the following line, so every mount threw a temporal-dead-zone `ReferenceError` and the Event Creation page crashed.

This PR moves the `useFormDirty(formData)` call to after `formData` is initialized, so the hook receives the initialized state on first render.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17762

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
