### PR TITLE
fix(frontend): remove duplicate exports in aiInsightsEngine.js (#18441)

### DIFF
--- a/src/utils/aiInsightsEngine.js
+++ b/src/utils/aiInsightsEngine.js
@@ -1176,15 +1176,8 @@ export const generateBulkAIInsights = async (events = [], profile = {}, options 
 // ============================================================================
 
 export {
-  AI_SERVICE_CONFIG,
-  configureAIService,
-  clearAICache,
-  getAITelemetry,
-  logAITelemetry,
-  resetAITelemetry,
   CircuitBreaker,
   createCacheKey,
-  createProfileHash,
 };
 
 export default {


### PR DESCRIPTION
## Description

Fixed a fatal ES module parse error in `src/utils/aiInsightsEngine.js` caused by duplicate export declarations. Seven identifiers (`AI_SERVICE_CONFIG`, `configureAIService`, `clearAICache`, `getAITelemetry`, `logAITelemetry`, `resetAITelemetry`, and `createProfileHash`) were being exported inline at their declaration sites as well as in the bottom export block.

The bottom export block has been updated to only export identifiers that are not exported inline (`CircuitBreaker` and `createCacheKey`), ensuring each exported identifier appears exactly once.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18441

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A (Internal code fix for duplicate module export error)

## Additional Notes

Resolving duplicate exports fixes the fatal `[PARSE_ERROR] Duplicated export` error during Vite dev server starts, production builds, ESLint parsing, and module imports.
