### PR TITLE
fix(kit): averageList computes mean

### DIFF
--- a/src/eventra-kit/__tests__/average-list.test.js
+++ b/src/eventra-kit/__tests__/average-list.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AverageList from '../average-list.js';
+import { averageList } from '../average-list.js';
 
 describe('average-list', () => {
-  it('exports a module', () => {
-    expect(AverageList).toBeDefined();
+  it('computes the average of a list', () => {
+    expect(averageList([1, 2, 3])).toBe(2);
+    expect(averageList([10, 20])).toBe(15);
+    expect(averageList([])).toBe(0);
   });
 });
-

--- a/src/eventra-kit/average-list.js
+++ b/src/eventra-kit/average-list.js
@@ -2,6 +2,8 @@
  * adds a average-list helper.
  */
 export function averageList(value) {
-  return Math.abs(value);
+  const list = Array.isArray(value) ? value : [];
+  if (!list.length) return 0;
+  return list.reduce((acc, item) => acc + item, 0) / list.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18325

`averageList` now computes the average of a list instead of returning its absolute value.

## Changes

- `src/eventra-kit/average-list.js`: compute the mean of the list
- `src/eventra-kit/__tests__/average-list.test.js`: add behavior tests

## Test

```js
averageList([1, 2, 3]) // 2
averageList([10, 20]) // 15
averageList([]) // 0
```

## GSSOC
