### PR TITLE
fix(backend): handle ResourceNotFoundException with 404 (#18278)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -204,6 +204,18 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleResourceNotFound(
+            ResourceNotFoundException ex,
+            HttpServletRequest request) {
+        return buildError(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                ex.getMessage(),
+                request
+        );
+    }
+
     @ExceptionHandler(ProjectNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleProjectNotFound(
             ProjectNotFoundException ex,


### PR DESCRIPTION
## Summary

`ResourceNotFoundException` is thrown across the API (e.g. `LostItemService`), but `GlobalExceptionHandler` had no handler for it, so the generic `@ExceptionHandler(Exception.class)` turned it into a **500 Internal Server Error**.

## Impact (issue #18278)

"Lost item not found" / "Event not found" responses returned 500 instead of 404, breaking the API contract and client error handling.

## Changes

- Added `@ExceptionHandler(ResourceNotFoundException.class)` returning 404, mirroring the existing `EventNotFoundException` / `HackathonNotFoundException` handlers.

## Verification

- Follows the exact `buildError(NOT_FOUND, "Not Found", ...)` pattern used by sibling handlers.
- Class is in the same package — no import required.

Closes #18278
