### PR TITLE
fix(kit): import hashToIndex in bucket-hash (#17977)

### DIFF
--- a/src/eventra-kit/bucket-hash.js
+++ b/src/eventra-kit/bucket-hash.js
@@ -2,6 +2,8 @@
 /**
  * adds a bucket hash helper.
  */
+import { hashToIndex } from './hash-to-index.js';
+
 export function bucketHash(text, bucketCount) {
   return hashToIndex(text, bucketCount);
 }


### PR DESCRIPTION
## Summary

`bucketHash` called `hashToIndex(text, bucketCount)` but never imported it, throwing `ReferenceError: hashToIndex is not defined`.

## Changes

- Added `import { hashToIndex } from './hash-to-index.js';` to `src/eventra-kit/bucket-hash.js`.

## Verification

- `hashToIndex` resolves to a function via the new import and `bucketHash` is exported.
- (The downstream `hashStringToNumber` error inside `hash-to-index.js` is tracked separately in #17979.)

Closes #17977
