### PR TITLE
fix: add authorization guards to project endpoints

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -84,6 +84,9 @@ public class ProjectController {
     public ResponseEntity<ProjectResponse> createProject(
             @Valid @RequestBody ProjectCreateRequest request,
             Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         String userEmail = authentication.getName();
         return ResponseEntity.status(HttpStatus.CREATED).body(projectService.createProject(request, userEmail));
     }
@@ -185,6 +188,9 @@ public class ProjectController {
             @Parameter(description = "ID of the project to upvote")
             @PathVariable Long id,
             Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         return ResponseEntity.ok(projectService.upvoteProject(id, authentication.getName()));
     }
 
@@ -199,6 +205,9 @@ public class ProjectController {
             @Parameter(description = "ID of the project to fork")
             @PathVariable Long id,
             Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(projectService.forkProject(id, authentication.getName()));
     }


### PR DESCRIPTION
## Description

Adds explicit authentication checks to project endpoints that access the authenticated user's identity.

## Changes

- Validate authentication before accessing `authentication.getName()`.
- Return `401 Unauthorized` for unauthenticated requests.
- Protect project creation, upvote, and fork endpoints from missing authentication.
- Prevent unauthenticated requests from causing `NullPointerException`.

## Security Impact

Ensures project endpoints require an authenticated user before performing user-specific operations and prevents missing authentication from being handled as an internal server error.

## Related Issue

Closes #18717