### PR TITLE
fix(kit): dedupeUri deduplicates uri lists

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-uri.test.js
+++ b/src/eventra-kit/__tests__/dedupe-uri.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DedupeUri from '../dedupe-uri.js';
+import { dedupeUri } from '../dedupe-uri.js';
 
 describe('dedupe-uri', () => {
-  it('exports a module', () => {
-    expect(DedupeUri).toBeDefined();
+  it('removes duplicate URIs while preserving order', () => {
+    expect(dedupeUri(['https://a.dev', 'https://b.dev', 'https://a.dev'])).toEqual(['https://a.dev', 'https://b.dev']);
+    expect(dedupeUri(['https://a.dev'])).toEqual(['https://a.dev']);
+    expect(dedupeUri([])).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/dedupe-uri.js
+++ b/src/eventra-kit/dedupe-uri.js
@@ -2,6 +2,6 @@
  * adds a dedupe-uri helper.
  */
 export function dedupeUri(value) {
-  return value.split(' ').filter(Boolean).length;
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18230

`dedupeUri` now returns an array of unique URIs instead of a count produced by splitting a non-string input.

## Changes

- `src/eventra-kit/dedupe-uri.js`: deduplicate URIs preserving first occurrence order
- `src/eventra-kit/__tests__/dedupe-uri.test.js`: add behavior tests

## Test

```js
dedupeUri(['https://a.dev', 'https://b.dev', 'https://a.dev']) // ['https://a.dev', 'https://b.dev']
dedupeUri(['https://a.dev']) // ['https://a.dev']
dedupeUri([]) // []
```

## GSSOC
