### PR TITLE
fix(backend): enforce write access before applying workspace update (#18332)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncService.java
@@ -67,6 +67,7 @@ public class TeamWorkspaceSyncService {
     }
 
     public Map<String, Object> applyUpdate(String roomKey, Map<String, Object> body) {
+        requireWriteAccess(roomKey);
         WorkspaceState room = roomFor(roomKey);
         synchronized (room.lock) {
             if (body != null) {


### PR DESCRIPTION
## Summary

`TeamWorkspaceSyncService.applyUpdate` overwrote the workspace state with no access check. `requireWriteAccess` (line 196) and `requireReadAccess` (line 175) were defined but never invoked — the controller only checks `isAuthenticated()`.

## Impact (issue #18332)

Any authenticated user could overwrite any hackathon team's shared workspace (tasks, pins, chat). The authorization helpers were dead code.

## Changes

- `applyUpdate` now calls `requireWriteAccess(roomKey)` before mutating state, which enforces hackathon ownership (or the caller's own user room).

## Verification

- `requireWriteAccess` rejects arbitrary/custom room keys and enforces ownership for `hackathon:` rooms.
- Read path (`snapshot`/`subscribe`) unchanged; a separate `requireReadAccess` already existed for future callers.

Closes #18332
