### PR TITLE
fix: replace base64 ticket token with HMAC-SHA256 signed token (#19028)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/ticket/TicketSignerService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/ticket/TicketSignerService.java
@@ -16,6 +16,12 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -41,9 +47,25 @@ public class TicketSignerService {
     
     private final PasskeyCredentialRepository credentialRepository;
     private final ConcurrentHashMap<String, SignatureChallenge> pendingChallenges = new ConcurrentHashMap<>();
+    private final SecretKey signingKey;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public TicketSignerService(PasskeyCredentialRepository credentialRepository) {
+    public TicketSignerService(PasskeyCredentialRepository credentialRepository,
+                               @Value("${eventra.ticket.signing-secret:}") String configuredSecret) {
         this.credentialRepository = credentialRepository;
+        this.signingKey = buildSigningKey(configuredSecret);
+    }
+
+    private SecretKey buildSigningKey(String configuredSecret) {
+        if (configuredSecret != null && !configuredSecret.isBlank()) {
+            return new SecretKeySpec(configuredSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        }
+        // No secret configured: generate an ephemeral per-JVM secret so tokens remain
+        // cryptographically signed and unforgeable within this process. Set
+        // eventra.ticket.signing-secret in production for cross-restart stability.
+        byte[] key = new byte[32];
+        new SecureRandom().nextBytes(key);
+        return new SecretKeySpec(key, "HmacSHA256");
     }
 
     /**
@@ -383,24 +405,135 @@ public class TicketSignerService {
     }
 
     /**
-     * Generate a signed ticket token for offline verification
-     * 
-     * @param ticketId The ticket ID
+     * Generate a cryptographically signed ticket token for offline verification.
+     *
+     * <p>The token is an HMAC-SHA256 signed {@code header.payload.signature} structure
+     * carrying {@code exp} and {@code jti}, so it cannot be forged without the
+     * server-held signing secret.
+     *
+     * @param ticketId    The ticket ID
      * @param credentialId The credential ID
-     * @param userEmail The user's email
-     * @return A signed token that can be verified offline
+     * @param userEmail   The user's email
+     * @return A signed token that can be verified offline via {@link #verifySignedTicketToken}
      */
     public String generateSignedTicketToken(String ticketId, String credentialId, String userEmail) {
-        // This is a placeholder for a real JWT or signed token
-        // In production, use proper JWT signing with a secret key
-        String tokenData = String.format("%s|%s|%s|%d", 
-            ticketId, credentialId, userEmail, System.currentTimeMillis());
-        
-        // For now, return a simple signed token
-        // In production, replace with proper JWT signing
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(
-            tokenData.getBytes(StandardCharsets.UTF_8)
-        );
+        long now = System.currentTimeMillis();
+        long exp = now + 86_400_000L; // 24 hours
+        String jti = UUID.randomUUID().toString();
+
+        String header = b64UrlEncode(toJson(Map.of("alg", "HS256", "typ", "JWT")));
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("ticketId", ticketId);
+        claims.put("credentialId", credentialId);
+        claims.put("userEmail", userEmail);
+        claims.put("iat", now);
+        claims.put("exp", exp);
+        claims.put("jti", jti);
+        String payload = b64UrlEncode(toJson(claims));
+
+        String signingInput = header + "." + payload;
+        String signature = b64UrlEncode(hmacSha256(signingInput));
+        return signingInput + "." + signature;
+    }
+
+    /**
+     * Verify a token produced by {@link #generateSignedTicketToken}.
+     *
+     * @param token the signed token
+     * @return result describing validity and, when valid, the embedded claims
+     */
+    public SignedTicketTokenResult verifySignedTicketToken(String token) {
+        try {
+            if (token == null || token.isBlank()) {
+                return new SignedTicketTokenResult(false, null, null, null, "Token is required");
+            }
+            String[] parts = token.split("\\.");
+            if (parts.length != 3) {
+                return new SignedTicketTokenResult(false, null, null, null, "Malformed token");
+            }
+            String signingInput = parts[0] + "." + parts[1];
+            byte[] expectedSig = hmacSha256(signingInput);
+            byte[] providedSig = b64UrlDecode(parts[2]);
+            if (expectedSig.length != providedSig.length) {
+                return new SignedTicketTokenResult(false, null, null, null, "Invalid signature");
+            }
+            int diff = 0;
+            for (int i = 0; i < expectedSig.length; i++) {
+                diff |= expectedSig[i] ^ providedSig[i];
+            }
+            if (diff != 0) {
+                return new SignedTicketTokenResult(false, null, null, null, "Invalid signature");
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> claims = objectMapper.readValue(b64UrlDecodeToString(parts[1]), Map.class);
+            Object expObj = claims.get("exp");
+            if (expObj instanceof Number && ((Number) expObj).longValue() < System.currentTimeMillis()) {
+                return new SignedTicketTokenResult(false, null, null, null, "Token expired");
+            }
+            return new SignedTicketTokenResult(true,
+                    (String) claims.get("ticketId"),
+                    (String) claims.get("credentialId"),
+                    (String) claims.get("userEmail"),
+                    "ok");
+        } catch (Exception e) {
+            return new SignedTicketTokenResult(false, null, null, null, "Failed to parse token");
+        }
+    }
+
+    private byte[] hmacSha256(String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(signingKey);
+            return mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to compute HMAC signature", e);
+        }
+    }
+
+    private String b64UrlEncode(byte[] data) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    private byte[] b64UrlDecode(String data) {
+        return Base64.getUrlDecoder().decode(data);
+    }
+
+    private String b64UrlDecodeToString(String data) {
+        return new String(b64UrlDecode(data), StandardCharsets.UTF_8);
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to serialize token claims", e);
+        }
+    }
+
+    /**
+     * Result of verifying a signed ticket token.
+     */
+    public static class SignedTicketTokenResult {
+        private final boolean valid;
+        private final String ticketId;
+        private final String credentialId;
+        private final String userEmail;
+        private final String message;
+
+        public SignedTicketTokenResult(boolean valid, String ticketId, String credentialId,
+                                       String userEmail, String message) {
+            this.valid = valid;
+            this.ticketId = ticketId;
+            this.credentialId = credentialId;
+            this.userEmail = userEmail;
+            this.message = message;
+        }
+
+        public boolean isValid() { return valid; }
+        public String getTicketId() { return ticketId; }
+        public String getCredentialId() { return credentialId; }
+        public String getUserEmail() { return userEmail; }
+        public String getMessage() { return message; }
     }
 
     /**

--- a/Backend/src/test/java/com/sandeep/eventrabackend/security/ticket/TicketSignerServiceTokenTests.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/security/ticket/TicketSignerServiceTokenTests.java
@@ -1,0 +1,56 @@
+package com.sandeep.eventrabackend.security.ticket;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TicketSignerServiceTokenTests {
+
+    private TicketSignerService newService() {
+        return new TicketSignerService(null, "unit-test-signing-secret");
+    }
+
+    @Test
+    void generatesVerifiableSignedToken() {
+        TicketSignerService service = newService();
+        String token = service.generateSignedTicketToken("t1", "c1", "a@example.com");
+
+        TicketSignerService.SignedTicketTokenResult result = service.verifySignedTicketToken(token);
+        assertTrue(result.isValid());
+        assertEquals("t1", result.getTicketId());
+        assertEquals("c1", result.getCredentialId());
+        assertEquals("a@example.com", result.getUserEmail());
+    }
+
+    @Test
+    void rejectsTamperedToken() {
+        TicketSignerService service = newService();
+        String token = service.generateSignedTicketToken("t1", "c1", "a@example.com");
+        String last = token.substring(token.length() - 1);
+        String replacement = last.equals("A") ? "B" : "A";
+        String tampered = token.substring(0, token.length() - 1) + replacement;
+
+        TicketSignerService.SignedTicketTokenResult result = service.verifySignedTicketToken(tampered);
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsTokenSignedWithDifferentSecret() {
+        TicketSignerService service = newService();
+        String token = service.generateSignedTicketToken("t1", "c1", "a@example.com");
+
+        TicketSignerService other = new TicketSignerService(null, "different-secret");
+        TicketSignerService.SignedTicketTokenResult result = other.verifySignedTicketToken(token);
+        assertFalse(result.isValid());
+    }
+
+    @Test
+    void rejectsMalformedAndEmptyTokens() {
+        TicketSignerService service = newService();
+        assertFalse(service.verifySignedTicketToken("not.a.jwt").isValid());
+        assertFalse(service.verifySignedTicketToken("").isValid());
+        assertFalse(service.verifySignedTicketToken(null).isValid());
+    }
+}


### PR DESCRIPTION
﻿## Problem

TicketSignerService.generateSignedTicketToken only performed Base64 encoding — there was no signature, MAC, or server secret. Anyone could forge a valid-looking token for any 	icketId/userEmail (e.g. an admin's), and the /api/tickets/{id}/generate-token endpoint returned it as authoritative, enabling ticket impersonation/forgery.

## Fix

- Replaced the placeholder with a real HMAC-SHA256 signing routine keyed by a server-held secret (eventra.ticket.signing-secret; an ephemeral per-JVM key is generated if unset).
- The token now uses a header.payload.signature structure (HS256) carrying iat, exp (24h), and jti.
- Added erifySignedTicketToken which validates the signature (constant-time compare), structure, and expiry, and rejects forgeries/tampering.
- The controller's generate-token endpoint is unchanged (it just forwards the string) and its expiresAt (24h) matches the token exp.
- Added TicketSignerServiceTokenTests covering valid verification, tampered-token rejection, wrong-secret rejection, and malformed/empty tokens.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/ticket/TicketSignerService.java
- Backend/src/test/java/com/sandeep/eventrabackend/security/ticket/TicketSignerServiceTokenTests.java

## Testing

Unit tests assert a generated token verifies with correct claims, a tampered token is rejected, a token signed with a different secret is rejected, and malformed/empty tokens are rejected.

Closes #19028
