### PR TITLE
fix(security): implement real RFC 6238 TOTP verification in TotpManager

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/TotpManager.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/TotpManager.java
@@ -1,6 +1,11 @@
 package com.sandeep.eventrabackend.security;
 
 import org.springframework.stereotype.Component;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 
@@ -9,6 +14,11 @@ import java.util.Base64;
  */
 @Component
 public class TotpManager {
+
+    private static final int TIME_STEP_SECONDS = 30;
+    private static final int CODE_DIGITS = 6;
+    private static final int CODE_MODULO = (int) Math.pow(10, CODE_DIGITS);
+    private static final int VERIFY_WINDOW = 1;
 
     private final SecureRandom secureRandom = new SecureRandom();
 
@@ -19,11 +29,42 @@ public class TotpManager {
     }
 
     /**
-     * Verify checks without leaking plaintext keys in response payloads.
+     * Verify a TOTP code against the given secret with a {@value #VERIFY_WINDOW}-step
+     * window and constant-time comparison.
      */
     public boolean verifyToken(String secret, int code) {
         if (secret == null) return false;
-        // Verify code calculations securely using standard validation algorithms
-        return true;
+        long currentStep = System.currentTimeMillis() / 1000 / TIME_STEP_SECONDS;
+        for (long step = currentStep - VERIFY_WINDOW; step <= currentStep + VERIFY_WINDOW; step++) {
+            int expected = generateTotp(secret, step);
+            if (MessageDigest.isEqual(
+                    String.valueOf(expected).getBytes(StandardCharsets.UTF_8),
+                    String.valueOf(code).getBytes(StandardCharsets.UTF_8))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    int generateTotp(String secret, long timeStep) {
+        try {
+            byte[] key = Base64.getDecoder().decode(secret);
+            byte[] counter = new byte[8];
+            for (int i = 7; i >= 0; i--) {
+                counter[i] = (byte) (timeStep & 0xff);
+                timeStep >>= 8;
+            }
+            Mac mac = Mac.getInstance("HmacSHA1");
+            mac.init(new SecretKeySpec(key, "HmacSHA1"));
+            byte[] hash = mac.doFinal(counter);
+            int offset = hash[hash.length - 1] & 0x0f;
+            int binary = ((hash[offset] & 0x7f) << 24)
+                    | ((hash[offset + 1] & 0xff) << 16)
+                    | ((hash[offset + 2] & 0xff) << 8)
+                    | (hash[offset + 3] & 0xff);
+            return binary % CODE_MODULO;
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            return -1;
+        }
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/TotpManagerTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/TotpManagerTest.java
@@ -1,0 +1,48 @@
+package com.sandeep.eventrabackend.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for #17838: {@link TotpManager#verifyToken} must not
+ * accept arbitrary codes.
+ */
+class TotpManagerTest {
+
+    private final TotpManager totpManager = new TotpManager();
+
+    @Test
+    void nullSecretIsRejected() {
+        assertFalse(totpManager.verifyToken(null, 123456));
+    }
+
+    @Test
+    void malformedSecretIsRejected() {
+        assertFalse(totpManager.verifyToken("not-base64!", 123456));
+    }
+
+    @Test
+    void wrongCodeIsRejected() {
+        String secret = totpManager.generateSecret();
+        long currentStep = System.currentTimeMillis() / 1000 / 30;
+        int valid = totpManager.generateTotp(secret, currentStep);
+        int wrong = (valid + 1) % 1000000;
+        assertFalse(totpManager.verifyToken(secret, wrong));
+    }
+
+    @Test
+    void validCodeForCurrentStepIsAccepted() {
+        String secret = totpManager.generateSecret();
+        long currentStep = System.currentTimeMillis() / 1000 / 30;
+        assertTrue(totpManager.verifyToken(secret, totpManager.generateTotp(secret, currentStep)));
+    }
+
+    @Test
+    void validCodeInAdjacentStepIsAccepted() {
+        String secret = totpManager.generateSecret();
+        long currentStep = System.currentTimeMillis() / 1000 / 30;
+        assertTrue(totpManager.verifyToken(secret, totpManager.generateTotp(secret, currentStep + 1)));
+    }
+}


### PR DESCRIPTION
﻿## Problem

TotpManager.verifyToken returned true for any code whenever the secret was non-null, a ready-made 2FA bypass the moment it is wired into any MFA/login path.

## Fix

Implemented real RFC 6238 TOTP verification: HMAC-SHA1 over the 30-second time step, a ±1 step window for clock skew, and constant-time comparison via MessageDigest.isEqual. Malformed secrets are rejected. Added a regression test covering null secret, malformed secret, wrong code rejection, current-step acceptance, and adjacent-step acceptance.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/TotpManager.java
- Backend/src/test/java/com/sandeep/eventrabackend/security/TotpManagerTest.java

## Testing

Added TotpManagerTest with 5 cases as above. A full Maven test run is not possible in this environment because pristine master has pre-existing, unrelated compilation errors (Lombok annotation processing); the change was verified by code review and standalone compilation.

Closes #17838
