### PR TITLE
PushSubscriptionService validates endpoint only at subscribe time - DNS-rebinding SSRF at dispatch

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/WebPushNotificationService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/WebPushNotificationService.java
@@ -1,22 +1,40 @@
 package com.sandeep.eventrabackend.service;
 
 import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Locale;
 
 @Service
 public class WebPushNotificationService {
 
+    private static final int MAX_ENDPOINT_LENGTH = 2048;
+
     private final HttpClient httpClient;
 
     public WebPushNotificationService() {
-        this.httpClient = HttpClient.newHttpClient();
+        // Never follow redirects: a 3xx pointing at an internal address must not
+        // be followed by the sender (#18841).
+        this(HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build());
+    }
+
+    WebPushNotificationService(HttpClient httpClient) {
+        this.httpClient = httpClient;
     }
 
     public boolean sendPushNotification(PushSubscriptionDto subscription, String payload) {
         try {
+            validateEndpointForDispatch(subscription.getEndpoint());
+
             HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(subscription.getEndpoint()))
                 .header("Content-Type", "application/octet-stream")
@@ -32,5 +50,167 @@ public class WebPushNotificationService {
             System.err.println("WebPush dispatch notification failed: " + e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Dispatch-time SSRF guard (#18841). Subscription-time validation only checks
+     * the endpoint string, but the sender re-resolves the stored hostname when it
+     * actually sends the push. A DNS-rebinding change after subscription could
+     * therefore point a previously public host at a loopback/private/link-local
+     * (cloud metadata) address. Re-validate the endpoint at dispatch time and
+     * reject it unless every resolved address is public.
+     */
+    void validateEndpointForDispatch(String endpoint) throws URISyntaxException, UnknownHostException {
+        String host = parseEndpoint(endpoint);
+        rejectNonPublicHost(host);
+        rejectNonPublicResolvedAddresses(InetAddress.getAllByName(host));
+    }
+
+    private String parseEndpoint(String endpoint) {
+        if (endpoint == null || endpoint.isBlank()) {
+            throw new IllegalArgumentException("Push subscription endpoint is required");
+        }
+        if (endpoint.length() > MAX_ENDPOINT_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Push subscription endpoint exceeds " + MAX_ENDPOINT_LENGTH + " characters");
+        }
+
+        URI uri;
+        try {
+            uri = new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Push subscription endpoint is not a valid URL");
+        }
+        if (!"https".equalsIgnoreCase(uri.getScheme())) {
+            throw new IllegalArgumentException("Push subscription endpoint must use the https scheme");
+        }
+        if (uri.getUserInfo() != null) {
+            throw new IllegalArgumentException("Push subscription endpoint must not contain user information");
+        }
+        int port = uri.getPort();
+        if (port != -1 && port != 443) {
+            throw new IllegalArgumentException("Push subscription endpoint must use the default https port (443)");
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("Push subscription endpoint must include a host");
+        }
+        return host;
+    }
+
+    /**
+     * Mirrors the subscription-time string checks so a hostname that is obviously
+     * internal (localhost, bare hostnames, reserved suffixes, private IP literals)
+     * is rejected even before DNS is consulted.
+     */
+    private void rejectNonPublicHost(String host) {
+        String h = host.toLowerCase(Locale.ROOT);
+        if ("localhost".equals(h) || h.endsWith(".localhost")) {
+            throw new IllegalArgumentException("Push subscription endpoint must not point at localhost");
+        }
+        if (h.endsWith(".local") || h.endsWith(".internal")
+                || h.endsWith(".home") || h.endsWith(".lan") || h.endsWith(".localdomain")) {
+            throw new IllegalArgumentException("Push subscription endpoint must use a public hostname");
+        }
+        if (!h.contains(".")) {
+            throw new IllegalArgumentException("Push subscription endpoint must use a public hostname");
+        }
+        if (isIpv4Literal(h) && isNonPublicIpv4(h)) {
+            throw new IllegalArgumentException("Push subscription endpoint must not point at a private IP address");
+        }
+    }
+
+    /**
+     * Rejects a resolved endpoint host that lands on loopback, link-local (which
+     * covers 169.254.x.x cloud metadata), site-local, multicast, any-local or
+     * CGNAT space — the actual DNS-rebinding defence at the moment of sending.
+     */
+    static void rejectNonPublicResolvedAddresses(InetAddress[] addresses) {
+        for (InetAddress address : addresses) {
+            if (!isPublicAddress(address)) {
+                throw new IllegalArgumentException(
+                        "Push subscription endpoint resolves to a non-public address: " + address.getHostAddress());
+            }
+        }
+    }
+
+    private static boolean isPublicAddress(InetAddress address) {
+        if (address.isAnyLocalAddress() || address.isLoopbackAddress()
+                || address.isLinkLocalAddress() || address.isSiteLocalAddress()
+                || address.isMulticastAddress()) {
+            return false;
+        }
+        byte[] bytes = address.getAddress();
+        int a;
+        int b;
+        if (address instanceof Inet6Address && isIpv4Mapped(bytes)) {
+            a = bytes[12] & 0xff;
+            b = bytes[13] & 0xff;
+        } else if (address instanceof Inet4Address) {
+            a = bytes[0] & 0xff;
+            b = bytes[1] & 0xff;
+        } else {
+            return true;
+        }
+        // 100.64.0.0/10 CGNAT space is not flagged by InetAddress's built-ins.
+        return !(a == 100 && b >= 64 && b <= 127);
+    }
+
+    private static boolean isIpv4Mapped(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return bytes[10] == (byte) 0xff && bytes[11] == (byte) 0xff;
+    }
+
+    private boolean isIpv4Literal(String host) {
+        if (host.startsWith(".") || host.endsWith(".")) {
+            return false;
+        }
+        String[] parts = host.split("\\.");
+        if (parts.length != 4) {
+            return false;
+        }
+        for (String part : parts) {
+            if (part.isEmpty() || part.length() > 3) {
+                return false;
+            }
+            for (int i = 0; i < part.length(); i++) {
+                if (!Character.isDigit(part.charAt(i))) {
+                    return false;
+                }
+            }
+            int value = Integer.parseInt(part);
+            if (value > 255) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isNonPublicIpv4(String host) {
+        int[] octets = new int[4];
+        String[] parts = host.split("\\.");
+        for (int i = 0; i < 4; i++) {
+            octets[i] = Integer.parseInt(parts[i]);
+        }
+        int a = octets[0], b = octets[1], c = octets[2], d = octets[3];
+        if (a == 100 && b >= 64 && b <= 127) return true;           // 100.64.0.0/10 CGNAT
+        if (a == 192 && b == 0 && c == 2) return true;               // 192.0.2.0/24 TEST-NET-1
+        if (a == 198 && b == 51 && c == 100) return true;            // 198.51.100.0/24 TEST-NET-2
+        if (a == 203 && b == 0 && c == 113) return true;             // 203.0.113.0/24 TEST-NET-3
+        if (a == 0 || a == 10) return true;                       // 0.0.0.0/8, 10.0.0.0/8
+        if (a == 127) return true;                                 // 127.0.0.0/8 loopback
+        if (a == 169 && b == 254) return true;                     // 169.254.0.0/16 incl. metadata
+        if (a == 172 && b >= 16 && b <= 31) return true;           // 172.16.0.0/12
+        if (a == 192 && b == 168) return true;                     // 192.168.0.0/16
+        if (a == 192 && b == 0 && c == 0) return true;             // 192.0.0.0/24 incl. 192.0.0.9/10
+        if (a == 198 && (b == 18 || b == 19)) return true;         // 198.18.0.0/15 benchmark
+        if (a >= 224) return true;                                 // multicast + reserved
+        if (a == 255) return true;                                 // broadcast
+        return d == 0 && c == 0 && b == 0;                         // x.x.x.0 reserved only if a was public
     }
 }

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/WebPushNotificationServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/WebPushNotificationServiceTest.java
@@ -1,0 +1,90 @@
+package com.sandeep.eventrabackend.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Dispatch-time SSRF guard tests (#18841). Subscription-time validation checks
+ * the endpoint string only; the sender re-resolves the stored hostname later, so
+ * a DNS-rebinding change after subscription must be rejected at dispatch time.
+ */
+class WebPushNotificationServiceTest {
+
+    private final WebPushNotificationService service = new WebPushNotificationService();
+
+    @Test
+    @DisplayName("dispatch rejects an endpoint that resolved to the cloud metadata address (DNS rebinding)")
+    void metadataIpIsRejectedAtDispatch() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.validateEndpointForDispatch("https://169.254.169.254/latest/meta-data/"));
+    }
+
+    @Test
+    @DisplayName("dispatch rejects a loopback endpoint")
+    void loopbackIsRejectedAtDispatch() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.validateEndpointForDispatch("https://127.0.0.1/admin"));
+    }
+
+    @Test
+    @DisplayName("dispatch rejects a localhost hostname even though subscribe accepted the string")
+    void localhostHostnameIsRejectedAtDispatch() throws Exception {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.validateEndpointForDispatch("https://localhost/push"));
+    }
+
+    @Test
+    @DisplayName("dispatch rejects a non-https endpoint")
+    void httpEndpointIsRejectedAtDispatch() {
+        assertThrows(IllegalArgumentException.class,
+                () -> service.validateEndpointForDispatch("http://push.example.com/endpoint"));
+    }
+
+    @Test
+    @DisplayName("a host rebound to a link-local address is rejected at dispatch (#18841)")
+    void resolvedLinkLocalAddressIsRejected() throws UnknownHostException {
+        InetAddress[] rebound = {InetAddress.getByName("169.254.169.254")};
+        assertThrows(IllegalArgumentException.class,
+                () -> WebPushNotificationService.rejectNonPublicResolvedAddresses(rebound));
+    }
+
+    @Test
+    @DisplayName("a host rebound to CGNAT space is rejected at dispatch (#18841)")
+    void resolvedCgnatAddressIsRejected() throws UnknownHostException {
+        InetAddress[] rebound = {InetAddress.getByName("100.64.0.1")};
+        assertThrows(IllegalArgumentException.class,
+                () -> WebPushNotificationService.rejectNonPublicResolvedAddresses(rebound));
+    }
+
+    @Test
+    @DisplayName("a host rebounding to one private address among public ones is rejected (#18841)")
+    void anyPrivateAddressRejectsTheWholeHost() throws UnknownHostException {
+        InetAddress[] rebound = {InetAddress.getByName("8.8.8.8"), InetAddress.getByName("192.168.1.5")};
+        assertThrows(IllegalArgumentException.class,
+                () -> WebPushNotificationService.rejectNonPublicResolvedAddresses(rebound));
+    }
+
+    @Test
+    @DisplayName("a host resolving only to public addresses passes the dispatch check")
+    void publicResolvedAddressIsAccepted() throws UnknownHostException {
+        InetAddress[] addresses = {InetAddress.getByName("8.8.8.8")};
+        assertDoesNotThrow(() -> WebPushNotificationService.rejectNonPublicResolvedAddresses(addresses));
+    }
+
+    @Test
+    @DisplayName("sendPushNotification returns false for a private endpoint without touching the network")
+    void sendRejectsPrivateEndpoint() throws URISyntaxException, UnknownHostException {
+        PushSubscriptionDto subscription = new PushSubscriptionDto();
+        subscription.setEndpoint("https://192.168.1.5/admin");
+
+        assertFalse(service.sendPushNotification(subscription, "payload"));
+    }
+}


### PR DESCRIPTION
Closes #18841

## Problem
\PushSubscriptionService\ validates the push endpoint only at subscription time. The dispatch path (\WebPushNotificationService.sendPushNotification\) later re-resolves the stored hostname via DNS when sending, so a DNS-rebinding change after subscription can turn a previously-public endpoint (e.g. \https://benign.example.com\) into an internal/metadata target (\169.254.169.254\, loopback, private ranges) → SSRF at send time.

## Fix
\WebPushNotificationService\ now re-validates the endpoint at dispatch time, immediately before the HTTP send:
- https-only, default port, no userinfo (mirrors subscribe-time string checks: localhost, bare hostnames, reserved suffixes, private IPv4 literals).
- **DNS-rebinding defence**: the host is resolved with \InetAddress.getAllByName\ and rejected unless **every** resolved address is public — loopback, link-local (covers \169.254.0.0/16\ cloud metadata), site-local, any-local, multicast, IPv4-mapped private ranges and \100.64.0.0/10\ CGNAT all cause rejection.
- The sender's \HttpClient\ now explicitly never follows redirects.
- \sendPushNotification\ keeps its fail-safe behavior: a rejected endpoint logs and returns \alse\ without touching the network.

New tests (\WebPushNotificationServiceTest\): metadata/link-local rebound address rejected, CGNAT rejected, one private address among public ones rejects the whole host, public-only addresses accepted, and \sendPushNotification\ returns \alse\ for a private endpoint without network I/O.