### PR TITLE
fix(kit): calculateList computes sum

### DIFF
--- a/src/eventra-kit/__tests__/calculate-list.test.js
+++ b/src/eventra-kit/__tests__/calculate-list.test.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import * as CalculateList from '../calculate-list.js';
+import { calculateList } from '../calculate-list.js';
 
 describe('calculate-list', () => {
-  it('exports a module', () => {
-    expect(CalculateList).toBeDefined();
+  it('computes the sum of a list', () => {
+    expect(calculateList([1, 2, 3])).toBe(6);
+    expect(calculateList([10, -4])).toBe(6);
+    expect(calculateList([])).toBe(0);
   });
 });
-

--- a/src/eventra-kit/calculate-list.js
+++ b/src/eventra-kit/calculate-list.js
@@ -2,6 +2,7 @@
  * adds a calculate-list helper.
  */
 export function calculateList(value) {
-  return typeof value === 'string';
+  const list = Array.isArray(value) ? value : [];
+  return list.reduce((acc, item) => acc + item, 0);
 }
 


### PR DESCRIPTION
## Summary

Fixes #18460

`calculateList` now computes the sum of a list instead of a type check.

## Changes

- `src/eventra-kit/calculate-list.js`: sum the list items
- `src/eventra-kit/__tests__/calculate-list.test.js`: add behavior tests

## Test

```js
calculateList([1, 2, 3]) // 6
calculateList([10, -4]) // 6
calculateList([]) // 0
```

## GSSOC
