### PR TITLE
fix(kit): buildVector builds vector array

### DIFF
--- a/src/eventra-kit/__tests__/build-vector.test.js
+++ b/src/eventra-kit/__tests__/build-vector.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as BuildVector from '../build-vector.js';
+import { buildVector } from '../build-vector.js';
 
 describe('build-vector', () => {
-  it('exports a module', () => {
-    expect(BuildVector).toBeDefined();
+  it('builds a vector array from a value', () => {
+    expect(buildVector([1, 2])).toEqual([1, 2]);
+    expect(buildVector(3)).toEqual([3]);
+    expect(buildVector('x')).toEqual(['x']);
   });
 });
-

--- a/src/eventra-kit/build-vector.js
+++ b/src/eventra-kit/build-vector.js
@@ -2,6 +2,6 @@
  * adds a build-vector helper.
  */
 export function buildVector(value) {
-  return value.length === 0;
+  return Array.isArray(value) ? value.slice() : [value];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18308

`buildVector` now builds a vector array from the input instead of returning a length check.

## Changes

- `src/eventra-kit/build-vector.js`: wrap non-array values in an array
- `src/eventra-kit/__tests__/build-vector.test.js`: add behavior tests

## Test

```js
buildVector([1, 2]) // [1, 2]
buildVector(3) // [3]
buildVector('x') // ['x']
```

## GSSOC
