### PR TITLE
fix(test-utils): import AuthContext from the correct path (#18043)

### DIFF
--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, waitForElementToBeRemoved, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter, MemoryRouter, Routes, Route } from 'react-router-dom';
-import { AuthProvider } from '../context/AuthContext';
+import { AuthProvider } from './context/AuthContext';
 
 /**
  * ============================================================================


### PR DESCRIPTION
## Summary

`src/test-utils.js` imported `AuthProvider` from `'../context/AuthContext'`, which resolves to `context/AuthContext` at the repo root and cannot be found. Any test importing this helper failed to resolve the module.

## Changes

- Fixed the relative path to `'./context/AuthContext'` in `src/test-utils.js`.

## Verification

- `src/context/AuthContext.js` exists and exports `AuthProvider` (line 103).

Closes #18043
