### PR TITLE
fix(kit): calculate pages in calculatePage (#18165)

### DIFF
--- a/src/eventra-kit/__tests__/calculate-page.test.js
+++ b/src/eventra-kit/__tests__/calculate-page.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CalculatePage from '../calculate-page.js';
+import { calculatePage } from '../calculate-page.js';
 
 describe('calculate-page', () => {
-  it('exports a module', () => {
-    expect(CalculatePage).toBeDefined();
+  it('calculates the number of pages', () => {
+    expect(calculatePage(10, 3)).toBe(4);
+    expect(calculatePage(9, 3)).toBe(3);
+    expect(calculatePage(0, 3)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/calculate-page.js
+++ b/src/eventra-kit/calculate-page.js
@@ -1,7 +1,8 @@
 /**
  * adds a calculate-page helper.
  */
-export function calculatePage(value) {
-  return value.trim();
+export function calculatePage(totalItems, perPage) {
+  const size = Number(perPage) > 0 ? Number(perPage) : 1;
+  return Math.max(0, Math.ceil(totalItems / size));
 }
 


### PR DESCRIPTION
## Summary

Fixes #18165

`calculatePage` now returns the number of pages needed to show `totalItems` items at `perPage` per page, instead of throwing a `TypeError`.

## Changes

- `src/eventra-kit/calculate-page.js`: compute `Math.ceil(totalItems / perPage)`
- `src/eventra-kit/__tests__/calculate-page.test.js`: add behavior tests

## Test

```js
calculatePage(10, 3) // 4
calculatePage(9, 3) // 3
calculatePage(0, 3) // 0
```

## GSSOC
