### PR TITLE
fix(utils): guard countdown parts against missing or NaN values (#18215)

### DIFF
--- a/src/utils/countdownUtils.js
+++ b/src/utils/countdownUtils.js
@@ -81,19 +81,25 @@ export const formatCountdown = (time) => {
     return "Registration Closed";
   }
 
+  const days = typeof time.days === "number" && !isNaN(time.days) ? time.days : 0;
+  const hours = typeof time.hours === "number" && !isNaN(time.hours) ? time.hours : 0;
+  const minutes = typeof time.minutes === "number" && !isNaN(time.minutes) ? time.minutes : 0;
+
   const parts = [];
 
-  if (time.days > 0) {
-    parts.push(`${time.days}d`);
+  if (days > 0) {
+    parts.push(`${days}d`);
   }
 
-  if (time.hours > 0 || time.days > 0) {
-    parts.push(`${time.hours}h`);
+  if (hours > 0 || days > 0) {
+    parts.push(`${hours}h`);
   }
 
-  parts.push(`${time.minutes}m`);
+  if (minutes > 0) {
+    parts.push(`${minutes}m`);
+  }
 
-  return parts.join(" ");
+  return parts.length > 0 ? parts.join(" ") : "0m";
 };
 
 /**


### PR DESCRIPTION
## Summary

`formatCountdown` read `time.days` / `time.hours` / `time.minutes` directly and always appended `parts.push(\`${time.minutes}m\`)`. A partial/malformed countdown object (missing `minutes`, or a `NaN` field) rendered strings like `"1d 2h undefinedm"` or `"NaNm"`. `formatDetailedCountdown` already coerces missing/NaN parts to 0 — `formatCountdown` was missed.

## Changes

- Extract days/hours/minutes with the same `typeof === "number" && !isNaN(...) ? value : 0` guard used by `formatDetailedCountdown`.
- Only append a minutes segment when it is actually `> 0` (a bare `"0m"` tail is no longer forced).

## Verification

```js
formatCountdown({ total: 100, days: 1, hours: 2 })          // "1d 2h"  (was "1d 2h undefinedm")
formatCountdown({ total: 100, days: 1, hours: 2, minutes: 25 }) // "1d 2h 25m"
formatCountdown({ total: 60, minutes: NaN })                // "0m"     (was "NaNm")
formatCountdown({ total: 0 })                               // "Registration Closed"
formatCountdown(null)                                       // "Registration Closed"
```

Closes #18215
