### PR TITLE
fix(kit): ensureNumber parses value into a number

### DIFF
--- a/src/eventra-kit/__tests__/ensure-number.test.js
+++ b/src/eventra-kit/__tests__/ensure-number.test.js
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import * as EnsureNumber from '../ensure-number.js';
+import { ensureNumber } from '../ensure-number.js';
 
 describe('ensure-number', () => {
-  it('exports a module', () => {
-    expect(EnsureNumber).toBeDefined();
+  it('parses a value into a number', () => {
+    expect(ensureNumber('42')).toBe(42);
+    expect(ensureNumber('12px')).toBe(12);
+    expect(ensureNumber(3.5)).toBe(3.5);
+    expect(ensureNumber('abc')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/ensure-number.js
+++ b/src/eventra-kit/ensure-number.js
@@ -2,6 +2,7 @@
  * adds a ensure-number helper.
  */
 export function ensureNumber(value) {
-  return Math.abs(value);
+  const n = Number.parseFloat(value);
+  return Number.isNaN(n) ? 0 : n;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18303

`ensureNumber` now parses a value into a number instead of returning its absolute value.

## Changes

- `src/eventra-kit/ensure-number.js`: parse the input into a number with a zero fallback
- `src/eventra-kit/__tests__/ensure-number.test.js`: add behavior tests

## Test

```js
ensureNumber('42') // 42
ensureNumber('12px') // 12
ensureNumber(3.5) // 3.5
ensureNumber('abc') // 0
```

## GSSOC
