### PR TITLE
fix: harden CSV formula-injection sanitizer (issue #19046)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PlagiarismDetectionService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PlagiarismDetectionService.java
@@ -77,7 +77,10 @@ public class PlagiarismDetectionService {
             return "";
         }
         String cleaned = value.replace("\"", "\"\"");
-        if (!cleaned.isEmpty() && "=+-@".indexOf(cleaned.charAt(0)) >= 0) {
+        // Spreadsheet apps strip leading whitespace/tabs/CR before interpreting a
+        // formula, so inspect the first significant character rather than charAt(0).
+        String significant = cleaned.replaceFirst("^[\\s\\t\\r\\n]+", "");
+        if (!significant.isEmpty() && "=+-@\t\r".indexOf(significant.charAt(0)) >= 0) {
             cleaned = "'" + cleaned;
         }
         return cleaned;


### PR DESCRIPTION
﻿## Problem

The CSV formula-injection sanitizer in PlagiarismDetectionService only neutralized a cell when its very first character was =, +, -, or @. Spreadsheet apps strip leading whitespace before interpreting a formula, so a value like  =HYPERLINK(...) or one starting with a tab still executes as a formula when opened — allowing formula injection / data exfiltration.

## Fix

sanitizeCsvCell now strips leading whitespace/tab/CR to find the first *significant* character and broadens the trigger set to include tab and CR. If that character is a formula metacharacter, the original cleaned value is prefixed with a single quote, rendering it inert text.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/PlagiarismDetectionService.java

## Testing

Inspected the change against the issue; the change is minimal and scoped to the sanitizer guard, preserving existing quote-escaping behavior.

Closes #19046
