### PR TITLE
fix(backend): evict idle client keys in SlidingWindowRateLimiter to bound memory

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/SlidingWindowRateLimiter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/SlidingWindowRateLimiter.java
@@ -33,6 +33,13 @@ public class SlidingWindowRateLimiter {
             // Remove timestamps older than current window
             timestamps.removeIf(t -> t < windowStartMs);
 
+            if (timestamps.isEmpty()) {
+                // Forget idle clients so the map stays bounded; a fresh entry
+                // is recreated lazily on the next request.
+                requestLogs.remove(clientKey, timestamps);
+                return true;
+            }
+
             if (timestamps.size() < maxRequests) {
                 timestamps.add(currentTimeMs);
                 return true;


### PR DESCRIPTION
Closes #18495

## Problem
`SlidingWindowRateLimiter.requestLogs` prunes timestamps inside each client's list but never evicts the client key itself once the list is empty, so every distinct `clientKey` (e.g. each unique IP) permanently adds a map entry ∩┐╜ unbounded memory growth over the JVM's lifetime.

## Fix
After pruning, if the list is empty the entry is removed with `requestLogs.remove(clientKey, timestamps)` and the request is allowed (a client with no in-window timestamps was allowed anyway). A fresh entry is recreated lazily by `putIfAbsent` on the next request. The `synchronized (timestamps)` block makes the conditional remove safe against concurrent re-creation for the same key.
