### PR TITLE
fix(validation): reject data:image/svg project images to prevent stored XSS

### DIFF
--- a/src/utils/submitProjectValidation.js
+++ b/src/utils/submitProjectValidation.js
@@ -18,7 +18,23 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const GITHUB_REGEX = /^(https?:\/\/)?(www\.)?github\.com\/[\w.-]+\/[\w.-]+(\/.*)?$/i;
 const URL_REGEX = /^(https?:\/\/)?([\w-]+(\.[\w-]+)+)(\/[\w-./?%&=]*)?$/i;
 
-const isValidProjectImage = (value) => value.startsWith("data:image/") || URL_REGEX.test(value);
+const SAFE_IMAGE_DATA_PREFIXES = [
+  "data:image/png;",
+  "data:image/jpeg;",
+  "data:image/jpg;",
+  "data:image/webp;",
+  "data:image/gif;",
+];
+
+// Reject data:image/svg+xml (and any other non-raster data URI) because an
+// SVG can carry <script>/event handlers and execute in the viewer's session
+// (stored XSS) when rendered as a project image.
+const isValidProjectImage = (value) => {
+  if (typeof value !== "string") return false;
+  if (SAFE_IMAGE_DATA_PREFIXES.some((p) => value.startsWith(p))) return true;
+  if (value.startsWith("data:image/")) return false;
+  return URL_REGEX.test(value);
+};
 
 const isOutOfBounds = (value, min, max) => {
   const length = value.trim().length;


### PR DESCRIPTION
## Summary
Fixes #18811

`src/utils/submitProjectValidation.js` line 21 accepted any `data:image/*` URI, including `data:image/svg+xml`, which can carry executable script. When the project image is later rendered (e.g. as an `<img src>` or inline), the SVG can execute JavaScript in the viewer's session (stored XSS).

## Actual behavior
`value.startsWith("data:image/")` matches `data:image/svg+xml;base64,...`. SVG documents can contain `<script>` and event handlers; if `projectImage` is rendered without an SVG sanitizer, an attacker submitting a project can achieve stored XSS on every page that displays the project logo. (Note `SvgSanitizationService` exists on the backend but the client validation still permitted the unsafe payload to be stored.)

## Fix
Restrict accepted image types to safe raster formats and reject SVG:

```diff
- const isValidProjectImage = (value) => value.startsWith("data:image/") || URL_REGEX.test(value);
+ const SAFE_IMAGE_DATA_PREFIXES = ["data:image/png;","data:image/jpeg;","data:image/jpg;","data:image/webp;","data:image/gif;"];
+ const isValidProjectImage = (value) => {
+   if (typeof value !== "string") return false;
+   if (SAFE_IMAGE_DATA_PREFIXES.some((p) => value.startsWith(p))) return true;
+   if (value.startsWith("data:image/")) return false; // reject svg/xml data URIs
+   return URL_REGEX.test(value);
+ };
```

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._