### PR TITLE
fix(kit): deduplicateItem removes duplicate items

### DIFF
--- a/src/eventra-kit/__tests__/deduplicate-item.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-item.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DeduplicateItem from '../deduplicate-item.js';
+import { deduplicateItem } from '../deduplicate-item.js';
 
 describe('deduplicate-item', () => {
-  it('exports a module', () => {
-    expect(DeduplicateItem).toBeDefined();
+  it('removes duplicate items while preserving order', () => {
+    expect(deduplicateItem([1, 1, 2, 3])).toEqual([1, 2, 3]);
+    expect(deduplicateItem([1, 2])).toEqual([1, 2]);
+    expect(deduplicateItem([])).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/deduplicate-item.js
+++ b/src/eventra-kit/deduplicate-item.js
@@ -2,6 +2,6 @@
  * adds a deduplicate-item helper.
  */
 export function deduplicateItem(value) {
-  return value.length === 0;
+  return [...new Set(value)];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18254

`deduplicateItem` now removes duplicate items instead of returning whether the input collection is empty.

## Changes

- `src/eventra-kit/deduplicate-item.js`: return unique items preserving first occurrence order
- `src/eventra-kit/__tests__/deduplicate-item.test.js`: add behavior tests

## Test

```js
deduplicateItem([1, 1, 2, 3]) // [1, 2, 3]
deduplicateItem([1, 2]) // [1, 2]
deduplicateItem([]) // []
```

## GSSOC
