### PR TITLE
fix(kit): extractDir returns directory part of path

### DIFF
--- a/src/eventra-kit/__tests__/extract-dir.test.js
+++ b/src/eventra-kit/__tests__/extract-dir.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ExtractDir from '../extract-dir.js';
+import { extractDir } from '../extract-dir.js';
 
 describe('extract-dir', () => {
-  it('exports a module', () => {
-    expect(ExtractDir).toBeDefined();
+  it('returns the directory part of a path', () => {
+    expect(extractDir('/home/user/docs/report.txt')).toBe('/home/user/docs');
+    expect(extractDir('a/b/c')).toBe('a/b');
+    expect(extractDir('report.txt')).toBe('');
   });
 });
-

--- a/src/eventra-kit/extract-dir.js
+++ b/src/eventra-kit/extract-dir.js
@@ -1,7 +1,9 @@
 /**
  * adds a extract-dir helper.
  */
-export function extractDir(value, separator) {
-  return value.join(separator);
+export function extractDir(value) {
+  const parts = String(value).split(/[\\/]/);
+  parts.pop();
+  return parts.join('/');
 }
 


### PR DESCRIPTION
## Summary

Fixes #18222

`extractDir` now returns the directory portion of a path instead of calling `.join` on the input.

## Changes

- `src/eventra-kit/extract-dir.js`: return the directory part of a path
- `src/eventra-kit/__tests__/extract-dir.test.js`: add behavior tests

## Test

```js
extractDir('/home/user/docs/report.txt') // '/home/user/docs'
extractDir('a/b/c') // 'a/b'
extractDir('report.txt') // ''
```

## GSSOC
