### PR TITLE
fix(components): import useScrollLock and call it at top level in CommunityEvent (#17766)

### DIFF
--- a/src/components/CommunityEvent.js
+++ b/src/components/CommunityEvent.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "framer-motion";
 import { useReducedMotion } from '../hooks/useReducedMotion';
+import useScrollLock from '../hooks/useScrollLock';
 import {
   CalendarDays,
   Users,
@@ -94,11 +95,9 @@ const events = [
 const CommunityEvent = () => {
   const prefersReducedMotion = useReducedMotion();
   const [selectedEvent, setSelectedEvent] = useState(null);
-  
+
   // 🔥 FIX: Safe scroll locking that caches and restores the original CSS value
-  useEffect(() => {
-    useScrollLock(!!selectedEvent);
-  }, [selectedEvent]);
+  useScrollLock(!!selectedEvent);
 
   // 🔥 FIX: Added Escape key listener to satisfy A11y dialog closing requirements
   useEffect(() => {


### PR DESCRIPTION
## Description

`CommunityEvent` called `useScrollLock(!!selectedEvent)` inside a `useEffect` without importing the hook, throwing `ReferenceError: useScrollLock is not defined` when the effect ran (and violating Rules of Hooks by calling a hook inside an effect).

This PR imports the hook and moves the call to the component top level, matching every other consumer of `useScrollLock`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17766

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
