### PR TITLE
fix(security): enforce event-role authorization on saveTemplate/getTemplate

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -257,6 +257,19 @@ public class NotificationController {
             @Valid @RequestBody SaveTemplateRequest request,
             Authentication authentication) {
         String organizerEmail = authentication.getName();
+
+        long eventId;
+        try {
+            eventId = Long.parseLong(request.getEventId());
+        } catch (NumberFormatException ex) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        // The caller must be an organizer of the specific event (or a platform
+        // admin / legacy owner). Platform authentication alone must not grant
+        // the ability to save templates for arbitrary events (#17849).
+        eventRoleService.requireRole(eventId, organizerEmail, EventRole.ORGANIZER);
+
         return ResponseEntity.ok(emailTemplateService.saveTemplate(request, organizerEmail));
     }
 
@@ -289,6 +302,19 @@ public class NotificationController {
             @PathVariable String templateType,
             Authentication authentication) {
         String organizerEmail = authentication.getName();
+
+        long parsedEventId;
+        try {
+            parsedEventId = Long.parseLong(eventId);
+        } catch (NumberFormatException ex) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        // The caller must be an organizer of the specific event (or a platform
+        // admin / legacy owner). Platform authentication alone must not grant
+        // the ability to read templates for arbitrary events (#17849).
+        eventRoleService.requireRole(parsedEventId, organizerEmail, EventRole.ORGANIZER);
+
         return ResponseEntity.ok(emailTemplateService.getTemplate(String.valueOf(eventId), templateType, organizerEmail));
     }
 }


### PR DESCRIPTION
## Summary

Fixes the broken-access-control (IDOR) issue reported in #17849.

`NotificationController.saveTemplate` and `getTemplate` were protected only by the class-level `@PreAuthorize("isAuthenticated()")` and then passed the caller's email straight to the service:

```java
String organizerEmail = authentication.getName();
return ResponseEntity.ok(emailTemplateService.saveTemplate(request, organizerEmail));
```

The service keys templates by `(eventId, templateType, organizerEmail)`, but there was **no check that the caller is actually an organizer of that event**. Any authenticated user could read or overwrite email templates for events they do not own, simply by supplying another event's `eventId`.

## Changes

`Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java`

- `saveTemplate`: parse `request.getEventId()` to `long` (return `400` on non-numeric), then call `eventRoleService.requireRole(eventId, organizerEmail, EventRole.ORGANIZER)` before delegating to the service.
- `getTemplate`: parse the `@PathVariable String eventId` to `long` (return `400` on non-numeric), then call `eventRoleService.requireRole(...)` before delegating.

This mirrors the existing authorization already present in `sendTestEmail` (added under #16253), which uses exactly this pattern. `eventRoleService`, `EventRole`, and the `requireRole` method are already imported/wired in this controller, so no new imports or constructor changes are needed.

`requireRole` throws `AccessDeniedException` when the caller lacks the role; platform admins / legacy owners are still allowed (the same policy used by `sendTestEmail` and the role-assignment endpoints).

## Verification

- Clean `mvn clean compile` on this branch produces a byte-for-byte identical error set to `master` (same 399 pre-existing error lines / same 7 files) — i.e. this change introduces **zero new** compile errors. (The pre-existing errors on `master` are unrelated: a duplicate `getName()` in `User.java`, an abstract `CacheMeterBinder` in `CacheConfig`, a public-class filename mismatch in `MultiTenantConnectionProvider`, etc.)
- The `400` path for a non-numeric `eventId` matches the behavior of `sendTestEmail`, which returns `badRequest()` for the same condition.
- Behavior is unchanged for legitimate organizers; only unauthorized callers are now rejected with `403`.

Closes #17849.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
