### PR TITLE
fix(kit): return an array from ensureArray (#17991)

### DIFF
--- a/src/eventra-kit/ensure-array.js
+++ b/src/eventra-kit/ensure-array.js
@@ -2,6 +2,6 @@
  * adds a ensure-array helper.
  */
 export function ensureArray(value) {
-  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+  return Array.isArray(value) ? value : value == null ? [] : [value];
 }
 


### PR DESCRIPTION
Closes #17991

\ensureArray\ extracted lowercase letters from the stringified input (\ensureArray('hello world')\ -> \'helloworld'\). Now wraps non-array values: \['hello world']\, and \[]\ for null/undefined.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17991.