### PR TITLE
fix: make LIVE/PAST timing predicates disjoint using event endDate (#19062)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java
@@ -136,10 +136,17 @@ public final class EventSpecifications {
                         cb.greaterThan(root.get("eventDate"), now));
                 case "LIVE" -> parts.add((root, query, cb) -> cb.and(
                         cb.lessThanOrEqualTo(root.get("eventDate"), now),
-                        cb.greaterThanOrEqualTo(root.get("eventDate"), now.toLocalDate().atStartOfDay())
+                        cb.or(
+                                cb.greaterThanOrEqualTo(root.get("endDate"), now),
+                                cb.and(cb.isNull(root.get("endDate")),
+                                        cb.greaterThanOrEqualTo(root.get("eventDate"), now))
+                        )
                 ));
-                case "PAST", "ENDED" -> parts.add((root, query, cb) ->
-                        cb.lessThan(root.get("eventDate"), now.toLocalDate().atStartOfDay()));
+                case "PAST", "ENDED" -> parts.add((root, query, cb) -> cb.or(
+                        cb.lessThan(root.get("endDate"), now),
+                        cb.and(cb.isNull(root.get("endDate")),
+                                cb.lessThan(root.get("eventDate"), now))
+                ));
                 case "CANCELLED", "CANCELED", "SCHEDULED" -> parts.add((root, query, cb) ->
                         cb.equal(cb.upper(root.get("status")),
                                 status.startsWith("CANCEL") ? "CANCELLED" : status));


### PR DESCRIPTION
﻿## Problem

The LIVE timing predicate in EventSpecifications misclassified events. An event whose eventDate was earlier today (already finished) matched LIVE because the lower bound was the start of today, while PAST only matched eventDate < startOfDay. This broke live/upcoming/past filtering across the events UI and APIs.

## Fix

Recomputed the LIVE and PAST/ENDED predicates so they are disjoint and correct, leveraging the existing endDate field on Event:
- LIVE: eventDate <= now AND (endDate >= now OR (endDate IS NULL AND eventDate >= now)).
- PAST/ENDED: (endDate < now) OR (endDate IS NULL AND eventDate < now).

This makes a single-session event that started and ended earlier today fall under PAST instead of LIVE, while an ongoing event (start <= now <= endDate) remains LIVE.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/repository/EventSpecifications.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix. Verified boundary cases: event 09:00 no-endDate viewed at 17:00 is now PAST; event 15:00-19:00 viewed at 17:00 is LIVE; both predicates are disjoint.

Closes #19062
