### PR TITLE
fix: validate rate limiter construction, cost and fn arguments

### DIFF
--- a/src/utils/rateLimiter.js
+++ b/src/utils/rateLimiter.js
@@ -35,6 +35,13 @@ export function createRateLimiter({
   initialTokens,
   channelName,
 } = {}) {
+  if (!Number.isFinite(maxTokens) || maxTokens <= 0) {
+    throw new RangeError("maxTokens must be a positive finite number");
+  }
+  if (!Number.isFinite(refillRate) || refillRate <= 0) {
+    throw new RangeError("refillRate must be a positive finite number");
+  }
+
   let tokens = initialTokens ?? maxTokens;
   let lastRefill = Date.now();
   let lockedUntil = 0;
@@ -70,6 +77,10 @@ export function createRateLimiter({
      * @returns {boolean}
      */
     tryConsume(cost = 1) {
+      if (!Number.isFinite(cost) || cost <= 0) {
+        throw new RangeError("cost must be a positive finite number");
+      }
+
       if (Date.now() < lockedUntil) return false;
 
       refill();
@@ -189,6 +200,10 @@ export function createRateLimiter({
  * @returns {Function} Rate-limited function
  */
 export function withRateLimit(fn, options = {}) {
+  if (typeof fn !== "function") {
+    throw new TypeError("withRateLimit requires a function as its first argument");
+  }
+
   const {
     cost = 1,
     mode = "throw",


### PR DESCRIPTION
## Description

Fixes #18687. `createRateLimiter()` documents `@throws {RangeError} When maxTokens or refillRate is not a positive finite number`, but the validation was never implemented. The test suite `src/utils/rateLimiter.test.js` asserts these validations, so they were failing.

This PR implements the documented contract:
- `createRateLimiter` throws `RangeError` when `maxTokens` or `refillRate` is not a positive finite number (0, negative, `Infinity`, `NaN`).
- `tryConsume(cost)` throws `RangeError` when `cost` is 0 or negative.
- `withRateLimit(fn)` throws `TypeError` when the first argument is not a function.

All existing consumers pass valid values (`authService.js`, `useEventRegistration.js`), so nothing breaks in production.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18687

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx vitest run src/utils/rateLimiter.test.js`: 18/21 pass (all validation tests now green). The remaining 3 failures use `jest.fn()` and fail with `ReferenceError: jest is not defined` — a pre-existing, repo-wide issue affecting ~95 test files, unrelated to this change.

## GSSOC

Contributor: Akshita-2307
