### PR TITLE
fix(backend): remove orphaned duplicate code in TeamWorkspaceSyncController (#18108)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
@@ -54,29 +54,3 @@ public class TeamWorkspaceSyncController {
         return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
     }
 }
-
-    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream(
-            @RequestParam(required = false) String roomKey,
-            @RequestParam(required = false) String hackathonId,
-            @RequestParam(required = false) String teamId) {
-        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
-        teamWorkspaceSyncService.requireReadAccess(resolved);
-        return teamWorkspaceSyncService.subscribe(resolved);
-    }
-
-    @PostMapping
-    public ResponseEntity<Map<String, Object>> pollOrUpdate(
-            @RequestParam(required = false) String roomKey,
-            @RequestParam(required = false) String hackathonId,
-            @RequestParam(required = false) String teamId,
-            @RequestBody(required = false) Map<String, Object> body) {
-        String resolved = teamWorkspaceSyncService.resolveRoomKey(roomKey, hackathonId, teamId);
-        if (body == null || body.isEmpty()) {
-            teamWorkspaceSyncService.requireReadAccess(resolved);
-            return ResponseEntity.ok(teamWorkspaceSyncService.snapshot(resolved));
-        }
-        teamWorkspaceSyncService.requireWriteAccess(resolved);
-        return ResponseEntity.ok(teamWorkspaceSyncService.applyUpdate(resolved, body));
-    }
-}


### PR DESCRIPTION
## Summary

`TeamWorkspaceSyncController.java` had orphaned duplicate code AFTER the class closing brace — a second `stream(...)` and `pollOrUpdate(...)` at the top level, which is a compile error (`class, interface, or enum expected`).

## Changes

- Deleted the orphaned lines 58-81 (26 lines). The valid `stream`/`pollOrUpdate` methods (lines 31-55) are unchanged; they already perform the access checks (`requireReadAccess`/`requireWriteAccess`) via the injected service.

## Verification

- File now contains exactly one class ending with the matching `}`.
- No backend CI/build in this repo; change is a pure dead-code deletion verified by reading the resulting file.

Closes #18108
