### PR TITLE
fix(security): scope PasskeyCredentialRepository by userEmail to prevent cross-account passkey overwrite (#17866)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/passkey/PasskeyCredentialRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/passkey/PasskeyCredentialRepository.java
@@ -2,12 +2,16 @@ package com.sandeep.eventrabackend.security.passkey;
 
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * FIDO2 Passkey Public Key Credential Repository.
+ * Stores credentials scoped per user and enforces cross-account credential isolation (#17866).
  */
 @Repository
 public class PasskeyCredentialRepository {
@@ -33,15 +37,69 @@ public class PasskeyCredentialRepository {
         public void setSignCount(long signCount) { this.signCount = signCount; }
     }
 
-    private final Map<String, PasskeyCredential> store = new ConcurrentHashMap<>();
+    // Outer map keyed by normalized userEmail, inner map keyed by normalized credentialId
+    private final Map<String, Map<String, PasskeyCredential>> userStore = new ConcurrentHashMap<>();
+    // Global index tracking credentialId owner (normalized credentialId -> normalized userEmail)
+    private final Map<String, String> credentialOwnerMap = new ConcurrentHashMap<>();
 
     public void save(PasskeyCredential credential) {
-        if (credential != null && credential.getCredentialId() != null) {
-            store.put(credential.getCredentialId(), credential);
+        if (credential == null) {
+            throw new IllegalArgumentException("Credential cannot be null.");
         }
+        if (credential.getCredentialId() == null || credential.getCredentialId().isBlank()) {
+            throw new IllegalArgumentException("credentialId is required.");
+        }
+        if (credential.getUserEmail() == null || credential.getUserEmail().isBlank()) {
+            throw new IllegalArgumentException("userEmail is required.");
+        }
+
+        String normEmail = credential.getUserEmail().trim().toLowerCase();
+        String normId = credential.getCredentialId().trim();
+
+        // Check if credentialId is already claimed by a different user
+        String existingOwner = credentialOwnerMap.putIfAbsent(normId, normEmail);
+        if (existingOwner != null && !existingOwner.equals(normEmail)) {
+            throw new IllegalArgumentException("Credential ID is already registered to another account.");
+        }
+
+        userStore.computeIfAbsent(normEmail, k -> new ConcurrentHashMap<>()).put(normId, credential);
     }
 
     public Optional<PasskeyCredential> findByCredentialId(String credentialId) {
-        return Optional.ofNullable(store.get(credentialId));
+        if (credentialId == null || credentialId.isBlank()) {
+            return Optional.empty();
+        }
+        String normId = credentialId.trim();
+        String ownerEmail = credentialOwnerMap.get(normId);
+        if (ownerEmail == null) {
+            return Optional.empty();
+        }
+        Map<String, PasskeyCredential> userMap = userStore.get(ownerEmail);
+        return userMap != null ? Optional.ofNullable(userMap.get(normId)) : Optional.empty();
+    }
+
+    public Optional<PasskeyCredential> findByUserEmailAndCredentialId(String userEmail, String credentialId) {
+        if (userEmail == null || userEmail.isBlank() || credentialId == null || credentialId.isBlank()) {
+            return Optional.empty();
+        }
+        String normEmail = userEmail.trim().toLowerCase();
+        String normId = credentialId.trim();
+        Map<String, PasskeyCredential> userMap = userStore.get(normEmail);
+        return userMap != null ? Optional.ofNullable(userMap.get(normId)) : Optional.empty();
+    }
+
+    public List<PasskeyCredential> findByUserEmail(String userEmail) {
+        if (userEmail == null || userEmail.isBlank()) {
+            return Collections.emptyList();
+        }
+        String normEmail = userEmail.trim().toLowerCase();
+        Map<String, PasskeyCredential> userMap = userStore.get(normEmail);
+        return userMap != null ? new ArrayList<>(userMap.values()) : Collections.emptyList();
+    }
+
+    public void clear() {
+        userStore.clear();
+        credentialOwnerMap.clear();
     }
 }
+

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/passkey/PasskeyCredentialRepositoryTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/passkey/PasskeyCredentialRepositoryTest.java
@@ -1,0 +1,123 @@
+package com.sandeep.eventrabackend.security.passkey;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasskeyCredentialRepositoryTest {
+
+    private PasskeyCredentialRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new PasskeyCredentialRepository();
+    }
+
+    @Test
+    @DisplayName("Successfully save and retrieve credential for a user")
+    void saveAndRetrieveForUser() {
+        PasskeyCredentialRepository.PasskeyCredential cred =
+                new PasskeyCredentialRepository.PasskeyCredential("cred-1", "alice@example.com", "pem-key-1");
+
+        repository.save(cred);
+
+        Optional<PasskeyCredentialRepository.PasskeyCredential> byId = repository.findByCredentialId("cred-1");
+        assertTrue(byId.isPresent());
+        assertEquals("alice@example.com", byId.get().getUserEmail());
+
+        Optional<PasskeyCredentialRepository.PasskeyCredential> byEmailAndId =
+                repository.findByUserEmailAndCredentialId("alice@example.com", "cred-1");
+        assertTrue(byEmailAndId.isPresent());
+        assertEquals("pem-key-1", byEmailAndId.get().getPublicKeyPem());
+    }
+
+    @Test
+    @DisplayName("Cross-user passkey overwrite attempt is rejected with IllegalArgumentException")
+    void crossUserOverwriteRejected() {
+        PasskeyCredentialRepository.PasskeyCredential aliceCred =
+                new PasskeyCredentialRepository.PasskeyCredential("shared-cred-id", "alice@example.com", "alice-pem");
+        repository.save(aliceCred);
+
+        PasskeyCredentialRepository.PasskeyCredential bobCred =
+                new PasskeyCredentialRepository.PasskeyCredential("shared-cred-id", "bob@example.com", "bob-pem");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> repository.save(bobCred));
+        assertEquals("Credential ID is already registered to another account.", ex.getMessage());
+
+        // Verify Alice's credential remains unchanged
+        Optional<PasskeyCredentialRepository.PasskeyCredential> aliceRetrieved =
+                repository.findByCredentialId("shared-cred-id");
+        assertTrue(aliceRetrieved.isPresent());
+        assertEquals("alice@example.com", aliceRetrieved.get().getUserEmail());
+        assertEquals("alice-pem", aliceRetrieved.get().getPublicKeyPem());
+
+        // Verify Bob cannot lookup Alice's credential under Bob's user email
+        Optional<PasskeyCredentialRepository.PasskeyCredential> bobLookup =
+                repository.findByUserEmailAndCredentialId("bob@example.com", "shared-cred-id");
+        assertFalse(bobLookup.isPresent());
+    }
+
+    @Test
+    @DisplayName("Same-user passkey update is allowed")
+    void sameUserUpdateAllowed() {
+        PasskeyCredentialRepository.PasskeyCredential initial =
+                new PasskeyCredentialRepository.PasskeyCredential("cred-1", "alice@example.com", "old-pem");
+        repository.save(initial);
+
+        PasskeyCredentialRepository.PasskeyCredential updated =
+                new PasskeyCredentialRepository.PasskeyCredential("cred-1", "alice@example.com", "new-pem");
+        updated.setSignCount(5);
+        repository.save(updated);
+
+        Optional<PasskeyCredentialRepository.PasskeyCredential> retrieved =
+                repository.findByUserEmailAndCredentialId("alice@example.com", "cred-1");
+        assertTrue(retrieved.isPresent());
+        assertEquals("new-pem", retrieved.get().getPublicKeyPem());
+        assertEquals(5, retrieved.get().getSignCount());
+    }
+
+    @Test
+    @DisplayName("Email and credential ID lookups are case-insensitive and trim whitespace")
+    void emailAndCredentialIdNormalization() {
+        PasskeyCredentialRepository.PasskeyCredential cred =
+                new PasskeyCredentialRepository.PasskeyCredential("  cred-xyz  ", " Alice@Example.com ", "pem-123");
+        repository.save(cred);
+
+        assertTrue(repository.findByCredentialId("cred-xyz").isPresent());
+        assertTrue(repository.findByUserEmailAndCredentialId("alice@example.com", "cred-xyz").isPresent());
+        assertEquals(1, repository.findByUserEmail("ALICE@EXAMPLE.COM").size());
+    }
+
+    @Test
+    @DisplayName("findByUserEmail returns only credentials belonging to specified user")
+    void findByUserEmailReturnsOnlyUserCredentials() {
+        repository.save(new PasskeyCredentialRepository.PasskeyCredential("c1", "alice@example.com", "p1"));
+        repository.save(new PasskeyCredentialRepository.PasskeyCredential("c2", "alice@example.com", "p2"));
+        repository.save(new PasskeyCredentialRepository.PasskeyCredential("c3", "bob@example.com", "p3"));
+
+        List<PasskeyCredentialRepository.PasskeyCredential> aliceCreds = repository.findByUserEmail("alice@example.com");
+        assertEquals(2, aliceCreds.size());
+
+        List<PasskeyCredentialRepository.PasskeyCredential> bobCreds = repository.findByUserEmail("bob@example.com");
+        assertEquals(1, bobCreds.size());
+    }
+
+    @Test
+    @DisplayName("Null or blank parameters in save throw IllegalArgumentException")
+    void invalidInputsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> repository.save(null));
+        assertThrows(IllegalArgumentException.class, () ->
+                repository.save(new PasskeyCredentialRepository.PasskeyCredential(null, "alice@example.com", "pem")));
+        assertThrows(IllegalArgumentException.class, () ->
+                repository.save(new PasskeyCredentialRepository.PasskeyCredential("   ", "alice@example.com", "pem")));
+        assertThrows(IllegalArgumentException.class, () ->
+                repository.save(new PasskeyCredentialRepository.PasskeyCredential("cred-1", null, "pem")));
+        assertThrows(IllegalArgumentException.class, () ->
+                repository.save(new PasskeyCredentialRepository.PasskeyCredential("cred-1", "  ", "pem")));
+    }
+}

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/passkey/WebAuthnControllerTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/passkey/WebAuthnControllerTest.java
@@ -153,4 +153,23 @@ class WebAuthnControllerTest {
 
         verify(credentialRepository).save(any());
     }
+
+    @Test
+    @DisplayName("Cross-account credential overwrite is rejected when repository save throws IllegalArgumentException")
+    void crossAccountCredentialOverwriteIsRejected() {
+        String challenge = (String) controller.generateRegisterChallenge(auth("attacker@example.com")).getBody().get("challenge");
+
+        Map<String, String> payload = Map.of(
+                "credentialId", "existing-victim-cred-id",
+                "userEmail", "attacker@example.com",
+                "publicKey", "-----BEGIN PUBLIC KEY-----MIIB-----END PUBLIC KEY-----",
+                "challenge", challenge);
+
+        org.mockito.Mockito.doThrow(new IllegalArgumentException("Credential ID is already registered to another account."))
+                .when(credentialRepository).save(any());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> controller.verifyRegistration(payload, auth("attacker@example.com")));
+    }
 }
+


### PR DESCRIPTION
## Description

This PR resolves a High Severity security issue (#17866) where `PasskeyCredentialRepository` stored WebAuthn credentials in an un-scoped map indexed solely by `credentialId`. Previously, any user registering a passkey with a duplicate or guessed `credentialId` would silently overwrite another user's stored passkey entry.

**Key Changes:**
- **User Scoping & Owner Indexing**: Refactored `PasskeyCredentialRepository` to maintain user-scoped storage (`userStore`) mapped by normalized `userEmail` and a global ownership index (`credentialOwnerMap`).
- **Cross-Account Overwrite Prevention**: `save(...)` normalizes emails/IDs and atomically verifies ownership. Registering a `credentialId` already bound to a different user throws an `IllegalArgumentException("Credential ID is already registered to another account.")`.
- **Same-User Updates**: Updating key credentials or signature counts by the same account (`userEmail`) remains permitted.
- **New Scoped Queries**: Added `findByUserEmailAndCredentialId(...)` and `findByUserEmail(...)` query methods while keeping `findByCredentialId(...)` backward-compatible.
- **Unit Tests**: Added `PasskeyCredentialRepositoryTest` to test user scoping, cross-account overwrite rejection, same-user updates, case-insensitivity, and input validation, along with exception propagation test in `WebAuthnControllerTest`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17866

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A (Backend security fix)

## Additional Notes

Repository methods use `ConcurrentHashMap` for thread safety and perform case-insensitive normalization on user emails (`trim().toLowerCase()`).
