### PR TITLE
fix(kit): import normalizePath in pathDepth (#17894)

### DIFF
--- a/src/eventra-kit/path-depth.js
+++ b/src/eventra-kit/path-depth.js
@@ -1,3 +1,4 @@
+import { normalizePath } from './normalize-path.js';
 
 /**
  * adds a path depth helper.


### PR DESCRIPTION
## Description

`pathDepth(path)` calls `normalizePath(path)` without importing it, throwing `ReferenceError: normalizePath is not defined`. The helper exists as a named export in `src/eventra-kit/normalize-path.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17894

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `pathDepth("a/b/c")` returns the path depth instead of throwing (`ReferenceError` before the fix). `src/eventra-kit/__tests__/path-depth.test.js` passes.
