### PR TITLE
fix(backend): stop mapping every RuntimeException to 404 in SubtitleController

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.subtitles;
 
+import com.sandeep.eventrabackend.exception.ResourceNotFoundException;
 import com.sandeep.eventrabackend.model.EventRole;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
@@ -361,7 +362,7 @@ public class SubtitleController {
      */
     private void assertCanModifySubtitle(Long subtitleId, Authentication authentication) {
         Subtitle subtitle = subtitleService.getSubtitleById(subtitleId)
-                .orElseThrow(() -> new RuntimeException("Subtitle not found with id: " + subtitleId));
+                .orElseThrow(() -> new ResourceNotFoundException("Subtitle not found with id: " + subtitleId));
         User caller = currentUser(authentication);
         if (isAdmin(caller)) {
             return;
@@ -466,8 +467,8 @@ public class SubtitleController {
     /**
      * Handle not found exceptions
      */
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleResourceNotFound(ResourceNotFoundException ex) {
         Map<String, String> error = new HashMap<>();
         error.put("error", "Not found");
         error.put("message", ex.getMessage());

--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleService.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.subtitles;
 
+import com.sandeep.eventrabackend.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -132,7 +133,7 @@ public class SubtitleService {
     @Transactional
     public Subtitle updateSubtitle(Long id, SubtitleDTO subtitleDTO) {
         Subtitle existingSubtitle = subtitleRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Subtitle not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Subtitle not found with id: " + id));
         
         // Update fields from DTO
         if (subtitleDTO.getOriginalText() != null) {
@@ -186,7 +187,7 @@ public class SubtitleService {
     @Transactional
     public Subtitle finalizeSubtitle(Long id) {
         Subtitle subtitle = subtitleRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Subtitle not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Subtitle not found with id: " + id));
         
         subtitle.setIsFinal(true);
         subtitle = subtitleRepository.save(subtitle);
@@ -282,7 +283,7 @@ public class SubtitleService {
     @Transactional
     public void deleteSubtitle(Long id) {
         Subtitle subtitle = subtitleRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Subtitle not found with id: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Subtitle not found with id: " + id));
         
         // Remove from cache
         removeFromCache(subtitle);


### PR DESCRIPTION
## Summary
`SubtitleController` registered `@ExceptionHandler(RuntimeException.class)` and returned **HTTP 404 "Not found" for every runtime exception** ΓÇö including genuine server errors (null dereferences, DB failures, etc.). Only `IllegalArgumentException` was handled separately (ΓåÆ 400). This masked real faults as "not found" and made the API contract misleading.

Meanwhile the subtitles module signalled "not found" by throwing a plain `new RuntimeException("Subtitle not found with id: ...")`, which is why the catch-all existed.

## Change
- Replace the 4 `new RuntimeException("Subtitle not found...")` throws (3 in `SubtitleService` ΓÇö `updateSubtitle`, `finalizeSubtitle`, `deleteSubtitle`; 1 in `SubtitleController.assertCanModifySubtitle`) with the typed `ResourceNotFoundException`.
- Narrow the controller's exception handler from `RuntimeException` to `ResourceNotFoundException`, so:
  - missing subtitles ΓåÆ 404 with a clear message (unchanged behavior);
  - any other runtime error ΓåÆ propagates to `GlobalExceptionHandler.handleGenericException` ΓåÆ 500 (correct, previously 404).

## Verification
- No plain `new RuntimeException` remains in the subtitles module.
- `ResourceNotFoundException` is already used across the codebase for the same "resource not found" semantics.
- The methods that throw are only called from `SubtitleController`, so `SubtitleStreamController` (SSE) behavior is unaffected.

Closes #18473
