### PR TITLE
fix(kit): detectObject detects objects

### DIFF
--- a/src/eventra-kit/__tests__/detect-object.test.js
+++ b/src/eventra-kit/__tests__/detect-object.test.js
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import * as DetectObject from '../detect-object.js';
+import { detectObject } from '../detect-object.js';
 
 describe('detect-object', () => {
-  it('exports a module', () => {
-    expect(DetectObject).toBeDefined();
+  it('checks whether the input is an object', () => {
+    expect(detectObject({ a: 1 })).toBe(true);
+    expect(detectObject({})).toBe(true);
+    expect(detectObject('abc')).toBe(false);
+    expect(detectObject(null)).toBe(false);
   });
 });
-

--- a/src/eventra-kit/detect-object.js
+++ b/src/eventra-kit/detect-object.js
@@ -2,6 +2,6 @@
  * adds a detect-object helper.
  */
 export function detectObject(value) {
-  return value.length === 0;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18439

`detectObject` now checks whether the input is an object instead of returning an emptiness check.

## Changes

- `src/eventra-kit/detect-object.js`: return whether the input is an object
- `src/eventra-kit/__tests__/detect-object.test.js`: add behavior tests

## Test

```js
detectObject({ a: 1 }) // true
detectObject({}) // true
detectObject('abc') // false
detectObject(null) // false
```

## GSSOC
