### PR TITLE
fix(kit): never exceed maxLength in truncateTo (#18020)

### DIFF
--- a/src/eventra-kit/truncate-to.js
+++ b/src/eventra-kit/truncate-to.js
@@ -4,6 +4,7 @@
  */
 export function truncateTo(text, maxLength, suffix = '...') {
   if (text.length <= maxLength) return text;
-  return text.slice(0, maxLength - suffix.length) + suffix;
+  const take = Math.max(0, maxLength - suffix.length);
+  return take > 0 ? text.slice(0, take) + suffix : suffix;
 }
 


### PR DESCRIPTION
Closes #18020

When \maxLength <= suffix.length\ the slice end went negative, so \	runcateTo('hello', 2)\ returned \'hell...'\ (7 chars). Now the slice is clamped to \maxLength\: \'...'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18020.