### PR TITLE
fix(leaderboard): pass plain value to value-only useLocalStorage setter

### DIFF
--- a/src/Pages/Leaderboard/Leaderboard.jsx
+++ b/src/Pages/Leaderboard/Leaderboard.jsx
@@ -110,7 +110,7 @@ export default function LeaderBoard() {
     return ts ? t("leaderboard.statusCached", { time: formatLastUpdated(ts, t) }) : "";
   });
   const [search, setSearch] = useState("");
-  const [, setRecentSearches] = useLocalStorage(
+  const [recentSearches, setRecentSearches] = useLocalStorage(
     STORAGE_KEYS.RECENT_SEARCHES,
     { queries: [], lastUpdated: Date.now() }
   );
@@ -311,12 +311,16 @@ export default function LeaderBoard() {
     setCurrentPage(1);
 
     if (query.trim().length >= 2) {
-      setRecentSearches((prev) => {
-        const queries = [query, ...prev.queries.filter((q) => q !== query)].slice(0, 5);
-        return { queries, lastUpdated: Date.now() };
-      });
+      // useLocalStorage's setter is value-only (it stringifies a function to
+      // undefined), so compute the next value from the current stored value
+      // and pass a plain object instead of a functional updater (issue #18821).
+      const prevQueries = Array.isArray(recentSearches?.queries)
+        ? recentSearches.queries
+        : [];
+      const queries = [query, ...prevQueries.filter((q) => q !== query)].slice(0, 5);
+      setRecentSearches({ queries, lastUpdated: Date.now() });
     }
-  }, [setRecentSearches]);
+  }, [setRecentSearches, recentSearches]);
 
   const handleRefresh = useCallback(async () => {
     if (isRefreshing) return;


### PR DESCRIPTION
## Summary
Fixes #18821

`src/Pages/Leaderboard/Leaderboard.jsx:314-317` passed a functional updater to `setRecentSearches`:

```js
setRecentSearches((prev) => {
  const queries = [query, ...prev.queries.filter((q) => q !== query)].slice(0, 5);
  return { queries, lastUpdated: Date.now() };
});
```

But `setRecentSearches` comes from the custom `useLocalStorage` hook (lines 71-91) whose setter is **value-only** — it calls `storageManager.set(key, value)` and `JSON.stringify`s the value. A function stringifies to `undefined`, so the recent-searches history is never persisted (and `prev` is `undefined` on the first call, so the updater body would throw if it ever ran).

## Fix
Compute the next value from the current stored value (`recentSearches`) and pass a plain object to the setter:

```diff
- const [, setRecentSearches] = useLocalStorage(STORAGE_KEYS.RECENT_SEARCHES, { queries: [], lastUpdated: Date.now() });
+ const [recentSearches, setRecentSearches] = useLocalStorage(STORAGE_KEYS.RECENT_SEARCHES, { queries: [], lastUpdated: Date.now() });
  ...
- setRecentSearches((prev) => {
-   const queries = [query, ...prev.queries.filter((q) => q !== query)].slice(0, 5);
-   return { queries, lastUpdated: Date.now() };
- });
+ const prevQueries = Array.isArray(recentSearches?.queries) ? recentSearches.queries : [];
+ const queries = [query, ...prevQueries.filter((q) => q !== query)].slice(0, 5);
+ setRecentSearches({ queries, lastUpdated: Date.now() });
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._