### PR TITLE
fix(utils): stop hardcoding en-IN in reminder dates (#18155)

### DIFF
--- a/src/utils/eventReminderUtils.js
+++ b/src/utils/eventReminderUtils.js
@@ -332,7 +332,7 @@ export const formatReminderDateTime = (
   }
 
   return parsedDate.toLocaleString(
-    "en-IN",
+    undefined,
     {
       day: "2-digit",
       month: "short",


### PR DESCRIPTION
## Summary

`formatReminderDateTime` forced `toLocaleString("en-IN", ...)`, so every user saw dates in Indian-English formatting (e.g. "25 May 2026, 03:30 pm") regardless of their browser locale. For a US user the month/day order and 24h markers were surprising and inconsistent with the rest of the app.

## Changes

- Pass `undefined` as the locale so the runtime uses the user's browser locale (falling back to `en-US`), matching how the rest of the UI formats dates.

## Verification

- `formatReminderDateTime("2026-05-25T10:00:00Z")` now renders in the host locale instead of always `en-IN`.

Closes #18155
