### PR TITLE
fix: declare valuesRef in useFormValidation

### DIFF
--- a/src/hooks/useFormValidation.base.test.js
+++ b/src/hooks/useFormValidation.base.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useFormValidation from "./useFormValidation";
+
+vi.mock("./useAsyncValidation", () => ({
+  __esModule: true,
+  default: () => ({
+    asyncErrors: {},
+    asyncTouched: {},
+    isAsyncValidating: false,
+    isAnyAsyncValidating: false,
+    hasAsyncErrors: false,
+    validateAsync: () => {},
+    clearAsyncError: () => {},
+    cleanup: () => {},
+  }),
+}));
+
+describe("useFormValidation (base hook)", () => {
+  it("mounts without ReferenceError (regression: valuesRef was undeclared)", () => {
+    const { result } = renderHook(() =>
+      useFormValidation({ email: "", name: "" }, {})
+    );
+    expect(result.current.values).toEqual({ email: "", name: "" });
+  });
+
+  it("validates on blur using the current values", () => {
+    const rules = {
+      email: (v) => (v && v.includes("@") ? null : "invalid email"),
+    };
+    const { result } = renderHook(() =>
+      useFormValidation({ email: "" }, rules)
+    );
+    act(() => {
+      result.current.handleBlur({ target: { name: "email", value: "bad" } });
+    });
+    expect(result.current.errors.email).toBe("invalid email");
+  });
+});

--- a/src/hooks/useFormValidation.js
+++ b/src/hooks/useFormValidation.js
@@ -27,6 +27,7 @@ export const useFormValidation = (initialState, validationRules, options = {}) =
 
   const validationRulesRef = useRef(validationRules);
   const initialStateRef = useRef(initialState);
+  const valuesRef = useRef(initialState);
   const optionsRef = useRef({ debounceMs, validateOnBlur });
 
   const [values, setValues] = useState(initialState);


### PR DESCRIPTION
## Description

Fixes #18681. `useFormValidation` assigned and read `valuesRef.current` (lines 62 and 176) but never declared the ref, so mounting the hook threw `ReferenceError: valuesRef is not defined` and broke the event registration form.

This PR declares `const valuesRef = useRef(initialState);` alongside the other refs (matching the enhanced twin `src/hooks/useFormValidation.enhanced.js`), and adds `src/hooks/useFormValidation.base.test.js` with a regression test covering mount and blur-validation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18681

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx eslint src/hooks/useFormValidation.js` (clean) and `npx vitest run src/hooks/useFormValidation.base.test.js` (2/2 pass).

## GSSOC

Contributor: Akshita-2307
