### PR TITLE
fix: restrict GitHubProxyService allowlist to curated safe sub-paths (#19050)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/GitHubProxyService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/GitHubProxyService.java
@@ -31,6 +31,22 @@ public class GitHubProxyService {
             "repos/sandeepvashishtha/eventra"
     );
 
+    /**
+     * Curated, read-only public sub-paths permitted beneath an allowlisted repo.
+     * Anything else (including {@code /hooks}, {@code /keys}, etc.) is rejected.
+     */
+    private static final Set<String> ALLOWED_REPO_SUBPATHS = Set.of(
+            "/contributors", "/stats", "/languages", "/commits", "/readme"
+    );
+
+    /**
+     * Sensitive sub-resources that must never be reachable through the proxy,
+     * even if nested under an allowlisted repo path.
+     */
+    private static final Set<String> BLOCKED_PATH_SEGMENTS = Set.of(
+            "hooks", "keys", "actions", "secrets", "environments", "deployments"
+    );
+
     private static final Pattern SAFE_PATH = Pattern.compile("^[A-Za-z0-9_./\\-]+$");
     private static final Pattern USERS_PATH = Pattern.compile(
             "^users/[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}(/[A-Za-z0-9_./\\-]*)?$",
@@ -102,8 +118,14 @@ public class GitHubProxyService {
     static boolean isAllowlisted(String normalizedPath) {
         String lower = normalizedPath.toLowerCase(Locale.ROOT);
         if (lower.startsWith("repos/")) {
+            if (BLOCKED_PATH_SEGMENTS.stream().anyMatch(lower::contains)) {
+                return false;
+            }
             return ALLOWED_REPOS.stream().anyMatch(repo ->
-                    lower.equals(repo) || lower.startsWith(repo + "/"));
+                    lower.equals(repo)
+                            || ALLOWED_REPO_SUBPATHS.stream().anyMatch(sub ->
+                                    lower.equals(repo + sub)
+                                            || lower.startsWith(repo + sub + "/")));
         }
         if (lower.startsWith("users/")) {
             return USERS_PATH.matcher(normalizedPath).matches();


### PR DESCRIPTION
﻿## Problem

GitHubProxyService.isAllowlisted() returned true for any path that merely starts with the configured repo prefix. Because the proxy endpoint is permitAll(), an anonymous caller could fetch sensitive sub-resources such as /hooks (webhook secrets) and /keys (deploy keys) using the shared GITHUB_TOKEN.

## Fix

Replaced the prefix check for repo paths with a curated allowlist of read-only sub-paths (/contributors, /stats, /languages, /commits, /readme). Added a blocklist covering sensitive segments (hooks, keys, ctions, secrets, environments, deployments) that hard-rejects any request containing them, even if nested under an allowlisted repo.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/GitHubProxyService.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix. Verified against the expected behavior: /hooks and /keys are now rejected while /contributors is allowed.

Closes #19050
