### PR TITLE
fix(kit): detectSize returns input size

### DIFF
--- a/src/eventra-kit/__tests__/detect-size.test.js
+++ b/src/eventra-kit/__tests__/detect-size.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectSize from '../detect-size.js';
+import { detectSize } from '../detect-size.js';
 
 describe('detect-size', () => {
-  it('exports a module', () => {
-    expect(DetectSize).toBeDefined();
+  it('returns the size of the input', () => {
+    expect(detectSize([1, 2, 3])).toBe(3);
+    expect(detectSize('hello')).toBe(5);
+    expect(detectSize(12345)).toBe(5);
   });
 });
-

--- a/src/eventra-kit/detect-size.js
+++ b/src/eventra-kit/detect-size.js
@@ -2,6 +2,7 @@
  * adds a detect-size helper.
  */
 export function detectSize(value) {
-  return String(value).slice(-1);
+  if (Array.isArray(value) || typeof value === 'string') return value.length;
+  return String(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18358

`detectSize` now returns the size of the input instead of its last character.

## Changes

- `src/eventra-kit/detect-size.js`: return the length of the input
- `src/eventra-kit/__tests__/detect-size.test.js`: add behavior tests

## Test

```js
detectSize([1, 2, 3]) // 3
detectSize('hello') // 5
detectSize(12345) // 5
```

## GSSOC
