### PR TITLE
fix(kit): fix high-median index for odd-length arrays (#18016)

### DIFF
--- a/src/eventra-kit/median-high.js
+++ b/src/eventra-kit/median-high.js
@@ -4,7 +4,7 @@
  */
 export function medianHigh(array) {
   const sorted = [...array].sort((a, b) => a - b);
-  const mid = Math.ceil(sorted.length / 2);
+  const mid = Math.floor(sorted.length / 2);
   return sorted[mid];
 }
 


### PR DESCRIPTION
Closes #18016

\Math.ceil(sorted.length / 2)\ overshot the middle index: \medianHigh([1])\ -> \undefined\, \medianHigh([1, 2, 3, 4, 5])\ -> \4\. Using \Math.floor\ yields the correct high median: \1\, \3\, and \3\ for \[1, 2, 3, 4]\.

Verified with node and vitest (both median tests); eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18016.