### PR TITLE
fix: derive payment plan price server-side (#18800)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
@@ -18,7 +18,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -48,17 +47,12 @@ public class PaymentController {
     @PreAuthorize("hasAnyAuthority('ATTENDEE', 'ORGANIZER', 'ADMIN')")
     public ResponseEntity<?> createPaymentPlan(
             Authentication authentication,
-            @RequestParam Long registrationId,
-            @RequestParam(required = false, defaultValue = "1000.00") BigDecimal ticketPrice,
-            @RequestParam(required = false, defaultValue = "USD") String currency,
-            @RequestParam(required = false, defaultValue = "25") Integer upfrontPercentage,
-            @RequestParam(required = false, defaultValue = "4") Integer totalInstallments) {
+            @RequestParam Long registrationId) {
 
         paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
 
         try {
-            PaymentPlan paymentPlan = paymentPlanService.createPaymentPlan(
-                    registrationId, ticketPrice, currency, upfrontPercentage, totalInstallments);
+            PaymentPlan paymentPlan = paymentPlanService.createPaymentPlan(registrationId);
             
             return ResponseEntity.ok(Map.of(
                     "success", true,

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -44,12 +44,7 @@ public class PaymentPlanService {
 
     // Create a new payment plan for installment payments
     @Transactional
-    public PaymentPlan createPaymentPlan(
-            Long registrationId,
-            BigDecimal ticketPrice,
-            String currency,
-            Integer upfrontPercentage,
-            Integer totalInstallments) {
+    public PaymentPlan createPaymentPlan(Long registrationId) {
         
         // Get registration
         EventRegistration registration = eventRegistrationRepository.findById(registrationId)
@@ -63,26 +58,16 @@ public class PaymentPlanService {
             return existingActivePlan.get();
         }
 
-        // Validate input
-        if (ticketPrice == null || ticketPrice.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new IllegalArgumentException("Ticket price must be greater than zero");
-        }
-
-        // The registration's ticket price is the source of truth once set:
-        // reject requests that try to change it (e.g. lower it) after creation.
-        if (registration.getTicketPrice() != null
-                && registration.getTicketPrice().compareTo(ticketPrice) != 0) {
-            throw new IllegalArgumentException(
-                    "Ticket price does not match the price set for this registration");
+        // The registration's stored ticket price is the server-side source of truth:
+        // the plan amount is derived from it and client-supplied prices are never used.
+        BigDecimal ticketPrice = registration.getTicketPrice();
+        if (ticketPrice == null || ticketPrice.signum() <= 0) {
+            throw new IllegalStateException(
+                    "No valid ticket price configured for this registration");
         }
         
-        if (upfrontPercentage == null || upfrontPercentage < 0 || upfrontPercentage > 100) {
-            upfrontPercentage = 25; // Default to 25%
-        }
-        
-        if (totalInstallments == null || totalInstallments < 2) {
-            totalInstallments = 4; // Default to 4 installments (25% + 3 monthly)
-        }
+        int upfrontPercentage = 25; // Default to 25%
+        int totalInstallments = 4; // Default to 4 installments (25% + 3 monthly)
         
         // Calculate amounts
         BigDecimal upfrontAmount = ticketPrice.multiply(new BigDecimal(upfrontPercentage))
@@ -94,7 +79,7 @@ public class PaymentPlanService {
         PaymentPlan paymentPlan = new PaymentPlan();
         paymentPlan.setRegistration(registration);
         paymentPlan.setTotalAmount(ticketPrice);
-        paymentPlan.setCurrency(currency != null ? currency : "USD");
+        paymentPlan.setCurrency("USD");
         paymentPlan.setTotalInstallments(totalInstallments);
         paymentPlan.setInstallmentAmount(installmentAmount);
         paymentPlan.setUpfrontPercentage(upfrontPercentage);
@@ -116,7 +101,6 @@ public class PaymentPlanService {
         
         // Update registration
         registration.setPaymentStatus("PARTIAL");
-        registration.setTicketPrice(ticketPrice);
         registration.setPaymentProvider("STRIPE");
         registration.setQrActivated(false);
         eventRegistrationRepository.save(registration);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java
@@ -117,11 +117,11 @@ class PaymentAccessControlTests {
         registration.setEvent(event);
         registration.setUser(attendee);
         registration.setStatus("CONFIRMED");
+        registration.setTicketPrice(new BigDecimal("1000.00"));
         registration = eventRegistrationRepository.save(registration);
         registrationId = registration.getId();
 
-        planId = paymentPlanService.createPaymentPlan(
-                registrationId, new BigDecimal("1000.00"), "USD", 25, 4).getId();
+        planId = paymentPlanService.createPaymentPlan(registrationId).getId();
         paymentId = paymentRepository.findByRegistration_IdOrderByInstallmentNumberAsc(registrationId)
                 .get(0)
                 .getId();

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentPlanPriceTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentPlanPriceTests.java
@@ -1,0 +1,145 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.PaymentPlan;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.PaymentPlanRepository;
+import com.sandeep.eventrabackend.repository.PaymentRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PaymentPlanPriceTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PaymentPlanRepository paymentPlanRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private final String organizerEmail = "priceorganizer@example.com";
+    private final String attendeeEmail = "priceattendee@example.com";
+    private User attendee;
+    private Long organizerId;
+
+    @BeforeEach
+    void setUp() {
+        paymentRepository.deleteAll();
+        paymentPlanRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User organizer = userRepository.save(User.builder()
+                .firstName("Price")
+                .lastName("Organizer")
+                .email(organizerEmail)
+                .username("priceorganizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        attendee = userRepository.save(User.builder()
+                .firstName("Price")
+                .lastName("Attendee")
+                .email(attendeeEmail)
+                .username("priceattendee")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        organizerId = organizer.getId();
+    }
+
+    private EventRegistration createRegistration(BigDecimal ticketPrice) {
+        Event event = new Event();
+        event.setTitle("Payment Plan Price Test Event");
+        event.setCapacity(50);
+        event.setEventDate(LocalDateTime.now().plusDays(10));
+        event.setOwnerId(organizerId);
+        event.setPublic(true);
+        event = eventRepository.save(event);
+
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(event);
+        registration.setUser(attendee);
+        registration.setStatus("CONFIRMED");
+        registration.setTicketPrice(ticketPrice);
+        return eventRegistrationRepository.save(registration);
+    }
+
+    @Test
+    @DisplayName("Plan amount equals the stored ticket price; client price/terms params are ignored")
+    void planPricedFromStoredTicketPrice() throws Exception {
+        EventRegistration registration = createRegistration(new BigDecimal("500.00"));
+
+        mockMvc.perform(post("/api/payments/plans")
+                        .with(user(attendeeEmail).authorities(new SimpleGrantedAuthority("ATTENDEE")))
+                        .param("registrationId", String.valueOf(registration.getId()))
+                        .param("ticketPrice", "0.01")
+                        .param("currency", "EUR")
+                        .param("upfrontPercentage", "1")
+                        .param("totalInstallments", "2"))
+                .andExpect(status().isOk());
+
+        PaymentPlan plan = paymentPlanRepository.findByRegistration_Id(registration.getId()).orElseThrow();
+        assertThat(plan.getTotalAmount()).isEqualByComparingTo(new BigDecimal("500.00"));
+        assertThat(plan.getUpfrontAmount()).isEqualByComparingTo(new BigDecimal("125.00"));
+        assertThat(plan.getCurrency()).isEqualTo("USD");
+
+        EventRegistration reloaded = eventRegistrationRepository.findById(registration.getId()).orElseThrow();
+        assertThat(reloaded.getTicketPrice()).isEqualByComparingTo(new BigDecimal("500.00"));
+    }
+
+    @Test
+    @DisplayName("Plan creation fails when the registration has no server-side price configured")
+    void planRejectedWithoutConfiguredPrice() throws Exception {
+        EventRegistration registration = createRegistration(null);
+
+        mockMvc.perform(post("/api/payments/plans")
+                        .with(user(attendeeEmail).authorities(new SimpleGrantedAuthority("ATTENDEE")))
+                        .param("registrationId", String.valueOf(registration.getId()))
+                        .param("ticketPrice", "0.01"))
+                .andExpect(status().isInternalServerError());
+
+        assertThat(paymentPlanRepository.findByRegistration_Id(registration.getId())).isEmpty();
+    }
+}


### PR DESCRIPTION
﻿## Problem

The installment payment plan endpoint derived the charged amount, currency, and schedule from client-supplied request parameters, so a registrant could call POST /api/payments/plans with ticketPrice=0.01 and pay a cent for a real ticket.

## Fix

Removed the client-controlled price/currency/terms parameters from PaymentController.createPaymentPlan and PaymentPlanService.createPaymentPlan. The plan amount is now derived from the registration's server-side stored ticket price, which is the source of truth, and client-supplied values are ignored. Added a test (PaymentPlanPriceTests) verifying the plan uses the stored price and rejecting registrations with no configured price.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
- Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentPlanPriceTests.java
- Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java

## Testing

Inspected the diff against the issue; a new integration test asserts the plan amount equals the stored ticket price () even when the client sends ticketPrice=0.01, currency=EUR, and that plan creation fails when no server-side price is configured.

Closes #18800
