### PR TITLE
fix(pages): replace process.env with import.meta.env in ApiDocs (#17786)

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -554,7 +554,7 @@ const ApiDocs = () => {
 
               <div className="flex-1 flex items-center gap-2 px-3 py-1 bg-slate-950 border border-slate-850 rounded-lg text-[10px] font-mono text-slate-400 select-all overflow-x-auto whitespace-nowrap scrollbar-none">
                 <span className="text-emerald-500 font-bold uppercase shrink-0">GET</span>
-                <span>{process.env.REACT_APP_API_URL || window.location.origin}{selectedEndpoint}</span>
+                <span>{import.meta.env.REACT_APP_API_URL || window.location.origin}{selectedEndpoint}</span>
                 {selectedEndpoint === "/mock-api/hackathons" && (
                   <span className="text-indigo-400 shrink-0">?limit={params.limit}&status={params.status}</span>
                 )}


### PR DESCRIPTION
## Description

`ApiDocs.js` reads `process.env.REACT_APP_API_URL` during render (line 557), but browsers have no `process` global and `vite.config.js` does not define it, so the `/api-docs` page throws `ReferenceError: process is not defined`.

This PR switches to the Vite-safe `import.meta.env` (the same pattern already applied in `SocialLogin.js`), falling back to `window.location.origin` when unset.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17786

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
