### PR TITLE
fix(kit): calculateCircle computes circle area

### DIFF
--- a/src/eventra-kit/__tests__/calculate-circle.test.js
+++ b/src/eventra-kit/__tests__/calculate-circle.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CalculateCircle from '../calculate-circle.js';
+import { calculateCircle } from '../calculate-circle.js';
 
 describe('calculate-circle', () => {
-  it('exports a module', () => {
-    expect(CalculateCircle).toBeDefined();
+  it('computes the area of a circle', () => {
+    expect(calculateCircle(1)).toBe(Math.PI);
+    expect(calculateCircle(2)).toBe(Math.PI * 4);
+    expect(calculateCircle(0)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/calculate-circle.js
+++ b/src/eventra-kit/calculate-circle.js
@@ -1,7 +1,7 @@
 /**
  * adds a calculate-circle helper.
  */
-export function calculateCircle(value, separator) {
-  return value.join(separator);
+export function calculateCircle(value) {
+  return Math.PI * value * value;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18306

`calculateCircle` now computes the area of a circle instead of calling `.join` on the input.

## Changes

- `src/eventra-kit/calculate-circle.js`: compute the area from the radius
- `src/eventra-kit/__tests__/calculate-circle.test.js`: add behavior tests

## Test

```js
calculateCircle(1) // Math.PI
calculateCircle(2) // Math.PI * 4
calculateCircle(0) // 0
```

## GSSOC
