### PR TITLE
fix(kit): diffChar computes length difference

### DIFF
--- a/src/eventra-kit/__tests__/diff-char.test.js
+++ b/src/eventra-kit/__tests__/diff-char.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as DiffChar from '../diff-char.js';
+import { diffChar } from '../diff-char.js';
 
 describe('diff-char', () => {
-  it('exports a module', () => {
-    expect(DiffChar).toBeDefined();
+  it('computes the difference in character counts', () => {
+    expect(diffChar('abcd', 'ab')).toBe(2);
+    expect(diffChar('ab', 'abcd')).toBe(2);
+    expect(diffChar('abc', 'abc')).toBe(0);
   });
 });
-

--- a/src/eventra-kit/diff-char.js
+++ b/src/eventra-kit/diff-char.js
@@ -1,7 +1,7 @@
 /**
  * adds a diff-char helper.
  */
-export function diffChar(value) {
-  return typeof value === 'string';
+export function diffChar(value, other) {
+  return Math.abs([...String(value)].length - [...String(other)].length);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18458

`diffChar` now returns the difference in character counts between two strings instead of a type check.

## Changes

- `src/eventra-kit/diff-char.js`: compute the absolute length difference
- `src/eventra-kit/__tests__/diff-char.test.js`: add behavior tests

## Test

```js
diffChar('abcd', 'ab') // 2
diffChar('ab', 'abcd') // 2
diffChar('abc', 'abc') // 0
```

## GSSOC
