### PR TITLE
fix(backend): enforce object-level event authorization on ticket stats and check-in history (#17771)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
@@ -207,9 +207,14 @@ public class TicketController {
                               "time": "2026-08-12T10:00:00"}]"""))),
             @ApiResponse(responseCode = "403", description = "Forbidden - organizer/admin access required")
     })
-    public ResponseEntity<List<Map<String, Object>>> checkInHistory(@RequestParam(required = false) Long eventId) {
+    public ResponseEntity<List<Map<String, Object>>> checkInHistory(Authentication authentication,
+            @RequestParam(required = false) Long eventId) {
         if (eventId == null) {
             return ResponseEntity.ok(List.of());
+        }
+        // Object-level authorization: the caller must organize the event being inspected.
+        if (!isAuthorizedForEvent(eventId, authentication)) {
+            return ResponseEntity.status(403).build();
         }
         List<Map<String, Object>> entries = ticketCheckInRepository
                 .findByEventIdOrderByCheckedInAtDesc(eventId)
@@ -242,9 +247,14 @@ public class TicketController {
                              "remainingAttendees": 55, "attendancePercentage": 45}"""))),
             @ApiResponse(responseCode = "403", description = "Forbidden - organizer/admin access required")
     })
-    public ResponseEntity<Map<String, Object>> ticketStats(@RequestParam(required = false) Long eventId) {
+    public ResponseEntity<Map<String, Object>> ticketStats(Authentication authentication,
+            @RequestParam(required = false) Long eventId) {
         if (eventId == null) {
             return ResponseEntity.ok(emptyStats());
+        }
+        // Object-level authorization: the caller must organize the event being inspected.
+        if (!isAuthorizedForEvent(eventId, authentication)) {
+            return forbidden();
         }
         long total = eventRegistrationRepository.countByEvent_IdAndStatus(eventId, "CONFIRMED");
         long checkedIn = ticketCheckInRepository.countByEventId(eventId);


### PR DESCRIPTION
## Description

`TicketController.checkInHistory` and `ticketStats` did not call `isAuthorizedForEvent`, unlike `validateTicket` and `checkIn` — so any organizer could read check-in history and ticket statistics for any other event (IDOR-style authorization gap).

This PR applies the same event-ownership guard to both endpoints.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17771

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
