### PR TITLE
fix: validate recipient email and strip CRLF from subject (#19057)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java
@@ -268,14 +268,18 @@ public class EmailTemplateService {
      */
     private String generateSubject(String templateType, Map<String, Object> event) {
         String eventTitle = event != null ? String.valueOf(event.getOrDefault("title", "Event")) : "Event";
-        
+        String subject;
         switch (templateType) {
             case "waitlist_promotion":
-                return "Good News! You've been promoted from the waitlist for " + eventTitle;
+                subject = "Good News! You've been promoted from the waitlist for " + eventTitle;
+                break;
             case "cancellation":
             default:
-                return "Event Cancelled: " + eventTitle;
+                subject = "Event Cancelled: " + eventTitle;
+                break;
         }
+        // Strip CR/LF to prevent email header injection from untrusted event titles
+        return subject.replaceAll("[\r\n]", "");
     }
 
     /**

--- a/Backend/src/main/java/com/sandeep/eventrabackend/util/EmailSender.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/util/EmailSender.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.util;
 
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class EmailSender {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
 
     /**
      * Send an email with the specified parameters
@@ -33,11 +37,18 @@ public class EmailSender {
             if (to == null || to.isBlank()) {
                 throw new IllegalArgumentException("Recipient email cannot be empty");
             }
-            
+
+            if (!EMAIL_PATTERN.matcher(to).matches() || to.chars().anyMatch(c -> c < 0x20)) {
+                throw new IllegalArgumentException("Recipient email is not a valid address");
+            }
+
             if (subject == null || subject.isBlank()) {
                 throw new IllegalArgumentException("Subject cannot be empty");
             }
-            
+
+            // Strip CR/LF to prevent email header injection (e.g. injecting Bcc:)
+            subject = subject.replaceAll("[\r\n]", "");
+
             if (body == null || body.isBlank()) {
                 throw new IllegalArgumentException("Body cannot be empty");
             }


### PR DESCRIPTION
﻿## Problem

EmailSender.sendEmail only checks the recipient for non-blank and builds the subject via raw concatenation of untrusted eventTitle. A malicious eventTitle containing \r\n enables email header injection (e.g. injecting Bcc:), and a malformed 	o is accepted as long as it is not empty.

## Fix

- Added an RFC-style address regex check on 	o (and rejected any control characters) in EmailSender.sendEmail.
- Strip \r/\n from the subject in EmailSender.sendEmail (defense-in-depth) and in EmailTemplateService.generateSubject before the transport call, preventing header injection.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/util/EmailSender.java
- Backend/src/main/java/com/sandeep/eventrabackend/service/EmailTemplateService.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix. The email validation and CRLF stripping are applied at the single send path and the subject-building method.

Closes #19057
