### PR TITLE
[AdminService] deleteEvent deletes registrations but never deletes Payment/PaymentPlan/EmailTemplate — orphaned rows / FK failure

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EmailTemplateRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EmailTemplateRepository.java
@@ -34,6 +34,8 @@ public interface EmailTemplateRepository extends JpaRepository<EmailTemplate, Lo
      */
     List<EmailTemplate> findByTemplateType(String templateType);
 
+    void deleteByEventId(String eventId);
+
     /**
      * Delete templates by event ID and organizer email
      */

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/PaymentRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/PaymentRepository.java
@@ -42,5 +42,7 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     void deleteByRegistration_Id(Long registrationId);
 
+    void deleteByRegistration_Event_Id(Long eventId);
+
     void deleteByRegistration_User_Id(Long userId);
 }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -51,6 +51,9 @@ public class AdminService {
     private final HackathonRegistrationRepository hackathonRegistrationRepository;
     private final ProjectUpvoteRepository projectUpvoteRepository;
     private final NotificationRepository notificationRepository;
+    private final PaymentRepository paymentRepository;
+    private final PaymentPlanRepository paymentPlanRepository;
+    private final EmailTemplateRepository emailTemplateRepository;
     private final EventService eventService;
 
     // ══════════════════════════════════════════════════════════════════════
@@ -278,6 +281,9 @@ public class AdminService {
         if (!eventRepository.existsById(id)) {
             throw new EntityNotFoundException("Event not found with id: " + id);
         }
+        paymentRepository.deleteByRegistration_Event_Id(id);
+        paymentPlanRepository.deleteByRegistration_Event_Id(id);
+        emailTemplateRepository.deleteByEventId(String.valueOf(id));
         eventRegistrationRepository.deleteByEventId(id);
         eventWaitlistRepository.deleteByEvent_Id(id);
         eventTeamMemberRepository.deleteByEvent_Id(id);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/AdminServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/AdminServiceTest.java
@@ -33,7 +33,7 @@ class AdminServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AdminService(userRepository, null, null, null, null, null, null, null, null, null, null, null, null, null);
+        service = new AdminService(userRepository, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @AfterEach


### PR DESCRIPTION
## Problem

`AdminService.deleteEvent(...)` removes EventRegistration, WaitlistEntry, team members, feedback, and role audit logs, but never removes the associated Payment and PaymentPlan rows nor the event's EmailTemplate records. Because Payment/PaymentPlan reference EventRegistration (and EmailTemplate references the event), deleting registrations either fails with a foreign-key constraint error (breaking event deletion entirely) or, if FKs are lax, leaves orphaned payment/payment-plan/email-template rows in the database referencing a deleted event.

## Fix

Before deleting the event's registrations, `deleteEvent` now explicitly deletes dependent financial/relational records:

- Added `PaymentRepository.deleteByRegistration_Event_Id(Long eventId)` (the method referenced by the issue did not exist yet) and call it for the event.
- Called the existing `PaymentPlanRepository.deleteByRegistration_Event_Id(Long eventId)` for the event.
- Added `EmailTemplateRepository.deleteByEventId(String eventId)` and call it with the event id, removing the event's email templates.

The three new deletes are executed before `eventRegistrationRepository.deleteByEventId(...)` and before the event row itself is removed, so no FK constraint is violated and no orphaned payment, payment-plan, or email-template rows remain. `AdminServiceTest`'s constructor call was updated to match the new injected repositories.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
- Backend/src/main/java/com/sandeep/eventrabackend/repository/PaymentRepository.java
- Backend/src/main/java/com/sandeep/eventrabackend/repository/EmailTemplateRepository.java
- Backend/src/test/java/com/sandeep/eventrabackend/service/AdminServiceTest.java

## Testing

Maven is not available on PATH here, and the pre-existing build already fails with unrelated Lombok/annotation-processing errors in this environment (verified identical on a clean tree). The change was verified via careful code review and syntax consistency: the new derived delete queries (`deleteByRegistration_Event_Id`, `deleteByEventId`) follow the exact naming pattern of existing repository methods, and the test constructor was updated to match the new 17-argument constructor.

Closes #17087
