### PR TITLE
fix(frontend): prevent duplicate active speakers on repeated transitions (#18344)

### DIFF
--- a/src/components/events/AIDirectorStream.jsx
+++ b/src/components/events/AIDirectorStream.jsx
@@ -108,7 +108,9 @@ const AIDirectorStream = () => {
     if (!canManageTransitions()) return;
     
     // Simulate transition - add speaker to active speakers
-    setActiveSpeakers(prev => [...prev, speakerId]);
+    setActiveSpeakers(prev =>
+      prev.includes(speakerId) ? prev : [...prev, speakerId]
+    );
     setPendingTransitions(prev => prev.filter(id => id !== speakerId));
     addLog(`Speaker ${speakerId} transitioned to live stage`);
     


### PR DESCRIPTION
## Summary

`handleTransitionSpeaker` in `AIDirectorStream.jsx` unconditionally appended the speaker to `activeSpeakers`. If the transition was triggered more than once for the same speaker (e.g. a stale event, double-click, or retry after a failed state update), the speaker appeared multiple times in the active list while `pendingTransitions` correctly removed the id.

## Impact (issue #18344)

Duplicate speaker tiles in the live-stage grid; React key warnings.

## Changes

- `setActiveSpeakers` now uses a functional update that only appends the id when it is not already present: `prev.includes(speakerId) ? prev : [...prev, speakerId]`.

## Verification

- Single add-site for active speakers in this file (confirmed via search); dedupe is applied at the state level so repeated calls are idempotent.

Closes #18344
