### PR TITLE
fix(backend): remove orphaned access-denied lines in SubtitleController (#18110)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java
@@ -436,8 +436,6 @@ public class SubtitleController {
         }
         throw new IllegalArgumentException("eventId or sessionId is required to create a subtitle.");
     }
-        throw new AccessDeniedException("You can only view your own subtitles.");
-    }
 
     private User currentUser(Authentication authentication) {
         String email = authentication != null ? authentication.getName() : null;


### PR DESCRIPTION
## Summary

`SubtitleController.java` had two orphaned copy-paste lines at the class level, outside any method: `throw new AccessDeniedException("You can only view your own subtitles.");` followed by a stray `}`, right after `resolveEventId(...)`. This is a compile error.

## Changes

- Deleted the two stray lines. The identical check already exists inside `assertCanReadUser` (line 420), so the behavior is unchanged.

## Verification

- File now has no statements outside class/method bodies.
- No backend CI/build in this repo; change is a pure dead-code deletion verified by reading the resulting file.

Closes #18110
