### PR TITLE
fix: enforce event-ownership authorization on saveTemplate/getTemplate (#19071)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -230,6 +230,7 @@ public class NotificationController {
     }
 
     @PostMapping("/save-template")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     @Operation(
             summary = "Save a custom email template",
             description = "Saves a custom email template for an event and template type.",
@@ -257,10 +258,22 @@ public class NotificationController {
             @Valid @RequestBody SaveTemplateRequest request,
             Authentication authentication) {
         String organizerEmail = authentication.getName();
+
+        long eventId;
+        try {
+            eventId = Long.parseLong(request.getEventId());
+        } catch (NumberFormatException ex) {
+            return ResponseEntity.badRequest().body(null);
+        }
+
+        // Only the event organizer (or an admin) may save templates for the event.
+        eventRoleService.requireRole(eventId, organizerEmail, EventRole.ORGANIZER);
+
         return ResponseEntity.ok(emailTemplateService.saveTemplate(request, organizerEmail));
     }
 
     @GetMapping("/templates/{eventId}/{templateType}")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
     @Operation(
             summary = "Get a custom email template",
             description = "Retrieves a custom email template for an event and template type.",
@@ -270,6 +283,10 @@ public class NotificationController {
             @ApiResponse(
                     responseCode = "200",
                     description = "Template retrieved successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid event id"
             ),
             @ApiResponse(
                     responseCode = "404",
@@ -289,6 +306,17 @@ public class NotificationController {
             @PathVariable String templateType,
             Authentication authentication) {
         String organizerEmail = authentication.getName();
-        return ResponseEntity.ok(emailTemplateService.getTemplate(String.valueOf(eventId), templateType, organizerEmail));
+
+        long parsedEventId;
+        try {
+            parsedEventId = Long.parseLong(eventId);
+        } catch (NumberFormatException ex) {
+            return ResponseEntity.badRequest().body(null);
+        }
+
+        // Only the event organizer (or an admin) may read templates for the event.
+        eventRoleService.requireRole(parsedEventId, organizerEmail, EventRole.ORGANIZER);
+
+        return ResponseEntity.ok(emailTemplateService.getTemplate(String.valueOf(parsedEventId), templateType, organizerEmail));
     }
 }


### PR DESCRIPTION
﻿## Problem

NotificationController.saveTemplate and getTemplate are only guarded by @PreAuthorize("isAuthenticated()"). Any authenticated user who knows (or enumerates) another organizer's eventId + 	emplateType can overwrite or read that event's notification templates (IDOR).

## Fix

Added @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')") to both saveTemplate and getTemplate, and invoked eventRoleService.requireRole(eventId, organizerEmail, EventRole.ORGANIZER) at the start of each (mirroring sendTestEmail). Non-owners now receive 403, and malformed event ids return 400.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix, mirroring the existing sendTestEmail authorization pattern.

Closes #19071
