### PR TITLE
fix(kit): computeFraction returns fractional part

### DIFF
--- a/src/eventra-kit/__tests__/compute-fraction.test.js
+++ b/src/eventra-kit/__tests__/compute-fraction.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeFraction from '../compute-fraction.js';
+import { computeFraction } from '../compute-fraction.js';
 
 describe('compute-fraction', () => {
-  it('exports a module', () => {
-    expect(ComputeFraction).toBeDefined();
+  it('returns the fractional part of a number', () => {
+    expect(computeFraction(3.75)).toBeCloseTo(0.75);
+    expect(computeFraction(7)).toBe(0);
+    expect(computeFraction(-1.5)).toBeCloseTo(-0.5);
   });
 });
-

--- a/src/eventra-kit/compute-fraction.js
+++ b/src/eventra-kit/compute-fraction.js
@@ -2,6 +2,7 @@
  * adds a compute-fraction helper.
  */
 export function computeFraction(value) {
-  return String(value).split('').reverse().join('');
+  const n = Number(value);
+  return n - Math.trunc(n);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18431

`computeFraction` now returns the fractional part of a number instead of reversing the string.

## Changes

- `src/eventra-kit/compute-fraction.js`: return the fractional part
- `src/eventra-kit/__tests__/compute-fraction.test.js`: add behavior tests

## Test

```js
computeFraction(3.75) // 0.75
computeFraction(7) // 0
computeFraction(-1.5) // -0.5
```

## GSSOC
