### PR TITLE
fix(project): reject null create payload with 400 before service layer (#18927)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -20,6 +20,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -81,11 +82,20 @@ public class ProjectController {
                     )
             )
     })
-    public ResponseEntity<ProjectResponse> createProject(
-            @Valid @RequestBody ProjectCreateRequest request,
+    public ResponseEntity<?> createProject(
+            @Valid @RequestBody(required = false) ProjectCreateRequest request,
             Authentication authentication) {
         if (authentication == null || !authentication.isAuthenticated()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if (request == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                    ErrorResponse.builder()
+                            .status(HttpStatus.BAD_REQUEST.value())
+                            .error("Bad Request")
+                            .message("Request body is required")
+                            .timestamp(LocalDateTime.now())
+                            .build());
         }
         String userEmail = authentication.getName();
         return ResponseEntity.status(HttpStatus.CREATED).body(projectService.createProject(request, userEmail));


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh.

Fixes #18927. The project creation endpoint verified auth but not that the ProjectCreateRequest body existed before passing it to projectService.createProject(). A missing/empty body could yield a null request that NPEs when its fields are accessed.

Fix: bind with @RequestBody(required=false) and add an explicit null check returning 400 ErrorResponse after the auth check. Scope: ProjectController.java only; returns ResponseEntity<?> to allow the ErrorResponse body on the 400 path.