### PR TITLE
fix(backend): honor Pageable in getAllHackathons (#18112)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -198,8 +198,8 @@ public class HackathonController {
                     )
             )
     })
-    public ResponseEntity<List<HackathonResponse>> getAllHackathons(@PageableDefault(size = 20, sort = "startDate") Pageable pageable) {
-        return ResponseEntity.ok(hackathonService.getAllHackathons());
+    public ResponseEntity<Page<HackathonResponse>> getAllHackathons(@PageableDefault(size = 20, sort = "startDate") Pageable pageable) {
+        return ResponseEntity.ok(hackathonService.getAllHackathons(pageable));
     }
 
     @GetMapping("/{id}")


### PR DESCRIPTION
## Summary

`HackathonController.getAllHackathons` accepted a `Pageable pageable` parameter (annotated `@PageableDefault(size = 20, sort = "startDate")`) but ignored it, calling the no-arg service overload which returns the full list. `?page=`, `?size=`, and `?sort=` query params were silently dropped.

## Changes

- Call `hackathonService.getAllHackathons(pageable)` (the `Page<HackathonResponse>` overload) and return it as the response body.
- Response type changed from `List<HackathonResponse>` to `Page<HackathonResponse>` so clients receive paging metadata.

## Verification

- `HackathonService` has both overloads; the controller now uses the paging one.
- `Page` and `Pageable` are already imported in the controller.
- No backend CI/build in this repo; change is a pure overload correction verified by reading the resulting code.

Closes #18112
