### PR TITLE
fix(kit): extract dictionary values in extractDict (#18167)

### DIFF
--- a/src/eventra-kit/__tests__/extract-dict.test.js
+++ b/src/eventra-kit/__tests__/extract-dict.test.js
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import * as ExtractDict from '../extract-dict.js';
+import { extractDict } from '../extract-dict.js';
 
 describe('extract-dict', () => {
-  it('exports a module', () => {
-    expect(ExtractDict).toBeDefined();
+  it('extracts the values of a dictionary', () => {
+    expect(extractDict({ a: 1, b: 2 })).toEqual([1, 2]);
   });
 });
-

--- a/src/eventra-kit/extract-dict.js
+++ b/src/eventra-kit/extract-dict.js
@@ -1,7 +1,10 @@
 /**
  * adds a extract-dict helper.
  */
-export function extractDict(value, separator) {
-  return value.split(separator);
+export function extractDict(value) {
+  if (value == null) return [];
+  if (value instanceof Map) return [...value.values()];
+  if (typeof value === 'object') return Object.values(value);
+  return [];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18167

`extractDict` now returns the values of an object or `Map` as an array, instead of throwing a `TypeError` by calling `.split()`.

## Changes

- `src/eventra-kit/extract-dict.js`: return `Object.values` for objects and `Map` values
- `src/eventra-kit/__tests__/extract-dict.test.js`: add behavior tests

## Test

```js
extractDict({ a: 1, b: 2 }) // [1, 2]
```

## GSSOC
