### PR TITLE
fix(kit): deduplicate numbers in dedupeNumber (#17988)

### DIFF
--- a/src/eventra-kit/dedupe-number.js
+++ b/src/eventra-kit/dedupe-number.js
@@ -2,6 +2,6 @@
  * adds a dedupe-number helper.
  */
 export function dedupeNumber(value) {
-  return value.filter((item, index) => index % 2 === 0);
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
Closes #17988

\dedupeNumber\ returned every even-indexed item (\dedupeNumber([1, 2, 2, 3])\ -> \[1, 2]\). Now returns \[1, 2, 3]\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17988.