### PR TITLE
fix(backend): map /signup to signup and drop duplicate reset-password (#18107)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -70,23 +70,6 @@ public class AuthController {
             @ApiResponse(responseCode = "429", description = "Signup rate limit exceeded",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public static class PasswordResetRequest {
-        private String email;
-        public String getEmail() { return email; }
-        public void setEmail(String email) { this.email = email; }
-    }
-
-    @PostMapping("/reset-password")
-    @SecurityRequirements
-    @Operation(summary = "Request password reset link")
-    public ResponseEntity<?> resetPassword(@RequestBody PasswordResetRequest request) {
-        String email = request.getEmail();
-        if (email == null || !org.springframework.util.StringUtils.hasText(email)) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Email is required"));
-        }
-        return ResponseEntity.ok(Map.of("message", "Password reset link sent! Check your email."));
-    }
-
     public ResponseEntity<AuthResponse> signup(@Valid @RequestBody SignupRequest request) {
         AuthResponse response = authService.signup(request);
         return withAuthCookie(ResponseEntity.status(HttpStatus.CREATED), response);


### PR DESCRIPTION
## Summary

`@PostMapping("/signup")` was attached to the inner `PasswordResetRequest` class instead of the `signup()` method, leaving `POST /api/auth/signup` unmapped (404). Additionally, two `@PostMapping("/reset-password")` methods existed — a stub that returns a canned message without calling any service, and the real one calling `authService.requestPasswordReset` — causing an ambiguous mapping and silently breaking password reset.

## Changes

- Moved `@PostMapping("/signup")` (+ its OpenAPI annotations) onto the `signup()` method.
- Deleted the stub `resetPassword` and the now-unused `PasswordResetRequest` inner class.
- Kept the single real `/reset-password` handler that calls `authService.requestPasswordReset`.

## Verification

- Only one `@PostMapping("/reset-password")` remains; `@PostMapping("/signup")` is directly above `signup()`.
- No other references to `PasswordResetRequest` exist in the controller.
- No backend CI/build in this repo; change is a pure annotation/mapping correction verified by reading the resulting file.

Closes #18107
