### PR TITLE
fix(components): import EmptyState in HackathonsTab (#17784)

### DIFF
--- a/src/components/user/HackathonsTab.jsx
+++ b/src/components/user/HackathonsTab.jsx
@@ -4,6 +4,7 @@ import { Trophy, Calendar, MapPin, Plus } from "lucide-react";
 import StatusBadge from "../common/StatusBadge";
 import { DashboardItemCardSkeleton } from "../common/SkeletonLoaders";
 import SearchEmptyState from "../common/SearchEmptyState";
+import EmptyState from "../common/EmptyState";
 import { getSmartDateLabel } from "utils/relativeTime";
 
 const HackathonsTab = ({ hackathons, loading, fadeUp }) => (


### PR DESCRIPTION
## Description

`HackathonsTab.jsx` renders `<EmptyState>` when the user has no hackathons but never imports it, throwing `ReferenceError: EmptyState is not defined`. The sibling `RegistrationsTab.jsx` already imports `EmptyState from "../common/EmptyState"`.

This PR adds the missing import so the "No Hackathons Yet" empty state renders instead of crashing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17784

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
