### PR TITLE
fix: ignore stale/invalid auth cookie when valid Bearer header present (#19052)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -55,12 +55,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // Token confusion protection: when a token is supplied via BOTH the
             // Authorization header and the auth cookie, they must resolve to the
             // same principal. A mismatch means the request is ambiguous/forged.
-            if (StringUtils.hasText(headerToken) && StringUtils.hasText(cookieToken)
-                    && !tokensResolveToSameUser(headerToken, cookieToken)) {
-                logger.warn("Rejected request with mismatched header/cookie JWT identities");
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write("Conflicting token identities");
-                return;
+            // An invalid/stale cookie is treated as absent and ignored so it never
+            // blocks a request that carries a valid Bearer header.
+            if (StringUtils.hasText(headerToken) && StringUtils.hasText(cookieToken)) {
+                boolean headerValid = jwtTokenProvider.validateToken(headerToken);
+                boolean cookieValid = jwtTokenProvider.validateToken(cookieToken);
+                if (headerValid && cookieValid && !tokensResolveToSameUser(headerToken, cookieToken)) {
+                    logger.warn("Rejected request with mismatched header/cookie JWT identities");
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    response.getWriter().write("Conflicting token identities");
+                    return;
+                }
             }
 
             String token = StringUtils.hasText(headerToken) ? headerToken : cookieToken;


### PR DESCRIPTION
﻿## Problem

JwtAuthenticationFilter rejected a request that carried BOTH a valid Authorization Bearer token and a stale/invalid auth cookie. 	okensResolveToSameUser() returned alse whenever *either* token failed validation, so the mismatch branch fired and returned 401 — blocking a perfectly valid Bearer header whenever a stale cookie coexisted (common for SPAs using withCredentials: true).

## Fix

The header/cookie identity-conflict check now only runs when **both** tokens are independently valid. A stale/expired/unparseable cookie is treated as absent and ignored, so a valid Bearer header is never blocked by it. 	okensResolveToSameUser is still called only with two valid tokens, preserving the original forge-protection semantics.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java

## Testing

Inspected the change against the issue; the conflict path is now gated on both tokens being valid, so a valid header + invalid cookie flows through to successful authentication.

Closes #19052
