### PR TITLE
fix: restrict analytics CORS origins

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AnalyticsController.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/analytics")
-@CrossOrigin(origins = "*")
 public class AnalyticsController {
 
     private final AnalyticsService analyticsService;


### PR DESCRIPTION
## Summary

Fixes #18931

### Changes

- Removed the wildcard `@CrossOrigin(origins = "*")` configuration from `AnalyticsController`.
- Analytics endpoints now rely on the application's centralized CORS configuration.
- Prevents arbitrary browser origins from being explicitly allowed at the controller level.

### Verification

- Confirmed `SecurityConfig` already configures allowed CORS origins through `app.cors.allowed-origins`.
- Confirmed `application.yml` provides configured allowed origins.
- Removed the controller-level wildcard CORS configuration.