### PR TITLE
fix(backend): return 400 for invalid phone numbers (#18157)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
@@ -109,11 +109,20 @@ public class ValidationController {
     }
 
     @PostMapping("/phone")
-    @Operation(summary = "Validate phone number format")
+    @Operation(
+            summary = "Validate phone number format",
+            description = "Rejects malformed phone numbers with 400 Bad Request."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Validation succeeded",
+                    content = @Content(schema = @Schema(implementation = ValidationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid phone number format",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public ResponseEntity<?> validatePhone(@RequestBody PhoneRequest request) {
         String phone = request.getPhone();
         if (phone == null || !PHONE_PATTERN.matcher(phone).matches()) {
-            return ResponseEntity.ok(Map.of("valid", false, "message", "Phone number is invalid"));
+            return ResponseEntity.badRequest().body(buildError("Invalid phone number format", "/api/validate/phone"));
         }
         return ResponseEntity.ok(Map.of("valid", true));
     }


### PR DESCRIPTION
## Summary

`validatePhone` returned HTTP `200` with `{ "valid": false }` for malformed input, while the sibling `validateEmail` and `validateUsername` endpoints return `400 Bad Request` with an `ErrorResponse` body. Clients treating any non-2xx as a hard failure would accept invalid phone numbers.

## Changes

- Invalid phone input now returns `400 Bad Request` via the same `buildError(...)` helper used by `validateEmail`/`validateUsername` (so the response shape is consistent across all three endpoints).
- Valid input still returns `200` with `{ "valid": true }`.

## Verification

- Matches the error contract documented on the sibling endpoints (`400` → `ErrorResponse`).
- No behavior change for valid numbers.

Closes #18157
