### PR TITLE
fix(utils): detect DST correctly in both hemispheres (#18116)

### DIFF
--- a/src/utils/timezoneUtils.js
+++ b/src/utils/timezoneUtils.js
@@ -216,25 +216,36 @@ export const getTimezoneOffsetInfo = (date = new Date(), timezone = getUserTimez
     const h = String(Math.floor(absMinutes / 60)).padStart(2, '0');
     const m = String(absMinutes % 60).padStart(2, '0');
 
-    // Heuristic DST check: compare current offset against January offset for the same timezone
+    // Heuristic DST check: compare the current offset against both the January
+    // and July offsets for the same timezone. DST always uses the larger offset,
+    // so the standard offset is the smaller of the two. This works for both
+    // northern-hemisphere (DST in July) and southern-hemisphere (DST in January)
+    // timezones.
     const janDate = new Date(targetDate.getFullYear(), 0, 1);
-    const janParts = Object.fromEntries(
-      formatter.formatToParts(janDate).map((p) => [p.type, p.value])
-    );
-    const janWallUtc = Date.UTC(
-      parseInt(janParts.year, 10),
-      parseInt(janParts.month, 10) - 1,
-      parseInt(janParts.day, 10),
-      parseInt(janParts.hour, 10) % 24,
-      parseInt(janParts.minute, 10)
-    );
-    const janOffset = Math.round((janWallUtc - janDate.getTime()) / 60000);
+    const julDate = new Date(targetDate.getFullYear(), 6, 1);
+    const offsetFor = (date) => {
+      const parts = Object.fromEntries(
+        formatter.formatToParts(date).map((p) => [p.type, p.value])
+      );
+      const wallUtc = Date.UTC(
+        parseInt(parts.year, 10),
+        parseInt(parts.month, 10) - 1,
+        parseInt(parts.day, 10),
+        parseInt(parts.hour, 10) % 24,
+        parseInt(parts.minute, 10)
+      );
+      return Math.round((wallUtc - date.getTime()) / 60000);
+    };
+    const janOffset = offsetFor(janDate);
+    const julOffset = offsetFor(julDate);
+    const standardOffset = Math.min(janOffset, julOffset);
+    const isDSTActive = offsetMinutes !== standardOffset;
 
     return {
       offsetMinutes,
       formattedOffset: `UTC${sign}${h}:${m}`,
       timeZoneName: parts.timeZoneName || timezone,
-      isDST: offsetMinutes !== janOffset,
+      isDST: janOffset !== julOffset && isDSTActive,
     };
   } catch {
     return {


### PR DESCRIPTION
## Summary

`getTimezoneOffsetInfo` detected DST by comparing the current offset against the **January** offset, assuming January is always standard time. For southern-hemisphere zones (e.g. `Australia/Sydney`, DST +11 in Jan, standard +10 in Jul) the result was inverted: `isDST` returned `true` in July during standard time and `false` in January during actual DST.

## Changes

- Compare the current offset against **both** the January and July offsets.
- The standard offset is the smaller of the two (DST always advances the clock), and `isDST` is true only when the current offset differs from the standard offset.
- Guard with `janOffset !== julOffset` so timezones without DST (e.g. `Asia/Kolkata`) always report `false`.

## Verification

```js
America/New_York  Jan offset -300 isDST false | Jul offset -240 isDST true
Australia/Sydney  Jan offset  660 isDST true  | Jul offset  600 isDST false
Asia/Kolkata      Jan offset  330 isDST false | Jul offset  330 isDST false
Europe/London     Jan offset    0 isDST false | Jul offset   60 isDST true
```

Closes #18116
