### PR TITLE
fix(components): base waitlist status on queue ratio (#18154)

### DIFF
--- a/src/components/registration/RegistrationWaitlistPosition.js
+++ b/src/components/registration/RegistrationWaitlistPosition.js
@@ -326,10 +326,6 @@ const getEstimatedStatus = (
   const ratio =
     position / total;
 
-  if (position <= 3) {
-    return "high";
-  }
-
   if (ratio <= 0.25) {
     return "high";
   }


### PR DESCRIPTION
## Summary

`getEstimatedStatus` short-circuited with `if (position <= 3) return "high"` **before** checking the queue ratio, so on a small waitlist a user far back in the queue was labeled "high chance". Example: total = 4, position = 3 → ratio 0.75 but reported "high". It also made the ratio checks below unreachable for the first three positions regardless of total.

## Changes

- Removed the position-based short-circuit. Status is now derived solely from the position/total ratio:
  - `<= 0.25` → high
  - `<= 0.6` → medium
  - otherwise → low

## Verification

- total=4: position 1 → high, position 2 → medium, position 3 → low (was "high" before).
- total=100: position 10 → high, position 40 → medium, position 90 → low (unchanged from before for large queues).

Closes #18154
