### PR TITLE
fix(kit): make createNumber convert to a number

### DIFF
--- a/src/eventra-kit/create-number.js
+++ b/src/eventra-kit/create-number.js
@@ -2,6 +2,6 @@
  * adds a create-number helper.
  */
 export function createNumber(value) {
-  return typeof value === 'string';
+  return Number(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes `createNumber` in `src/eventra-kit/create-number.js`. The function returned `typeof value === 'string'` (a boolean) instead of converting the input to a number, so `createNumber('42')` returned `true`.

## Changes

- `createNumber(value)` now converts the input to a number via `Number(value)`.

## Verification

- `createNumber('42')` -> `42`
- `createNumber(7)` -> `7`
- `createNumber('abc')` -> `NaN`

## Related

Closes #18070

## GSSOC
