### PR TITLE
fix(backend): move misplaced @Transactional from field onto createEvent (#17788)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -467,13 +467,6 @@ public class EventService {
                 return categoryCounts;
         }
 
-        /**
-         * Creates a new event.
-         *
-         * @param request event creation details
-         * @return the saved event
-         */
-        @Transactional
         private static final Set<String> ALLOWED_CATEGORIES = Set.of(
                 "Tech", "Art", "Music", "Sports", "Education", "Networking", "Other"
         );
@@ -494,6 +487,13 @@ public class EventService {
                 }
         }
 
+        /**
+         * Creates a new event.
+         *
+         * @param request event creation details
+         * @return the saved event
+         */
+        @Transactional
         public EventResponse createEvent(EventCreateRequest request, String userEmail) {
                 Event event = new Event();
                 validateEventCategory(request.getCategory());


### PR DESCRIPTION
## Description

`EventService.java` annotates the `ALLOWED_CATEGORIES` field with `@Transactional` (line 476). `@Transactional` is only legal on types and methods, so this is a compile error (`annotation type not applicable to this kind of declaration`). The javadoc above it ("Creates a new event") shows the annotation was meant for `createEvent`.

This PR moves the javadoc + `@Transactional` onto `createEvent`, restoring the intended transaction boundary and making the project compile.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17788

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
