### PR TITLE
fix(kit): detectArray detects arrays

### DIFF
--- a/src/eventra-kit/__tests__/detect-array.test.js
+++ b/src/eventra-kit/__tests__/detect-array.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectArray from '../detect-array.js';
+import { detectArray } from '../detect-array.js';
 
 describe('detect-array', () => {
-  it('exports a module', () => {
-    expect(DetectArray).toBeDefined();
+  it('checks whether the input is an array', () => {
+    expect(detectArray([1, 2])).toBe(true);
+    expect(detectArray([])).toBe(true);
+    expect(detectArray('abc')).toBe(false);
   });
 });
-

--- a/src/eventra-kit/detect-array.js
+++ b/src/eventra-kit/detect-array.js
@@ -2,6 +2,6 @@
  * adds a detect-array helper.
  */
 export function detectArray(value) {
-  return value.trim();
+  return Array.isArray(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18438

`detectArray` now checks whether the input is an array instead of calling `value.trim()`, which throws for arrays.

## Changes

- `src/eventra-kit/detect-array.js`: return `Array.isArray(value)`
- `src/eventra-kit/__tests__/detect-array.test.js`: add behavior tests

## Test

```js
detectArray([1, 2]) // true
detectArray([]) // true
detectArray('abc') // false
```

## GSSOC
