### PR TITLE
fix(kit): averageValue computes mean of values

### DIFF
--- a/src/eventra-kit/__tests__/average-value.test.js
+++ b/src/eventra-kit/__tests__/average-value.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AverageValue from '../average-value.js';
+import { averageValue } from '../average-value.js';
 
 describe('average-value', () => {
-  it('exports a module', () => {
-    expect(AverageValue).toBeDefined();
+  it('computes the average of a list of values', () => {
+    expect(averageValue([1, 2, 3])).toBe(2);
+    expect(averageValue([10, 20])).toBe(15);
+    expect(averageValue([])).toBe(0);
   });
 });
-

--- a/src/eventra-kit/average-value.js
+++ b/src/eventra-kit/average-value.js
@@ -1,7 +1,9 @@
 /**
  * adds a average-value helper.
  */
-export function averageValue(value, separator) {
-  return value.join(separator);
+export function averageValue(value) {
+  const list = Array.isArray(value) ? value : [];
+  if (!list.length) return 0;
+  return list.reduce((acc, item) => acc + item, 0) / list.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18326

`averageValue` now computes the average of a list of values instead of joining them into a string.

## Changes

- `src/eventra-kit/average-value.js`: compute the mean of the input list
- `src/eventra-kit/__tests__/average-value.test.js`: add behavior tests

## Test

```js
averageValue([1, 2, 3]) // 2
averageValue([10, 20]) // 15
averageValue([]) // 0
```

## GSSOC
