### PR TITLE
fix(kit): computeObject counts fields

### DIFF
--- a/src/eventra-kit/__tests__/compute-object.test.js
+++ b/src/eventra-kit/__tests__/compute-object.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as ComputeObject from '../compute-object.js';
+import { computeObject } from '../compute-object.js';
 
 describe('compute-object', () => {
-  it('exports a module', () => {
-    expect(ComputeObject).toBeDefined();
+  it('counts the number of fields in an object', () => {
+    expect(computeObject({ a: 1, b: 2 })).toBe(2);
+    expect(computeObject({})).toBe(0);
+    expect(computeObject(null)).toBe(0);
   });
 });
-

--- a/src/eventra-kit/compute-object.js
+++ b/src/eventra-kit/compute-object.js
@@ -2,6 +2,6 @@
  * adds a compute-object helper.
  */
 export function computeObject(value) {
-  return String(value).match(/[0-9]/g)?.length ?? 0;
+  return typeof value === 'object' && value !== null ? Object.keys(value).length : 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18453

`computeObject` now counts the number of fields in an object instead of counting digits.

## Changes

- `src/eventra-kit/compute-object.js`: count the object keys
- `src/eventra-kit/__tests__/compute-object.test.js`: add behavior tests

## Test

```js
computeObject({ a: 1, b: 2 }) // 2
computeObject({}) // 0
computeObject(null) // 0
```

## GSSOC
