### PR TITLE
fix(kit): import toCamelCaseLower in to-pascal-case-upper (#18039)

### DIFF
--- a/src/eventra-kit/to-pascal-case-upper.js
+++ b/src/eventra-kit/to-pascal-case-upper.js
@@ -2,6 +2,8 @@
 /**
  * adds a pascal case helper.
  */
+import { toCamelCaseLower } from './to-camel-case-lower.js';
+
 export function toPascalCaseUpper(str) {
   const camel = toCamelCaseLower(str);
   return camel.charAt(0).toUpperCase() + camel.slice(1);


### PR DESCRIPTION
## Summary

`toPascalCaseUpper` called `toCamelCaseLower(str)` but never imported it, throwing `ReferenceError: toCamelCaseLower is not defined`.

## Changes

- Added `import { toCamelCaseLower } from './to-camel-case-lower.js';` to `src/eventra-kit/to-pascal-case-upper.js`.

## Verification

- `toPascalCaseUpper('hello world')` returns `"HelloWorld"` without error.

Closes #18039
