### PR TITLE
fix(kit): computeString returns string length

### DIFF
--- a/src/eventra-kit/__tests__/compute-string.test.js
+++ b/src/eventra-kit/__tests__/compute-string.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeString from '../compute-string.js';
+import { computeString } from '../compute-string.js';
 
 describe('compute-string', () => {
-  it('exports a module', () => {
-    expect(ComputeString).toBeDefined();
+  it('returns the length of a string', () => {
+    expect(computeString('hello')).toBe(5);
+    expect(computeString('')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/compute-string.js
+++ b/src/eventra-kit/compute-string.js
@@ -1,7 +1,7 @@
 /**
  * adds a compute-string helper.
  */
-export function computeString(value, separator) {
-  return value.split(separator);
+export function computeString(value) {
+  return String(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18250

`computeString` now returns the length of a string instead of splitting the input by a separator.

## Changes

- `src/eventra-kit/compute-string.js`: return the string length
- `src/eventra-kit/__tests__/compute-string.test.js`: add behavior tests

## Test

```js
computeString('hello') // 5
computeString('') // 0
```

## GSSOC
