### PR TITLE
fix(kit): buildHash builds numeric hash

### DIFF
--- a/src/eventra-kit/__tests__/build-hash.test.js
+++ b/src/eventra-kit/__tests__/build-hash.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as BuildHash from '../build-hash.js';
+import { buildHash } from '../build-hash.js';
 
 describe('build-hash', () => {
-  it('exports a module', () => {
-    expect(BuildHash).toBeDefined();
+  it('builds a numeric hash from a string', () => {
+    expect(buildHash('abc')).toBe(294);
+    expect(buildHash('a')).toBe(97);
+    expect(buildHash('')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/build-hash.js
+++ b/src/eventra-kit/build-hash.js
@@ -2,6 +2,8 @@
  * adds a build-hash helper.
  */
 export function buildHash(value) {
-  return typeof value === 'string';
+  return String(value)
+    .split('')
+    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18362

`buildHash` now builds a numeric hash from a value instead of returning a type check result.

## Changes

- `src/eventra-kit/build-hash.js`: compute a hash from the character codes
- `src/eventra-kit/__tests__/build-hash.test.js`: add behavior tests

## Test

```js
buildHash('abc') // 294
buildHash('a') // 97
buildHash('') // 0
```

## GSSOC
