### PR TITLE
fix(kit): validate n in everyNth and default to 1

### DIFF
--- a/src/eventra-kit/every-nth.js
+++ b/src/eventra-kit/every-nth.js
@@ -2,7 +2,10 @@
 /**
  * adds an nth-item helper.
  */
-export function everyNth(array, n) {
+export function everyNth(array, n = 1) {
+  if (!Number.isInteger(n) || n < 1) {
+    throw new TypeError('n must be a positive integer');
+  }
   return array.filter((_, i) => i % n === 0);
 }
 


### PR DESCRIPTION
## Summary

Fixes `everyNth` in `src/eventra-kit/every-nth.js`. When `n` was missing or `0`, `i % n` became `NaN` and the function silently returned an empty array.

## Changes

- Added a default `n` of `1` and validate that `n` is a positive integer, throwing a descriptive `TypeError` otherwise.

## Verification

- `everyNth([1, 2, 3])` -> `[1, 2, 3]`
- `everyNth([1, 2, 3, 4, 5], 2)` -> `[1, 3, 5]`
- `everyNth([1, 2, 3], 0)` -> throws `TypeError: n must be a positive integer`

## Related

Closes #18098

## GSSOC
