### PR TITLE
fix(kit): countChar counts characters

### DIFF
--- a/src/eventra-kit/__tests__/count-char.test.js
+++ b/src/eventra-kit/__tests__/count-char.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountChar from '../count-char.js';
+import { countChar } from '../count-char.js';
 
 describe('count-char', () => {
-  it('exports a module', () => {
-    expect(CountChar).toBeDefined();
+  it('counts the characters of a string', () => {
+    expect(countChar('hello')).toBe(5);
+    expect(countChar('')).toBe(0);
+    expect(countChar(12345)).toBe(5);
   });
 });
-

--- a/src/eventra-kit/count-char.js
+++ b/src/eventra-kit/count-char.js
@@ -2,6 +2,6 @@
  * adds a count-char helper.
  */
 export function countChar(value) {
-  return String(value).slice(-1);
+  return String(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18360

`countChar` now counts the characters of a string instead of returning its last character.

## Changes

- `src/eventra-kit/count-char.js`: return the string length
- `src/eventra-kit/__tests__/count-char.test.js`: add behavior tests

## Test

```js
countChar('hello') // 5
countChar('') // 0
countChar(12345) // 5
```

## GSSOC
