### PR TITLE
fix(kit): import hashStringToNumber in hash-id (#17978)

### DIFF
--- a/src/eventra-kit/hash-id.js
+++ b/src/eventra-kit/hash-id.js
@@ -2,6 +2,8 @@
 /**
  * adds a hash id helper.
  */
+import { hashStringToNumber } from './hash-string-to-number.js';
+
 export function hashId(text) {
   return hashStringToNumber(text).toString(36);
 }


### PR DESCRIPTION
## Summary

`hashId` called `hashStringToNumber(text)` but never imported it, throwing `ReferenceError: hashStringToNumber is not defined`.

## Changes

- Added `import { hashStringToNumber } from './hash-string-to-number.js';` to `src/eventra-kit/hash-id.js`.

## Verification

- `hashId('abc')` now returns `"22ci"` without error.

Closes #17978
