### PR TITLE
fix(backend): clamp limit in getPopularEvents (#18221)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -338,7 +338,7 @@ public class AdminController {
             @Parameter(description = "Maximum number of events to return", example = "10")
             @RequestParam(defaultValue = "10") int limit
     ) {
-        return ResponseEntity.ok(adminService.getPopularEvents(limit));
+        return ResponseEntity.ok(adminService.getPopularEvents(Math.min(Math.max(limit, 1), 100)));
     }
 
     // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

`getPopularEvents` passed the caller-supplied `limit` straight to `AdminService.getPopularEvents`, which calls `PageRequest.of(0, limit)`. `limit <= 0` throws `IllegalArgumentException` → 400 even though the endpoint is documented to return the top-N popular events, and there was no upper bound.

## Changes

- Clamp `limit` to `[1, 100]` before delegating, matching the pagination-clamping convention used by `getAllEvents`.

## Verification

- `?limit=0` or `?limit=-5` → treated as `1` (no more 400).
- `?limit=100000` → capped at `100`.
- `?limit=10` → unchanged.

Closes #18221
