### PR TITLE
fix(kit): escape regex metacharacters in splitKeepDelimiter (#18022)

### DIFF
--- a/src/eventra-kit/split-keep-delimiter.js
+++ b/src/eventra-kit/split-keep-delimiter.js
@@ -3,6 +3,7 @@
  * adds a delimiter-keeping splitter.
  */
 export function splitKeepDelimiter(text, delimiter) {
-  return String(text).split(new RegExp(`(${delimiter})`));
+  const escaped = delimiter.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return String(text).split(new RegExp(`(${escaped})`));
 }
 


### PR DESCRIPTION
Closes #18022

The delimiter was interpolated into a \
ew RegExp(...)\ unescaped, so \'.'\ matched any character (\splitKeepDelimiter('a.b', '.')\ produced spurious empties) and \'+'\ threw \SyntaxError: Invalid regular expression\. The delimiter is now regex-escaped: \['a', '.', 'b']\ and \['a', '+', 'b']\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18022.