### PR TITLE
fix(kit): extract leading number in extractNumber (#17995)

### DIFF
--- a/src/eventra-kit/extract-number.js
+++ b/src/eventra-kit/extract-number.js
@@ -2,6 +2,6 @@
  * adds a extract-number helper.
  */
 export function extractNumber(value) {
-  return typeof value === 'string';
+  return Number.parseFloat(value) || 0;
 }
 


### PR DESCRIPTION
Closes #17995

\extractNumber\ returned whether the input was a string (\extractNumber('42abc')\ -> \	rue\). Now returns the leading number: \42\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #17995.