### PR TITLE
fix(backend): fail closed on partial refund with null percent (#18282)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -517,7 +517,10 @@ public class StripeService {
 
         long chargeAmount = charge.getAmount();
         long refundAmount;
-        if ("PARTIAL".equalsIgnoreCase(refundPolicy) && refundPercent != null) {
+        if ("PARTIAL".equalsIgnoreCase(refundPolicy)) {
+            if (refundPercent == null) {
+                return null;
+            }
             refundAmount = (long) (chargeAmount * refundPercent / 100.0);
         } else {
             refundAmount = chargeAmount;


### PR DESCRIPTION
## Summary

`StripeService.refundPayment` falls through to the full-refund branch when the policy is `PARTIAL` but `refundPercent` is `null`, silently issuing a full charge refund.

## Impact (issue #18282)

Any caller passing a null percent for a partial refund would refund the full amount. The helper now fails closed.

## Changes

- When `PARTIAL` and `refundPercent == null`, return `null` (no refund issued) instead of refunding the full charge.
- `FULL` and `NONE` behavior unchanged.

## Verification

- `PARTIAL` + null percent → `null` (no `createRefund` call).
- `PARTIAL` + valid percent → percentage refund.
- `FULL` → full refund.

Closes #18282
