### PR TITLE
fix(kit): createDict builds dictionary from pairs

### DIFF
--- a/src/eventra-kit/__tests__/create-dict.test.js
+++ b/src/eventra-kit/__tests__/create-dict.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as CreateDict from '../create-dict.js';
+import { createDict } from '../create-dict.js';
 
 describe('create-dict', () => {
-  it('exports a module', () => {
-    expect(CreateDict).toBeDefined();
+  it('builds a dictionary from key-value pairs', () => {
+    expect(createDict([['a', 1], ['b', 2]])).toEqual({ a: 1, b: 2 });
+    expect(createDict([])).toEqual({});
   });
 });
-

--- a/src/eventra-kit/create-dict.js
+++ b/src/eventra-kit/create-dict.js
@@ -1,7 +1,7 @@
 /**
  * adds a create-dict helper.
  */
-export function createDict(value, separator) {
-  return value.split(separator);
+export function createDict(value) {
+  return Object.fromEntries(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18247

`createDict` now builds a dictionary object from an array of key-value pairs instead of splitting the input.

## Changes

- `src/eventra-kit/create-dict.js`: build an object from key-value pairs
- `src/eventra-kit/__tests__/create-dict.test.js`: add behavior tests

## Test

```js
createDict([['a', 1], ['b', 2]]) // { a: 1, b: 2 }
createDict([]) // {}
```

## GSSOC
