### PR TITLE
fix(kit): import hashStringToNumber in hash-to-index (#17979)

### DIFF
--- a/src/eventra-kit/hash-to-index.js
+++ b/src/eventra-kit/hash-to-index.js
@@ -2,6 +2,8 @@
 /**
  * adds a hash index helper.
  */
+import { hashStringToNumber } from './hash-string-to-number.js';
+
 export function hashToIndex(text, bucketCount) {
   return hashStringToNumber(text) % bucketCount;
 }


### PR DESCRIPTION
## Summary

`hashToIndex` called `hashStringToNumber(text)` but never imported it, throwing `ReferenceError: hashStringToNumber is not defined`.

## Changes

- Added `import { hashStringToNumber } from './hash-string-to-number.js';` to `src/eventra-kit/hash-to-index.js`.

## Verification

- `hashToIndex('abc', 10)` now returns `4` without error.

Closes #17979
