### PR TITLE
fix: align getOptimizedImageUrl with documented contract and tests

### DIFF
--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -22,7 +22,7 @@
  * @returns {string}
  */
 export const getOptimizedImageUrl = (originalUrl, options = {}) => {
-  if (!originalUrl || typeof originalUrl !== "string") return "";
+  if (!originalUrl || typeof originalUrl !== "string") return originalUrl;
 
   // If already a Cloudinary URL, return as is
   if (originalUrl.includes("res.cloudinary.com")) {
@@ -34,17 +34,15 @@ export const getOptimizedImageUrl = (originalUrl, options = {}) => {
   let transformations = `w_${width},q_${quality},f_${format}`;
   if (height) transformations += `,h_${height},c_fill`;
 
-  // Use Cloudinary fetch API for real format conversion
-  const cloudName = import.meta.env?.VITE_CLOUDINARY_CLOUD_NAME;
-  if (!cloudName) {
-    return originalUrl;
-  }
+  // Use Cloudinary fetch API for real format conversion.
+  // Fall back to Cloudinary's "demo" cloud when the cloud name is unset.
+  const cloudName = import.meta.env?.VITE_CLOUDINARY_CLOUD_NAME || "demo";
 
   // Only apply to absolute HTTP/HTTPS URLs that Cloudinary can fetch.
   // Relative paths (/images/hero.jpg), blob: URLs, and data: URIs cannot
   // be Cloudinary-transformed and are returned unchanged.
   if (originalUrl.startsWith("http")) {
-    return `https://res.cloudinary.com/${cloudName}/image/fetch/${transformations}/${originalUrl}`;
+    return `https://res.cloudinary.com/${cloudName}/image/fetch/${transformations}/${encodeURIComponent(originalUrl)}`;
   }
 
   // Fallback for local assets


### PR DESCRIPTION
## Description

Fixes #18688. `getOptimizedImageUrl()` diverged from its JSDoc and its test contract (`src/utils/imageOptimizer.test.js` — 13 tests failing) in three ways:

1. Returned `""` for `null`/`undefined`/non-string input instead of the original value (the JSDoc says "Returns the original URL unchanged for non-string or falsy values").
2. Short-circuited to the original URL whenever `VITE_CLOUDINARY_CLOUD_NAME` was unset instead of defaulting to Cloudinary's `demo` cloud.
3. Did not `encodeURIComponent` the fetched URL, producing malformed Cloudinary fetch URLs.

This PR returns the original value for non-strings, defaults the cloud name to `demo`, and percent-encodes the upstream URL in the fetch URL.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18688

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `npx vitest run src/utils/imageOptimizer.test.js`: 27/27 pass. `npx eslint src/utils/imageOptimizer.js` is clean. Consumers (`OptimizedImage.jsx`, `generateSrcSet`) only pass valid HTTP URLs, so the demo default and encoding do not affect them negatively.

## GSSOC

Contributor: Akshita-2307
