### PR TITLE
fix(kit): guard rangeArray against step 0 and direction mismatch (#17792)

### DIFF
--- a/src/eventra-kit/range-array.js
+++ b/src/eventra-kit/range-array.js
@@ -4,7 +4,9 @@
  */
 export function rangeArray(start, end, step = 1) {
   const out = [];
+  if (step === 0) return out;
   if (start <= end) {
+    if (step < 0) return out;
     for (let i = start; i <= end; i += step) out.push(i);
   } else {
     for (let i = start; i >= end; i -= Math.abs(step)) out.push(i);


### PR DESCRIPTION
## Description

`rangeArray(start, end, step)` loops forever when `step === 0` or when the step direction mismatches the range direction (e.g. `rangeArray(0, 5, 0)` or `rangeArray(0, 5, -1)`), hanging the page.

This PR applies the same guard already merged into the sibling `range-numbers.js` (return `[]` for `step === 0` and for direction-mismatched steps).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17792

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
