### PR TITLE
fix: chain audit block hashes so verify-chain succeeds (#19086)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/security/audit/AuditLogManager.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/security/audit/AuditLogManager.java
@@ -137,10 +137,14 @@ public class AuditLogManager {
         String rootHash = hasher.computeRootHash(logStrings);
         String previousHash = hashChain.isEmpty() ? "" : hashChain.get(hashChain.size() - 1);
 
+        // Link this block to the previous one so the chain is tamper-evident:
+        // each stored entry is sha256(previousChainedHash + rootHash), not the raw root hash.
+        String chainedHash = hasher.sha256(previousHash + rootHash);
+
         // Create the block
         Block block = new Block(blockId, rootHash, previousHash, new ArrayList<>(currentBlockLogs));
         blocks.put(blockId, block);
-        hashChain.add(rootHash);
+        hashChain.add(chainedHash);
 
         logger.info("Created new audit block: {} with {} logs, rootHash: {}", 
                 blockId, currentBlockLogs.size(), rootHash);


### PR DESCRIPTION
﻿## Problem

AuditLogManager.createBlock() appended the per-block Merkle ootHash to hashChain as-is, but MerkleTreeHasher.validateHashChain() (used by POST /api/audit/verify-chain) expects each stored entry to be sha256(previousHash + rootHash). Because the stored value was the raw root hash, verification always returned alse, so the chain provided no integrity guarantee.

## Fix

In createBlock, compute chainedHash = hasher.sha256(previousHash + rootHash) and store that in hashChain (while the Block still records the raw ootHash and the previous chained hash for audit display). alidateHashChain already computes sha256(previousHash + rootHashes.get(i)) and compares against the stored entry, so the chain is now internally consistent and tampering/reordering breaks verification.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/security/audit/AuditLogManager.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix and matches the existing alidateHashChain contract.

Closes #19086
