### PR TITLE
fix: handle unset username during profile update

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -136,7 +136,7 @@ public class UserController {
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
 
         // Check if username is being changed and if new username already exists
-        if (!user.getUsername().equals(request.getUsername()) && 
+        if (!java.util.Objects.equals(user.getUsername(), request.getUsername()) && 
                 userRepository.existsByUsername(request.getUsername())) {
             throw new UserAlreadyExistsException("Username already exists: " + request.getUsername());
         }


### PR DESCRIPTION
## Description

Prevents a `NullPointerException` when users with an unset username update their profile.

## Changes

- Replaced the null-unsafe username comparison with `Objects.equals()`.
- Safely handles users whose existing username is `null`.
- Allows OAuth/SSO users to set an available username during profile setup.

## Impact

Users with a null username can now complete their profile update without encountering a server-side `NullPointerException`.

## Related Issue

Closes #18727