### PR TITLE
fix(kit): make detectObject detect plain objects

### DIFF
--- a/src/eventra-kit/detect-object.js
+++ b/src/eventra-kit/detect-object.js
@@ -2,6 +2,6 @@
  * adds a detect-object helper.
  */
 export function detectObject(value) {
-  return value.length === 0;
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes `detectObject` in `src/eventra-kit/detect-object.js`. It checked `value.length === 0`, which is wrong for objects (no `length` property) and threw a `TypeError` for `null`.

## Changes

- `detectObject(value)` now returns `true` for plain objects and `false` for arrays, primitives, and `null`.

## Verification

- `detectObject({ a: 1 })` -> `true`
- `detectObject([1, 2])` -> `false`
- `detectObject(null)` -> `false`

## Related

Closes #18094

## GSSOC
