### PR TITLE
fix: validate datasource password and Google client secret in prod (#18805)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/ProdEnvironmentValidator.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/ProdEnvironmentValidator.java
@@ -25,12 +25,20 @@ public class ProdEnvironmentValidator {
     @Value("${spring.datasource.username:}")
     private String datasourceUsername;
 
+    @Value("${spring.datasource.password:}")
+    private String datasourcePassword;
+
+    @Value("${google.client.secret:}")
+    private String googleClientSecret;
+
     @PostConstruct
     public void validate() {
         require("JWT_SECRET / app.jwt.secret", jwtSecret);
         require("GOOGLE_CLIENT_ID / google.client.id", googleClientId);
+        require("GOOGLE_CLIENT_SECRET / google.client.secret", googleClientSecret);
         require("DATABASE_URL / spring.datasource.url", datasourceUrl);
         require("DATABASE_USERNAME / spring.datasource.username", datasourceUsername);
+        require("DATABASE_PASSWORD / spring.datasource.password", datasourcePassword);
 
         if (datasourceUrl.toLowerCase().contains(":h2:")) {
             throw new IllegalStateException(
@@ -40,6 +48,16 @@ public class ProdEnvironmentValidator {
         if (googleClientId.contains("<") || "dev-google-client-id".equals(googleClientId)) {
             throw new IllegalStateException(
                     "Production Google client id is unset or still a placeholder.");
+        }
+
+        if (googleClientSecret.contains("<") || "dev-google-secret".equals(googleClientSecret)) {
+            throw new IllegalStateException(
+                    "Production Google client secret is unset or still a placeholder.");
+        }
+
+        if (datasourcePassword.contains("<") || "dev-db-password".equals(datasourcePassword)) {
+            throw new IllegalStateException(
+                    "Production database password is unset or still a placeholder.");
         }
 
         if (jwtSecret.length() < 32 || jwtSecret.startsWith("dev-only-secret")) {


### PR DESCRIPTION
﻿## Problem

ProdEnvironmentValidator failed fast only for JWT secret, Google client id, datasource URL and username, never validating the database password or the Google OAuth client secret, so a production deploy could start with empty or placeholder credentials.

## Fix

Added two new @Value-injected fields (spring.datasource.password, google.client.secret), required them via equire(...), and added placeholder checks that abort startup when the password or secret is unset or still a dev placeholder.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/config/ProdEnvironmentValidator.java

## Testing

Inspected the change against the issue; the change is minimal and scoped to adding the two missing required validations and their placeholder guards.

Closes #18805
