### PR TITLE
fix(kit): import frequencyMap in sort-by-count (#17982)

### DIFF
--- a/src/eventra-kit/sort-by-count.js
+++ b/src/eventra-kit/sort-by-count.js
@@ -2,6 +2,8 @@
 /**
  * adds a frequency sorter.
  */
+import { frequencyMap } from './frequency-map.js';
+
 export function sortByCount(array, descending = true) {
   const freq = frequencyMap(array);
   return [...new Set(array)].sort((a, b) => (descending ? freq.get(b) - freq.get(a) : freq.get(a) - freq.get(b)));


### PR DESCRIPTION
## Summary

`sortByCount` called `frequencyMap(array)` but never imported it, throwing `ReferenceError: frequencyMap is not defined`.

## Changes

- Added `import { frequencyMap } from './frequency-map.js';` to `src/eventra-kit/sort-by-count.js`.

## Verification

- `sortByCount(['a','b','a','a','c'])` returns `['a','b','c']` (descending by frequency) without error.

Closes #17982
