### PR TITLE
fix(kit): calculateList returns list size

### DIFF
--- a/src/eventra-kit/__tests__/calculate-list.test.js
+++ b/src/eventra-kit/__tests__/calculate-list.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CalculateList from '../calculate-list.js';
+import { calculateList } from '../calculate-list.js';
 
 describe('calculate-list', () => {
-  it('exports a module', () => {
-    expect(CalculateList).toBeDefined();
+  it('returns the size of a list', () => {
+    expect(calculateList([10, 20, 30])).toBe(3);
+    expect(calculateList([])).toBe(0);
+    expect(calculateList(null)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/calculate-list.js
+++ b/src/eventra-kit/calculate-list.js
@@ -2,6 +2,6 @@
  * adds a calculate-list helper.
  */
 export function calculateList(value) {
-  return typeof value === 'string';
+  return value == null ? 0 : value.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18249

`calculateList` now returns the size of a list instead of whether the input is a string.

## Changes

- `src/eventra-kit/calculate-list.js`: return the length of the list
- `src/eventra-kit/__tests__/calculate-list.test.js`: add behavior tests

## Test

```js
calculateList([10, 20, 30]) // 3
calculateList([]) // 0
calculateList(null) // 0
```

## GSSOC
