### PR TITLE
fix(kit): clampIndex clamps into range

### DIFF
--- a/src/eventra-kit/__tests__/clamp-index.test.js
+++ b/src/eventra-kit/__tests__/clamp-index.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ClampIndex from '../clamp-index.js';
+import { clampIndex } from '../clamp-index.js';
 
 describe('clamp-index', () => {
-  it('exports a module', () => {
-    expect(ClampIndex).toBeDefined();
+  it('clamps the index between zero and the upper bound', () => {
+    expect(clampIndex(5, 3)).toBe(3);
+    expect(clampIndex(-2, 10)).toBe(0);
+    expect(clampIndex(7, 10)).toBe(7);
   });
 });
-

--- a/src/eventra-kit/clamp-index.js
+++ b/src/eventra-kit/clamp-index.js
@@ -1,7 +1,9 @@
 /**
  * adds a clamp-index helper.
  */
-export function clampIndex(value) {
-  return String(value).match(/[a-z]/gi)?.length ?? 0;
+export function clampIndex(value, max) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  const upper = typeof max === 'number' && Number.isFinite(max) ? max : value;
+  return Math.min(Math.max(0, value), upper);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18407

`clampIndex` now clamps an index between zero and an upper bound instead of counting letters.

## Changes

- `src/eventra-kit/clamp-index.js`: clamp the index into the valid range
- `src/eventra-kit/__tests__/clamp-index.test.js`: add behavior tests

## Test

```js
clampIndex(5, 3) // 3
clampIndex(-2, 10) // 0
clampIndex(7, 10) // 7
```

## GSSOC
