### PR TITLE
fix(backend): resolve current user id from CustomUserDetails principal (#18277)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/LostItemController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/LostItemController.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.dto.request.CreateLostItemRequest;
 import com.sandeep.eventrabackend.dto.request.UpdateLostItemRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.LostItemResponse;
+import com.sandeep.eventrabackend.security.CustomUserDetails;
 import com.sandeep.eventrabackend.service.LostItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -268,6 +269,9 @@ public class LostItemController {
         }
         
         Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails customUserDetails) {
+            return customUserDetails.getUser().getId();
+        }
         if (principal instanceof Map) {
             Map<?, ?> principalMap = (Map<?, ?>) principal;
             Object userIdObj = principalMap.get("userId");
@@ -276,8 +280,6 @@ public class LostItemController {
             }
         }
         
-        // If the principal is a string (username/email), we might need to look it up
-        // For now, return null if we can't extract the user ID
         return null;
     }
 }


### PR DESCRIPTION
## Summary

`LostItemController.getCurrentUserId()` always returned `null` because it only handled a `Map` principal, but `JwtAuthenticationFilter` sets a `CustomUserDetails` principal.

## Impact (issue #18277)

- `createLostItem` stored `foundBy=null`.
- `updateLostItem`/`deleteLostItem` ownership checks never fired → any authenticated user could edit/delete any lost item.
- `markAsClaimed` persisted `claimedById=null`.

## Changes

- Resolve the user id from the `CustomUserDetails` principal (`customUserDetails.getUser().getId()`), keeping the `Map` branch as a fallback.

## Verification

- Principal type matches what `JwtAuthenticationFilter` sets (line 108-109: `new UsernamePasswordAuthenticationToken(userDetails, ...)`).
- Follows the same `CustomUserDetails.getUser()` accessor used across the codebase.

Closes #18277
