### PR TITLE
fix(security): reject path traversal in attachment extension validation (#18934)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/AttachmentUploadController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/AttachmentUploadController.java
@@ -89,10 +89,18 @@ public class AttachmentUploadController {
      * Checks both the original filename and the content type for consistency.
      */
     private boolean hasAllowedExtension(String filename) {
-        if (filename == null) {
+        if (filename == null || filename.isBlank()) {
             return false;
         }
         String lowerFilename = filename.toLowerCase();
+        // Reject path traversal: do not allow directory separators or parent-directory
+        // sequences, which could otherwise bypass the extension check and create
+        // inconsistencies between validation and later filesystem handling.
+        if (lowerFilename.indexOf('/') != -1
+                || lowerFilename.indexOf('\\') != -1
+                || lowerFilename.contains("..")) {
+            return false;
+        }
         return ALLOWED_EXTENSIONS.stream().anyMatch(lowerFilename::endsWith);
     }
 }


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh.

Fixes #18934. hasAllowedExtension only checked filename.endsWith(allowedExt) without normalizing the filename, so crafted filenames containing path separators or parent-directory sequences (e.g. ../, backslash, ..) could bypass the extension check and create inconsistencies between validation and later filesystem handling.

Fix: reject filenames containing '/', '\', or '..' (and blank names) before the extension check. Scope: AttachmentUploadController.hasAllowedExtension only; valid filenames are unaffected.