### PR TITLE
fix(backend): evict per-code coupon locks so the lock map stays bounded

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/CouponService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/CouponService.java
@@ -59,6 +59,8 @@ public class CouponService implements ApplicationRunner {
             throw new CouponRedemptionException("Interrupted while acquiring coupon lock for code: " + code, e);
         }
         if (!acquired) {
+            // Not acquired: no other holder will release this entry for us.
+            locks.remove(code, lock);
             throw new CouponRedemptionException(
                     "Timed out after " + LOCK_WAIT_SECONDS + "s acquiring coupon lock for code: " + code);
         }
@@ -66,8 +68,9 @@ public class CouponService implements ApplicationRunner {
         try {
             // Release the lock when the transaction finishes, whether it
             // commits or rolls back (#14507) — afterCommit alone leaks the
-            // lock permanently on rollback.
-            syncAdapter.registerReleaseOnCompletion(lock);
+            // lock permanently on rollback — then evict the per-code entry so
+            // the lock map stays bounded.
+            syncAdapter.registerReleaseOnCompletion(lock, () -> locks.remove(code, lock));
 
             // Atomic, DB-backed decrement guarded by remaining > 0, executed in
             // the current transaction; rollback restores the slot.

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/TransactionLockSyncAdapter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/TransactionLockSyncAdapter.java
@@ -16,21 +16,29 @@ import java.util.concurrent.locks.ReentrantLock;
 public class TransactionLockSyncAdapter {
 
     public void registerReleaseOnCompletion(ReentrantLock lock) {
+        registerReleaseOnCompletion(lock, null);
+    }
+
+    public void registerReleaseOnCompletion(ReentrantLock lock, Runnable afterRelease) {
+        Runnable cleanup = () -> {
+            // Releases on STATUS_COMMITTED, STATUS_ROLLED_BACK and STATUS_UNKNOWN.
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+            if (afterRelease != null) {
+                afterRelease.run();
+            }
+        };
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCompletion(int status) {
-                    // Releases on STATUS_COMMITTED, STATUS_ROLLED_BACK and STATUS_UNKNOWN.
-                    if (lock.isHeldByCurrentThread()) {
-                        lock.unlock();
-                    }
+                    cleanup.run();
                 }
             });
         } else {
             // No active transaction; release immediately
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+            cleanup.run();
         }
     }
 }


### PR DESCRIPTION
Closes #18492

## Problem
`CouponService` keeps a `ConcurrentHashMap<String, ReentrantLock>` whose per-code locks are created via `computeIfAbsent` but never removed, so every coupon code (including typos/abuse attempts) permanently leaks an entry in the JVM.

## Fix
- `TransactionLockSyncAdapter`: added a `registerReleaseOnCompletion(lock, afterRelease)` overload (existing single-arg method delegates to it), so callers can run cleanup at the exact moment the lock is released ΓÇö commit, rollback, or no active transaction.
- `CouponService.redeemCoupon`:
  - evicts the entry inside the release callback (`locks.remove(code, lock)`), preserving the per-code mutual-exclusion guarantee since the entry is removed only after the lock is released;
  - evicts the entry on the acquisition-timeout path too (no holder will release it for us).

The map now stays bounded by the number of codes currently being redeemed rather than growing forever.
