### PR TITLE
fix(kit): import hexToRgb in shift-hue (#18036)

### DIFF
--- a/src/eventra-kit/shift-hue.js
+++ b/src/eventra-kit/shift-hue.js
@@ -2,6 +2,8 @@
 /**
  * adds a hue shift helper.
  */
+import { hexToRgb } from './hex-to-rgb.js';
+
 export function shiftHue(hex, shift) {
   const { r, g, b } = hexToRgb(hex);
   const max = Math.max(r, g, b) / 255;


### PR DESCRIPTION
## Summary

`shiftHue` called `hexToRgb(hex)` but never imported it, throwing `ReferenceError: hexToRgb is not defined`.

## Changes

- Added `import { hexToRgb } from './hex-to-rgb.js';` to `src/eventra-kit/shift-hue.js`.

## Verification

- `shiftHue('#ff0000', 30)` returns `hsl(30, 100%, 100%)` without error.

Closes #18036
