### PR TITLE
fix(frontend): flag reversed schedule ranges instead of silently swapping (#18391)

### DIFF
--- a/src/utils/scheduleConflictUtils.js
+++ b/src/utils/scheduleConflictUtils.js
@@ -162,6 +162,7 @@ export const getEventScheduleRange = (
     return {
       start: end,
       end: start,
+      reversed: true,
     };
   }
 
@@ -1003,6 +1004,17 @@ export const validateEventSchedule = (
       valid: false,
       errors: [
         "Event start and end times are required.",
+      ],
+    };
+  }
+
+  if (
+    range.reversed
+  ) {
+    return {
+      valid: false,
+      errors: [
+        "Event end time must be after the start time.",
       ],
     };
   }


### PR DESCRIPTION
## Summary

`getEventScheduleRange` silently swapped reversed ranges (`end < start`), so `validateEventSchedule` — which relies on the returned range — never saw the malformed input and reported such events as valid.

## Impact (issue #18391)

An event with `endDate < startDate` passed validation and the UI showed a valid-looking range instead of an "end after start" error.

## Changes

- `getEventScheduleRange` now returns `{ start, end, reversed: true }` when the end precedes the start (still swapped for downstream overlap math, but explicitly flagged).
- `validateEventSchedule` returns `valid: false` with "Event end time must be after the start time." when `range.reversed` is set.

## Verification

- Normal range → `valid: true`.
- Reversed range → `valid: false` with the end-before-start error.
- Existing callers (`schedulesOverlap`, `detectScheduleConflicts`, etc.) still receive a valid `{ start, end }` shape; the new flag is additive.
- `node --check` passes.

Closes #18391
