### PR TITLE
fix: make PushSubscriptionService.subscribe idempotent under concurrency (#19074)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
@@ -6,6 +6,7 @@ import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.PushSubscriptionRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,15 +42,35 @@ public class PushSubscriptionService {
         // port is accepted (#16257).
         validateEndpoint(request.getEndpoint());
 
-        PushSubscription subscription = pushSubscriptionRepository
-                .findByUser_IdAndEndpoint(user.getId(), request.getEndpoint())
-                .orElseGet(PushSubscription::new);
-
-        subscription.setUser(user);
-        subscription.setEndpoint(request.getEndpoint());
-        subscription.setP256dh(p256dh);
-        subscription.setAuth(auth);
-        pushSubscriptionRepository.save(subscription);
+        try {
+            PushSubscription subscription = pushSubscriptionRepository
+                    .findByUser_IdAndEndpoint(user.getId(), request.getEndpoint())
+                    .orElseGet(() -> {
+                        PushSubscription created = new PushSubscription();
+                        created.setUser(user);
+                        created.setEndpoint(request.getEndpoint());
+                        created.setP256dh(p256dh);
+                        created.setAuth(auth);
+                        return pushSubscriptionRepository.save(created);
+                    });
+            // Row was either found or just created; keep its keys current.
+            if (!p256dh.equals(subscription.getP256dh())
+                    || !auth.equals(subscription.getAuth())) {
+                subscription.setP256dh(p256dh);
+                subscription.setAuth(auth);
+                pushSubscriptionRepository.save(subscription);
+            }
+        } catch (DataIntegrityViolationException ex) {
+            // A concurrent request inserted the (user_id, endpoint) row between
+            // our lookup and our save. Load the surviving row and update it so
+            // the double-subscribe is idempotent instead of failing with a 500.
+            PushSubscription existing = pushSubscriptionRepository
+                    .findByUser_IdAndEndpoint(user.getId(), request.getEndpoint())
+                    .orElseThrow(() -> ex);
+            existing.setP256dh(p256dh);
+            existing.setAuth(auth);
+            pushSubscriptionRepository.save(existing);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
﻿## Problem

PushSubscriptionService.subscribe performed a check-then-act: it looked up an existing subscription by (user, endpoint) and, if absent, built a new one via orElseGet and saved it. With the existing unique constraint on (user_id, endpoint), two concurrent requests for the same user+endpoint both observed "absent", both created a new entity, and the second save violated the unique index, surfacing as an HTTP 500.

## Fix

Refactored subscribe so the new entity is fully populated before its first save, and wrapped the lookup/save in a try/catch for DataIntegrityViolationException. When a concurrent insert wins the race, the catch re-loads the surviving row and updates its keys, making a double-subscribe idempotent instead of throwing 500. The existing unique constraint remains the source of truth.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the subscribe method. The unique constraint on (user_id, endpoint) already exists, so the retry path is exercised only on a genuine race.

Closes #19074
