### PR TITLE
fix: restore getImageAspectRatioStyle export in lenisUtils

### DIFF
--- a/src/utils/lenisUtils.js
+++ b/src/utils/lenisUtils.js
@@ -37,6 +37,21 @@ export function notifyLenisResize(delayMs = 150) {
 }
 
 /**
+ * Generates a CSS aspect-ratio style object for a bounding box.
+ * Used by the event grid to reserve image space and avoid layout thrashing.
+ * @param {number} [width=16] - Aspect ratio width
+ * @param {number} [height=9] - Aspect ratio height
+ * @returns {{ aspectRatio: string, width: string, height: string }}
+ */
+export function getImageAspectRatioStyle(width = 16, height = 9) {
+  return {
+    aspectRatio: `${width} / ${height}`,
+    width: "100%",
+    height: "auto",
+  };
+}
+
+/**
  * Stop Lenis scrolling (useful for modals)
  */
 export const stopScroll = () => {


### PR DESCRIPTION
## Description

Fixes #18707. `getImageAspectRatioStyle` was added to `src/utils/lenisUtils.js` in commit `aed19489c` and later removed, but it is still imported by:

- `src/Pages/Events/EventGridVirtualizer.jsx` (the events grid) — calls it at line 10
- `tests/lenisUtils.test.mjs` — asserts `getImageAspectRatioStyle(16, 9)` returns `{ aspectRatio: "16 / 9", width: "100%" }`

Importing a non-existent named export throws `SyntaxError: The requested module '.../lenisUtils.js' does not provide an export named 'getImageAspectRatioStyle'`, which crashes the events-grid module and makes the lenis test file un-runnable.

This PR restores the export with its documented contract.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #18707

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] My commit messages follow the conventional commit format.

## Additional Notes

Verified with `node --import ./tests/setup.js --test tests/lenisUtils.test.mjs`: the "should generate CSS aspect-ratio style bounding box" test now passes (previously failed at import). The remaining failure in that file (`resizeTimeout` in `notifyLenisResize`) is a separate bug tracked in #18683 / PR #18705. `npx eslint src/utils/lenisUtils.js` is clean.

## GSSOC

Contributor: Akshita-2307
