### PR TITLE
fix(kit): count numeric values in countNumber (#18193)

### DIFF
--- a/src/eventra-kit/__tests__/count-number.test.js
+++ b/src/eventra-kit/__tests__/count-number.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as CountNumber from '../count-number.js';
+import { countNumber } from '../count-number.js';
 
 describe('count-number', () => {
-  it('exports a module', () => {
-    expect(CountNumber).toBeDefined();
+  it('counts numeric values in an array', () => {
+    expect(countNumber([1, 2, 'x'])).toBe(2);
+    expect(countNumber(['a', 'b'])).toBe(0);
   });
 });
-

--- a/src/eventra-kit/count-number.js
+++ b/src/eventra-kit/count-number.js
@@ -1,7 +1,8 @@
 /**
  * adds a count-number helper.
  */
-export function countNumber(value) {
-  return value.split(' ').filter(Boolean).length;
+export function countNumber(array) {
+  if (!Array.isArray(array)) return 0;
+  return array.filter((value) => typeof value === 'number' && Number.isFinite(value)).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18193

`countNumber` now returns the number of numeric values in an array, instead of throwing a `TypeError`.

## Changes

- `src/eventra-kit/count-number.js`: count numeric entries
- `src/eventra-kit/__tests__/count-number.test.js`: add behavior tests

## Test

```js
countNumber([1, 2, 'x']) // 2
countNumber(['a', 'b']) // 0
```

## GSSOC
