### PR TITLE
fix(kit): extract URL path in extractPath (#18189)

### DIFF
--- a/src/eventra-kit/__tests__/extract-path.test.js
+++ b/src/eventra-kit/__tests__/extract-path.test.js
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import * as ExtractPath from '../extract-path.js';
+import { extractPath } from '../extract-path.js';
 
 describe('extract-path', () => {
-  it('exports a module', () => {
-    expect(ExtractPath).toBeDefined();
+  it('extracts the path from a URL', () => {
+    expect(extractPath('https://x.com/a/b?q=1')).toBe('/a/b');
   });
 });
-

--- a/src/eventra-kit/extract-path.js
+++ b/src/eventra-kit/extract-path.js
@@ -1,7 +1,11 @@
 /**
  * adds a extract-path helper.
  */
-export function extractPath(value, target) {
-  return value.indexOf(target);
+export function extractPath(value) {
+  try {
+    return new URL(String(value)).pathname;
+  } catch {
+    return '';
+  }
 }
 


### PR DESCRIPTION
## Summary

Fixes #18189

`extractPath` now returns the pathname of a URL, instead of returning `-1`.

## Changes

- `src/eventra-kit/extract-path.js`: return the URL pathname
- `src/eventra-kit/__tests__/extract-path.test.js`: add behavior tests

## Test

```js
extractPath('https://x.com/a/b?q=1') // '/a/b'
```

## GSSOC
