### PR TITLE
fix(kit): import randomSubset in sample-without-replacement (#18038)

### DIFF
--- a/src/eventra-kit/sample-without-replacement.js
+++ b/src/eventra-kit/sample-without-replacement.js
@@ -2,6 +2,8 @@
 /**
  * adds a no-replacement sampler.
  */
+import { randomSubset } from './random-subset.js';
+
 export function sampleWithoutReplacement(array, size) {
   return randomSubset(array, size);
 }


### PR DESCRIPTION
## Summary

`sampleWithoutReplacement` called `randomSubset(array, size)` but never imported it, throwing `ReferenceError: randomSubset is not defined`.

## Changes

- Added `import { randomSubset } from './random-subset.js';` to `src/eventra-kit/sample-without-replacement.js`.

## Verification

- `sampleWithoutReplacement([1,2,3,4,5], 2)` returns a 2-element sample without error.

Closes #18038
