### PR TITLE
fix: guard AdminService.updateEvent setters against null partial payloads (#19091)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -243,10 +243,18 @@ public class AdminService {
                             + event.getRegisteredCount() + ")");
         }
 
-        event.setTitle(request.getTitle());
-        event.setDescription(request.getDescription());
-        event.setLocation(request.getLocation());
-        event.setEventDate(request.getEventDate());
+        if (request.getTitle() != null) {
+            event.setTitle(request.getTitle());
+        }
+        if (request.getDescription() != null) {
+            event.setDescription(request.getDescription());
+        }
+        if (request.getLocation() != null) {
+            event.setLocation(request.getLocation());
+        }
+        if (request.getEventDate() != null) {
+            event.setEventDate(request.getEventDate());
+        }
         if (request.getCapacity() != null) {
             event.setCapacity(request.getCapacity());
         }


### PR DESCRIPTION
﻿## Problem

AdminService.updateEvent set title/description/location/eventDate unconditionally, so any partial admin edit (e.g. only capacity) nulled those fields.

## Fix

Guarded all four setters with null checks, mirroring the existing pattern used for the other fields (and HackathonService.updateHackathon).

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/AdminService.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix.

Closes #19091
