### PR TITLE
fix(kit): guard matrixTranspose against empty matrices (#17812)

### DIFF
--- a/src/eventra-kit/matrix-transpose.js
+++ b/src/eventra-kit/matrix-transpose.js
@@ -3,6 +3,7 @@
  * adds a matrix transpose helper.
  */
 export function matrixTranspose(matrix) {
+  if (!matrix.length || !matrix[0].length) return [];
   return matrix[0].map((_, col) => matrix.map((row) => row[col]));
 }
 


### PR DESCRIPTION
## Description

`matrixTranspose(matrix)` dereferences `matrix[0]` without checking, so `matrixTranspose([])` throws `TypeError: Cannot read properties of undefined (reading 'map')`.

This PR guards empty input so it returns `[]`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17812

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
