### PR TITLE
fix: ContactService email validation now runs outside the name check

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java
@@ -22,7 +22,9 @@ public class ContactService {
     public ContactResponse submitContactMessage(ContactRequest request) {
         if (request.getName() == null || request.getName().trim().length() < 2 || request.getName().trim().length() > 100) {
             throw new IllegalArgumentException("Name must be between 2 and 100 characters.");
-        if (request.getEmail() == null || !request.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) { throw new IllegalArgumentException("Invalid email format."); }
+        }
+        if (request.getEmail() == null || !request.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+            throw new IllegalArgumentException("Invalid email format.");
         }
         ContactMessage contactMessage = new ContactMessage();
         contactMessage.setName(request.getName().trim());


### PR DESCRIPTION
Closes #18900

## Problem
In `ContactService.submitContactMessage`, the email-format check is nested **inside** the name-validation `if` block. When the name is valid (the common case) the email regex never runs, so invalid emails are accepted; when the name is invalid the code throws before the email check is reached. The email validation is effectively dead.

## Fix
Close the name-validation block before the email check so the email format is always validated.
