### PR TITLE
fix(kit): make diffArray compute the array difference

### DIFF
--- a/src/eventra-kit/diff-array.js
+++ b/src/eventra-kit/diff-array.js
@@ -1,7 +1,7 @@
 /**
  * adds a diff-array helper.
  */
-export function diffArray(value) {
-  return value === undefined;
+export function diffArray(a, b) {
+  return a.filter(x => !b.includes(x));
 }
 


### PR DESCRIPTION
## Summary

Fixes `diffArray` in `src/eventra-kit/diff-array.js`. The function previously took a single argument and returned `value === undefined`, so `diffArray([1, 2, 3], [2, 3])` returned `false` instead of `[1]`.

## Changes

- `diffArray(a, b)` now returns the elements of `a` that are not present in `b`.
- Handles both missing values in `b` and empty arrays correctly.

## Verification

- `diffArray([1, 2, 3], [2, 3])` -> `[1]`
- `diffArray([1, 2], [1, 2])` -> `[]`

## Related

Closes #18066

## GSSOC
