### PR TITLE
fix(kit): estimateRecord counts fields

### DIFF
--- a/src/eventra-kit/__tests__/estimate-record.test.js
+++ b/src/eventra-kit/__tests__/estimate-record.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as EstimateRecord from '../estimate-record.js';
+import { estimateRecord } from '../estimate-record.js';
 
 describe('estimate-record', () => {
-  it('exports a module', () => {
-    expect(EstimateRecord).toBeDefined();
+  it('counts the number of fields in a record', () => {
+    expect(estimateRecord({ a: 1, b: 2 })).toBe(2);
+    expect(estimateRecord({})).toBe(0);
+    expect(estimateRecord(null)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/estimate-record.js
+++ b/src/eventra-kit/estimate-record.js
@@ -2,6 +2,6 @@
  * adds a estimate-record helper.
  */
 export function estimateRecord(value) {
-  return Math.abs(value);
+  return typeof value === 'object' && value !== null ? Object.keys(value).length : 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18433

`estimateRecord` now counts the number of fields in a record instead of calling `Math.abs`.

## Changes

- `src/eventra-kit/estimate-record.js`: count the record keys
- `src/eventra-kit/__tests__/estimate-record.test.js`: add behavior tests

## Test

```js
estimateRecord({ a: 1, b: 2 }) // 2
estimateRecord({}) // 0
estimateRecord(null) // 0
```

## GSSOC
