### PR TITLE
fix(kit): create an array in createArray (#17993)

### DIFF
--- a/src/eventra-kit/create-array.js
+++ b/src/eventra-kit/create-array.js
@@ -2,6 +2,6 @@
  * adds a create-array helper.
  */
 export function createArray(value) {
-  return value.length === 0;
+  return Array.isArray(value) ? [...value] : value == null ? [] : [value];
 }
 


### PR DESCRIPTION
Closes #17993

\createArray\ returned whether the input was empty (\createArray([1, 2])\ -> \alse\). Now copies arrays and wraps scalars: \[1, 2]\ / \[5]\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17993.