### PR TITLE
fix(kit): ensureFile coerces value into string

### DIFF
--- a/src/eventra-kit/__tests__/ensure-file.test.js
+++ b/src/eventra-kit/__tests__/ensure-file.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as EnsureFile from '../ensure-file.js';
+import { ensureFile } from '../ensure-file.js';
 
 describe('ensure-file', () => {
-  it('exports a module', () => {
-    expect(EnsureFile).toBeDefined();
+  it('coerces a value into a file path string', () => {
+    expect(ensureFile(42)).toBe('42');
+    expect(ensureFile('abc')).toBe('abc');
+    expect(ensureFile(true)).toBe('true');
   });
 });
-

--- a/src/eventra-kit/ensure-file.js
+++ b/src/eventra-kit/ensure-file.js
@@ -2,6 +2,6 @@
  * adds a ensure-file helper.
  */
 export function ensureFile(value) {
-  return typeof value === 'string';
+  return String(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18365

`ensureFile` now coerces a value into a file path string instead of returning a type check result.

## Changes

- `src/eventra-kit/ensure-file.js`: return the string representation of the input
- `src/eventra-kit/__tests__/ensure-file.test.js`: add behavior tests

## Test

```js
ensureFile(42) // '42'
ensureFile('abc') // 'abc'
ensureFile(true) // 'true'
```

## GSSOC
