### PR TITLE
fix(frontend): record AI insight telemetry once per request (#18343)

### DIFF
--- a/src/utils/aiInsightsEngine.js
+++ b/src/utils/aiInsightsEngine.js
@@ -961,7 +961,6 @@ const _sanitizeProfileForAI = (profile) => {
  */
 export const generateAIInsights = async (event, profile = {}, options = {}) => {
   const startTime = Date.now();
-  _telemetry.recordRequest(startTime, 'start');
   
   const {
     signal,
@@ -1019,11 +1018,6 @@ export const generateAIInsights = async (event, profile = {}, options = {}) => {
         
         logger.info(`[AIInsightsEngine] Cache hit for event ${eventId}`);
         
-        // Update telemetry with cache latency
-        const latency = Date.now() - startTime;
-        _telemetry.metrics.totalLatency += latency;
-        _telemetry.metrics.latencies.push(latency);
-        
         return { ...cachedInsights, cached: true };
       }
       _telemetry.recordCacheMiss();
@@ -1078,8 +1072,7 @@ export const generateAIInsights = async (event, profile = {}, options = {}) => {
         
         return insights;
       } else {
-        // No fallback enabled, rethrow the error
-        _telemetry.recordRequest(startTime, 'fallback_disabled');
+        // No fallback enabled, rethrow the error (outer catch records once)
         throw new Error(`AI service failed and local fallback disabled: ${aiError.message}`);
       }
     }


### PR DESCRIPTION
## Summary

`generateAIInsights` recorded telemetry more than once per logical request: an unconditional `recordRequest(startTime, 'start')` ran at the top, then each terminal branch (`cache_hit`, `ai_success`, `fallback_success`, `fallback_disabled`, `error`) recorded again. The cache-hit path also manually added `totalLatency`/`latencies` a third time. The `fallback_disabled` branch recorded before throwing, then the outer catch recorded again.

## Impact (issue #18343)

Every request counted as 2-3 requests — `cacheHitRate` was halved and `averageLatency` inflated in `getMetrics()`.

## Changes

- Removed the unconditional `recordRequest(startTime, 'start')` at the top.
- Removed the manual `totalLatency`/`latencies.push` on the cache-hit path.
- Removed the redundant `recordRequest` in the `fallback_disabled` branch (the throw is caught by the outer catch which records once).

Each logical request now records exactly once.

## Verification

- `node --check` passes for the changed regions (the file has a pre-existing duplicate `createProfileHash` export on master, unrelated to this change).
- Terminal branches: cache_hit / ai_success / fallback_success / error each record once.

Closes #18343
