### PR TITLE
fix(frontend): seed auto-assign occupancy with already-assigned sessions (#18390)

### DIFF
--- a/src/hooks/useMultiTrackSchedule.js
+++ b/src/hooks/useMultiTrackSchedule.js
@@ -290,7 +290,7 @@ export const useMultiTrackSchedule = (eventId) => {
         throw new Error('All sessions are already assigned');
       }
 
-      const assigned = autoAssignSessionsToTracks(unassignedSessions, state.tracks);
+      const assigned = autoAssignSessionsToTracks(state.sessions, state.tracks);
       const updatedSessions = state.sessions.map(s => {
         const assignedSession = assigned.find(a => a.id === s.id);
         return assignedSession || s;

--- a/src/utils/multiTrackScheduleUtils.js
+++ b/src/utils/multiTrackScheduleUtils.js
@@ -177,7 +177,7 @@ export const calculateOverlapMinutes = (session1, session2) => {
 
 /**
  * Auto-assign sessions to tracks using a greedy algorithm
- * @param {Array} sessions - Unassigned sessions
+ * @param {Array} sessions - All sessions (assigned and unassigned)
  * @param {Array} tracks - Available tracks
  * @returns {Array} Sessions with assigned tracks
  */
@@ -190,15 +190,27 @@ export const autoAssignSessionsToTracks = (sessions, tracks) => {
     trackOccupancy.set(track.id, []);
   });
 
-  // Sort sessions by duration (longest first) for better packing
-  assignedSessions.sort((a, b) => {
-    const durationA = new Date(a.endTime) - new Date(a.startTime);
-    const durationB = new Date(b.endTime) - new Date(b.startTime);
-    return durationB - durationA;
+  // Seed occupancy with already-assigned sessions so the greedy placement
+  // never overlaps sessions the user assigned manually.
+  assignedSessions.forEach(session => {
+    if (session.trackId) {
+      const occupancy = trackOccupancy.get(session.trackId) || [];
+      occupancy.push(session);
+      trackOccupancy.set(session.trackId, occupancy);
+    }
   });
 
+  // Sort unassigned sessions by duration (longest first) for better packing
+  const unassignedSessions = assignedSessions
+    .filter(session => !session.trackId)
+    .sort((a, b) => {
+      const durationA = new Date(a.endTime) - new Date(a.startTime);
+      const durationB = new Date(b.endTime) - new Date(b.startTime);
+      return durationB - durationA;
+    });
+
   // Assign each session to the best available track
-  assignedSessions.forEach(session => {
+  unassignedSessions.forEach(session => {
     const bestTrack = findBestAvailableTrack(session, tracks, trackOccupancy);
     if (bestTrack) {
       session.trackId = bestTrack.id;


### PR DESCRIPTION
## Summary

`useMultiTrackSchedule`'s auto-assign passed only the **unassigned** sessions to `autoAssignSessionsToTracks`, and the util built its `trackOccupancy` solely from those. Sessions the user had already assigned manually were invisible to the conflict check, so auto-assign could place a new session directly over a manually-assigned one — then `updateConflicts` flagged the conflict the feature itself created.

## Impact (issue #18390)

Auto-assigned schedules contradicted the user's manual assignments; the conflict modal immediately reported new conflicts.

## Changes

- `autoAssignSessionsToTracks` now:
  - Seeds `trackOccupancy` from sessions that already have a `trackId` (preserving manual assignments),
  - Only (re)assigns sessions without a `trackId`.
- Hook passes the full `state.sessions` list instead of the filtered `unassignedSessions`.

## Verification

- Simulation: track A has a manual 10:00-11:00 session; an unassigned 10:30-11:30 session now assigns to track B (previously would take A and overlap).
- Already-assigned sessions keep their track. `node --check` passes on both files.

Closes #18390
