### PR TITLE
fix(contact): reject null request body with 400 before service layer (#18929)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ContactController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ContactController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+
 @RestController
 @RequestMapping("/api/contact")
 @RequiredArgsConstructor
@@ -40,7 +42,16 @@ public class ContactController {
             @ApiResponse(responseCode = "429", description = "Too many requests",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ContactResponse> submitContactMessage(@Valid @RequestBody ContactRequest request) {
+    public ResponseEntity<?> submitContactMessage(@Valid @RequestBody(required = false) ContactRequest request) {
+        if (request == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    ErrorResponse.builder()
+                            .status(HttpStatus.BAD_REQUEST.value())
+                            .error("Bad Request")
+                            .message("Request body is required")
+                            .timestamp(LocalDateTime.now())
+                            .build());
+        }
         ContactResponse response = contactService.submitContactMessage(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh.

Fixes #18929. Null request body in the contact endpoint causes an NPE in the service layer. ContactController bound the body with @Valid @RequestBody (required=true), relying on Spring to reject a missing body; a null/empty body could still reach contactService.submitContactMessage where field access threw NPE.

Fix: bind with @RequestBody(required=false) and add an explicit controller-level null check returning 400 ErrorResponse before the service is called. Scope: ContactController.java only; returns ResponseEntity<?> to allow the ErrorResponse body on the 400 path.