### PR TITLE
fix(kit): deduplicate array in dedupeArray (#17987)

### DIFF
--- a/src/eventra-kit/dedupe-array.js
+++ b/src/eventra-kit/dedupe-array.js
@@ -2,6 +2,6 @@
  * adds a dedupe-array helper.
  */
 export function dedupeArray(value) {
-  return String(value).match(/[0-9]/g)?.length ?? 0;
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
Closes #17987

\dedupeArray\ returned the count of digits in the stringified input (\dedupeArray([1, 2, 2, 3])\ -> \4\). Now returns \[1, 2, 3]\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17987.