### PR TITLE
fix: correctly resolve current user id

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/LostItemController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/LostItemController.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.dto.request.CreateLostItemRequest;
 import com.sandeep.eventrabackend.dto.request.UpdateLostItemRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.LostItemResponse;
+import com.sandeep.eventrabackend.security.CustomUserDetails;
 import com.sandeep.eventrabackend.service.LostItemService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -268,16 +269,10 @@ public class LostItemController {
         }
         
         Object principal = authentication.getPrincipal();
-        if (principal instanceof Map) {
-            Map<?, ?> principalMap = (Map<?, ?>) principal;
-            Object userIdObj = principalMap.get("userId");
-            if (userIdObj instanceof Number) {
-                return ((Number) userIdObj).longValue();
-            }
+        if (principal instanceof CustomUserDetails customUser) {
+            return customUser.getUser().getId();
         }
         
-        // If the principal is a string (username/email), we might need to look it up
-        // For now, return null if we can't extract the user ID
         return null;
     }
 }


### PR DESCRIPTION
## Description

Fixes current user ID resolution for authenticated principals in `LostItemController`.

## Changes

- Updated `getCurrentUserId()` to support `CustomUserDetails`.
- Resolve the authenticated user's database ID from `CustomUserDetails`.
- Prevent valid authenticated users from being treated as having a null user ID.
- Ensures lost-item ownership and attribution operations receive the correct user ID.

## Impact

Fixes incorrect user identification during lost-item creation, updating, and claiming operations.

## Related Issue

Closes #18722