### PR TITLE
fix(utils): validate event start for 12-hour times (#18152)

### DIFF
--- a/src/utils/eventFormValidation.js
+++ b/src/utils/eventFormValidation.js
@@ -1,4 +1,5 @@
 import { parseTimeToMinutes } from "./eventCreationUtils";
+import { parseTimeString } from "./timezoneUtils.js";
 export const validateForm = (formData) => {
   const newErrors = {};
 
@@ -63,7 +64,11 @@ export const validateForm = (formData) => {
     // Normalize date to YYYY-MM-DD format before combining with time
     const rawDate = formData.isMultiDay ? formData.startDate : formData.date;
     const dateStr = rawDate?.includes("T") ? rawDate.split("T")[0] : rawDate;
-    const eventStart = new Date(`${dateStr}T${formData.startTime}`);
+    const parsedTime = parseTimeString(formData.startTime);
+    const eventStart =
+      parsedTime && dateStr
+        ? new Date(dateStr + "T" + String(parsedTime.hours).padStart(2, "0") + ":" + String(parsedTime.minutes).padStart(2, "0"))
+        : new Date(`${dateStr}T${formData.startTime}`);
 
     if (registrationStart && isNaN(registrationStart.getTime())) {
       newErrors.registrationStart = "Invalid registration start date";


### PR DESCRIPTION
## Summary

`validateEventForm` built the event start as `new Date(\`${dateStr}T${formData.startTime}\`)`. For the app's standard 12-hour times (e.g. `"10:00 AM"`), this yields **Invalid Date**, so the `!isNaN(eventStart.getTime())` guards silently skipped the "registration must close before the event starts" checks for the format the UI actually produces.

## Changes

- Normalize `startTime` with `parseTimeString` (the same helper the rest of the app uses), then build a `HH:mm` datetime string so `new Date(...)` is valid for both 12-hour and 24-hour inputs.

## Verification

- `validateForm` now emits `"Registration start must be before the event starts"` / `"Registration must close before the event starts"` identically for `10:00 AM` and `10:00` inputs (previously the 12-hour input produced no such error).

Closes #18152
