### PR TITLE
fix(utils): include sourceEvent on conflict objects (#18153)

### DIFF
--- a/src/utils/scheduleConflictUtils.js
+++ b/src/utils/scheduleConflictUtils.js
@@ -362,6 +362,9 @@ export const detectScheduleConflict = (
         registeredEvent
       ),
 
+    sourceEvent:
+      newEvent,
+
     event:
       registeredEvent,
 


### PR DESCRIPTION
## Summary

`filterConflictsBySeverity` read `conflict.sourceEvent`, but `detectScheduleConflict` never set that field — conflict objects only carried `{ eventId, event, overlap, message }`. So `sourceEvent` was always `{}`, `getConflictSeverity` always returned `"none"`, and filtering for `"severe"`/`"moderate"` always returned an empty list.

## Changes

- Added `sourceEvent: newEvent` to the conflict object returned by `detectScheduleConflict`, so severity can be computed from the candidate and the conflicting event.

## Verification

```js
const conflicts = findScheduleConflicts(newEvent, [overlapping]);
conflicts[0].sourceEvent           // the new event (previously undefined)
filterConflictsBySeverity(conflicts, 'moderate').length  // 1 (previously 0)
filterConflictsBySeverity(conflicts, 'none').length      // 0
```

Closes #18153
