### PR TITLE
fix(backend): move read-only transaction hint onto getAllEvents (#18383)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -212,11 +212,6 @@ public class EventService {
                                                 "Event not found with id: " + id));
         }
 
-        /**
-         * Retrieves a page of public events with optional search / status / sort.
-         */
-        @Transactional(readOnly = true)
-
         private Event requirePublicEvent(Long id) {
                 return eventRepository.findById(id)
                                 .filter(Event::isPublic)
@@ -226,6 +221,10 @@ public class EventService {
                                                 "Event not found with id: " + id));
         }
 
+        /**
+         * Retrieves a page of public events with optional search / status / sort.
+         */
+        @Transactional(readOnly = true)
         public PagedResponse<EventResponse> getAllEvents(
                         int page,
                         int size,


### PR DESCRIPTION
## Summary

In `EventService.java`, the `@Transactional(readOnly = true)` annotation (plus the "Retrieves a page of public events…" javadoc) sat on the private method `requirePublicEvent`. Private methods aren't proxied by Spring, so the hint was dead code — while `getAllEvents`, the read method the javadoc describes, ran without it.

## Impact (issue #18383)

`getAllEvents` missed its intended read-only transaction optimization; the annotation was misleading.

## Changes

- Moved the javadoc + `@Transactional(readOnly = true)` onto `getAllEvents`.
- Kept `requirePublicEvent` as a plain private helper (behavior unchanged).

## Verification

- `requirePublicEvent` still defined exactly once; all four call sites unaffected.
- `getAllEvents` now carries the read-only hint it was always meant to have.

Closes #18383
