### PR TITLE
fix(backend): remove orphaned nested class so signup annotations attach to the signup method (#17767)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -70,23 +70,6 @@ public class AuthController {
             @ApiResponse(responseCode = "429", description = "Signup rate limit exceeded",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public static class PasswordResetRequest {
-        private String email;
-        public String getEmail() { return email; }
-        public void setEmail(String email) { this.email = email; }
-    }
-
-    @PostMapping("/reset-password")
-    @SecurityRequirements
-    @Operation(summary = "Request password reset link")
-    public ResponseEntity<?> resetPassword(@RequestBody PasswordResetRequest request) {
-        String email = request.getEmail();
-        if (email == null || !org.springframework.util.StringUtils.hasText(email)) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Email is required"));
-        }
-        return ResponseEntity.ok(Map.of("message", "Password reset link sent! Check your email."));
-    }
-
     public ResponseEntity<AuthResponse> signup(@Valid @RequestBody SignupRequest request) {
         AuthResponse response = authService.signup(request);
         return withAuthCookie(ResponseEntity.status(HttpStatus.CREATED), response);


### PR DESCRIPTION
## Description

The `signup` annotation block in `AuthController` (`@PostMapping("/signup")`, `@Operation`, `@ApiResponses`, `@SecurityRequirements`) was followed by a nested `PasswordResetRequest` class instead of the `signup` method, so the METHOD-targeted annotations were bound to the class — a compile error — and `signup` (line 90) had no mapping. A dead stub `@PostMapping("/reset-password")` (lines 79-88) also duplicated the real handler at line 152, producing an ambiguous mapping at startup.

This PR removes the orphaned nested class and the dead stub, so the annotation block attaches to `signup` and only the real `resetPassword` handler remains.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17767

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
