### PR TITLE
fix(kit): computeWord counts words

### DIFF
--- a/src/eventra-kit/__tests__/compute-word.test.js
+++ b/src/eventra-kit/__tests__/compute-word.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeWord from '../compute-word.js';
+import { computeWord } from '../compute-word.js';
 
 describe('compute-word', () => {
-  it('exports a module', () => {
-    expect(ComputeWord).toBeDefined();
+  it('counts the words of the input', () => {
+    expect(computeWord('hello world')).toBe(2);
+    expect(computeWord('')).toBe(0);
+    expect(computeWord('one')).toBe(1);
   });
 });
-

--- a/src/eventra-kit/compute-word.js
+++ b/src/eventra-kit/compute-word.js
@@ -2,6 +2,7 @@
  * adds a compute-word helper.
  */
 export function computeWord(value) {
-  return String(value).match(/\d+/g)?.map(Number) ?? [];
+  const words = String(value).trim().split(/\s+/).filter(Boolean);
+  return words.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18323

`computeWord` now counts the words of the input instead of extracting digits.

## Changes

- `src/eventra-kit/compute-word.js`: count the words of the input
- `src/eventra-kit/__tests__/compute-word.test.js`: add behavior tests

## Test

```js
computeWord('hello world') // 2
computeWord('') // 0
computeWord('one') // 1
```

## GSSOC
