### PR TITLE
fix(kit): dedupeHash removes duplicate values

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-hash.test.js
+++ b/src/eventra-kit/__tests__/dedupe-hash.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DedupeHash from '../dedupe-hash.js';
+import { dedupeHash } from '../dedupe-hash.js';
 
 describe('dedupe-hash', () => {
-  it('exports a module', () => {
-    expect(DedupeHash).toBeDefined();
+  it('removes duplicate values from an array', () => {
+    expect(dedupeHash([1, 1, 2, 2])).toEqual([1, 2]);
+    expect(dedupeHash(['a', 'a', 'b'])).toEqual(['a', 'b']);
+    expect(dedupeHash([])).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/dedupe-hash.js
+++ b/src/eventra-kit/dedupe-hash.js
@@ -1,7 +1,7 @@
 /**
  * adds a dedupe-hash helper.
  */
-export function dedupeHash(value, separator) {
-  return value.join(separator);
+export function dedupeHash(value) {
+  return Array.isArray(value) ? [...new Set(value)] : [];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18327

`dedupeHash` now removes duplicate values from an array instead of joining them into a string.

## Changes

- `src/eventra-kit/dedupe-hash.js`: return the array with duplicates removed
- `src/eventra-kit/__tests__/dedupe-hash.test.js`: add behavior tests

## Test

```js
dedupeHash([1, 1, 2, 2]) // [1, 2]
dedupeHash(['a', 'a', 'b']) // ['a', 'b']
dedupeHash([]) // []
```

## GSSOC
