### PR TITLE
fix(kit): diffString removes characters of second string

### DIFF
--- a/src/eventra-kit/__tests__/diff-string.test.js
+++ b/src/eventra-kit/__tests__/diff-string.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DiffString from '../diff-string.js';
+import { diffString } from '../diff-string.js';
 
 describe('diff-string', () => {
-  it('exports a module', () => {
-    expect(DiffString).toBeDefined();
+  it('removes the characters of the second string from the first', () => {
+    expect(diffString('hello', 'l')).toBe('heo');
+    expect(diffString('banana', 'an')).toBe('b');
+    expect(diffString('abc', 'xyz')).toBe('abc');
   });
 });
-

--- a/src/eventra-kit/diff-string.js
+++ b/src/eventra-kit/diff-string.js
@@ -1,7 +1,8 @@
 /**
  * adds a diff-string helper.
  */
-export function diffString(value, separator) {
-  return value.split(separator);
+export function diffString(a, b) {
+  const chars = new Set(String(b));
+  return String(a).split('').filter((ch) => !chars.has(ch)).join('');
 }
 


### PR DESCRIPTION
## Summary

Fixes #18224

`diffString` now removes the characters of the second string from the first instead of splitting the first argument.

## Changes

- `src/eventra-kit/diff-string.js`: filter out characters present in the second string
- `src/eventra-kit/__tests__/diff-string.test.js`: add behavior tests

## Test

```js
diffString('hello', 'l') // 'heo'
diffString('banana', 'an') // 'b'
diffString('abc', 'xyz') // 'abc'
```

## GSSOC
