### PR TITLE
fix(kit): estimate collection length in estimateLength (#18191)

### DIFF
--- a/src/eventra-kit/__tests__/estimate-length.test.js
+++ b/src/eventra-kit/__tests__/estimate-length.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as EstimateLength from '../estimate-length.js';
+import { estimateLength } from '../estimate-length.js';
 
 describe('estimate-length', () => {
-  it('exports a module', () => {
-    expect(EstimateLength).toBeDefined();
+  it('estimates the length of strings, arrays, and objects', () => {
+    expect(estimateLength([1, 2, 3])).toBe(3);
+    expect(estimateLength('hi')).toBe(2);
   });
 });
-

--- a/src/eventra-kit/estimate-length.js
+++ b/src/eventra-kit/estimate-length.js
@@ -1,7 +1,10 @@
 /**
  * adds a estimate-length helper.
  */
-export function estimateLength(value, target) {
-  return value.indexOf(target);
+export function estimateLength(value) {
+  if (value == null) return 0;
+  if (typeof value === 'string' || Array.isArray(value)) return value.length;
+  if (typeof value === 'object') return Object.keys(value).length;
+  return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18191

`estimateLength` now returns the length of strings, arrays, and objects, instead of returning `-1`.

## Changes

- `src/eventra-kit/estimate-length.js`: return the length of the collection
- `src/eventra-kit/__tests__/estimate-length.test.js`: add behavior tests

## Test

```js
estimateLength([1, 2, 3]) // 3
estimateLength('hi') // 2
```

## GSSOC
