### PR TITLE
fix: wire drag-drop dropzone to useDragAndDrop prop getters

### DIFF
--- a/src/Pages/Projects/SubmitProject.js
+++ b/src/Pages/Projects/SubmitProject.js
@@ -49,14 +49,8 @@ const SubmitProject = () => {
     targetAudience: "", // Added to state
   });
   const [errors, setErrors] = useState({});
-  const fileInputRef = useRef(null);
 
   // Fix: drag handlers now provided by useDragAndDrop hook above
-
-  const handleFileChange = (e) => {
-    const file = e.target.files[0];
-    processFile(file);
-  };
 
   const processFile = (file) => {
     if (!file) return;
@@ -396,23 +390,14 @@ const handleSubmit = async (e) => {
               </label>
               {field.name === "projectImage" ? (
                 <div
-                  onDragOver={handleDragOver}
-                  onDragLeave={handleDragLeave}
-                  onDrop={handleDrop}
-                  onClick={() => fileInputRef.current?.click()}
+                  {...getRootProps()}
                   className={`w-full border-2 border-dashed rounded-xl p-6 flex flex-col items-center justify-center cursor-pointer transition-all duration-300 ${
                     isDragging
                       ? "border-primary bg-primary/10"
                       : "border-border hover:border-primary hover:bg-bg/50"
                   }`}
                 >
-                  <input
-                    type="file"
-                    accept="image/*"
-                    ref={fileInputRef}
-                    className="hidden"
-                    onChange={handleFileChange}
-                  />
+                  <input {...getInputProps()} />
                   {formData.projectImage ? (
                     <div className="relative w-full max-w-[200px] aspect-square flex items-center justify-center rounded-lg border border-border overflow-hidden bg-bg group">
                       <img
@@ -440,6 +425,11 @@ const handleSubmit = async (e) => {
                         Supports PNG, JPG, JPEG, SVG up to 5MB
                       </div>
                     </div>
+                  )}
+                  {dragError && (
+                    <p className="text-red-500 text-xs mt-2" role="alert">
+                      {dragError}
+                    </p>
                   )}
                 </div>
               ) : (


### PR DESCRIPTION
## Description

Fixes #18686. The project-image dropzone in `src/Pages/Projects/SubmitProject.js` referenced `handleDragOver`, `handleDragLeave` and `handleDrop`, none of which are defined — so rendering the submit-project page threw `ReferenceError`. The component had already migrated to the `useDragAndDrop` hook (which provides these handlers via `getRootProps()`), but the JSX still used the old manual handlers plus a redundant hidden `<input>`.

This PR:
- Spreads `{...getRootProps()}` onto the dropzone container (drag handlers, click/keyboard accessibility, `role="button"`, `aria-label`).
- Replaces the manual hidden input with `{...getInputProps()}`.
- Removes the now-dead `handleFileChange`, `fileInputRef`, and the dangling handler references.
- Surfaces the hook's `dragError` inside the dropzone so validation failures (wrong type / >5MB) are visible to the user.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18686

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx eslint src/Pages/Projects/SubmitProject.js` (clean); no remaining references to the removed identifiers.

## GSSOC

Contributor: Akshita-2307
