### PR TITLE
fix: declare module-scope resizeTimeout in notifyLenisResize

### DIFF
--- a/src/utils/lenisUtils.js
+++ b/src/utils/lenisUtils.js
@@ -2,6 +2,8 @@
  * Lenis Smooth Scroll Debouncing & Image Aspect-Ratio Bounding Box Utility (#13911)
  */
 
+let resizeTimeout;
+
 /**
  * Scroll to a specific element smoothly
  * @param {string|HTMLElement} target - CSS selector or target HTML element


### PR DESCRIPTION
## Description

Fixes #18683. `notifyLenisResize()` in `src/utils/lenisUtils.js` assigned to `resizeTimeout` without declaring it. Since the file is an ES module (strict mode), every call threw `ReferenceError: resizeTimeout is not defined`, breaking Lenis resize recalibration — this function is invoked by `EventGridVirtualizer.jsx` when lazy images load.

This PR adds the missing module-scope `let resizeTimeout;` declaration.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18683

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx eslint src/utils/lenisUtils.js` (clean) and a direct smoke check: `notifyLenisResize(10)` now calls `window.lenis.resize()` without throwing.

## GSSOC

Contributor: Akshita-2307
