### PR TITLE
fix: dashboard shows error instead of fake success when profile update fails

### DIFF
--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -51,6 +51,7 @@ export default function DashboardPage() {
   const [editLastName, setEditLastName] = useState("");
   const [editUsername, setEditUsername] = useState("");
   const [saveSuccess, setSaveSuccess] = useState(false);
+const [profileError, setProfileError] = useState("");
 
   useEffect(() => {
     async function loadDashboardData() {
@@ -140,21 +141,14 @@ export default function DashboardPage() {
         localStorage.setItem("eventra_user", JSON.stringify(newProf));
       }
       setSaveSuccess(true);
+      setProfileError("");
       setTimeout(() => {
         setSaveSuccess(false);
         setIsEditingProfile(false);
       }, 1000);
     } catch (err) {
-      const newProf = { ...profile, firstName: editFirstName, lastName: editLastName, username: editUsername };
-      setProfile(newProf);
-      if (typeof window !== "undefined") {
-        localStorage.setItem("eventra_user", JSON.stringify(newProf));
-      }
-      setSaveSuccess(true);
-      setTimeout(() => {
-        setSaveSuccess(false);
-        setIsEditingProfile(false);
-      }, 1000);
+      console.warn("Error updating profile", err);
+      setProfileError("Failed to update profile. Please try again.");
     }
   };
 
@@ -266,7 +260,7 @@ export default function DashboardPage() {
             {/* Profile Action Buttons */}
             <div className="flex items-center gap-3 w-full md:w-auto justify-end">
               <button
-                onClick={() => setIsEditingProfile(true)}
+                onClick={() => { setIsEditingProfile(true); setProfileError(""); }}
                 className="inline-flex items-center gap-2 px-4 py-2.5 bg-zinc-100 hover:bg-zinc-200 text-zinc-800 text-xs font-bold rounded-xl transition-all cursor-pointer"
               >
                 <Edit3 className="w-4 h-4 text-zinc-600" />
@@ -533,6 +527,12 @@ export default function DashboardPage() {
               <div className="p-3 bg-emerald-50 border border-emerald-200 text-emerald-900 text-xs font-bold rounded-xl flex items-center gap-2">
                 <CheckCircle2 className="w-4 h-4 text-[#00b887]" />
                 <span>Profile updated successfully!</span>
+              </div>
+            )}
+
+            {profileError && (
+              <div className="p-3 bg-rose-50 border border-rose-200 text-rose-800 text-xs font-bold rounded-xl flex items-center gap-2">
+                <span>{profileError}</span>
               </div>
             )}
 


### PR DESCRIPTION
Closes #18918

## Problem
In `src/app/dashboard/page.jsx`, `handleUpdateProfile`'s `catch` block duplicated the entire success path: on a failed API call it still updated `profile`, wrote it to `localStorage`, and called `setSaveSuccess(true)` — so the modal showed **"Profile updated successfully!"** and closed even though nothing was saved on the server.

## Fix
- Catch block now logs the error and sets a `profileError` message instead of faking success.
- Added an error banner in the edit modal.
- Success path clears any stale error; reopening the editor clears it too.
