### PR TITLE
fix(kit): capitalize sentences in sentenceCase (#18195)

### DIFF
--- a/src/eventra-kit/__tests__/sentence-case.test.js
+++ b/src/eventra-kit/__tests__/sentence-case.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as SentenceCase from '../sentence-case.js';
+import { sentenceCase } from '../sentence-case.js';
 
 describe('sentence-case', () => {
-  it('exports a module', () => {
-    expect(SentenceCase).toBeDefined();
+  it('capitalizes the first letter of every sentence', () => {
+    expect(sentenceCase('hello world. foo')).toBe('Hello world. Foo');
+    expect(sentenceCase('HELLO!')).toBe('Hello!');
   });
 });
-

--- a/src/eventra-kit/sentence-case.js
+++ b/src/eventra-kit/sentence-case.js
@@ -3,6 +3,8 @@
  * adds a sentence case helper.
  */
 export function sentenceCase(text) {
-  return String(text).toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
+  return String(text)
+    .toLowerCase()
+    .replace(/(^|[.!?]\s+)(\w)/g, (match, pre, word) => pre + word.toUpperCase());
 }
 


### PR DESCRIPTION
## Summary

Fixes #18195

`sentenceCase` now capitalizes the first letter of every sentence, instead of only the first character of the whole string.

## Changes

- `src/eventra-kit/sentence-case.js`: capitalize each sentence start
- `src/eventra-kit/__tests__/sentence-case.test.js`: add behavior tests

## Test

```js
sentenceCase('hello world. foo') // 'Hello world. Foo'
sentenceCase('HELLO!') // 'Hello!'
```

## GSSOC
