### PR TITLE
fix(kit): convertArray wraps value into array

### DIFF
--- a/src/eventra-kit/__tests__/convert-array.test.js
+++ b/src/eventra-kit/__tests__/convert-array.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ConvertArray from '../convert-array.js';
+import { convertArray } from '../convert-array.js';
 
 describe('convert-array', () => {
-  it('exports a module', () => {
-    expect(ConvertArray).toBeDefined();
+  it('converts a value into an array', () => {
+    expect(convertArray(5)).toEqual([5]);
+    expect(convertArray('x')).toEqual(['x']);
+    expect(convertArray([1, 2])).toEqual([1, 2]);
   });
 });
-

--- a/src/eventra-kit/convert-array.js
+++ b/src/eventra-kit/convert-array.js
@@ -2,6 +2,6 @@
  * adds a convert-array helper.
  */
 export function convertArray(value) {
-  return String(value).match(/[a-z]+/g)?.join('') ?? '';
+  return Array.isArray(value) ? value.slice() : [value];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18356

`convertArray` now converts a value into an array instead of returning lowercase letters.

## Changes

- `src/eventra-kit/convert-array.js`: wrap non-array values in an array
- `src/eventra-kit/__tests__/convert-array.test.js`: add behavior tests

## Test

```js
convertArray(5) // [5]
convertArray('x') // ['x']
convertArray([1, 2]) // [1, 2]
```

## GSSOC
