### PR TITLE
fix(kit): import randomSubset in sampleWithoutReplacement (#17881)

### DIFF
--- a/src/eventra-kit/sample-without-replacement.js
+++ b/src/eventra-kit/sample-without-replacement.js
@@ -1,3 +1,4 @@
+import { randomSubset } from './random-subset.js';
 
 /**
  * adds a no-replacement sampler.


### PR DESCRIPTION
## Description

`sampleWithoutReplacement(array, size)` calls `randomSubset(array, size)` without importing it, throwing `ReferenceError: randomSubset is not defined`. The helper exists as a named export in `src/eventra-kit/random-subset.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17881

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `sampleWithoutReplacement([1, 2, 3, 4, 5], 3)` returns a 3-element subset without duplicates after the fix (previously threw `ReferenceError`). `src/eventra-kit/__tests__/sample-without-replacement.test.js` passes.
