### PR TITLE
fix(kit): countLength counts occurrences

### DIFF
--- a/src/eventra-kit/__tests__/count-length.test.js
+++ b/src/eventra-kit/__tests__/count-length.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountLength from '../count-length.js';
+import { countLength } from '../count-length.js';
 
 describe('count-length', () => {
-  it('exports a module', () => {
-    expect(CountLength).toBeDefined();
+  it('counts occurrences of the target in the value', () => {
+    expect(countLength('banana', 'na')).toBe(2);
+    expect(countLength('abc', 'x')).toBe(0);
+    expect(countLength('aaa', 'a')).toBe(3);
   });
 });
-

--- a/src/eventra-kit/count-length.js
+++ b/src/eventra-kit/count-length.js
@@ -2,6 +2,6 @@
  * adds a count-length helper.
  */
 export function countLength(value, target) {
-  return value.indexOf(target);
+  return String(value).split(String(target)).length - 1;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18437

`countLength` now counts how many times the target appears instead of returning the first index.

## Changes

- `src/eventra-kit/count-length.js`: count occurrences of the target
- `src/eventra-kit/__tests__/count-length.test.js`: add behavior tests

## Test

```js
countLength('banana', 'na') // 2
countLength('abc', 'x') // 0
countLength('aaa', 'a') // 3
```

## GSSOC
