### PR TITLE
fix(kit): clampString clamps string length

### DIFF
--- a/src/eventra-kit/__tests__/clamp-string.test.js
+++ b/src/eventra-kit/__tests__/clamp-string.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ClampString from '../clamp-string.js';
+import { clampString } from '../clamp-string.js';
 
 describe('clamp-string', () => {
-  it('exports a module', () => {
-    expect(ClampString).toBeDefined();
+  it('clamps a string to a maximum length', () => {
+    expect(clampString('hello world', 5)).toBe('hello');
+    expect(clampString('hi', 5)).toBe('hi');
+    expect(clampString('hello', 0)).toBe('');
   });
 });
-

--- a/src/eventra-kit/clamp-string.js
+++ b/src/eventra-kit/clamp-string.js
@@ -1,7 +1,7 @@
 /**
  * adds a clamp-string helper.
  */
-export function clampString(value) {
-  return String(value).match(/\d+/g)?.map(Number) ?? [];
+export function clampString(value, max) {
+  return String(value).slice(0, max);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18363

`clampString` now clamps a string to a maximum length instead of extracting digits.

## Changes

- `src/eventra-kit/clamp-string.js`: truncate the string to the maximum length
- `src/eventra-kit/__tests__/clamp-string.test.js`: add behavior tests

## Test

```js
clampString('hello world', 5) // 'hello'
clampString('hi', 5) // 'hi'
clampString('hello', 0) // ''
```

## GSSOC
