### PR TITLE
fix(kit): import frequencyMap in sortByCount (#17896)

### DIFF
--- a/src/eventra-kit/sort-by-count.js
+++ b/src/eventra-kit/sort-by-count.js
@@ -1,3 +1,4 @@
+import { frequencyMap } from './frequency-map.js';
 
 /**
  * adds a frequency sorter.


### PR DESCRIPTION
## Description

`sortByCount(array, descending)` calls `frequencyMap(array)` without importing it, throwing `ReferenceError: frequencyMap is not defined`. The helper exists as a named export in `src/eventra-kit/frequency-map.js`.

This PR adds the missing import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17896

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A — pure import fix.

## Additional Notes

Verified: `sortByCount(["a", "b", "a", "a", "c"])` returns `["a", "b", "c"]` after the fix (previously threw `ReferenceError`). `src/eventra-kit/__tests__/sort-by-count.test.js` passes.
