### PR TITLE
fix(backend): guard null eventDate and single-installment plans in StripeService (#17770)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -184,8 +184,11 @@ public class StripeService {
         
         for (int i = 2; i <= paymentPlan.getTotalInstallments(); i++) {
             // Calculate due date: spread payments evenly between now and event date
-            long daysBetween = ChronoUnit.DAYS.between(now.toLocalDate(), eventDate.toLocalDate());
-            long daysUntilInstallment = (daysBetween / (paymentPlan.getTotalInstallments() - 1)) * (i - 1);
+            long daysBetween = eventDate != null
+                    ? ChronoUnit.DAYS.between(now.toLocalDate(), eventDate.toLocalDate())
+                    : 0;
+            long interval = Math.max(1, paymentPlan.getTotalInstallments() - 1);
+            long daysUntilInstallment = (daysBetween / interval) * (i - 1);
             LocalDateTime dueDate = now.plusDays(daysUntilInstallment);
             
             PaymentIntent intent = createPaymentIntentWithoutConfirmation(


### PR DESCRIPTION
## Description

`StripeService.scheduleInstallmentPayments` called `eventDate.toLocalDate()` on a nullable `eventDate` (NPE) and divided by `totalInstallments - 1` which is zero for single-installment plans (`ArithmeticException`).

This PR null-guards `eventDate` and clamps the interval divisor to at least 1.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17770

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
