### PR TITLE
fix: secure GitHub API proxy endpoint

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/GitHubProxyController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/GitHubProxyController.java
@@ -3,7 +3,10 @@ package com.sandeep.eventrabackend.controller;
 import com.sandeep.eventrabackend.service.GitHubProxyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,10 +26,15 @@ public class GitHubProxyController {
     }
 
     @GetMapping
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Proxy an allowlisted GitHub API path")
     public ResponseEntity<String> proxy(
             @RequestParam("path") String path,
-            @RequestParam Map<String, String> allParams) {
+            @RequestParam Map<String, String> allParams,
+            Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         return gitHubProxyService.proxy(path, allParams);
     }
 }


### PR DESCRIPTION
## Description

Fixes #18728

Secures the GitHub API proxy endpoint by requiring an authenticated user before forwarding requests.

### Changes

- Added `@PreAuthorize("isAuthenticated()")` to the GitHub proxy endpoint.
- Added an explicit authentication check before accessing the proxy service.
- Unauthenticated requests now receive `401 Unauthorized` instead of being forwarded to the GitHub API.

### Security Impact

This prevents unauthenticated clients from abusing the backend as a GitHub API proxy and consuming backend/GitHub API resources without an authenticated Eventra account.

### Testing

- Verified the controller contains method-level authentication enforcement.
- Verified unauthenticated requests are rejected with `401 Unauthorized`.
- Existing authenticated proxy behavior remains unchanged.