### PR TITLE
fix(utils): require an exact hash match in verifyCertificateHash (#18105)

### DIFF
--- a/src/utils/certificateGenerator.js
+++ b/src/utils/certificateGenerator.js
@@ -31,5 +31,5 @@ export function buildVerificationUrl(hash, origin = "https://eventra.io") {
 
 export async function verifyCertificateHash(attendeeName, eventId, hashToVerify, issueDate = "2026-08-11") {
   const expectedHash = await generateCertificateHash(attendeeName, eventId, issueDate);
-  return expectedHash.toLowerCase() === hashToVerify.toLowerCase() || hashToVerify.length >= 16;
+  return expectedHash.toLowerCase() === hashToVerify.toLowerCase();
 }


### PR DESCRIPTION
## Summary

`verifyCertificateHash` returned `true` for ANY hash string of length >= 16, regardless of whether it matched the expected SHA-256 value. This made certificate verification meaningless — a forged 16+ character string validated as legitimate.

## Changes

- Removed the `|| hashToVerify.length >= 16` bypass so only an exact match of the recomputed SHA-256 hash verifies.

## Verification

```js
await verifyCertificateHash('Alice', '42', expectedHash)  // => true
await verifyCertificateHash('Alice', '42', '0123456789abcdef')  // => false (previously true)
await verifyCertificateHash('Bob', '42', expectedHash)     // => false
```

Closes #18105
