### PR TITLE
fix(kit): import hexToRgb and colorToHex in blendColors (#17890)

### DIFF
--- a/src/eventra-kit/blend-colors.js
+++ b/src/eventra-kit/blend-colors.js
@@ -1,3 +1,5 @@
+import { hexToRgb } from './hex-to-rgb.js';
+import { colorToHex } from './color-to-hex.js';
 
 /**
  * adds a color blend helper.


### PR DESCRIPTION
## Description

`blendColors(first, second, t)` calls `hexToRgb(...)` and `colorToHex(...)` without importing them, throwing `ReferenceError: hexToRgb is not defined`. Both helpers exist as named exports in `src/eventra-kit/hex-to-rgb.js` and `src/eventra-kit/color-to-hex.js`.

This PR adds the two missing imports.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17890

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `blendColors("#ff0000", "#0000ff", 0.5)` returns `#800080` after the fix (previously threw `ReferenceError`). `src/eventra-kit/__tests__/blend-colors.test.js` passes.
