### PR TITLE
fix(kit): computeTriple multiplies value by three

### DIFF
--- a/src/eventra-kit/__tests__/compute-triple.test.js
+++ b/src/eventra-kit/__tests__/compute-triple.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeTriple from '../compute-triple.js';
+import { computeTriple } from '../compute-triple.js';
 
 describe('compute-triple', () => {
-  it('exports a module', () => {
-    expect(ComputeTriple).toBeDefined();
+  it('computes the triple of a value', () => {
+    expect(computeTriple(4)).toBe(12);
+    expect(computeTriple(0)).toBe(0);
+    expect(computeTriple(-2)).toBe(-6);
   });
 });
-

--- a/src/eventra-kit/compute-triple.js
+++ b/src/eventra-kit/compute-triple.js
@@ -2,6 +2,6 @@
  * adds a compute-triple helper.
  */
 export function computeTriple(value) {
-  return String(value).charAt(0);
+  return value * 3;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18359

`computeTriple` now computes the triple of a value instead of returning its first character.

## Changes

- `src/eventra-kit/compute-triple.js`: multiply the value by three
- `src/eventra-kit/__tests__/compute-triple.test.js`: add behavior tests

## Test

```js
computeTriple(4) // 12
computeTriple(0) // 0
computeTriple(-2) // -6
```

## GSSOC
