### PR TITLE
Stripe webhook handlers swallow all exceptions → lost payments and inconsistent ledger

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -266,68 +266,63 @@ public class StripeService {
             return;
         }
         
-        try {
-            Long regId = Long.parseLong(registrationId);
-            Integer installmentNumber = installmentNumberStr != null ? Integer.parseInt(installmentNumberStr) : 1;
-            Integer totalInstallments = totalInstallmentsStr != null ? Integer.parseInt(totalInstallmentsStr) : 1;
-            
-            // Find the payment in database
-            Optional<Payment> paymentOptional = paymentRepository.findByStripePaymentIntentId(paymentIntentId);
+        Long regId = Long.parseLong(registrationId);
+        Integer installmentNumber = installmentNumberStr != null ? Integer.parseInt(installmentNumberStr) : 1;
+        Integer totalInstallments = totalInstallmentsStr != null ? Integer.parseInt(totalInstallmentsStr) : 1;
+        
+        // Find the payment in database
+        Optional<Payment> paymentOptional = paymentRepository.findByStripePaymentIntentId(paymentIntentId);
 
-            // Idempotency: skip if this payment intent was already completed
-            if (paymentOptional.isPresent() && "COMPLETED".equals(paymentOptional.get().getStatus())) {
-                return;
-            }
-            
-            Payment payment;
-            if (paymentOptional.isPresent()) {
-                payment = paymentOptional.get();
-            } else {
-                // Create new payment record
-                payment = new Payment();
-                payment.setStripePaymentIntentId(paymentIntentId);
-                payment.setTransactionId(paymentIntent.getLatestChargeObject() != null ?
-                        paymentIntent.getLatestChargeObject().getId() : null);
-                payment.setAmount(new BigDecimal(paymentIntent.getAmount()).divide(new BigDecimal(100)));
-                payment.setCurrency(paymentIntent.getCurrency().toUpperCase());
-                payment.setPaymentMethod(paymentIntent.getPaymentMethod());
-                payment.setPaymentProvider("STRIPE");
-                payment.setInstallmentNumber(installmentNumber);
-                payment.setTotalInstallments(totalInstallments);
+        // Idempotency: skip if this payment intent was already completed
+        if (paymentOptional.isPresent() && "COMPLETED".equals(paymentOptional.get().getStatus())) {
+            return;
+        }
+        
+        Payment payment;
+        if (paymentOptional.isPresent()) {
+            payment = paymentOptional.get();
+        } else {
+            // Create new payment record
+            payment = new Payment();
+            payment.setStripePaymentIntentId(paymentIntentId);
+            payment.setTransactionId(paymentIntent.getLatestChargeObject() != null ?
+                    paymentIntent.getLatestChargeObject().getId() : null);
+            payment.setAmount(new BigDecimal(paymentIntent.getAmount()).divide(new BigDecimal(100)));
+            payment.setCurrency(paymentIntent.getCurrency().toUpperCase());
+            payment.setPaymentMethod(paymentIntent.getPaymentMethod());
+            payment.setPaymentProvider("STRIPE");
+            payment.setInstallmentNumber(installmentNumber);
+            payment.setTotalInstallments(totalInstallments);
 
-                // Load the MANAGED EventRegistration to avoid a detached entity / broken FK
-                EventRegistration registration = eventRegistrationRepository.findById(regId)
-                        .orElseThrow(() -> new IllegalArgumentException(
-                                "EventRegistration not found for id: " + regId));
-                payment.setRegistration(registration);
+            // Load the MANAGED EventRegistration to avoid a detached entity / broken FK
+            EventRegistration registration = eventRegistrationRepository.findById(regId)
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "EventRegistration not found for id: " + regId));
+            payment.setRegistration(registration);
+        }
+        
+        // Update payment status
+        payment.setStatus("COMPLETED");
+        payment.setPaidAt(LocalDateTime.now());
+        paymentRepository.save(payment);
+        
+        // Check if this is the last installment
+        if (installmentNumber.equals(totalInstallments)) {
+            // Mark payment plan as completed
+            Optional<PaymentPlan> paymentPlanOptional = paymentPlanRepository.findByRegistration_Id(regId);
+            if (paymentPlanOptional.isPresent()) {
+                PaymentPlan paymentPlan = paymentPlanOptional.get();
+                paymentPlan.setStatus("COMPLETED");
+                paymentPlan.setCompletedAt(LocalDateTime.now());
+                paymentPlanRepository.save(paymentPlan);
+                
+                // Update registration payment status and persist it within the same transaction
+                EventRegistration registration = paymentPlan.getRegistration();
+                registration.setPaymentStatus("COMPLETED");
+                registration.setQrActivated(true);
+                registration.setQrActivationDate(LocalDateTime.now());
+                eventRegistrationRepository.save(registration);
             }
-            
-            // Update payment status
-            payment.setStatus("COMPLETED");
-            payment.setPaidAt(LocalDateTime.now());
-            paymentRepository.save(payment);
-            
-            // Check if this is the last installment
-            if (installmentNumber.equals(totalInstallments)) {
-                // Mark payment plan as completed
-                Optional<PaymentPlan> paymentPlanOptional = paymentPlanRepository.findByRegistration_Id(regId);
-                if (paymentPlanOptional.isPresent()) {
-                    PaymentPlan paymentPlan = paymentPlanOptional.get();
-                    paymentPlan.setStatus("COMPLETED");
-                    paymentPlan.setCompletedAt(LocalDateTime.now());
-                    paymentPlanRepository.save(paymentPlan);
-                    
-                    // Update registration payment status and persist it within the same transaction
-                    EventRegistration registration = paymentPlan.getRegistration();
-                    registration.setPaymentStatus("COMPLETED");
-                    registration.setQrActivated(true);
-                    registration.setQrActivationDate(LocalDateTime.now());
-                    eventRegistrationRepository.save(registration);
-                }
-            }
-            
-        } catch (Exception e) {
-            System.err.println("Error handling payment intent succeeded: " + e.getMessage());
         }
     }
 
@@ -341,39 +336,34 @@ public class StripeService {
             return;
         }
         
-        try {
-            Long regId = Long.parseLong(registrationId);
-            
-            Optional<Payment> paymentOptional = paymentRepository.findByStripePaymentIntentId(paymentIntentId);
+        Long regId = Long.parseLong(registrationId);
+        
+        Optional<Payment> paymentOptional = paymentRepository.findByStripePaymentIntentId(paymentIntentId);
 
-            // Idempotency: skip if this payment intent was already marked failed
-            if (paymentOptional.isPresent() && "FAILED".equals(paymentOptional.get().getStatus())) {
-                return;
-            }
-            
-            Payment payment;
-            if (paymentOptional.isPresent()) {
-                payment = paymentOptional.get();
-            } else {
-                // Create a failed payment record linked to the MANAGED registration
-                payment = new Payment();
-                payment.setStripePaymentIntentId(paymentIntentId);
-                payment.setPaymentProvider("STRIPE");
-                EventRegistration registration = eventRegistrationRepository.findById(regId)
-                        .orElseThrow(() -> new IllegalArgumentException(
-                                "EventRegistration not found for id: " + regId));
-                payment.setRegistration(registration);
-            }
-            
-            payment.setStatus("FAILED");
-            payment.setFailedAt(LocalDateTime.now());
-            payment.setFailureReason(paymentIntent.getLastPaymentError() != null ? 
-                    paymentIntent.getLastPaymentError().getMessage() : "Payment failed");
-            paymentRepository.save(payment);
-            
-        } catch (Exception e) {
-            System.err.println("Error handling payment intent failed: " + e.getMessage());
+        // Idempotency: skip if this payment intent was already marked failed
+        if (paymentOptional.isPresent() && "FAILED".equals(paymentOptional.get().getStatus())) {
+            return;
         }
+        
+        Payment payment;
+        if (paymentOptional.isPresent()) {
+            payment = paymentOptional.get();
+        } else {
+            // Create a failed payment record linked to the MANAGED registration
+            payment = new Payment();
+            payment.setStripePaymentIntentId(paymentIntentId);
+            payment.setPaymentProvider("STRIPE");
+            EventRegistration registration = eventRegistrationRepository.findById(regId)
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "EventRegistration not found for id: " + regId));
+            payment.setRegistration(registration);
+        }
+        
+        payment.setStatus("FAILED");
+        payment.setFailedAt(LocalDateTime.now());
+        payment.setFailureReason(paymentIntent.getLastPaymentError() != null ? 
+                paymentIntent.getLastPaymentError().getMessage() : "Payment failed");
+        paymentRepository.save(payment);
     }
 
     // Calculate installment schedule

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/StripeWebhookRollbackTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/StripeWebhookRollbackTests.java
@@ -1,0 +1,232 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Payment;
+import com.sandeep.eventrabackend.model.PaymentPlan;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.ratelimit.RedisTokenBucketLimiter;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.PaymentPlanRepository;
+import com.sandeep.eventrabackend.repository.PaymentRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #17830 - Stripe webhook handlers must not swallow exceptions inside a
+ * @Transactional method: a failed downstream write must roll back the whole
+ * transaction and surface as HTTP 500 so Stripe retries, instead of committing
+ * a partial state where the Payment is COMPLETED but the plan/registration were
+ * never updated.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = "stripe.webhook.secret=whsec_test_webhook_secret_for_17830")
+class StripeWebhookRollbackTests {
+
+    private static final String PAYMENT_INTENT_ID = "pi_test_17830";
+    private static final String WEBHOOK_SECRET = "whsec_test_webhook_secret_for_17830";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private PaymentPlanRepository paymentPlanRepository;
+
+    @MockBean
+    private RedisTokenBucketLimiter redisTokenBucketLimiter;
+
+    private Long registrationId;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+        reset(paymentPlanRepository);
+        when(redisTokenBucketLimiter.isAllowed(anyString(), anyInt())).thenReturn(true);
+
+        User attendee = userRepository.save(User.builder()
+                .firstName("Stripe")
+                .lastName("Attendee")
+                .email("stripeattendee@example.com")
+                .username("stripeattendee")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        Event event = new Event();
+        event.setTitle("Stripe Webhook Rollback Test Event");
+        event.setCapacity(50);
+        event.setEventDate(LocalDateTime.now().plusDays(10));
+        event.setOwnerId(attendee.getId());
+        event.setPublic(true);
+        event = eventRepository.save(event);
+
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(event);
+        registration.setUser(attendee);
+        registration.setStatus("CONFIRMED");
+        registration = eventRegistrationRepository.save(registration);
+        registrationId = registration.getId();
+    }
+
+    @Test
+    @DisplayName("Webhook returns 500 and rolls back the Payment when the payment plan write fails")
+    void failedPlanWriteReturns500AndDoesNotCommitPartialPayment() throws Exception {
+        savePendingPayment();
+
+        PaymentPlan plan = new PaymentPlan();
+        plan.setRegistration(loadRegistration());
+        plan.setTotalAmount(new BigDecimal("1000.00"));
+        plan.setCurrency("USD");
+        plan.setTotalInstallments(2);
+        plan.setInstallmentAmount(new BigDecimal("375.00"));
+        plan.setPaymentProvider("STRIPE");
+        plan.setStatus("ACTIVE");
+
+        when(paymentPlanRepository.findByRegistration_Id(registrationId)).thenReturn(Optional.of(plan));
+        when(paymentPlanRepository.save(any(PaymentPlan.class)))
+                .thenThrow(new RuntimeException("simulated database outage"));
+
+        String payload = succeededWebhookPayload(2, 2);
+
+        mockMvc.perform(post("/api/payments/webhook")
+                        .with(user("stripe-webhook"))
+                        .header("Stripe-Signature", signWebhook(payload))
+                        .contentType("application/json")
+                        .content(payload))
+                .andExpect(status().isInternalServerError());
+
+        Payment after = paymentRepository.findByStripePaymentIntentId(PAYMENT_INTENT_ID).orElseThrow();
+        assertNotEquals("COMPLETED", after.getStatus());
+        assertEquals("PENDING", after.getStatus());
+    }
+
+    @Test
+    @DisplayName("Webhook commits the Payment on the success path when the plan write succeeds")
+    void successPathStillCommitsPayment() throws Exception {
+        savePendingPayment();
+
+        PaymentPlan plan = new PaymentPlan();
+        plan.setRegistration(loadRegistration());
+        plan.setTotalAmount(new BigDecimal("1000.00"));
+        plan.setCurrency("USD");
+        plan.setTotalInstallments(2);
+        plan.setInstallmentAmount(new BigDecimal("375.00"));
+        plan.setPaymentProvider("STRIPE");
+        plan.setStatus("ACTIVE");
+
+        when(paymentPlanRepository.findByRegistration_Id(registrationId)).thenReturn(Optional.of(plan));
+        when(paymentPlanRepository.save(any(PaymentPlan.class))).thenReturn(plan);
+
+        String payload = succeededWebhookPayload(2, 2);
+
+        mockMvc.perform(post("/api/payments/webhook")
+                        .with(user("stripe-webhook"))
+                        .header("Stripe-Signature", signWebhook(payload))
+                        .contentType("application/json")
+                        .content(payload))
+                .andExpect(status().isOk());
+
+        Payment after = paymentRepository.findByStripePaymentIntentId(PAYMENT_INTENT_ID).orElseThrow();
+        assertEquals("COMPLETED", after.getStatus());
+    }
+
+    private void savePendingPayment() {
+        Payment payment = new Payment();
+        payment.setRegistration(loadRegistration());
+        payment.setStripePaymentIntentId(PAYMENT_INTENT_ID);
+        payment.setAmount(new BigDecimal("250.00"));
+        payment.setCurrency("USD");
+        payment.setPaymentMethod("CARD");
+        payment.setPaymentProvider("STRIPE");
+        payment.setStatus("PENDING");
+        payment.setInstallmentNumber(2);
+        payment.setTotalInstallments(2);
+        paymentRepository.save(payment);
+    }
+
+    private EventRegistration loadRegistration() {
+        return eventRegistrationRepository.findById(registrationId).orElseThrow();
+    }
+
+    private String succeededWebhookPayload(int installmentNumber, int totalInstallments) {
+        return "{\n"
+                + "  \"id\": \"evt_test_17830\",\n"
+                + "  \"object\": \"event\",\n"
+                + "  \"type\": \"payment_intent.succeeded\",\n"
+                + "  \"data\": {\n"
+                + "    \"object\": {\n"
+                + "      \"id\": \"" + PAYMENT_INTENT_ID + "\",\n"
+                + "      \"object\": \"payment_intent\",\n"
+                + "      \"amount\": 25000,\n"
+                + "      \"currency\": \"usd\",\n"
+                + "      \"metadata\": {\n"
+                + "        \"registration_id\": \"" + registrationId + "\",\n"
+                + "        \"installment_number\": \"" + installmentNumber + "\",\n"
+                + "        \"total_installments\": \"" + totalInstallments + "\"\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+    }
+
+    private String signWebhook(String payload) throws Exception {
+        long timestamp = Instant.now().getEpochSecond();
+        String signedPayload = timestamp + "." + payload;
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(WEBHOOK_SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        String signature = HexFormat.of().formatHex(mac.doFinal(signedPayload.getBytes(StandardCharsets.UTF_8)));
+        return "t=" + timestamp + ",v1=" + signature;
+    }
+}


### PR DESCRIPTION
## Problem

`StripeService.handlePaymentIntentSucceeded(...)` and `handlePaymentIntentFailed(...)` wrapped their entire body in a blanket `try/catch (Exception e)` that only printed to stderr. Because both methods are `@Transactional`, Spring observed a normal return and **committed whatever was already persisted** (e.g. `paymentRepository.save(payment)`) while later writes (`paymentPlanRepository.save`, `eventRegistrationRepository.save`) may have thrown — leaving a `Payment` marked `COMPLETED` while the plan/registration were never updated. Stripe treats the resulting `200` as successful delivery and **stops retrying**, so a transient DB outage during a webhook permanently desynchronizes the ledger.

## Fix

Removed both `try/catch` blocks entirely (StripeService.java). Runtime exceptions (DB write failures, `Long.parseLong`, etc.) now propagate out of the `@Transactional` handler, so Spring rolls back the whole transaction and `PaymentController.handleStripeWebhook` returns HTTP 500 — which makes Stripe retry until the ledger is consistent. No other logic was changed; method signatures are unchanged (the bodies only throw unchecked exceptions).

## Files changed

- `Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java` — dropped the blanket `try/catch` in `handlePaymentIntentSucceeded` and `handlePaymentIntentFailed`; body de-indented, no behavior change otherwise.
- `Backend/src/test/java/com/sandeep/eventrabackend/controller/StripeWebhookRollbackTests.java` — new `@SpringBootTest` regression test that POSTs a signed Stripe `payment_intent.succeeded` webhook to `/api/payments/webhook`:
  - Forces `paymentPlanRepository.save(...)` to throw (mocked) and asserts HTTP 500 and that the `Payment` stays `PENDING` (not `COMPLETED`) — this test fails on the old swallowed-exception code.
  - Success path asserts HTTP 200 and the `Payment` becomes `COMPLETED`.
  - Signs the webhook exactly as Stripe does (`HMAC-SHA256(secret, "<timestamp>.<payload>")`, `Stripe-Signature: t=<ts>,v1=<hex>`), mocks the Redis token-bucket rate limiter, and authenticates the request as the webhook caller.

## Testing

Run (requires JDK 17):

```
cd Backend
mvnw.cmd -Dmaven.compiler.proc=full test -Dtest=StripeWebhookRollbackTests
```

Result: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0` — BUILD SUCCESS.

**Important — local test environment caveats.** The repo's master branch currently has several pre-existing, unrelated build blockers that must be worked around to run *any* `@SpringBootTest` locally:

- `maven-compiler-plugin` 3.13.0 defaults annotation processing to off, so Lombok-generated methods are missing unless `-Dmaven.compiler.proc=full` is passed (noted above).
- Master does not compile cleanly: `User.java` has two `getName()` methods; `MultiTenantConnectionProvider.java` declares `MultiTenantConnectionProviderImpl` (file/class name mismatch, dead code); `CacheConfig.java` instantiates the abstract `io.micrometer...CacheMeterBinder` and references `CacheMeterBinderProvider`, which does not exist in micrometer-core 1.14.5; `ContactService.java` has an unreachable statement (email check nested inside the name-check `if`); `CouponService.java` captures a non-final `code` in a lambda.
- Runtime, the context cannot start: `zk.ZkRangeVerifierService`/`zkp.ZkRangeVerifierService` and `zk.ZkVerificationController`/`zkp.ZkVerificationController` register colliding default bean names.
- `AttachmentUploadControllerTests.java` references `MediaType.IMAGE_SVG_XML_VALUE`/`IMAGE_WEBP_VALUE`, removed in Spring 6.2.

To validate the change, temporary **local-only** patches (reverted after testing, not part of this PR) neutralized the above so the new test could run. The test itself also `@MockBean`s `RedisTokenBucketLimiter` so it runs without a Redis instance; the production `redisMessageListenerContainer` bean in `CacheConfig` only activates when `spring.cache.type=redis`.

Closes #17830
