### PR TITLE
fix(kit): estimateChar returns character count

### DIFF
--- a/src/eventra-kit/__tests__/estimate-char.test.js
+++ b/src/eventra-kit/__tests__/estimate-char.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as EstimateChar from '../estimate-char.js';
+import { estimateChar } from '../estimate-char.js';
 
 describe('estimate-char', () => {
-  it('exports a module', () => {
-    expect(EstimateChar).toBeDefined();
+  it('estimates the character count of a string', () => {
+    expect(estimateChar('hello')).toBe(5);
+    expect(estimateChar('')).toBe(0);
+    expect(estimateChar(12345)).toBe(5);
   });
 });
-

--- a/src/eventra-kit/estimate-char.js
+++ b/src/eventra-kit/estimate-char.js
@@ -2,6 +2,6 @@
  * adds a estimate-char helper.
  */
 export function estimateChar(value) {
-  return String(value).slice(-1);
+  return String(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18310

`estimateChar` now returns the character count of a string instead of its last character.

## Changes

- `src/eventra-kit/estimate-char.js`: return the string length
- `src/eventra-kit/__tests__/estimate-char.test.js`: add behavior tests

## Test

```js
estimateChar('hello') // 5
estimateChar('') // 0
estimateChar(12345) // 5
```

## GSSOC
