### PR TITLE
fix(backend): clamp installment divisor in calculateInstallmentSchedule (#17813)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -377,7 +377,7 @@ public class StripeService {
         List<LocalDateTime> schedule = new ArrayList<>();
         
         long totalDays = ChronoUnit.DAYS.between(startDate.toLocalDate(), eventDate.toLocalDate());
-        long intervalDays = totalDays / (totalInstallments - 1);
+        long intervalDays = totalDays / Math.max(1, totalInstallments - 1);
         
         for (int i = 0; i < totalInstallments; i++) {
             LocalDateTime dueDate = startDate.plusDays(i * intervalDays);


### PR DESCRIPTION
## Description

`calculateInstallmentSchedule(startDate, eventDate, totalInstallments)` divides by `totalInstallments - 1`, throwing `ArithmeticException: / by zero` when `totalInstallments` is `1`. The live path clamps installments to at least 4, but this public helper crashes when called directly with `1`.

This PR clamps the divisor so `totalInstallments == 1` yields a single-element schedule.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17813

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] My commit messages follow the conventional commit format.
- [x] My code is self-documenting or the comments are clear and purposeful.
