### PR TITLE
fix(kit): truncate multi-char fill to target length in padBoth (#18019)

### DIFF
--- a/src/eventra-kit/pad-both.js
+++ b/src/eventra-kit/pad-both.js
@@ -5,6 +5,7 @@
 export function padBoth(str, length, fill = ' ') {
   const total = Math.max(0, length - str.length);
   const left = Math.floor(total / 2);
-  return fill.repeat(left) + str + fill.repeat(total - left);
+  const pad = (n) => fill.repeat(Math.ceil(n / fill.length)).slice(0, n);
+  return pad(left) + str + pad(total - left);
 }
 


### PR DESCRIPTION
Closes #18019

\padBoth('ab', 6, 'xy')\ produced \'xyxyabxyxy'\ (10 chars) because the fill string was repeated without truncation. Padding is now truncated to the exact remaining width: \'xyabxy'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18019.