### PR TITLE
fix(backend): clamp pagination in searchEvents (#18232)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -187,7 +187,9 @@ public class EventController {
                         @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
                         @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
 
-                Pageable pageable = PageRequest.of(page, size);
+                int clampedSize = Math.min(Math.max(size, 1), 100);
+                int safePage = Math.max(page, 0);
+                Pageable pageable = PageRequest.of(safePage, clampedSize);
                 Page<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free,
                                 pageable);
                 return ResponseEntity.ok(events);


### PR DESCRIPTION
## Summary

`searchEvents` built the `Pageable` directly from request params:

```java
Pageable pageable = PageRequest.of(page, size);
```

`PageRequest.of` throws `IllegalArgumentException` for `page < 0` or `size < 1`, so `GET /api/events/search?size=0` or `?page=-1` returned a 400. A huge `size` also produced an unbounded query. The sibling `getAllEvents` already clamps both values (lines 151-152).

## Changes

- Clamp `size` to `[1, 100]` and `page` to `>= 0` before building the `Pageable`, mirroring `getAllEvents`.

## Verification

- `?size=0` → size `1`, no 400.
- `?page=-1` → page `0`.
- `?size=100000` → capped at `100`.
- Normal values unchanged.

Closes #18232
