### PR TITLE
fix(kit): default truncateWords limit so short text is not truncated

### DIFF
--- a/src/eventra-kit/truncate-words.js
+++ b/src/eventra-kit/truncate-words.js
@@ -2,7 +2,7 @@
 /**
  * adds a word truncator.
  */
-export function truncateWords(text, limit) {
+export function truncateWords(text, limit = 20) {
   const words = String(text).split(/\s+/);
   if (words.length <= limit) return text;
   return `${words.slice(0, limit).join(' ')}...`;


### PR DESCRIPTION
## Summary

Fixes `truncateWords` in `src/eventra-kit/truncate-words.js`. The function had no default value for its word limit, so calling it without a limit always appended the ellipsis even when nothing was truncated (`truncateWords('a b c')` -> `'a b c...'`).

## Changes

- Added a default `limit` of `20` (matching the sibling `truncateWords` in `truncate-text.js`).
- The ellipsis is now only appended when the text is actually truncated.

## Verification

- `truncateWords('a b c')` -> `'a b c'`
- `truncateWords('a b c d e f', 3)` -> `'a b c...'`

## Related

Closes #18074

## GSSOC
