### PR TITLE
fix(backend): compare lost item owner ids with Objects.equals (#18283)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LostItemService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LostItemService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -99,7 +100,7 @@ public class LostItemService {
                 .orElseThrow(() -> new ResourceNotFoundException("Lost item not found with id: " + id));
         
         // Only allow update by the user who found the item or admin
-        if (lostItem.getFoundBy() != null && lostItem.getFoundBy().getId() != userId) {
+        if (lostItem.getFoundBy() != null && !Objects.equals(lostItem.getFoundBy().getId(), userId)) {
             throw new RuntimeException("You are not authorized to update this lost item");
         }
         
@@ -170,7 +171,7 @@ public class LostItemService {
                 .orElseThrow(() -> new ResourceNotFoundException("Lost item not found with id: " + id));
         
         // Only allow deletion by the user who found the item or admin
-        if (lostItem.getFoundBy() != null && lostItem.getFoundBy().getId() != userId) {
+        if (lostItem.getFoundBy() != null && !Objects.equals(lostItem.getFoundBy().getId(), userId)) {
             throw new RuntimeException("You are not authorized to delete this lost item");
         }
         


### PR DESCRIPTION
## Summary

`LostItemService` compared owner ids with `!=` on boxed `Long` values in `updateLostItem` and `deleteLostItem`. `!=` on `Long` references compares object identity, not value.

## Impact (issue #18283)

Values ≤ 127 are cached by the JVM so they compare equal; ids > 127 always fail the comparison, so legitimate owners were wrongly denied (403 instead of 200) once the current-user id is correctly resolved.

## Changes

- Use `!Objects.equals(lostItem.getFoundBy().getId(), userId)` in both owner checks.
- Added the `java.util.Objects` import.

## Verification

- `Objects.equals` performs value equality with null safety on boxed `Long`.
- Applies to both `updateLostItem` and `deleteLostItem`.

Closes #18283
