### PR TITLE
fix(frontend): guard postMessage to service worker in try/catch (#18286)

### DIFF
--- a/src/hooks/useLowBandwidthMode.js
+++ b/src/hooks/useLowBandwidthMode.js
@@ -65,12 +65,14 @@ const useLowBandwidthMode = () => {
   const notifyServiceWorker = (enabled) => {
     // Check if service worker is available and ready
     if ('serviceWorker' in navigator && navigator.serviceWorker?.controller) {
-      navigator.serviceWorker.controller.postMessage({
-        type: 'LOW_BANDWIDTH_MODE_CHANGED',
-        enabled: enabled,
-      }).catch(() => {
+      try {
+        navigator.serviceWorker.controller.postMessage({
+          type: 'LOW_BANDWIDTH_MODE_CHANGED',
+          enabled: enabled,
+        });
+      } catch {
         // Service worker might not be ready, that's okay
-      });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

`notifyServiceWorker` called `.catch()` on the return value of `navigator.serviceWorker.controller.postMessage(...)`. Per the spec, `postMessage` returns `undefined`, so `.catch(...)` threw a TypeError whenever a service-worker controller was active.

## Impact (issue #18286)

Toggling Low Bandwidth Mode threw whenever a SW controller was present — and the service worker was never notified of the mode change.

## Changes

- Wrapped the `postMessage` call in try/catch (matching `src/utils/lowBandwidthMode.js`).

## Verification

- No more `.catch` on `undefined`; exceptions are swallowed.
- The SW now actually receives `LOW_BANDWIDTH_MODE_CHANGED`.

Closes #18286
