### PR TITLE
fix(frontend): guard getAvailableTimeSlots against non-positive duration (#18382)

### DIFF
--- a/src/utils/multiTrackScheduleUtils.js
+++ b/src/utils/multiTrackScheduleUtils.js
@@ -259,6 +259,15 @@ export const getAvailableTimeSlots = (
   trackId,
   occupiedSlots = []
 ) => {
+  if (
+    !Number.isFinite(slotDurationMinutes) ||
+    slotDurationMinutes <= 0 ||
+    !(startDate instanceof Date) ||
+    !(endDate instanceof Date)
+  ) {
+    return [];
+  }
+
   const slots = [];
   let currentTime = new Date(startDate);
   const endTime = new Date(endDate);


### PR DESCRIPTION
## Summary

`getAvailableTimeSlots` advanced `currentTime` by `slotDurationMinutes * 60 * 1000` in a `while` loop. A `slotDurationMinutes` of `0` or negative never advanced the pointer, causing an infinite loop.

## Impact (issue #18382)

Calling the util with a zero/negative duration froze the page. The default parameter (`= 60`) only fires on `undefined`, not `0`, so the guard was needed. `buildTimeSlots` in `eventSchedulingUtils.js` already had this exact guard; `getAvailableTimeSlots` was missed.

## Changes

- Return `[]` early when `slotDurationMinutes` is non-finite, `<= 0`, or when start/end dates are invalid.

## Verification

- `node --check` passes.
- The loop can no longer run unbounded for any input combination.

Closes #18382
