### PR TITLE
fix(kit): count ellipsis toward maxLength in addEllipsis (#18024)

### DIFF
--- a/src/eventra-kit/add-ellipsis.js
+++ b/src/eventra-kit/add-ellipsis.js
@@ -3,6 +3,6 @@
  * adds an ellipsis helper.
  */
 export function addEllipsis(text, maxLength) {
-  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+  return text.length > maxLength ? `${text.slice(0, Math.max(0, maxLength - 3))}...` : text;
 }
 


### PR DESCRIPTION
Closes #18024

\ddEllipsis('hello', 4)\ returned \'hell...'\ (7 chars) because the 3-char ellipsis was appended on top of a full \maxLength\ slice. The ellipsis is now counted toward the limit: \'h...'\.

Verified with node and vitest; eslint clean.

## GSSOC
This PR is part of my GSSoC contribution for issue #18024.