### PR TITLE
fix(kit): import brightnessOf in isDarkColor and hexToRgb in brightnessOf (#17804)

### DIFF
--- a/src/eventra-kit/brightness-of.js
+++ b/src/eventra-kit/brightness-of.js
@@ -1,4 +1,6 @@
 
+import { hexToRgb } from './hex-to-rgb.js';
+
 /**
  * adds a brightness helper.
  */

--- a/src/eventra-kit/is-dark-color.js
+++ b/src/eventra-kit/is-dark-color.js
@@ -1,4 +1,6 @@
 
+import { brightnessOf } from './brightness-of.js';
+
 /**
  * adds a dark color check.
  */


### PR DESCRIPTION
## Description

`isDarkColor(hex)` calls `brightnessOf(hex)` without importing it, throwing `ReferenceError: brightnessOf is not defined`. The helper exists as a named export in `src/eventra-kit/brightness-of.js`.

This PR adds the missing import to `is-dark-color.js`, plus the transitive `hexToRgb` import that `brightness-of.js` is itself missing, so the whole chain works end-to-end (verified: `isDarkColor("#000000")` → `true`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17804

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
