### PR TITLE
fix(kit): detectString detects string values

### DIFF
--- a/src/eventra-kit/__tests__/detect-string.test.js
+++ b/src/eventra-kit/__tests__/detect-string.test.js
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectString from '../detect-string.js';
+import { detectString } from '../detect-string.js';
 
 describe('detect-string', () => {
-  it('exports a module', () => {
-    expect(DetectString).toBeDefined();
+  it('detects string values', () => {
+    expect(detectString('abc')).toBe(true);
+    expect(detectString('')).toBe(true);
+    expect(detectString(42)).toBe(false);
+    expect(detectString(null)).toBe(false);
   });
 });
-

--- a/src/eventra-kit/detect-string.js
+++ b/src/eventra-kit/detect-string.js
@@ -2,6 +2,6 @@
  * adds a detect-string helper.
  */
 export function detectString(value) {
-  return String(value).match(/\d+/g)?.map(Number) ?? [];
+  return typeof value === 'string';
 }
 


### PR DESCRIPTION
## Summary

Fixes #18301

`detectString` now detects whether a value is a string instead of extracting the numbers found in the input.

## Changes

- `src/eventra-kit/detect-string.js`: return whether the input is a string
- `src/eventra-kit/__tests__/detect-string.test.js`: add behavior tests

## Test

```js
detectString('abc') // true
detectString('') // true
detectString(42) // false
detectString(null) // false
```

## GSSOC
