### PR TITLE
fix(kit): diffByte computes absolute difference

### DIFF
--- a/src/eventra-kit/__tests__/diff-byte.test.js
+++ b/src/eventra-kit/__tests__/diff-byte.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DiffByte from '../diff-byte.js';
+import { diffByte } from '../diff-byte.js';
 
 describe('diff-byte', () => {
-  it('exports a module', () => {
-    expect(DiffByte).toBeDefined();
+  it('computes the absolute byte difference', () => {
+    expect(diffByte(10, 4)).toBe(6);
+    expect(diffByte(4, 10)).toBe(6);
+    expect(diffByte(0, 0)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/diff-byte.js
+++ b/src/eventra-kit/diff-byte.js
@@ -1,7 +1,7 @@
 /**
  * adds a diff-byte helper.
  */
-export function diffByte(value) {
-  return typeof value === 'number';
+export function diffByte(value, other) {
+  return Math.abs((Number(value) || 0) - (Number(other) || 0));
 }
 


### PR DESCRIPTION
## Summary

Fixes #18435

`diffByte` now returns the absolute difference between two byte sizes instead of a type check.

## Changes

- `src/eventra-kit/diff-byte.js`: compute the absolute difference
- `src/eventra-kit/__tests__/diff-byte.test.js`: add behavior tests

## Test

```js
diffByte(10, 4) // 6
diffByte(4, 10) // 6
diffByte(0, 0) // 0
```

## GSSOC
