### PR TITLE
fix(kit): support strings in countOccurrences (#18197)

### DIFF
--- a/src/eventra-kit/__tests__/count-occurrences.test.js
+++ b/src/eventra-kit/__tests__/count-occurrences.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as CountOccurrences from '../count-occurrences.js';
+import { countOccurrences } from '../count-occurrences.js';
 
 describe('count-occurrences', () => {
-  it('exports a module', () => {
-    expect(CountOccurrences).toBeDefined();
+  it('counts occurrences in strings and arrays', () => {
+    expect(countOccurrences('banana', 'a')).toBe(3);
+    expect(countOccurrences([1, 2, 1], 1)).toBe(2);
   });
 });
-

--- a/src/eventra-kit/count-occurrences.js
+++ b/src/eventra-kit/count-occurrences.js
@@ -2,8 +2,9 @@
 /**
  * adds a count helper.
  */
-export function countOccurrences(array, value) {
-  return array.filter(v => v === value).length;
+export function countOccurrences(value, target) {
+  const items = Array.isArray(value) ? value : String(value).split('');
+  return items.filter((v) => v === target).length;
 }
 
 export function countBy(array, keyFn) {


### PR DESCRIPTION
## Summary

Fixes #18197

`countOccurrences` now works with both strings and arrays, instead of throwing a `TypeError` when given a string.

## Changes

- `src/eventra-kit/count-occurrences.js`: support string inputs
- `src/eventra-kit/__tests__/count-occurrences.test.js`: add behavior tests

## Test

```js
countOccurrences('banana', 'a') // 3
countOccurrences([1, 2, 1], 1) // 2
```

## GSSOC
