### PR TITLE
fix(kit): countInterval counts range integers

### DIFF
--- a/src/eventra-kit/__tests__/count-interval.test.js
+++ b/src/eventra-kit/__tests__/count-interval.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CountInterval from '../count-interval.js';
+import { countInterval } from '../count-interval.js';
 
 describe('count-interval', () => {
-  it('exports a module', () => {
-    expect(CountInterval).toBeDefined();
+  it('counts the integers between two bounds', () => {
+    expect(countInterval(2, 5)).toBe(4);
+    expect(countInterval(5, 5)).toBe(1);
+    expect(countInterval(5, 2)).toBe(4);
   });
 });
-

--- a/src/eventra-kit/count-interval.js
+++ b/src/eventra-kit/count-interval.js
@@ -1,7 +1,12 @@
 /**
  * adds a count-interval helper.
  */
-export function countInterval(value) {
-  return typeof value === 'string';
+export function countInterval(start, end) {
+  const a = Number(start);
+  const b = Number(end);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return 0;
+  const lo = Math.min(a, b);
+  const hi = Math.max(a, b);
+  return Math.floor(hi) - Math.ceil(lo) + 1;
 }
 


### PR DESCRIPTION
## Summary

Fixes #18454

`countInterval` now counts the integers between two bounds instead of a type check.

## Changes

- `src/eventra-kit/count-interval.js`: count the integers in the interval
- `src/eventra-kit/__tests__/count-interval.test.js`: add behavior tests

## Test

```js
countInterval(2, 5) // 4
countInterval(5, 5) // 1
countInterval(5, 2) // 4
```

## GSSOC
