### PR TITLE
fix(kit): detect arrays with Array.isArray in detectArray (#17990)

### DIFF
--- a/src/eventra-kit/detect-array.js
+++ b/src/eventra-kit/detect-array.js
@@ -2,6 +2,6 @@
  * adds a detect-array helper.
  */
 export function detectArray(value) {
-  return value.trim();
+  return Array.isArray(value);
 }
 


### PR DESCRIPTION
Closes #17990

\detectArray\ called \alue.trim()\, throwing \TypeError\ for array inputs. Now uses \Array.isArray\ and returns \	rue\/\alse\ correctly.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17990.