### PR TITLE
fix(api): merge per-request headers over defaults in fetchAPI (#19095)

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -6,16 +6,17 @@ function getAuthHeader() {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
-async function fetchAPI(endpoint, options = {}) {
+export async function fetchAPI(endpoint, options = {}) {
   const url = `${API_BASE_URL}${endpoint}`;
   try {
+    const { headers: optHeaders, ...rest } = options;
     const res = await fetch(url, {
+      ...rest,
       headers: {
         "Content-Type": "application/json",
         ...getAuthHeader(),
-        ...options.headers,
+        ...(optHeaders || {}),
       },
-      ...options,
     });
 
     if (!res.ok) {

--- a/tests/api.fetchAPI.test.mjs
+++ b/tests/api.fetchAPI.test.mjs
@@ -1,0 +1,78 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Regression for #19095: fetchAPI built a merged `headers` object
+// (Content-Type + auth + caller headers) but then spread `...options` AFTER
+// it, so any caller-supplied `options.headers` replaced the entire `headers`
+// object — discarding Content-Type and Authorization. The first caller to
+// pass custom headers (multipart, CSRF, Idempotency-Key) would lose auth on
+// every request. This test calls fetchAPI with custom headers and asserts the
+// defaults are retained AND the caller headers are merged on top.
+
+let capturedUrl, capturedInit;
+let storedToken = null;
+
+globalThis.fetch = async (url, init) => {
+  capturedUrl = url;
+  capturedInit = init;
+  return { ok: true, status: 200, json: async () => ({ ok: true }) };
+};
+
+// getAuthHeader() reads the global `localStorage` when `window` is defined.
+// In node we shim the minimal surface it touches (global + window).
+globalThis.window = globalThis.window || {};
+const localStorageShim = {
+  getItem: (k) => (k === "eventra_token" ? storedToken : null),
+  setItem: (k, v) => { storedToken = v; },
+  removeItem: () => { storedToken = null; },
+};
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: localStorageShim,
+});
+Object.defineProperty(globalThis.window, "localStorage", {
+  configurable: true,
+  value: localStorageShim,
+});
+
+const { fetchAPI } = await import("../src/lib/api.js");
+
+describe("fetchAPI merges per-request headers over defaults (#19095)", () => {
+  beforeEach(() => { capturedUrl = capturedInit = undefined; });
+  afterEach(() => { storedToken = null; });
+
+  it("retains Content-Type and Authorization when caller passes custom headers", async () => {
+    storedToken = "tok-123";
+    await fetchAPI("/api/x", {
+      method: "POST",
+      headers: { "Idempotency-Key": "abc", "X-Custom": "v" },
+      body: JSON.stringify({ a: 1 }),
+    });
+
+    const headers = new Headers(capturedInit.headers);
+    assert.equal(headers.get("Content-Type"), "application/json");
+    assert.equal(headers.get("Authorization"), "Bearer tok-123");
+    assert.equal(headers.get("Idempotency-Key"), "abc");
+    assert.equal(headers.get("X-Custom"), "v");
+    // non-header options still flow through
+    assert.equal(capturedInit.method, "POST");
+    assert.equal(capturedInit.body, JSON.stringify({ a: 1 }));
+  });
+
+  it("works without custom headers (Content-Type + Authorization only)", async () => {
+    storedToken = "tok-456";
+    await fetchAPI("/api/y");
+    const headers = new Headers(capturedInit.headers);
+    assert.equal(headers.get("Content-Type"), "application/json");
+    assert.equal(headers.get("Authorization"), "Bearer tok-456");
+  });
+
+  it("does not include Authorization when no token is stored", async () => {
+    storedToken = null;
+    await fetchAPI("/api/z", { headers: { "X-Trace": "1" } });
+    const headers = new Headers(capturedInit.headers);
+    assert.equal(headers.get("Authorization"), null);
+    assert.equal(headers.get("X-Trace"), "1");
+    assert.equal(headers.get("Content-Type"), "application/json");
+  });
+});


### PR DESCRIPTION
Closes #19095.

## Problem

In `src/lib/api.js`, `fetchAPI` built a merged `headers` object (`Content-Type` + auth + caller headers) but then spread `...options` **after** it. Any caller-supplied `options.headers` therefore **replaced the entire `headers` object**, discarding `Content-Type` and `Authorization`.

```js
const res = await fetch(url, {
  headers: { "Content-Type": "application/json", ...getAuthHeader(), ...options.headers },
  ...options,            // overwrites `headers` if options.headers exists
});
```

Latent today (no caller passes custom headers) but structurally unsafe: the first caller to add a multipart, CSRF, or `Idempotency-Key` header would silently lose authentication on every request (hard-to-trace 401s).

## Fix

Destructure caller headers out of `options`, spread the remaining (`method`/`body`/etc.) first, then build headers with defaults + auth + caller headers merged on top:

```js
const { headers: optHeaders, ...rest } = options;
const res = await fetch(url, {
  ...rest,
  headers: { "Content-Type": "application/json", ...getAuthHeader(), ...(optHeaders || {}) },
});
```

Per-request headers now augment, never replace, the defaults. `fetchAPI` is also exported for direct testability (previously internal-only).

## Validation

This repo has no test framework configured, so the regression test uses Node's built-in `node:test` (no new dependencies): `tests/api.fetchAPI.test.mjs` mocks `fetch` + `localStorage`, calls `fetchAPI` with custom headers, and asserts `Content-Type` + `Authorization` are retained alongside the caller headers, plus no-token and no-custom-headers paths.

**TDD-verified:** with the broken `...options` spread restored (export kept), the custom-headers cases fail (`Content-Type` dropped); with the fix, all 3 pass:

```
$ node --test tests/api.fetchAPI.test.mjs
# tests 3  # pass 3  # fail 0
```

Diff vs `master`: `src/lib/api.js` (+4/-3) and `tests/api.fetchAPI.test.mjs` (new).

Note: this PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh.

Closes #19095.