### PR TITLE
fix(frontend): split teleprompter script on whitespace (#18285)

### DIFF
--- a/src/components/events/HolographicTeleprompter.jsx
+++ b/src/components/events/HolographicTeleprompter.jsx
@@ -31,7 +31,7 @@ Because the future is not something we wait for.
 The future is something we create.
 Thank you.`;
 
-  const scriptWords = script.split(/\\s+/);
+  const scriptWords = script.split(/\s+/);
 
   useEffect(() => {
     let loop;


### PR DESCRIPTION
## Summary

`HolographicTeleprompter.jsx` used `script.split(/\\s+/)`. In a regex literal `\\` matches a literal backslash, so the script was split on backslash-`s` sequences — not whitespace.

## Impact (issue #18285)

The default script (plain text with spaces/newlines) became a single element. The word-by-word teleprompter rendered the whole script as one token, and the NLP word counter finished after one tick.

## Changes

- Use `/\s+/` to split on whitespace.

## Verification

- `/\s+/` splits on spaces/newlines/tabs → word array.
- With the default script this yields ~40 words instead of 1 token.

Closes #18285
