### PR TITLE
test(auth): regression tests for password-reset token secrecy and single-use consumption

### DIFF
--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthPasswordResetTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthPasswordResetTests.java
@@ -211,4 +211,78 @@ public class AuthPasswordResetTests {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Invalid or expired password reset token"));
     }
+
+    @Test
+    @DisplayName("POST /api/auth/reset-password never discloses the raw token or its hash (#17079)")
+    void testRequestPasswordResetDoesNotExposeToken() throws Exception {
+        ResetPasswordRequest request = new ResetPasswordRequest();
+        request.setEmail("testuser@example.com");
+
+        String responseBody = mockMvc.perform(post("/api/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("If an account exists for that email, a password reset link has been sent."))
+                .andExpect(jsonPath("$.token").doesNotExist())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        // The raw token (or any token-bearing field) must never appear in the HTTP response.
+        assertFalse(responseBody.contains("token"),
+                "Raw reset token must never be disclosed in the API response");
+        assertFalse(responseBody.contains("resetToken"));
+        assertFalse(responseBody.contains("tokenHash"));
+
+        // Only a SHA-256 hex digest is persisted, never the raw token.
+        PasswordResetToken stored = passwordResetTokenRepository.findAll().get(0);
+        assertEquals(64, stored.getTokenHash().length());
+        assertTrue(stored.getTokenHash().matches("[0-9a-f]{64}"));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/reset-password/confirm consumes the token; a second use of the same token fails (#17079)")
+    void testConfirmPasswordResetConsumesToken() throws Exception {
+        String rawToken = "single-use-reset-token-77777";
+        String tokenHash = hashToken(rawToken);
+
+        passwordResetTokenRepository.save(PasswordResetToken.builder()
+                .user(testUser)
+                .tokenHash(tokenHash)
+                .expiresAt(LocalDateTime.now().plusMinutes(30))
+                .used(false)
+                .build());
+
+        ConfirmResetPasswordRequest firstUse = ConfirmResetPasswordRequest.builder()
+                .token(rawToken)
+                .newPassword("firstNewPass123")
+                .build();
+
+        mockMvc.perform(post("/api/auth/reset-password/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(firstUse)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password has been successfully reset."));
+
+        // The same raw token is now invalidated: reset-password must consume, not regenerate.
+        ConfirmResetPasswordRequest secondUse = ConfirmResetPasswordRequest.builder()
+                .token(rawToken)
+                .newPassword("secondNewPass123")
+                .build();
+
+        mockMvc.perform(post("/api/auth/reset-password/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(secondUse)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Invalid or expired password reset token"));
+
+        // The password set by the first (successful) use remains effective.
+        LoginRequest login = new LoginRequest();
+        login.setUsernameOrEmail("testuser@example.com");
+        login.setPassword("firstNewPass123");
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("testuser@example.com"));
+    }
 }


### PR DESCRIPTION
﻿## Problem

Two related defects were reported in the password-reset flow:

1. AuthService.requestPasswordReset returned the raw reset token to the caller in the API response body, disclosing it to anyone who can see the response (proxy logs, browser history, shared machines) and enabling account takeover.
2. The reset endpoint called requestPasswordReset(...) again (regenerating a token) instead of consuming/verifying the supplied token, so there was effectively no working "consume token" endpoint.

## Fix

The code-level fixes for both defects are already present on master (the raw token is never returned from requestPasswordReset and POST /api/auth/reset-password/confirm verifies, then invalidates, the supplied single-use token). This PR adds the regression tests that were missing:

- testRequestPasswordResetDoesNotExposeToken: asserts the response contains no token-bearing field, and only a SHA-256 hex digest is persisted in the repository, never the raw token.
- testConfirmPasswordResetConsumesToken: completes a reset with a token, then asserts a second use of the same token fails and that the password set by the first use remains effective (token is consumed, not regenerated).

## Files changed

- Backend/src/test/java/com/sandeep/eventrabackend/controller/AuthPasswordResetTests.java

## Testing

Added the two regression tests described above to the existing AuthPasswordResetTests suite. A full Maven test run is not possible in this environment because the pristine master tree has pre-existing, unrelated compilation errors (Lombok annotation-processing); the tests were verified by careful review against the existing test conventions and the current AuthService/AuthController implementations.

Closes #17079
