### PR TITLE
fix(kit): detectSet detects Set instances

### DIFF
--- a/src/eventra-kit/__tests__/detect-set.test.js
+++ b/src/eventra-kit/__tests__/detect-set.test.js
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectSet from '../detect-set.js';
+import { detectSet } from '../detect-set.js';
 
 describe('detect-set', () => {
-  it('exports a module', () => {
-    expect(DetectSet).toBeDefined();
+  it('detects Set instances', () => {
+    expect(detectSet(new Set([1, 2]))).toBe(true);
+    expect(detectSet(new Set())).toBe(true);
+    expect(detectSet([1, 2])).toBe(false);
+    expect(detectSet(null)).toBe(false);
   });
 });
-

--- a/src/eventra-kit/detect-set.js
+++ b/src/eventra-kit/detect-set.js
@@ -2,6 +2,6 @@
  * adds a detect-set helper.
  */
 export function detectSet(value) {
-  return String(value).charAt(0);
+  return value instanceof Set;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18302

`detectSet` now detects whether a value is a Set instead of returning the first character of the stringified input.

## Changes

- `src/eventra-kit/detect-set.js`: return whether the input is a Set instance
- `src/eventra-kit/__tests__/detect-set.test.js`: add behavior tests

## Test

```js
detectSet(new Set([1, 2])) // true
detectSet(new Set()) // true
detectSet([1, 2]) // false
detectSet(null) // false
```

## GSSOC
