### PR TITLE
fix: pin payment plan currency and installment terms server-side (#18803)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
@@ -49,16 +49,13 @@ public class PaymentController {
     public ResponseEntity<?> createPaymentPlan(
             Authentication authentication,
             @RequestParam Long registrationId,
-            @RequestParam(required = false, defaultValue = "1000.00") BigDecimal ticketPrice,
-            @RequestParam(required = false, defaultValue = "USD") String currency,
-            @RequestParam(required = false, defaultValue = "25") Integer upfrontPercentage,
-            @RequestParam(required = false, defaultValue = "4") Integer totalInstallments) {
+            @RequestParam(required = false, defaultValue = "1000.00") BigDecimal ticketPrice) {
 
         paymentPlanService.requirePaymentAccessByRegistration(registrationId, authentication.getName());
 
         try {
             PaymentPlan paymentPlan = paymentPlanService.createPaymentPlan(
-                    registrationId, ticketPrice, currency, upfrontPercentage, totalInstallments);
+                    registrationId, ticketPrice);
             
             return ResponseEntity.ok(Map.of(
                     "success", true,

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
@@ -46,10 +46,7 @@ public class PaymentPlanService {
     @Transactional
     public PaymentPlan createPaymentPlan(
             Long registrationId,
-            BigDecimal ticketPrice,
-            String currency,
-            Integer upfrontPercentage,
-            Integer totalInstallments) {
+            BigDecimal ticketPrice) {
         
         // Get registration
         EventRegistration registration = eventRegistrationRepository.findById(registrationId)
@@ -76,13 +73,12 @@ public class PaymentPlanService {
                     "Ticket price does not match the price set for this registration");
         }
         
-        if (upfrontPercentage == null || upfrontPercentage < 0 || upfrontPercentage > 100) {
-            upfrontPercentage = 25; // Default to 25%
+        String currency = "USD";
+        int upfrontPercentage = 25;
+        if (upfrontPercentage < 20 || upfrontPercentage > 100) {
+            throw new IllegalArgumentException("Unsupported upfront percentage");
         }
-        
-        if (totalInstallments == null || totalInstallments < 2) {
-            totalInstallments = 4; // Default to 4 installments (25% + 3 monthly)
-        }
+        int totalInstallments = 4;
         
         // Calculate amounts
         BigDecimal upfrontAmount = ticketPrice.multiply(new BigDecimal(upfrontPercentage))
@@ -94,7 +90,7 @@ public class PaymentPlanService {
         PaymentPlan paymentPlan = new PaymentPlan();
         paymentPlan.setRegistration(registration);
         paymentPlan.setTotalAmount(ticketPrice);
-        paymentPlan.setCurrency(currency != null ? currency : "USD");
+        paymentPlan.setCurrency(currency);
         paymentPlan.setTotalInstallments(totalInstallments);
         paymentPlan.setInstallmentAmount(installmentAmount);
         paymentPlan.setUpfrontPercentage(upfrontPercentage);

--- a/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.PaymentPlan;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -121,7 +123,7 @@ class PaymentAccessControlTests {
         registrationId = registration.getId();
 
         planId = paymentPlanService.createPaymentPlan(
-                registrationId, new BigDecimal("1000.00"), "USD", 25, 4).getId();
+                registrationId, new BigDecimal("1000.00")).getId();
         paymentId = paymentRepository.findByRegistration_IdOrderByInstallmentNumberAsc(registrationId)
                 .get(0)
                 .getId();
@@ -164,6 +166,31 @@ class PaymentAccessControlTests {
                 .andExpect(status().isForbidden());
         mockMvc.perform(get("/api/payments/active/{id}", registrationId).with(user(attackerEmail)))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Client-supplied currency and installment terms are pinned server-side")
+    void clientCannotChooseCurrencyOrInstallmentTerms() throws Exception {
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(eventRepository.findAll().iterator().next());
+        registration.setUser(userRepository.findByEmail(attendeeEmail).orElseThrow());
+        registration.setStatus("CONFIRMED");
+        registration = eventRegistrationRepository.save(registration);
+
+        mockMvc.perform(post("/api/payments/plans")
+                        .with(user(attendeeEmail))
+                        .param("registrationId", String.valueOf(registration.getId()))
+                        .param("ticketPrice", "1000.00")
+                        .param("currency", "INR")
+                        .param("upfrontPercentage", "0")
+                        .param("totalInstallments", "10"))
+                .andExpect(status().isOk());
+
+        PaymentPlan plan = paymentPlanRepository.findByRegistration_Id(registration.getId()).orElseThrow();
+        assertEquals("USD", plan.getCurrency());
+        assertEquals(25, plan.getUpfrontPercentage().intValue());
+        assertEquals(4, plan.getTotalInstallments().intValue());
+        assertEquals(0, new BigDecimal("1000.00").compareTo(plan.getTotalAmount()));
     }
 
     @Test


### PR DESCRIPTION
﻿## Problem

The payment-plan endpoint let the registrant choose currency and upfrontPercentage (and 	otalInstallments) via request parameters. A client could pass upfrontPercentage=0 to defer the entire charge, or supply an arbitrary currency, bypassing server-side economic controls.

## Fix

- Removed currency, upfrontPercentage, and 	otalInstallments from PaymentController.createPaymentPlan and from PaymentPlanService.createPaymentPlan.
- Currency is now pinned server-side to USD; upfrontPercentage is fixed to 25 (with a guard rejecting values outside 20-100), and 	otalInstallments is fixed to 4.
- Added a test asserting client-supplied currency/terms are ignored and server values are applied.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/controller/PaymentController.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/PaymentPlanService.java
- Backend/src/test/java/com/sandeep/eventrabackend/controller/PaymentAccessControlTests.java

## Testing

Built the change against the issue; the included test posts client-supplied currency/terms and asserts the server-pinned values are stored.

Closes #18803
