### PR TITLE
fix(kit): diffChar computes character difference

### DIFF
--- a/src/eventra-kit/__tests__/diff-char.test.js
+++ b/src/eventra-kit/__tests__/diff-char.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DiffChar from '../diff-char.js';
+import { diffChar } from '../diff-char.js';
 
 describe('diff-char', () => {
-  it('exports a module', () => {
-    expect(DiffChar).toBeDefined();
+  it('computes the numeric difference between two characters', () => {
+    expect(diffChar('a', 'c')).toBe(2);
+    expect(diffChar('c', 'a')).toBe(2);
+    expect(diffChar('a', 'a')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/diff-char.js
+++ b/src/eventra-kit/diff-char.js
@@ -1,7 +1,7 @@
 /**
  * adds a diff-char helper.
  */
-export function diffChar(value) {
-  return typeof value === 'string';
+export function diffChar(a, b) {
+  return Math.abs(String(a).charCodeAt(0) - String(b).charCodeAt(0));
 }
 


### PR DESCRIPTION
## Summary

Fixes #18223

`diffChar` now computes the numeric difference between two characters instead of returning whether the input is a string.

## Changes

- `src/eventra-kit/diff-char.js`: return the absolute character-code difference
- `src/eventra-kit/__tests__/diff-char.test.js`: add behavior tests

## Test

```js
diffChar('a', 'c') // 2
diffChar('c', 'a') // 2
diffChar('a', 'a') // 0
```

## GSSOC
