### PR TITLE
fix(components): import useCSVExport in RegistrationsTab (#17785)

### DIFF
--- a/src/components/user/RegistrationsTab.jsx
+++ b/src/components/user/RegistrationsTab.jsx
@@ -9,6 +9,7 @@ import { DashboardTableSkeleton } from "../common/SkeletonLoaders";
 import { getSmartDateLabel } from "utils/relativeTime";
 import { downloadBulkICSFile } from "utils/calendarExporter";
 import CertificateDownload from "../CertificateDownload";
+import { useCSVExport } from "hooks/useCSVExport";
 const TYPE_OPTIONS = ["Event", "Hackathon", "Project"];
 const STATUS_OPTIONS = ["Upcoming", "Completed", "In Progress", "Done"];
 const TICKET_TYPE_OPTIONS = ["All", "VIP", "Early Bird", "General"];


### PR DESCRIPTION
## Description

`RegistrationsTab.jsx` calls `useCSVExport()` (line 127) but never imports it, throwing `ReferenceError: useCSVExport is not defined` on render. The hook exists as a named export in `src/hooks/useCSVExport.js`.

This PR adds the missing import so the Registrations tab renders and CSV export works.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17785

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
