### PR TITLE
fix: remove no-op free filter from event search (#19076)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -184,14 +184,13 @@ public class EventController {
                         @Parameter(description = "Event category for filtering") @RequestParam(required = false) String category,
                         @Parameter(description = "Start date for filtering (ISO format)") @RequestParam(required = false) String startDate,
                         @Parameter(description = "End date for filtering (ISO format)") @RequestParam(required = false) String endDate,
-                        @Parameter(description = "Filter for free events only") @RequestParam(required = false) Boolean free,
                         @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
                         @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
 
                 int clampedSize = Math.min(Math.max(size, 1), 100);
                 int safePage = Math.max(page, 0);
                 Pageable pageable = PageRequest.of(safePage, clampedSize);
-                Page<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate, free,
+                Page<EventResponse> events = eventService.searchEvents(search, category, startDate, endDate,
                                 pageable);
                 return ResponseEntity.ok(events);
         }

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -421,12 +421,11 @@ public class EventService {
          * @param category  Event category for filtering
          * @param startDate Start date for filtering (ISO format)
          * @param endDate   End date for filtering (ISO format)
-         * @param free      Filter for free events only
          * @return List of events matching the search criteria
          */
         @Transactional(readOnly = true)
         public Page<EventResponse> searchEvents(String search, String category, String startDate, String endDate,
-                        Boolean free, Pageable pageable) {
+                        Pageable pageable) {
                 // Push all filtering down to the database via a dynamic Specification.
                 Specification<Event> spec = Specification
                                 .where(EventSpecifications.isPublic())
@@ -436,11 +435,8 @@ public class EventService {
                                 .and(EventSpecifications.eventDateAfter(startDate))
                                 .and(EventSpecifications.eventDateBefore(endDate));
 
-                // Events do not currently model price, so a free filter cannot be applied.
-                // Do not use capacity as a proxy for price.
-                if (free != null && free) {
-                        // Intentionally no-op until pricing data is available.
-                }
+                // Events do not currently model price, so a "free" filter cannot be applied.
+                // The parameter was removed to avoid silently returning unfiltered results.
 
                 Page<Event> page = eventRepository.findAll(spec, pageable);
                 return page.map(this::toPublicEventResponse);


### PR DESCRIPTION
﻿## Problem

EventService.searchEvents accepted a Boolean free parameter but never applied it — the code contained an explicit no-op block. The "Free events only" UI toggle therefore silently returned all events, implying a filter that did not exist.

## Fix

The Event model does not model price, so a real ree filter cannot be implemented. Following the issue's guidance, the ree parameter was removed from both EventController.searchEvents and EventService.searchEvents (and the stale javadoc), so the endpoint no longer advertises a filter it cannot honor. The UI toggle should be hidden until pricing is modeled.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
- Backend/src/main/java/com/sandeep/eventrabackend/controller/EventController.java

## Testing

Inspected the change against the issue; no callers or tests reference the removed parameter, and the method signature/usage are consistent.

Closes #19076
