### PR TITLE
fix(kit): skip empty lines in wrapText

### DIFF
--- a/src/eventra-kit/wrap-text.js
+++ b/src/eventra-kit/wrap-text.js
@@ -8,7 +8,8 @@ export function wrapText(text, width) {
   let line = '';
   for (const word of words) {
     if (line.length + word.length > width) {
-      lines.push(line.trim());
+      const trimmed = line.trim();
+      if (trimmed) lines.push(trimmed);
       line = word;
     } else {
       line += ` ${word}`;


### PR DESCRIPTION
## Summary

Fixes `wrapText` in `src/eventra-kit/wrap-text.js`. When the first word is longer than the width, the empty initial line was pushed into the result, producing a leading empty string.

## Changes

- Skip empty lines when pushing a wrapped line to the result.

## Verification

- `wrapText('supercalifragilistic', 5)` -> `['supercalifragilistic']`
- `wrapText('a b c', 10)` -> `['a b c']`
- `wrapText('a longword here', 5)` -> `['a', 'longword', 'here']`

## Related

Closes #18092

## GSSOC
