### PR TITLE
fix: rename leaderboard minRank param to maxRank to reflect upper-bound filter (#19064)

### DIFF
--- a/Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java
+++ b/Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java
@@ -109,7 +109,7 @@ public class HackathonLeaderboardSseController implements MessageListener, Healt
     public ResponseEntity<SseEmitter> streamLeaderboardUpdates(
             @PathVariable("id") Long hackathonId,
             @RequestParam(value = "teamId", required = false) Long teamIdFilter,
-            @RequestParam(value = "minRank", required = false, defaultValue = "100") Integer maxRankFilter,
+            @RequestParam(value = "maxRank", required = false, defaultValue = "100") Integer maxRankFilter,
             @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId,
             HttpServletRequest request) {
 


### PR DESCRIPTION
﻿## Problem

The hackathon leaderboard SSE endpoint exposed a request parameter named minRank, but it was stored as maxRankFilter and applied as an **upper bound** (payload.getRank() > session.getMaxRankFilter()). A client sending minRank=10 (expecting ranks >= 10) instead received only ranks <= 10, inverting the filter and misleading API consumers.

## Fix

Renamed the public request parameter from minRank to maxRank so the name matches its true, already-correct upper-bound (top-N cutoff) semantics. No filtering behavior changed — the existing > maxRankFilter comparison already implements the intended top-N cutoff; only the misleading name was corrected.

## Files changed

- Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java

## Testing

Inspected the change against the issue; the parameter name now matches the comparison logic and the default value (100, top-100 cutoff) remains sensible.

Closes #19064
