### PR TITLE
fix: SponsorDashboard reads settings from hook instead of stale localStorage key

### DIFF
--- a/src/Pages/Sponsors/SponsorDashboard.jsx
+++ b/src/Pages/Sponsors/SponsorDashboard.jsx
@@ -47,16 +47,13 @@ const SponsorDashboard = () => {
   }, []);
 
   useEffect(() => {
-  // Load custom settings
-  const saved = localStorage.getItem("eventra_sponsor_settings");
-
-  if (saved) {
-    try {
-      setSettings(safeJsonParse(saved, {}));
-    } catch (e) {
-      console.error("Failed to parse sponsor settings", e);
-    }
-  }
+  // Load settings from the hook (namespace "sponsor") instead of the stale
+  // raw localStorage key eventra_sponsor_settings that nothing writes anymore.
+  setSettings(
+    sponsorPrefs && Object.keys(sponsorPrefs).length > 0
+      ? sponsorPrefs
+      : DEFAULT_SETTINGS
+  );
 
   // Load captured leads
   const savedLeads = localStorage.getItem("eventra_sponsor_leads");


### PR DESCRIPTION
Closes #18820

## Problem
`SponsorDashboard.jsx` reads `localStorage.getItem("eventra_sponsor_settings")` on mount, but the page persists settings through `useUserPreferences({ namespace: "sponsor" })` (`setSponsorPrefs` writes to the hook's namespace key). Nothing writes the raw `eventra_sponsor_settings` key anymore — the only other read is `VirtualVenueWalkthrough.jsx:154`. Saved booth settings are silently lost on reload and the "Changes will reflect in the Virtual Venue" toast is misleading.

## Fix
Load the settings state from the hook value (`sponsorPrefs`), falling back to `DEFAULT_SETTINGS` when nothing is saved, and drop the stale raw `localStorage` read.
