### PR TITLE
fix(backend): reject non-positive quantity in PurchaseService (#17768)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PurchaseService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PurchaseService.java
@@ -27,6 +27,9 @@ public class PurchaseService {
      */
     @Transactional
     public boolean purchaseTicket(String tier, int quantity) {
+        if (quantity <= 0) {
+            return false;
+        }
         eventLock.lock();
         try {
             int tierCapacity = ticketTiers.getOrDefault(tier, 0);


### PR DESCRIPTION
## Description

`PurchaseService.purchaseTicket` accepted negative quantities: both capacity guards passed for `quantity <= 0`, then `ticketTiers.put(tier, tierCapacity - quantity)` increased inventory and `totalSold += quantity` drove `totalSold` negative. The publicly reachable `POST /api/purchases/checkout?tier=VIP&qty=-5` returned success while inflating capacity.

This PR rejects non-positive quantities.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17768

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
