### PR TITLE
fix(kit): import charFrequency in mostCommonChar (#17807)

### DIFF
--- a/src/eventra-kit/most-common-char.js
+++ b/src/eventra-kit/most-common-char.js
@@ -1,4 +1,6 @@
 
+import { charFrequency } from './char-frequency.js';
+
 /**
  * adds a most common char helper.
  */


### PR DESCRIPTION
## Description

`mostCommonChar(text)` calls `charFrequency(text)` without importing it, throwing `ReferenceError: charFrequency is not defined`. The helper exists as a named export in `src/eventra-kit/char-frequency.js`.

This PR adds the missing import (same pattern as `pad-array.js`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17807

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
