### PR TITLE
fix(kit): count entries in countMap (#18162)

### DIFF
--- a/src/eventra-kit/__tests__/count-map.test.js
+++ b/src/eventra-kit/__tests__/count-map.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountMap from '../count-map.js';
+import { countMap } from '../count-map.js';
 
 describe('count-map', () => {
-  it('exports a module', () => {
-    expect(CountMap).toBeDefined();
+  it('counts entries in a map or object', () => {
+    expect(countMap({ a: 1, b: 2 })).toBe(2);
+    expect(countMap(new Map([['a', 1], ['b', 2]]))).toBe(2);
+    expect(countMap({})).toBe(0);
   });
 });
-

--- a/src/eventra-kit/count-map.js
+++ b/src/eventra-kit/count-map.js
@@ -2,6 +2,9 @@
  * adds a count-map helper.
  */
 export function countMap(value) {
-  return value.trim();
+  if (value == null) return 0;
+  if (value instanceof Map) return value.size;
+  if (typeof value === 'object') return Object.keys(value).length;
+  return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18162

`countMap` now returns the number of entries in a plain object or `Map`, instead of throwing a `TypeError` by calling `.trim()`.

## Changes

- `src/eventra-kit/count-map.js`: count entries for objects and `Map` instances
- `src/eventra-kit/__tests__/count-map.test.js`: add behavior tests

## Test

```js
countMap({ a: 1, b: 2 }) // 2
countMap(new Map([['a', 1], ['b', 2]])) // 2
countMap({}) // 0
```

## GSSOC
