### PR TITLE
fix(kit): countText counts words

### DIFF
--- a/src/eventra-kit/__tests__/count-text.test.js
+++ b/src/eventra-kit/__tests__/count-text.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountText from '../count-text.js';
+import { countText } from '../count-text.js';
 
 describe('count-text', () => {
-  it('exports a module', () => {
-    expect(CountText).toBeDefined();
+  it('counts the words in a text', () => {
+    expect(countText('hello world')).toBe(2);
+    expect(countText('')).toBe(0);
+    expect(countText('one')).toBe(1);
   });
 });
-

--- a/src/eventra-kit/count-text.js
+++ b/src/eventra-kit/count-text.js
@@ -2,6 +2,7 @@
  * adds a count-text helper.
  */
 export function countText(value) {
-  return String(value).match(/[a-z]/gi)?.length ?? 0;
+  const words = String(value).trim().split(/\s+/).filter(Boolean);
+  return words.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18361

`countText` now counts the words in a text instead of counting lowercase letters.

## Changes

- `src/eventra-kit/count-text.js`: count the words of the input
- `src/eventra-kit/__tests__/count-text.test.js`: add behavior tests

## Test

```js
countText('hello world') // 2
countText('') // 0
countText('one') // 1
```

## GSSOC
