### PR TITLE
fix: SSE base URL uses import.meta.env instead of process.env

### DIFF
--- a/src/services/sseConnectionManager.js
+++ b/src/services/sseConnectionManager.js
@@ -26,8 +26,8 @@ const JITTER_MS = 1000;
 function getSseBaseUrl() {
   if (typeof window !== "undefined") {
     return (
-      process.env.VITE_API_URL ||
-      process.env.REACT_APP_API_URL ||
+      import.meta.env?.VITE_API_URL ||
+      import.meta.env?.REACT_APP_API_URL ||
       "http://localhost:8080/api/v1"
     );
   }


### PR DESCRIPTION
## Description

Fixes #18679. `getSseBaseUrl()` in `src/services/sseConnectionManager.js` referenced `process.env.VITE_API_URL` / `process.env.REACT_APP_API_URL`, but `process` is not defined in the browser, so every Server-Sent Events attempt threw `ReferenceError: process is not defined` and live updates (notifications, realtime context, event availability) never connected.

This PR switches to the Vite-exposed `import.meta.env` (with optional chaining so node-based test environments don't crash) while preserving the `http://localhost:8080/api/v1` fallback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18679

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx eslint src/services/sseConnectionManager.js` (clean).

## GSSOC

Contributor: Akshita-2307
