### PR TITLE
fix(utils): base64url-encode the PKCE code challenge per RFC 7636 (#18213)

### DIFF
--- a/src/utils/exportGoogleSheets.js
+++ b/src/utils/exportGoogleSheets.js
@@ -98,7 +98,10 @@ const createCodeChallenge = async (codeVerifier) => {
     const data = encoder.encode(codeVerifier);
     const hashBuffer = await window.crypto.subtle.digest('SHA-256', data);
     const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    return btoa(String.fromCharCode(...hashArray))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
   }
   // Fallback - not secure, but works in environments without subtle crypto
   return codeVerifier;


### PR DESCRIPTION
## Summary

`createCodeChallenge` returned the SHA-256 digest as a **hex** string, but the flow sends `code_challenge_method=S256`, and RFC 7636 §4.2 requires a **base64url**-encoded digest. Google recomputes `base64url(SHA256(verifier))`, which never matched the hex value, so the token exchange always failed with `invalid_grant` and the Google Sheets export could never authenticate.

## Changes

- Encode the digest as base64url (RFC 4648 §5, without padding) so the challenge matches what the authorization server derives from the verifier.

## Verification

Using the RFC 7636 §4.2 reference verifier `dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk`:

```js
base64url(SHA256(verifier)) === "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"  // matches the spec example
```

The hex encoding previously produced a 64-char hex digest that never matched.

Closes #18213
