### PR TITLE
fix: validate live audience question text

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/LiveAudienceController.java
@@ -81,10 +81,14 @@ public class LiveAudienceController {
     })
     public ResponseEntity<LiveAudienceQuestionResponse> createQuestion(
             @PathVariable Long eventId,
-            @Valid @RequestBody CreateQuestionRequest request,
+            @Valid @RequestBody(required = false) CreateQuestionRequest request,
             Authentication authentication) {
+        if (request == null || request.getText() == null || request.getText().isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        String trimmedText = request.getText().trim();
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(liveAudienceService.createQuestion(eventId, request.getText(), authentication.getName()));
+                .body(liveAudienceService.createQuestion(eventId, trimmedText, authentication.getName()));
     }
 
     @PostMapping("/questions/{questionId}/upvote")


### PR DESCRIPTION
## Summary

Fixes #18932 by validating live audience question requests before passing them to the service layer.

## Changes

- Rejects a null question request with `400 Bad Request`
- Rejects null or blank question text
- Trims question text before passing it to the service layer
- Prevents invalid question data from reaching the service/database layer

## Testing

- Verified null request validation
- Verified missing/blank question text validation
- Verified valid question text continues to the service layer

Fixes #18932