### PR TITLE
fix(backend): clamp months window in getUserGrowthTrend (#18389)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -373,7 +373,8 @@ public class AdminService {
      * their {@code createdAt}, not event registrations (Issue #11232).
      */
     public List<RegistrationTrendDTO> getUserGrowthTrend(int months) {
-        LocalDateTime from = LocalDateTime.now().minusMonths(months);
+        int safeMonths = Math.max(1, Math.min(months, 24));
+        LocalDateTime from = LocalDateTime.now().minusMonths(safeMonths);
         List<Object[]> raw = userRepository.findMonthlySignupTrend(from);
 
         final long[] cumulative = { 0 };


### PR DESCRIPTION
## Summary

`getUserGrowthTrend(months)` used the caller-supplied `months` directly in `LocalDateTime.now().minusMonths(months)`:
- `months = 0` → window is now → empty trend
- `months < 0` → window is in the future → meaningless chart
- huge values → unnecessarily expensive query

## Impact (issue #18389)

An admin caller could request a nonsensical window and get a 200 with empty data instead of a sane clamped range.

## Changes

- Clamp to `[1, 24]`: `int safeMonths = Math.max(1, Math.min(months, 24));`

## Verification

- `months = 0` → `1`; `months = -5` → `1`; `months = 999` → `24`; default `6` unchanged.
- Matches the clamping style already used for paging elsewhere (e.g. `Math.min(Math.max(0, page), MAX_EVENTS_PAGE)`).

Closes #18389
