### PR TITLE
fix(kit): import brightnessOf in isLightColor (#17805)

### DIFF
--- a/src/eventra-kit/is-light-color.js
+++ b/src/eventra-kit/is-light-color.js
@@ -1,4 +1,6 @@
 
+import { brightnessOf } from './brightness-of.js';
+
 /**
  * adds a light color check.
  */


### PR DESCRIPTION
## Description

`isLightColor(hex)` calls `brightnessOf(hex)` without importing it, throwing `ReferenceError: brightnessOf is not defined`. The helper exists as a named export in `src/eventra-kit/brightness-of.js`.

This PR adds the missing import (same pattern as `pad-array.js`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17805

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
