### PR TITLE
[EventService] cancelEvent has only in-memory idempotency guard, no optimistic lock — concurrent cancels double-refund

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -44,6 +44,21 @@ public interface EventRepository extends JpaRepository<Event, Long>, JpaSpecific
             + "WHERE e.id = :id AND (e.capacity IS NULL OR e.capacity > e.registeredCount)")
     int incrementRegisteredCountAtomically(@Param("id") Long id);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Event e SET "
+            + "e.status = 'CANCELLED', "
+            + "e.cancellationReason = :reason, "
+            + "e.cancelledAt = :cancelledAt, "
+            + "e.refundPolicy = :refundPolicy, "
+            + "e.refundPercent = :refundPercent "
+            + "WHERE e.id = :id AND e.status <> 'CANCELLED'")
+    int markCancelled(
+            @Param("id") Long id,
+            @Param("reason") String reason,
+            @Param("cancelledAt") LocalDateTime cancelledAt,
+            @Param("refundPolicy") String refundPolicy,
+            @Param("refundPercent") Integer refundPercent);
+
     /**
      * Case-insensitive search over title OR description.
      * Used by {@code GET /api/events/search} (#15364).

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -688,13 +688,21 @@ public class EventService {
                         }
                 }
 
-                event.setStatus("CANCELLED");
-                event.setCancellationReason(request.getReason());
-                event.setCancelledAt(request.getCancelledAt() != null ? request.getCancelledAt() : LocalDateTime.now());
-                event.setRefundPolicy(refundPolicy);
-                event.setRefundPercent("PARTIAL".equals(refundPolicy) ? request.getRefundPercent() : null);
+                int cancelled = eventRepository.markCancelled(
+                                id,
+                                request.getReason(),
+                                request.getCancelledAt() != null ? request.getCancelledAt() : LocalDateTime.now(),
+                                refundPolicy,
+                                "PARTIAL".equals(refundPolicy) ? request.getRefundPercent() : null);
 
-                Event saved = eventRepository.save(event);
+                if (cancelled == 0) {
+                        return toEventResponse(eventRepository.findById(id)
+                                        .orElseThrow(() -> new EventNotFoundException(
+                                                        "Event not found with id: " + id)));
+                }
+
+                Event saved = eventRepository.findById(id)
+                                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
                 if (!Boolean.FALSE.equals(request.getNotifyAttendees())) {
                         notifyCancellation(saved, request.getReason());
                 }
@@ -785,12 +793,15 @@ public class EventService {
 
                                         if (refundDue
                                                         && registration.isPaymentCompleted()
-                                                        && registration.getStripePaymentIntentId() != null) {
+                                                        && registration.getStripePaymentIntentId() != null
+                                                        && !"REFUNDED".equalsIgnoreCase(registration.getPaymentStatus())) {
                                                 try {
                                                         stripeService.refundPayment(
                                                                         registration.getStripePaymentIntentId(),
                                                                         refundPolicy,
                                                                         refundPercent);
+                                                        registration.setPaymentStatus("REFUNDED");
+                                                        eventRegistrationRepository.save(registration);
                                                 } catch (Exception e) {
                                                         log.error(
                                                                         "Failed to refund payment for registration {} on cancelled event {}: {}",

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventCancelTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/EventCancelTests.java
@@ -155,4 +155,23 @@ class EventCancelTests {
                 .andExpect(jsonPath("$.status").value("CANCELLED"))
                 .andExpect(jsonPath("$.refundPolicy").value("NONE"));
     }
+
+    @Test
+    @DisplayName("Cancelling an already-cancelled event is idempotent")
+    void cancelEvent_AlreadyCancelled_IdempotentSuccess() throws Exception {
+        mockMvc.perform(post("/api/events/" + existingEvent.getId() + "/cancel")
+                        .with(user("admin@example.com").authorities(new SimpleGrantedAuthority("ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "weather", "refundPolicy", "FULL"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        mockMvc.perform(post("/api/events/" + existingEvent.getId() + "/cancel")
+                        .with(user("admin@example.com").authorities(new SimpleGrantedAuthority("ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "weather", "refundPolicy", "FULL"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"))
+                .andExpect(jsonPath("$.refundPolicy").value("FULL"));
+    }
 }


### PR DESCRIPTION
## Problem

`cancelEvent` guarded against duplicate cancellation with only an in-memory status check and then performed the refunds and status update without any optimistic lock or conditional update. Two near-simultaneous cancel requests can both pass the in-memory guard (and the guard state is not shared across instances), so both proceed to issue Stripe refunds, resulting in double refunds (money lost). Refunds were also not idempotent per payment.

## Fix

- Added an atomic conditional status transition in `EventRepository.markCancelled(...)`: a single `UPDATE events SET status='CANCELLED', ... WHERE id=? AND status<>'CANCELLED'`. Only one concurrent caller can flip the event to CANCELLED; the affected-row count distinguishes the winner (1) from a concurrent loser (0).
- `cancelEvent` now performs this atomic transition first. A caller that loses the race (0 rows affected) returns the already-cancelled event idempotently without re-sending notifications or re-processing refunds.
- Made the refund idempotent per payment in `notifyCancellation`: skip registrations already in `REFUNDED` state, and mark the registration `REFUNDED` after a successful refund, persisted in the same transaction.
- The existing `@Version` field on `Event` remains as the optimistic-lock safety net across all event writes.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
- Backend/src/test/java/com/sandeep/eventrabackend/controller/EventCancelTests.java

## Testing

The project does not compile in this environment due to a pre-existing Lombok annotation-processing issue affecting the pristine `master` tree as well (verified by compiling the unmodified code, which fails with the same `cannot find symbol` errors on Lombok-generated getters/builders), so a full build/test run was not possible. The change was verified via careful code review and syntax consistency with the surrounding code. Added a regression test `cancelEvent_AlreadyCancelled_IdempotentSuccess` to `EventCancelTests` verifying that cancelling an already-cancelled event succeeds idempotently.

Closes #17081
