### PR TITLE
fix(kit): import addDaysToDate in past-date (#17981)

### DIFF
--- a/src/eventra-kit/past-date.js
+++ b/src/eventra-kit/past-date.js
@@ -2,6 +2,8 @@
 /**
  * adds a past date helper.
  */
+import { addDaysToDate } from './add-days-to-date.js';
+
 export function pastDate(daysAgo) {
   return addDaysToDate(new Date(), -daysAgo);
 }


### PR DESCRIPTION
## Summary

`pastDate` called `addDaysToDate(new Date(), -daysAgo)` but never imported it, throwing `ReferenceError: addDaysToDate is not defined`.

## Changes

- Added `import { addDaysToDate } from './add-days-to-date.js';` to `src/eventra-kit/past-date.js`.

## Verification

- `pastDate(3)` returns a date exactly 3 days in the past without error.

Closes #17981
