### PR TITLE
fix: WhatsHappeningNow mouse-leave no longer overrides explicit pause

### DIFF
--- a/src/components/home/WhatsHappeningNow.jsx
+++ b/src/components/home/WhatsHappeningNow.jsx
@@ -27,6 +27,7 @@ export default function WhatsHappeningNow() {
   const [loading, setLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isAutoplay, setIsAutoplay] = useState(true);
+  const userPausedRef = useRef(false);
 
   const [events, setEvents] = useState([]);
   const [hackathons, setHackathons] = useState([]);
@@ -183,7 +184,11 @@ export default function WhatsHappeningNow() {
             </button>
 
             <button
-              onClick={() => setIsAutoplay(!isAutoplay)}
+              onClick={() => {
+                const next = !isAutoplay;
+                userPausedRef.current = !next;
+                setIsAutoplay(next);
+              }}
               className="p-2 bg-white border border-zinc-200 hover:bg-zinc-50 rounded-xl text-zinc-600 transition-colors shadow-2xs cursor-pointer"
               title={isAutoplay ? "Pause Autoplay" : "Resume Autoplay"}
             >
@@ -289,7 +294,7 @@ export default function WhatsHappeningNow() {
               className="flex items-stretch gap-6 overflow-x-auto scrollbar-none scroll-smooth pb-4 pt-1 snap-x snap-mandatory"
               style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
               onMouseEnter={() => setIsAutoplay(false)}
-              onMouseLeave={() => setIsAutoplay(true)}
+              onMouseLeave={() => setIsAutoplay(!userPausedRef.current)}
             >
               {carouselItems.map((item) => (
                 <div


### PR DESCRIPTION
Closes #18928

## Problem
In `src/components/home/WhatsHappeningNow.jsx`, the carousel's Pause button sets `isAutoplay = false`, but `onMouseLeave={() => setIsAutoplay(true)}` on the carousel container silently re-enabled autoplay whenever the mouse left the area — overriding the user's explicit pause.

## Fix
Track the user's explicit pause choice in a ref (`userPausedRef`). The Pause/Resume button records it, and `onMouseLeave` only resumes autoplay if the user had not explicitly paused. Hover-pause behavior is unchanged.
