### PR TITLE
fix(components): import Users icon in EventRegistrationQRScanner (#17793)

### DIFF
--- a/src/components/events/EventRegistrationQRScanner.js
+++ b/src/components/events/EventRegistrationQRScanner.js
@@ -5,6 +5,7 @@ import {
   RefreshCw,
   Search,
   UserCheck,
+  Users,
   UserX,
   X,
 } from "lucide-react";


### PR DESCRIPTION
## Description

`EventRegistrationQRScanner.js` renders `<Users size={15} />` in a local `UsersIcon` (line 980), but `Users` is not among the lucide-react imports, throwing `ReferenceError: Users is not defined`.

This PR adds `Users` to the lucide-react import list.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17793

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
