### PR TITLE
fix: handle invalid event dates in PDF tickets

### DIFF
--- a/src/utils/exportTicketToPdf.js
+++ b/src/utils/exportTicketToPdf.js
@@ -14,9 +14,16 @@ export const exportTicketToPdf = async (event, userData) => {
   const title = String(event.title || "Unknown Event").slice(0, 80);
   const attendee = String(userData?.name || userData?.email || "Guest").slice(0, 60);
   const location = String(event.location || "Virtual").slice(0, 60);
-  const eventDate = event.date
-    ? new Date(event.date).toLocaleDateString()
-    : new Date().toLocaleDateString();
+
+  let eventDate;
+  if (event.date) {
+    const parsed = new Date(event.date);
+    eventDate = !Number.isNaN(parsed.getTime())
+      ? parsed.toLocaleDateString()
+      : String(event.date);
+  } else {
+    eventDate = "TBD";
+  }
 
   const ticketId = String(event.id || Date.now());
 


### PR DESCRIPTION
## Summary

Fixes #18523

- Handle missing event dates gracefully.
- Prevent invalid date values from rendering as `Invalid Date`.
- Preserve the original date label when the value cannot be parsed.
- Use `TBD` when no event date is available.

## Testing

- Verified valid event dates are formatted normally.
- Verified invalid/non-standard dates fall back to their original value.
- Verified missing dates fall back to `TBD`.
- Ran `git diff --check`.