### PR TITLE
fix(utils): guard formatICSDate against invalid dates (#18216)

### DIFF
--- a/src/utils/calendarLinks.js
+++ b/src/utils/calendarLinks.js
@@ -4,7 +4,9 @@
  */
 export const formatICSDate = (dateString) => {
   if (!dateString) return "";
-  return new Date(dateString).toISOString().replace(/-|:|\.\d\d\d/g, "");
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().replace(/-|:|\.\d\d\d/g, "");
 };
 
 /**


### PR DESCRIPTION
## Summary

`formatICSDate` called `new Date(dateString).toISOString()` with no validation. For any non-empty invalid date string, `toISOString()` throws `RangeError: Invalid time value`, crashing `getGoogleCalendarUrl` and `generateRawICSContent` (used by `AddToCalendar.jsx` and `EventRegistration.js`). The sibling `calendarUtils.js` already guards with an `isNaN` check.

## Changes

- Parse the date first and return `""` when `getTime()` is `NaN`, so malformed dates degrade gracefully instead of throwing.

## Verification

```js
formatICSDate("2026-07-15T18:00:00.000Z") // "20260715T180000Z"
formatICSDate("not-a-date")               // "" (was RangeError)
formatICSDate("")                         // ""
```

Closes #18216
