### PR TITLE
fix(kit): deduplicatePath removes duplicate paths

### DIFF
--- a/src/eventra-kit/__tests__/deduplicate-path.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-path.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DeduplicatePath from '../deduplicate-path.js';
+import { deduplicatePath } from '../deduplicate-path.js';
 
 describe('deduplicate-path', () => {
-  it('exports a module', () => {
-    expect(DeduplicatePath).toBeDefined();
+  it('removes duplicate paths from a space separated list', () => {
+    expect(deduplicatePath('/a /a /b')).toBe('/a /b');
+    expect(deduplicatePath('/x /y /y')).toBe('/x /y');
+    expect(deduplicatePath('')).toBe('');
   });
 });
-

--- a/src/eventra-kit/deduplicate-path.js
+++ b/src/eventra-kit/deduplicate-path.js
@@ -2,6 +2,6 @@
  * adds a deduplicate-path helper.
  */
 export function deduplicatePath(value) {
-  return String(value).slice(-1);
+  return [...new Set(String(value).split(/\s+/).filter(Boolean))].join(' ');
 }
 


### PR DESCRIPTION
## Summary

Fixes #18329

`deduplicatePath` now removes duplicate paths from a space separated list instead of returning the last character.

## Changes

- `src/eventra-kit/deduplicate-path.js`: split, dedupe, and rejoin the paths
- `src/eventra-kit/__tests__/deduplicate-path.test.js`: add behavior tests

## Test

```js
deduplicatePath('/a /a /b') // '/a /b'
deduplicatePath('/x /y /y') // '/x /y'
deduplicatePath('') // ''
```

## GSSOC
