### PR TITLE
fix: make rate limiter updates atomic

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/FallbackLimiter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/FallbackLimiter.java
@@ -16,12 +16,16 @@ public class FallbackLimiter {
         if (clientKey == null) return true;
 
         try {
-            int current = requestCounts.getOrDefault(clientKey, 0);
-            if (current < maxLimit) {
-                requestCounts.put(clientKey, current + 1);
-                return true;
-            }
-            return false;
+            final boolean[] allowed = {false};
+            requestCounts.compute(clientKey, (key, current) -> {
+                int count = current == null ? 0 : current;
+                if (count < maxLimit) {
+                    allowed[0] = true;
+                    return count + 1;
+                }
+                return count;
+            });
+            return allowed[0];
         } catch (Exception e) {
             // Log local check failure and fail open to prevent blocking clients
             return true;


### PR DESCRIPTION
## Description

Fixes #18544

### What changed

- Replaced the non-atomic rate-limit read/check/write sequence with an atomic `Map.compute()` operation.
- Ensured concurrent requests cannot bypass the configured rate limit by observing the same counter value.
- Preserved the existing fail-open behavior for unexpected limiter errors.

### Impact

Concurrent requests can no longer race during rate-limit counter updates and exceed the configured request limit.

### Testing

- Verified the counter check and increment occur atomically.
- Verified requests at or above the configured limit are rejected.
- Verified the existing fallback behavior remains unchanged.