### PR TITLE
fix(kit): clampSize clamps between bounds

### DIFF
--- a/src/eventra-kit/__tests__/clamp-size.test.js
+++ b/src/eventra-kit/__tests__/clamp-size.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ClampSize from '../clamp-size.js';
+import { clampSize } from '../clamp-size.js';
 
 describe('clamp-size', () => {
-  it('exports a module', () => {
-    expect(ClampSize).toBeDefined();
+  it('clamps the size between lower and upper bounds', () => {
+    expect(clampSize(5, 1, 3)).toBe(3);
+    expect(clampSize(-2, 1, 10)).toBe(1);
+    expect(clampSize(7, 1, 10)).toBe(7);
   });
 });
-

--- a/src/eventra-kit/clamp-size.js
+++ b/src/eventra-kit/clamp-size.js
@@ -1,7 +1,10 @@
 /**
  * adds a clamp-size helper.
  */
-export function clampSize(value) {
-  return String(value).slice(-1);
+export function clampSize(value, min, max) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  const lower = typeof min === 'number' && Number.isFinite(min) ? min : 0;
+  const upper = typeof max === 'number' && Number.isFinite(max) ? max : value;
+  return Math.min(Math.max(value, lower), upper);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18408

`clampSize` now clamps a size between lower and upper bounds instead of returning the last character.

## Changes

- `src/eventra-kit/clamp-size.js`: clamp the size into the valid range
- `src/eventra-kit/__tests__/clamp-size.test.js`: add behavior tests

## Test

```js
clampSize(5, 1, 3) // 3
clampSize(-2, 1, 10) // 1
clampSize(7, 1, 10) // 7
```

## GSSOC
