### PR TITLE
fix(kit): buildPage builds pages of items

### DIFF
--- a/src/eventra-kit/__tests__/build-page.test.js
+++ b/src/eventra-kit/__tests__/build-page.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as BuildPage from '../build-page.js';
+import { buildPage } from '../build-page.js';
 
 describe('build-page', () => {
-  it('exports a module', () => {
-    expect(BuildPage).toBeDefined();
+  it('builds pages of items of the given size', () => {
+    expect(buildPage([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(buildPage([1, 2, 3, 4], 2)).toEqual([[1, 2], [3, 4]]);
+    expect(buildPage([], 2)).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/build-page.js
+++ b/src/eventra-kit/build-page.js
@@ -1,7 +1,11 @@
 /**
  * adds a build-page helper.
  */
-export function buildPage(value) {
-  return String(value).padStart(10, '0');
+export function buildPage(value, size) {
+  const out = [];
+  for (let i = 0; i < value.length; i += size) {
+    out.push(value.slice(i, i + size));
+  }
+  return out;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18227

`buildPage` now builds pages of items of the given page size instead of padding a stringified value with zeros.

## Changes

- `src/eventra-kit/build-page.js`: chunk items into pages of the given size
- `src/eventra-kit/__tests__/build-page.test.js`: add behavior tests

## Test

```js
buildPage([1, 2, 3, 4, 5], 2) // [[1, 2], [3, 4], [5]]
buildPage([1, 2, 3, 4], 2) // [[1, 2], [3, 4]]
buildPage([], 2) // []
```

## GSSOC
