### PR TITLE
fix(kit): import hexToRgb in contrastRatio (#17887)

### DIFF
--- a/src/eventra-kit/contrast-ratio.js
+++ b/src/eventra-kit/contrast-ratio.js
@@ -1,3 +1,4 @@
+import { hexToRgb } from './hex-to-rgb.js';
 
 /**
  * adds a contrast helper.


### PR DESCRIPTION
## Description

`contrastRatio(first, second)` calls `hexToRgb(hex)` without importing it, throwing `ReferenceError: hexToRgb is not defined`. The helper exists as a named export in `src/eventra-kit/hex-to-rgb.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17887

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `contrastRatio("#ffffff", "#000000")` returns `21` after the fix (previously threw `ReferenceError`). `src/eventra-kit/__tests__/contrast-ratio.test.js` passes.
