### PR TITLE
fix(kit): preserve order in flattenNested (#18015)

### DIFF
--- a/src/eventra-kit/flatten-nested.js
+++ b/src/eventra-kit/flatten-nested.js
@@ -3,15 +3,6 @@
  * adds a deep flatten helper.
  */
 export function flattenNested(array, depth = Infinity) {
-  const result = [];
-  const stack = [[array, 0]];
-  while (stack.length) {
-    const [current, d] = stack.pop();
-    for (const item of current) {
-      if (Array.isArray(item) && d < depth) stack.push([item, d + 1]);
-      else result.push(item);
-    }
-  }
-  return result.slice().reverse();
+  return array.flat(depth);
 }
 


### PR DESCRIPTION
Closes #18015

The stack-based DFS plus a trailing \.reverse()\ produced a reversed flat array (\lattenNested([1, [2, [3]]])\ -> \[3, 2, 1]\). Replaced with \rray.flat(depth)\, which preserves order and honors the depth argument.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18015.