### PR TITLE
fix: Leaderboard recent searches persist via functional updater

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -79,13 +79,14 @@ const useLocalStorage = (key, initialValue) => {
   });
 
   const setValue = useCallback((value) => {
+    const next = typeof value === "function" ? value(storedValue) : value;
     try {
-      storageManager.set(key, value);
-      setStoredValue(value);
+      storageManager.set(key, next);
+      setStoredValue(next);
     } catch (error) {
       logger.error(`Error saving to localStorage (${key}):`, error);
     }
-  }, [key]);
+  }, [key, storedValue]);
 
   return [storedValue, setValue];
 };


### PR DESCRIPTION
Closes #18821

## Problem
`Leaderboard.jsx:314` passes a functional updater to `setRecentSearches`, but that setter comes from the file-local `useLocalStorage` hook whose setter is value-only — it calls `storageManager.set(key, value)` and `JSON.stringify`s whatever it receives. A function stringifies to `undefined`, so the recent-searches history is never persisted, and `prev` would be `undefined` if the updater were ever invoked.

## Fix
Make the `useLocalStorage` setter support functional updaters (resolve the updater against the current stored value before persisting). This is backward compatible with plain-value callers and makes the existing call site work.
