### PR TITLE
fix(frontend): honor popularTags prop in SearchEmptyState so the tags section renders

### DIFF
--- a/src/components/common/SearchEmptyState.jsx
+++ b/src/components/common/SearchEmptyState.jsx
@@ -20,6 +20,7 @@ const SearchEmptyState = ({
   browseLabel = "Browse",
   browsePath = "/",
   onClear,
+  popularTags = [],
   // eslint-disable-next-line no-unused-vars
   variant: _variant = "search",
   title: customTitle,
@@ -38,8 +39,6 @@ const SearchEmptyState = ({
     "Try adjusting your search or explore other sections on Eventra.";
 
   const suggestions = DEFAULT_SUGGESTIONS;
-
-  const popularTags = [];
 
   return (
     <EmptyState


### PR DESCRIPTION
Closes #18497

## Problem
`SearchEmptyState` hardcoded `const popularTags = [];` (shadowing the prop) and never declared `popularTags` in its destructuring, so the popular-tags UI block could never render ∩┐╜ even though `EventsPage` passes `popularTags={[AI, Blockchain, Web, DevOps, React, UX]}`.

## Fix
Added `popularTags = []` to the prop signature and removed the local shadowing constant. Callers that don't pass the prop keep the previous behavior (empty array ? section hidden).
