### PR TITLE
fix(kit): import sortAlphabetically in reverse-sort (#17983)

### DIFF
--- a/src/eventra-kit/reverse-sort.js
+++ b/src/eventra-kit/reverse-sort.js
@@ -2,6 +2,8 @@
 /**
  * adds a descending sorter.
  */
+import { sortAlphabetically } from './sort-alphabetically.js';
+
 export function reverseSort(array, key) {
   const sorted = sortAlphabetically(array, key);
   return sorted.reverse();


### PR DESCRIPTION
## Summary

`reverseSort` called `sortAlphabetically(array, key)` but never imported it, throwing `ReferenceError: sortAlphabetically is not defined`.

## Changes

- Added `import { sortAlphabetically } from './sort-alphabetically.js';` to `src/eventra-kit/reverse-sort.js`.

## Verification

- `reverseSort(['b','d','a','c'])` returns `['d','c','b','a']` without error.

Closes #17983
