### PR TITLE
fix(backend): collapse maybeEvictExpired to a single elapsed-window check (Closes #18678)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitService.java
@@ -70,12 +70,9 @@ public class RateLimitService {
             Map.Entry<String, Counter> entry = iterator.next();
             Counter counter = entry.getValue();
             synchronized (counter) {
-                if (counter.windowStart.isBefore(cutoff) && counter.requests == 0
-                        || !counter.windowStart.plus(window).isAfter(cutoff)) {
-                    // Drop counters whose window has fully elapsed.
-                    if (!clock.instant().isBefore(counter.windowStart.plus(window))) {
-                        iterator.remove();
-                    }
+                // Drop counters whose window has fully elapsed.
+                if (!counter.windowStart.plus(window).isAfter(cutoff)) {
+                    iterator.remove();
                 }
             }
         }


### PR DESCRIPTION
Closes #18678

## Problem

`RateLimitService.maybeEvictExpired` had a dead eviction clause and a redundant re-check:

```java
if (counter.windowStart.isBefore(cutoff) && counter.requests == 0
        || !counter.windowStart.plus(window).isAfter(cutoff)) {
    if (!clock.instant().isBefore(counter.windowStart.plus(window))) {
        iterator.remove();
    }
}
```

- The first disjunct can never be true: counters are created via `computeIfAbsent` with `windowStart = now` and immediately incremented, so a counter with `requests == 0` never has `windowStart.isBefore(cutoff)`.
- The inner `if` repeats the same "window fully elapsed" check as the second disjunct.

## Fix

`Backend/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitService.java`: collapsed the condition to the single elapsed-window check `!counter.windowStart.plus(window).isAfter(cutoff)` and removed the redundant inner guard. Eviction behavior is unchanged; only the dead logic was removed.
