### PR TITLE
fix(kit): ensureString coerces value into a string

### DIFF
--- a/src/eventra-kit/__tests__/ensure-string.test.js
+++ b/src/eventra-kit/__tests__/ensure-string.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as EnsureString from '../ensure-string.js';
+import { ensureString } from '../ensure-string.js';
 
 describe('ensure-string', () => {
-  it('exports a module', () => {
-    expect(EnsureString).toBeDefined();
+  it('coerces a value into a string', () => {
+    expect(ensureString(42)).toBe('42');
+    expect(ensureString('abc')).toBe('abc');
+    expect(ensureString(true)).toBe('true');
   });
 });
-

--- a/src/eventra-kit/ensure-string.js
+++ b/src/eventra-kit/ensure-string.js
@@ -2,6 +2,6 @@
  * adds a ensure-string helper.
  */
 export function ensureString(value) {
-  return value[0];
+  return String(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18304

`ensureString` now coerces a value into a string instead of returning its first element.

## Changes

- `src/eventra-kit/ensure-string.js`: return the string representation of the input
- `src/eventra-kit/__tests__/ensure-string.test.js`: add behavior tests

## Test

```js
ensureString(42) // '42'
ensureString('abc') // 'abc'
ensureString(true) // 'true'
```

## GSSOC
