### PR TITLE
fix: handle null phone validation request

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ValidationController.java
@@ -110,9 +110,12 @@ public class ValidationController {
 
     @PostMapping("/phone")
     @Operation(summary = "Validate phone number format")
-    public ResponseEntity<?> validatePhone(@RequestBody PhoneRequest request) {
+    public ResponseEntity<?> validatePhone(@RequestBody(required = false) PhoneRequest request) {
+        if (request == null || request.getPhone() == null) {
+            return ResponseEntity.ok(Map.of("valid", false, "message", "Phone number is required"));
+        }
         String phone = request.getPhone();
-        if (phone == null || !PHONE_PATTERN.matcher(phone).matches()) {
+        if (!PHONE_PATTERN.matcher(phone).matches()) {
             return ResponseEntity.ok(Map.of("valid", false, "message", "Phone number is invalid"));
         }
         return ResponseEntity.ok(Map.of("valid", true));


### PR DESCRIPTION
## Description

Handles missing request bodies in the phone validation endpoint to prevent a `NullPointerException`.

## Changes

- Check whether the `PhoneRequest` body is null before accessing `getPhone()`.
- Return a controlled validation response when the phone number is missing.
- Prevent HTTP 500 errors caused by empty request bodies.

## Impact

Malformed or empty requests now receive a proper validation response instead of causing an unhandled server-side exception.

## Related Issue

Closes #18726