### PR TITLE
fix(kit): count properties in countProp (#18163)

### DIFF
--- a/src/eventra-kit/__tests__/count-prop.test.js
+++ b/src/eventra-kit/__tests__/count-prop.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as CountProp from '../count-prop.js';
+import { countProp } from '../count-prop.js';
 
 describe('count-prop', () => {
-  it('exports a module', () => {
-    expect(CountProp).toBeDefined();
+  it('counts the properties of an object', () => {
+    expect(countProp({ a: 1, b: 2, c: 3 })).toBe(3);
+    expect(countProp({})).toBe(0);
   });
 });
-

--- a/src/eventra-kit/count-prop.js
+++ b/src/eventra-kit/count-prop.js
@@ -2,6 +2,7 @@
  * adds a count-prop helper.
  */
 export function countProp(value) {
-  return String(value).padStart(10, '0');
+  if (value == null) return 0;
+  return Object.keys(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18163

`countProp` now returns the number of own properties of an object, instead of a zero-padded string of the object.

## Changes

- `src/eventra-kit/count-prop.js`: count own properties via `Object.keys`
- `src/eventra-kit/__tests__/count-prop.test.js`: add behavior tests

## Test

```js
countProp({ a: 1, b: 2, c: 3 }) // 3
countProp({}) // 0
```

## GSSOC
