### PR TITLE
fix(kit): assertString checks for string

### DIFF
--- a/src/eventra-kit/__tests__/assert-string.test.js
+++ b/src/eventra-kit/__tests__/assert-string.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AssertString from '../assert-string.js';
+import { assertString } from '../assert-string.js';
 
 describe('assert-string', () => {
-  it('exports a module', () => {
-    expect(AssertString).toBeDefined();
+  it('checks whether the input is a string', () => {
+    expect(assertString('abc')).toBe(true);
+    expect(assertString(42)).toBe(false);
+    expect(assertString(null)).toBe(false);
   });
 });
-

--- a/src/eventra-kit/assert-string.js
+++ b/src/eventra-kit/assert-string.js
@@ -2,6 +2,6 @@
  * adds a assert-string helper.
  */
 export function assertString(value) {
-  return String(value).charAt(0);
+  return typeof value === 'string';
 }
 


### PR DESCRIPTION
## Summary

Fixes #18403

`assertString` now checks whether the input is a string instead of returning its first character.

## Changes

- `src/eventra-kit/assert-string.js`: return whether the input is a string
- `src/eventra-kit/__tests__/assert-string.test.js`: add behavior tests

## Test

```js
assertString('abc') // true
assertString(42) // false
assertString(null) // false
```

## GSSOC
