### PR TITLE
fix(kit): averageWord computes average word length

### DIFF
--- a/src/eventra-kit/__tests__/average-word.test.js
+++ b/src/eventra-kit/__tests__/average-word.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AverageWord from '../average-word.js';
+import { averageWord } from '../average-word.js';
 
 describe('average-word', () => {
-  it('exports a module', () => {
-    expect(AverageWord).toBeDefined();
+  it('computes the average word length of a text', () => {
+    expect(averageWord('hello world')).toBe(5);
+    expect(averageWord('a bb')).toBe(1.5);
+    expect(averageWord('')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/average-word.js
+++ b/src/eventra-kit/average-word.js
@@ -2,6 +2,8 @@
  * adds a average-word helper.
  */
 export function averageWord(value) {
-  return String(value).charAt(0);
+  const words = String(value).trim().split(/\s+/).filter(Boolean);
+  if (!words.length) return 0;
+  return words.reduce((acc, word) => acc + word.length, 0) / words.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18307

`averageWord` now computes the average word length of a text instead of returning the first character.

## Changes

- `src/eventra-kit/average-word.js`: compute the mean word length
- `src/eventra-kit/__tests__/average-word.test.js`: add behavior tests

## Test

```js
averageWord('hello world') // 5
averageWord('a bb') // 1.5
averageWord('') // 0
```

## GSSOC
