### PR TITLE
[Security] Add authentication and file validation to attachment upload

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AttachmentUploadController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AttachmentUploadController.java
@@ -1,9 +1,14 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.eventra.service.SvgSanitizationService;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Controller decoupled from transaction blocks during multi-part file uploads (#16508).
@@ -12,28 +17,60 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/attachments")
 public class AttachmentUploadController {
 
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
+            ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".pdf"
+    );
+
+    private static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList(
+            "image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml", "application/pdf"
+    );
+
     private final AsyncUploadManager uploadManager;
     private final SvgSanitizationService svgSanitizationService;
+    private final long maxFileSize;
 
-    public AttachmentUploadController(AsyncUploadManager uploadManager, SvgSanitizationService svgSanitizationService) {
+    public AttachmentUploadController(AsyncUploadManager uploadManager, 
+            SvgSanitizationService svgSanitizationService,
+            @Value("${eventra.max-upload-size:10485760}") long maxFileSize) {
         this.uploadManager = uploadManager;
         this.svgSanitizationService = svgSanitizationService;
+        this.maxFileSize = maxFileSize;
     }
 
     /**
      * File upload endpoints must run OUTSIDE active @Transactional blocks to prevent connection leaks.
      */
     @PostMapping("/upload")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<String> uploadAttachment(@RequestParam("file") MultipartFile file) {
+        // Check if file is empty
         if (file.isEmpty()) {
             return ResponseEntity.badRequest().body("File is empty.");
         }
 
+        // Check file size
+        if (file.getSize() > maxFileSize) {
+            return ResponseEntity.badRequest().body(
+                    String.format("File size exceeds maximum limit of %d bytes.", maxFileSize));
+        }
+
+        // Validate file extension
+        String filename = file.getOriginalFilename();
+        if (filename == null || !hasAllowedExtension(filename)) {
+            return ResponseEntity.badRequest().body("File type not allowed. Allowed extensions: " + ALLOWED_EXTENSIONS);
+        }
+
+        // Validate content type
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            return ResponseEntity.badRequest().body("File content type not allowed.");
+        }
+
         try {
             byte[] content = file.getBytes();
-            String filename = file.getOriginalFilename();
-            if (filename != null && filename.toLowerCase().endsWith(".svg")) {
-                // Sanitize SVG uploads against stored XSS before they reach storage.
+            
+            // Sanitize SVG uploads against stored XSS before they reach storage
+            if (filename.toLowerCase().endsWith(".svg")) {
                 content = svgSanitizationService.sanitizeSvgContent(content);
             }
 
@@ -45,5 +82,17 @@ public class AttachmentUploadController {
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Upload failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * Validates that the file has an allowed extension.
+     * Checks both the original filename and the content type for consistency.
+     */
+    private boolean hasAllowedExtension(String filename) {
+        if (filename == null) {
+            return false;
+        }
+        String lowerFilename = filename.toLowerCase();
+        return ALLOWED_EXTENSIONS.stream().anyMatch(lowerFilename::endsWith);
     }
 }

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -60,6 +60,10 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
       timeout: ${REDIS_TIMEOUT:2s}
+  servlet:
+    multipart:
+      max-file-size: ${EVENTRA_MAX_UPLOAD_SIZE:10MB}
+      max-request-size: ${EVENTRA_MAX_UPLOAD_SIZE:10MB}
 
 management:
   endpoints:
@@ -74,6 +78,7 @@ server:
 eventra:
   api-docs:
     enabled: ${EVENTRA_API_DOCS_ENABLED:false}
+  max-upload-size: ${EVENTRA_MAX_UPLOAD_SIZE:10485760}
 
 springdoc:
   api-docs:

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AttachmentUploadControllerTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AttachmentUploadControllerTests.java
@@ -1,0 +1,290 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.eventra.service.SvgSanitizationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Security tests for AttachmentUploadController (#18729).
+ * 
+ * Verifies that:
+ * - The endpoint requires authentication
+ * - Empty files are rejected
+ * - File extensions are validated
+ * - Content types are validated
+ * - File size limits are enforced
+ * - SVG files are sanitized
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AttachmentUploadControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AsyncUploadManager uploadManager;
+
+    @MockBean
+    private SvgSanitizationService svgSanitizationService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+    }
+
+    // ==================== Authentication Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload without authentication returns 401 (#18729)")
+    void testUploadWithoutAuthentication() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "test image content".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ==================== Empty File Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with empty file returns 400 (#18729)")
+    @WithMockUser
+    void testUploadEmptyFile() throws Exception {
+        MockMultipartFile emptyFile = new MockMultipartFile(
+                "file",
+                "empty.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                new byte[0]
+        );
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(emptyFile))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("File is empty."));
+    }
+
+    // ==================== File Extension Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with disallowed extension returns 400 (#18729)")
+    @WithMockUser
+    void testUploadDisallowedExtension() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.exe",
+                MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                "test content".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("File type not allowed. Allowed extensions: [.jpg, .jpeg, .png, .gif, .webp, .svg, .pdf]"));
+    }
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with allowed extension (jpg) succeeds (#18729)")
+    @WithMockUser
+    void testUploadAllowedExtension() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "test image content".getBytes()
+        );
+
+        when(uploadManager.writeToStorage(anyString(), any())).thenReturn("/uploads/test.jpg");
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+    }
+
+    // ==================== Content Type Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with disallowed content type returns 400 (#18729)")
+    @WithMockUser
+    void testUploadDisallowedContentType() throws Exception {
+        // File has .jpg extension but wrong content type
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.jpg",
+                MediaType.TEXT_PLAIN_VALUE,
+                "test content".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("File content type not allowed."));
+    }
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with matching extension and content type succeeds (#18729)")
+    @WithMockUser
+    void testUploadMatchingExtensionAndContentType() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "test image content".getBytes()
+        );
+
+        when(uploadManager.writeToStorage(anyString(), any())).thenReturn("/uploads/test.png");
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+    }
+
+    // ==================== File Size Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with file exceeding size limit returns 400 (#18729)")
+    @WithMockUser
+    void testUploadFileExceedingSizeLimit() throws Exception {
+        // Create a file larger than the default max size (10MB)
+        byte[] largeContent = new byte[10 * 1024 * 1024 + 1]; // 10MB + 1 byte
+        Arrays.fill(largeContent, (byte) 'a');
+        
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "large.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                largeContent
+        );
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("File size exceeds maximum limit of 10485760 bytes."));
+    }
+
+    // ==================== SVG Sanitization Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with SVG file sanitizes content (#18729)")
+    @WithMockUser
+    void testUploadSvgFileSanitizesContent() throws Exception {
+        String svgContent = "<svg xmlns='http://www.w3.org/2000/svg'><script>alert('xss')</script></svg>";
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.svg",
+                MediaType.IMAGE_SVG_XML_VALUE,
+                svgContent.getBytes()
+        );
+
+        when(svgSanitizationService.sanitizeSvgContent(any())).thenReturn(
+                "<svg xmlns='http://www.w3.org/2000/svg'></svg>".getBytes()
+        );
+        when(uploadManager.writeToStorage(anyString(), any())).thenReturn("/uploads/test.svg");
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with invalid SVG content returns 400 (#18729)")
+    @WithMockUser
+    void testUploadInvalidSvgContent() throws Exception {
+        String invalidSvgContent = "not a valid svg";
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.svg",
+                MediaType.IMAGE_SVG_XML_VALUE,
+                invalidSvgContent.getBytes()
+        );
+
+        when(svgSanitizationService.sanitizeSvgContent(any())).thenThrow(
+                new IllegalArgumentException("Not a valid SVG document")
+        );
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Rejected SVG upload: Not a valid SVG document"));
+    }
+
+    // ==================== Allowed File Types Tests ====================
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with PDF file succeeds (#18729)")
+    @WithMockUser
+    void testUploadPdfFile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "%PDF-1.4 test content".getBytes()
+        );
+
+        when(uploadManager.writeToStorage(anyString(), any())).thenReturn("/uploads/test.pdf");
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with GIF file succeeds (#18729)")
+    @WithMockUser
+    void testUploadGifFile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.gif",
+                MediaType.IMAGE_GIF_VALUE,
+                "GIF89a test content".getBytes()
+        );
+
+        when(uploadManager.writeToStorage(anyString(), any())).thenReturn("/uploads/test.gif");
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("POST /api/attachments/upload with WebP file succeeds (#18729)")
+    @WithMockUser
+    void testUploadWebPFile() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.webp",
+                MediaType.IMAGE_WEBP_VALUE,
+                "RIFF test WEBP".getBytes()
+        );
+
+        when(uploadManager.writeToStorage(anyString(), any())).thenReturn("/uploads/test.webp");
+
+        mockMvc.perform(multipart("/api/attachments/upload")
+                        .file(file))
+                .andExpect(status().isOk());
+    }
+}

--- a/Backend/src/test/resources/application-test.properties
+++ b/Backend/src/test/resources/application-test.properties
@@ -25,3 +25,8 @@ app.rate-limit.enabled=false
 
 # Tests run without Redis; use the simple in-memory cache so @Cacheable/@CacheEvict work.
 spring.cache.type=simple
+
+# File upload test configuration
+eventra.max-upload-size=10485760
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
## Description

Fixes security issue #18729: Missing authentication and file validation on attachment upload endpoint.

## Changes

### Security Enhancements
- **Authentication**: Added `@PreAuthorize("isAuthenticated()")` to ensure only authenticated users can upload files
- **File Size Limit**: Added configurable maximum file size (default: 10MB) to prevent large file attacks
- **Extension Validation**: Validates file extensions against allowed list (jpg, jpeg, png, gif, webp, svg, pdf)
- **Content Type Validation**: Validates MIME type to prevent filename spoofing attacks
- **Existing Protections**: Maintained empty file check and SVG sanitization

### Configuration
- Added `eventra.max-upload-size` property (default: 10485760 bytes / 10MB)
- Added Spring multipart file size limits

### Testing
- Added comprehensive test suite (`AttachmentUploadControllerTests.java`)
- Tests cover all security validations:
  - Authentication requirement (401 for unauthenticated)
  - Empty file rejection
  - File extension validation
  - Content type validation
  - File size limit enforcement
  - SVG sanitization
  - All allowed file types

## Related Issue
Fixes #18729