### PR TITLE
fix(utils): build calendar dates in local time (#18148)

### DIFF
--- a/src/utils/calendarUtils.js
+++ b/src/utils/calendarUtils.js
@@ -34,7 +34,8 @@ export const generateGoogleCalendarUrl = (eventData) => {
   if (eventData.startTime) {
     // If we have a start time, combine date and time
     const [hours, minutes] = eventData.startTime.split(":");
-    const startDate = new Date(eventData.startDate);
+    const [y, mo, d] = eventData.startDate.split("-").map(Number);
+    const startDate = new Date(y, mo - 1, d);
     startDate.setHours(parseInt(hours), parseInt(minutes), 0);
     startDateTime = startDate.toISOString().replace(/-|:|\.\d+/g, "");
   } else {
@@ -47,7 +48,8 @@ export const generateGoogleCalendarUrl = (eventData) => {
     if (eventData.endTime) {
       // If we have an end time, combine date and time
       const [hours, minutes] = eventData.endTime.split(":");
-      const endDate = new Date(eventData.endDate);
+      const [y, mo, d] = eventData.endDate.split("-").map(Number);
+      const endDate = new Date(y, mo - 1, d);
       endDate.setHours(parseInt(hours), parseInt(minutes), 0);
       endDateTime = endDate.toISOString().replace(/-|:|\.\d+/g, "");
     } else {


### PR DESCRIPTION
## Summary

`generateGoogleCalendarUrl` parsed `"YYYY-MM-DD"` with `new Date(...)` (UTC midnight) but applied `setHours(...)` in the **local** timezone, then serialized with `toISOString()` back to UTC. For users west of UTC this shifts the event to the wrong day (e.g. a `2026-05-25` event created for a PDT user landed on `2026-05-24T17:00Z`).

## Changes

- Parse the date components explicitly with `new Date(y, mo - 1, d)` so the wall-clock time the user enters is interpreted in local time for both the start and end blocks.

## Verification

```js
// America/Los_Angeles
original: 2026-05-24T17:00:00Z  // wrong day
fixed:    2026-05-25T17:00:00Z  // May 25 10:00 local, as entered
```

Closes #18148
