### PR TITLE
fix(kit): make toNumberOrNull return null for non-numbers

### DIFF
--- a/src/eventra-kit/to-number-or-null.js
+++ b/src/eventra-kit/to-number-or-null.js
@@ -3,6 +3,8 @@
  * adds a number or null helper.
  */
 export function toNumberOrNull(value) {
+  if (value === null || value === undefined || value === false) return null;
+  if (typeof value === 'string' && value.trim() === '') return null;
   const n = Number(value);
   return Number.isNaN(n) ? null : n;
 }


### PR DESCRIPTION
## Summary

Fixes `toNumberOrNull` in `src/eventra-kit/to-number-or-null.js`. The function returned `0` for `null`, `undefined`, `false`, and empty/whitespace strings because `Number()` coerces them to `0`.

## Changes

- `toNumberOrNull(value)` now returns `null` for `null`, `undefined`, `false`, and empty/whitespace strings.
- Returns `null` for non-numeric input and the numeric value otherwise.

## Verification

- `toNumberOrNull('42')` -> `42`
- `toNumberOrNull(null)` -> `null`
- `toNumberOrNull('')` -> `null`
- `toNumberOrNull('abc')` -> `null`

## Related

Closes #18073

## GSSOC
