### PR TITLE
fix(kit): make deduplicateNumber return unique values

### DIFF
--- a/src/eventra-kit/deduplicate-number.js
+++ b/src/eventra-kit/deduplicate-number.js
@@ -1,7 +1,7 @@
 /**
  * adds a deduplicate-number helper.
  */
-export function deduplicateNumber(value, separator) {
-  return value.join(separator);
+export function deduplicateNumber(value) {
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
## Summary

Fixes `deduplicateNumber` in `src/eventra-kit/deduplicate-number.js`. The function joined the input into a comma-separated string (`value.join(separator)`) instead of deduplicating, so `deduplicateNumber([1, 2, 2, 3])` returned `'1,2,2,3'`.

## Changes

- `deduplicateNumber(numbers)` now returns an array of unique numbers, preserving first-seen order.

## Verification

- `deduplicateNumber([1, 2, 2, 3])` -> `[1, 2, 3]`
- `deduplicateNumber([7, 7, 7])` -> `[7]`

## Related

Closes #18068

## GSSOC
