### PR TITLE
fix(frontend): compare peer id against current user peer id (#18284)

### DIFF
--- a/src/components/events/SpeakerGreenRoom.jsx
+++ b/src/components/events/SpeakerGreenRoom.jsx
@@ -142,20 +142,20 @@ const SpeakerGreenRoom = ({
   };
 
   // Get display name for a peer
-  const getPeerDisplayName = (peerId) => {
-    if (peerId === peerId) {
+  const getPeerDisplayName = (targetPeerId) => {
+    if (targetPeerId === peerId) {
       return authUser?.firstName || authUser?.username || "You";
     }
-    const speaker = speakersInRoom.find(s => s.peerId === peerId);
-    return speaker?.user?.firstName || speaker?.user?.username || peerId;
+    const speaker = speakersInRoom.find(s => s.peerId === targetPeerId);
+    return speaker?.user?.firstName || speaker?.user?.username || targetPeerId;
   };
 
   // Get role indicator for a peer
-  const getPeerRoleIndicator = (peerId) => {
-    if (peerId === peerId) {
+  const getPeerRoleIndicator = (targetPeerId) => {
+    if (targetPeerId === peerId) {
       return isOrganizer ? "Organizer" : "Speaker";
     }
-    const speaker = speakersInRoom.find(s => s.peerId === peerId);
+    const speaker = speakersInRoom.find(s => s.peerId === targetPeerId);
     return speaker?.isOrganizer ? "Organizer" : "Speaker";
   };
 


### PR DESCRIPTION
## Summary

`getPeerDisplayName(peerId)` and `getPeerRoleIndicator(peerId)` contained `if (peerId === peerId)`. The function parameter shadowed the hook's real current-user `peerId`, so the condition was always true.

## Impact (issue #18284)

Every remote speaker's video tile showed the viewer's own name and role. The organizer's "Transition to Stage" button (`!getPeerDisplayName(peerId).includes("You")`) was driven by the same broken name.

## Changes

- Renamed the parameter to `targetPeerId` and compare it against the current user's `peerId` from `useGreenRoomWebRTC`.

## Verification

- `peerId` (component line 40) is the current user's peer id from `useGreenRoomWebRTC`.
- Remote peers now resolve via `speakersInRoom`; self resolves to "You"/own role.

Closes #18284
