### PR TITLE
fix(frontend): use useCountdown ended flag in HackathonCard countdown checks

### DIFF
--- a/src/Pages/Hackathons/HackathonCard.js
+++ b/src/Pages/Hackathons/HackathonCard.js
@@ -19,7 +19,7 @@ import { generateEventSharingData } from "utils/shareUtils";
 const CountdownTimer = ({ targetDate, label }) => {
   const timeLeft = useCountdown(targetDate);
 
-  if (!timeLeft) {
+  if (timeLeft.ended) {
     return (
       <span className="text-xs font-semibold text-red-500 dark:text-red-400">Deadline passed</span>
     );
@@ -48,7 +48,7 @@ const CountdownTimer = ({ targetDate, label }) => {
 const UrgencyBadge = ({ startDate, endDate, status }) => {
   const timeLeft = useCountdown(status === "upcoming" ? startDate : endDate);
 
-  if (status === "completed" || !timeLeft || timeLeft.days >= 3) {
+  if (status === "completed" || timeLeft.ended || timeLeft.days >= 3) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
`useCountdown` (in `src/hooks/useCountdown.js`) **never returns `null`/`undefined`** ΓÇö it always returns an object `{ days, hours, minutes, seconds, ended, total }` (see L67-83: it returns an ended-state object instead of `null`). So the `!timeLeft` checks in `HackathonCard.js` were unreachable dead code, which silently disabled two intended states:

1. `CountdownTimer` (L22): the `if (!timeLeft)` branch meant to show "Deadline passed" for ended hackathons never fired ΓÇö ended hackathons rendered `0d 00h 00m` in "urgent" styling instead.
2. `UrgencyBadge` (L51): the `!timeLeft` guard meant to hide the badge for ended deadlines never fired ΓÇö a stale "live" card whose end date had passed would still render "Closing today".

`useCountdown` documents the `ended` flag exactly for this ("consumers can show 'Event started' instead of 00:00:00").

## Change
```diff
-  if (!timeLeft) {
+  if (timeLeft.ended) {
```
```diff
-  if (status === "completed" || !timeLeft || timeLeft.days >= 3) {
+  if (status === "completed" || timeLeft.ended || timeLeft.days >= 3) {
```

## Verification
- `useCountdown`'s contract confirmed: ended ΓåÆ `{ days: 0, ..., ended: true, total: 0 }`, never `null`.
- Behavior for live/upcoming countdowns is unchanged (`ended` is `false` while counting).
- Ended hackathons now correctly show "Deadline passed", and the urgency badge is suppressed once the deadline has passed.

Closes #18478
