### PR TITLE
fix(kit): lowercase input in toCamelCaseLower

### DIFF
--- a/src/eventra-kit/to-camel-case-lower.js
+++ b/src/eventra-kit/to-camel-case-lower.js
@@ -4,6 +4,7 @@
  */
 export function toCamelCaseLower(str) {
   return String(str)
+    .toLowerCase()
     .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
     .replace(/^(.)/, (c) => c.toLowerCase());
 }


### PR DESCRIPTION
## Summary

Fixes `toCamelCaseLower` in `src/eventra-kit/to-camel-case-lower.js`. Only the first character was lowercased, so `toCamelCaseLower('HELLO_WORLD')` returned `'hELLOWORLD'` instead of `'helloWorld'`.

## Changes

- Lowercase the whole input before converting separators to camel case.

## Verification

- `toCamelCaseLower('HELLO_WORLD')` -> `'helloWorld'`
- `toCamelCaseLower('Hello World')` -> `'helloWorld'`
- `toCamelCaseLower('hello_world')` -> `'helloWorld'`

## Related

Closes #18091

## GSSOC
