### PR TITLE
fix(kit): createNumber converts to number

### DIFF
--- a/src/eventra-kit/__tests__/create-number.test.js
+++ b/src/eventra-kit/__tests__/create-number.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CreateNumber from '../create-number.js';
+import { createNumber } from '../create-number.js';
 
 describe('create-number', () => {
-  it('exports a module', () => {
-    expect(CreateNumber).toBeDefined();
+  it('converts the input to a number', () => {
+    expect(createNumber('42')).toBe(42);
+    expect(createNumber('3.5')).toBe(3.5);
+    expect(createNumber(7)).toBe(7);
   });
 });
-

--- a/src/eventra-kit/create-number.js
+++ b/src/eventra-kit/create-number.js
@@ -2,6 +2,6 @@
  * adds a create-number helper.
  */
 export function createNumber(value) {
-  return typeof value === 'string';
+  return Number(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18455

`createNumber` now converts the input to a number instead of a type check.

## Changes

- `src/eventra-kit/create-number.js`: return `Number(value)`
- `src/eventra-kit/__tests__/create-number.test.js`: add behavior tests

## Test

```js
createNumber('42') // 42
createNumber('3.5') // 3.5
createNumber(7) // 7
```

## GSSOC
