### PR TITLE
fix(utils): replace process.env with import.meta.env in shareUtils (#17787)

### DIFF
--- a/src/utils/shareUtils.js
+++ b/src/utils/shareUtils.js
@@ -168,7 +168,7 @@ export const generateSharingUrl = (shareData = {}, platform = "") => {
       return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
 
     case "messenger": {
-      const fbAppId = process.env.REACT_APP_FACEBOOK_APP_ID;
+      const fbAppId = import.meta.env.REACT_APP_FACEBOOK_APP_ID;
       if (fbAppId) {
         return `https://www.facebook.com/dialog/send?app_id=${fbAppId}&link=${encodedUrl}&redirect_uri=${encodedUrl}`;
       }
@@ -284,7 +284,7 @@ export const openShareWindow = (url, platform = "facebook") => {
  * @returns {Object} Sharing data object
  */
 export const generateEventSharingData = (event = {}, baseUrl = null) => {
-  const deployedDomain = process.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech";
+  const deployedDomain = import.meta.env.REACT_APP_PUBLIC_URL || "eventra.sandeepvashishtha.tech";
 
   if (!baseUrl) {
     if (typeof window !== "undefined") {
@@ -295,7 +295,7 @@ export const generateEventSharingData = (event = {}, baseUrl = null) => {
         baseUrl = window.location.origin;
       }
     } else {
-      baseUrl = process.env.REACT_APP_PUBLIC_URL || `https://${deployedDomain}`;
+      baseUrl = import.meta.env.REACT_APP_PUBLIC_URL || `https://${deployedDomain}`;
     }
   }
 


### PR DESCRIPTION
## Description

`shareUtils.js` reads `process.env` at lines 171, 287 and 298. Browsers have no `process` global, so Messenger shares and any call to `generateEventSharingData` throw `ReferenceError: process is not defined`.

This PR switches those reads to the Vite-safe `import.meta.env`, keeping the existing fallbacks (WhatsApp fallback for Messenger, `eventra.sandeepvashishtha.tech` for the public URL).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17787

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
