### PR TITLE
fix(security): exclude password from User toString/equals/hashCode

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import com.sandeep.eventrabackend.config.JsonMapAttributeConverter;
@@ -49,6 +51,8 @@ public class User {
     private String username;
 
     @Column(nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private String password;
 
     @Column(name = "profile_headline", length = 160)


### PR DESCRIPTION
## Summary

Fixes the credential-leak vector reported in #16515.

The `User` entity is annotated with Lombok `@Data`, which generates `toString()`, `equals()`, and `hashCode()` over **all** fields, including the `password` column (which stores the password hash). Any code path that logged a `User`, included one in an exception message, serialized one to a response, or used it in a hash-based structure would silently expose the credential hash.

## Changes

`Backend/src/main/java/com/sandeep/eventrabackend/model/User.java`
- Added `@ToString.Exclude` on `password` so `toString()` never includes the hash.
- Added `@EqualsAndHashCode.Exclude` on `password` so `equals()`/`hashCode()` never read the hash (and two users can't collide solely on a shared hash).
- Added the corresponding `lombok.ToString` / `lombok.EqualsAndHashCode` imports.

No other fields hold secrets (`passwordChangedAt` is a timestamp), so only `password` needs exclusion.

## Why this is the minimal, safe fix

`@Data` is convenient for the rest of the entity, and removing it would require hand-writing getters/setters for ~15 fields. Lombok provides `@ToString.Exclude` / `@EqualsAndHashCode.Exclude` precisely for this case — they surgically remove a single field from the generated methods without touching anything else. This mirrors the standard Lombok guidance for credential/secret fields.

## Verification

- The backend does not compile cleanly in a fresh environment regardless of this change (pre-existing issues on `master`: a duplicate `getName()` in this same file, an abstract `CacheMeterBinder` in `CacheConfig`, a public-class filename mismatch in `MultiTenantConnectionProvider`, and several `cannot find symbol` errors under JDK 21's Lombok processing). These are unrelated to this PR.
- I confirmed the change introduces **zero new** compile errors: a clean `mvn clean compile` produces a byte-for-byte identical error set to `master` (same 399 error lines / same 7 files), with only the line number of the pre-existing `getName() already defined` error shifting by the 4 lines this PR adds.
- `@ToString.Exclude` / `@EqualsAndHashCode.Exclude` are valid Lombok annotations available in the Lombok version pulled in by Spring Boot 3.4.4.

Closes #16515.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
