### PR TITLE
fix: import normalizeApiError used by response interceptor

### DIFF
--- a/src/config/api/interceptors.js
+++ b/src/config/api/interceptors.js
@@ -2,7 +2,7 @@ import { syncServerTimeFromHeader } from "../../utils/timeSync.js";
 import { getCSRFToken, requiresCSRF, getCSRFEnforcementMode } from "../../utils/csrfToken.js";
 import { signRequest } from "../../utils/requestSigner.js";
 import { logger } from "../../utils/logger.js";
-import { ApiError, RateLimitError, CSRFError } from "./errors.js";
+import { ApiError, RateLimitError, CSRFError, normalizeApiError } from "./errors.js";
 import { logCategorizedError } from "../../utils/errorRecovery.js";
 
 const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];


### PR DESCRIPTION
## Description

Fixes #18685. `createResponseInterceptor` in `src/config/api/interceptors.js` calls `normalizeApiError(error)` (line 153), but the function was never imported. Since `normalizeApiError` is exported from `src/config/api/errors.js`, the interceptor threw `ReferenceError: normalizeApiError is not defined` on the first network error, breaking unified error handling for every API call.

This PR adds `normalizeApiError` to the existing `./errors.js` import.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18685

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx eslint src/config/api/interceptors.js` (clean).

## GSSOC

Contributor: Akshita-2307
