### PR TITLE
fix(backend): remove orphaned @CacheEvict(events) with no matching cache (#18386)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,8 +1,5 @@
 package com.sandeep.eventrabackend.service;
 
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-
 import com.sandeep.eventrabackend.dto.request.CancelEventRequest;
 import com.sandeep.eventrabackend.dto.request.CsvWaitlistImportRequest;
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
@@ -544,7 +541,6 @@ public class EventService {
          * @throws EventNotFoundException if the event does not exist
          */
         @Transactional
-        @CacheEvict(value = "events", key = "#id")
         public EventResponse updateEvent(Long id, EventUpdateRequest request, String userEmail) {
                 Event event = eventRepository.findById(id)
                                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));


### PR DESCRIPTION
## Summary

`EventService.updateEvent` carried `@CacheEvict(value = "events", key = "#id")`, but no method in the backend ever populates an `"events"` cache (no matching `@Cacheable("events")` exists). The eviction was a permanent no-op. The only real cache pair in the backend is `@Cacheable`/`@CacheEvict` on `"hackathons"` in `HackathonService`.

## Impact (issue #18386)

Misleading annotation implying the events cache is invalidated on update; the unused cache annotations (`CacheEvict`/`Cacheable` imports) were also dead.

## Changes

- Removed the orphaned `@CacheEvict(value = "events", key = "#id")` from `updateEvent`.
- Removed the now-unused `CacheEvict` and `Cacheable` imports from `EventService`.

## Verification

- Full-tree search confirms only `"hackathons"` has both `@Cacheable` and `@CacheEvict`; `"events"` is never read from cache.
- Pure deletion, no behavior change.

Closes #18386
