### PR TITLE
fix: handle JWT token expiry with auto-redirect to login

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -18,6 +18,13 @@ async function fetchAPI(endpoint, options = {}) {
       ...options,
     });
 
+    if (res.status === 401 && typeof window !== "undefined") {
+      localStorage.removeItem("eventra_token");
+      localStorage.removeItem("eventra_user");
+      window.location.href = "/login";
+      throw new Error("Session expired. Please log in again.");
+    }
+
     if (!res.ok) {
       let errText = res.statusText;
       try {


### PR DESCRIPTION
## Description
When a JWT token expires mid-session, API calls silently fail with 401 Unauthorized errors, leaving users confused.

## Changes
- Added 401 status detection in the centralized `fetchAPI` client
- Clears expired token and user data from localStorage
- Redirects to `/login` page
- Throws descriptive error message

## Related Issue
Relates to #19153

## Type of Change
- [x] Bug fix (non-breaking)