### PR TITLE
fix(kit): extractFile extracts file name from path

### DIFF
--- a/src/eventra-kit/__tests__/extract-file.test.js
+++ b/src/eventra-kit/__tests__/extract-file.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ExtractFile from '../extract-file.js';
+import { extractFile } from '../extract-file.js';
 
 describe('extract-file', () => {
-  it('exports a module', () => {
-    expect(ExtractFile).toBeDefined();
+  it('extracts the file name from a path', () => {
+    expect(extractFile('/home/user/docs/report.txt')).toBe('report.txt');
+    expect(extractFile('a/b/c')).toBe('c');
+    expect(extractFile('report.txt')).toBe('report.txt');
   });
 });
-

--- a/src/eventra-kit/extract-file.js
+++ b/src/eventra-kit/extract-file.js
@@ -2,6 +2,6 @@
  * adds a extract-file helper.
  */
 export function extractFile(value) {
-  return String(value).slice(-1);
+  return String(value).split(/[\\/]/).pop();
 }
 


### PR DESCRIPTION
## Summary

Fixes #18305

`extractFile` now extracts the file name from a path instead of returning the last character of the input.

## Changes

- `src/eventra-kit/extract-file.js`: return the part after the last path separator
- `src/eventra-kit/__tests__/extract-file.test.js`: add behavior tests

## Test

```js
extractFile('/home/user/docs/report.txt') // 'report.txt'
extractFile('a/b/c') // 'c'
extractFile('report.txt') // 'report.txt'
```

## GSSOC
