### PR TITLE
fix(frontend): compose caller onLoad instead of letting it override internal handler (#18340)

### DIFF
--- a/src/components/common/LazyImage.jsx
+++ b/src/components/common/LazyImage.jsx
@@ -28,6 +28,7 @@ const LazyImage = ({
   imgStyle,
   useWebP = false,
   onError,
+  onLoad,
   previewSrc,
   // Low bandwidth mode options
   lowBandwidthPlaceholder = true,
@@ -176,6 +177,7 @@ const LazyImage = ({
       onLoad={(e) => {
         setLoaded(true);
         handleLoad?.(e);
+        onLoad?.(e);
       }}
       onError={handleOnError}
       className={`lazy-img ${


### PR DESCRIPTION
## Summary

`LazyImage` only destructured `onError` out of props — `onLoad` landed in the `{...props}` spread, which was applied **after** the internal `onLoad`, silently replacing it.

## Impact (issue #18340)

Any consumer passing `onLoad` replaced the internal handler → `setLoaded(true)` never ran → the skeleton shimmer never faded.

## Changes

- Destructured `onLoad` from props.
- Composed it into the internal `onLoad` handler (`setLoaded` + `handleLoad` + caller `onLoad`), mirroring how `onError`/`handleError` already work.

## Verification

- No current callers pass `onLoad`, so behavior is unchanged; future callers compose correctly.

Closes #18340
