### PR TITLE
fix(kit): make deduplicateArray return unique values

### DIFF
--- a/src/eventra-kit/deduplicate-array.js
+++ b/src/eventra-kit/deduplicate-array.js
@@ -2,6 +2,6 @@
  * adds a deduplicate-array helper.
  */
 export function deduplicateArray(value) {
-  return String(value).padStart(10, '0');
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
## Summary

Fixes `deduplicateArray` in `src/eventra-kit/deduplicate-array.js`. The function returned a zero-padded string (`String(value).padStart(10, '0')`) instead of the deduplicated array, so `deduplicateArray([1, 2, 2, 3])` returned `'0001,2,2,3'`.

## Changes

- `deduplicateArray(array)` now returns a new array of unique values, preserving first-seen order.

## Verification

- `deduplicateArray([1, 2, 2, 3])` -> `[1, 2, 3]`
- `deduplicateArray(['a', 'b', 'a'])` -> `['a', 'b']`

## Related

Closes #18067

## GSSOC
