### PR TITLE
fix(kit): collapse whitespace runs to a single space in compressWhitespace (#18021)

### DIFF
--- a/src/eventra-kit/compress-whitespace.js
+++ b/src/eventra-kit/compress-whitespace.js
@@ -3,6 +3,6 @@
  * adds a whitespace compressor.
  */
 export function compressWhitespace(text) {
-  return String(text).replace(/\s+/g, '').trim();
+  return String(text).replace(/\s+/g, ' ').trim();
 }
 


### PR DESCRIPTION
Closes #18021

\compressWhitespace('a   b')\ returned \'ab'\ because it stripped every whitespace char. Now collapses runs to one space: \'a b'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18021.