### PR TITLE
fix(backend): encode plagiarism CSV as UTF-8 and declare charset in response

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 @RestController
@@ -38,11 +39,11 @@ public class PlagiarismController {
     @PostMapping("/export-report")
     public ResponseEntity<byte[]> exportCsvReport(@RequestBody List<SubmissionComparison> comparisons) {
         String csvData = plagiarismService.generateCsvAuditReport(comparisons);
-        byte[] output = csvData.getBytes();
+        byte[] output = csvData.getBytes(StandardCharsets.UTF_8);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=plagiarism_audit_report.csv")
-                .contentType(MediaType.parseMediaType("text/csv"))
+                .contentType(MediaType.parseMediaType("text/csv; charset=UTF-8"))
                 .body(output);
     }
 }


### PR DESCRIPTION
Closes #18493

## Problem
`PlagiarismController.exportCsvReport` serialized the CSV with `csvData.getBytes()`, which uses the JVM platform default charset (Windows-1252 on Windows) and set `Content-Type: text/csv` without a charset ∩┐╜ non-ASCII characters (accents, em-dashes, CJK) could be mojibake in the exported `plagiarism_audit_report.csv`.

## Fix
- Encode with `csvData.getBytes(StandardCharsets.UTF_8)`.
- Declare `text/csv; charset=UTF-8` so clients decode it correctly.
