### PR TITLE
fix(kit): chunkValue chunks arrays by size

### DIFF
--- a/src/eventra-kit/__tests__/chunk-value.test.js
+++ b/src/eventra-kit/__tests__/chunk-value.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as ChunkValue from '../chunk-value.js';
+import { chunkValue } from '../chunk-value.js';
 
 describe('chunk-value', () => {
-  it('exports a module', () => {
-    expect(ChunkValue).toBeDefined();
+  it('chunks an array into sub-arrays of the given size', () => {
+    expect(chunkValue([1, 2, 3, 4], 2)).toEqual([[1, 2], [3, 4]]);
+    expect(chunkValue([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
   });
 });
-

--- a/src/eventra-kit/chunk-value.js
+++ b/src/eventra-kit/chunk-value.js
@@ -1,7 +1,11 @@
 /**
  * adds a chunk-value helper.
  */
-export function chunkValue(value, target) {
-  return value.indexOf(target);
+export function chunkValue(value, size) {
+  const out = [];
+  for (let i = 0; i < value.length; i += size) {
+    out.push(value.slice(i, i + size));
+  }
+  return out;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18248

`chunkValue` now chunks an array into sub-arrays of the given size instead of returning the index of a target value.

## Changes

- `src/eventra-kit/chunk-value.js`: split the array into sub-arrays of the given size
- `src/eventra-kit/__tests__/chunk-value.test.js`: add behavior tests

## Test

```js
chunkValue([1, 2, 3, 4], 2) // [[1, 2], [3, 4]]
chunkValue([1, 2, 3, 4, 5], 2) // [[1, 2], [3, 4], [5]]
```

## GSSOC
