### PR TITLE
fix: parse real table and column in IndexOptimizer instead of stubs (#19044)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/IndexOptimizer.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/IndexOptimizer.java
@@ -22,12 +22,20 @@ public class IndexOptimizer {
     }
 
     private String parseTableName(String query) {
-        // Mock parsing table name
-        return "event_registrations";
+        // Extract the table referenced after FROM / UPDATE / JOIN.
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+                "\\b(?:from|update|join)\\s+([a-z_][a-z0-9_]*)",
+                java.util.regex.Pattern.CASE_INSENSITIVE);
+        java.util.regex.Matcher matcher = pattern.matcher(query);
+        return matcher.find() ? matcher.group(1) : "unknown";
     }
 
     private String parseColumnName(String query) {
-        // Mock parsing column name
-        return "user_id";
+        // Extract the column compared in the WHERE clause (e.g. WHERE col = ?).
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+                "\\bwhere\\s+([a-z_][a-z0-9_]*)\\s*=",
+                java.util.regex.Pattern.CASE_INSENSITIVE);
+        java.util.regex.Matcher matcher = pattern.matcher(query);
+        return matcher.find() ? matcher.group(1) : "unknown";
     }
 }


### PR DESCRIPTION
﻿## Problem

IndexOptimizer.analyzeQueryLogs is supposed to recommend indexes for slow queries, but parseTableName() and parseColumnName() were stubbed to always return "event_registrations" / "user_id". Every slow query produced the identical, usually-wrong recommendation, giving operators false guidance.

## Fix

Replaced the stub parsers with real tokenization using regular expressions:
- parseTableName extracts the table referenced after FROM / UPDATE / JOIN.
- parseColumnName extracts the column compared in the WHERE clause (WHERE col = ...).
Both fall back to "unknown" when no match is found.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/IndexOptimizer.java

## Testing

Inspected the change against the issue; the fix matches the proposed fix and is scoped to the described behavior.

Closes #19044
