### PR TITLE
fix(frontend): resync TagSelector internal state when tags prop changes (Closes #18692)

### DIFF
--- a/src/components/TagSelector.jsx
+++ b/src/components/TagSelector.jsx
@@ -1,9 +1,13 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 export const TagSelector = ({ tags = [], onTagsChange }) => {
   const [selectedTags, setSelectedTags] = useState(tags);
   const [inputValue, setInputValue] = useState('');
   const inputRef = useRef(null);
+
+  useEffect(() => {
+    setSelectedTags(tags);
+  }, [tags]);
 
   const handleKeyDown = (e) => {
     if (e.key === 'Backspace' && inputValue === '' && selectedTags.length > 0) {


### PR DESCRIPTION
Closes #18692

## Problem

`TagSelector` seeded its internal `selectedTags` state once from the `tags` prop and never resynced:

```js
const [selectedTags, setSelectedTags] = useState(tags);
```

When a parent updated `tags` (e.g. tags loaded asynchronously after mount, or cleared by another control), the selector kept rendering stale chips while the parent's `onTagsChange` callbacks diverged from what was shown.

## Fix

`src/components/TagSelector.jsx`: added a `useEffect` that syncs `selectedTags` whenever the `tags` prop changes:

```js
useEffect(() => {
  setSelectedTags(tags);
}, [tags]);
```

Now an updated `tags` prop is reflected in the chip list.
