### PR TITLE
fix: make PushSubscriptionService.subscribe idempotent under concurrent duplicate insert (#19059)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java
@@ -6,6 +6,7 @@ import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.PushSubscriptionRepository;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,7 +50,22 @@ public class PushSubscriptionService {
         subscription.setEndpoint(request.getEndpoint());
         subscription.setP256dh(p256dh);
         subscription.setAuth(auth);
-        pushSubscriptionRepository.save(subscription);
+
+        try {
+            pushSubscriptionRepository.save(subscription);
+        } catch (DataIntegrityViolationException e) {
+            // Two near-simultaneous subscribe calls for the same (user, endpoint)
+            // can both miss the row in findByUser_IdAndEndpoint and then race on
+            // the unique constraint, surfacing an unhandled 500. Treat a
+            // concurrent duplicate insert as an idempotent re-subscribe by
+            // refreshing the existing row and updating its keys (#19059).
+            PushSubscription existing = pushSubscriptionRepository
+                    .findByUser_IdAndEndpoint(user.getId(), request.getEndpoint())
+                    .orElseThrow(() -> e);
+            existing.setP256dh(p256dh);
+            existing.setAuth(auth);
+            pushSubscriptionRepository.save(existing);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
﻿## Problem

PushSubscriptionService.subscribe deduplicates via indByUser_IdAndEndpoint(...).orElseGet(PushSubscription::new) then save. Under concurrency, two near-simultaneous subscribe calls for the same (user, endpoint) may both find no row, both build a 
ew PushSubscription, and the second save violates the (user_id, endpoint) unique constraint, surfacing an unhandled 500 instead of an idempotent success.

## Fix

Wrapped the save in a 	ry/catch (DataIntegrityViolationException). On a concurrent duplicate insert, the existing row is re-fetched and its p256dh/uth keys are updated, so re-subscribing the same (user, endpoint) is idempotent (updates keys) and no longer throws a 500.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/PushSubscriptionService.java

## Testing

Inspected the change against the issue; the fix is minimal and scoped to the described race. A concurrent duplicate insert now resolves to an idempotent update of the existing subscription rather than an unhandled 500.

Closes #19059
