### PR TITLE
fix(frontend): implement QR code download instead of alert stub (Closes #18693)

### DIFF
--- a/src/components/events/EventQRCode.js
+++ b/src/components/events/EventQRCode.js
@@ -6,8 +6,32 @@ const EventQRCode = ({
   registrationId = "",
   qrValue = "",
 }) => {
-  const handleDownload = () => {
-    alert("QR download functionality can be integrated later.");
+  const handleDownload = async () => {
+    if (!qrValue) {
+      alert("No QR code available to download.");
+      return;
+    }
+
+    try {
+      const link = document.createElement("a");
+      if (qrValue.startsWith("data:")) {
+        link.href = qrValue;
+      } else {
+        const response = await fetch(qrValue);
+        if (!response.ok) throw new Error(`Download failed (${response.status})`);
+        const blob = await response.blob();
+        link.href = URL.createObjectURL(blob);
+      }
+      link.download = `event-qr-${registrationId || "ticket"}.png`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      if (link.href.startsWith("blob:")) {
+        URL.revokeObjectURL(link.href);
+      }
+    } catch (error) {
+      alert("Failed to download QR code. Please try again.");
+    }
   };
 
   return (


### PR DESCRIPTION
Closes #18693

## Problem

`EventQRCode` rendered a working QR `<img>` but its "Download QR Code" button was a stub that only showed an alert:

```js
const handleDownload = () => {
  alert("QR download functionality can be integrated later.");
};
```

## Fix

`src/components/events/EventQRCode.js`: implemented a real download from `qrValue`.

- If `qrValue` is a data URL, it is used directly on an `<a download>` element.
- Otherwise the image is fetched, converted to a Blob object URL, and downloaded.
- The object URL is revoked after the download, and failures surface as an alert.
- The downloaded file is named `event-qr-<registrationId>.png` (falls back to `ticket`).
