### PR TITLE
fix(backend): null-guard ownerId check in upvoteProject (#17791)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -73,7 +73,7 @@ public class ProjectService {
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
 
-        if (project.getOwnerId().equals(user.getId())) {
+        if (project.getOwnerId() != null && project.getOwnerId().equals(user.getId())) {
             throw new RegistrationConflictException("You cannot upvote your own project.");
         }
 


### PR DESCRIPTION
## Description

`ProjectService.upvoteProject` calls `project.getOwnerId().equals(user.getId())` (line 76) without a null check, so a project with a null `ownerId` (legacy/corrupt row) throws a `NullPointerException` instead of a clean conflict response.

This PR null-guards the ownership check, mirroring the pattern used in `EventService` and `HackathonService`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17791

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
