### PR TITLE
fix(kit): guard chunkInto against zero or negative size (#18018)

### DIFF
--- a/src/eventra-kit/chunk-into.js
+++ b/src/eventra-kit/chunk-into.js
@@ -3,9 +3,9 @@
  * adds a fixed-chunk helper.
  */
 export function chunkInto(array, size) {
-  const s = Math.max(1, Math.floor(size));
+  if (size <= 0) return [array];
   const out = [];
-  for (let i = 0; i < array.length; i += s) out.push(array.slice(i, i + s));
+  for (let i = 0; i < array.length; i += size) out.push(array.slice(i, i + size));
   return out;
 }
 

--- a/src/eventra-kit/chunk-into.js
+++ b/src/eventra-kit/chunk-into.js
@@ -3,8 +3,9 @@
  * adds a fixed-chunk helper.
  */
 export function chunkInto(array, size) {
+  const s = Math.max(1, Math.floor(size));
   const out = [];
-  for (let i = 0; i < array.length; i += size) out.push(array.slice(i, i + size));
+  for (let i = 0; i < array.length; i += s) out.push(array.slice(i, i + s));
   return out;
 }
 


### PR DESCRIPTION
Closes #18018

\chunkInto\ incremented by \i += size\, so \chunkInto([1, 2, 3], 0)\ looped forever. Now a non-positive size returns the input as a single chunk: \[[1, 2, 3]]\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18018.