### PR TITLE
fix(components): fire onExpired once when the reservation expires (#18151)

### DIFF
--- a/src/components/registration/RegistrationCapacityReservation.js
+++ b/src/components/registration/RegistrationCapacityReservation.js
@@ -191,19 +191,6 @@ const RegistrationCapacityReservation = ({
     onExpired,
   ]);
 
-  useEffect(() => {
-    if (
-      reserved &&
-      remainingSeconds === 0
-    ) {
-      onExpired?.();
-    }
-  }, [
-    reserved,
-    remainingSeconds,
-    onExpired,
-  ]);
-
   const progress = reserved
     ? Math.max(
         0,


### PR DESCRIPTION
## Summary

`RegistrationCapacityReservation.js` had two `useEffect` blocks that both fired `onExpired` when the timer reached zero — once via the countdown effect (`remainingSeconds <= 0` → `setReserved(false)` + `onExpired?.()`) and a second time via a separate effect watching `reserved && remainingSeconds === 0`. Because `reserved` is still `true` in that render cycle, `onExpired` fired **twice**.

## Changes

- Removed the redundant second effect. The countdown effect already handles expiry (line 170-174), so `onExpired` now fires exactly once.

## Verification

- `onExpired` is referenced only at the single call site inside the countdown effect.
- Consumers releasing the server-side reservation on expiry will now fire one release.

Closes #18151
