### PR TITLE
fix(utils): format same-day durations in hours and minutes (#18150)

### DIFF
--- a/src/utils/eventDurationUtils.js
+++ b/src/utils/eventDurationUtils.js
@@ -15,12 +15,21 @@ export const getEventDuration = (event) => {
     return "";
   }
 
-  const diffDays = Math.ceil(
-    (endDate - startDate) / (1000 * 60 * 60 * 24)
-  );
+  const diffMs = endDate - startDate;
+  const diffMinutes = Math.round(diffMs / (1000 * 60));
 
-  if (diffDays <= 1) return "1 Day";
-  if (diffDays < 7) return `${diffDays} Days`;
+  if (diffMinutes <= 0) return "0 Minutes";
+
+  if (diffMinutes < 24 * 60) {
+    const hours = Math.floor(diffMinutes / 60);
+    const minutes = diffMinutes % 60;
+    if (hours === 0) return `${minutes} Minute${minutes > 1 ? "s" : ""}`;
+    if (minutes === 0) return `${hours} Hour${hours > 1 ? "s" : ""}`;
+    return `${hours} Hour${hours > 1 ? "s" : ""} ${minutes} Minute${minutes > 1 ? "s" : ""}`;
+  }
+
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays < 7) return `${diffDays} Day${diffDays > 1 ? "s" : ""}`;
 
   const weeks = Math.ceil(diffDays / 7);
   return `${weeks} Week${weeks > 1 ? "s" : ""}`;


### PR DESCRIPTION
## Summary

`getEventDuration` used `Math.ceil` on the day difference with a `diffDays <= 1 → "1 Day"` shortcut, so same-day events (2 hours ≈ 0.08 days) and zero-duration events were both labeled "1 Day".

## Changes

- Compute the difference in minutes first.
- Return `"0 Minutes"` for zero-length events.
- For durations under 24h, format as hours/minutes (e.g. `"2 Hours"`, `"30 Minutes"`, `"1 Hour 30 Minutes"`).
- Days/weeks are only used when the event actually spans multiple days.

## Verification

```js
same start/end  => "0 Minutes"
2 hours         => "2 Hours"
30 minutes      => "30 Minutes"
1.5 hours       => "1 Hour 30 Minutes"
3 days          => "3 Days"
9 days          => "2 Weeks"
```

Closes #18150
