### PR TITLE
fix(home): respect manual Pause toggle separately from hover-pause (#19106)

### DIFF
--- a/src/components/home/WhatsHappeningNow.jsx
+++ b/src/components/home/WhatsHappeningNow.jsx
@@ -27,6 +27,7 @@ export default function WhatsHappeningNow() {
   const [loading, setLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isAutoplay, setIsAutoplay] = useState(true);
+  const [isHovering, setIsHovering] = useState(false);
 
   const [events, setEvents] = useState([]);
   const [hackathons, setHackathons] = useState([]);
@@ -107,7 +108,7 @@ export default function WhatsHappeningNow() {
   };
 
   useEffect(() => {
-    if (!isAutoplay || loading || carouselItems.length === 0 || drawerState.isOpen) return;
+    if (!isAutoplay || isHovering || loading || carouselItems.length === 0 || drawerState.isOpen) return;
 
     const interval = setInterval(() => {
       if (!carouselRef.current) return;
@@ -123,7 +124,7 @@ export default function WhatsHappeningNow() {
     }, 3200);
 
     return () => clearInterval(interval);
-  }, [isAutoplay, loading, carouselItems.length, drawerState.isOpen]);
+  }, [isAutoplay, isHovering, loading, carouselItems.length, drawerState.isOpen]);
 
   const openItemDrawer = (itemType, itemData) => {
     setDrawerState({
@@ -288,8 +289,8 @@ export default function WhatsHappeningNow() {
               ref={carouselRef}
               className="flex items-stretch gap-6 overflow-x-auto scrollbar-none scroll-smooth pb-4 pt-1 snap-x snap-mandatory"
               style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-              onMouseEnter={() => setIsAutoplay(false)}
-              onMouseLeave={() => setIsAutoplay(true)}
+              onMouseEnter={() => setIsHovering(true)}
+              onMouseLeave={() => setIsHovering(false)}
             >
               {carouselItems.map((item) => (
                 <div


### PR DESCRIPTION
## Summary

The "What's Happening Now" carousel on the home page used a single `isAutoplay` state for both the **Pause/Play button** and the **hover-pause** behavior. Because `onMouseLeave` unconditionally set `isAutoplay` back to `true`, a user who clicked **Pause** had their choice silently reverted as soon as the pointer entered and then left the carousel — autoplay restarted on its own.

## Root Cause

`src/components/home/WhatsHappeningNow.jsx`:

\`\`\`jsx
onMouseEnter={() => setIsAutoplay(false)}
onMouseLeave={() => setIsAutoplay(true)}
\`\`\`

The hover handlers wrote directly to the same `isAutoplay` state that the manual Pause/Play button controls, so hover clobbered the user's explicit toggle.

## Changes

- Added a separate transient `isHovering` state.
- Hover handlers now toggle `isHovering` instead of `isAutoplay`.
- The autoplay `useEffect` (and its dependency array) now gates on `isAutoplay && !isHovering`, so:
  - The Pause/Play button still drives the persisted user choice (`isAutoplay`).
  - Hovering still temporarily pauses an active carousel, and leaving resumes it **only when the user has not manually paused**.

## Reproduction

1. Load the home page (autoplay running).
2. Click **Pause** — autoplay stops, icon flips to Play.
3. Move the mouse into the carousel, then out of it.
4. **Before fix:** autoplay restarts and the icon flips back to Pause. **After fix:** autoplay stays paused.

## Testing / Validation

- \`npm run build\` passes (clean build, all 11 routes generated).
- \`npm run lint\` introduces no new errors on this file. The pre-existing \`react-hooks/set-state-in-effect\` error on \`fetchData()\` (line 66) exists on \`master\` and is unrelated to this change.
- Note: This repository has no test framework configured. Per the contribution workflow (building test infrastructure requires significant setup), validation was done via the project's own \`build\` and \`lint\` scripts rather than a new unit test.

## Related Issue

Closes #19106

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._