### PR TITLE
fix(backend): count promoted waitlist entries against capacity (#18214)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1191,7 +1191,12 @@ public class EventService {
                         throw new EventFullException("Event is already full. Capacity: " + event.getCapacity());
                 }
 
-                return promoteEntry(event, entry);
+                RegistrationResponse response = promoteEntry(event, entry);
+                // Mirrors promoteWaitlistAfterVacancy: manual promotion also consumes a seat.
+                event.setRegisteredCount(event.getRegisteredCount() + 1);
+                eventRepository.save(event);
+                broadcastAvailability(event);
+                return response;
         }
 
         /**


### PR DESCRIPTION
## Summary

`promoteWaitlistedUser` promoted a waitlisted entry into a CONFIRMED registration via `promoteEntry` but never incremented `event.registeredCount`, never saved the event, and never broadcast availability. After a manual promotion the count stayed stale, which:
- lets the event oversell (the full-check `registeredCount >= capacity` uses the stale count),
- reports wrong `spotsRemaining` values,
- skips the websocket availability broadcast.

`promoteWaitlistAfterVacancy` already does all three; the manual path was missed.

## Changes

- After `promoteEntry`, increment `registeredCount`, persist the event, and call `broadcastAvailability(event)` — mirroring `promoteWaitlistAfterVacancy`.

## Verification

- Manually promoting a waitlisted user now consumes a seat: `registeredCount` +1, event persisted, availability broadcast fired.
- Matches the established pattern at `promoteWaitlistAfterVacancy` (registeredCount +1 → save → broadcast).

Closes #18214
