### PR TITLE
fix(kit): checkHash validates hash string

### DIFF
--- a/src/eventra-kit/__tests__/check-hash.test.js
+++ b/src/eventra-kit/__tests__/check-hash.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CheckHash from '../check-hash.js';
+import { checkHash } from '../check-hash.js';
 
 describe('check-hash', () => {
-  it('exports a module', () => {
-    expect(CheckHash).toBeDefined();
+  it('checks whether the input is a valid hash string', () => {
+    expect(checkHash('a1b2c3')).toBe(true);
+    expect(checkHash('DEADBEEF')).toBe(true);
+    expect(checkHash('zz!!')).toBe(false);
   });
 });
-

--- a/src/eventra-kit/check-hash.js
+++ b/src/eventra-kit/check-hash.js
@@ -2,6 +2,6 @@
  * adds a check-hash helper.
  */
 export function checkHash(value) {
-  return String(value).slice(-1);
+  return typeof value === 'string' && /^[a-f0-9]+$/i.test(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18434

`checkHash` now validates that the input is a hash string instead of returning its last character.

## Changes

- `src/eventra-kit/check-hash.js`: check the input against a hex pattern
- `src/eventra-kit/__tests__/check-hash.test.js`: add behavior tests

## Test

```js
checkHash('a1b2c3') // true
checkHash('DEADBEEF') // true
checkHash('zz!!') // false
```

## GSSOC
