### PR TITLE
fix: validate custom email template

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
@@ -43,6 +43,12 @@ public class EmailTemplateService {
         if (request == null || request.getTemplateType() == null) {
             throw new IllegalArgumentException("Invalid template type");
         }
+        if (organizerEmail == null || organizerEmail.isBlank()) {
+            throw new IllegalArgumentException("Organizer email is required");
+        }
+        if (request.getCustomTemplate() == null || request.getCustomTemplate().isBlank()) {
+            throw new IllegalArgumentException("Custom template is required");
+        }
         String type = request.getTemplateType();
         if (!type.equals("waitlist_promotion") && !type.equals("cancellation")) {
             throw new IllegalArgumentException("Invalid template type");


### PR DESCRIPTION
## Summary

Fixes #18919

### Changes

- Validate that the custom template is present before rendering.
- Reject null or blank custom templates with a controlled validation error.
- Prevent `NullPointerException` during test email generation.

### Testing

- Verified null `customTemplate` is rejected.
- Verified blank `customTemplate` is rejected.
- Verified supported template types continue through the existing rendering flow.