### PR TITLE
fix(frontend): compare date range filter bounds in local time (#18381)

### DIFF
--- a/src/hooks/useAdvancedEventSearch.js
+++ b/src/hooks/useAdvancedEventSearch.js
@@ -136,8 +136,12 @@ export default function useAdvancedEventSearch(events = [], { debounceMs = 250 }
 
   // ---- Filter + sort pipeline ----
   const results = useMemo(() => {
-    const from = filters.dateFrom ? new Date(filters.dateFrom) : null;
-    const to   = filters.dateTo   ? new Date(filters.dateTo)   : null;
+    const from = filters.dateFrom
+      ? new Date(filters.dateFrom + "T00:00:00")
+      : null;
+    const to = filters.dateTo
+      ? new Date(filters.dateTo + "T23:59:59.999")
+      : null;
 
     return events
       .filter((event) => {


### PR DESCRIPTION
## Summary

`useAdvancedEventSearch.js` parsed the date-range bounds with `new Date("YYYY-MM-DD")`, which is interpreted as **UTC midnight**, then compared against `event.date`/`event.startDate` parsed in **local time**.

## Impact (issue #18381)

For a UTC-5 user with `dateTo = "2026-08-14"`, the `to` bound resolved to Aug 13 19:00 local, dropping legitimate events on Aug 14. `dateFrom` had the symmetric problem. Date-range results shifted by the local offset everywhere outside UTC.

## Changes

- `from` → `new Date(filters.dateFrom + "T00:00:00")` (local midnight)
- `to` → `new Date(filters.dateTo + "T23:59:59.999")` (local end-of-day)

## Verification

- `node --check` passes.
- Bounds now parse in the same local-time zone as the event dates being compared.

Closes #18381
