### PR TITLE
fix(kit): countRecord counts records in collection

### DIFF
--- a/src/eventra-kit/__tests__/count-record.test.js
+++ b/src/eventra-kit/__tests__/count-record.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountRecord from '../count-record.js';
+import { countRecord } from '../count-record.js';
 
 describe('count-record', () => {
-  it('exports a module', () => {
-    expect(CountRecord).toBeDefined();
+  it('counts the records in a collection', () => {
+    expect(countRecord([{ id: 1 }, { id: 2 }, { id: 3 }])).toBe(3);
+    expect(countRecord([])).toBe(0);
+    expect(countRecord(null)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/count-record.js
+++ b/src/eventra-kit/count-record.js
@@ -2,6 +2,6 @@
  * adds a count-record helper.
  */
 export function countRecord(value) {
-  return Math.abs(value);
+  return value == null ? 0 : value.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18225

`countRecord` now returns the number of records in a collection instead of the absolute value of the input.

## Changes

- `src/eventra-kit/count-record.js`: count records via collection length
- `src/eventra-kit/__tests__/count-record.test.js`: add behavior tests

## Test

```js
countRecord([{ id: 1 }, { id: 2 }, { id: 3 }]) // 3
countRecord([]) // 0
countRecord(null) // 0
```

## GSSOC
