### PR TITLE
fix(backend): correct hackathon registration rate-limit path regex

### DIFF
--- a/Backend/src/main/java/com/eventra/config/RateLimitFilter.java
+++ b/Backend/src/main/java/com/eventra/config/RateLimitFilter.java
@@ -32,7 +32,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         String path = request.getRequestURI();
 
-        if (path != null && path.matches("^/api/v1/hackathons/[^/]+/register$") && "POST".equalsIgnoreCase(request.getMethod())) {
+        if (path != null && path.matches("^/api/hackathons/[^/]+/register$") && "POST".equalsIgnoreCase(request.getMethod())) {
             String clientIp = getClientIp(request);
             Bucket bucket = buckets.computeIfAbsent(clientIp, k -> createNewBucket());
 


### PR DESCRIPTION
## Summary
The `RateLimitFilter` was intended to rate-limit hackathon registration to 10 requests/minute per client IP, but its path regex `^/api/v1/hackathons/[^/]+/register$` never matched the real endpoint. `HackathonController` is mapped with `@RequestMapping(/api/hackathons)` ΓÇö there is no `/api/v1` prefix ΓÇö so the condition never evaluated true, no bucket was ever created, and the rate limit was completely inert.

## Change
Correct the regex to match the actual endpoint path:
```diff
- if (path != null && path.matches(^/api/v1/hackathons/[^/]+/register$) && POST.equalsIgnoreCase(request.getMethod())) {
+ if (path != null && path.matches(^/api/hackathons/[^/]+/register$) && POST.equalsIgnoreCase(request.getMethod())) {
```

This restores per-IP rate limiting (10 req/min) on `POST /api/hackathons/{id}/register`.

## Verification
- The real route is `@RequestMapping(/api/hackathons)` + `@PostMapping(/{id}/register)` in `HackathonController`, confirming the corrected pattern matches.
- The filter only acts on `POST` requests; public `GET /api/hackathons/...` endpoints are unaffected.
- Scope is intentionally limited to the path fix ΓÇö the separate bucket-eviction concern is tracked in #17850.

Closes #18471
