### PR TITLE
fix(frontend): upload lost-and-found images via /api/attachments/upload instead of leaking object URLs (Closes #18698)

### DIFF
--- a/src/services/lostAndFoundService.js
+++ b/src/services/lostAndFoundService.js
@@ -155,14 +155,14 @@ export const lostAndFoundService = {
     }
   },
 
-  // Upload an image and get URL (this would be handled by your existing file upload service)
+  // Upload an image and get a persisted URL via the attachments upload endpoint
   uploadImage: async (file) => {
-    // This is a placeholder - you would integrate with your existing file upload service
-    // For now, we'll return a mock URL or handle the upload differently
-    return Promise.resolve({
-      imageUrl: URL.createObjectURL(file),
-      thumbnailUrl: URL.createObjectURL(file)
-    });
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await apiUtils.post("/api/attachments/upload", formData);
+    const text = await response.text();
+    const link = text.replace("File uploaded to: ", "").trim();
+    return { imageUrl: link, thumbnailUrl: link };
   }
 };
 


### PR DESCRIPTION
Closes #18698

## Problem

`lostAndFoundService.uploadImage` was a placeholder that never uploaded:

```js
uploadImage: async (file) => {
  return Promise.resolve({
    imageUrl: URL.createObjectURL(file),
    thumbnailUrl: URL.createObjectURL(file)
  });
}
```

- It created **two** `URL.createObjectURL` blobs per call and never called `revokeObjectURL`, leaking browser memory.
- The returned blob URLs only lived in the current tab and died on reload — nothing was persisted.

## Fix

`src/services/lostAndFoundService.js`: `uploadImage` now POSTs the file as `FormData` to the existing `POST /api/attachments/upload` endpoint via `apiUtils.post`, parses the returned `File uploaded to: <link>` text, and returns `{ imageUrl: link, thumbnailUrl: link }`. This removes the object-URL leak and returns real, persisted URLs.
