### PR TITLE
fix(kit): import hexToRgb and colorToHex in blend-colors (#18037)

### DIFF
--- a/src/eventra-kit/blend-colors.js
+++ b/src/eventra-kit/blend-colors.js
@@ -2,6 +2,9 @@
 /**
  * adds a color blend helper.
  */
+import { hexToRgb } from './hex-to-rgb.js';
+import { colorToHex } from './color-to-hex.js';
+
 export function blendColors(first, second, t = 0.5) {
   const a = hexToRgb(first);
   const b = hexToRgb(second);


### PR DESCRIPTION
## Summary

`blendColors` called `hexToRgb(...)` and `colorToHex(...)` but never imported them, throwing `ReferenceError: hexToRgb is not defined`.

## Changes

- Added `import { hexToRgb } from './hex-to-rgb.js';` and `import { colorToHex } from './color-to-hex.js';` to `src/eventra-kit/blend-colors.js`.

## Verification

- `blendColors('#ff0000', '#0000ff', 0.5)` returns `#800080` and `blendColors('#ff0000', '#ffffff', 0)` returns `#FF0000` without error.

Closes #18037
