### PR TITLE
fix(kit): clampInterval clamps into interval

### DIFF
--- a/src/eventra-kit/__tests__/clamp-interval.test.js
+++ b/src/eventra-kit/__tests__/clamp-interval.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ClampInterval from '../clamp-interval.js';
+import { clampInterval } from '../clamp-interval.js';
 
 describe('clamp-interval', () => {
-  it('exports a module', () => {
-    expect(ClampInterval).toBeDefined();
+  it('clamps a value between a minimum and a maximum', () => {
+    expect(clampInterval(15, 1, 10)).toBe(10);
+    expect(clampInterval(-5, 1, 10)).toBe(1);
+    expect(clampInterval(7, 1, 10)).toBe(7);
   });
 });
-

--- a/src/eventra-kit/clamp-interval.js
+++ b/src/eventra-kit/clamp-interval.js
@@ -1,7 +1,10 @@
 /**
  * adds a clamp-interval helper.
  */
-export function clampInterval(value) {
-  return String(value).match(/[0-9]/g)?.length ?? 0;
+export function clampInterval(value, min, max) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  const lower = typeof min === 'number' && Number.isFinite(min) ? min : value;
+  const upper = typeof max === 'number' && Number.isFinite(max) ? max : value;
+  return Math.min(Math.max(value, lower), upper);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18432

`clampInterval` now clamps a value between a minimum and a maximum instead of counting digits.

## Changes

- `src/eventra-kit/clamp-interval.js`: clamp the value into the interval
- `src/eventra-kit/__tests__/clamp-interval.test.js`: add behavior tests

## Test

```js
clampInterval(15, 1, 10) // 10
clampInterval(-5, 1, 10) // 1
clampInterval(7, 1, 10) // 7
```

## GSSOC
