### PR TITLE
fix(kit): import normalizePath in path-depth (#17985)

### DIFF
--- a/src/eventra-kit/path-depth.js
+++ b/src/eventra-kit/path-depth.js
@@ -2,6 +2,8 @@
 /**
  * adds a path depth helper.
  */
+import { normalizePath } from './normalize-path.js';
+
 export function pathDepth(path) {
   return normalizePath(path).split('/').filter(Boolean).length;
 }


### PR DESCRIPTION
## Summary

`pathDepth` called `normalizePath(path)` but never imported it, throwing `ReferenceError: normalizePath is not defined`.

## Changes

- Added `import { normalizePath } from './normalize-path.js';` to `src/eventra-kit/path-depth.js`.

## Verification

- `pathDepth('a/b/c')` returns `3` and `pathDepth('/a//b/')` returns `2` without error.

Closes #17985
