### PR TITLE
fix: make ContactService email validation reachable (#19089)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java
@@ -22,7 +22,9 @@ public class ContactService {
     public ContactResponse submitContactMessage(ContactRequest request) {
         if (request.getName() == null || request.getName().trim().length() < 2 || request.getName().trim().length() > 100) {
             throw new IllegalArgumentException("Name must be between 2 and 100 characters.");
-        if (request.getEmail() == null || !request.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) { throw new IllegalArgumentException("Invalid email format."); }
+        }
+        if (request.getEmail() == null || !request.getEmail().matches("^[A-Za-z0-9+_.-]+@(.+)$")) {
+            throw new IllegalArgumentException("Invalid email format.");
         }
         ContactMessage contactMessage = new ContactMessage();
         contactMessage.setName(request.getName().trim());


### PR DESCRIPTION
﻿## Problem

In ContactService.submitContactMessage, the email-format validation was nested inside the name-validation if block but placed *after* an unconditional 	hrow. Because the 	hrow always exited, the email check became unreachable dead code, so the public "Contact Us" form never validated the email and persisted junk/blank submissions.

## Fix

Moved the email-format validation out of the name if block so it runs independently and rejects malformed/empty emails with HTTP 400 before persistence.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/ContactService.java

## Testing

Inspected the change against the issue; the email validation is now at the same scope as the name validation and executes for every request.

Closes #19089
