### PR TITLE
refactor(backend): remove duplicated null-check in ZkpVerifierService (#18385)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ZkpVerifierService.java
@@ -89,9 +89,6 @@ public class ZkpVerifierService {
         if (!payload.getEventId().matches("^[0-9]+$")) {
             return false;
         }
-        if (payload == null || payload.getEventId() == null || payload.getProofHash() == null || payload.getNullifierHash() == null) {
-            return false;
-        }
 
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");


### PR DESCRIPTION
## Summary

`ZkpVerifierService.verifyProof` ran an identical null/field guard twice in a row (the second block is unreachable for its own conditions since the first already returned).

## Impact (issue #18385)

Pure redundant code; no behavior change from removing it.

## Changes

- Deleted the duplicate `if` block.

## Verification

- Pure deletion; the first guard still covers all four null checks before the eventId regex check.

Closes #18385
