### PR TITLE
fix(kit): extractKey extracts key values from items

### DIFF
--- a/src/eventra-kit/__tests__/extract-key.test.js
+++ b/src/eventra-kit/__tests__/extract-key.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as ExtractKey from '../extract-key.js';
+import { extractKey } from '../extract-key.js';
 
 describe('extract-key', () => {
-  it('exports a module', () => {
-    expect(ExtractKey).toBeDefined();
+  it('extracts the values of a key from each item', () => {
+    expect(extractKey([{ id: 1 }, { id: 2 }], 'id')).toEqual([1, 2]);
+    expect(extractKey([], 'id')).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/extract-key.js
+++ b/src/eventra-kit/extract-key.js
@@ -1,7 +1,7 @@
 /**
  * adds a extract-key helper.
  */
-export function extractKey(value) {
-  return value.map((item, index) => [index, item]);
+export function extractKey(value, key) {
+  return value.map((item) => item[key]);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18256

`extractKey` now extracts the values of a given key from each item instead of returning indexed pairs.

## Changes

- `src/eventra-kit/extract-key.js`: map each item to the value of the given key
- `src/eventra-kit/__tests__/extract-key.test.js`: add behavior tests

## Test

```js
extractKey([{ id: 1 }, { id: 2 }], 'id') // [1, 2]
extractKey([], 'id') // []
```

## GSSOC
