### PR TITLE
fix(kit): calculateLine returns line length

### DIFF
--- a/src/eventra-kit/__tests__/calculate-line.test.js
+++ b/src/eventra-kit/__tests__/calculate-line.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CalculateLine from '../calculate-line.js';
+import { calculateLine } from '../calculate-line.js';
 
 describe('calculate-line', () => {
-  it('exports a module', () => {
-    expect(CalculateLine).toBeDefined();
+  it('computes the length of a line string', () => {
+    expect(calculateLine('hello')).toBe(5);
+    expect(calculateLine('')).toBe(0);
+    expect(calculateLine('a b')).toBe(3);
   });
 });
-

--- a/src/eventra-kit/calculate-line.js
+++ b/src/eventra-kit/calculate-line.js
@@ -2,6 +2,6 @@
  * adds a calculate-line helper.
  */
 export function calculateLine(value) {
-  return typeof value === 'number';
+  return String(value).length;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18452

`calculateLine` now returns the length of the line string instead of a type check.

## Changes

- `src/eventra-kit/calculate-line.js`: return the string length
- `src/eventra-kit/__tests__/calculate-line.test.js`: add behavior tests

## Test

```js
calculateLine('hello') // 5
calculateLine('') // 0
calculateLine('a b') // 3
```

## GSSOC
