### PR TITLE
[OAuth2] InMemoryRegisteredClientRepository used for client registration — secrets lost on restart, unsuitable for production

### DIFF
--- a/Backend/src/main/java/com/eventra/config/OAuth2AuthorizationServerConfig.java
+++ b/Backend/src/main/java/com/eventra/config/OAuth2AuthorizationServerConfig.java
@@ -1,16 +1,16 @@
 package com.eventra.config;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
-import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.ClientSettings;
-import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.UUID;
 
@@ -18,25 +18,34 @@ import java.util.UUID;
 @EnableWebSecurity
 public class OAuth2AuthorizationServerConfig {
 
-    @Bean
-    public RegisteredClientRepository registeredClientRepository() {
-        RegisteredClient spaAndMobileClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("eventra-mobile-spa-client")
-                .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .redirectUri("https://app.eventra.io/oauth2/callback")
-                .redirectUri("com.eventra.mobile://oauth2/callback")
-                .scope("openid")
-                .scope("profile")
-                .scope("events.read")
-                .scope("events.write")
-                .clientSettings(ClientSettings.builder()
-                        .requireProofKey(true) // Enforce PKCE (S256)
-                        .requireAuthorizationConsent(true)
-                        .build())
-                .build();
+    private static final String DEFAULT_CLIENT_ID = "eventra-mobile-spa-client";
 
-        return new InMemoryRegisteredClientRepository(spaAndMobileClient);
+    @Bean
+    public RegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate) {
+        return new JdbcRegisteredClientRepository(jdbcTemplate);
+    }
+
+    @Bean
+    public CommandLineRunner seedOAuth2RegisteredClient(RegisteredClientRepository registeredClientRepository) {
+        return args -> {
+            if (registeredClientRepository.findByClientId(DEFAULT_CLIENT_ID) == null) {
+                registeredClientRepository.save(RegisteredClient.withId(UUID.randomUUID().toString())
+                        .clientId(DEFAULT_CLIENT_ID)
+                        .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                        .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                        .redirectUri("https://app.eventra.io/oauth2/callback")
+                        .redirectUri("com.eventra.mobile://oauth2/callback")
+                        .scope("openid")
+                        .scope("profile")
+                        .scope("events.read")
+                        .scope("events.write")
+                        .clientSettings(ClientSettings.builder()
+                                .requireProofKey(true)
+                                .requireAuthorizationConsent(true)
+                                .build())
+                        .build());
+            }
+        };
     }
 }

--- a/Backend/src/main/resources/application-dev.yml
+++ b/Backend/src/main/resources/application-dev.yml
@@ -8,6 +8,11 @@ spring:
     username: ${DB_USERNAME:sa}
     password: ${DB_PASSWORD:}
 
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:oauth2-registered-client-schema.sql
+
   jpa:
     hibernate:
       ddl-auto: update

--- a/Backend/src/main/resources/db/migration/V9__oauth2_registered_client.sql
+++ b/Backend/src/main/resources/db/migration/V9__oauth2_registered_client.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS oauth2_registered_client (
+    id varchar(100) NOT NULL,
+    client_id varchar(100) NOT NULL,
+    client_id_issued_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret varchar(200) DEFAULT NULL,
+    client_secret_expires_at timestamp DEFAULT NULL,
+    client_name varchar(200) NOT NULL,
+    client_authentication_methods varchar(1000) NOT NULL,
+    authorization_grant_types varchar(1000) NOT NULL,
+    redirect_uris varchar(1000) DEFAULT NULL,
+    post_logout_redirect_uris varchar(1000) DEFAULT NULL,
+    scopes varchar(1000) NOT NULL,
+    client_settings varchar(2000) NOT NULL,
+    token_settings varchar(2000) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/Backend/src/main/resources/oauth2-registered-client-schema.sql
+++ b/Backend/src/main/resources/oauth2-registered-client-schema.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS oauth2_registered_client (
+    id varchar(100) NOT NULL,
+    client_id varchar(100) NOT NULL,
+    client_id_issued_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret varchar(200) DEFAULT NULL,
+    client_secret_expires_at timestamp DEFAULT NULL,
+    client_name varchar(200) NOT NULL,
+    client_authentication_methods varchar(1000) NOT NULL,
+    authorization_grant_types varchar(1000) NOT NULL,
+    redirect_uris varchar(1000) DEFAULT NULL,
+    post_logout_redirect_uris varchar(1000) DEFAULT NULL,
+    scopes varchar(1000) NOT NULL,
+    client_settings varchar(2000) NOT NULL,
+    token_settings varchar(2000) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/Backend/src/test/resources/application-test.properties
+++ b/Backend/src/test/resources/application-test.properties
@@ -5,6 +5,9 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:oauth2-registered-client-schema.sql
+
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false


### PR DESCRIPTION
## Problem

`OAuth2AuthorizationServerConfig` constructs an `InMemoryRegisteredClientRepository` with a single hardcoded client, so all OAuth2 client registrations live only in JVM memory. Every restart loses the clients (and any issued/rotated secrets), which breaks SSO integrations and makes secret rotation and multi-client management impossible; clustered deployments even end up with divergent in-memory sets per node.

## Fix

- Switched the `RegisteredClientRepository` bean to a `JdbcRegisteredClientRepository` backed by the application's `JdbcTemplate`/DataSource, so client registrations (and their secrets) are persisted and survive restarts, support multiple clients, and can be rotated via `save`/`update`.
- Added a startup seeder (`CommandLineRunner`) that idempotently registers the existing `eventra-mobile-spa-client` (PKCE public client) if missing, preserving current SSO behaviour while moving it into the persistent store.
- Added Flyway migration `V9__oauth2_registered_client.sql` (Postgres/prod) and an idempotent `oauth2-registered-client-schema.sql` wired into the dev and test H2 profiles via `spring.sql.init`, so the `oauth2_registered_client` table is created on every environment the app runs in.

## Files changed

- Backend/src/main/java/com/eventra/config/OAuth2AuthorizationServerConfig.java
- Backend/src/main/resources/db/migration/V9__oauth2_registered_client.sql
- Backend/src/main/resources/oauth2-registered-client-schema.sql
- Backend/src/main/resources/application-dev.yml
- Backend/src/test/resources/application-test.properties

## Testing

Maven is not fully usable in the local environment (pre-existing Lombok annotation-processing failures on master in unrelated files such as `AdminService`/`EventService`/`CacheConfig`), so verification was done via careful code review plus a standalone `javac` compilation of the modified `OAuth2AuthorizationServerConfig` against the project's exact dependency jars (spring-boot 3.4.4, spring-framework 6.2.x, spring-security 6.4.x, spring-security-oauth2-authorization-server 1.4.2), which passes. The schema script matches the official Spring Authorization Server `oauth2_registered_client` columns, and the `JdbcRegisteredClientRepository(JdbcTemplate)` API used is the documented one. No test file was added since the issue does not request one and no config-level test exists in the repo.

Closes #17074
