### PR TITLE
fix(components): import useCSVExport in RegistrationsTab (#18045)

### DIFF
--- a/src/components/user/RegistrationsTab.jsx
+++ b/src/components/user/RegistrationsTab.jsx
@@ -9,6 +9,7 @@ import { DashboardTableSkeleton } from "../common/SkeletonLoaders";
 import { getSmartDateLabel } from "utils/relativeTime";
 import { downloadBulkICSFile } from "utils/calendarExporter";
 import CertificateDownload from "../CertificateDownload";
+import { useCSVExport } from "../../hooks/useCSVExport";
 const TYPE_OPTIONS = ["Event", "Hackathon", "Project"];
 const STATUS_OPTIONS = ["Upcoming", "Completed", "In Progress", "Done"];
 const TICKET_TYPE_OPTIONS = ["All", "VIP", "Early Bird", "General"];


### PR DESCRIPTION
## Summary

`RegistrationsTab` called `useCSVExport()` (line 128) but never imported the hook, throwing `ReferenceError: useCSVExport is not defined` when the component rendered.

## Changes

- Added `import { useCSVExport } from "../../hooks/useCSVExport";` to `src/components/user/RegistrationsTab.jsx`.

## Verification

- `src/hooks/useCSVExport.js` exists and exports `useCSVExport` (line 14); the relative path from `src/components/user/` resolves correctly.

Closes #18045
