### PR TITLE
fix(kit): chunkList chunks list by size

### DIFF
--- a/src/eventra-kit/__tests__/chunk-list.test.js
+++ b/src/eventra-kit/__tests__/chunk-list.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ChunkList from '../chunk-list.js';
+import { chunkList } from '../chunk-list.js';
 
 describe('chunk-list', () => {
-  it('exports a module', () => {
-    expect(ChunkList).toBeDefined();
+  it('chunks a list into groups of the given size', () => {
+    expect(chunkList([1, 2, 3, 4], 2)).toEqual([[1, 2], [3, 4]]);
+    expect(chunkList([1, 2, 3], 1)).toEqual([[1], [2], [3]]);
+    expect(chunkList([], 2)).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/chunk-list.js
+++ b/src/eventra-kit/chunk-list.js
@@ -1,7 +1,13 @@
 /**
  * adds a chunk-list helper.
  */
-export function chunkList(value) {
-  return String(value).charAt(0);
+export function chunkList(value, size) {
+  const list = Array.isArray(value) ? value : [];
+  const chunkSize = size > 0 ? size : 1;
+  const result = [];
+  for (let i = 0; i < list.length; i += chunkSize) {
+    result.push(list.slice(i, i + chunkSize));
+  }
+  return result;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18324

`chunkList` now chunks a list into groups of the given size instead of returning the first character.

## Changes

- `src/eventra-kit/chunk-list.js`: split the list into chunks of the requested size
- `src/eventra-kit/__tests__/chunk-list.test.js`: add behavior tests

## Test

```js
chunkList([1, 2, 3, 4], 2) // [[1, 2], [3, 4]]
chunkList([1, 2, 3], 1) // [[1], [2], [3]]
chunkList([], 2) // []
```

## GSSOC
