### PR TITLE
Audit Merkle integrity is fundamentally broken (collision-prone hashing, uncommitted tail, collisions)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/audit/MerkleTreeHasher.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/audit/MerkleTreeHasher.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.*;
@@ -44,8 +45,7 @@ public class MerkleTreeHasher {
             for (int i = 0; i < currentLevel.size(); i += 2) {
                 String left = currentLevel.get(i);
                 String right = (i + 1 < currentLevel.size()) ? currentLevel.get(i + 1) : left;
-                String combined = left + right;
-                String hash = sha256(combined);
+                String hash = combineAndHash(left, right);
                 nextLevel.add(hash);
             }
 
@@ -72,6 +72,40 @@ public class MerkleTreeHasher {
         } catch (Exception ex) {
             logger.error("SHA-256 hashing failed", ex);
             throw new RuntimeException("Failed to compute SHA-256 hash", ex);
+        }
+    }
+
+    /**
+     * Combines two node values with domain separation and hashes the result.
+     * Each operand is length-prefixed before concatenation, preventing
+     * delimiter-free second-preimage collisions (e.g. "ab"+"c" == "a"+"bc").
+     * 
+     * @param left Left node value
+     * @param right Right node value
+     * @return Hex-encoded SHA-256 hash of the domain-separated pair
+     * @throws RuntimeException if hashing fails
+     */
+    public String combineAndHash(String left, String right) {
+        try {
+            byte[] leftBytes = left.getBytes(StandardCharsets.UTF_8);
+            byte[] rightBytes = right.getBytes(StandardCharsets.UTF_8);
+            ByteArrayOutputStream out = new ByteArrayOutputStream(leftBytes.length + rightBytes.length + 8);
+            appendLengthPrefixed(out, leftBytes);
+            appendLengthPrefixed(out, rightBytes);
+            return bytesToHex(MessageDigest.getInstance("SHA-256").digest(out.toByteArray()));
+        } catch (Exception ex) {
+            logger.error("SHA-256 hashing failed", ex);
+            throw new RuntimeException("Failed to compute SHA-256 hash", ex);
+        }
+    }
+
+    private static void appendLengthPrefixed(ByteArrayOutputStream out, byte[] bytes) {
+        out.write((bytes.length >>> 24) & 0xFF);
+        out.write((bytes.length >>> 16) & 0xFF);
+        out.write((bytes.length >>> 8) & 0xFF);
+        out.write(bytes.length & 0xFF);
+        for (byte b : bytes) {
+            out.write(b);
         }
     }
 
@@ -163,7 +197,7 @@ public class MerkleTreeHasher {
         for (int i = 0; i < currentLevel.size(); i += 2) {
             String left = currentLevel.get(i);
             String right = (i + 1 < currentLevel.size()) ? currentLevel.get(i + 1) : left;
-            nextLevel.add(sha256(left + right));
+            nextLevel.add(combineAndHash(left, right));
         }
 
         return nextLevel;
@@ -187,9 +221,9 @@ public class MerkleTreeHasher {
 
         for (String sibling : proof) {
             if (leafIndex % 2 == 0) {
-                currentHash = sha256(currentHash + sibling);
+                currentHash = combineAndHash(currentHash, sibling);
             } else {
-                currentHash = sha256(sibling + currentHash);
+                currentHash = combineAndHash(sibling, currentHash);
             }
             leafIndex = leafIndex / 2;
         }
@@ -209,7 +243,7 @@ public class MerkleTreeHasher {
         String previousHash = "";
 
         for (String rootHash : rootHashes) {
-            String chainedHash = sha256(previousHash + rootHash);
+            String chainedHash = combineAndHash(previousHash, rootHash);
             chain.add(chainedHash);
             previousHash = chainedHash;
         }
@@ -232,7 +266,7 @@ public class MerkleTreeHasher {
         String previousHash = "";
 
         for (int i = 0; i < hashChain.size(); i++) {
-            String expectedHash = sha256(previousHash + rootHashes.get(i));
+            String expectedHash = combineAndHash(previousHash, rootHashes.get(i));
             if (!expectedHash.equals(hashChain.get(i))) {
                 return false;
             }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/audit/MerkleTreeHasherTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/audit/MerkleTreeHasherTest.java
@@ -1,0 +1,80 @@
+package com.sandeep.eventrabackend.security.audit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the Merkle tree hashing integrity guarantees
+ * (issue #17837).
+ */
+class MerkleTreeHasherTest {
+
+    private final MerkleTreeHasher hasher = new MerkleTreeHasher();
+
+    @Test
+    void delimiterCollisionMustProduceDifferentRoots() {
+        String rootAbC = hasher.computeRootHash(Arrays.asList("ab", "c"));
+        String rootABC = hasher.computeRootHash(Arrays.asList("a", "bc"));
+
+        assertNotEquals(rootAbC, rootABC,
+                "delimiter-free concatenation would let ['ab','c'] and ['a','bc'] share a root");
+    }
+
+    @Test
+    void combineAndHashIsLengthPrefixedAndOrderSensitive() {
+        assertNotEquals(hasher.combineAndHash("ab", "c"), hasher.combineAndHash("a", "bc"));
+        assertNotEquals(hasher.combineAndHash("a", "bc"), hasher.combineAndHash("bc", "a"));
+    }
+
+    @Test
+    void rootHashIsDeterministicForSameLogs() {
+        List<String> logs = Arrays.asList("log-one", "log-two", "log-three", "log-four");
+        assertEquals(hasher.computeRootHash(logs), hasher.computeRootHash(logs));
+    }
+
+    @Test
+    void tamperedLogIsDetected() {
+        List<String> logs = Arrays.asList("log-one", "log-two", "log-three", "log-four");
+        String root = hasher.computeRootHash(logs);
+
+        assertTrue(hasher.verifyIntegrity(logs, root));
+        assertFalse(hasher.verifyIntegrity(Arrays.asList("log-one", "tampered", "log-three", "log-four"), root));
+    }
+
+    @Test
+    void merkleProofVerifiesInclusionAndRejectsTampering() {
+        List<String> logs = Arrays.asList("a", "b", "c", "d", "e");
+        String root = hasher.computeRootHash(logs);
+
+        for (int i = 0; i < logs.size(); i++) {
+            List<String> proof = hasher.computeMerkleProof(logs, i);
+            assertTrue(hasher.verifyMerkleProof(logs.get(i), i, proof, root),
+                    "valid proof for leaf " + i + " must verify");
+        }
+
+        List<String> tamperedProof = hasher.computeMerkleProof(logs, 0);
+        tamperedProof.set(0, hasher.sha256("some-other-hash"));
+        assertFalse(hasher.verifyMerkleProof(logs.get(0), 0, tamperedProof, root),
+                "tampered proof must be rejected");
+    }
+
+    @Test
+    void hashChainValidatesAndDetectsTampering() {
+        List<String> roots = Arrays.asList(
+                hasher.computeRootHash(Arrays.asList("a", "b", "c", "d")),
+                hasher.computeRootHash(Arrays.asList("e", "f", "g", "h")));
+
+        List<String> chain = hasher.computeHashChain(roots);
+        assertTrue(hasher.validateHashChain(chain, roots));
+
+        List<String> tamperedChain = new java.util.ArrayList<>(chain);
+        tamperedChain.set(0, hasher.sha256("tampered"));
+        assertFalse(hasher.validateHashChain(tamperedChain, roots));
+    }
+}


### PR DESCRIPTION
## Problem

The audit Merkle integrity subsystem hashes combined nodes by raw string concatenation (`sha256(left + right)`), which allows trivial second-preimage collisions — a tampered log set such as `["ab","c"]` produces the same root as the legitimate `["a","bc"]`. This defeats the tamper-evidence purpose of the published block roots. (The related concerns from the issue — block-id collisions and returning a mutable map — were already addressed on master by UUID-suffixed block ids and copy/unmodifiable map returns; recent tail activity can also be sealed via the existing `finalizeCurrentBlock()`.)

## Fix

Added a domain-separated `combineAndHash(String left, String right)` in `MerkleTreeHasher` that length-prefixes each operand (4-byte big-endian) before SHA-256 hashing, eliminating delimiter-free ambiguity. All tree node combinations (`computeRootHash`, `buildNextLevel`), proof verification (`verifyMerkleProof`), and hash-chain construction/validation (`computeHashChain`, `validateHashChain`) now use it. Added a regression test suite covering the collision case, determinism, tamper detection, Merkle proof verification, and hash-chain validation.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/audit/MerkleTreeHasher.java
- Backend/src/test/java/com/sandeep/eventrabackend/security/audit/MerkleTreeHasherTest.java

## Testing

Verified with the JUnit 5 tests run standalone against the cached dependencies (all 6 pass). Also empirically confirmed the pre-fix code collides on `["ab","c"]` vs `["a","bc"]` (identical root) while the fixed code does not. Full `mvnw test` could not run because master has pre-existing unrelated compile errors in `EventService.java` (missing methods on `EventCreateRequest`/`EventUpdateRequest`), unrelated to this change.

Closes #17837
