### PR TITLE
fix(kit): countByte counts UTF-8 bytes

### DIFF
--- a/src/eventra-kit/__tests__/count-byte.test.js
+++ b/src/eventra-kit/__tests__/count-byte.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountByte from '../count-byte.js';
+import { countByte } from '../count-byte.js';
 
 describe('count-byte', () => {
-  it('exports a module', () => {
-    expect(CountByte).toBeDefined();
+  it('counts the bytes of a value', () => {
+    expect(countByte('abc')).toBe(3);
+    expect(countByte('')).toBe(0);
+    expect(countByte('é')).toBe(2);
   });
 });
-

--- a/src/eventra-kit/count-byte.js
+++ b/src/eventra-kit/count-byte.js
@@ -2,6 +2,6 @@
  * adds a count-byte helper.
  */
 export function countByte(value) {
-  return String(value).charAt(0);
+  return new TextEncoder().encode(String(value)).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18309

`countByte` now counts the UTF-8 bytes of a value instead of returning its first character.

## Changes

- `src/eventra-kit/count-byte.js`: count the UTF-8 encoded byte length
- `src/eventra-kit/__tests__/count-byte.test.js`: add behavior tests

## Test

```js
countByte('abc') // 3
countByte('') // 0
countByte('é') // 2
```

## GSSOC
