### PR TITLE
fix(kit): computeDelta computes absolute difference

### DIFF
--- a/src/eventra-kit/__tests__/compute-delta.test.js
+++ b/src/eventra-kit/__tests__/compute-delta.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeDelta from '../compute-delta.js';
+import { computeDelta } from '../compute-delta.js';
 
 describe('compute-delta', () => {
-  it('exports a module', () => {
-    expect(ComputeDelta).toBeDefined();
+  it('computes the absolute difference between two numbers', () => {
+    expect(computeDelta(5, 8)).toBe(3);
+    expect(computeDelta(8, 5)).toBe(3);
+    expect(computeDelta(3, 3)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/compute-delta.js
+++ b/src/eventra-kit/compute-delta.js
@@ -1,7 +1,7 @@
 /**
  * adds a compute-delta helper.
  */
-export function computeDelta(value, target) {
-  return value.indexOf(target);
+export function computeDelta(a, b) {
+  return Math.abs(a - b);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18228

`computeDelta` now returns the absolute difference between two numbers instead of calling `indexOf` on the first argument.

## Changes

- `src/eventra-kit/compute-delta.js`: compute the absolute numeric difference
- `src/eventra-kit/__tests__/compute-delta.test.js`: add behavior tests

## Test

```js
computeDelta(5, 8) // 3
computeDelta(8, 5) // 3
computeDelta(3, 3) // 0
```

## GSSOC
