### PR TITLE
fix(backend): authorize check-in history and ticket stats (#18156)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TicketController.java
@@ -207,9 +207,13 @@ public class TicketController {
                               "time": "2026-08-12T10:00:00"}]"""))),
             @ApiResponse(responseCode = "403", description = "Forbidden - organizer/admin access required")
     })
-    public ResponseEntity<List<Map<String, Object>>> checkInHistory(@RequestParam(required = false) Long eventId) {
+    public ResponseEntity<List<Map<String, Object>>> checkInHistory(Authentication authentication,
+            @RequestParam(required = false) Long eventId) {
         if (eventId == null) {
             return ResponseEntity.ok(List.of());
+        }
+        if (!isAuthorizedForEvent(eventId, authentication)) {
+            return forbiddenList();
         }
         List<Map<String, Object>> entries = ticketCheckInRepository
                 .findByEventIdOrderByCheckedInAtDesc(eventId)
@@ -242,9 +246,13 @@ public class TicketController {
                              "remainingAttendees": 55, "attendancePercentage": 45}"""))),
             @ApiResponse(responseCode = "403", description = "Forbidden - organizer/admin access required")
     })
-    public ResponseEntity<Map<String, Object>> ticketStats(@RequestParam(required = false) Long eventId) {
+    public ResponseEntity<Map<String, Object>> ticketStats(Authentication authentication,
+            @RequestParam(required = false) Long eventId) {
         if (eventId == null) {
             return ResponseEntity.ok(emptyStats());
+        }
+        if (!isAuthorizedForEvent(eventId, authentication)) {
+            return forbidden();
         }
         long total = eventRegistrationRepository.countByEvent_IdAndStatus(eventId, "CONFIRMED");
         long checkedIn = ticketCheckInRepository.countByEventId(eventId);
@@ -296,6 +304,10 @@ public class TicketController {
         response.put("valid", false);
         response.put("message", "You are not authorized to manage this event.");
         return ResponseEntity.status(403).body(response);
+    }
+
+    private ResponseEntity<List<Map<String, Object>>> forbiddenList() {
+        return ResponseEntity.status(403).body(List.of());
     }
 
     private String displayName(EventRegistration reg) {


### PR DESCRIPTION
## Summary

`GET /checkins` (`checkInHistory`) and `GET /stats` (`ticketStats`) returned event data to **any authenticated user** for any eventId — they never checked whether the caller organizes the event. `validateTicket` and `checkIn` already enforce this via `isAuthorizedForEvent(...)`.

## Changes

- Added `Authentication` parameter to both endpoints and guarded them with the existing `isAuthorizedForEvent(eventId, authentication)` check.
- Unauthorized callers now receive `403` (empty list for `checkInHistory` via the new `forbiddenList()` helper; the existing `forbidden()` map for `ticketStats`).

## Verification

- Matches the authorization pattern already used at `validateTicket` (L87) and `checkIn` (L147).
- No new imports needed (`Authentication` already imported).

Closes #18156
