### PR TITLE
fix: correct X-Forwarded-For client IP index in RateLimitingFilter (#19026)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -162,11 +162,11 @@ public class RateLimitingFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(forwarded)) {
             String[] parts = forwarded.split(",");
             // Proxies append the connecting peer on the right. Trust the rightmost
-            // N entries as infrastructure; the client is the leftmost of that
-            // trusted suffix (ignoring any client-supplied left-hand spoof).
-            // hops=1 on "spoof, real" → index length-1 = real.
-            int clientIndex = Math.min(parts.length - 1,
-                    Math.max(0, parts.length - trustedProxyHops));
+            // N entries as infrastructure; the client is the entry that is N
+            // positions to the left of the rightmost (ignoring any client-supplied
+            // left-hand spoof).
+            // hops=1 on "client, proxy" (length 2) → index 0 = client.
+            int clientIndex = Math.max(0, parts.length - 1 - trustedProxyHops);
             String candidate = parts[clientIndex].trim();
             if (StringUtils.hasText(candidate) && !"unknown".equalsIgnoreCase(candidate)) {
                 return candidate;


### PR DESCRIPTION
﻿## Problem

RateLimitingFilter resolves the client IP from X-Forwarded-For using an off-by-	rustedProxyHops index, so with 	rustedProxyHops=1 and X-Forwarded-For: client, proxy it keys the throttle bucket on the proxy IP instead of the real client. This undermines per-client brute-force protection.

## Fix

Changed the client index from Math.min(parts.length - 1, Math.max(0, parts.length - trustedProxyHops)) to Math.max(0, parts.length - 1 - trustedProxyHops), so the client is correctly the entry N positions left of the rightmost trusted proxy. Updated the explanatory comment to match.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix. With 	rustedProxyHops=1 and a two-part header the index now resolves to the leftmost (client) entry.

Closes #19026
