### PR TITLE
fix: replace process.env with ENV.API_URL in ApiDocs examples

### DIFF
--- a/src/Pages/ApiDocs.js
+++ b/src/Pages/ApiDocs.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import useReducedMotion from "../hooks/useReducedMotion.js";
+import { ENV } from "../config/env";
 import { Server, AlertCircle, BookOpen, Users, Trophy, Play, RefreshCw, Terminal, Settings } from "lucide-react";
 
 const endpoints = [
@@ -32,7 +33,7 @@ const endpoints = [
     desc: "Retrieve projects submitted to hackathons.",
     method: "GET",
     url: "/mock-api/projects?hackathonId=<id>",
-example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
+    example: `curl -X GET ${ENV.API_URL}/projects?hackathonId=1`,
     response: `[
   {
     "id": 42,
@@ -48,7 +49,7 @@ example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
     desc: "Get a list of top contributors and GSOC participants.",
     method: "GET",
     url: "/mock-api/contributors",
-  example: `fetch("${process.env.REACT_APP_API_URL}/contributors", {
+  example: `fetch("${ENV.API_URL}/contributors", {
   headers: { Authorization: "Bearer <API_KEY>" }
 })`,
     response: `[
@@ -66,7 +67,7 @@ example: `curl -X GET ${process.env.REACT_APP_API_URL}/projects?hackathonId=1`,
     desc: "Fetch leaderboard rankings of participants.",
     method: "GET",
     url: "/mock-api/leaderboard?limit=10",
-    example: `curl -X GET \${process.env.REACT_APP_API_URL}/leaderboard?limit=10`,
+    example: `curl -X GET ${ENV.API_URL}/leaderboard?limit=10`,
     response: `[
   {
     "rank": 1,


### PR DESCRIPTION
## Description

Fixes #18684. `src/Pages/ApiDocs.js` evaluated `process.env.REACT_APP_API_URL` at module scope in the endpoint examples (lines 35, 51, 69). `process` is undefined in the browser, so rendering the API docs page threw `ReferenceError: process is not defined`.

This PR uses the canonical `ENV.API_URL` helper from `src/config/env.js`, which resolves `VITE_API_URL` or `REACT_APP_API_URL` from `import.meta.env` in the browser (with a development fallback), consistent with how the rest of the app reads env vars. The escaped placeholder in the Leaderboard example is also unescaped for consistency with the other examples.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18684

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx eslint src/Pages/ApiDocs.js` (clean). No remaining `process.env` references in the file.

## GSSOC

Contributor: Akshita-2307
