### PR TITLE
fix(kit): clamp ellipsizeStart output to maxLength

### DIFF
--- a/src/eventra-kit/ellipsize-start.js
+++ b/src/eventra-kit/ellipsize-start.js
@@ -3,7 +3,10 @@
  * adds a start ellipsis helper.
  */
 export function ellipsizeStart(text, maxLength) {
-  if (text.length <= maxLength) return text;
-  return `...${text.slice(-(maxLength - 3))}`;
+  const s = String(text);
+  if (s.length <= maxLength) return s;
+  const ellipsis = '...';
+  if (maxLength <= ellipsis.length) return ellipsis.slice(0, maxLength);
+  return `${ellipsis}${s.slice(-(maxLength - ellipsis.length))}`;
 }
 


### PR DESCRIPTION
## Summary

Fixes `ellipsizeStart` in `src/eventra-kit/ellipsize-start.js`. For `maxLength` smaller than the ellipsis length, the slice used a negative computed index and returned more characters than requested (`ellipsizeStart('abcdef', 2)` -> `'...bcdef'`).

## Changes

- `ellipsizeStart(text, maxLength)` now never returns more than `maxLength` characters.
- For `maxLength` shorter than the ellipsis, the ellipsis itself is trimmed to fit.

## Verification

- `ellipsizeStart('abcdef', 2)` -> `'..'`
- `ellipsizeStart('abcdef', 4)` -> `'...f'`
- `ellipsizeStart('abcdef', 10)` -> `'abcdef'`

## Related

Closes #18075

## GSSOC
