### PR TITLE
fix(backend): use String eventId in NotificationController.getTemplate (#18111)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -285,7 +285,7 @@ public class NotificationController {
             )
     })
     public ResponseEntity<TemplateResponse> getTemplate(
-            @PathVariable Long eventId,
+            @PathVariable String eventId,
             @PathVariable String templateType,
             Authentication authentication) {
         String organizerEmail = authentication.getName();


### PR DESCRIPTION
## Summary

`NotificationController.getTemplate` declared `@PathVariable Long eventId` but the service signature is `getTemplate(String eventId, ...)` — a compile error (`Long` cannot be passed to a `String` parameter).

## Changes

- Changed the controller's `@PathVariable Long eventId` to `@PathVariable String eventId`.

## Verification

- The `EmailTemplate` entity, `EmailTemplateRepository.findByEventIdAndTemplateTypeAndOrganizerEmail(String, String, String)`, `EmailTemplateService.getTemplate(String, ...)`, and `SaveTemplateRequest.getEventId()` (String) all use String — the controller now matches the rest of the stack.
- No backend CI/build in this repo; change is a one-line type correction verified by reading the resulting signatures.

Closes #18111
