### PR TITLE
fix(user): EventTicket renders real agenda or honest placeholder

### DIFF
--- a/src/components/user/EventTicket.js
+++ b/src/components/user/EventTicket.js
@@ -382,18 +382,22 @@ const EventTicket = ({ event, user, onClose }) => {
                       EVENT AGENDA
                     </span>
                     <ul className="ud-ticket-agenda-list mt-1 space-y-2 text-xs text-zinc-300">
-                      <li className="flex justify-between items-center border-b border-white/5 pb-1">
-                        <span>1. Welcome & Keynote</span>
-                        <span className="text-zinc-400 font-semibold">10:00 AM</span>
-                      </li>
-                      <li className="flex justify-between items-center border-b border-white/5 pb-1">
-                        <span>2. Technical Deep-Dive</span>
-                        <span className="text-zinc-400 font-semibold">11:30 AM</span>
-                      </li>
-                      <li className="flex justify-between items-center border-b border-white/5 pb-1">
-                        <span>3. Interactive Q&A</span>
-                        <span className="text-zinc-400 font-semibold">02:00 PM</span>
-                      </li>
+                      {Array.isArray(event?.agenda) && event.agenda.length > 0
+                        ? event.agenda.map((item, idx) => (
+                            <li
+                              key={idx}
+                              className="flex justify-between items-center border-b border-white/5 pb-1"
+                            >
+                              <span>{idx + 1}. {item.title || item.label || item.name || 'Session'}</span>
+                              <span className="text-zinc-400 font-semibold">{item.time || item.startTime || 'TBA'}</span>
+                            </li>
+                          ))
+                        : (
+                          <li className="flex justify-between items-center border-b border-white/5 pb-1">
+                            <span>Full agenda shared at check-in</span>
+                            <span className="text-zinc-400 font-semibold">See organizer</span>
+                          </li>
+                        )}
                     </ul>
                   </div>
 


### PR DESCRIPTION
## Summary
Fixes #18826

`src/components/user/EventTicket.js:384-397` prints the same hardcoded three-item agenda ("1. Welcome & Keynote 10:00 AM", "2. Technical Deep-Dive 11:30 AM", "3. Interactive Q&A 02:00 PM") on the back of **every** ticket, regardless of the actual event schedule.

## Actual behavior
Users see a fabricated schedule that never matches the real event program.

## Fix
Render the event's real agenda when `event.agenda` is provided, otherwise show an honest placeholder ("Full agenda shared at check-in"):

```diff
  <ul className="ud-ticket-agenda-list ...">
-   <li ...><span>1. Welcome & Keynote</span><span>10:00 AM</span></li>
-   <li ...><span>2. Technical Deep-Dive</span><span>11:30 AM</span></li>
-   <li ...><span>3. Interactive Q&A</span><span>02:00 PM</span></li>
+   {Array.isArray(event?.agenda) && event.agenda.length > 0
+     ? event.agenda.map((item, idx) => (
+         <li key={idx} ...>
+           <span>{idx + 1}. {item.title || item.label || item.name || 'Session'}</span>
+           <span>{item.time || item.startTime || 'TBA'}</span>
+         </li>
+       ))
+     : (
+       <li ...><span>Full agenda shared at check-in</span><span>See organizer</span></li>
+     )}
  </ul>
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._