### PR TITLE
fix(components): import translationService in SubtitleDisplay (#17764)

### DIFF
--- a/src/components/subtitles/SubtitleDisplay.jsx
+++ b/src/components/subtitles/SubtitleDisplay.jsx
@@ -27,6 +27,7 @@ import {
   SUBTITLE_CONFIG,
 } from "../../context/RealTimeSubtitleContext.jsx";
 import { SUBTITLE_STATE } from "../../context/RealTimeSubtitleContext.jsx";
+import { translationService } from "../../services/translationService.js";
 
 /**
  * Subtitle display animation presets


### PR DESCRIPTION
## Description

`SubtitleDisplay` destructured `getSupportedLanguages` / `getLanguageName` from `translationService` (lines 209 and 473) without importing it, throwing `ReferenceError: translationService is not defined` on every render.

This PR adds the missing import, mirroring `src/components/subtitles/index.js`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17764

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
