### PR TITLE
fix: useEmailTemplates resolves USER.ME to undefined endpoint

### DIFF
--- a/src/hooks/useEmailTemplates.js
+++ b/src/hooks/useEmailTemplates.js
@@ -213,7 +213,7 @@ export const useEmailTemplates = (eventId, organizerEmail = null) => {
   const getCurrentUserEmail = useCallback(async () => {
     try {
       // This would be replaced with actual auth context in a real implementation
-      const userResponse = await apiUtils.get(API_ENDPOINTS.USER.ME);
+      const userResponse = await apiUtils.get(API_ENDPOINTS.USERS.PROFILE);
       return userResponse.data?.email;
     } catch (err) {
       console.warn('Could not fetch current user email:', err);


### PR DESCRIPTION
Closes #18818

## Problem
`src/hooks/useEmailTemplates.js:216` calls `API_ENDPOINTS.USER.ME`, but `src/config/api.js` only defines `USERS` (no `USER` key). `API_ENDPOINTS.USER` is `undefined`, so the `.ME` access throws a TypeError that is swallowed by the try/catch. `getCurrentUserEmail()` always returns `null` and `sendTestEmail` reports "Unable to determine your email address" whenever `organizerEmail` is not passed as a prop.

## Fix
Use the existing endpoint key `API_ENDPOINTS.USERS.PROFILE`.
