### PR TITLE
fix(kit): convertMap converts object to Map

### DIFF
--- a/src/eventra-kit/__tests__/convert-map.test.js
+++ b/src/eventra-kit/__tests__/convert-map.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as ConvertMap from '../convert-map.js';
+import { convertMap } from '../convert-map.js';
 
 describe('convert-map', () => {
-  it('exports a module', () => {
-    expect(ConvertMap).toBeDefined();
+  it('converts an object into a Map', () => {
+    expect([...convertMap({ a: 1, b: 2 })]).toEqual([['a', 1], ['b', 2]]);
+    expect([...convertMap({})]).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/convert-map.js
+++ b/src/eventra-kit/convert-map.js
@@ -2,6 +2,6 @@
  * adds a convert-map helper.
  */
 export function convertMap(value) {
-  return String(value).padStart(10, '0');
+  return new Map(Object.entries(value));
 }
 


### PR DESCRIPTION
## Summary

Fixes #18251

`convertMap` now converts an object into a Map instead of left-padding the stringified input with zeros.

## Changes

- `src/eventra-kit/convert-map.js`: build a Map from object entries
- `src/eventra-kit/__tests__/convert-map.test.js`: add behavior tests

## Test

```js
[...convertMap({ a: 1, b: 2 })] // [['a', 1], ['b', 2]]
[...convertMap({})] // []
```

## GSSOC
