### PR TITLE
fix(kit): dedupe arrays in dedupeGroup (#18170)

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-group.test.js
+++ b/src/eventra-kit/__tests__/dedupe-group.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as DedupeGroup from '../dedupe-group.js';
+import { dedupeGroup } from '../dedupe-group.js';
 
 describe('dedupe-group', () => {
-  it('exports a module', () => {
-    expect(DedupeGroup).toBeDefined();
+  it('removes duplicate values', () => {
+    expect(dedupeGroup([1, 1, 2])).toEqual([1, 2]);
+    expect(dedupeGroup(['a', 'b', 'a'])).toEqual(['a', 'b']);
   });
 });
-

--- a/src/eventra-kit/dedupe-group.js
+++ b/src/eventra-kit/dedupe-group.js
@@ -1,7 +1,8 @@
 /**
  * adds a dedupe-group helper.
  */
-export function dedupeGroup(value, separator) {
-  return value.split(separator);
+export function dedupeGroup(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18170

`dedupeGroup` now returns an array with duplicate values removed, instead of throwing a `TypeError` by calling `.split()`.

## Changes

- `src/eventra-kit/dedupe-group.js`: dedupe via `Set`
- `src/eventra-kit/__tests__/dedupe-group.test.js`: add behavior tests

## Test

```js
dedupeGroup([1, 1, 2]) // [1, 2]
dedupeGroup(['a', 'b', 'a']) // ['a', 'b']
```

## GSSOC
