### PR TITLE
fix: validate plagiarism analysis request body

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PlagiarismController.java
@@ -21,7 +21,11 @@ public class PlagiarismController {
     private PlagiarismDetectionService plagiarismService;
 
     @PostMapping("/analyze")
-    public ResponseEntity<Map<String, Object>> analyzeSubmissions(@RequestBody Map<String, Map<String, String>> teamSubmissions) {
+    public ResponseEntity<Map<String, Object>> analyzeSubmissions(
+            @RequestBody(required = false) Map<String, Map<String, String>> teamSubmissions) {
+        if (teamSubmissions == null || teamSubmissions.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Team submissions cannot be null or empty"));
+        }
         List<SubmissionComparison> comparisons = plagiarismService.analyzeHackathonSubmissions(teamSubmissions);
 
         long highRiskCount = comparisons.stream().filter(c -> "HIGH".equals(c.getRiskLevel())).count();


### PR DESCRIPTION
## Summary

Fixes #18899 by validating the plagiarism analysis request body before invoking the service layer.

## Changes

- Reject null submission maps.
- Reject empty submission maps.
- Return `400 Bad Request` for invalid requests.
- Prevent invalid request data from reaching the plagiarism service.

## Testing

- Verified null request-body validation.
- Verified empty submission validation.
- Verified valid submissions continue to the service layer.

Fixes #18899