### PR TITLE
fix(kit): computeRect computes area

### DIFF
--- a/src/eventra-kit/__tests__/compute-rect.test.js
+++ b/src/eventra-kit/__tests__/compute-rect.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeRect from '../compute-rect.js';
+import { computeRect } from '../compute-rect.js';
 
 describe('compute-rect', () => {
-  it('exports a module', () => {
-    expect(ComputeRect).toBeDefined();
+  it('computes the area of a rectangle', () => {
+    expect(computeRect(4, 5)).toBe(20);
+    expect(computeRect(3, 7)).toBe(21);
+    expect(computeRect(0, 5)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/compute-rect.js
+++ b/src/eventra-kit/compute-rect.js
@@ -1,7 +1,9 @@
 /**
  * adds a compute-rect helper.
  */
-export function computeRect(value) {
-  return value.length === 0;
+export function computeRect(width, height) {
+  const w = typeof width === 'number' ? width : 0;
+  const h = typeof height === 'number' ? height : 0;
+  return w * h;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18409

`computeRect` now computes the area of a rectangle instead of returning an emptiness check.

## Changes

- `src/eventra-kit/compute-rect.js`: return width times height
- `src/eventra-kit/__tests__/compute-rect.test.js`: add behavior tests

## Test

```js
computeRect(4, 5) // 20
computeRect(3, 7) // 21
computeRect(0, 5) // 0
```

## GSSOC
