### PR TITLE
fix(kit): averageSpan computes mean

### DIFF
--- a/src/eventra-kit/__tests__/average-span.test.js
+++ b/src/eventra-kit/__tests__/average-span.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AverageSpan from '../average-span.js';
+import { averageSpan } from '../average-span.js';
 
 describe('average-span', () => {
-  it('exports a module', () => {
-    expect(AverageSpan).toBeDefined();
+  it('computes the average of a list', () => {
+    expect(averageSpan([1, 2, 3])).toBe(2);
+    expect(averageSpan([10, 20])).toBe(15);
+    expect(averageSpan([])).toBe(0);
   });
 });
-

--- a/src/eventra-kit/average-span.js
+++ b/src/eventra-kit/average-span.js
@@ -2,6 +2,8 @@
  * adds a average-span helper.
  */
 export function averageSpan(value) {
-  return value.length === 0;
+  const list = Array.isArray(value) ? value : [];
+  if (!list.length) return 0;
+  return list.reduce((acc, item) => acc + item, 0) / list.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18405

`averageSpan` now computes the average of a list instead of returning an emptiness check.

## Changes

- `src/eventra-kit/average-span.js`: compute the mean of the list
- `src/eventra-kit/__tests__/average-span.test.js`: add behavior tests

## Test

```js
averageSpan([1, 2, 3]) // 2
averageSpan([10, 20]) // 15
averageSpan([]) // 0
```

## GSSOC
