### PR TITLE
fix(kit): dedupe records by key in dedupeRecord (#18194)

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-record.test.js
+++ b/src/eventra-kit/__tests__/dedupe-record.test.js
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import * as DedupeRecord from '../dedupe-record.js';
+import { dedupeRecord } from '../dedupe-record.js';
 
 describe('dedupe-record', () => {
-  it('exports a module', () => {
-    expect(DedupeRecord).toBeDefined();
+  it('removes duplicate records by key', () => {
+    expect(dedupeRecord([{ id: 1 }, { id: 1 }, { id: 2 }])).toEqual([{ id: 1 }, { id: 2 }]);
   });
 });
-

--- a/src/eventra-kit/dedupe-record.js
+++ b/src/eventra-kit/dedupe-record.js
@@ -1,7 +1,14 @@
 /**
  * adds a dedupe-record helper.
  */
-export function dedupeRecord(value) {
-  return typeof value === 'string';
+export function dedupeRecord(records, key = 'id') {
+  if (!Array.isArray(records)) return [];
+  const seen = new Set();
+  return records.filter((record) => {
+    const id = record && record[key];
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
 }
 


### PR DESCRIPTION
## Summary

Fixes #18194

`dedupeRecord` now returns records with duplicate keys removed, instead of returning a boolean.

## Changes

- `src/eventra-kit/dedupe-record.js`: dedupe records by key
- `src/eventra-kit/__tests__/dedupe-record.test.js`: add behavior tests

## Test

```js
dedupeRecord([{ id: 1 }, { id: 1 }, { id: 2 }]) // [{ id: 1 }, { id: 2 }]
```

## GSSOC
