### PR TITLE
fix(backend): evict hackathons cache on deleteHackathon (#18280)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -247,6 +247,7 @@ public class HackathonService {
     }
 
     @Transactional
+    @CacheEvict(value = "hackathons", key = "#id")
     public void deleteHackathon(Long id, String userEmail) {
         Hackathon hackathon = hackathonRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));


### PR DESCRIPTION
## Summary

`HackathonService.deleteHackathon` performs a soft delete but had no `@CacheEvict`, unlike `updateHackathon`. `getHackathonById` is `@Cacheable`, so a deleted hackathon kept being served from cache for the TTL.

## Impact (issue #18280)

After deleting a hackathon, `GET /api/hackathons/{id}` (public endpoint) continued to return the stale cached entry for up to 10 minutes (`CacheConfig` TTL).

## Changes

- Added `@CacheEvict(value = "hackathons", key = "#id")` to `deleteHackathon`, matching `updateHackathon`.

## Verification

- `@CacheEvict`/`@Cacheable` imports already present.
- Matches the existing evict on `updateHackathon` (line 116).

Closes #18280
