### PR TITLE
fix(kit): return the shortest word in shortestWord (#18014)

### DIFF
--- a/src/eventra-kit/shortest-word.js
+++ b/src/eventra-kit/shortest-word.js
@@ -3,6 +3,7 @@
  * adds a shortest-word helper.
  */
 export function shortestWord(text) {
-  return String(text).split(/\s+/).filter(Boolean).reduce((best, w) => (w.length < best.length ? w : best), '');
+  const words = String(text).split(/\s+/).filter(Boolean);
+  return words.reduce((best, w) => (w.length < best.length ? w : best), words[0] ?? '');
 }
 


### PR DESCRIPTION
Closes #18014

\shortestWord\ seeded its reduce with \''\, so no word ever replaced it (\shortestWord('hello world')\ -> \''\). Now seeds with the first word and returns \'hello'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18014.