### PR TITLE
fix(kit): default truncateByWord maxLength so short text is not truncated

### DIFF
--- a/src/eventra-kit/truncate-by-word.js
+++ b/src/eventra-kit/truncate-by-word.js
@@ -2,7 +2,7 @@
 /**
  * adds a word truncator.
  */
-export function truncateByWord(text, maxLength) {
+export function truncateByWord(text, maxLength = 100) {
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength).replace(/\s+\S*$/, '') + '...';
 }


### PR DESCRIPTION
## Summary

Fixes `truncateByWord` in `src/eventra-kit/truncate-by-word.js`. It had no default value for `maxLength`, so calling it without a limit always truncated and appended the ellipsis.

## Changes

- Added a default `maxLength` of `100` (matching the sibling `truncateText` in `truncate-text.js`).
- The ellipsis is only appended when the text is actually truncated.

## Verification

- `truncateByWord('a b c')` -> `'a b c'`
- `truncateByWord('a b c d e f', 6)` -> `'a b c...'`

## Related

Closes #18097

## GSSOC
