### PR TITLE
fix(live-audience): enforce active poll lifecycle contract and retire prior active polls (#17869)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/LiveAudiencePollRepository.java
@@ -14,6 +14,8 @@ public interface LiveAudiencePollRepository extends JpaRepository<LiveAudiencePo
 
     List<LiveAudiencePoll> findByEventIdOrderByCreatedAtDesc(Long eventId);
 
+    List<LiveAudiencePoll> findByEventIdAndStatusOrderByCreatedAtDesc(Long eventId, String status);
+
     Optional<LiveAudiencePoll> findByIdAndEventId(Long id, Long eventId);
 
     /**

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/LiveAudienceService.java
@@ -59,7 +59,7 @@ public class LiveAudienceService {
         requireEventAccess(eventId, email);
         List<LiveAudienceQuestionResponse> questions = getQuestions(eventId, email);
         LiveAudiencePollResponse activePoll = pollRepository
-                .findByEventIdOrderByCreatedAtDesc(eventId)
+                .findByEventIdAndStatusOrderByCreatedAtDesc(eventId, "active")
                 .stream()
                 .findFirst()
                 .map(this::toPollResponse)
@@ -187,6 +187,13 @@ public class LiveAudienceService {
         Map<String, Object> results = new HashMap<>();
         options.forEach(opt -> results.put(opt, 0));
 
+        List<LiveAudiencePoll> priorActivePolls = pollRepository.findByEventIdAndStatusOrderByCreatedAtDesc(eventId, "active");
+        for (LiveAudiencePoll prior : priorActivePolls) {
+            prior.setStatus("closed");
+            prior.setUpdatedAt(LocalDateTime.now());
+            pollRepository.save(prior);
+        }
+
         LiveAudiencePoll poll = LiveAudiencePoll.builder()
                 .eventId(eventId)
                 .question(request.getQuestion().trim())
@@ -209,6 +216,16 @@ public class LiveAudienceService {
             throw new IllegalArgumentException("Poll status must be 'active', 'paused' or 'closed'");
         }
         LiveAudiencePoll poll = requirePoll(eventId, pollId);
+        if ("active".equals(status)) {
+            List<LiveAudiencePoll> priorActivePolls = pollRepository.findByEventIdAndStatusOrderByCreatedAtDesc(eventId, "active");
+            for (LiveAudiencePoll prior : priorActivePolls) {
+                if (!prior.getId().equals(pollId)) {
+                    prior.setStatus("closed");
+                    prior.setUpdatedAt(LocalDateTime.now());
+                    pollRepository.save(prior);
+                }
+            }
+        }
         poll.setStatus(status);
         poll.setUpdatedAt(LocalDateTime.now());
         poll = pollRepository.save(poll);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/LiveAudienceControllerTests.java
@@ -494,4 +494,64 @@ public class LiveAudienceControllerTests {
                         .with(user(organizerEmail)))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @DisplayName("GET initial data — returns null activePoll when current poll is closed (#17869)")
+    void testGetInitialDataReturnsNullWhenPollClosed() throws Exception {
+        MvcResult created = mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("question", "Closed poll", "options", List.of("Yes", "No")))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        long pollId = objectMapper.readTree(created.getResponse().getContentAsString()).get("id").asLong();
+
+        // Close the poll
+        mockMvc.perform(post("/api/events/{id}/live-audience/polls/{pid}/status", eventId, pollId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of("status", "closed"))))
+                .andExpect(status().isOk());
+
+        // GET initial data should return activePoll = null
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activePoll").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("POST /polls — creating a new poll retires prior active poll (#17869)")
+    void testCreatePollClosesPreviousActivePoll() throws Exception {
+        MvcResult poll1 = mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("question", "First poll", "options", List.of("A", "B")))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long poll1Id = objectMapper.readTree(poll1.getResponse().getContentAsString()).get("id").asLong();
+
+        MvcResult poll2 = mockMvc.perform(post("/api/events/{id}/live-audience/polls", eventId)
+                        .with(user(organizerEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("question", "Second poll", "options", List.of("X", "Y")))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long poll2Id = objectMapper.readTree(poll2.getResponse().getContentAsString()).get("id").asLong();
+
+        // Check DB status of poll 1 is closed
+        org.junit.jupiter.api.Assertions.assertEquals("closed", pollRepository.findById(poll1Id).orElseThrow().getStatus());
+        org.junit.jupiter.api.Assertions.assertEquals("active", pollRepository.findById(poll2Id).orElseThrow().getStatus());
+
+        // GET initial data returns poll2 as active
+        mockMvc.perform(get("/api/events/{id}/live-audience", eventId)
+                        .with(user(attendeeEmail)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activePoll.id").value(poll2Id))
+                .andExpect(jsonPath("$.activePoll.question").value("Second poll"));
+    }
 }


### PR DESCRIPTION
## Description

Fixes the `LiveAudienceService` active poll contract so that only currently active polls are exposed to clients, and at most one poll can be active per event at a time:

- **`getInitialData`**: Filtered poll retrieval explicitly by `status = "active"` via `pollRepository.findByEventIdAndStatusOrderByCreatedAtDesc(eventId, "active")`. If the latest poll is closed or paused, `activePoll` returns `null` instead of handing clients a non-votable poll.
- **`createPoll` & `updatePollStatus`**: Automatically retires any existing active poll for that event (setting `status = "closed"` and updating `updatedAt`) before setting a new poll as active.
- **Unit & Integration Tests**: Added test cases in `LiveAudienceControllerTests` covering active-poll selection (`activePoll` is null when poll closed) and retiring previous active polls on creation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17869

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A (Backend service and API response lifecycle fixes)

## Additional Notes

No breaking changes introduced. Existing APIs and endpoints retain backwards compatibility while strictly enforcing the active-poll lifecycle invariant.
