### PR TITLE
fix(kit): extract first element in extractArray (#17992)

### DIFF
--- a/src/eventra-kit/extract-array.js
+++ b/src/eventra-kit/extract-array.js
@@ -2,6 +2,6 @@
  * adds a extract-array helper.
  */
 export function extractArray(value) {
-  return value.length === 0;
+  return Array.isArray(value) ? value[0] : undefined;
 }
 


### PR DESCRIPTION
Closes #17992

\extractArray\ returned whether the input was empty (\extractArray([10, 20, 30])\ -> \alse\). Now returns the first element: \10\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17992.