### PR TITLE
fix(kit): detectFile detects file name from path

### DIFF
--- a/src/eventra-kit/__tests__/detect-file.test.js
+++ b/src/eventra-kit/__tests__/detect-file.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectFile from '../detect-file.js';
+import { detectFile } from '../detect-file.js';
 
 describe('detect-file', () => {
-  it('exports a module', () => {
-    expect(DetectFile).toBeDefined();
+  it('detects the file name from a path', () => {
+    expect(detectFile('/a/b/c.txt')).toBe('c.txt');
+    expect(detectFile('dir/file')).toBe('file');
+    expect(detectFile('report.txt')).toBe('report.txt');
   });
 });
-

--- a/src/eventra-kit/detect-file.js
+++ b/src/eventra-kit/detect-file.js
@@ -2,6 +2,6 @@
  * adds a detect-file helper.
  */
 export function detectFile(value) {
-  return Math.abs(value);
+  return String(value).split(/[\\/]/).pop();
 }
 


### PR DESCRIPTION
## Summary

Fixes #18364

`detectFile` now detects the file name from a path instead of returning its absolute value.

## Changes

- `src/eventra-kit/detect-file.js`: return the part after the last path separator
- `src/eventra-kit/__tests__/detect-file.test.js`: add behavior tests

## Test

```js
detectFile('/a/b/c.txt') // 'c.txt'
detectFile('dir/file') // 'file'
detectFile('report.txt') // 'report.txt'
```

## GSSOC
