### PR TITLE
fix(kit): import combinations in pairwiseCombos (#17879)

### DIFF
--- a/src/eventra-kit/pairwise-combos.js
+++ b/src/eventra-kit/pairwise-combos.js
@@ -1,3 +1,4 @@
+import { combinations } from './combinations.js';
 
 /**
  * adds a pair combos helper.


### PR DESCRIPTION
## Description

`pairwiseCombos(array)` calls `combinations(array, 2)` without importing it, throwing `ReferenceError: combinations is not defined`. The helper exists as a named export in `src/eventra-kit/combinations.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17879

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `pairwiseCombos([1, 2, 3])` returns `[[1, 2], [1, 3], [2, 3]]` after the fix (previously threw `ReferenceError`). `src/eventra-kit/__tests__/pairwise-combos.test.js` passes.
