### PR TITLE
fix(frontend): make collection View button expand the full event list (Closes #18695)

### DIFF
--- a/src/components/events/BookmarkCollectionCard.js
+++ b/src/components/events/BookmarkCollectionCard.js
@@ -2,6 +2,7 @@ import { Folder, Edit2, Trash2, Calendar, Eye } from "lucide-react";
 
 const BookmarkCollectionCard = ({
   collection,
+  expanded = false,
   onRename,
   onDelete,
   onView,
@@ -9,6 +10,9 @@ const BookmarkCollectionCard = ({
   if (!collection) return null;
 
   const eventCount = collection.events?.length || 0;
+  const visibleEvents = expanded
+    ? collection.events
+    : collection.events.slice(0, 3);
 
   return (
     <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-md hover:shadow-lg transition-all duration-300 p-6">
@@ -70,7 +74,7 @@ const BookmarkCollectionCard = ({
           className="flex-1 flex items-center justify-center gap-2 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white py-2.5 transition"
         >
           <Eye size={18} />
-          View
+          {expanded ? "Hide" : "View"}
         </button>
 
         <button
@@ -102,7 +106,7 @@ const BookmarkCollectionCard = ({
 
           <div className="space-y-2">
 
-            {collection.events.slice(0, 3).map((event) => (
+            {visibleEvents.map((event) => (
               <div
                 key={event.id}
                 className="flex justify-between items-center rounded-lg bg-slate-50 dark:bg-slate-800 px-3 py-2"
@@ -119,7 +123,7 @@ const BookmarkCollectionCard = ({
               </div>
             ))}
 
-            {eventCount > 3 && (
+            {!expanded && eventCount > 3 && (
               <p className="text-xs text-slate-500 text-center">
                 +{eventCount - 3} more event{eventCount - 3 > 1 ? "s" : ""}
               </p>

--- a/src/components/events/BookmarkCollections.js
+++ b/src/components/events/BookmarkCollections.js
@@ -15,6 +15,7 @@ const BookmarkCollections = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [newCollectionName, setNewCollectionName] = useState("");
+  const [expandedCollectionId, setExpandedCollectionId] = useState(null);
 
   const filteredCollections = useMemo(() => {
     const searched = searchCollections(collections, searchQuery);
@@ -66,7 +67,9 @@ const BookmarkCollections = ({
   };
 
   const handleView = (collection) => {
-    console.log("Open collection:", collection);
+    setExpandedCollectionId((prev) =>
+      prev === collection.id ? null : collection.id
+    );
   };
 
   return (
@@ -165,6 +168,7 @@ const BookmarkCollections = ({
             <BookmarkCollectionCard
               key={collection.id}
               collection={collection}
+              expanded={expandedCollectionId === collection.id}
               onRename={handleRename}
               onDelete={handleDelete}
               onView={handleView}


### PR DESCRIPTION
Closes #18695

## Problem

`BookmarkCollections` passed `handleView` to every `BookmarkCollectionCard`, but the handler only logged to the console:

```js
const handleView = (collection) => {
  console.log("Open collection:", collection);
};
```

The "View" button on each card was a no-op — users could not expand a collection, even though each card already showed a 3-event "Recent Events" preview.

## Fix

- `src/components/events/BookmarkCollections.js`: added an `expandedCollectionId` state; `handleView` now toggles it, and the card receives an `expanded` prop.
- `src/components/events/BookmarkCollectionCard.js`: when `expanded`, the card renders the complete event list instead of the first 3; the button label toggles between "View" and "Hide", and the "+N more events" line is hidden when expanded.

The View button now works and reveals the full collection contents.
