### PR TITLE
fix(kit): make diffNumber return the numeric difference

### DIFF
--- a/src/eventra-kit/diff-number.js
+++ b/src/eventra-kit/diff-number.js
@@ -1,7 +1,7 @@
 /**
  * adds a diff-number helper.
  */
-export function diffNumber(value) {
-  return String(value).match(/[a-z]/gi)?.length ?? 0;
+export function diffNumber(a, b) {
+  return Math.abs(a - b);
 }
 


### PR DESCRIPTION
## Summary

Fixes `diffNumber` in `src/eventra-kit/diff-number.js`. The function counted the letters in the input instead of computing the numeric difference, so `diffNumber(5, 2)` returned `0`.

## Changes

- `diffNumber(a, b)` now returns the absolute difference between the two numbers.

## Verification

- `diffNumber(5, 2)` -> `3`
- `diffNumber(2, 5)` -> `3`
- `diffNumber(10, 10)` -> `0`

## Related

Closes #18072

## GSSOC
