### PR TITLE
fix(kit): import getPathValue in hasPath (#17808)

### DIFF
--- a/src/eventra-kit/has-path.js
+++ b/src/eventra-kit/has-path.js
@@ -1,4 +1,6 @@
 
+import { getPathValue } from './get-path-value.js';
+
 /**
  * adds a path check helper.
  */


### PR DESCRIPTION
## Description

`hasPath(object, path)` calls `getPathValue(object, path, '__missing__')` without importing it, throwing `ReferenceError: getPathValue is not defined`. The helper exists as a named export in `src/eventra-kit/get-path-value.js`.

This PR adds the missing import (same pattern as `pad-array.js`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17808

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
