### PR TITLE
fix(backend): allow public read access to GET /api/events/{id}/schedule

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -152,6 +152,7 @@ public class SecurityConfig {
                                 "/api/events/{id}",
                                 "/api/events/{id}/availability",
                                 "/api/events/{id}/seats",
+                                "/api/events/{id}/schedule",
                                 "/api/events/{id}/feed.ics",
                                 "/api/events/stream",
                                 "/api/events/{id}/stream"


### PR DESCRIPTION
## Summary
`GET /api/events/{id}/schedule` returns the persisted schedule for a public event ΓÇö read-only public data, exactly like `GET /api/events/{id}/availability` and `GET /api/events/{id}/seats`, which are already in the public GET matcher list. But `/api/events/{id}/schedule` was missing from `SecurityConfig`, so anonymous users got `401 Unauthorized` even for public events.

`EventService.getEventSchedule` already enforces public-event visibility via `requirePublicEvent(id)`, so allowing anonymous read access does not expose private events.

## Change
Add `/api/events/{id}/schedule` to the existing public GET `requestMatchers` block:
```diff
 /api/events/{id},
 /api/events/{id}/availability,
 /api/events/{id}/seats,
+/api/events/{id}/schedule,
 /api/events/{id}/feed.ics,
```

## Verification
- The matcher is scoped to `HttpMethod.GET` only ΓÇö `PATCH /api/events/{id}/schedule` (persisting schedule changes) remains authenticated.
- Public-event enforcement stays in the service layer (`requirePublicEvent`), so private-event schedule data is still rejected.
- Matches the existing pattern of public read endpoints (`availability`, `seats`, `feed.ics`).

Closes #18474
