### PR TITLE
fix(utils): close checkEmailAvailability and checkUsernameAvailability (#18104)

### DIFF
--- a/src/utils/validationApi.js
+++ b/src/utils/validationApi.js
@@ -240,6 +240,7 @@ export const checkEmailAvailability = (email, options = {}) => {
       ...options,
     },
   );
+};
 
 export const checkUsernameAvailability = (username, options = {}) => {
   if (!username || typeof username !== "string" || !username.trim()) {
@@ -254,6 +255,7 @@ export const checkUsernameAvailability = (username, options = {}) => {
       ...options,
     },
   );
+};
 
 export const checkPhoneValidation = (phone, options = {}) =>
   requestValidation(options.endpoint || "/api/validate/phone", {


### PR DESCRIPTION
## Summary

`checkEmailAvailability` and `checkUsernameAvailability` in `src/utils/validationApi.js` were missing their closing `};`, so `checkUsernameAvailability` and `checkPhoneValidation` were parsed inside the previous arrow function body. `node --check` reported `SyntaxError: Unexpected token 'export'` and the module could not be loaded.

## Changes

- Added the missing `};` to close `checkEmailAvailability` (line 243) and `checkUsernameAvailability` (line 258).

## Verification

- `node --check src/utils/validationApi.js` now passes.
- All exports (`checkEmailAvailability`, `checkUsernameAvailability`, `checkPhoneValidation`, `clearValidationCache`, `createValidationResponse`, `normalizeValidationApiResponse`, `requestValidation`, `validationLoadingResponse`) are defined.
- Note: a full module import additionally surfaces a pre-existing unrelated `SyntaxError` in `src/config/api.js:385` (`getApiErrorMessage` is not defined) which is outside this fix's scope.

Closes #18104
