### PR TITLE
Subtitle READ REST endpoints have no per-event authorization (IDOR / caption exposure)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java
@@ -80,31 +80,37 @@ public class SubtitleController {
      * Get subtitle by ID
      */
     @GetMapping("/{id}")
-    public ResponseEntity<SubtitleDTO> getSubtitleById(@PathVariable Long id) {
-        Optional<Subtitle> subtitle = subtitleService.getSubtitleById(id);
-        return subtitle
-                .map(SubtitleDTO::fromEntity)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    public ResponseEntity<SubtitleDTO> getSubtitleById(@PathVariable Long id,
+            Authentication authentication) {
+        Subtitle subtitle = subtitleService.getSubtitleById(id).orElse(null);
+        if (subtitle == null) {
+            return ResponseEntity.notFound().build();
+        }
+        assertCanModifyEvent(subtitle.getEventId(), authentication);
+        return ResponseEntity.ok(SubtitleDTO.fromEntity(subtitle));
     }
     
     /**
      * Get subtitle by UUID
      */
     @GetMapping("/uuid/{uuid}")
-    public ResponseEntity<SubtitleDTO> getSubtitleByUuid(@PathVariable String uuid) {
-        Optional<Subtitle> subtitle = subtitleService.getSubtitleByUuid(uuid);
-        return subtitle
-                .map(SubtitleDTO::fromEntity)
-                .map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+    public ResponseEntity<SubtitleDTO> getSubtitleByUuid(@PathVariable String uuid,
+            Authentication authentication) {
+        Subtitle subtitle = subtitleService.getSubtitleByUuid(uuid).orElse(null);
+        if (subtitle == null) {
+            return ResponseEntity.notFound().build();
+        }
+        assertCanModifyEvent(subtitle.getEventId(), authentication);
+        return ResponseEntity.ok(SubtitleDTO.fromEntity(subtitle));
     }
     
     /**
      * Get subtitles by event ID
      */
     @GetMapping("/event/{eventId}")
-    public ResponseEntity<List<SubtitleDTO>> getSubtitlesByEventId(@PathVariable Long eventId) {
+    public ResponseEntity<List<SubtitleDTO>> getSubtitlesByEventId(@PathVariable Long eventId,
+            Authentication authentication) {
+        assertCanModifyEvent(eventId, authentication);
         List<Subtitle> subtitles = subtitleService.getSubtitlesByEventId(eventId);
         List<SubtitleDTO> dtos = subtitles.stream()
                 .map(SubtitleDTO::fromEntity)
@@ -116,7 +122,9 @@ public class SubtitleController {
      * Get active subtitles for an event
      */
     @GetMapping("/event/{eventId}/active")
-    public ResponseEntity<List<SubtitleDTO>> getActiveSubtitlesByEventId(@PathVariable Long eventId) {
+    public ResponseEntity<List<SubtitleDTO>> getActiveSubtitlesByEventId(@PathVariable Long eventId,
+            Authentication authentication) {
+        assertCanModifyEvent(eventId, authentication);
         List<Subtitle> subtitles = subtitleService.getActiveSubtitlesByEventId(eventId);
         List<SubtitleDTO> dtos = subtitles.stream()
                 .map(SubtitleDTO::fromEntity)
@@ -130,7 +138,9 @@ public class SubtitleController {
     @GetMapping("/event/{eventId}/recent")
     public ResponseEntity<Page<SubtitleDTO>> getRecentSubtitlesByEventId(
             @PathVariable Long eventId,
-            @PageableDefault(size = 20, sort = "createdAt,desc") Pageable pageable) {
+            @PageableDefault(size = 20, sort = "createdAt,desc") Pageable pageable,
+            Authentication authentication) {
+        assertCanModifyEvent(eventId, authentication);
         Page<Subtitle> page = subtitleService.getRecentSubtitlesByEventId(eventId, pageable);
         Page<SubtitleDTO> dtoPage = page.map(SubtitleDTO::fromEntity);
         return ResponseEntity.ok(dtoPage);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/SubtitleAccessControlTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/SubtitleAccessControlTests.java
@@ -1,0 +1,156 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import com.sandeep.eventrabackend.subtitles.Subtitle;
+import com.sandeep.eventrabackend.subtitles.SubtitleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #17836 — subtitle READ endpoints must enforce per-event authorization.
+ * Only the event organizer (or an admin) may read an event's captions;
+ * any other authenticated user gets 403.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SubtitleAccessControlTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SubtitleRepository subtitleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Long subtitleId;
+    private String subtitleUuid;
+    private Long eventId;
+    private final String organizerEmail = "suborganizer@example.com";
+    private final String attackerEmail = "subattacker@example.com";
+    private final String adminEmail = "subadmin@example.com";
+
+    @BeforeEach
+    void setUp() {
+        subtitleRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User organizer = userRepository.save(User.builder()
+                .firstName("Sub")
+                .lastName("Organizer")
+                .email(organizerEmail)
+                .username("suborganizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        userRepository.save(User.builder()
+                .firstName("Sub")
+                .lastName("Attacker")
+                .email(attackerEmail)
+                .username("subattacker")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        userRepository.save(User.builder()
+                .firstName("Sub")
+                .lastName("Admin")
+                .email(adminEmail)
+                .username("subadmin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+
+        Event event = new Event();
+        event.setTitle("Subtitle Access Test Event");
+        event.setCapacity(50);
+        event.setEventDate(LocalDateTime.now().plusDays(10));
+        event.setOwnerId(organizer.getId());
+        event.setPublic(true);
+        event = eventRepository.save(event);
+        eventId = event.getId();
+
+        Subtitle subtitle = Subtitle.builder()
+                .eventId(eventId)
+                .originalText("Hello")
+                .translatedText("Hola")
+                .sourceLanguage("en")
+                .targetLanguage("es")
+                .build();
+        subtitle = subtitleRepository.save(subtitle);
+        subtitleId = subtitle.getId();
+        subtitleUuid = subtitle.getUuid();
+    }
+
+    @Test
+    @DisplayName("Event organizer can read all subtitle endpoints (200)")
+    void organizerCanReadEventSubtitles() throws Exception {
+        mockMvc.perform(get("/api/v1/subtitles/{id}", subtitleId).with(user(organizerEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/uuid/{uuid}", subtitleUuid).with(user(organizerEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}", eventId).with(user(organizerEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}/active", eventId).with(user(organizerEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}/recent", eventId).with(user(organizerEmail)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Admin can read any event's subtitle endpoints (200)")
+    void adminCanReadEventSubtitles() throws Exception {
+        mockMvc.perform(get("/api/v1/subtitles/{id}", subtitleId).with(user(adminEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/uuid/{uuid}", subtitleUuid).with(user(adminEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}", eventId).with(user(adminEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}/active", eventId).with(user(adminEmail)))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}/recent", eventId).with(user(adminEmail)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Unrelated user is denied on every subtitle read endpoint (403)")
+    void attackerIsDeniedEverywhere() throws Exception {
+        mockMvc.perform(get("/api/v1/subtitles/{id}", subtitleId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/v1/subtitles/uuid/{uuid}", subtitleUuid).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}", eventId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}/active", eventId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/v1/subtitles/event/{eventId}/recent", eventId).with(user(attackerEmail)))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Problem

The subtitle READ REST endpoints (`getSubtitleById`, `getSubtitleByUuid`, `getSubtitlesByEventId`, `getActiveSubtitlesByEventId`, `getRecentSubtitlesByEventId`) enforce only global authentication, with no per-event ownership/role check. Any authenticated low-privilege user can enumerate and read every event's live captions/subtitles (sequential numeric IDs plus UUIDs), exposing potentially confidential real-time transcript content and mapping which events have captions and their participants (IDOR / broken access control).

## Fix

Applied the existing `assertCanModifyEvent` organizer-or-admin check (already used by the SSE stream endpoints and the write/delete endpoints) to all five subtitle read endpoints. For the ID/UUID lookups the subtitle is resolved first and its event is then authorized; the 404 behavior for missing subtitles is preserved. Also added `SubtitleAccessControlTests` asserting that the event organizer and an admin receive 200 while an unrelated authenticated user receives 403 on every read endpoint.

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/subtitles/SubtitleController.java`
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/SubtitleAccessControlTests.java`

## Testing

New regression test `SubtitleAccessControlTests` added following the conventions of the existing controller tests (SpringBootTest + MockMvc + H2 test profile). Could not execute the Maven build locally because master currently does not compile in this environment due to pre-existing unrelated compile errors (e.g. `MultiTenantConnectionProvider.java` declares a public class with a mismatched file name, duplicate `getName()` in `User.java`, `CacheConfig` CacheMeterBinder misuse, and Lombok-generated methods unresolved in several DTOs/services). Verified the changed files introduce no additional compile errors in the build output.

Closes #17836
