### PR TITLE
[TeamService] sendInvite is a no-op stub returning Optional.empty() — invited users can never join the team

### DIFF
--- a/Backend/src/main/java/com/eventra/model/TeamInvite.java
+++ b/Backend/src/main/java/com/eventra/model/TeamInvite.java
@@ -1,0 +1,55 @@
+package com.eventra.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "team_invites",
+        indexes = {
+                @Index(name = "idx_team_invite_team", columnList = "team_id"),
+                @Index(name = "idx_team_invite_token_hash", columnList = "token_hash")
+        })
+public class TeamInvite {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "team_id", nullable = false)
+    private Long teamId;
+
+    @Column(name = "recipient_email", nullable = false, length = 100)
+    private String recipientEmail;
+
+    @Column(name = "inviter_user_id", nullable = false, length = 100)
+    private String inviterUserId;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private boolean used = false;
+}

--- a/Backend/src/main/java/com/eventra/repository/TeamInviteRepository.java
+++ b/Backend/src/main/java/com/eventra/repository/TeamInviteRepository.java
@@ -1,0 +1,9 @@
+package com.eventra.repository;
+
+import com.eventra.model.TeamInvite;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamInviteRepository extends JpaRepository<TeamInvite, Long> {
+}

--- a/Backend/src/main/java/com/eventra/service/TeamService.java
+++ b/Backend/src/main/java/com/eventra/service/TeamService.java
@@ -1,6 +1,17 @@
 package com.eventra.service;
 
+import com.eventra.model.TeamInvite;
+import com.eventra.repository.TeamInviteRepository;
+import jakarta.mail.MessagingException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -8,28 +19,86 @@ import java.util.logging.Logger;
 public class TeamService {
 
     private static final Logger logger = Logger.getLogger(TeamService.class.getName());
+    private static final int INVITE_TOKEN_BYTE_LENGTH = 32;
+    private static final int INVITE_EXPIRATION_DAYS = 7;
+    private static final String INVITE_ACCEPT_BASE_URL = "https://eventra.sandeepvashishtha.in";
 
-    public void sendInvite(Long teamId, String recipientEmail, String inviterUserId) {
+    @Autowired
+    private TeamInviteRepository teamInviteRepository;
+
+    @Autowired
+    private EmailService emailService;
+
+    public TeamInvite sendInvite(Long teamId, String recipientEmail, String inviterUserId) {
         if (recipientEmail == null || recipientEmail.trim().isEmpty()) {
             throw new IllegalArgumentException("Recipient email address cannot be null or empty.");
         }
 
-        logger.info("Processing team invitation for email: " + recipientEmail + " on team ID: " + teamId);
+        String normalizedEmail = recipientEmail.trim().toLowerCase();
+        logger.info("Processing team invitation for email: " + normalizedEmail + " on team ID: " + teamId);
+
+        String rawToken = generateInviteToken();
+        TeamInvite savedInvite = teamInviteRepository.save(TeamInvite.builder()
+                .teamId(teamId)
+                .recipientEmail(normalizedEmail)
+                .inviterUserId(inviterUserId)
+                .tokenHash(hashToken(rawToken))
+                .expiresAt(LocalDateTime.now().plusDays(INVITE_EXPIRATION_DAYS))
+                .used(false)
+                .build());
 
         // Safe user lookup handling null/unregistered user accounts gracefully
-        Optional<Object> userOptional = findUserByEmailOptional(recipientEmail);
+        Optional<Object> userOptional = findUserByEmailOptional(normalizedEmail);
 
         if (userOptional.isPresent()) {
-            logger.info("Registered user account found for " + recipientEmail + ". Creating in-app team invitation.");
-            // Logic for inviting an existing registered user
+            logger.info("Registered user account found for " + normalizedEmail + ". Creating in-app team invitation.");
         } else {
-            logger.info("Unregistered email address " + recipientEmail + ". Issuing pending email invitation link.");
-            // Logic for issuing pending email invitation token
+            logger.info("Unregistered email address " + normalizedEmail + ". Issuing pending email invitation link.");
+        }
+
+        dispatchInviteEmail(normalizedEmail, inviterUserId, savedInvite.getId(), rawToken);
+
+        return savedInvite;
+    }
+
+    private void dispatchInviteEmail(String recipientEmail, String inviterUserId, Long inviteId, String rawToken) {
+        String actionUrl = INVITE_ACCEPT_BASE_URL + "/teams/" + inviteId + "/invite?token=" + rawToken;
+        try {
+            emailService.sendTransactionalEmail(
+                    recipientEmail,
+                    "You're invited to join a team on Eventra",
+                    "Team invitation",
+                    inviterUserId,
+                    "You have been invited to join a team on Eventra. Click the button below to accept the invitation.",
+                    actionUrl,
+                    "Accept invitation");
+        } catch (MessagingException ex) {
+            logger.warning("Failed to dispatch team invitation email to " + recipientEmail + ": " + ex.getMessage());
         }
     }
 
     private Optional<Object> findUserByEmailOptional(String email) {
         // Safe lookup returning Optional to avoid uncaught NullPointerExceptions
         return Optional.empty();
+    }
+
+    private String generateInviteToken() {
+        byte[] bytes = new byte[INVITE_TOKEN_BYTE_LENGTH];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String hashToken(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is unavailable on this JVM", ex);
+        }
     }
 }


### PR DESCRIPTION
## Problem

`com/eventra/service/TeamService.java`'s `sendInvite(...)` is a no-op stub: it validates the recipient email and logs, but never creates an invite record or delivers one, so invited users can never accept and join a team. Callers that expect an invite to exist treat the absence of one as a silent failure.

## Fix

Implemented `sendInvite` so it now:

- Generates a cryptographically secure, single-use invite token (32 random bytes, URL-safe base64) and persists only its SHA-256 hash, following the existing `PasswordResetToken`/`AuthService` convention.
- Creates and persists a `TeamInvite` entity with the team ID, recipient email, inviter user ID, token hash, and a 7-day expiry.
- Dispatches the invitation via `EmailService.sendTransactionalEmail`, with an accept link containing the raw token. Email failures are logged and do not discard the already-persisted invite.
- Returns the saved `TeamInvite` entity so callers no longer receive an empty/void result.

Added a minimal `TeamInvite` JPA entity and a `TeamInviteRepository` to support persistence.

## Files changed

- `Backend/src/main/java/com/eventra/service/TeamService.java`
- `Backend/src/main/java/com/eventra/model/TeamInvite.java`
- `Backend/src/main/java/com/eventra/repository/TeamInviteRepository.java`

## Testing

No Maven build is available in this environment (the offline Maven build on master also fails on pre-existing, unrelated errors such as the duplicate `getName()` in `User.java`, `MultiTenantConnectionProviderImpl` file-name mismatch, and missing micrometer classes). Verified by compiling the new/modified `com.eventra` sources directly with `javac` plus the Lombok annotation processor — `TeamService`, `TeamInvite`, `TeamInviteRepository`, and `EmailService` all compile cleanly (only the same harmless Lombok `@Builder` initializer warning that already exists in `PasswordResetToken`). No test file exists for `TeamService` and the issue did not request one.

Closes #17076
