### PR TITLE
fix: batch event cancellation notifications

### DIFF
--- a/src/utils/eventCancellationNotifications.js
+++ b/src/utils/eventCancellationNotifications.js
@@ -117,17 +117,35 @@ This is an automated message. Please do not reply to this email.
   }
 
   /**
+   * Process an array of tasks in controlled batches to avoid rate limits.
+   * @param {Array} items - Items to process
+   * @param {number} concurrency - Max parallel tasks per batch
+   * @param {Function} taskFn - Async function to call for each item
+   * @returns {Promise<Array>} Array of settled results in original order
+   */
+  async processInBatches(items, concurrency, taskFn) {
+    const results = [];
+    for (let i = 0; i < items.length; i += concurrency) {
+      const batch = items.slice(i, i + concurrency);
+      const settled = await Promise.allSettled(batch.map(taskFn));
+      results.push(...settled);
+    }
+    return results;
+  }
+
+  /**
    * Dispatch cancellation emails to every attendee and collect settled results
    */
   async dispatchCancellationEmails(event, attendees) {
-    return Promise.allSettled(
-      attendees.map(attendee =>
+    return this.processInBatches(
+      attendees,
+      10,
+      (attendee) =>
         this.notifyAttendee(
           attendee.email,
           event,
           { firstName: attendee.firstName, lastName: attendee.lastName }
         )
-      )
     );
   }
 


### PR DESCRIPTION
## Description

Fixes #18532

### What changed

- Added controlled batching for event cancellation notifications.
- Limited concurrent attendee notification processing to 10 requests at a time.
- Replaced unbounded parallel notification dispatch with sequential batches.
- Preserved settled results so one failed notification does not stop the remaining notifications.

### Impact

Large event cancellations no longer create thousands of concurrent email/API requests, reducing the risk of rate limiting, timeouts, and incomplete notifications.

### Testing

- Verified attendees are processed in batches.
- Verified a maximum of 10 notification operations run concurrently.
- Verified individual notification failures do not stop subsequent batches.