### PR TITLE
fix(backend): persist uploaded bytes to local uploads dir and serve them back (Closes #18676)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/WebConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/WebConfig.java
@@ -1,0 +1,27 @@
+package com.sandeep.eventrabackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
+
+/**
+ * Serves locally persisted uploads (see AsyncUploadManager) at /uploads/**.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${eventra.upload-dir:./uploads}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String location = Paths.get(uploadDir).toAbsolutePath().normalize().toUri().toString();
+        if (!location.endsWith("/")) {
+            location += "/";
+        }
+        registry.addResourceHandler("/uploads/**").addResourceLocations(location);
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AsyncUploadManager.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AsyncUploadManager.java
@@ -1,15 +1,45 @@
 package com.sandeep.eventrabackend.controller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
 
 /**
  * Async Storage File Manager mapping uploads to static links (#16508).
+ * Persists uploaded bytes to a local uploads directory and returns a
+ * URL that the static resource handler serves back.
  */
 @Component
 public class AsyncUploadManager {
 
+    private final Path uploadDir;
+
+    public AsyncUploadManager(@Value("${eventra.upload-dir:./uploads}") String uploadDir) {
+        this.uploadDir = Paths.get(uploadDir);
+    }
+
     public String writeToStorage(String filename, byte[] bytes) {
-        // Simulates saving attachments asynchronously to static cloud storage
-        return "https://eventra-assets.io/files/" + filename;
+        String safeName = sanitizeFileName(filename);
+        String storedName = UUID.randomUUID() + "_" + safeName;
+        try {
+            Files.createDirectories(uploadDir);
+            Files.write(uploadDir.resolve(storedName), bytes);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to persist uploaded file " + storedName, e);
+        }
+        return "/uploads/" + storedName;
+    }
+
+    private String sanitizeFileName(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return "file";
+        }
+        return Paths.get(filename).getFileName().toString();
     }
 }


### PR DESCRIPTION
Closes #18676

## Problem

`AsyncUploadManager.writeToStorage` discarded the uploaded bytes and returned a hardcoded fake CDN URL, so `POST /api/attachments/upload` reported success but stored nothing — the returned `https://eventra-assets.io/...` link always 404ed.

## Fix

- `AsyncUploadManager`: writes the bytes to a local uploads directory (`${eventra.upload-dir:./uploads}`) using a UUID-prefixed filename (path-traversal safe via `Paths.get(...).getFileName()`) and returns `/uploads/<storedName>`.
- New `WebConfig`: registers a static resource handler so `/uploads/**` is served back from disk.
- On write failure an `UncheckedIOException` is thrown, which the controller already maps to a 500.

Minimal, self-contained change to `Backend/src/main/java/com/sandeep/eventrabackend/controller/AsyncUploadManager.java` plus a new `Backend/src/main/java/com/sandeep/eventrabackend/config/WebConfig.java`.
