### PR TITLE
fix(utils): emit real timezone offsets in the ICS VTIMEZONE block (#18149)

### DIFF
--- a/src/utils/calendarExportIcs.js
+++ b/src/utils/calendarExportIcs.js
@@ -2,14 +2,26 @@
  * Export Event Schedule to ICS Format with VTIMEZONE and DST boundary support.
  */
 
+import { getTimezoneOffsetInfo } from "./timezoneUtils.js";
+
+const formatOffset = (offsetMinutes) => {
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absMinutes = Math.abs(offsetMinutes);
+  const hh = String(Math.floor(absMinutes / 60)).padStart(2, "0");
+  const mm = String(absMinutes % 60).padStart(2, "0");
+  return `${sign}${hh}${mm}`;
+};
+
 export function buildVTimezoneBlock(tz = "UTC") {
+  const standard = getTimezoneOffsetInfo(new Date(), tz);
+  const offset = formatOffset(standard.offsetMinutes);
   return `BEGIN:VTIMEZONE
 TZID:${tz}
 X-LIC-LOCATION:${tz}
 BEGIN:STANDARD
-TZOFFSETFROM:+0000
-TZOFFSETTO:+0000
-TZNAME:UTC
+TZOFFSETFROM:${offset}
+TZOFFSETTO:${offset}
+TZNAME:${standard.timeZoneName || tz}
 DTSTART:19700101T000000
 END:STANDARD
 END:VTIMEZONE`;


### PR DESCRIPTION
## Summary

`buildVTimezoneBlock` always emitted `TZOFFSETFROM:+0000 / TZOFFSETTO:+0000 / TZNAME:UTC` regardless of the `tz` argument. Non-UTC calendars imported events at the wrong time (calendar clients resolve the declared offsets against the actual timezone).

## Changes

- Compute the timezone's real offset via `getTimezoneOffsetInfo` from `timezoneUtils.js` and emit it in the VTIMEZONE block.
- Use the timezone name from the runtime as `TZNAME`.

## Verification

```js
buildVTimezoneBlock('America/New_York')  // TZOFFSETFROM:-0400 TZOFFSETTO:-0400 TZNAME:EDT
buildVTimezoneBlock('Asia/Kolkata')      // TZOFFSETFROM:+0530 TZOFFSETTO:+0530
```

Closes #18149
