### PR TITLE
fix(kit): detect numbers in detectNumber (#17994)

### DIFF
--- a/src/eventra-kit/detect-number.js
+++ b/src/eventra-kit/detect-number.js
@@ -2,6 +2,6 @@
  * adds a detect-number helper.
  */
 export function detectNumber(value) {
-  return value[value.length - 1];
+  return typeof value === 'number' && Number.isFinite(value);
 }
 


### PR DESCRIPTION
Closes #17994

\detectNumber\ returned the last element of the input (\detectNumber(42)\ -> \undefined\). Now returns \	rue\/\alse\ via \	ypeof value === 'number'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17994.