### PR TITLE
fix: enforce ownership/authorization in WebAuthn ticket verification (#19029)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/ticket/WebAuthnSignatureVerifier.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/ticket/WebAuthnSignatureVerifier.java
@@ -136,8 +136,13 @@ public class WebAuthnSignatureVerifier {
             @PathVariable String ticketId,
             @RequestParam(required = false) String userEmail) {
         
-        // Use the authenticated user's email if not provided
-        String email = userEmail != null ? userEmail : getCurrentUserEmail();
+        // Always derive the identity from the authenticated session; never trust a caller-supplied email.
+        String email = getCurrentUserEmail();
+        if (email == null || email.isBlank() || "unknown".equals(email)) {
+            return ResponseEntity.status(401).body(
+                Map.of("error", "Authenticated user email is required to generate a challenge")
+            );
+        }
         
         // Clean up expired challenges
         cleanupExpiredChallenges();
@@ -222,6 +227,16 @@ public class WebAuthnSignatureVerifier {
                     new VerificationResponse(false, "Invalid or expired challenge", ticketId, credentialId)
                 );
             }
+
+            // Authorization: the challenge must belong to the authenticated principal.
+            String principalEmail = getCurrentUserEmail();
+            if (principalEmail == null || principalEmail.isBlank() || "unknown".equals(principalEmail)
+                    || !principalEmail.equalsIgnoreCase(challengeEntry.userEmail)) {
+                return ResponseEntity.status(403).body(
+                    new VerificationResponse(false, "Challenge does not belong to the authenticated user",
+                            ticketId, credentialId)
+                );
+            }
             
             // Verify the challenge hasn't expired
             if (challengeEntry.isExpired()) {
@@ -247,7 +262,15 @@ public class WebAuthnSignatureVerifier {
             }
             
             PasskeyCredential credential = credentialOpt.get();
-            
+
+            // Authorization: the credential must be owned by the authenticated principal.
+            if (!credential.getUserEmail().equalsIgnoreCase(principalEmail)) {
+                return ResponseEntity.status(403).body(
+                    new VerificationResponse(false, "Credential is not owned by the authenticated user",
+                            ticketId, credentialId)
+                );
+            }
+
             // Parse the public key
             PublicKey publicKey = parsePublicKey(credential.getPublicKeyPem());
             if (publicKey == null) {
@@ -352,8 +375,13 @@ public class WebAuthnSignatureVerifier {
         
         try {
             String credentialId = getString(request, "credentialId");
-            String userEmail = getString(request, "userEmail") != null ? 
-                getString(request, "userEmail") : getCurrentUserEmail();
+            // Always derive the identity from the authenticated session; never trust a caller-supplied email.
+            String userEmail = getCurrentUserEmail();
+            if (userEmail == null || userEmail.isBlank() || "unknown".equals(userEmail)) {
+                return ResponseEntity.status(401).body(
+                    Map.of("error", "Authenticated user email is required to bind a credential")
+                );
+            }
             
             if (credentialId == null || credentialId.isBlank()) {
                 return ResponseEntity.badRequest().body(
@@ -366,6 +394,14 @@ public class WebAuthnSignatureVerifier {
             if (credentialOpt.isEmpty()) {
                 return ResponseEntity.badRequest().body(
                     Map.of("error", "Credential not found: " + credentialId)
+                );
+            }
+
+            // Authorization: the credential must be owned by the authenticated principal.
+            PasskeyCredential credential = credentialOpt.get();
+            if (!credential.getUserEmail().equalsIgnoreCase(userEmail)) {
+                return ResponseEntity.status(403).body(
+                    Map.of("error", "Credential is not owned by the authenticated user")
                 );
             }
             


### PR DESCRIPTION
﻿## Problem

The WebAuthn ticket verification endpoints (generateSignatureChallenge, erifySignature, indCredentialToTicket) were only guarded by @PreAuthorize("isAuthenticated()"). They accepted caller-supplied userEmail, never compared the authenticated principal to the challenge owner, and never verified credential→user ownership. Any logged-in user could mint a challenge for a victim's 	icketId/userEmail, reference any registered credentialId, and pass verification — attributing the result to an attacker-chosen email (IDOR / impersonation).

## Fix

In WebAuthnSignatureVerifier.java:
- generateSignatureChallenge and indCredentialToTicket now derive the email exclusively from the authenticated session (getCurrentUserEmail()) and reject unauthenticated/"unknown" callers (401) rather than trusting a request-supplied value.
- erifySignature asserts the authenticated principal equals the challenge's userEmail (403), and that the presented credential.getUserEmail() matches the principal (403).
- indCredentialToTicket asserts the credential is owned by the authenticated principal (403) before binding.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/ticket/WebAuthnSignatureVerifier.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix. Used the existing PasskeyCredential.getUserEmail() and getCurrentUserEmail() so it compiles within the current API.

Closes #19029
