### PR TITLE
fix(backend): verify room key prefix constants and add unit tests for TeamWorkspaceSyncService (#17862)

### DIFF
--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/TeamWorkspaceSyncServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -160,5 +161,71 @@ class TeamWorkspaceSyncServiceTest {
                 () -> service.requireReadAccess("some-arbitrary-room"));
         assertThrows(AccessDeniedException.class,
                 () -> service.requireWriteAccess("some-arbitrary-room"));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKey uses provided roomKey when available")
+    void resolveRoomKeyUsesProvidedKey() {
+        assertEquals("hackathon:10:team:5", service.resolveRoomKey("hackathon:10:team:5", "10", "5"));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKey builds hackathon room prefix with hackathonId and teamId")
+    void resolveRoomKeyWithHackathonAndTeam() {
+        assertEquals("hackathon:10:team:7", service.resolveRoomKey(null, "10", "7"));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKey builds hackathon room prefix with hackathonId only")
+    void resolveRoomKeyWithHackathonOnly() {
+        assertEquals("hackathon:10", service.resolveRoomKey("", "10", null));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKey defaults to user room prefix when caller authenticated")
+    void resolveRoomKeyWithUserPrefix() {
+        authenticateAs("alice@example.com");
+        assertEquals("user:alice@example.com", service.resolveRoomKey(null, null, null));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKey defaults to 'default' when no auth or params")
+    void resolveRoomKeyDefaultFallback() {
+        assertEquals("default", service.resolveRoomKey(null, null, null));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKeyForMember succeeds for registered member (#15367)")
+    void resolveRoomKeyForMemberAllowed() {
+        when(hackathonRegistrationRepository.existsByHackathon_IdAndUser_Email(10L, "alice@example.com"))
+                .thenReturn(true);
+
+        String resolved = service.resolveRoomKeyForMember(null, "10", "7", "alice@example.com");
+        assertEquals("hackathon:10:team:7", resolved);
+    }
+
+    @Test
+    @DisplayName("resolveRoomKeyForMember throws AccessDeniedException for non-member (#15367)")
+    void resolveRoomKeyForMemberDenied() {
+        when(hackathonRegistrationRepository.existsByHackathon_IdAndUser_Email(10L, "bob@example.com"))
+                .thenReturn(false);
+
+        assertThrows(AccessDeniedException.class,
+                () -> service.resolveRoomKeyForMember(null, "10", "7", "bob@example.com"));
+    }
+
+    @Test
+    @DisplayName("resolveRoomKeyForMember throws AccessDeniedException when room key cannot derive hackathon id")
+    void resolveRoomKeyForMemberInvalidRoomKey() {
+        assertThrows(AccessDeniedException.class,
+                () -> service.resolveRoomKeyForMember("invalid-room-key", null, null, "alice@example.com"));
+    }
+
+    @Test
+    @DisplayName("parseHackathonId throws AccessDeniedException for invalid hackathon room key format")
+    void parseHackathonIdInvalidFormat() {
+        authenticateAs("alice@example.com");
+        assertThrows(AccessDeniedException.class,
+                () -> service.requireReadAccess("hackathon:notanumber"));
     }
 }


### PR DESCRIPTION
## Description

Verified room key prefix constants `HACKATHON_ROOM_PREFIX` (`"hackathon:"`) and `USER_ROOM_PREFIX` (`"user:"`) in `TeamWorkspaceSyncService` to prevent compilation failures and ensure room key authorization helper methods function correctly. Added unit test cases covering room key resolution, member access checks, user room scoping, default fallback behavior, and room key ID parsing errors.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #17862

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [ ] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A (Backend service and unit tests)

## Additional Notes

- Added 9 unit tests in `TeamWorkspaceSyncServiceTest` covering `resolveRoomKey`, `resolveRoomKeyForMember`, and `parseHackathonId` error conditions. All 18 unit tests in `TeamWorkspaceSyncServiceTest` pass cleanly.
