### PR TITLE
fix(kit): deduplicateUri removes duplicate URIs

### DIFF
--- a/src/eventra-kit/__tests__/deduplicate-uri.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-uri.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DeduplicateUri from '../deduplicate-uri.js';
+import { deduplicateUri } from '../deduplicate-uri.js';
 
 describe('deduplicate-uri', () => {
-  it('exports a module', () => {
-    expect(DeduplicateUri).toBeDefined();
+  it('removes duplicate URIs from a list', () => {
+    expect(deduplicateUri(['/a', '/a', '/b'])).toEqual(['/a', '/b']);
+    expect(deduplicateUri(['/x'])).toEqual(['/x']);
+    expect(deduplicateUri([])).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/deduplicate-uri.js
+++ b/src/eventra-kit/deduplicate-uri.js
@@ -2,6 +2,6 @@
  * adds a deduplicate-uri helper.
  */
 export function deduplicateUri(value) {
-  return typeof value === 'string';
+  return Array.isArray(value) ? [...new Set(value)] : [];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18328

`deduplicateUri` now removes duplicate URIs from a list instead of returning a type check result.

## Changes

- `src/eventra-kit/deduplicate-uri.js`: return the list with duplicate URIs removed
- `src/eventra-kit/__tests__/deduplicate-uri.test.js`: add behavior tests

## Test

```js
deduplicateUri(['/a', '/a', '/b']) // ['/a', '/b']
deduplicateUri(['/x']) // ['/x']
deduplicateUri([]) // []
```

## GSSOC
