### PR TITLE
fix(frontend): correct EventDetails relative date mislabeling today's events as Tomorrow

### DIFF
--- a/src/Pages/Events/EventDetails.js
+++ b/src/Pages/Events/EventDetails.js
@@ -70,7 +70,7 @@ const formatEventDate = (dateValue) => {
 
   const now = new Date();
   const diffMs = d - now;
-  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
   let relative = "";
   if (diffMs < 0) {


### PR DESCRIPTION
## Summary
`formatEventDate` in `src/Pages/Events/EventDetails.js` computes the relative date offset with `Math.round`:

```js
const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
```

Because `Math.round` rounds up, an event occurring later today (e.g. 13ΓÇô23 hours from now ΓåÆ 0.5ΓÇô0.99 days) becomes `diffDays === 1`, so the header shows **"Tomorrow"** even though the event is today. The `Today` branch (`diffDays === 0`) is effectively unreachable for any future event more than ~12 hours away, and the 1ΓÇô2 day offsets are also shifted.

## Change
Use `Math.floor` so the day offset is truncation-based:
```diff
- const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+ const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
```

The `diffMs < 0` "Past" branch and the `days`/`weeks`/`months` branches are unaffected.

## Verification
- Event 13h from now: `Math.floor(0.54)` ΓåÆ `0` ΓåÆ "Today" (was "Tomorrow"). 
- Event 36h from now: `Math.floor(1.5)` ΓåÆ `1` ΓåÆ "Tomorrow" (was "In 2 days").
- Event 6.5 days out: `Math.floor(6.5)` ΓåÆ `6` ΓåÆ "In 6 days" (unchanged semantics).

Closes #18472
