### PR TITLE
fix(session): connect cloud session recovery frontend service with backend REST endpoints (#14203)

### DIFF
--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/SessionRecoveryControllerTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/SessionRecoveryControllerTest.java
@@ -1,0 +1,167 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.RecoverySessionRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class SessionRecoveryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RecoverySessionRepository recoverySessionRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        recoverySessionRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser = userRepository.save(User.builder()
+                .firstName("Session")
+                .lastName("Tester")
+                .email("tester@example.com")
+                .username("tester")
+                .password(passwordEncoder.encode("password123"))
+                .role(Role.CLIENT)
+                .build());
+    }
+
+    @Test
+    @DisplayName("POST /api/session-recovery without authentication returns 401 (#14203)")
+    void save_WithoutAuth_Returns401() throws Exception {
+        mockMvc.perform(post("/api/session-recovery")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("name", "Draft"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/session-recovery with empty body returns 400 (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void save_EmptyBody_Returns400() throws Exception {
+        mockMvc.perform(post("/api/session-recovery")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"));
+    }
+
+    @Test
+    @DisplayName("POST /api/session-recovery with valid payload returns 201 Created (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void save_ValidPayload_Returns201() throws Exception {
+        Map<String, Object> payload = Map.of(
+                "sessionId", "session-101",
+                "name", "Form Draft",
+                "type", "event_registration",
+                "draftData", Map.of("step", 2, "eventId", "ev-123")
+        );
+
+        mockMvc.perform(post("/api/session-recovery")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.sessionId").value("session-101"))
+                .andExpect(jsonPath("$.name").value("Form Draft"))
+                .andExpect(jsonPath("$.type").value("event_registration"));
+    }
+
+    @Test
+    @DisplayName("GET /api/session-recovery lists active sessions for user (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void list_ReturnsSessions() throws Exception {
+        mockMvc.perform(get("/api/session-recovery"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessions").isArray());
+    }
+
+    @Test
+    @DisplayName("PUT /api/session-recovery/{id} updates existing draft (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void update_ExistingSession_Returns200() throws Exception {
+        Map<String, Object> payload = Map.of(
+                "name", "Updated Draft",
+                "type", "generic",
+                "draftData", Map.of("data", "hello")
+        );
+
+        mockMvc.perform(put("/api/session-recovery/session-101")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value("session-101"))
+                .andExpect(jsonPath("$.name").value("Updated Draft"));
+    }
+
+    @Test
+    @DisplayName("POST /api/session-recovery/{id}/restore restores session draft (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void restore_ExistingSession_Returns200() throws Exception {
+        // Create session first
+        Map<String, Object> payload = Map.of(
+                "sessionId", "restore-me",
+                "name", "Restore Test",
+                "draftData", Map.of("restored", true)
+        );
+        mockMvc.perform(post("/api/session-recovery")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload)));
+
+        mockMvc.perform(post("/api/session-recovery/restore-me/restore"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.session.sessionId").value("restore-me"));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session-recovery/{id} deletes specified draft (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void delete_ExistingSession_Returns204() throws Exception {
+        mockMvc.perform(delete("/api/session-recovery/del-101"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("DELETE /api/session-recovery/cleanup cleans up expired sessions (#14203)")
+    @WithMockUser(username = "tester@example.com")
+    void cleanup_ExpiredSessions_Returns200() throws Exception {
+        mockMvc.perform(delete("/api/session-recovery/cleanup"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deleted").exists());
+    }
+}

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import { DrawerProvider } from "@/context/DrawerContext";
+import { SessionRecoveryProvider } from "@/context/SessionRecoveryContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,13 +27,15 @@ export default function RootLayout({ children }) {
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-[#f4fbf7] text-zinc-900 selection:bg-emerald-200 selection:text-emerald-950">
-        <DrawerProvider>
-          <Navbar />
-          <div className="flex-1">
-            {children}
-          </div>
-          <Footer />
-        </DrawerProvider>
+        <SessionRecoveryProvider>
+          <DrawerProvider>
+            <Navbar />
+            <div className="flex-1">
+              {children}
+            </div>
+            <Footer />
+          </DrawerProvider>
+        </SessionRecoveryProvider>
       </body>
     </html>
   );

--- a/src/context/SessionRecoveryContext.jsx
+++ b/src/context/SessionRecoveryContext.jsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import {
+  saveSessionRecovery,
+  updateSessionRecovery,
+  getSessionRecoveryList,
+  restoreSessionRecovery,
+  deleteSessionRecovery,
+  cleanupExpiredSessionRecovery,
+} from "@/lib/api";
+
+const SessionRecoveryContext = createContext();
+
+const LOCAL_STORAGE_KEY = "eventra_recovery_sessions_v1";
+
+export function SessionRecoveryProvider({ children }) {
+  const [sessions, setSessions] = useState([]);
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  // Helper to read local drafts
+  const getLocalDrafts = () => {
+    if (typeof window === "undefined") return [];
+    try {
+      const data = localStorage.getItem(LOCAL_STORAGE_KEY);
+      return data ? JSON.parse(data) : [];
+    } catch {
+      return [];
+    }
+  };
+
+  // Helper to write local drafts
+  const saveLocalDrafts = (drafts) => {
+    if (typeof window === "undefined") return;
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(drafts));
+    } catch (e) {
+      console.warn("Failed to write recovery sessions to localStorage:", e);
+    }
+  };
+
+  // Synchronize local and cloud sessions
+  const syncSessions = useCallback(async () => {
+    if (typeof window === "undefined") return;
+    const token = localStorage.getItem("eventra_token");
+
+    const localDrafts = getLocalDrafts();
+
+    if (!token) {
+      setSessions(localDrafts);
+      return;
+    }
+
+    setIsSyncing(true);
+    try {
+      // 1. Fetch remote cloud sessions
+      const remoteSessions = await getSessionRecoveryList();
+      
+      // 2. Combine remote and local drafts without duplication
+      const remoteMap = new Map((remoteSessions || []).map((s) => [s.sessionId, s]));
+      localDrafts.forEach((local) => {
+        if (!remoteMap.has(local.sessionId)) {
+          remoteMap.set(local.sessionId, local);
+        }
+      });
+
+      const merged = Array.from(remoteMap.values());
+      setSessions(merged);
+      saveLocalDrafts(merged);
+    } catch (err) {
+      console.warn("[SessionRecovery] Cloud sync failed, using local storage:", err);
+      setSessions(localDrafts);
+    } finally {
+      setIsSyncing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    syncSessions();
+  }, [syncSessions]);
+
+  // Save or Update a recovery session draft
+  const saveDraft = async ({ sessionId, name = "Recovery Session", type = "generic", draftData = {} }) => {
+    const id = sessionId || `session_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+    const payload = { sessionId: id, name, type, draftData };
+
+    // Update local state immediately
+    const updatedLocal = getLocalDrafts().filter((s) => s.sessionId !== id);
+    const updatedSession = { ...payload, lastUpdated: new Date().toISOString() };
+    updatedLocal.unshift(updatedSession);
+    saveLocalDrafts(updatedLocal);
+    setSessions(updatedLocal);
+
+    // Sync to cloud if authenticated
+    if (typeof window !== "undefined" && localStorage.getItem("eventra_token")) {
+      try {
+        if (sessionId) {
+          await updateSessionRecovery(id, payload);
+        } else {
+          await saveSessionRecovery(payload);
+        }
+      } catch (err) {
+        console.warn("[SessionRecovery] Could not save draft to cloud:", err);
+      }
+    }
+
+    return id;
+  };
+
+  // Restore session data by ID
+  const restoreDraft = async (sessionId) => {
+    if (typeof window !== "undefined" && localStorage.getItem("eventra_token")) {
+      try {
+        const restored = await restoreSessionRecovery(sessionId);
+        if (restored) return restored;
+      } catch (err) {
+        console.warn("[SessionRecovery] Cloud restore failed, checking local:", err);
+      }
+    }
+    const local = getLocalDrafts().find((s) => s.sessionId === sessionId);
+    return local || null;
+  };
+
+  // Delete session draft by ID
+  const removeDraft = async (sessionId) => {
+    const updatedLocal = getLocalDrafts().filter((s) => s.sessionId !== sessionId);
+    saveLocalDrafts(updatedLocal);
+    setSessions(updatedLocal);
+
+    if (typeof window !== "undefined" && localStorage.getItem("eventra_token")) {
+      try {
+        await deleteSessionRecovery(sessionId);
+      } catch (err) {
+        console.warn("[SessionRecovery] Could not delete cloud draft:", err);
+      }
+    }
+  };
+
+  // Clean up expired sessions
+  const cleanupExpired = async () => {
+    if (typeof window !== "undefined" && localStorage.getItem("eventra_token")) {
+      try {
+        await cleanupExpiredSessionRecovery();
+        await syncSessions();
+      } catch (err) {
+        console.warn("[SessionRecovery] Cloud cleanup failed:", err);
+      }
+    }
+  };
+
+  return (
+    <SessionRecoveryContext.Provider
+      value={{
+        sessions,
+        isSyncing,
+        syncSessions,
+        saveDraft,
+        restoreDraft,
+        removeDraft,
+        cleanupExpired,
+      }}
+    >
+      {children}
+    </SessionRecoveryContext.Provider>
+  );
+}
+
+export function useSessionRecovery() {
+  const context = useContext(SessionRecoveryContext);
+  if (!context) {
+    throw new Error("useSessionRecovery must be used within a SessionRecoveryProvider");
+  }
+  return context;
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -236,3 +236,76 @@ export async function createProject(projectData) {
     throw err;
   }
 }
+
+/* ==========================================
+   SESSION RECOVERY API ENDPOINTS (#14203)
+   ========================================== */
+
+export async function saveSessionRecovery(sessionData) {
+  try {
+    return await fetchAPI("/api/session-recovery", {
+      method: "POST",
+      body: JSON.stringify(sessionData)
+    });
+  } catch (err) {
+    console.error("Failed to save session recovery draft:", err);
+    throw err;
+  }
+}
+
+export async function updateSessionRecovery(sessionId, sessionData) {
+  try {
+    return await fetchAPI(`/api/session-recovery/${sessionId}`, {
+      method: "PUT",
+      body: JSON.stringify(sessionData)
+    });
+  } catch (err) {
+    console.error(`Failed to update session recovery draft ${sessionId}:`, err);
+    throw err;
+  }
+}
+
+export async function getSessionRecoveryList() {
+  try {
+    const res = await fetchAPI("/api/session-recovery");
+    return res?.sessions || [];
+  } catch (err) {
+    console.error("Failed to fetch session recovery list:", err);
+    return [];
+  }
+}
+
+export async function restoreSessionRecovery(sessionId) {
+  try {
+    const res = await fetchAPI(`/api/session-recovery/${sessionId}/restore`, {
+      method: "POST"
+    });
+    return res?.session || null;
+  } catch (err) {
+    console.error(`Failed to restore session recovery draft ${sessionId}:`, err);
+    throw err;
+  }
+}
+
+export async function deleteSessionRecovery(sessionId) {
+  try {
+    return await fetchAPI(`/api/session-recovery/${sessionId}`, {
+      method: "DELETE"
+    });
+  } catch (err) {
+    console.error(`Failed to delete session recovery draft ${sessionId}:`, err);
+    throw err;
+  }
+}
+
+export async function cleanupExpiredSessionRecovery() {
+  try {
+    return await fetchAPI("/api/session-recovery/cleanup", {
+      method: "DELETE"
+    });
+  } catch (err) {
+    console.error("Failed to clean up expired session recovery drafts:", err);
+    throw err;
+  }
+}
+


### PR DESCRIPTION
## Description

This PR resolves issue #14203 by integrating the Cloud Session Recovery feature between the Next.js frontend and Spring Boot backend `/api/session-recovery/*` REST endpoints. 

Key changes include:
- **Backend Controller Integration & Tests**: Verified REST contract endpoints (`POST`, `GET`, `PUT`, `POST .../restore`, `DELETE`, `DELETE .../cleanup`) in `SessionRecoveryController.java` with 64KB draft limit validation and user ownership scoping. Added unit and Web layer tests in `SessionRecoveryControllerTest.java`.
- **Frontend API Client**: Added export helper functions in `src/lib/api.js` for session recovery endpoints (`saveSessionRecovery`, `updateSessionRecovery`, `getSessionRecoveryList`, `restoreSessionRecovery`, `deleteSessionRecovery`, `cleanupExpiredSessionRecovery`).
- **Session Recovery Context & Provider**: Created `SessionRecoveryContext.jsx` (`SessionRecoveryProvider` and `useSessionRecovery` hook) to manage session draft synchronization between local storage and cloud backend endpoints when authenticated, with automatic offline fallback.
- **Global Layout Mounting**: Wrapped the application root in `SessionRecoveryProvider` inside `src/app/layout.jsx`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Test additions or fixes
- [ ] CI/CD / Infrastructure

## Related Issue

Closes #14203

## Checklist

Before submitting this PR, please confirm the following:

- [x] I have read and followed the [CONTRIBUTING.md](../../CONTRIBUTING.md) guidelines.
- [x] My changes are scoped to a single purpose (one fix or feature per PR).
- [x] I have run `npm run lint` locally and there are no errors.
- [x] I have run `npm run format:check` locally and there are no formatting issues.
- [x] I have run `npm run build:fast` locally and the application builds successfully.
- [x] I have run `npm test` locally and all tests pass.
- [x] New functionality includes tests where applicable.
- [x] UI changes have been tested in light and dark mode.
- [x] My commit messages follow the conventional commit format.

## Screenshots (if applicable)

N/A (Backend REST API endpoints & frontend session context provider).

## Additional Notes

- All `/api/session-recovery/*` endpoints require JWT authentication (`@PreAuthorize("isAuthenticated()")`).
- Session draft persistence gracefully falls back to `localStorage` when unauthenticated or offline.
