### PR TITLE
fix(kit): import isAscii in is-unicode (#17984)

### DIFF
--- a/src/eventra-kit/is-unicode.js
+++ b/src/eventra-kit/is-unicode.js
@@ -2,6 +2,8 @@
 /**
  * adds a unicode check.
  */
+import { isAscii } from './is-ascii.js';
+
 export function isUnicode(text) {
   return !isAscii(text);
 }


### PR DESCRIPTION
## Summary

`isUnicode` called `isAscii(text)` but never imported it, throwing `ReferenceError: isAscii is not defined`.

## Changes

- Added `import { isAscii } from './is-ascii.js';` to `src/eventra-kit/is-unicode.js`.

## Verification

- `isUnicode('abc')` returns `false` and `isUnicode('é')` returns `true` without error.

Closes #17984
