### PR TITLE
fix(backend): use existing ATTENDEE authority in payment endpoints (#18279)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
@@ -39,7 +39,7 @@ public class PaymentController {
      * Create a new payment plan for installment payments
      */
     @PostMapping("/plans")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> createPaymentPlan(
             Authentication authentication,
             @RequestParam Long registrationId,
@@ -80,7 +80,7 @@ public class PaymentController {
      * Initialize Stripe customer and setup intent for a registration
      */
     @PostMapping("/initialize/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> initializeStripePayment(
             Authentication authentication,
             @PathVariable Long registrationId,
@@ -113,7 +113,7 @@ public class PaymentController {
      * Setup payment method and create upfront payment intent
      */
     @PostMapping("/setup-method/{paymentPlanId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> setupPaymentMethodAndCreateUpfrontPayment(
             Authentication authentication,
             @PathVariable Long paymentPlanId,
@@ -153,7 +153,7 @@ public class PaymentController {
      * Confirm upfront payment and schedule remaining installments
      */
     @PostMapping("/confirm-upfront/{paymentPlanId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> confirmUpfrontPaymentAndScheduleInstallments(
             Authentication authentication,
             @PathVariable Long paymentPlanId,
@@ -193,7 +193,7 @@ public class PaymentController {
      * Get payment plan by registration ID
      */
     @GetMapping("/plans/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getPaymentPlanByRegistrationId(
             Authentication authentication,
             @PathVariable Long registrationId) {
@@ -235,7 +235,7 @@ public class PaymentController {
      * Get all payments for a registration
      */
     @GetMapping("/registrations/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getPaymentsByRegistrationId(
             Authentication authentication,
             @PathVariable Long registrationId) {
@@ -263,7 +263,7 @@ public class PaymentController {
      * Get installment schedule for a registration
      */
     @GetMapping("/schedule/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getInstallmentSchedule(
             Authentication authentication,
             @PathVariable Long registrationId) {
@@ -291,7 +291,7 @@ public class PaymentController {
      * Retry a failed payment
      */
     @PostMapping("/retry/{paymentId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> retryFailedPayment(
             Authentication authentication,
             @PathVariable Long paymentId,
@@ -321,7 +321,7 @@ public class PaymentController {
      * Get customer payment methods
      */
     @GetMapping("/methods/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getCustomerPaymentMethods(
             Authentication authentication,
             @PathVariable Long registrationId) {
@@ -354,7 +354,7 @@ public class PaymentController {
      * Check if QR code is activated for a registration
      */
     @GetMapping("/qr-status/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> isQRCodeActivated(
             Authentication authentication,
             @PathVariable Long registrationId) {
@@ -383,7 +383,7 @@ public class PaymentController {
      * Cancel a payment plan
      */
     @DeleteMapping("/plans/{paymentPlanId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> cancelPaymentPlan(
             Authentication authentication,
             @PathVariable Long paymentPlanId,
@@ -411,7 +411,7 @@ public class PaymentController {
      * Check if registration has an active payment plan
      */
     @GetMapping("/active/{registrationId}")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> hasActivePaymentPlan(
             Authentication authentication,
             @PathVariable Long registrationId) {
@@ -546,7 +546,7 @@ public class PaymentController {
      * Get user's payment history
      */
     @GetMapping("/user/history")
-    @PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")
+    @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> getUserPaymentHistory() {
         try {
             // Implementation would return payment history for the authenticated user


### PR DESCRIPTION
## Summary

Every endpoint in `PaymentController` was annotated `@PreAuthorize("hasAnyAuthority('USER', 'ORGANIZER', 'ADMIN')")`. The `Role` enum has no `USER` value — signup assigns `Role.ATTENDEE`, so attendees got **403 on every payment endpoint**.

## Impact (issue #18279)

The installment/payment flow (create plan, initialize, confirm, schedule, retry, payment methods, cancel, etc.) was unusable for the default role.

## Changes

- Replaced `'USER'` with `'ATTENDEE'` in all 13 `@PreAuthorize` annotations so the actual role granted at signup is authorized.

## Verification

- `Role` enum defines `ATTENDEE, ORGANIZER, ADMIN, SUPER_ADMIN` (no `USER`).
- `AuthService` assigns `Role.ATTENDEE` at signup.
- Verified all 13 occurrences replaced; no other changes to the file.

Closes #18279
