### PR TITLE
fix: reject unsupported 'free' event search filter with 400 (#19061)

### DIFF
--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -50,7 +50,9 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
@@ -437,9 +439,10 @@ public class EventService {
                                 .and(EventSpecifications.eventDateBefore(endDate));
 
                 // Events do not currently model price, so a free filter cannot be applied.
-                // Do not use capacity as a proxy for price.
+                // Reject the unsupported parameter instead of silently returning all events.
                 if (free != null && free) {
-                        // Intentionally no-op until pricing data is available.
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                "The 'free' filter is not supported: events do not currently model price.");
                 }
 
                 Page<Event> page = eventRepository.findAll(spec, pageable);


### PR DESCRIPTION
﻿## Problem

EventService.searchEvents advertised a 'free' filter but the implementation was an empty no-op, so callers filtering for free events received every event (incorrect results).

## Fix

Replaced the no-op block with a 400 BAD_REQUEST ResponseStatusException, documenting that events do not model price. This stops silently returning wrong results while the unsupported parameter is documented.

## Files changed

- Backend/src/main/java/com/sandeep/eventrabackend/service/EventService.java

## Testing

Inspected the change against the issue; change is minimal and scoped to the described fix.

Closes #19061
