### PR TITLE
fix(kit): count collection length in countLength (#18190)

### DIFF
--- a/src/eventra-kit/__tests__/count-length.test.js
+++ b/src/eventra-kit/__tests__/count-length.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountLength from '../count-length.js';
+import { countLength } from '../count-length.js';
 
 describe('count-length', () => {
-  it('exports a module', () => {
-    expect(CountLength).toBeDefined();
+  it('counts the length of strings, arrays, and objects', () => {
+    expect(countLength('hello')).toBe(5);
+    expect(countLength([1, 2, 3])).toBe(3);
+    expect(countLength({ a: 1 })).toBe(1);
   });
 });
-

--- a/src/eventra-kit/count-length.js
+++ b/src/eventra-kit/count-length.js
@@ -1,7 +1,10 @@
 /**
  * adds a count-length helper.
  */
-export function countLength(value, target) {
-  return value.indexOf(target);
+export function countLength(value) {
+  if (value == null) return 0;
+  if (typeof value === 'string' || Array.isArray(value)) return value.length;
+  if (typeof value === 'object') return Object.keys(value).length;
+  return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18190

`countLength` now returns the length of strings, arrays, and objects, instead of returning `-1`.

## Changes

- `src/eventra-kit/count-length.js`: return the length of the collection
- `src/eventra-kit/__tests__/count-length.test.js`: add behavior tests

## Test

```js
countLength('hello') // 5
countLength([1, 2, 3]) // 3
countLength({ a: 1 }) // 1
```

## GSSOC
