### PR TITLE
fix(kit): join path segments in createPath (#18188)

### DIFF
--- a/src/eventra-kit/__tests__/create-path.test.js
+++ b/src/eventra-kit/__tests__/create-path.test.js
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import * as CreatePath from '../create-path.js';
+import { createPath } from '../create-path.js';
 
 describe('create-path', () => {
-  it('exports a module', () => {
-    expect(CreatePath).toBeDefined();
+  it('joins path segments', () => {
+    expect(createPath(['a', 'b'])).toBe('a/b');
   });
 });
-

--- a/src/eventra-kit/create-path.js
+++ b/src/eventra-kit/create-path.js
@@ -1,7 +1,7 @@
 /**
  * adds a create-path helper.
  */
-export function createPath(value, target) {
-  return value.indexOf(target);
+export function createPath(parts) {
+  return Array.isArray(parts) ? parts.join('/') : String(parts);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18188

`createPath` now joins the given path segments into a path string, instead of returning `-1`.

## Changes

- `src/eventra-kit/create-path.js`: join segments with `/`
- `src/eventra-kit/__tests__/create-path.test.js`: add behavior tests

## Test

```js
createPath(['a', 'b']) // 'a/b'
```

## GSSOC
