### PR TITLE
fix(kit): check record type in checkRecord (#18192)

### DIFF
--- a/src/eventra-kit/__tests__/check-record.test.js
+++ b/src/eventra-kit/__tests__/check-record.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CheckRecord from '../check-record.js';
+import { checkRecord } from '../check-record.js';
 
 describe('check-record', () => {
-  it('exports a module', () => {
-    expect(CheckRecord).toBeDefined();
+  it('checks whether a value is a record', () => {
+    expect(checkRecord({ a: 1 })).toBe(true);
+    expect(checkRecord([1])).toBe(false);
+    expect(checkRecord(null)).toBe(false);
   });
 });
-

--- a/src/eventra-kit/check-record.js
+++ b/src/eventra-kit/check-record.js
@@ -1,7 +1,7 @@
 /**
  * adds a check-record helper.
  */
-export function checkRecord(value, target) {
-  return value.indexOf(target);
+export function checkRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18192

`checkRecord` now returns a boolean indicating whether the value is a record (a plain object), instead of throwing a `TypeError`.

## Changes

- `src/eventra-kit/check-record.js`: check for a non-null object that is not an array
- `src/eventra-kit/__tests__/check-record.test.js`: add behavior tests

## Test

```js
checkRecord({ a: 1 }) // true
checkRecord([1]) // false
checkRecord(null) // false
```

## GSSOC
