### PR TITLE
fix: charge corrected last-installment amount in Stripe scheduleInstallmentPayments (#19033)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java
@@ -174,10 +174,20 @@ public class StripeService {
         // Calculate installment amounts
         BigDecimal installmentAmount = paymentPlan.getInstallmentAmount();
         BigDecimal remainingAmount = paymentPlan.getRemainingAmount();
-        
+
         // Convert to cents (Stripe uses smallest currency unit)
         long installmentAmountCents = installmentAmount.multiply(new BigDecimal(100)).longValue();
-        
+
+        // The DB applies a rounding correction to the final installment
+        // (lastInstallmentAmount) so the plan total reconciles exactly. Charge
+        // that corrected amount on the last installment instead of the rounded
+        // per-installment amount, otherwise Stripe totals would not match the
+        // persisted Payment records.
+        int numInstallments = paymentPlan.getTotalInstallments() - 1;
+        BigDecimal lastInstallmentAmount = remainingAmount.subtract(
+                installmentAmount.multiply(new BigDecimal(Math.max(0, numInstallments - 1))));
+        long lastInstallmentCents = lastInstallmentAmount.multiply(new BigDecimal(100)).longValue();
+
         // Create remaining installments (2..N); the upfront payment is created
         // and confirmed separately by PaymentPlanService.
         LocalDateTime eventDate = paymentPlan.getRegistration().getEvent().getEventDate();
@@ -192,9 +202,11 @@ public class StripeService {
             long daysUntilInstallment = (daysBetween / interval) * (i - 1);
             LocalDateTime dueDate = now.plusDays(daysUntilInstallment);
             
+            long amountCents = (i == paymentPlan.getTotalInstallments())
+                    ? lastInstallmentCents : installmentAmountCents;
             PaymentIntent intent = createPaymentIntentWithoutConfirmation(
                     customerId,
-                    installmentAmountCents,
+                    amountCents,
                     paymentPlan.getCurrency().toLowerCase(),
                     "Installment " + i + " of " + paymentPlan.getTotalInstallments() + 
                             " for " + paymentPlan.getRegistration().getEvent().getTitle(),


### PR DESCRIPTION
﻿## Problem

StripeService.scheduleInstallmentPayments charged every installment (including the final one) the same rounded installmentAmountCents. The DB, however, applies a rounding correction to the last installment (lastInstallmentAmount in PaymentPlanService), so Stripe charges no longer reconcile with the persisted Payment records and corrupt the plan total.

## Fix

In scheduleInstallmentPayments (Backend/.../service/StripeService.java) I compute the same rounding-corrected last-installment amount the DB uses (emainingAmount - installmentAmount * (numInstallments - 1)) and pass that exact mountCents on the final installment (i == totalInstallments); all other installments keep installmentAmountCents.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/StripeService.java

## Testing

Inspected the change against the DB logic in PaymentPlanService (last-installment amount). The per-installment charge now mirrors the persisted Payment amounts, making Stripe totals reconcile.

Closes #19033
