### PR TITLE
fix(kit): averageDict computes mean of values

### DIFF
--- a/src/eventra-kit/__tests__/average-dict.test.js
+++ b/src/eventra-kit/__tests__/average-dict.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as AverageDict from '../average-dict.js';
+import { averageDict } from '../average-dict.js';
 
 describe('average-dict', () => {
-  it('exports a module', () => {
-    expect(AverageDict).toBeDefined();
+  it('computes the average of dictionary values', () => {
+    expect(averageDict({ a: 1, b: 3 })).toBe(2);
+    expect(averageDict({ a: 10, b: 20 })).toBe(15);
+    expect(averageDict({})).toBe(0);
   });
 });
-

--- a/src/eventra-kit/average-dict.js
+++ b/src/eventra-kit/average-dict.js
@@ -2,6 +2,8 @@
  * adds a average-dict helper.
  */
 export function averageDict(value) {
-  return typeof value === 'number';
+  const list = typeof value === 'object' && value !== null ? Object.values(value) : [];
+  if (!list.length) return 0;
+  return list.reduce((acc, item) => acc + item, 0) / list.length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18451

`averageDict` now computes the average of the values in a dictionary instead of a type check.

## Changes

- `src/eventra-kit/average-dict.js`: compute the mean of the dictionary values
- `src/eventra-kit/__tests__/average-dict.test.js`: add behavior tests

## Test

```js
averageDict({ a: 1, b: 3 }) // 2
averageDict({ a: 10, b: 20 }) // 15
averageDict({}) // 0
```

## GSSOC
