### PR TITLE
fix(kit): import toOrdinal in toOrdinalWord (#17892)

### DIFF
--- a/src/eventra-kit/to-ordinal-word.js
+++ b/src/eventra-kit/to-ordinal-word.js
@@ -1,3 +1,4 @@
+import { toOrdinal } from './to-ordinal.js';
 
 /**
  * adds an ordinal word helper.


### PR DESCRIPTION
## Description

`toOrdinalWord(value)` calls `toOrdinal(value)` (the fallback for values above 10) without importing it, throwing `ReferenceError: toOrdinal is not defined`. The helper exists as a named export in `src/eventra-kit/to-ordinal.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17892

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `toOrdinalWord(12)` returns `"12th"` after the fix (previously threw `ReferenceError`); `toOrdinalWord(1)` still returns `"first"`. `src/eventra-kit/__tests__/to-ordinal-word.test.js` passes.
