### PR TITLE
fix: sanitize email header values to prevent CRLF injection (#18804)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
@@ -59,8 +59,10 @@ public class EmailTemplateService {
             // Send the email using the email sender. The recipient is pinned to
             // the authenticated organizer — request.getRecipientEmail() is never
             // trusted, preventing arbitrary-recipient phishing relays.
+            // Both header-derived values (recipient + subject) are sanitized to
+            // strip CR/LF and prevent email header injection (#18804).
             String messageId = emailSender.sendEmail(
-                    organizerEmail,
+                    sanitizeHeaderValue(organizerEmail),
                     subject,
                     renderedContent,
                     true // isHtml
@@ -264,11 +266,21 @@ public class EmailTemplateService {
     }
 
     /**
+     * Sanitize a value destined for an email header (e.g. Subject, recipient name)
+     * so that CR/LF sequences cannot be interpreted as header separators and used
+     * for header injection. The body is HTML-escaped separately.
+     */
+    private static String sanitizeHeaderValue(String v) {
+        return v == null ? "" : v.replaceAll("[\r\n]+", " ").trim();
+    }
+
+    /**
      * Generate subject based on template type
      */
     private String generateSubject(String templateType, Map<String, Object> event) {
-        String eventTitle = event != null ? String.valueOf(event.getOrDefault("title", "Event")) : "Event";
-        
+        String eventTitle = sanitizeHeaderValue(
+                event != null ? String.valueOf(event.getOrDefault("title", "Event")) : "Event");
+
         switch (templateType) {
             case "waitlist_promotion":
                 return "Good News! You've been promoted from the waitlist for " + eventTitle;


### PR DESCRIPTION
﻿## Problem

Test emails build the Subject header by concatenating the organizer-controlled event title without CRLF sanitization. A crafted title containing \r\n can inject additional email headers (e.g. Bcc:), enabling spam/phishing from the organizer's mail configuration.

## Fix

Added a sanitizeHeaderValue helper that strips CR/LF sequences from any value destined for an email header, and applied it to the event title in generateSubject. Also applied the same sanitizer to the recipient (organizer email) before sending, so no header-derived value can carry a CRLF injection.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java

## Testing

Inspected the change against the issue; the fix is minimal and scoped to the described CRLF sanitization. The new sanitizeHeaderValue replaces CR/LF with a space and trims, preventing header injection while preserving readability.

Closes #18804
