### PR TITLE
fix(kit): align ceilTo and floorTo default precision with roundTo

### DIFF
--- a/src/eventra-kit/round-to.js
+++ b/src/eventra-kit/round-to.js
@@ -7,12 +7,12 @@ export function roundTo(value, precision = 2) {
   return Math.round((value + Number.EPSILON) * factor) / factor;
 }
 
-export function ceilTo(value, precision = 0) {
+export function ceilTo(value, precision = 2) {
   const factor = 10 ** precision;
   return Math.ceil(value * factor) / factor;
 }
 
-export function floorTo(value, precision = 0) {
+export function floorTo(value, precision = 2) {
   const factor = 10 ** precision;
   return Math.floor(value * factor) / factor;
 }


### PR DESCRIPTION
## Summary

Fixes inconsistent default precisions in `src/eventra-kit/round-to.js`. `roundTo` defaulted to `2` while `ceilTo` and `floorTo` defaulted to `0`, so the same call shape gave inconsistent results.

## Changes

- Set the default `precision` to `2` for all three helpers so they behave consistently.

## Verification

- `roundTo(3.14159)` -> `3.14`
- `ceilTo(3.14159)` -> `3.15`
- `floorTo(3.14159)` -> `3.14`

## Related

Closes #18090

## GSSOC
