### PR TITLE
fix(utils): add TB unit and clamp index in formatBytes (#18115)

### DIFF
--- a/src/utils/wasmCompressor/wasmLoader.js
+++ b/src/utils/wasmCompressor/wasmLoader.js
@@ -70,7 +70,7 @@ export function formatBytes(bytes, decimals = 2) {
   if (bytes === 0) return "0 Bytes";
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ["Bytes", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }


### PR DESCRIPTION
## Summary

`formatBytes` in `src/utils/wasmCompressor/wasmLoader.js` had only 4 size units (`Bytes, KB, MB, GB`). For `bytes >= 1024^4` (1 TB), the computed index was `4` and `sizes[4]` was `undefined`, producing output like `"1.00 undefined"`. The index was also unclamped for anything larger.

## Changes

- Added `"TB"` to the sizes array.
- Clamped the index with `Math.min(..., sizes.length - 1)` so any larger value falls back to TB.

## Verification

```js
formatBytes(1024 ** 4) // => "1 TB" (previously "1.00 undefined")
formatBytes(1024 ** 5) // => "1024 TB" (clamped)
formatBytes(0)         // => "0 Bytes"
```

Closes #18115
