### PR TITLE
fix(backend): declare missing room prefix constants in TeamWorkspaceSyncService (#17790)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
@@ -24,6 +24,9 @@ public class TeamWorkspaceSyncService {
     private static final Pattern HACKATHON_ROOM_KEY =
             Pattern.compile("^hackathon:(\\d+)(?::team:.*)?$");
 
+    private static final String HACKATHON_ROOM_PREFIX = "hackathon:";
+    private static final String USER_ROOM_PREFIX = "user:";
+
     private static final class WorkspaceState {
         private final Object lock = new Object();
         private List<Map<String, Object>> tasks = new ArrayList<>();


### PR DESCRIPTION
## Description

`TeamWorkspaceSyncService.java` references `HACKATHON_ROOM_PREFIX` and `USER_ROOM_PREFIX` (lines 172, 176, 193, 197, 223, 236) but never declares them, so the backend cannot compile (`cannot find symbol`).

This PR declares both constants next to `HACKATHON_ROOM_KEY`, matching the `hackathon:` / `user:` prefixes the room-key regex already assumes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17790

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
