### PR TITLE
fix(backend): validate event id in importLegacyWaitlist (#18044)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -30,6 +30,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import java.util.Objects;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -337,6 +338,10 @@ public class EventController {
                         @Parameter(description = "ID of the event") @PathVariable Long id,
                         @Valid @RequestBody CsvWaitlistImportRequest request,
                         Authentication authentication) {
+
+                if (!Objects.equals(id, request.getEventId())) {
+                        throw new IllegalArgumentException("Event id in path must match the event id in the request body");
+                }
 
                 return ResponseEntity.ok(eventService.importLegacyWaitlist(request, authentication.getName()));
         }


### PR DESCRIPTION
## Summary

`EventController.importLegacyWaitlist` (`POST /api/events/{id}/waitlist/import`) declared `@PathVariable Long id` but never used it — the service reads the event id from the request body instead. A mismatch between the path id and the body `eventId` would silently import rows into the wrong event.

## Changes

- Added a guard in `importLegacyWaitlist` that rejects requests where the path `id` does not match `request.getEventId()`.
- Added `import java.util.Objects;`.

## Verification

- `IllegalArgumentException` is mapped to `400 Bad Request` by `GlobalExceptionHandler.handleIllegalArgument`.
- No backend CI/build in this repo; the change is a two-line guard using an already-imported DTO getter.

Closes #18044
