### PR TITLE
fix(kit): createRecord builds record from pairs

### DIFF
--- a/src/eventra-kit/__tests__/create-record.test.js
+++ b/src/eventra-kit/__tests__/create-record.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import * as CreateRecord from '../create-record.js';
+import { createRecord } from '../create-record.js';
 
 describe('create-record', () => {
-  it('exports a module', () => {
-    expect(CreateRecord).toBeDefined();
+  it('builds a record from key/value pairs', () => {
+    expect(createRecord([['a', 1], ['b', 2]])).toEqual({ a: 1, b: 2 });
+    expect(createRecord([])).toEqual({});
   });
 });
-

--- a/src/eventra-kit/create-record.js
+++ b/src/eventra-kit/create-record.js
@@ -2,6 +2,6 @@
  * adds a create-record helper.
  */
 export function createRecord(value) {
-  return value.split(' ').filter(Boolean).length;
+  return Array.isArray(value) ? Object.fromEntries(value) : {};
 }
 


### PR DESCRIPTION
## Summary

Fixes #18330

`createRecord` now builds a record from key/value pairs instead of throwing or counting words.

## Changes

- `src/eventra-kit/create-record.js`: build an object from the input pairs
- `src/eventra-kit/__tests__/create-record.test.js`: add behavior tests

## Test

```js
createRecord([['a', 1], ['b', 2]]) // { a: 1, b: 2 }
createRecord([]) // {}
```

## GSSOC
