### PR TITLE
fix(kit): dedupeArray removes duplicate values

### DIFF
--- a/src/eventra-kit/__tests__/dedupe-array.test.js
+++ b/src/eventra-kit/__tests__/dedupe-array.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DedupeArray from '../dedupe-array.js';
+import { dedupeArray } from '../dedupe-array.js';
 
 describe('dedupe-array', () => {
-  it('exports a module', () => {
-    expect(DedupeArray).toBeDefined();
+  it('removes duplicate values from an array', () => {
+    expect(dedupeArray([1, 1, 2, 2])).toEqual([1, 2]);
+    expect(dedupeArray(['a', 'a', 'b'])).toEqual(['a', 'b']);
+    expect(dedupeArray([])).toEqual([]);
   });
 });
-

--- a/src/eventra-kit/dedupe-array.js
+++ b/src/eventra-kit/dedupe-array.js
@@ -2,6 +2,6 @@
  * adds a dedupe-array helper.
  */
 export function dedupeArray(value) {
-  return String(value).match(/[0-9]/g)?.length ?? 0;
+  return Array.isArray(value) ? [...new Set(value)] : [];
 }
 


### PR DESCRIPTION
## Summary

Fixes #18357

`dedupeArray` now removes duplicate values from an array instead of counting digits.

## Changes

- `src/eventra-kit/dedupe-array.js`: return the array with duplicates removed
- `src/eventra-kit/__tests__/dedupe-array.test.js`: add behavior tests

## Test

```js
dedupeArray([1, 1, 2, 2]) // [1, 2]
dedupeArray(['a', 'a', 'b']) // ['a', 'b']
dedupeArray([]) // []
```

## GSSOC
