### PR TITLE
fix: bound event search pagination parameters

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -187,7 +187,7 @@ public class EventController {
                         @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
                         @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
 
-                Pageable pageable = PageRequest.of(page, size);
+                Pageable pageable = PageRequest.of(Math.max(page, 0), Math.min(Math.max(size, 1), 100));
                 Page<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free,
                                 pageable);
                 return ResponseEntity.ok(events);


### PR DESCRIPTION
## Description

Fixes #18546

### What changed

- Prevent negative page values from reaching `PageRequest`.
- Enforce a minimum page size of 1.
- Cap the requested page size at 100.
- Prevent excessively large pagination requests from causing unnecessary resource consumption.

### Impact

This prevents invalid pagination requests from causing server errors and limits excessively large database result sets.

### Testing

- Verified negative page values are clamped safely.
- Verified invalid/zero page sizes are corrected.
- Verified page sizes above 100 are capped.