### PR TITLE
fix: bound popular events limit

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -338,7 +338,8 @@ public class AdminController {
             @Parameter(description = "Maximum number of events to return", example = "10")
             @RequestParam(defaultValue = "10") int limit
     ) {
-        return ResponseEntity.ok(adminService.getPopularEvents(limit));
+        int clampedLimit = Math.min(Math.max(limit, 1), 100);
+        return ResponseEntity.ok(adminService.getPopularEvents(clampedLimit));
     }
 
     // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Description

Fixes #18547

### What changed

- Validate the `limit` parameter for the popular events endpoint.
- Enforce a minimum limit of 1.
- Cap the maximum limit at 100.
- Prevent invalid or excessively large values from reaching the service/database layer.

### Impact

Prevents malformed requests and unnecessarily expensive database operations caused by unbounded event limits.

### Testing

- Verified non-positive limits are clamped to 1.
- Verified limits between 1 and 100 are preserved.
- Verified limits above 100 are capped at 100.