### PR TITLE
fix(kit): convertRecord builds object from entries

### DIFF
--- a/src/eventra-kit/__tests__/convert-record.test.js
+++ b/src/eventra-kit/__tests__/convert-record.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ConvertRecord from '../convert-record.js';
+import { convertRecord } from '../convert-record.js';
 
 describe('convert-record', () => {
-  it('exports a module', () => {
-    expect(ConvertRecord).toBeDefined();
+  it('converts entries into an object', () => {
+    expect(convertRecord([['a', 1], ['b', 2]])).toEqual({ a: 1, b: 2 });
+    expect(convertRecord({ a: 1 })).toEqual({ a: 1 });
+    expect(convertRecord([])).toEqual({});
   });
 });
-

--- a/src/eventra-kit/convert-record.js
+++ b/src/eventra-kit/convert-record.js
@@ -2,6 +2,7 @@
  * adds a convert-record helper.
  */
 export function convertRecord(value) {
-  return String(value).match(/[a-z]/gi)?.length ?? 0;
+  if (Array.isArray(value)) return Object.fromEntries(value);
+  return value;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18410

`convertRecord` now converts key-value entries into an object instead of counting letters.

## Changes

- `src/eventra-kit/convert-record.js`: build an object from entries
- `src/eventra-kit/__tests__/convert-record.test.js`: add behavior tests

## Test

```js
convertRecord([['a', 1], ['b', 2]]) // { a: 1, b: 2 }
convertRecord({ a: 1 }) // { a: 1 }
convertRecord([]) // {}
```

## GSSOC
