### PR TITLE
PurchaseService enforces ticket capacity only in JVM memory (no DB, no cluster sharing)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/TicketTier.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/TicketTier.java
@@ -1,0 +1,49 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * DB-backed ticket tier capacity (#17833).
+ *
+ * Per-tier remaining capacity is stored in the database so it is shared
+ * across application instances and survives restarts, and is decremented
+ * atomically inside the surrounding database transaction.
+ */
+@Entity
+@Table(name = "ticket_tier")
+public class TicketTier {
+
+    @Id
+    @Column(name = "tier", length = 64, nullable = false)
+    private String tier;
+
+    @Column(name = "remaining", nullable = false)
+    private int remaining;
+
+    public TicketTier() {
+    }
+
+    public TicketTier(String tier, int remaining) {
+        this.tier = tier;
+        this.remaining = remaining;
+    }
+
+    public String getTier() {
+        return tier;
+    }
+
+    public void setTier(String tier) {
+        this.tier = tier;
+    }
+
+    public int getRemaining() {
+        return remaining;
+    }
+
+    public void setRemaining(int remaining) {
+        this.remaining = remaining;
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/TicketTierRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/TicketTierRepository.java
@@ -1,0 +1,34 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.TicketTier;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TicketTierRepository extends JpaRepository<TicketTier, String> {
+
+    Optional<TicketTier> findByTier(String tier);
+
+    /**
+     * Atomically decrements the tier's remaining capacity, guarded by
+     * {@code remaining >= quantity}. Executes within the caller's transaction,
+     * so a rollback restores the slot.
+     *
+     * @return number of rows updated (1 = purchased, 0 = exhausted/unknown tier)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE TicketTier t
+            SET t.remaining = t.remaining - :quantity
+            WHERE t.tier = :tier AND t.remaining >= :quantity
+            """)
+    int decrementRemainingIfAvailable(@Param("tier") String tier, @Param("quantity") int quantity);
+
+    @Query("SELECT COALESCE(SUM(t.remaining), 0) FROM TicketTier t")
+    int sumRemaining();
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PurchaseService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PurchaseService.java
@@ -1,49 +1,66 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.model.TicketTier;
+import com.sandeep.eventrabackend.repository.TicketTierRepository;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Purchase service preventing capacity write skew overselling (#16469).
+ * Purchase service enforcing ticket capacity against the database (#17833).
+ *
+ * Per-tier capacity is stored in {@code ticket_tier} and decremented atomically
+ * inside the surrounding transaction, so concurrent purchases across all
+ * instances (and restarts) can never oversell or lose sold counts.
  */
 @Service
 public class PurchaseService {
 
-    private final Map<String, AtomicInteger> ticketTiers = new ConcurrentHashMap<>();
-    private final AtomicInteger totalSold = new AtomicInteger(0);
-    private final int eventCapacity = 200;
+    private static final String VIP_TIER = "VIP";
+    private static final String GENERAL_TIER = "GENERAL";
+    private static final int VIP_CAPACITY = 50;
+    private static final int GENERAL_CAPACITY = 150;
 
-    public PurchaseService() {
-        ticketTiers.put("VIP", new AtomicInteger(50));
-        ticketTiers.put("GENERAL", new AtomicInteger(150));
+    private final TicketTierRepository ticketTierRepository;
+
+    public PurchaseService(TicketTierRepository ticketTierRepository) {
+        this.ticketTierRepository = ticketTierRepository;
     }
 
     /**
-     * Enforce atomic capacity checks and decrements to prevent overselling.
+     * Ensures the seeded tiers exist once the application is ready (covers
+     * dev/test profiles where Flyway is disabled and Hibernate owns the schema).
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void seedTiersIfAbsent() {
+        if (ticketTierRepository.findByTier(VIP_TIER).isEmpty()) {
+            ticketTierRepository.save(new TicketTier(VIP_TIER, VIP_CAPACITY));
+        }
+        if (ticketTierRepository.findByTier(GENERAL_TIER).isEmpty()) {
+            ticketTierRepository.save(new TicketTier(GENERAL_TIER, GENERAL_CAPACITY));
+        }
+    }
+
+    /**
+     * Atomically decrements the tier's remaining capacity in the database.
+     * The UPDATE is guarded by {@code remaining >= quantity}, so concurrent
+     * purchases across all instances can never oversell.
      */
     @Transactional
-    public synchronized boolean purchaseTicket(String tier, int quantity) {
+    public boolean purchaseTicket(String tier, int quantity) {
         if (quantity <= 0) {
             return false;
         }
-        AtomicInteger tierCapacity = ticketTiers.get(tier);
-        if (tierCapacity == null) {
-            return false;
-        }
-        int currentTier = tierCapacity.get();
-        int currentTotal = totalSold.get();
-        if (currentTier >= quantity && (currentTotal + quantity) <= eventCapacity) {
-            tierCapacity.addAndGet(-quantity);
-            totalSold.addAndGet(quantity);
-            return true;
-        }
-        return false;
+        return ticketTierRepository.decrementRemainingIfAvailable(tier, quantity) > 0;
     }
 
+    /**
+     * Remaining capacity across all tiers, read from the shared store.
+     */
+    @Transactional(readOnly = true)
     public int getRemainingCapacity() {
-        return eventCapacity - totalSold.get();
+        return ticketTierRepository.sumRemaining();
     }
 }

--- a/Backend/src/main/resources/db/migration/V9__ticket_tier_capacity.sql
+++ b/Backend/src/main/resources/db/migration/V9__ticket_tier_capacity.sql
@@ -1,0 +1,17 @@
+-- Ticket tier capacity table (matches TicketTier.java entity exactly).
+-- Backs ticket purchases with transactional, DB-level capacity so concurrent
+-- purchases across instances can never oversell and restarts preserve state
+-- (see #17833).
+CREATE TABLE IF NOT EXISTS ticket_tier (
+    tier      VARCHAR(64) NOT NULL PRIMARY KEY,
+    remaining INT         NOT NULL CHECK (remaining >= 0)
+);
+
+-- Preserve the tiers previously seeded in-memory by PurchaseService.
+INSERT INTO ticket_tier (tier, remaining)
+SELECT 'VIP', 50
+WHERE NOT EXISTS (SELECT 1 FROM ticket_tier WHERE tier = 'VIP');
+
+INSERT INTO ticket_tier (tier, remaining)
+SELECT 'GENERAL', 150
+WHERE NOT EXISTS (SELECT 1 FROM ticket_tier WHERE tier = 'GENERAL');

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/PurchaseServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/PurchaseServiceTest.java
@@ -1,0 +1,129 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.repository.TicketTierRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for Issue #17833: ticket capacity must be enforced against a
+ * shared, durable store so concurrent purchases across instances (and restarts)
+ * can never oversell.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class PurchaseServiceTest {
+
+    @Autowired
+    private PurchaseService purchaseService;
+
+    @Autowired
+    private TicketTierRepository ticketTierRepository;
+
+    @BeforeEach
+    void setUp() {
+        ticketTierRepository.deleteAll();
+        purchaseService.seedTiersIfAbsent();
+    }
+
+    @Test
+    @DisplayName("#17833 — successful purchase decrements the shared tier capacity")
+    void purchaseDecrementsRemainingCapacity() {
+        assertTrue(purchaseService.purchaseTicket("VIP", 10));
+        assertEquals(190, purchaseService.getRemainingCapacity());
+        assertEquals(40, ticketTierRepository.findByTier("VIP").orElseThrow().getRemaining());
+    }
+
+    @Test
+    @DisplayName("#17833 — purchase is rejected once the tier is exhausted")
+    void purchaseFailsWhenTierExhausted() {
+        assertTrue(purchaseService.purchaseTicket("VIP", 50));
+        assertFalse(purchaseService.purchaseTicket("VIP", 1));
+        assertEquals(150, purchaseService.getRemainingCapacity());
+    }
+
+    @Test
+    @DisplayName("#17833 — purchase is rejected when it exceeds total event capacity")
+    void purchaseFailsWhenEventCapacityExceeded() {
+        assertTrue(purchaseService.purchaseTicket("VIP", 50));
+        assertTrue(purchaseService.purchaseTicket("GENERAL", 150));
+        assertEquals(0, purchaseService.getRemainingCapacity());
+        assertFalse(purchaseService.purchaseTicket("GENERAL", 1));
+    }
+
+    @Test
+    @DisplayName("#17833 — non-positive quantities and unknown tiers are rejected")
+    void purchaseRejectsInvalidArguments() {
+        assertFalse(purchaseService.purchaseTicket("VIP", 0));
+        assertFalse(purchaseService.purchaseTicket("VIP", -3));
+        assertFalse(purchaseService.purchaseTicket("GOLD", 1));
+        assertEquals(200, purchaseService.getRemainingCapacity());
+    }
+
+    @Test
+    @DisplayName("#17833 — capacity is shared across service instances (no per-JVM counters)")
+    void capacityIsSharedAcrossServiceInstances() {
+        PurchaseService otherInstance = new PurchaseService(ticketTierRepository);
+
+        assertTrue(purchaseService.purchaseTicket("VIP", 30));
+        assertEquals(30, ticketTierRepository.findByTier("VIP").orElseThrow().getRemaining());
+
+        assertFalse(otherInstance.purchaseTicket("VIP", 30), "other instance must not oversell the shared tier");
+        assertTrue(otherInstance.purchaseTicket("VIP", 20));
+        assertEquals(0, otherInstance.getRemainingCapacity());
+
+        assertTrue(purchaseService.purchaseTicket("GENERAL", 150));
+        assertFalse(otherInstance.purchaseTicket("GENERAL", 1));
+    }
+
+    @Test
+    @DisplayName("#17833 — concurrent purchases across threads never oversell")
+    void concurrentPurchasesNeverOversell() throws InterruptedException {
+        int capacity = 50;
+        int threads = 100;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        AtomicInteger successCount = new AtomicInteger();
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    if (purchaseService.purchaseTicket("VIP", 1)) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+        executor.shutdown();
+
+        assertEquals(capacity, successCount.get());
+        assertEquals(150, purchaseService.getRemainingCapacity());
+        assertEquals(0, ticketTierRepository.findByTier("VIP").orElseThrow().getRemaining());
+    }
+}


### PR DESCRIPTION
## Problem

`PurchaseService` enforced ticket capacity entirely in JVM memory (`ConcurrentHashMap` counters guarded by an in-process lock), so each application instance kept its own independent counters. Concurrent purchases across instances could oversell freely, a restart reset all sold counts to the constructor defaults, and the `@Transactional` annotation did nothing because there was no repository/table behind it.

## Fix

Backed ticket capacity with a durable DB-level store. Added a `ticket_tier` table (Flyway migration `V9`) plus the `TicketTier` entity and `TicketTierRepository`; `purchaseTicket` now performs an atomic conditional `UPDATE ... WHERE remaining >= quantity` inside a transaction, so concurrent purchases across all instances (and restarts) can never oversell and sold counts survive restarts. `getRemainingCapacity()` reads the shared sum from the DB. A `seedTiersIfAbsent` listener preserves the previously in-memory VIP/GENERAL defaults for profiles where Hibernate owns the schema (Flyway disabled).

Added `PurchaseServiceTest` regression coverage: tier exhaustion, event-capacity exhaustion, invalid/unknown tiers, capacity shared across separate service instances (the cluster-sharing concern), and a 100-thread concurrency test asserting exactly capacity purchases succeed.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/model/TicketTier.java` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/repository/TicketTierRepository.java` (new)
- `Backend/src/main/resources/db/migration/V9__ticket_tier_capacity.sql` (new)
- `Backend/src/main/java/com/sandeep/eventrabackend/service/PurchaseService.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/service/PurchaseServiceTest.java` (new)

## Testing

Changed sources and the new test compile cleanly (verified with `javac` against the project dependency classpath). The full Maven build/test run is blocked by pre-existing, unrelated master compile errors in `EventService.java`, `AdminService.java`, `CacheConfig.java`, `User.java`, and `MultiTenantConnectionProvider.java`, which prevent `mvn compile`/`mvn test` from reaching the new code.

Closes #17833
