### PR TITLE
fix(kit): import hexToRgb in contrast-ratio (#18035)

### DIFF
--- a/src/eventra-kit/contrast-ratio.js
+++ b/src/eventra-kit/contrast-ratio.js
@@ -2,6 +2,8 @@
 /**
  * adds a contrast helper.
  */
+import { hexToRgb } from './hex-to-rgb.js';
+
 export function contrastRatio(first, second) {
   const lum = (hex) => {
     const { r, g, b } = hexToRgb(hex);


### PR DESCRIPTION
## Summary

`contrastRatio` called `hexToRgb(hex)` but never imported it, throwing `ReferenceError: hexToRgb is not defined`.

## Changes

- Added `import { hexToRgb } from './hex-to-rgb.js';` to `src/eventra-kit/contrast-ratio.js`.

## Verification

- `contrastRatio('#ffffff', '#000000')` returns `21.00` (WCAG max contrast) without error.

Closes #18035
