### PR TITLE
fix(kit): chunkToken splits text into fixed-size tokens

### DIFF
--- a/src/eventra-kit/__tests__/chunk-token.test.js
+++ b/src/eventra-kit/__tests__/chunk-token.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ChunkToken from '../chunk-token.js';
+import { chunkToken } from '../chunk-token.js';
 
 describe('chunk-token', () => {
-  it('exports a module', () => {
-    expect(ChunkToken).toBeDefined();
+  it('splits text into tokens of the given size', () => {
+    expect(chunkToken('abcdef', 2)).toEqual(['ab', 'cd', 'ef']);
+    expect(chunkToken('abcdef', 3)).toEqual(['abc', 'def']);
+    expect(chunkToken('abcde', 2)).toEqual(['ab', 'cd', 'e']);
   });
 });
-

--- a/src/eventra-kit/chunk-token.js
+++ b/src/eventra-kit/chunk-token.js
@@ -1,7 +1,12 @@
 /**
  * adds a chunk-token helper.
  */
-export function chunkToken(value, target) {
-  return value.indexOf(target);
+export function chunkToken(value, size) {
+  const text = String(value);
+  const out = [];
+  for (let i = 0; i < text.length; i += size) {
+    out.push(text.slice(i, i + size));
+  }
+  return out;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18226

`chunkToken` now splits text into fixed-size tokens instead of returning the index of a target value.

## Changes

- `src/eventra-kit/chunk-token.js`: split text into tokens of the given size
- `src/eventra-kit/__tests__/chunk-token.test.js`: add behavior tests

## Test

```js
chunkToken('abcdef', 2) // ['ab', 'cd', 'ef']
chunkToken('abcdef', 3) // ['abc', 'def']
chunkToken('abcde', 2) // ['ab', 'cd', 'e']
```

## GSSOC
