### PR TITLE
fix(frontend): cap EditProfile completion percentage at 100

### DIFF
--- a/src/components/user/EditProfile.js
+++ b/src/components/user/EditProfile.js
@@ -221,7 +221,7 @@ const EditProfile = () => {
 
     if (form.skills && form.skills.length > 0) filled++;
 
-    return Math.round((filled / 10) * 100);
+    return Math.round((filled / 11) * 100);
   }, [form, user]);
 
   const completionPercentage = useMemo(() => calculateCompletion(), [calculateCompletion]);


### PR DESCRIPTION
## Summary
`EditProfile.calculateCompletion` counts **11** possible contributions but divides by **10**:

- 9 fields: `username`, `email`, `phone`, `bio`, `profileHeadline`, `github`, `linkedin`, `portfolio`, `avatarBase64`
- +1 for a resolved full name
- +1 for at least one skill

```js
return Math.round((filled / 10) * 100);   // max = 110
```

A fully completed profile therefore displays **110%** on the progress bar (`EditProfile.js` L398-404), which is impossible/inconsistent and breaks the "100% = complete" assumption.

## Change
Divide by the actual number of counted fields:
```diff
- return Math.round((filled / 10) * 100);
+ return Math.round((filled / 11) * 100);
```

## Verification
- All 11 contributions ΓåÆ `Math.round(11/11 * 100)` ΓåÆ 100%.
- Previously 11/11 would round to 110%.
- Intermediate values are unaffected in spirit (e.g. 6/11 Γëê 55%).

Closes #18479
