### PR TITLE
fix(events): remove invalid hover:translateZ from VirtualVenueWalkthrough transform

### DIFF
--- a/src/Pages/Events/VirtualVenueWalkthrough.jsx
+++ b/src/Pages/Events/VirtualVenueWalkthrough.jsx
@@ -274,10 +274,13 @@ const VirtualVenueWalkthrough = () => {
                       width: room.coordinates.width,
                       height: room.coordinates.height,
                       transformStyle: "preserve-3d",
-                      // Animate height offset on hover or selection
+                      // Animate height offset on selection. (A `hover:translateZ`
+                      // value is a Tailwind class, not a valid CSS transform
+                      // function, so the browser dropped the whole declaration
+                      // and the base translateZ(8px) never applied either.)
                       transform: isSelected
                         ? `translateZ(${room.coordinates.z}) scale(1.03)`
-                        : `translateZ(8px) hover:translateZ(20px)`,
+                        : "translateZ(8px)",
                       borderColor: isSelected ? "#818cf8" : "rgba(255,255,255,0.05)",
                       boxShadow: isSelected
                         ? `0 20px 40px -10px ${room.glowColor}, inset 0 0 16px rgba(255,255,255,0.1)`


### PR DESCRIPTION
## Summary
Fixes #18822

`src/Pages/Events/VirtualVenueWalkthrough.jsx:281` set an invalid CSS transform value:

```js
transform: isSelected
  ? `translateZ(${room.coordinates.z}) scale(1.03)`
  : 'translateZ(8px) hover:translateZ(20px)',
```

`hover:translateZ(20px)` is not valid CSS inside a `transform` declaration (that is a Tailwind class concept, not a CSS transform function). The browser drops the whole declaration, so the base `translateZ(8px)` never applies either and the rooms have no Z-depth in the 3D walkthrough.

## Fix
Drop the invalid hover part and keep the base `translateZ(8px)`:

```diff
  transform: isSelected
    ? `translateZ(${room.coordinates.z}) scale(1.03)`
-   : 'translateZ(8px) hover:translateZ(20px)',
+   : 'translateZ(8px)',
```

(Note: the hover lift cannot be expressed with a Tailwind `hover:` class here because the inline `style.transform` would override it; the selection-based transform already provides the depth cue.)

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._