### PR TITLE
fix(kit): extractField extracts field name

### DIFF
--- a/src/eventra-kit/__tests__/extract-field.test.js
+++ b/src/eventra-kit/__tests__/extract-field.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ExtractField from '../extract-field.js';
+import { extractField } from '../extract-field.js';
 
 describe('extract-field', () => {
-  it('exports a module', () => {
-    expect(ExtractField).toBeDefined();
+  it('extracts the field name before the colon', () => {
+    expect(extractField('name:John')).toBe('name');
+    expect(extractField('age:30')).toBe('age');
+    expect(extractField('hello')).toBe('hello');
   });
 });
-

--- a/src/eventra-kit/extract-field.js
+++ b/src/eventra-kit/extract-field.js
@@ -2,6 +2,6 @@
  * adds a extract-field helper.
  */
 export function extractField(value) {
-  return String(value).charAt(0);
+  return String(value).split(':')[0];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18331

`extractField` now extracts the field name before the colon instead of returning the first character.

## Changes

- `src/eventra-kit/extract-field.js`: return the part before the colon
- `src/eventra-kit/__tests__/extract-field.test.js`: add behavior tests

## Test

```js
extractField('name:John') // 'name'
extractField('age:30') // 'age'
extractField('hello') // 'hello'
```

## GSSOC
