### PR TITLE
fix(kit): estimateMap estimates map size

### DIFF
--- a/src/eventra-kit/__tests__/estimate-map.test.js
+++ b/src/eventra-kit/__tests__/estimate-map.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as EstimateMap from '../estimate-map.js';
+import { estimateMap } from '../estimate-map.js';
 
 describe('estimate-map', () => {
-  it('exports a module', () => {
-    expect(EstimateMap).toBeDefined();
+  it('estimates the number of entries in a map or object', () => {
+    expect(estimateMap({ a: 1, b: 2 })).toBe(2);
+    expect(estimateMap(new Map([['a', 1], ['b', 2], ['c', 3]]))).toBe(3);
+    expect(estimateMap({})).toBe(0);
   });
 });
-

--- a/src/eventra-kit/estimate-map.js
+++ b/src/eventra-kit/estimate-map.js
@@ -2,6 +2,7 @@
  * adds a estimate-map helper.
  */
 export function estimateMap(value) {
-  return value.trim();
+  if (value instanceof Map) return value.size;
+  return value == null ? 0 : Object.keys(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18252

`estimateMap` now estimates the number of entries in a map or object instead of calling `.trim` on the input.

## Changes

- `src/eventra-kit/estimate-map.js`: count entries of a Map or object
- `src/eventra-kit/__tests__/estimate-map.test.js`: add behavior tests

## Test

```js
estimateMap({ a: 1, b: 2 }) // 2
estimateMap(new Map([['a', 1], ['b', 2], ['c', 3]])) // 3
estimateMap({}) // 0
```

## GSSOC
