### PR TITLE
fix(frontend): re-export API error helpers from errors.js to fix module parse error

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -382,7 +382,7 @@ export const apiUtils = {
 
 export default API;
 
-export { ApiError, RateLimitError, normalizeApiError, getApiErrorStatus, getApiErrorMessage };
+export { ApiError, RateLimitError, normalizeApiError, getApiErrorStatus, getApiErrorMessage } from "./api/errors.js";
 
 // Centralized configuration cache store for fallback endpoints
 export const apiConfigCache = {


### PR DESCRIPTION
## Summary
`src/config/api.js` ended with a named-export statement referencing three bindings that are never defined in the module:

```js
export { ApiError, RateLimitError, normalizeApiError, getApiErrorStatus, getApiErrorMessage };  // L385
```

Only `ApiError` and `RateLimitError` were imported (L5); `normalizeApiError`, `getApiErrorStatus` and `getApiErrorMessage` live in `src/config/api/errors.js` but were never imported. This is an ESM parse-time error:

```
$ node --check src/config/api.js
SyntaxError: Export 'getApiErrorMessage' is not defined in module
```

`src/config/api` is imported by 11+ modules (`EventDetails.js`, `EventRegistration.js`, `useEventListing.js`, `ContactUs.js`, `AskTheOrganizer.jsx`, `SpatialSeatSelector.jsx`, `TicketScanner.jsx`, `EventSchedulerCalendar.jsx`, `lostAndFoundService.js`, `ReAuthModal.jsx`, ...), so loading any of them fails at parse time.

## Change
Turn the dead export into a re-export from the module where the helpers actually live:
```diff
- export { ApiError, RateLimitError, normalizeApiError, getApiErrorStatus, getApiErrorMessage };
+ export { ApiError, RateLimitError, normalizeApiError, getApiErrorStatus, getApiErrorMessage } from ./api/errors.js;
```

## Verification
- `node --check src/config/api.js` now passes (previously failed with the SyntaxError above).
- Consumers that import the helpers from `config/api/errors.js` directly are unaffected; `config/api` now also exposes them consistently.
- Distinct from #14668 (a runtime `undefined` import for `API_BASE_URL`); this change fixes the module's parse failure.

Closes #18477
