### PR TITLE
fix(qr): validate registrationId before DB lookup (#18998)

### DIFF
--- a/Backend/src/main/java/com/eventra/service/QrCodeValidationService.java
+++ b/Backend/src/main/java/com/eventra/service/QrCodeValidationService.java
@@ -22,7 +22,8 @@ public class QrCodeValidationService {
         INVALID_EVENT,
         INELIGIBLE,
         PAYMENT_PENDING,
-        PAYMENT_INCOMPLETE
+        PAYMENT_INCOMPLETE,
+        INVALID_REQUEST
     }
 
     public QrValidationResult validateQrCode(String ticketId, String eventId, String registrationStatus, String eventStatus, Instant qrExpirationTime) {
@@ -59,6 +60,10 @@ public class QrCodeValidationService {
     }
 
     public QrValidationResult validateQrCodeWithRegistrationId(Long registrationId, String registrationStatus, String eventStatus, Instant qrExpirationTime) {
+        if (registrationId == null || registrationId <= 0) {
+            return new QrValidationResult(false, QrValidationStatus.INVALID_REQUEST, "❌ Invalid registration ID.");
+        }
+
         if (qrExpirationTime != null && Instant.now().isAfter(qrExpirationTime)) {
             return new QrValidationResult(false, QrValidationStatus.EXPIRED, "❌ Registration QR code has expired.");
         }


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh.

Fixes #18998. validateQrCodeWithRegistrationId queried paymentPlanRepository.findByRegistration_Id(registrationId) without first checking that registrationId is non-null or positive; a null or non-positive id was forwarded to the repository lookup.

Fix: add a guard at the top of validateQrCodeWithRegistrationId returning INVALID_REQUEST for null or <=0 ids before any DB access, and expose a new INVALID_REQUEST status on QrValidationStatus (the enum is referenced only within this service, so adding the value is safe — no exhaustive switches elsewhere).