### PR TITLE
fix(kit): clamp formatBytes tier index for fractional values

### DIFF
--- a/src/eventra-kit/format-bytes.js
+++ b/src/eventra-kit/format-bytes.js
@@ -6,7 +6,7 @@ export function formatBytes(bytes, decimals = 2) {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
   const k = 1024;
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  const i = Math.max(0, Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1));
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
 }
 


### PR DESCRIPTION
## Summary

Fixes `formatBytes` in `src/eventra-kit/format-bytes.js`. For values between `0` and `1`, `Math.floor(Math.log(bytes) / Math.log(1024))` is `-1`, indexing `sizes[-1]` as `undefined` and producing `'512 undefined'`.

## Changes

- Clamped the tier index to a minimum of `0` so fractional byte values fall back to the `'B'` tier.

## Verification

- `formatBytes(0.5)` -> `'0.5 B'`
- `formatBytes(1)` -> `'1 B'`
- `formatBytes(2048)` -> `'2 KB'`

## Related

Closes #18100

## GSSOC
