### PR TITLE
fix(backend): return 201 when submitting a QA question (#18220)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/QAStreamController.java
@@ -43,7 +43,7 @@ public class QAStreamController {
         String id = "q-" + UUID.randomUUID().toString().substring(0, 8);
         SessionQuestion q = new SessionQuestion(id, payload.getSessionId(), payload.getAuthorName(), payload.getQuestionText());
         questionsDatabase.put(id, q);
-        return ResponseEntity.ok(q);
+        return ResponseEntity.status(HttpStatus.CREATED).body(q);
     }
 
     @PostMapping("/{id}/upvote")


### PR DESCRIPTION
## Summary

`submitQuestion` created a new resource (a question in the in-memory database) but returned HTTP `200` instead of `201 Created`. The sibling `FeedbackController.submitFeedback` already returns `201` for the same operation, so clients can't distinguish a successful question creation from other 200 responses.

## Changes

- Return `ResponseEntity.status(HttpStatus.CREATED).body(q)` on successful submission. Unauthorized (401) and bad request (400) paths are unchanged.

## Verification

- `POST /submit` with a valid body → `201 Created` with the created `SessionQuestion`.
- Matches `FeedbackController.submitFeedback`'s 201 behavior.

Closes #18220
