### PR TITLE
fix(kit): estimateProp estimates property count

### DIFF
--- a/src/eventra-kit/__tests__/estimate-prop.test.js
+++ b/src/eventra-kit/__tests__/estimate-prop.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as EstimateProp from '../estimate-prop.js';
+import { estimateProp } from '../estimate-prop.js';
 
 describe('estimate-prop', () => {
-  it('exports a module', () => {
-    expect(EstimateProp).toBeDefined();
+  it('estimates the number of properties of an object', () => {
+    expect(estimateProp({ a: 1, b: 2 })).toBe(2);
+    expect(estimateProp({})).toBe(0);
+    expect(estimateProp(null)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/estimate-prop.js
+++ b/src/eventra-kit/estimate-prop.js
@@ -2,6 +2,6 @@
  * adds a estimate-prop helper.
  */
 export function estimateProp(value) {
-  return String(value).padStart(10, '0');
+  return value == null ? 0 : Object.keys(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18253

`estimateProp` now estimates the number of properties of an object instead of left-padding the stringified input with zeros.

## Changes

- `src/eventra-kit/estimate-prop.js`: count the own properties of the object
- `src/eventra-kit/__tests__/estimate-prop.test.js`: add behavior tests

## Test

```js
estimateProp({ a: 1, b: 2 }) // 2
estimateProp({}) // 0
estimateProp(null) // 0
```

## GSSOC
