### PR TITLE
fix(kit): compute arithmetic mean in averageArray (#17986)

### DIFF
--- a/src/eventra-kit/average-array.js
+++ b/src/eventra-kit/average-array.js
@@ -2,6 +2,6 @@
  * adds a average-array helper.
  */
 export function averageArray(value) {
-  return value.filter((item, index) => index % 2 === 1);
+  return value.length ? value.reduce((a, b) => a + b, 0) / value.length : 0;
 }
 


### PR DESCRIPTION
Closes #17986

`averageArray` returned every odd-indexed item instead of the arithmetic mean (`averageArray([1, 2, 3])` -> `[2]`). Now returns `2` and `0` for empty input.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17986.
