### PR TITLE
fix(backend): use @NotNull for Long eventId in CreateLostItemRequest (#18335)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreateLostItemRequest.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/dto/request/CreateLostItemRequest.java
@@ -1,12 +1,13 @@
 package com.sandeep.eventrabackend.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public class CreateLostItemRequest {
 
-    @NotBlank(message = "Event ID is required")
+    @NotNull(message = "Event ID is required")
     private Long eventId;
 
     @NotBlank(message = "Title is required")


### PR DESCRIPTION
## Summary

`CreateLostItemRequest` used `@NotBlank` on the `Long eventId` field. `@NotBlank` only validates `CharSequence`, so it silently did nothing on a numeric type.

## Impact (issue #18335)

A `null` `eventId` passed validation and reached `lostItemService` → `eventRepository.findById(null)`. The documented "Event ID is required" message never fired.

## Changes

- Replaced with `@NotNull(message = "Event ID is required")` and added the `jakarta.validation.constraints.NotNull` import.

## Verification

- `@NotNull` works for `Long` fields.
- Other string fields keep their `@NotBlank` annotations.

Closes #18335
