### PR TITLE
fix: handle null contact form fields

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java
@@ -25,9 +25,9 @@ public class ContactService {
         }
         ContactMessage contactMessage = new ContactMessage();
         contactMessage.setName(request.getName().trim());
-        contactMessage.setEmail(request.getEmail().trim());
-        contactMessage.setSubject(request.getSubject().trim());
-        contactMessage.setMessage(request.getMessage().trim());
+        contactMessage.setEmail(request.getEmail() != null ? request.getEmail().trim() : "");
+        contactMessage.setSubject(request.getSubject() != null ? request.getSubject().trim() : "");
+        contactMessage.setMessage(request.getMessage() != null ? request.getMessage().trim() : "");
 
         ContactMessage saved = contactMessageRepository.save(contactMessage);
 


### PR DESCRIPTION
## Summary

Fixes #18521

- Prevents `NullPointerException` when optional contact form fields are missing.
- Safely handles null `email`, `subject`, and `message` values before calling `trim()`.
- Preserves existing behavior for populated fields.

## Testing

- Verified the contact service handles missing optional fields without throwing `NullPointerException`.
- Ran `git diff --check`.