### PR TITLE
fix: stop TrendingEventCard fabricating date and attendance (#19139)

### DIFF
--- a/src/components/ui/TrendingEventCard.jsx
+++ b/src/components/ui/TrendingEventCard.jsx
@@ -14,7 +14,9 @@ export default function TrendingEventCard({ event, onClick }) {
         day: "numeric",
         year: "numeric"
       })
-    : "Aug 28, 2026";
+    : "Date TBD";
+
+  const registeredCount = event?.registeredCount;
 
   const imageUrl =
     event?.imageUrl ||
@@ -80,7 +82,7 @@ export default function TrendingEventCard({ event, onClick }) {
           </span>
           <span className="flex items-center gap-1">
             <Users className="w-3.5 h-3.5 text-emerald-600" />
-            <span>{event?.registeredCount ?? 120} going</span>
+            <span>{registeredCount != null ? `${registeredCount} going` : "Be the first"}</span>
           </span>
         </div>
 


### PR DESCRIPTION
## Summary

Fixes #19139.

`src/components/ui/TrendingEventCard.jsx` displayed fabricated placeholder data when the API omitted fields:
- A hardcoded future date **"Aug 28, 2026"** when `eventDate` was missing.
- Fake **"120 going"** when `registeredCount` was `null`/`undefined`.

Both were rendered as real event metadata, misleading users (especially for newly created/draft events that legitimately have no date or registrations).

## Root Cause

The fallback branches used hardcoded literal values instead of neutral placeholders, inconsistent with `EventCard.jsx` which already uses `"Date TBD"`.

```jsx
const formattedDate = event?.eventDate ? new Date(event.eventDate)... : "Aug 28, 2026";   // fabricated
...
<span>{event?.registeredCount ?? 120} going</span>   // fabricated
```

## Changes

`src/components/ui/TrendingEventCard.jsx`:
- Date fallback: `"Aug 28, 2026"` → `"Date TBD"` (matches `EventCard.jsx`).
- Attendance: render the real `registeredCount` when present (`!= null`), otherwise show `"Be the first"` instead of fabricating `120`. `registeredCount: 0` still renders `"0 going"` (preserved, since `!= null` keeps 0).

```diff
-    : "Aug 28, 2026";
+    : "Date TBD";
+
+  const registeredCount = event?.registeredCount;
...
-            <span>{event?.registeredCount ?? 120} going</span>
+            <span>{registeredCount != null ? `${registeredCount} going` : "Be the first"}</span>
```

No API or structural change; single component, minimal diff.

## Testing

This repository has **no test framework** configured (no jest/vitest, no test files, `package.json` scripts are only `dev`/`build`/`lint`). Per the audit policy of not introducing a new testing framework for a single UI fix, validation was done via lint + build + manual reasoning:

- `npx eslint src/components/ui/TrendingEventCard.jsx` → **passes** (0 errors).
- `npm run build` → **passes** (all 10 routes generated, exit 0).
- Manual verification of rendering logic:
  - `eventDate` missing → `"Date TBD"` (was `"Aug 28, 2026"`).
  - `registeredCount: 0` → `"0 going"` (unchanged, `!= null` preserves 0).
  - `registeredCount: null`/`undefined` → `"Be the first"` (was `"120 going"`).
  - Real date/count → renders the real values (unchanged).

## Related Issue

Closes #19139

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._
