### PR TITLE
fix(backend): remove duplicate methods declared outside the controller class (#17789)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
@@ -54,29 +54,3 @@ public class TeamWorkspaceSyncController {
         return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
     }
 }
-
-    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(
-            @RequestParam(required = false) String roomKey,
-            @RequestParam(required = false) String hackathonId,
-            @RequestParam(required = false) String teamId) {
-        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
-        teamWorkspaceSyncService.requireReadAccess(resolved);
-        return teamWorkspaceSyncService.subscribe(resolved);
-    }
-
-    @PostMapping
-    public ResponseEntity<Map<String, Object>> pollOrUpdate(
-            @RequestParam(required = false) String roomKey,
-            @RequestParam(required = false) String hackathonId,
-            @RequestParam(required = false) String teamId,
-            @RequestBody(required = false) Map<String, Object> body) {
-        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
-        if (body == null || body.isEmpty()) {
-            teamWorkspaceSyncService.requireReadAccess(resolved);
-            return ResponseEntity.ok(teamWorkspaceSyncService.snapshot(resolved));
-        }
-        teamWorkspaceSyncService.requireWriteAccess(resolved);
-        return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
-    }
-}


### PR DESCRIPTION
## Description

`TeamWorkspaceSyncController.java` closes its class at line 56, then repeats `stream` and `pollOrUpdate` plus a stray `}` at lines 57-82. Methods declared outside the class body are a compile error (`class, interface, or enum expected`).

The first copies (lines 31-55) are the complete, authorization-aware versions that resolve room keys with the caller's identity. This PR deletes the leftover duplicate block.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17789

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
