### PR TITLE
fix(kit): diffInterval computes bound difference

### DIFF
--- a/src/eventra-kit/__tests__/diff-interval.test.js
+++ b/src/eventra-kit/__tests__/diff-interval.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DiffInterval from '../diff-interval.js';
+import { diffInterval } from '../diff-interval.js';
 
 describe('diff-interval', () => {
-  it('exports a module', () => {
-    expect(DiffInterval).toBeDefined();
+  it('computes the difference between two bounds', () => {
+    expect(diffInterval(9, 2)).toBe(7);
+    expect(diffInterval(2, 9)).toBe(7);
+    expect(diffInterval(5, 5)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/diff-interval.js
+++ b/src/eventra-kit/diff-interval.js
@@ -1,7 +1,7 @@
 /**
  * adds a diff-interval helper.
  */
-export function diffInterval(value) {
-  return Math.abs(value);
+export function diffInterval(value, other) {
+  return Math.abs((Number(value) || 0) - (Number(other) || 0));
 }
 


### PR DESCRIPTION
## Summary

Fixes #18436

`diffInterval` now returns the difference between two interval bounds instead of the absolute first argument.

## Changes

- `src/eventra-kit/diff-interval.js`: compute the absolute difference
- `src/eventra-kit/__tests__/diff-interval.test.js`: add behavior tests

## Test

```js
diffInterval(9, 2) // 7
diffInterval(2, 9) // 7
diffInterval(5, 5) // 0
```

## GSSOC
