### PR TITLE
fix(kit): detectRecord detects record objects

### DIFF
--- a/src/eventra-kit/__tests__/detect-record.test.js
+++ b/src/eventra-kit/__tests__/detect-record.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectRecord from '../detect-record.js';
+import { detectRecord } from '../detect-record.js';
 
 describe('detect-record', () => {
-  it('exports a module', () => {
-    expect(DetectRecord).toBeDefined();
+  it('detects record objects', () => {
+    expect(detectRecord({ name: 'ada' })).toBe(true);
+    expect(detectRecord([1, 2])).toBe(false);
+    expect(detectRecord(null)).toBe(false);
   });
 });
-

--- a/src/eventra-kit/detect-record.js
+++ b/src/eventra-kit/detect-record.js
@@ -1,7 +1,9 @@
 /**
  * adds a detect-record helper.
  */
-export function detectRecord(value, separator) {
-  return value.join(separator);
+export function detectRecord(value) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18231

`detectRecord` now detects record objects instead of calling `.join` on the input.

## Changes

- `src/eventra-kit/detect-record.js`: return whether the input is a non-array object
- `src/eventra-kit/__tests__/detect-record.test.js`: add behavior tests

## Test

```js
detectRecord({ name: 'ada' }) // true
detectRecord([1, 2]) // false
detectRecord(null) // false
```

## GSSOC
