### PR TITLE
fix(utils): export persistErrors from errorLogger (#17976)

### DIFF
--- a/src/utils/errorLogger.js
+++ b/src/utils/errorLogger.js
@@ -527,3 +527,4 @@ export const exportErrorLogAsJSON = () => {
 };
 
 export default logError;
+export { persistToLocalStorage as persistErrors };


### PR DESCRIPTION
## Summary

`persistErrors` is imported by `src/utils/errorRecovery.js` and `src/components/common/ErrorBoundary.jsx` (which is loaded by `src/index.jsx`), but it was never exported from `src/utils/errorLogger.js`. The function existed as `persistToLocalStorage` without an `export` keyword, so ES module linking failed and the app could not boot.

## Changes

- Added `export { persistToLocalStorage as persistErrors };` to `src/utils/errorLogger.js`, exposing the existing function under the name the two consumers import.

## Verification

- `import` of `errorLogger.js` now exposes `persistErrors` as a function.
- `import` of `errorRecovery.js` (a `persistErrors` consumer) now resolves successfully.

Closes #17976
