### PR TITLE
fix(frontend): compute check-in window state in the event timezone (#18342)

### DIFF
--- a/src/components/events/checkin-window/EventCheckinWindow.tsx
+++ b/src/components/events/checkin-window/EventCheckinWindow.tsx
@@ -78,6 +78,35 @@ const getMinutesFromTime = (time: string): number => {
   return hours * 60 + minutes;
 };
 
+const getCurrentMinutesInTimezone = (timezone?: string): number => {
+  const date = new Date();
+  const timeZone = timezone && timezone.trim() ? timezone : undefined;
+
+  if (timeZone) {
+    try {
+      const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        hour: "numeric",
+        minute: "numeric",
+        hourCycle: "h23",
+      }).formatToParts(date);
+
+      const hour = Number(
+        parts.find((part) => part.type === "hour")?.value ?? "0",
+      );
+      const minute = Number(
+        parts.find((part) => part.type === "minute")?.value ?? "0",
+      );
+      return hour * 60 + minute;
+    } catch {
+      // Invalid timezone id — fall back to the caller's local time.
+      return date.getHours() * 60 + date.getMinutes();
+    }
+  }
+
+  return date.getHours() * 60 + date.getMinutes();
+};
+
 const getWindowState = (
   config: EventCheckinWindowConfig | null,
 ): CheckInWindowState => {
@@ -92,10 +121,7 @@ const getWindowState = (
     return "not-configured";
   }
 
-  const currentDate = new Date();
-
-  const currentMinutes =
-    currentDate.getHours() * 60 + currentDate.getMinutes();
+  const currentMinutes = getCurrentMinutesInTimezone(config.timezone);
 
   if (currentMinutes < startMinutes) {
     return "upcoming";


### PR DESCRIPTION
## Summary

`EventCheckinWindow.tsx` computed the current time with `new Date().getHours()/getMinutes()` — the browser's local clock — and compared it against `startTime`/`endTime` which are expressed in the event's configured `timezone`. The timezone field was validated and displayed but never used.

## Impact (issue #18342)

For a user whose local timezone differs from the event's configured timezone, the window state (upcoming/open/closed) was wrong around boundary hours (e.g. an event in UTC+1 viewed from UTC-8).

## Changes

- Added `getCurrentMinutesInTimezone(timezone)` which resolves the current hour/minute in the configured timezone via `Intl.DateTimeFormat` (`hourCycle: "h23"`), falling back to the caller's local time when the timezone is missing or invalid.
- `getWindowState` now uses it.

## Verification

- Local vs `America/New_York` produce different minute values as expected.
- Invalid timezone falls back to local time.
- `hourCycle: "h23"` avoids the `24:xx` midnight edge case across browsers.

Closes #18342
