### PR TITLE
fix(notifications): re-home legacy IndexedDB notifications to active user inbox on login (#16538)

### DIFF
--- a/src/hooks/useNotificationPoller.js
+++ b/src/hooks/useNotificationPoller.js
@@ -94,8 +94,17 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
         const normalized = normalize(n);
         if (!seen.has(normalized.id)) merged.push(normalized);
       });
+      merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
       window.localStorage.setItem(userKey, JSON.stringify(merged));
       window.localStorage.removeItem(GUEST_INBOX_KEY);
+      if (isMounted.current) {
+        setNotifications(merged);
+        notificationsRef.current = merged;
+        setUnreadCount(merged.filter((n) => !n.isRead).length);
+        merged.forEach((n) => {
+          if (n.id) addSeenId(n.id);
+        });
+      }
     } catch (e) { console.warn("[useNotificationPoller] Failed to persist notifications", e); }
   }, [user?.id]);
 
@@ -129,7 +138,12 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
       });
       deduped.forEach((n) => addSeenId(n.id));
       const prev = notificationsRef.current || [];
-      const merged = deduped.concat(prev.filter((p) => !byId.has(p.id)));
+      const persisted = loadPersisted(storageKeyRef.current) || [];
+      const existingMap = new Map();
+      persisted.forEach((p) => { if (p?.id) existingMap.set(p.id, p); });
+      prev.forEach((p) => { if (p?.id) existingMap.set(p.id, p); });
+      const existingList = Array.from(existingMap.values());
+      const merged = deduped.concat(existingList.filter((p) => !byId.has(p.id)));
       const sorted = merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
       notificationsRef.current = sorted;
       setNotifications(sorted);
@@ -343,7 +357,8 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
         if (raw) {
           const legacy = safeJsonParse(raw, []);
           if (Array.isArray(legacy) && legacy.length > 0) {
-            const currentPersisted = loadPersisted(storageKeyRef.current) || [];
+            const targetKey = getStorageKey(user?.id);
+            const currentPersisted = loadPersisted(targetKey) || [];
             const merged = [...currentPersisted];
 
             legacy.forEach((ln) => {
@@ -375,13 +390,15 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
 
             // Sort newest first
             merged.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
-            persist(merged, storageKeyRef.current);
-            setNotifications(merged);
-            notificationsRef.current = merged;
-            setUnreadCount(merged.filter((n) => !n.isRead).length);
-            merged.forEach((n) => {
-              if (n.id) seenIds.current.add(n.id);
-            });
+            persist(merged, targetKey);
+            if (isMounted.current) {
+              setNotifications(merged);
+              notificationsRef.current = merged;
+              setUnreadCount(merged.filter((n) => !n.isRead).length);
+              merged.forEach((n) => {
+                if (n.id) addSeenId(n.id);
+              });
+            }
           }
           await idbDel("eventra_notifications");
         }
@@ -391,7 +408,7 @@ export function useNotificationPoller(deliverNew, hasCompletedInitialFetchRef) {
     };
 
     migrateLegacy();
-  }, []);
+  }, [user?.id]);
 
   return {
     notifications, unreadCount, loading,

--- a/src/hooks/useNotificationPoller.test.js
+++ b/src/hooks/useNotificationPoller.test.js
@@ -2,8 +2,9 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { useNotificationPoller } from "./useNotificationPoller";
 import { showUndoToast } from "../utils/toast.js";
 
+let mockAuth = { token: "tok-123", user: { id: "user-1" } };
 vi.mock("../context/AuthContext", () => ({
-  useAuth: () => ({ token: "tok-123", user: { id: "user-1" } }),
+  useAuth: () => mockAuth,
 }));
 
 vi.mock("../utils/toast.js", () => ({
@@ -19,9 +20,12 @@ vi.mock("../utils/notificationQueue.js", () => ({
   syncNotificationQueue: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockIdbGet = vi.fn().mockResolvedValue(undefined);
+const mockIdbDel = vi.fn().mockResolvedValue(undefined);
+
 vi.mock("idb-keyval", () => ({
-  get: vi.fn().mockResolvedValue(undefined),
-  del: vi.fn().mockResolvedValue(undefined),
+  get: (...args) => mockIdbGet(...args),
+  del: (...args) => mockIdbDel(...args),
 }));
 
 const mockGet = vi.fn();
@@ -146,5 +150,42 @@ describe("useNotificationPoller - deleteNotification", () => {
 
     // Undo cancels the commit, so the delete must not reach the server.
     expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("migrates legacy IndexedDB notifications when user logs in after mounting logged-out (#16538)", async () => {
+    const legacyItem = {
+      id: "legacy-1",
+      title: "Legacy Notification",
+      message: "Old event",
+      isRead: false,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    };
+
+    mockIdbGet.mockResolvedValue(JSON.stringify([legacyItem]));
+    mockGet.mockResolvedValue({ data: [] });
+
+    mockAuth = { token: null, user: null };
+
+    const hasCompletedInitialFetchRef = { current: false };
+    const deliverNew = vi.fn();
+
+    const { result, rerender } = renderHook(() =>
+      useNotificationPoller(deliverNew, hasCompletedInitialFetchRef),
+    );
+
+    await waitFor(() => {
+      expect(mockIdbGet).toHaveBeenCalledWith("eventra_notifications");
+    });
+
+    // Now user logs in
+    mockAuth = { token: "tok-abc", user: { id: "user-456" } };
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.notifications.some((n) => n.id === "legacy-1")).toBe(true);
+    });
+
+    expect(result.current.unreadCount).toBeGreaterThanOrEqual(1);
+    expect(mockIdbDel).toHaveBeenCalledWith("eventra_notifications");
   });
 });


### PR DESCRIPTION
## Description

Fixes issue #16538 where legacy IndexedDB notifications (`eventra_notifications`) were misrouted or stranded under the guest notification key (`eventra_notification_inbox_guest`) when the application mounted logged-out or before authentication state resolved.

Key changes:
- **Dynamic Key Resolution**: Updated legacy IndexedDB migration in `useNotificationPoller.js` to dynamically compute `targetKey = getStorageKey(user?.id)` upon execution and re-run when `user?.id` becomes available.
- **In-Memory State Sync**: Synchronized React state (`notifications`, `unreadCount`, `notificationsRef`) during guest-to-user and legacy IndexedDB storage key migrations so migrated items are immediately active in memory.
- **Persisted Item Preservation**: Combined in-memory state with persisted local storage records in `applyList` so that migrated local items are preserved when server polling responses return.
- **Unit Tests**: Added test coverage in `useNotificationPoller.test.js` to verify logged-out mount -> logged-in legacy notification migration flow.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Fixes #16538

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A (Logic and state synchronization changes in notification hook)

## Additional Notes

Verified with unit tests running under `npx vitest run src/hooks/useNotificationPoller.test.js`.
