### PR TITLE
fix(kit): import charFrequency in least-common-char (#17980)

### DIFF
--- a/src/eventra-kit/least-common-char.js
+++ b/src/eventra-kit/least-common-char.js
@@ -2,6 +2,8 @@
 /**
  * adds a least common char helper.
  */
+import { charFrequency } from './char-frequency.js';
+
 export function leastCommonChar(text) {
   const freq = charFrequency(text);
   let best = '';


### PR DESCRIPTION
## Summary

`leastCommonChar` called `charFrequency(text)` but never imported it, throwing `ReferenceError: charFrequency is not defined`.

## Changes

- Added `import { charFrequency } from './char-frequency.js';` to `src/eventra-kit/least-common-char.js`.

## Verification

- `leastCommonChar('aabbc')` returns `"c"` and `leastCommonChar('hello')` returns `"h"` without error.

Closes #17980
