### PR TITLE
fix(kit): import padBoth in alignCenter (#17809)

### DIFF
--- a/src/eventra-kit/align-center.js
+++ b/src/eventra-kit/align-center.js
@@ -1,4 +1,6 @@
 
+import { padBoth } from './pad-both.js';
+
 /**
  * adds a center align helper.
  */


### PR DESCRIPTION
## Description

`alignCenter(text, width)` calls `padBoth(text, width)` without importing it, throwing `ReferenceError: padBoth is not defined`. The helper exists as a named export in `src/eventra-kit/pad-both.js`.

This PR adds the missing import (same pattern as `pad-array.js`).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17809

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
