### PR TITLE
fix(kit): split string into list in buildList (#18168)

### DIFF
--- a/src/eventra-kit/__tests__/build-list.test.js
+++ b/src/eventra-kit/__tests__/build-list.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as BuildList from '../build-list.js';
+import { buildList } from '../build-list.js';
 
 describe('build-list', () => {
-  it('exports a module', () => {
-    expect(BuildList).toBeDefined();
+  it('splits a string into a list', () => {
+    expect(buildList('a,b,c', ',')).toEqual(['a', 'b', 'c']);
+    expect(buildList('x y z')).toEqual(['x', 'y', 'z']);
   });
 });
-

--- a/src/eventra-kit/build-list.js
+++ b/src/eventra-kit/build-list.js
@@ -1,7 +1,7 @@
 /**
  * adds a build-list helper.
  */
-export function buildList(value) {
-  return value.split(' ').filter(Boolean).length;
+export function buildList(text, separator = ' ') {
+  return String(text).split(separator);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18168

`buildList` now returns the string split into a list of items by the given separator, instead of returning a word count.

## Changes

- `src/eventra-kit/build-list.js`: split the string by the separator
- `src/eventra-kit/__tests__/build-list.test.js`: add behavior tests

## Test

```js
buildList('a,b,c', ',') // ['a', 'b', 'c']
buildList('x y z') // ['x', 'y', 'z']
```

## GSSOC
