### PR TITLE
fix(kit): add trillion tier to formatLargeNumber

### DIFF
--- a/src/eventra-kit/format-large-number.js
+++ b/src/eventra-kit/format-large-number.js
@@ -3,7 +3,7 @@
  * adds a large number helper.
  */
 export function formatLargeNumber(value) {
-  const tiers = [[1e9, 'B'], [1e6, 'M'], [1e3, 'K']];
+  const tiers = [[1e12, 'T'], [1e9, 'B'], [1e6, 'M'], [1e3, 'K']];
   for (let i = 0; i < tiers.length; i++) {
     const [divisor, suffix] = tiers[i];
     if (value >= divisor) {


### PR DESCRIPTION
## Summary

Fixes `formatLargeNumber` in `src/eventra-kit/format-large-number.js`. The tier list stopped at `1e9` (`'B'`), so values at or above one trillion were returned unformatted.

## Changes

- Added a `'T'` (`1e12`) tier, keeping the existing `K`/`M`/`B` behavior and carry logic.

## Verification

- `formatLargeNumber(1234)` -> `'1.2K'`
- `formatLargeNumber(1234567890)` -> `'1.2B'`
- `formatLargeNumber(1e12)` -> `'1.0T'`

## Related

Closes #18093

## GSSOC
