### PR TITLE
fix(frontend): replace undefined isPaged with content check (#18321)

### DIFF
--- a/src/Pages/Events/useEventListing.js
+++ b/src/Pages/Events/useEventListing.js
@@ -158,7 +158,7 @@ const useEventListing = () => {
 
       const normalizedEvents = apiEvents.map(normalizeEventItem);
       setEvents(normalizedEvents);
-      setServerPaged(isPaged);
+      setServerPaged(Array.isArray(responseData.content));
       setLastUpdated(new Date());
 
       setPagination({


### PR DESCRIPTION
## Summary

`useEventListing.js` line 161 referenced `isPaged`, which was never declared or imported anywhere in the codebase. It was dropped in commit `83e8e85c1` (#16167) which removed `const isPaged = Array.isArray(responseData.content);` but kept the usage.

## Impact (issue #18321)

Every successful fetch threw a `ReferenceError` → caught → `setEvents([])` + `setLoadError(...)` → the events listing was permanently stuck in the error state.

## Changes

- `setServerPaged(Array.isArray(responseData.content))` — matches the value already used for `pagination.serverPaginated` a few lines below.

## Verification

- `node --check` passes.
- No remaining references to `isPaged` in `src/`.

Closes #18321
