### PR TITLE
fix(kit): import hashStringToNumber in hashId (#17889)

### DIFF
--- a/src/eventra-kit/hash-id.js
+++ b/src/eventra-kit/hash-id.js
@@ -1,3 +1,4 @@
+import { hashStringToNumber } from './hash-string-to-number.js';
 
 /**
  * adds a hash id helper.


### PR DESCRIPTION
## Description

`hashId(text)` calls `hashStringToNumber(text)` without importing it, throwing `ReferenceError: hashStringToNumber is not defined`. The helper exists as a named export in `src/eventra-kit/hash-string-to-number.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17889

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `hashId("event-123")` returns a stable base-36 string after the fix (previously threw `ReferenceError`). `src/eventra-kit/__tests__/hash-id.test.js` passes.
