### PR TITLE
fix(pdf): close Document in finally to avoid resource leak on exception (#18996)

### DIFF
--- a/Backend/src/main/java/com/eventra/service/PdfTicketGeneratorService.java
+++ b/Backend/src/main/java/com/eventra/service/PdfTicketGeneratorService.java
@@ -23,21 +23,22 @@ public class PdfTicketGeneratorService {
             Document document = new Document();
             PdfWriter.getInstance(document, baos);
             document.open();
+            try {
+                document.add(new Paragraph("Eventra - Official Ticket"));
+                document.add(new Paragraph("Event: " + eventName));
+                document.add(new Paragraph("Attendee: " + attendeeName));
+                document.add(new Paragraph("Ticket ID: " + ticketId));
 
-            document.add(new Paragraph("Eventra - Official Ticket"));
-            document.add(new Paragraph("Event: " + eventName));
-            document.add(new Paragraph("Attendee: " + attendeeName));
-            document.add(new Paragraph("Ticket ID: " + ticketId));
+                QRCodeWriter qrCodeWriter = new QRCodeWriter();
+                BitMatrix bitMatrix = qrCodeWriter.encode(ticketId, BarcodeFormat.QR_CODE, 200, 200);
+                ByteArrayOutputStream qrBaos = new ByteArrayOutputStream();
+                MatrixToImageWriter.writeToStream(bitMatrix, "PNG", qrBaos);
 
-            QRCodeWriter qrCodeWriter = new QRCodeWriter();
-            BitMatrix bitMatrix = qrCodeWriter.encode(ticketId, BarcodeFormat.QR_CODE, 200, 200);
-            ByteArrayOutputStream qrBaos = new ByteArrayOutputStream();
-            MatrixToImageWriter.writeToStream(bitMatrix, "PNG", qrBaos);
-
-            Image qrImage = Image.getInstance(qrBaos.toByteArray());
-            document.add(qrImage);
-
-            document.close();
+                Image qrImage = Image.getInstance(qrBaos.toByteArray());
+                document.add(qrImage);
+            } finally {
+                document.close();
+            }
             return CompletableFuture.completedFuture(baos.toByteArray());
         } catch (Exception e) {
             CompletableFuture<byte[]> failedFuture = new CompletableFuture<>();


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh.

Fixes #18996. generateTicketPdfAsync opened the iText Document and only closed it on the happy path; if any step between open() and close() threw (QR encode, Image.getInstance, document.add), the document was never closed, leaking resources.

Fix: wrap the document body in try/finally so document.close() always runs, and read baos.toByteArray() after close so the returned PDF is complete. Scope: PdfTicketGeneratorService.generateTicketPdfAsync only.