### PR TITLE
fix: validate authentication in workspace SSE

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/TeamWorkspaceSyncController.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.service.TeamWorkspaceSyncService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,6 +35,11 @@ public class TeamWorkspaceSyncController {
             @RequestParam(required = false) String hackathonId,
             @RequestParam(required = false) String teamId,
             Authentication authentication) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AccessDeniedException("Authentication required for workspace SSE stream.");
+        }
+
         String resolved = teamWorkspaceSyncService.resolveRoomKeyForMember(
                 roomKey, hackathonId, teamId, authentication.getName());
         return teamWorkspaceSyncService.subscribe(resolved);
@@ -46,6 +52,11 @@ public class TeamWorkspaceSyncController {
             @RequestParam(required = false) String teamId,
             @RequestBody(required = false) Map<String, Object> body,
             Authentication authentication) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AccessDeniedException("Authentication required for workspace sync polling.");
+        }
+
         String resolved = teamWorkspaceSyncService.resolveRoomKeyForMember(
                 roomKey, hackathonId, teamId, authentication.getName());
         if (body == null || body.isEmpty()) {


### PR DESCRIPTION
## Description

Adds explicit authentication validation to the team workspace SSE endpoints.

## Changes

- Validate that the `Authentication` object is present.
- Reject unauthenticated requests before accessing `authentication.getName()`.
- Prevent `NullPointerException` when authentication is unavailable.
- Return an appropriate authorization failure for unauthenticated clients.

## Impact

Prevents unauthenticated requests from causing server-side exceptions in the team workspace SSE and synchronization endpoints.

## Related Issue

Closes #18720