### PR TITLE
fix: enable CSRF token protection (#19053)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -11,7 +11,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -122,9 +122,15 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                // Disable CSRF — JWT auth (Bearer or SameSite=None HttpOnly cookie).
-                // Cookie is not readable by JS; SPA uses withCredentials for cookie sessions.
-                .csrf(AbstractHttpConfigurer::disable)
+                // Enable CSRF protection via a cookie-borne token repository.
+                // The auth cookie is intentionally SameSite=None (required for the
+                // cross-site SPA) and HttpOnly, so cross-site requests are still
+                // authenticated by the cookie. Requiring a CSRF token on state-changing
+                // requests prevents forged cross-site mutations. The SPA reads the
+                // XSRF-TOKEN cookie (httpOnly=false) and echoes it as the X-CSRF-Token
+                // header, which is already allowed by the CORS configuration.
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
                 // Disable CORS — open for testing; re-enable before production
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 // Stateless sessions — JWT handles auth


### PR DESCRIPTION
﻿## Problem

SecurityConfig globally disables CSRF (.csrf(AbstractHttpConfigurer::disable)), while the auth cookie is issued as SameSite=None; HttpOnly; Secure with setAllowCredentials(true) and CORS allows credentialed cross-origin requests. Because SameSite=None makes the browser send the auth cookie on cross-site POSTs and there is no CSRF token to verify them, any state-changing authenticated endpoint is reachable cross-site via the cookie — a classic CSRF exposure.

## Fix

In SecurityConfig.securityFilterChain (Backend/.../config/SecurityConfig.java) I replaced .csrf(AbstractHttpConfigurer::disable) with csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())). This keeps the SameSite=None cookie working for the cross-site SPA but now requires a CSRF token on mutating requests. The X-CSRF-Token header is already allow-listed by the CORS config; the SPA reads the XSRF-TOKEN cookie (httpOnly=false) and echoes it as the X-CSRF-Token header.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java

## Testing

Inspected the change against the issue; CSRF is now enabled with a cookie token repository. Note: SPA clients must echo the XSRF-TOKEN cookie as the X-CSRF-Token header on state-changing requests.

Closes #19053
