### PR TITLE
fix(kit): make estimateArray return the array length

### DIFF
--- a/src/eventra-kit/estimate-array.js
+++ b/src/eventra-kit/estimate-array.js
@@ -2,6 +2,6 @@
  * adds a estimate-array helper.
  */
 export function estimateArray(value) {
-  return String(value).split('').sort().join('');
+  return Array.isArray(value) ? value.length : 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes `estimateArray` in `src/eventra-kit/estimate-array.js`. The function sorted the array's characters into a string instead of returning its length, so `estimateArray([1, 2, 3])` returned `',123'`.

## Changes

- `estimateArray(array)` now returns the number of elements in the array.
- Returns `0` for non-array input.

## Verification

- `estimateArray([1, 2, 3])` -> `3`
- `estimateArray([])` -> `0`
- `estimateArray(null)` -> `0`

## Related

Closes #18069

## GSSOC
