### PR TITLE
fix: remove invalid hover:translateZ from inline transform

### DIFF
--- a/src/Pages/Events/VirtualVenueWalkthrough.jsx
+++ b/src/Pages/Events/VirtualVenueWalkthrough.jsx
@@ -278,7 +278,7 @@ const VirtualVenueWalkthrough = () => {
                       // Animate height offset on hover or selection
                       transform: isSelected
                         ? `translateZ(${room.coordinates.z}) scale(1.03)`
-                        : `translateZ(8px) hover:translateZ(20px)`,
+                        : "translateZ(8px)",
                       borderColor: isSelected ? "#818cf8" : "rgba(255,255,255,0.05)",
                       boxShadow: isSelected
                         ? `0 20px 40px -10px ${room.glowColor}, inset 0 0 16px rgba(255,255,255,0.1)`


### PR DESCRIPTION
Closes #18822

## Problem
`VirtualVenueWalkthrough.jsx:281` sets an invalid CSS `transform` value: `'translateZ(8px) hover:translateZ(20px)'`. `hover:translateZ(20px)` is not a CSS transform function (that is a Tailwind class concept). The browser rejects the whole declaration, so even the base `translateZ(8px)` is dropped and the 3D rooms get no Z-depth.

## Fix
Remove the invalid `hover:translateZ(20px)` part, keeping the valid base transform `translateZ(8px)`.
