### PR TITLE
fix: validate session recovery payload

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/SessionRecoveryController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/SessionRecoveryController.java
@@ -23,8 +23,23 @@ public class SessionRecoveryController {
     }
 
     @PostMapping
-    public ResponseEntity<Map<String, Object>> save(@RequestBody Map<String, Object> body, Authentication authentication) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(sessionRecoveryService.save(authentication.getName(), body));
+    public ResponseEntity<?> save(
+            @RequestBody(required = false) Map<String, Object> body,
+            Authentication authentication) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        if (body == null || body.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "Bad Request",
+                    "message", "Session recovery payload cannot be null or empty."
+            ));
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(sessionRecoveryService.save(authentication.getName(), body));
     }
 
     @GetMapping


### PR DESCRIPTION
## Description

Validates the session recovery request payload before passing it to the service layer.

## Changes

- Reject unauthenticated requests with `401 Unauthorized`.
- Validate that the session recovery request body is not null or empty.
- Return `400 Bad Request` for invalid or empty payloads.
- Prevent null payloads from reaching the service layer and causing `NullPointerException`.

## Impact

This prevents malformed session recovery requests from causing unhandled server-side exceptions and ensures invalid requests receive controlled HTTP responses.

## Related Issue

Closes #18715