### PR TITLE
fix(utils): exclude invalid issue dates from certificate year filtering (#18217)

### DIFF
--- a/src/utils/certificateUtils.js
+++ b/src/utils/certificateUtils.js
@@ -53,6 +53,12 @@ export const searchCertificates = (certificates = [], query = "") => {
   );
 };
 
+const certificateYear = (issueDate) => {
+  if (!issueDate) return "";
+  const year = new Date(issueDate).getFullYear();
+  return Number.isNaN(year) ? "" : year.toString();
+};
+
 /**
  * Filter certificates by issue year, category, and status.
  */
@@ -63,11 +69,9 @@ export const filterCertificates = (
   status = "All"
 ) => {
   return certificates.filter((certificate) => {
-    const certificateYear = certificate.issueDate
-      ? new Date(certificate.issueDate).getFullYear().toString()
-      : "";
+    const certificateYearValue = certificateYear(certificate.issueDate);
 
-    const matchesYear = year === "All" || certificateYear === year;
+    const matchesYear = year === "All" || certificateYearValue === year;
     const matchesCategory = category === "All" || certificate.category === category;
     const matchesStatus = status === "All" || certificate.status === status;
 
@@ -82,10 +86,8 @@ export const getCertificateYears = (certificates = []) => {
   return [
     ...new Set(
       certificates
-        .filter((certificate) => certificate.issueDate)
-        .map((certificate) =>
-          new Date(certificate.issueDate).getFullYear().toString()
-        )
+        .filter((certificate) => certificateYear(certificate.issueDate))
+        .map((certificate) => certificateYear(certificate.issueDate))
     ),
   ].sort((a, b) => b.localeCompare(a));
 };


### PR DESCRIPTION
## Summary

`filterCertificates` and `getCertificateYears` derived the issue year via `new Date(certificate.issueDate).getFullYear().toString()`. For a malformed `issueDate` this yields `"NaN"`, so:
- `filterCertificates` silently dropped the certificate from any year-filtered view, and
- `getCertificateYears` surfaced `"NaN"` as a selectable year option.

## Changes

- Added a single `certificateYear(issueDate)` helper that returns `""` for missing or invalid dates.
- Both `filterCertificates` and `getCertificateYears` now use it, so invalid dates are excluded from year lists but still appear under "All".

## Verification

```js
getCertificateYears([{issueDate:'2025-05-01'},{issueDate:'2025-13-45'},{issueDate:'2024-03-15'}])
// ["2025","2024"]  (was ["2025","NaN","2024"])

filterCertificates(certs, '2025').length // 1 (was 1, but "NaN" option gone)
filterCertificates(certs, 'All').length  // 3 (unchanged)
```

Closes #18217
