### PR TITLE
fix(backend): validate merged date ranges on partial hackathon updates (#18219)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -131,6 +131,15 @@ public class HackathonService {
 
         // FIX (#14532): shared chronological validation, null-safe for partial updates.
         validateDateRanges(request.getStartDate(), request.getEndDate(), request.getRegistrationDeadline());
+        // The range must also stay consistent against pre-existing dates that a
+        // partial update does not touch (e.g. moving only startDate past endDate).
+        LocalDateTime effectiveStart = request.getStartDate() != null
+                ? request.getStartDate() : hackathon.getStartDate();
+        LocalDateTime effectiveEnd = request.getEndDate() != null
+                ? request.getEndDate() : hackathon.getEndDate();
+        LocalDateTime effectiveDeadline = request.getRegistrationDeadline() != null
+                ? request.getRegistrationDeadline() : hackathon.getRegistrationDeadline();
+        validateMergedDateRanges(effectiveStart, effectiveEnd, effectiveDeadline);
         if (request.getTitle() != null && (request.getTitle().trim().length() < 3 || request.getTitle().trim().length() > 100)) {
             throw new IllegalArgumentException("Title must be between 3 and 100 characters.");
         }
@@ -195,6 +204,23 @@ public class HackathonService {
         }
         if (registrationDeadline != null && registrationDeadline.isBefore(LocalDateTime.now())) {
             throw new IllegalArgumentException("Registration deadline must be in the future.");
+        }
+    }
+
+    /**
+     * Validates ordering only (no future-in-time checks) against the merged
+     * date values of a partial update, so a new date cannot contradict an
+     * existing one it does not touch.
+     */
+    private void validateMergedDateRanges(LocalDateTime startDate, LocalDateTime endDate, LocalDateTime registrationDeadline) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("Start date cannot be after end date.");
+        }
+        if (registrationDeadline != null && endDate != null && registrationDeadline.isAfter(endDate)) {
+            throw new IllegalArgumentException("Registration deadline cannot be after end date.");
+        }
+        if (registrationDeadline != null && startDate != null && registrationDeadline.isAfter(startDate)) {
+            throw new IllegalArgumentException("Registration deadline cannot be after start date.");
         }
     }
 


### PR DESCRIPTION
## Summary

`updateHackathon` validated date ranges only against the **request-supplied** fields (`validateDateRanges(request.getStartDate(), ...)`). Since the update is partial, a caller updating only `startDate` was never checked against the existing `endDate`. E.g. a hackathon with `endDate = 2026-12-31` accepted `{startDate: 2027-01-01}` → an inverted range persisted with no error.

## Changes

- After the existing null-safe request validation, validate the **merged** effective values (existing entity dates + incoming non-null fields) with a new `validateMergedDateRanges` helper.
- The merged helper only checks ordering (start ≤ end, deadline within range) — it deliberately does **not** re-run the "must be in the future" checks, so updating unrelated fields on an already-started hackathon still works.

## Verification

- PATCH `{startDate}` alone on a hackathon whose existing endDate is earlier → throws `IllegalArgumentException` ("Start date cannot be after end date").
- Updating only `title` on an in-progress hackathon still succeeds (future-date checks untouched).

Closes #18219
