### PR TITLE
fix(email): validate recipient address before sending transactional email (#18992)

### DIFF
--- a/Backend/src/main/java/com/eventra/service/EmailService.java
+++ b/Backend/src/main/java/com/eventra/service/EmailService.java
@@ -10,11 +10,15 @@ import org.thymeleaf.context.Context;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 @Service
 public class EmailService {
 
     private static final Logger logger = Logger.getLogger(EmailService.class.getName());
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
 
     @Autowired
     private JavaMailSender mailSender;
@@ -23,6 +27,9 @@ public class EmailService {
     private TemplateEngine templateEngine;
 
     public void sendTransactionalEmail(String to, String subject, String title, String recipientName, String messageBody, String actionUrl, String actionText) throws MessagingException {
+        if (to == null || to.isBlank() || !EMAIL_PATTERN.matcher(to).matches()) {
+            throw new IllegalArgumentException("Invalid recipient email address: " + to);
+        }
         Context context = new Context();
         context.setVariable("subject", subject);
         context.setVariable("title", title);


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh.

Fixes #18992. sendTransactionalEmail passed the 'to' argument straight to MimeMessageHelper.setTo without validating it; malformed strings or values containing CR/LF could cause header injection, and null/blank values caused failures deeper in the mail stack.

Fix: validate the recipient against an email pattern (which also rejects CR/LF and other control characters) and throw IllegalArgumentException for invalid input before any mail object is built. Scope: EmailService.sendTransactionalEmail only.