### PR TITLE
fix: stabilize hackathon date display for viewers behind UTC (#19085)

### DIFF
--- a/src/app/hackathons/[id]/page.jsx
+++ b/src/app/hackathons/[id]/page.jsx
@@ -82,7 +82,7 @@ export default function HackathonDetailPage() {
   }
 
   const formattedStart = hackathon.startDate
-    ? new Date(hackathon.startDate).toLocaleDateString(undefined, {
+    ? new Date(`${hackathon.startDate}T00:00:00`).toLocaleDateString(undefined, {
         month: "short",
         day: "numeric",
         year: "numeric"
@@ -90,7 +90,7 @@ export default function HackathonDetailPage() {
     : "TBD";
 
   const formattedEnd = hackathon.endDate
-    ? new Date(hackathon.endDate).toLocaleDateString(undefined, {
+    ? new Date(`${hackathon.endDate}T00:00:00`).toLocaleDateString(undefined, {
         month: "short",
         day: "numeric",
         year: "numeric"


### PR DESCRIPTION
﻿## Problem

On the hackathon detail page, startDate/endDate are date-only strings. 
ew Date(hackathon.startDate) parses the ISO date-only string as UTC midnight, then .toLocaleDateString(...) renders it in the viewer's local timezone, so for viewers behind UTC the date rolls back one calendar day.

## Fix

Parse the date in a timezone-stable way by appending T00:00:00 (interpreted as local time) before formatting, so 	oLocaleDateString renders the stored calendar date regardless of the viewer's timezone.

## Files changed

- src/app/hackathons/[id]/page.jsx

## Testing

- Verified the date-only string is now interpreted as local midnight, eliminating the UTC-to-local shift for viewers behind UTC.

Closes #19085
