### PR TITLE
fix: implement GDPR anonymization job for pending-deletion users (#19043)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
@@ -82,6 +82,14 @@ public class User {
     @Column(name = "auth_provider", length = 30)
     private String authProvider;
 
+    @Builder.Default
+    @Column(name = "deletion_requested", nullable = false)
+    private boolean deletionRequested = false;
+
+    @Builder.Default
+    @Column(name = "anonymized", nullable = false)
+    private boolean anonymized = false;
+
     @Convert(converter = JsonMapAttributeConverter.class)
     @Column(name = "preferences", columnDefinition = "TEXT")
     private Map<String, Object> preferences = new HashMap<>();

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
@@ -22,6 +22,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailOrUsername(String email, String username);
 
+    // GDPR: users who have requested deletion but have not yet been anonymized.
+    List<User> findByDeletionRequestedTrueAndAnonymizedFalse();
+
     boolean existsByEmail(String email);
 
     boolean existsByEmailIgnoreCase(String email);

--- a/Backend/src/main/java/com/sandeep/eventrabackend/scheduler/GdprAnonymizationJob.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/scheduler/GdprAnonymizationJob.java
@@ -1,16 +1,49 @@
 package com.sandeep.eventrabackend.scheduler;
 
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import java.util.List;
 import java.util.UUID;
 
 @Component
 public class GdprAnonymizationJob {
 
+    private final UserRepository userRepository;
+
+    public GdprAnonymizationJob(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
     @Scheduled(cron = "0 0 2 * * *") // Runs every day at 2:00 AM
     public void runAnonymization() {
-        // Find users requested for deletions and anonymize their profile details
         System.out.println("Executing daily GDPR-compliant user profile anonymization task...");
+
+        // Honor pending deletion/anonymization requests instead of being a no-op.
+        List<User> pendingDeletion = userRepository.findByDeletionRequestedTrueAndAnonymizedFalse();
+        for (User user : pendingDeletion) {
+            anonymizeUser(user);
+        }
+
+        if (!pendingDeletion.isEmpty()) {
+            userRepository.saveAll(pendingDeletion);
+            System.out.println("Anonymized " + pendingDeletion.size()
+                    + " user profile(s) per GDPR deletion request.");
+        }
+    }
+
+    private void anonymizeUser(User user) {
+        String anonToken = anonymizeString(user.getEmail());
+        user.setFirstName(anonToken);
+        user.setLastName(anonToken);
+        // Scope the anonymous value to the user id to keep unique columns (email/username) valid.
+        user.setEmail("anon_" + user.getId() + "@deleted.invalid");
+        user.setUsername("anon_" + user.getId());
+        user.setProfileHeadline(null);
+        user.setLinkedinUrl(null);
+        user.setGithubUrl(null);
+        user.setAnonymized(true);
     }
 
     public String anonymizeString(String input) {

--- a/Backend/src/main/resources/db/migration/V9__gdpr_anonymization_flag.sql
+++ b/Backend/src/main/resources/db/migration/V9__gdpr_anonymization_flag.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS deletion_requested BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS anonymized BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_users_gdpr_pending
+    ON users(deletion_requested, anonymized);


### PR DESCRIPTION
﻿## Problem

The daily GDPR anonymization job (@Scheduled unAnonymization()) only logged a message; it never loaded users who requested deletion/anonymization, never called nonymizeString(...), and never persisted anything. Deletion/anonymization requests were silently never honored.

## Fix

- Added deletionRequested and nonymized boolean columns to User (with a V9 Flyway migration mirroring the existing Postgres style).
- Added UserRepository.findByDeletionRequestedTrueAndAnonymizedFalse() to fetch pending users.
- GdprAnonymizationJob now injects UserRepository, loads pending-deletion users, anonymizes PII (firstName, lastName, email, username, profileHeadline, linkedinUrl, githubUrl) via nonymizeString, marks nonymized=true, and saves — scoping anonymous email/username to the user id to keep unique constraints valid.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/model/User.java
- Backend/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
- Backend/src/main/java/com/sandeep/eventrabackend/scheduler/GdprAnonymizationJob.java
- Backend/src/main/resources/db/migration/V9__gdpr_anonymization_flag.sql

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix. The @Builder-only usage of User means the new fields don't break existing construction, and no test references the job directly.

Closes #19043
