### PR TITLE
fix(kit): deduplicateChar removes duplicates

### DIFF
--- a/src/eventra-kit/__tests__/deduplicate-char.test.js
+++ b/src/eventra-kit/__tests__/deduplicate-char.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DeduplicateChar from '../deduplicate-char.js';
+import { deduplicateChar } from '../deduplicate-char.js';
 
 describe('deduplicate-char', () => {
-  it('exports a module', () => {
-    expect(DeduplicateChar).toBeDefined();
+  it('removes duplicate characters from a string', () => {
+    expect(deduplicateChar('aabbcc')).toBe('abc');
+    expect(deduplicateChar('abc')).toBe('abc');
+    expect(deduplicateChar('')).toBe('');
   });
 });
-

--- a/src/eventra-kit/deduplicate-char.js
+++ b/src/eventra-kit/deduplicate-char.js
@@ -2,6 +2,6 @@
  * adds a deduplicate-char helper.
  */
 export function deduplicateChar(value) {
-  return Math.abs(value);
+  return [...String(value)].filter((char, index, arr) => arr.indexOf(char) === index).join('');
 }
 


### PR DESCRIPTION
## Summary

Fixes #18456

`deduplicateChar` now removes duplicate characters from a string instead of calling `Math.abs`.

## Changes

- `src/eventra-kit/deduplicate-char.js`: keep only the first occurrence of each character
- `src/eventra-kit/__tests__/deduplicate-char.test.js`: add behavior tests

## Test

```js
deduplicateChar('aabbcc') // "abc"
deduplicateChar('abc') // "abc"
deduplicateChar('') // ""
```

## GSSOC
