### PR TITLE
[HackathonLeaderboardSse] removeEmitter mutates shared emitters list without synchronization — CME / lost broadcasters

### DIFF
--- a/Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java
+++ b/Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java
@@ -140,7 +140,11 @@ public class HackathonLeaderboardSseController implements MessageListener, Healt
                 emitter
         );
 
-        sessions.add(session);
+        leaderboardSessions.compute(hackathonId, (id, list) -> {
+            if (list == null) list = new CopyOnWriteArrayList<>();
+            list.add(session);
+            return list;
+        });
         if (activeConnectionsCounter != null) activeConnectionsCounter.increment();
 
         // Register Lifecycles
@@ -367,13 +371,10 @@ public class HackathonLeaderboardSseController implements MessageListener, Healt
     }
 
     private void removeSession(Long hackathonId, ClientSession session) {
-        CopyOnWriteArrayList<ClientSession> sessions = leaderboardSessions.get(hackathonId);
-        if (sessions != null) {
+        leaderboardSessions.computeIfPresent(hackathonId, (id, sessions) -> {
             sessions.remove(session);
-            if (sessions.isEmpty()) {
-                leaderboardSessions.remove(hackathonId);
-            }
-        }
+            return sessions.isEmpty() ? null : sessions;
+        });
     }
 
     public int getTotalActiveConnections() {


### PR DESCRIPTION
## Problem

HackathonLeaderboardSseController maintains a shared per-hackathon registry of active SSE client sessions that is mutated on every connect/disconnect while other threads iterate it to broadcast leaderboard updates. The removal path in `removeSession` performed a non-atomic empty-check-then-`remove` on the map entry, and the connect path added to a list reference that could have been concurrently orphaned, so a fast connect/disconnect cycle could skip or leak an emitter and break the live feed. ConcurrentMutationException-style races are also possible whenever the shared collection is touched without synchronization.

## Fix

Made both registration and deregistration atomic at the map level so the shared session list can never be mutated concurrently with its own removal:

- Connect path (`streamLeaderboardUpdates`): register the session via `leaderboardSessions.compute(...)`, which atomically obtains-or-creates the per-hackathon list and adds the session, instead of adding to a possibly-orphaned list reference.
- Remove path (`removeSession`): use `leaderboardSessions.computeIfPresent(...)`, which removes the session and atomically drops the empty list from the map (returning `null`), eliminating the unsynchronized empty-check-then-remove window.

The per-hackathon session list remains a `CopyOnWriteArrayList` inside a `ConcurrentHashMap`, so concurrent connect/disconnect no longer risks a lost or leaked emitter during broadcast.

## Files changed

- Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java

## Testing

No Maven build was run in this environment; the fix was verified via careful code review and syntax consistency with the surrounding code. `ConcurrentHashMap.compute`/`computeIfPresent` are existing standard-library methods and the needed imports are already present. No existing test file covers this controller, so no test was added.

Closes #17080
