### PR TITLE
fix(kit): make estimateNumber parse a number from the input

### DIFF
--- a/src/eventra-kit/estimate-number.js
+++ b/src/eventra-kit/estimate-number.js
@@ -2,6 +2,7 @@
  * adds a estimate-number helper.
  */
 export function estimateNumber(value) {
-  return value.split(' ').filter(Boolean).length;
+  const n = Number(String(value).replace(/\s+/g, ''));
+  return Number.isNaN(n) ? 0 : n;
 }
 


### PR DESCRIPTION
## Summary

Fixes `estimateNumber` in `src/eventra-kit/estimate-number.js`. The function counted the words in the input string instead of parsing it as a number, so `estimateNumber('1 2 3')` returned `3`.

## Changes

- `estimateNumber(value)` now parses the input to a number via `Number(value)`.
- Returns `0` when the value cannot be parsed to a number.

## Verification

- `estimateNumber('123')` -> `123`
- `estimateNumber('1 2 3')` -> `123`
- `estimateNumber('abc')` -> `0`

## Related

Closes #18071

## GSSOC
