### PR TITLE
refactor(backend): use SLF4J logging in EmailSender instead of console printing

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/util/EmailSender.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/util/EmailSender.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.util;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
  * Feature: #12139 - "Send Test Email" button for custom notifications
  */
 @Component
+@Slf4j
 public class EmailSender {
 
     /**
@@ -51,13 +53,11 @@ public class EmailSender {
             // - etc.
             
             // Log the email details (for development/debugging)
-            System.out.println("[Email Sent] To: " + to + ", Subject: " + subject +
-                            ", Message ID: " + messageId +
-                            ", Is HTML: " + isHtml);
+            log.info("Email sent to: {}, subject: {}, messageId: {}, isHtml: {}", to, subject, messageId, isHtml);
             
             return messageId;
         } catch (Exception e) {
-            System.err.println("[Email Error] Failed to send email to " + to + ": " + e.getMessage());
+            log.error("Failed to send email to {}", to, e);
             return null;
         }
     }


### PR DESCRIPTION
## Summary
`EmailSender` logged via `System.out.println` / `System.err.println`, bypassing the logging framework. This means no log levels, no timestamps, no configurable output, and no stack traces ΓÇö and it is inconsistent with the rest of the codebase, which uses SLF4J (`@Slf4j` / `LoggerFactory.getLogger`).

## Change
- Annotate the class with `@Slf4j` (Lombok), matching the subtitles module and the codebase-wide SLF4J idiom.
- Success path: `System.out.println("[Email Sent] ...")` ΓåÆ `log.info("Email sent to: {}, subject: {}, messageId: {}, isHtml: {}", ...)`.
- Failure path: `System.err.println("[Email Error] ...")` ΓåÆ `log.error("Failed to send email to {}", to, e)` (exception passed as last arg so the stack trace is retained).

## Verification
- No `System.out` / `System.err` usage remains in the class.
- `@Slf4j` is already used elsewhere (`SubtitleController`, `SubtitleService`, `SubtitleStreamController`), so Lombok support is present.
- Behavior unchanged: still returns the mock message ID on success and `null` on failure.

Closes #18475
