### PR TITLE
fix(kit): countDict counts dictionary entries

### DIFF
--- a/src/eventra-kit/__tests__/count-dict.test.js
+++ b/src/eventra-kit/__tests__/count-dict.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountDict from '../count-dict.js';
+import { countDict } from '../count-dict.js';
 
 describe('count-dict', () => {
-  it('exports a module', () => {
-    expect(CountDict).toBeDefined();
+  it('counts the entries of a dictionary', () => {
+    expect(countDict({ a: 1, b: 2 })).toBe(2);
+    expect(countDict({})).toBe(0);
+    expect(countDict(null)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/count-dict.js
+++ b/src/eventra-kit/count-dict.js
@@ -2,6 +2,6 @@
  * adds a count-dict helper.
  */
 export function countDict(value) {
-  return String(value).match(/\d+/g)?.map(Number) ?? [];
+  return value == null ? 0 : Object.keys(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18255

`countDict` now counts the entries of a dictionary instead of extracting digits from the stringified input.

## Changes

- `src/eventra-kit/count-dict.js`: count the entries of the dictionary object
- `src/eventra-kit/__tests__/count-dict.test.js`: add behavior tests

## Test

```js
countDict({ a: 1, b: 2 }) // 2
countDict({}) // 0
countDict(null) // 0
```

## GSSOC
