### PR TITLE
refactor(frontend): remove unused hasChatbot state in BackToTop

### DIFF
--- a/src/components/common/BackToTop.jsx
+++ b/src/components/common/BackToTop.jsx
@@ -12,7 +12,6 @@ const BackToTop = ({
   const [visible, setVisible] = useState(false);
   const [progress, setProgress] = useState(0);
   const [isChatbotOpen, setIsChatbotOpen] = useState(false);
-  const [hasChatbot, setHasChatbot] = useState(false);
 
   const prefersReducedMotion =
     typeof window !== "undefined"
@@ -34,7 +33,6 @@ const BackToTop = ({
     const handleChatbotState = () => {
       if (typeof document === "undefined") return;
       setIsChatbotOpen(document.querySelector('[data-chatbot-open]') !== null);
-      setHasChatbot(document.querySelector('[data-chatbot-launcher]') !== null);
     };
 
     handleChatbotState();


### PR DESCRIPTION
Closes #18499

## Problem
`BackToTop` declared `hasChatbot` state and set it in the chatbot-detection observer, but the value was never read ∩┐╜ only `isChatbotOpen` is used to hide the button. The `data-chatbot-launcher` lookup + `setHasChatbot` ran on every DOM mutation for no effect (positioning was moved to the `avoidChatbot` prop in #10496).

## Fix
Removed the unused `hasChatbot` state and its setter from `BackToTop.jsx`. `isChatbotOpen` detection and all rendering logic are untouched.
