### PR TITLE
fix(components): import formatDraftUpdatedAt from eventDraftUtils-jp (#18042)

### DIFF
--- a/src/components/events/DraftEventCard.js
+++ b/src/components/events/DraftEventCard.js
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import {
   formatDraftUpdatedAt,
-} from "../../utils/eventDraftUtils";
+} from "../../utils/eventDraftUtils-jp";
 
 const DraftEventCard = ({
   draft,


### PR DESCRIPTION
## Summary

`DraftEventCard` imported `formatDraftUpdatedAt` from `../../utils/eventDraftUtils`, but that module does not export it — the function only exists in `eventDraftUtils-jp.js`. ES module linking therefore failed.

## Changes

- Pointed the import at the correct module: `../../utils/eventDraftUtils-jp`.

## Verification

- `eventDraftUtils-jp.js` exports `formatDraftUpdatedAt` as a function (verified via dynamic import).

Closes #18042
