### PR TITLE
fix(kit): assertMap checks for object

### DIFF
--- a/src/eventra-kit/__tests__/assert-map.test.js
+++ b/src/eventra-kit/__tests__/assert-map.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AssertMap from '../assert-map.js';
+import { assertMap } from '../assert-map.js';
 
 describe('assert-map', () => {
-  it('exports a module', () => {
-    expect(AssertMap).toBeDefined();
+  it('checks whether the input is an object', () => {
+    expect(assertMap({ a: 1 })).toBe(true);
+    expect(assertMap(null)).toBe(false);
+    expect(assertMap([1, 2])).toBe(false);
   });
 });
-

--- a/src/eventra-kit/assert-map.js
+++ b/src/eventra-kit/assert-map.js
@@ -2,6 +2,6 @@
  * adds a assert-map helper.
  */
 export function assertMap(value) {
-  return String(value).match(/[0-9]/g)?.length ?? 0;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18402

`assertMap` now checks whether the input is an object instead of counting digits.

## Changes

- `src/eventra-kit/assert-map.js`: return whether the input is a plain object
- `src/eventra-kit/__tests__/assert-map.test.js`: add behavior tests

## Test

```js
assertMap({ a: 1 }) // true
assertMap(null) // false
assertMap([1, 2]) // false
```

## GSSOC
