### PR TITLE
fix: normalize protected SSE topics before authorization

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/StreamController.java
@@ -36,13 +36,13 @@ public class StreamController {
     public ResponseEntity<SseEmitter> subscribe(
             @PathVariable String topic,
             Authentication authentication) {
-        String normalized = topic == null ? "" : topic.trim().toLowerCase();
+        String normalized = topic == null ? "" : topic.trim().toLowerCase(java.util.Locale.ROOT);
         if (AUTH_REQUIRED_TOPICS.contains(normalized)
                 && (authentication == null || !authentication.isAuthenticated())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         try {
-            return ResponseEntity.ok(eventStreamService.createEmitter(topic));
+            return ResponseEntity.ok(eventStreamService.createEmitter(normalized));
         } catch (IllegalArgumentException ex) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         } catch (IllegalStateException ex) {


### PR DESCRIPTION
## Description

Fixes authorization checks for protected SSE topics by consistently normalizing the requested topic before performing the protected-topic comparison.

## Changes

- Trim whitespace from the requested SSE topic.
- Normalize the topic using lowercase casing with `Locale.ROOT`.
- Perform protected-topic authorization checks against the normalized topic.
- Prevent casing and formatting variations from bypassing authentication requirements.

## Security Impact

Prevents unauthorized clients from accessing protected SSE topics by exploiting differences in topic casing or formatting.

## Related Issue

Closes #18716