### PR TITLE
fix(kit): guard chunkArray against non-positive size

### DIFF
--- a/src/eventra-kit/chunk-array.js
+++ b/src/eventra-kit/chunk-array.js
@@ -3,6 +3,9 @@
  * adds an array chunker.
  */
 export function chunkArray(array, size) {
+  if (!Number.isInteger(size) || size < 1) {
+    throw new TypeError('size must be a positive integer');
+  }
   const out = [];
   for (let i = 0; i < array.length; i += size) out.push(array.slice(i, i + size));
   return out;


### PR DESCRIPTION
## Summary

Fixes `chunkArray` in `src/eventra-kit/chunk-array.js`. Passing `0` as `size` caused an infinite loop (the loop index never advanced), which hung or crashed the process with an out-of-memory error.

## Changes

- Validate that `size` is a positive integer and throw a descriptive `TypeError` otherwise.

## Verification

- `chunkArray([1, 2, 3, 4], 2)` -> `[[1, 2], [3, 4]]`
- `chunkArray([1, 2, 3], 0)` -> throws `TypeError: size must be a positive integer`

## Related

Closes #18095

## GSSOC
