### PR TITLE
fix(frontend): detect markdown list items with regex in RichTextEditor (#18287)

### DIFF
--- a/src/components/common/RichTextEditor.jsx
+++ b/src/components/common/RichTextEditor.jsx
@@ -123,7 +123,7 @@ const RichTextEditor = forwardRef(({
       // Check if the value is markdown that needs conversion
       const isMarkdown = !value || value.trim().startsWith("#") || 
                         value.includes("**") || value.includes("*") || 
-                        value.includes("-\s") || value.includes("1.\s");
+                        /(^|\n)[-*]\s/.test(value) || /(^|\n)\d+\.\s/.test(value);
       
       if (isMarkdown && value) {
         // Convert markdown to HTML


### PR DESCRIPTION
## Summary

`RichTextEditor`'s markdown detection used `value.includes("-\s")` and `value.includes("1.\s")`. In a JS string literal `\s` is just the character `s`, so these tested for the literal substrings `-s` / `1.s`.

## Impact (issue #18287)

Restoring a draft with markdown list items (`- item`, `1. item`) was not detected as markdown, so the editor inserted the raw markdown text instead of converting it to HTML.

## Changes

- Replaced the literal checks with regexes: `/(^|\n)[-*]\s/` and `/(^|\n)\d+\.\s/`.

## Verification

- `- item` at line start or after a newline → matches.
- `1. item` / `3. item` → matches.
- Plain text without list markers → unchanged.

Closes #18287
