### PR TITLE
fix: handle null contact request

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ContactController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ContactController.java
@@ -40,7 +40,11 @@ public class ContactController {
             @ApiResponse(responseCode = "429", description = "Too many requests",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ContactResponse> submitContactMessage(@Valid @RequestBody ContactRequest request) {
+    public ResponseEntity<ContactResponse> submitContactMessage(
+            @Valid @RequestBody(required = false) ContactRequest request) {
+        if (request == null) {
+            return ResponseEntity.badRequest().build();
+        }
         ContactResponse response = contactService.submitContactMessage(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }


### PR DESCRIPTION
## Summary

Fixes #18929

### Changes

- Allow the contact request body to be absent at the controller boundary.
- Explicitly reject a null request with `400 Bad Request`.
- Prevent null requests from reaching the service layer and causing an exception.

### Testing

- Verified requests with a missing body return `400 Bad Request`.
- Verified valid contact requests continue through the existing service flow.