### PR TITLE
[PasswordResetToken] @Data exposes tokenHash via generated toString()/equals() — log/debug leakage of reset tokens

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/PasswordResetToken.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/PasswordResetToken.java
@@ -3,13 +3,17 @@ package com.sandeep.eventrabackend.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@Setter
+@ToString(exclude = "tokenHash")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
## Problem

`PasswordResetToken.java` is annotated with Lombok `@Data`, which auto-generates `toString()`, `equals()`, and `hashCode()` that include every field — including the sensitive `tokenHash`. Because frameworks and loggers (Spring/Hibernate/SLF4J) often call `toString()` on entities, the reset-token hash can leak into logs. `equals()`/`hashCode()` over a secret also invites leak and timing issues. This is the same class of bug as exposing password hashes.

## Fix

Replaced `@Data` with explicit Lombok annotations that preserve the class behavior without exposing the secret:

- `@Getter` / `@Setter` for the fields (same accessors `@Data` would have generated).
- `@ToString(exclude = "tokenHash")` so `toString()` omits the token hash.
- Dropped `@EqualsAndHashCode` (previously generated by `@Data`), so no `equals()`/`hashCode()` over the token hash is generated at all.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/model/PasswordResetToken.java

## Testing

Verified via careful code review and syntax consistency (no Maven build available in this environment). The existing `AuthPasswordResetTests` suite still uses only the unaffected accessors (`getTokenHash`, `builder().tokenHash(...)`, `isUsed()`, etc.), which remain available. The issue did not request a regression test, so none was added.

Closes #17075
