### PR TITLE
fix(kit): assertUrl validates URL

### DIFF
--- a/src/eventra-kit/__tests__/assert-url.test.js
+++ b/src/eventra-kit/__tests__/assert-url.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AssertUrl from '../assert-url.js';
+import { assertUrl } from '../assert-url.js';
 
 describe('assert-url', () => {
-  it('exports a module', () => {
-    expect(AssertUrl).toBeDefined();
+  it('checks whether the input is a valid URL', () => {
+    expect(assertUrl('https://example.com')).toBe(true);
+    expect(assertUrl('http://localhost:3000')).toBe(true);
+    expect(assertUrl('not-a-url')).toBe(false);
   });
 });
-

--- a/src/eventra-kit/assert-url.js
+++ b/src/eventra-kit/assert-url.js
@@ -2,6 +2,11 @@
  * adds a assert-url helper.
  */
 export function assertUrl(value) {
-  return String(value).match(/\d+/g)?.map(Number) ?? [];
+  try {
+    new URL(String(value));
+    return true;
+  } catch {
+    return false;
+  }
 }
 


### PR DESCRIPTION
## Summary

Fixes #18404

`assertUrl` now checks whether the input is a valid URL instead of extracting digits.

## Changes

- `src/eventra-kit/assert-url.js`: return whether the input parses as a URL
- `src/eventra-kit/__tests__/assert-url.test.js`: add behavior tests

## Test

```js
assertUrl('https://example.com') // true
assertUrl('http://localhost:3000') // true
assertUrl('not-a-url') // false
```

## GSSOC
