### PR TITLE
fix(components): import useScrollLock in EventConflictModal (#17763)

### DIFF
--- a/src/components/EventConflictModal.jsx
+++ b/src/components/EventConflictModal.jsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Clock, Calendar, X, ArrowRight, Globe } from 'lucide-rea
 import { formatTimeRange } from '../utils/conflictDetection';
 import { getUserTimezone } from '../utils/timezoneUtils';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import useScrollLock from 'hooks/useScrollLock';
 
 /**
  * EventConflictModal


### PR DESCRIPTION
## Description

`EventConflictModal` called `useScrollLock(isOpen)` at line 41 but never imported the hook, throwing `ReferenceError: useScrollLock is not defined` on every render and preventing the modal from opening.

This PR adds the missing import, matching the convention used by `ReAuthModal.jsx` and `EventCalendarView.jsx` (`import useScrollLock from 'hooks/useScrollLock'`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17763

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
