### PR TITLE
fix(frontend): persist profile theme under THEME_STORAGE_KEY so it survives cold load (Closes #18696)

### DIFF
--- a/src/context/ThemeContext.js
+++ b/src/context/ThemeContext.js
@@ -114,9 +114,9 @@ export const ThemeProvider = ({ children }) => {
       // Also persist to localStorage so it survives the next cold load
       // before the next validateSession() completes.
       if (profileTheme === "system") {
-        safeStorage.removeItem("theme");
+        safeStorage.removeItem(THEME_STORAGE_KEY);
       } else {
-        safeStorage.setItem("theme", profileTheme);
+        safeStorage.setItem(THEME_STORAGE_KEY, profileTheme);
       }
     }
 


### PR DESCRIPTION
Closes #18696

## Problem

`ThemeContext` persisted the profile theme under the wrong storage key.

- `THEME_STORAGE_KEY` is `"eventra_theme"` (line 16).
- `getInitialTheme()` reads `safeStorage.getItem(THEME_STORAGE_KEY)` (line 52).
- But the FIX #7653 persistence block wrote/removed the literal key `"theme"`:

```js
if (profileTheme === "system") {
  safeStorage.removeItem("theme");
} else {
  safeStorage.setItem("theme", profileTheme);
}
```

So the theme saved at login was stored under `"theme"`, which is never read on the next cold load — `getInitialTheme()` returned `"system"` and the saved preference was lost until `validateSession()` resolved again.

## Fix

`src/context/ThemeContext.js`: replaced both literals with the constant so the persisted value is stored under the same key that `getInitialTheme()` reads:

```js
safeStorage.removeItem(THEME_STORAGE_KEY);
...
safeStorage.setItem(THEME_STORAGE_KEY, profileTheme);
```

The theme now survives a cold reload.
