### PR TITLE
fix: correctly resolve lost item owner

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/LostItemController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/LostItemController.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.dto.request.CreateLostItemRequest;
 import com.sandeep.eventrabackend.dto.request.UpdateLostItemRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.LostItemResponse;
+import com.sandeep.eventrabackend.security.CustomUserDetails;
 import com.sandeep.eventrabackend.service.LostItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -268,16 +269,10 @@ public class LostItemController {
         }
         
         Object principal = authentication.getPrincipal();
-        if (principal instanceof Map) {
-            Map<?, ?> principalMap = (Map<?, ?>) principal;
-            Object userIdObj = principalMap.get("userId");
-            if (userIdObj instanceof Number) {
-                return ((Number) userIdObj).longValue();
-            }
+        if (principal instanceof CustomUserDetails customUser) {
+            return customUser.getUser().getId();
         }
         
-        // If the principal is a string (username/email), we might need to look it up
-        // For now, return null if we can't extract the user ID
         return null;
     }
 }


### PR DESCRIPTION
## Description

Fixes #18545

### What changed

- Updated `LostItemController` to correctly extract the authenticated user's ID from `CustomUserDetails`.
- Removed the incorrect assumption that the authentication principal is always a `Map`.
- Ensured lost item ownership checks receive the actual authenticated user's ID.

### Impact

Prevents ownership checks from receiving a null user ID and incorrectly allowing unauthorized lost-item updates or deletions.

### Testing

- Verified the controller handles the `CustomUserDetails` principal returned by the JWT authentication flow.
- Verified the authenticated user's ID is correctly resolved before ownership checks.