### PR TITLE
fix: authorize leaderboard broadcast endpoint (issue #19063)

### DIFF
--- a/Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java
+++ b/Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java
@@ -21,6 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -173,6 +174,7 @@ public class HackathonLeaderboardSseController implements MessageListener, Healt
     /**
      * Broadcasts leaderboard updates. High-frequency updates get queued into the batch engine.
      */
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')")
     @PostMapping("/{id}/leaderboard/broadcast")
     public ResponseEntity<Void> broadcastLeaderboardUpdate(
             @PathVariable("id") Long hackathonId,


### PR DESCRIPTION
﻿## Problem

HackathonLeaderboardSseController.broadcastLeaderboardUpdate (POST /api/v1/hackathons/{id}/leaderboard/broadcast) had no @PreAuthorize and no role/ownership check, so any authenticated user (even an ATTENDEE) could push arbitrary leaderboard payloads to every SSE subscriber of a hackathon.

## Fix

Added @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN', 'ORGANIZER')") to roadcastLeaderboardUpdate, matching the authorization style already used across the codebase (e.g. AnalyticsController). Method-level security is enabled via @EnableMethodSecurity in SecurityConfig, so the annotation is enforced. Also added the required PreAuthorize import.

## Files changed

- Backend/src/main/java/com/eventra/controller/HackathonLeaderboardSseController.java

## Testing

Inspected the change against the issue; the change is minimal (import + annotation) and follows the existing, verified @PreAuthorize pattern used by other controllers.

Closes #19063
