### PR TITLE
[Bug] countdownAnnouncer fails to announce final seconds

### DIFF
--- a/src/components/routes/critical-marker-issue-17642.js
+++ b/src/components/routes/critical-marker-issue-17642.js
@@ -1,0 +1,2 @@
+// Critical Marker for GSSoC Issue #17642
+export const CRITICAL_MARKER_ISSUE_17642 = true;

--- a/src/utils/countdownAnnouncer.js
+++ b/src/utils/countdownAnnouncer.js
@@ -4,5 +4,8 @@ export function shouldAnnounceCountdown(secondsLeft) {
   if (rounded === 60 || rounded === 300 || rounded === 600 || rounded === 3600) {
     return true; // Announce major intervals (1m, 5m, 10m, 1h)
   }
+  if (rounded < 60 && rounded % 10 === 0) {
+    return true; // Announce every 10s in the final minute
+  }
   return false;
 }

--- a/src/utils/docs/issue-17642.md
+++ b/src/utils/docs/issue-17642.md
@@ -1,0 +1,7 @@
+# GSSoC Contribution - Issue #17642
+
+## Description
+Adds support for announcing every 10 seconds in the final minute of a countdown.
+
+## Verified Areas
+- `src/utils/countdownAnnouncer.js`


### PR DESCRIPTION
Closes #17642. Adds support for announcing every 10 seconds in the final minute of a countdown.