### PR TITLE
fix(kit): chunk arrays in chunkJson (#18169)

### DIFF
--- a/src/eventra-kit/__tests__/chunk-json.test.js
+++ b/src/eventra-kit/__tests__/chunk-json.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as ChunkJson from '../chunk-json.js';
+import { chunkJson } from '../chunk-json.js';
 
 describe('chunk-json', () => {
-  it('exports a module', () => {
-    expect(ChunkJson).toBeDefined();
+  it('splits an array into chunks', () => {
+    expect(chunkJson([1, 2, 3, 4], 2)).toEqual([[1, 2], [3, 4]]);
+    expect(chunkJson([1, 2, 3], 2)).toEqual([[1, 2], [3]]);
   });
 });
-

--- a/src/eventra-kit/chunk-json.js
+++ b/src/eventra-kit/chunk-json.js
@@ -1,7 +1,13 @@
 /**
  * adds a chunk-json helper.
  */
-export function chunkJson(value, separator) {
-  return value.split(separator);
+export function chunkJson(array, size) {
+  if (!Array.isArray(array)) return [];
+  if (!Number.isInteger(size) || size < 1) throw new TypeError('size must be a positive integer');
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18169

`chunkJson` now splits an array into smaller arrays of the given size, instead of throwing a `TypeError` by calling `.split()`.

## Changes

- `src/eventra-kit/chunk-json.js`: chunk the array by `size`
- `src/eventra-kit/__tests__/chunk-json.test.js`: add behavior tests

## Test

```js
chunkJson([1, 2, 3, 4], 2) // [[1, 2], [3, 4]]
chunkJson([1, 2, 3], 2) // [[1, 2], [3]]
```

## GSSOC
