### PR TITLE
fix(kit): import toCamelCaseLower in toPascalCaseUpper

### DIFF
--- a/src/eventra-kit/to-pascal-case-upper.js
+++ b/src/eventra-kit/to-pascal-case-upper.js
@@ -2,6 +2,8 @@
 /**
  * adds a pascal case helper.
  */
+import { toCamelCaseLower } from './to-camel-case-lower.js';
+
 export function toPascalCaseUpper(str) {
   const camel = toCamelCaseLower(str);
   return camel.charAt(0).toUpperCase() + camel.slice(1);


### PR DESCRIPTION
## Summary

Fixes `toPascalCaseUpper` in `src/eventra-kit/to-pascal-case-upper.js`. It called `toCamelCaseLower` without importing it, so every call threw a `ReferenceError`.

## Changes

- Added the missing import of `toCamelCaseLower` from `to-camel-case-lower.js`.

## Verification

- `toPascalCaseUpper('hello world')` -> `'HelloWorld'`
- `toPascalCaseUpper('user-name')` -> `'UserName'`

## Related

Closes #18096

## GSSOC
