### PR TITLE
fix(components): use formatShort from useDateFormatter in EventCard (#18113)

### DIFF
--- a/src/components/user/EventCard.jsx
+++ b/src/components/user/EventCard.jsx
@@ -57,9 +57,10 @@ const EventCard = memo(({
 }) => {
   const prefersReducedMotion = useReducedMotion();
   const isOffline = useOfflineStatus();
+  const { formatShort } = useDateFormatter();
   const fadeUpVariants = fadeUp(prefersReducedMotion);
   const status = getEventStatus(event);
-  const shortDate = formatShortDate(event?.date);
+  const shortDate = formatShort(event?.date);
 
   // Render tags
   const renderTags = () => {


### PR DESCRIPTION
## Summary

`EventCard.jsx` called `formatShortDate(...)` which is never defined or imported — rendering the component threw `ReferenceError: formatShortDate is not defined`. The `useDateFormatter` hook was imported but never invoked; its real export is `formatShort`.

## Changes

- Invoke the hook: `const { formatShort } = useDateFormatter();`
- Replace `formatShortDate(event?.date)` with `formatShort(event?.date)`.

## Verification

- No remaining `formatShortDate` references (except the stale comment).
- `src/hooks/useDateFormatter.js:113` defines `formatShort` (month + day, e.g. "Jun 12").
- `.jsx` cannot be checked with plain `node --check`; change is a hook-invocation correction verified by reading the resulting code and diff.

Closes #18113
