### PR TITLE
fix(kit): import countFrequency in modeOf (#17806)

### DIFF
--- a/src/eventra-kit/mode-of.js
+++ b/src/eventra-kit/mode-of.js
@@ -1,4 +1,6 @@
 
+import { countFrequency } from './count-frequency.js';
+
 /**
  * adds a mode helper.
  */


### PR DESCRIPTION
## Description

`modeOf(array)` calls `countFrequency(array)` without importing it, throwing `ReferenceError: countFrequency is not defined`. The helper exists as a named export in `src/eventra-kit/count-frequency.js`.

This PR adds the missing import (same pattern as `pad-array.js`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17806

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
