### PR TITLE
fix(frontend): re-filter results on back/forward navigation (#18337)

### DIFF
--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -151,6 +151,10 @@ const useSearch = (options = {}) => {
     const urlQuery = searchParams.get(urlParam) || "";
     if (urlQuery !== query) {
       setQueryState(urlQuery);
+      setDebouncedQuery(
+        sanitize ? prepareSafeSearchQuery(urlQuery) : urlQuery
+      );
+      setIsSearching(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, urlParam, syncUrl]);


### PR DESCRIPTION
## Summary

`useSearch.js`'s URL→state effect (back/forward navigation) only updated `query` (the input text). It never updated `debouncedQuery` — the value components actually use for filtering/API calls — nor reset `isSearching`.

## Impact (issue #18337)

Search "react" on /projects, navigate away, press Back → input showed "react" but `debouncedQuery` stayed stale, so results were not filtered by the restored URL.

## Changes

- In the URL→state effect, also update `debouncedQuery` (sanitized via `prepareSafeSearchQuery`, consistent with initialization) and reset `isSearching`.

## Verification

- `node --check` passes.
- Matches how `debouncedQuery` is initialized from the URL param on mount (lines 132-134).

Closes #18337
