### PR TITLE
fix(waitlist): lock event row and retry position collisions in importLegacyWaitlist (#17870)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
@@ -35,6 +35,13 @@ public class User {
     @Column(name = "last_name", nullable = false, length = 50)
     private String lastName;
 
+    public String getName() {
+        if (firstName == null && lastName == null) return null;
+        if (firstName == null) return lastName;
+        if (lastName == null) return firstName;
+        return firstName + " " + lastName;
+    }
+
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -996,8 +996,8 @@ public class EventService {
                 Long eventId = request.getEventId();
                 List<CsvWaitlistImportRequest.CsvWaitlistEntry> entries = request.getEntries();
                 
-                // Validate event exists and organizer has permission
-                Event event = eventRepository.findById(eventId)
+                // Validate event exists and organizer has permission (use findByIdWithLock to serialize waitlist position updates)
+                Event event = eventRepository.findByIdWithLock(eventId)
                                 .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
                 
                 eventRoleService.requireRole(eventId, organizerEmail, EventRole.ORGANIZER);
@@ -1034,9 +1034,6 @@ public class EventService {
                                                 LocalDateTime::compareTo))
                                 .toList();
                 
-                // Get current max position for this event
-                int currentMaxPosition = eventWaitlistRepository.findMaxPositionByEventId(eventId);
-                
                 for (int i = 0; i < sortedEntries.size(); i++) {
                         CsvWaitlistImportRequest.CsvWaitlistEntry entry = sortedEntries.get(i);
                         
@@ -1072,17 +1069,44 @@ public class EventService {
                                         continue;
                                 }
                                 
-                                // Create and save the waitlist entry
-                                EventWaitlist waitlistEntry = new EventWaitlist();
-                                waitlistEntry.setEvent(event);
-                                waitlistEntry.setUser(user);
-                                waitlistEntry.setPosition(currentMaxPosition + successfulImports + 1);
-                                waitlistEntry.setStatus("WAITING");
-                                // Use parsed timestamp or current time
-                                waitlistEntry.setJoinedAt(joinedAt);
-                                
-                                eventWaitlistRepository.save(waitlistEntry);
-                                successfulImports++;
+                                boolean saved = false;
+                                for (int attempt = 1; attempt <= MAX_REGISTRATION_RETRIES; attempt++) {
+                                        EventWaitlist waitlistEntry = new EventWaitlist();
+                                        waitlistEntry.setEvent(event);
+                                        waitlistEntry.setUser(user);
+                                        int currentMaxPosition = eventWaitlistRepository.findMaxPositionByEventId(eventId);
+                                        waitlistEntry.setPosition(currentMaxPosition + 1);
+                                        waitlistEntry.setStatus("WAITING");
+                                        waitlistEntry.setJoinedAt(joinedAt);
+                                        
+                                        try {
+                                                eventWaitlistRepository.saveAndFlush(waitlistEntry);
+                                                successfulImports++;
+                                                saved = true;
+                                                break;
+                                        } catch (DataIntegrityViolationException ex) {
+                                                String details = String.valueOf(ex.getMostSpecificCause() != null
+                                                                ? ex.getMostSpecificCause().getMessage()
+                                                                : ex.getMessage()).toLowerCase();
+                                                if (details.contains("uk_event_waitlist_event_position") || details.contains("position")) {
+                                                        continue;
+                                                }
+                                                if (details.contains("user") || details.contains("event_id")) {
+                                                        response.addFailure(new CsvWaitlistImportResponse.ImportFailure(
+                                                                        i, entry.getEmail(), "User already on waitlist for this event"));
+                                                        failedImports++;
+                                                        saved = true;
+                                                        break;
+                                                }
+                                                throw ex;
+                                        }
+                                }
+
+                                if (!saved) {
+                                        response.addFailure(new CsvWaitlistImportResponse.ImportFailure(
+                                                        i, entry.getEmail(), "Could not import waitlist entry due to high demand position collisions"));
+                                        failedImports++;
+                                }
                                 
                         } catch (Exception e) {
                                 // Handle parsing errors and other exceptions

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventWaitlistConcurrencyTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventWaitlistConcurrencyTests.java
@@ -7,6 +7,8 @@ import com.sandeep.eventrabackend.repository.EventRepository;
 import com.sandeep.eventrabackend.repository.EventWaitlistRepository;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
+import com.sandeep.eventrabackend.dto.request.CsvWaitlistImportRequest;
+import com.sandeep.eventrabackend.service.EventService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,9 @@ class EventWaitlistConcurrencyTests {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private EventService eventService;
 
     @Autowired
     private EventRepository eventRepository;
@@ -133,5 +138,89 @@ class EventWaitlistConcurrencyTests {
 
         assertEquals(JOINERS, eventWaitlistRepository.count(),
                 "all joins should be persisted");
+    }
+
+    @Test
+    @DisplayName("Concurrent legacy import and waitlist joins produce gap-free distinct positions without dropping members")
+    void concurrentImportAndJoinWaitlist_NoMembersDropped() throws Exception {
+        int legacyCount = 5;
+        int liveJoinersCount = 5;
+
+        // Create users for legacy import
+        List<CsvWaitlistImportRequest.CsvWaitlistEntry> csvEntries = new ArrayList<>();
+        for (int i = 1; i <= legacyCount; i++) {
+            String email = "legacy" + i + "@example.com";
+            userRepository.save(User.builder()
+                    .firstName("Legacy")
+                    .lastName(String.valueOf(i))
+                    .email(email)
+                    .username("legacy" + i)
+                    .password(passwordEncoder.encode("password"))
+                    .role(Role.CLIENT)
+                    .build());
+            csvEntries.add(new CsvWaitlistImportRequest.CsvWaitlistEntry(
+                    "Legacy User " + i, email, "2024-01-0" + i + "T10:00:00Z"));
+        }
+
+        // Create users for live joiners
+        for (int i = 1; i <= liveJoinersCount; i++) {
+            String email = "livejoiner" + i + "@example.com";
+            userRepository.save(User.builder()
+                    .firstName("Live")
+                    .lastName(String.valueOf(i))
+                    .email(email)
+                    .username("livejoiner" + i)
+                    .password(passwordEncoder.encode("password"))
+                    .role(Role.CLIENT)
+                    .build());
+        }
+
+        ExecutorService pool = Executors.newFixedThreadPool(liveJoinersCount + 1);
+        List<Future<Void>> futures = new ArrayList<>();
+
+        // Submit legacy import task
+        futures.add(pool.submit(() -> {
+            CsvWaitlistImportRequest request = new CsvWaitlistImportRequest(eventId, csvEntries);
+            var response = eventService.importLegacyWaitlist(request, "admin@example.com");
+            assertEquals(legacyCount, response.getSuccessfulImports(), "All legacy entries must be imported successfully");
+            assertEquals(0, response.getFailedImports(), "No legacy entries should fail");
+            return null;
+        }));
+
+        // Submit live waitlist join tasks concurrently
+        for (int i = 1; i <= liveJoinersCount; i++) {
+            final String email = "livejoiner" + i + "@example.com";
+            futures.add(pool.submit(() -> {
+                MvcResult result = mockMvc.perform(post("/api/events/" + eventId + "/waitlist")
+                                .with(user(email)))
+                        .andReturn();
+                assertEquals(201, result.getResponse().getStatus(), "Waitlist join failed for " + email);
+                return null;
+            }));
+        }
+
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "Concurrent tasks did not finish in time");
+
+        for (Future<Void> future : futures) {
+            future.get(5, TimeUnit.SECONDS);
+        }
+
+        int totalExpected = legacyCount + liveJoinersCount;
+        assertEquals(totalExpected, eventWaitlistRepository.count(), "All legacy and live members should be persisted");
+
+        var allEntries = eventWaitlistRepository.findByEvent_IdAndStatusOrderByPositionAscJoinedAtAsc(eventId, "WAITING");
+        assertEquals(totalExpected, allEntries.size());
+
+        Set<Integer> positions = new HashSet<>();
+        for (int p = 0; p < allEntries.size(); p++) {
+            int position = allEntries.get(p).getPosition();
+            positions.add(position);
+        }
+
+        assertEquals(totalExpected, positions.size(), "Positions must all be distinct");
+        for (int p = 1; p <= totalExpected; p++) {
+            assertTrue(positions.contains(p), "Expected position " + p + " to exist");
+        }
     }
 }


### PR DESCRIPTION
## Description

Resolves an issue where `EventService.importLegacyWaitlist(...)` assigned waitlist positions using a non-locking aggregate query while live `joinWaitlist(...)` calls locked the event row. Under concurrent activity, duplicate position numbers caused database `(event_id, position)` unique-constraint violations (`uk_event_waitlist_event_position`). The resulting exception was caught as a generic error, silently dropping legitimate waitlist members instead of retrying.

Key changes:
- Locked the target `Event` entity row with `eventRepository.findByIdWithLock(eventId)` in `importLegacyWaitlist(...)` to enforce mutual exclusion with concurrent `joinWaitlist(...)` calls.
- Enclosed entry persistence in a retry loop using `eventWaitlistRepository.saveAndFlush(...)`. On position constraint collision (`DataIntegrityViolationException`), `currentMaxPosition` is dynamically re-fetched from the database and position assignment is retried.
- Added `getName()` helper to `User.java`.
- Added multi-threaded integration test `concurrentImportAndJoinWaitlist_NoMembersDropped()` to `EventWaitlistConcurrencyTests.java` asserting 0 dropped members and continuous 1..N positions under concurrent import and join activity.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17870

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [ ] I have run `npm run lint` locally and there are no errors.
- [ ] I have run `npm run format:check` locally and there are no formatting issues.
- [ ] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes. -->

## Additional Notes

Backend concurrency unit & integration tests passed via Maven (`EventWaitlistConcurrencyTests` ran 2 tests with 0 errors/failures).
