### PR TITLE
fix(kit): respect step direction in range (#18023)

### DIFF
--- a/src/eventra-kit/range.js
+++ b/src/eventra-kit/range.js
@@ -5,7 +5,8 @@ export function range(start, end, step = 1) {
   const out = [];
   if (step === 0) return out;
   const forward = end >= start;
-  const inc = step > 0 ? step : 1;
+  if ((step > 0) !== forward) return out;
+  const inc = Math.abs(step);
   if (forward) {
     for (let i = start; i <= end; i += inc) out.push(i);
   } else {


### PR DESCRIPTION
Closes #18023

\ange(0, 5, -1)\ returned \[0, 1, 2, 3, 4, 5]\ because any step was coerced to a positive increment. Now a sign mismatch between the step and the start/end direction yields \[]\ (mirroring \ange-numbers.js\), and a genuinely negative step descends correctly: \ange(5, 0, -1)\ -> \[5, 4, 3, 2, 1, 0]\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18023.