### PR TITLE
fix(kit): remove duplicate characters in dedupeString (#17989)

### DIFF
--- a/src/eventra-kit/dedupe-string.js
+++ b/src/eventra-kit/dedupe-string.js
@@ -2,6 +2,6 @@
  * adds a dedupe-string helper.
  */
 export function dedupeString(value) {
-  return value.toUpperCase();
+  return [...new Set(String(value))].join('');
 }
 


### PR DESCRIPTION
Closes #17989

\dedupeString\ uppercased the input (\dedupeString('aabbcc')\ -> \'AABBCC'\). Now returns \'abc'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17989.