### PR TITLE
refactor(backend): use SLF4J logging in WebhookDispatchService (#18388)

### DIFF
--- a/Backend/src/main/java/com/eventra/service/WebhookDispatchService.java
+++ b/Backend/src/main/java/com/eventra/service/WebhookDispatchService.java
@@ -1,5 +1,7 @@
 package com.eventra.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -8,12 +10,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.util.Map;
-import java.util.logging.Logger;
 
 @Service
 public class WebhookDispatchService {
 
-    private static final Logger logger = Logger.getLogger(WebhookDispatchService.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(WebhookDispatchService.class);
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Async
@@ -25,9 +26,9 @@ public class WebhookDispatchService {
 
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
             restTemplate.postForEntity(webhookUrl, request, String.class);
-            logger.info("Successfully dispatched webhook notification to: " + webhookUrl);
+            logger.info("Successfully dispatched webhook notification to: {}", webhookUrl);
         } catch (Exception e) {
-            logger.severe("Failed to dispatch webhook to " + webhookUrl + ": " + e.getMessage());
+            logger.error("Failed to dispatch webhook to {}: {}", webhookUrl, e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
## Summary

`WebhookDispatchService` used `java.util.logging.Logger` while the rest of the backend logs through SLF4J, so webhook dispatch messages never reached the application's structured logging pipeline.

## Impact (issue #18388)

Webhook dispatch failures were invisible in production log aggregation, making lost callbacks hard to diagnose.

## Changes

- Switched to SLF4J (`LoggerFactory`), matching the standard pattern used across the backend (`ContactService`, `EventService`, etc.).
- `logger.severe(...)` → `logger.error(..., e)` (includes stack trace).
- String concatenation → SLF4J `{}` placeholders (avoids formatting cost when the line isn't logged).

## Verification

- Matches the `org.slf4j.Logger` + `LoggerFactory.getLogger` convention used elsewhere in the codebase.
- `java.util.logging` import removed.

Closes #18388
