### PR TITLE
fix(kit): computeByte returns byte length

### DIFF
--- a/src/eventra-kit/__tests__/compute-byte.test.js
+++ b/src/eventra-kit/__tests__/compute-byte.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeByte from '../compute-byte.js';
+import { computeByte } from '../compute-byte.js';
 
 describe('compute-byte', () => {
-  it('exports a module', () => {
-    expect(ComputeByte).toBeDefined();
+  it('computes the UTF-8 byte length of a string', () => {
+    expect(computeByte('abc')).toBe(3);
+    expect(computeByte('é')).toBe(2);
+    expect(computeByte('')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/compute-byte.js
+++ b/src/eventra-kit/compute-byte.js
@@ -2,6 +2,6 @@
  * adds a compute-byte helper.
  */
 export function computeByte(value) {
-  return typeof value === 'number';
+  return new TextEncoder().encode(String(value)).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18430

`computeByte` now returns the UTF-8 byte length of the input string instead of a type check.

## Changes

- `src/eventra-kit/compute-byte.js`: compute byte length with `TextEncoder`
- `src/eventra-kit/__tests__/compute-byte.test.js`: add behavior tests

## Test

```js
computeByte('abc') // 3
computeByte('é') // 2
computeByte('') // 0
```

## GSSOC
