### PR TITLE
fix(components): guard process.env access in SocialLogin (#17765)

### DIFF
--- a/src/components/auth/SocialLogin.js
+++ b/src/components/auth/SocialLogin.js
@@ -4,7 +4,10 @@ import { useAuth } from '../../context/AuthContext';
 import './Auth.css';
 
 const GOOGLE_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
-const GOOGLE_CLIENT_ID = process.env.VITE_GOOGLE_CLIENT_ID || process.env.REACT_APP_GOOGLE_CLIENT_ID || '';
+const GOOGLE_CLIENT_ID =
+  import.meta.env.VITE_GOOGLE_CLIENT_ID ||
+  (typeof process !== 'undefined' && process.env.REACT_APP_GOOGLE_CLIENT_ID) ||
+  '';
 
 const loadGoogleScript = () => {
   if (typeof window === 'undefined') return Promise.reject(new Error('Browser required'));


### PR DESCRIPTION
## Description

`SocialLogin` read `process.env.VITE_GOOGLE_CLIENT_ID` / `process.env.REACT_APP_GOOGLE_CLIENT_ID` at module scope. There is no `process` global in the browser and Vite does not statically replace arbitrary `process.env.X` references, so importing the module threw `ReferenceError: process is not defined` and crashed the Login page.

This PR reads the client ID from `import.meta.env` with a guarded `typeof process !== 'undefined'` fallback, matching the pattern used across the rest of the codebase (`config/env.js`, `interceptors.js`, `logger.js`, etc.).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17765

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
