### PR TITLE
fix: parse serialized session draft data

### DIFF
--- a/src/components/SessionRecovery.js
+++ b/src/components/SessionRecovery.js
@@ -91,7 +91,15 @@ const SessionRecovery = () => {
     try {
       const session = await restoreRecoverySessionById?.(sessionId);
       if (session && typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('sessionRestored', { detail: session.draftData || session }));
+        let draftData = session.draftData || session;
+        if (typeof draftData === 'string') {
+          try {
+            draftData = JSON.parse(draftData);
+          } catch {
+            // keep as string if parsing fails
+          }
+        }
+        window.dispatchEvent(new CustomEvent('sessionRestored', { detail: draftData }));
         window.dispatchEvent(new CustomEvent('cloudSessionRestored', { detail: session }));
       }
       dismissRecoveryPrompt?.();


### PR DESCRIPTION
## Summary

Fixes #18524

- Parse serialized `draftData` before dispatching the `sessionRestored` event.
- Preserve already-parsed draft objects.
- Gracefully fall back to the original value when JSON parsing fails.
- Ensure session restoration consumers receive the expected payload format.

## Testing

- Verified serialized JSON draft data is parsed before dispatch.
- Verified object draft data remains unchanged.
- Verified invalid JSON does not crash session restoration.
- Ran `git diff --check`.