### PR TITLE
fix(frontend): remove duplicate calendar provider buttons in AddToCalendar

### DIFF
--- a/src/components/common/AddToCalendar.jsx
+++ b/src/components/common/AddToCalendar.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { Calendar, ChevronDown, Download, ExternalLink, X } from 'lucide-react';
+import { Calendar, ChevronDown, X } from 'lucide-react';
 import {
     generateIcsFileBlobUrl,
     getGoogleCalendarUrl,
@@ -210,18 +210,6 @@ const [reminder, setReminder] = useState("30");
   <Calendar className="w-4 h-4 text-gray-400" />
   Export to Apple Calendar (.ics)
 </button>
-          <button onClick={handleGoogle} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left">
-            <ExternalLink className="w-4 h-4 text-blue-500" />
-            Google Calendar
-          </button>
-          <button onClick={handleOutlook} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left border-t border-gray-100 dark:border-gray-800">
-            <ExternalLink className="w-4 h-4 text-sky-600" />
-            Outlook Calendar
-          </button>
-          <button onClick={handleIcal} className="w-full flex items-center gap-3 px-4 py-3 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left border-t border-gray-100 dark:border-gray-800">
-            <Download className="w-4 h-4 text-gray-400" />
-            Download iCal (.ics)
-          </button>
           {added && (
             <div className="px-4 py-2 bg-green-50 dark:bg-green-900/20 border-t border-green-100 dark:border-green-800">
               <p className="text-xs text-green-600 dark:text-green-400">Opening {added}...</p>


### PR DESCRIPTION
## Summary
The "Add to Calendar" dropdown in `src/components/common/AddToCalendar.jsx` rendered two sets of provider actions:

- Set A (Google, Outlook, reminder `<select>`, "Export to Apple Calendar (.ics)")
- Set B ΓÇö a duplicate block: "Google Calendar", "Outlook Calendar", "Download iCal (.ics)" calling the exact same handlers (`handleGoogle`, `handleOutlook`, `handleIcal`)

Users saw Google Calendar twice, Outlook twice, and two iCal actions, making the menu longer than intended with zero added functionality.

## Change
- Remove the duplicate Set B block (13 lines).
- Drop the now-unused `ExternalLink` and `Download` icons from the lucide import (they were only referenced inside the removed block).
- Set A is kept as-is, so every provider action still appears exactly once.

## Verification
- `ExternalLink` / `Download` no longer appear anywhere in the file except the `downloadIcal` helper name and `a.download` property (both unrelated to the removed icons).
- The `added` success message block that follows the actions is preserved.
- Rendering: dropdown now lists Google, Outlook, reminder, and Apple Calendar (.ics) exactly once.

Closes #18480
