### PR TITLE
fix: CardSkeleton uses valid zinc shade instead of non-existent zinc-150

### DIFF
--- a/src/components/ui/Skeleton.jsx
+++ b/src/components/ui/Skeleton.jsx
@@ -5,15 +5,15 @@ export function CardSkeleton() {
     <div className="bg-white border border-zinc-200 rounded-2xl p-6 shadow-2xs space-y-4 animate-pulse">
       <div className="flex items-center justify-between">
         <div className="w-20 h-5 bg-zinc-200 rounded-full" />
-        <div className="w-24 h-4 bg-zinc-150 rounded" />
+        <div className="w-24 h-4 bg-zinc-100 rounded" />
       </div>
       <div className="w-3/4 h-6 bg-zinc-200 rounded" />
       <div className="space-y-2">
-        <div className="w-full h-4 bg-zinc-150 rounded" />
-        <div className="w-5/6 h-4 bg-zinc-150 rounded" />
+        <div className="w-full h-4 bg-zinc-100 rounded" />
+        <div className="w-5/6 h-4 bg-zinc-100 rounded" />
       </div>
       <div className="pt-4 border-t border-zinc-100 flex justify-between items-center">
-        <div className="w-24 h-4 bg-zinc-150 rounded" />
+        <div className="w-24 h-4 bg-zinc-100 rounded" />
         <div className="w-20 h-4 bg-zinc-200 rounded" />
       </div>
     </div>


### PR DESCRIPTION
Closes #18930

## Problem
`src/components/ui/Skeleton.jsx` used `bg-zinc-150` on several skeleton bars (lines 8, 12, 13, 16). The Tailwind zinc scale has no `150` shade, so the class generates no CSS and those bars render with no background — invisible skeleton placeholders. Sibling bars in the same file correctly use `bg-zinc-200`.

## Fix
Replace the invalid `bg-zinc-150` with `bg-zinc-100`.
