### PR TITLE
ProjectService.upvoteProject uses save() not saveAndFlush() → 500 instead of 409 on duplicate

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -91,7 +91,7 @@ public class ProjectService {
         // then violates the (project_id, user_id) unique constraint.
         // Surface that as a friendly conflict instead of a 500 (#11776).
         try {
-            projectUpvoteRepository.save(upvote);
+            projectUpvoteRepository.saveAndFlush(upvote);
         } catch (DataIntegrityViolationException ex) {
             throw new RegistrationConflictException("You have already upvoted this project.");
         }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/ProjectUpvoteConcurrencyIntegrationTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/ProjectUpvoteConcurrencyIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.exception.RegistrationConflictException;
+import com.sandeep.eventrabackend.model.Project;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.ProjectRepository;
+import com.sandeep.eventrabackend.repository.ProjectUpvoteRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ProjectUpvoteConcurrencyIntegrationTest {
+
+    private static final String USER_EMAIL = "race@example.com";
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ProjectUpvoteRepository projectUpvoteRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        projectUpvoteRepository.deleteAll();
+        projectRepository.deleteAll();
+        userRepository.deleteAll();
+
+        userRepository.save(User.builder()
+                .firstName("Race")
+                .lastName("Client")
+                .email(USER_EMAIL)
+                .username("raceclient")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Concurrent double-upvote returns a conflict, not a 500")
+    void concurrentDoubleUpvote_ReturnsOneSuccessAndOneConflict() throws InterruptedException {
+        Project project = Project.builder()
+                .title("Raced Upvote")
+                .description("Description")
+                .category("Web Development")
+                .thumbnailUrl("http://example.com/thumb.png")
+                .githubUrl("http://github.com/test/raced")
+                .upvotes(5)
+                .build();
+        project = projectRepository.save(project);
+        Long projectId = project.getId();
+
+        int threads = 2;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger conflictCount = new AtomicInteger();
+        AtomicInteger unexpectedCount = new AtomicInteger();
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                try {
+                    ready.countDown();
+                    start.await();
+                    projectService.upvoteProject(projectId, USER_EMAIL);
+                    successCount.incrementAndGet();
+                } catch (RegistrationConflictException ex) {
+                    conflictCount.incrementAndGet();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                } catch (Exception ex) {
+                    unexpectedCount.incrementAndGet();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await(10, TimeUnit.SECONDS);
+        start.countDown();
+        done.await(30, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(1, successCount.get(),
+                "Exactly one thread should have upvoted successfully");
+        assertEquals(1, conflictCount.get(),
+                "The racing thread should receive a conflict, not a 500");
+        assertEquals(0, unexpectedCount.get(),
+                "No thread should have encountered an unexpected exception");
+
+        Project updated = projectRepository.findById(projectId).orElseThrow();
+        assertEquals(6, updated.getUpvotes(), "Upvote count should increment exactly once");
+        assertEquals(1, projectUpvoteRepository.count(), "Exactly one upvote row should be persisted");
+        assertTrue(done.getCount() == 0, "All racing threads should have finished");
+    }
+}


### PR DESCRIPTION
## Problem

`ProjectService.upvoteProject` guards against duplicate upvotes with a `try/catch (DataIntegrityViolationException)` around the insert, intending to return a friendly 409 conflict. However it uses `save()` (deferred persist) instead of `saveAndFlush()`. The unique `(project_id, user_id)` constraint violation is only surfaced when the persistence context is flushed, which happens at the `@Modifying(flushAutomatically = true)` `incrementUpvotes(id)` call — outside the try/catch. Under a concurrent double-upvote this produces an unhandled 500 instead of the intended 409, making the idempotency guard dead code.

## Fix

Changed `projectUpvoteRepository.save(upvote)` to `projectUpvoteRepository.saveAndFlush(upvote)` inside the try block, so the constraint is checked at the point the insert happens and a `DataIntegrityViolationException` is translated to `RegistrationConflictException` (409). This mirrors the correct pattern already used in `LiveAudienceService.upvoteQuestion`. Added `ProjectUpvoteConcurrencyIntegrationTest`, a two-thread service-level regression test (modeled on `EventRegistrationConcurrencyIntegrationTest`) that asserts exactly one upvote succeeds and the racing request gets a `RegistrationConflictException` (409), with the upvote count incrementing exactly once.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/ProjectUpvoteConcurrencyIntegrationTest.java`

## Testing

Maven build could not be run because the `master` branch currently fails to compile for pre-existing, unrelated reasons (`MultiTenantConnectionProvider.java` public-class/file-name mismatch, `User.getName()` Lombok conflict, `CacheConfig`/Micrometer API mismatch, and missing Lombok builders in `AdminService`/`EventService` DTOs) — verified with both JDK 17 and JDK 19; none of these files are touched by this change. The fix itself is a one-line change using the already-available `saveAndFlush()` repository method, and the regression test follows the existing `EventRegistrationConcurrencyIntegrationTest` concurrency-test conventions.

Closes #17832
