### PR TITLE
fix(kit): computeChar returns first character

### DIFF
--- a/src/eventra-kit/__tests__/compute-char.test.js
+++ b/src/eventra-kit/__tests__/compute-char.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeChar from '../compute-char.js';
+import { computeChar } from '../compute-char.js';
 
 describe('compute-char', () => {
-  it('exports a module', () => {
-    expect(ComputeChar).toBeDefined();
+  it('returns the first character of the input', () => {
+    expect(computeChar('hello')).toBe('h');
+    expect(computeChar('')).toBe('');
+    expect(computeChar(42)).toBe('4');
   });
 });
-

--- a/src/eventra-kit/compute-char.js
+++ b/src/eventra-kit/compute-char.js
@@ -2,6 +2,6 @@
  * adds a compute-char helper.
  */
 export function computeChar(value) {
-  return typeof value === 'string';
+  return String(value).charAt(0);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18322

`computeChar` now returns the first character of the input instead of a type check result.

## Changes

- `src/eventra-kit/compute-char.js`: return the first character of the input
- `src/eventra-kit/__tests__/compute-char.test.js`: add behavior tests

## Test

```js
computeChar('hello') // 'h'
computeChar('') // ''
computeChar(42) // '4'
```

## GSSOC
