### PR TITLE
fix: surface errors when registration or upvote fails

### DIFF
--- a/src/app/events/[id]/page.jsx
+++ b/src/app/events/[id]/page.jsx
@@ -15,7 +15,8 @@ import {
   Sparkles,
   Award,
   ShieldCheck,
-  UserCheck
+  UserCheck,
+  AlertCircle
 } from "lucide-react";
 import { getEventById, registerForEvent } from "@/lib/api";
 import { CardSkeleton } from "@/components/ui/Skeleton";
@@ -27,6 +28,7 @@ export default function EventDetailPage() {
   const [event, setEvent] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isRegistering, setIsRegistering] = useState(false);
+  const [actionError, setActionError] = useState("");
   const [registered, setRegistered] = useState(false);
 
   useEffect(() => {
@@ -49,6 +51,7 @@ export default function EventDetailPage() {
 
   const handleRegister = async () => {
     setIsRegistering(true);
+    setActionError("");
     try {
       await registerForEvent(eventId);
       setRegistered(true);
@@ -58,6 +61,7 @@ export default function EventDetailPage() {
       }));
     } catch (err) {
       console.warn("Registration error", err);
+      setActionError(err?.message || "Could not complete your registration. Please try again.");
     } finally {
       setIsRegistering(false);
     }
@@ -247,6 +251,16 @@ export default function EventDetailPage() {
                   <UserCheck className="w-4 h-4" />
                   <span>{isRegistering ? "Registering..." : "RSVP / Register Now"}</span>
                 </button>
+              )}
+
+              {actionError && (
+                <div
+                  role="alert"
+                  className="p-3 bg-red-50 border border-red-200 text-red-700 rounded-2xl text-xs flex items-start gap-2 font-medium"
+                >
+                  <AlertCircle className="w-4 h-4 shrink-0 text-red-600 mt-px" />
+                  <span>{actionError}</span>
+                </div>
               )}
 
               <div className="flex items-center justify-center gap-2 text-xs text-zinc-500 pt-2 border-t border-zinc-100">

--- a/src/app/hackathons/[id]/page.jsx
+++ b/src/app/hackathons/[id]/page.jsx
@@ -17,7 +17,8 @@ import {
   Clock,
   Layers,
   Cpu,
-  Check
+  Check,
+  AlertCircle
 } from "lucide-react";
 import { getHackathonById, registerForHackathon } from "@/lib/api";
 import { CardSkeleton } from "@/components/ui/Skeleton";
@@ -29,6 +30,7 @@ export default function HackathonDetailPage() {
   const [hackathon, setHackathon] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isRegistering, setIsRegistering] = useState(false);
+  const [actionError, setActionError] = useState("");
   const [registered, setRegistered] = useState(false);
 
   useEffect(() => {
@@ -51,11 +53,13 @@ export default function HackathonDetailPage() {
 
   const handleRegister = async () => {
     setIsRegistering(true);
+    setActionError("");
     try {
       await registerForHackathon(hackathonId);
       setRegistered(true);
     } catch (err) {
       console.warn("Registration error", err);
+      setActionError(err?.message || "Could not complete your registration. Please try again.");
     } finally {
       setIsRegistering(false);
     }
@@ -252,6 +256,16 @@ export default function HackathonDetailPage() {
                   <Trophy className="w-4 h-4" />
                   <span>{isRegistering ? "Registering..." : "Register Team / Submit"}</span>
                 </button>
+              )}
+
+              {actionError && (
+                <div
+                  role="alert"
+                  className="p-3 bg-red-50 border border-red-200 text-red-700 rounded-2xl text-xs flex items-start gap-2 font-medium"
+                >
+                  <AlertCircle className="w-4 h-4 shrink-0 text-red-600 mt-px" />
+                  <span>{actionError}</span>
+                </div>
               )}
 
               <div className="flex items-center justify-center gap-2 text-xs text-zinc-500 pt-2 border-t border-zinc-100">

--- a/src/app/projects/[id]/page.jsx
+++ b/src/app/projects/[id]/page.jsx
@@ -13,7 +13,8 @@ import {
   Sparkles, 
   CheckCircle2, 
   ShieldCheck,
-  Star
+  Star,
+  AlertCircle
 } from "lucide-react";
 import { getProjectById, upvoteProject } from "@/lib/api";
 import { CardSkeleton } from "@/components/ui/Skeleton";
@@ -26,6 +27,7 @@ export default function ProjectDetailPage() {
   const [loading, setLoading] = useState(true);
   const [upvotes, setUpvotes] = useState(0);
   const [hasUpvoted, setHasUpvoted] = useState(false);
+  const [actionError, setActionError] = useState("");
 
   useEffect(() => {
     async function loadProject() {
@@ -48,12 +50,17 @@ export default function ProjectDetailPage() {
 
   const handleUpvote = async () => {
     if (hasUpvoted) return;
+    setActionError("");
+    // Optimistic update, rolled back below if the request fails.
     setUpvotes((prev) => prev + 1);
     setHasUpvoted(true);
     try {
       await upvoteProject(projectId);
     } catch (err) {
       console.warn("Upvote error", err);
+      setUpvotes((prev) => Math.max(0, prev - 1));
+      setHasUpvoted(false);
+      setActionError(err?.message || "Could not record your upvote. Please try again.");
     }
   };
 
@@ -195,6 +202,16 @@ export default function ProjectDetailPage() {
                   <ThumbsUp className="w-4 h-4" />
                   <span>{hasUpvoted ? `Upvoted (${upvotes})` : `Upvote Project (${upvotes})`}</span>
                 </button>
+
+                {actionError && (
+                  <div
+                    role="alert"
+                    className="p-3 bg-red-50 border border-red-200 text-red-700 rounded-2xl text-xs flex items-start gap-2 font-medium"
+                  >
+                    <AlertCircle className="w-4 h-4 shrink-0 text-red-600 mt-px" />
+                    <span>{actionError}</span>
+                  </div>
+                )}
 
                 {/* GitHub Repository Link */}
                 {project.githubUrl && (


### PR DESCRIPTION
Fixes #19155

### Description

Registering for an event, registering for a hackathon, and upvoting a project all discarded their errors into `console.warn` and showed the user nothing. A failed action left the page visually unchanged, so users had no way to tell whether anything happened.

The project upvote additionally applied its optimistic increment and set `hasUpvoted` before awaiting the request, with no rollback on failure — so a rejected upvote left the button reading "Upvoted (n+1)" and disabled. The UI reported success for an operation that failed, and the count reverted on the next page load.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes

- Add an `actionError` state to the event, hackathon and project detail pages, rendered next to the action button with `role="alert"` and styled to match the existing error treatment on the login page.
- Roll back the optimistic upvote count and the `hasUpvoted` flag when the request fails, so the user can retry and the displayed count stays consistent with the server.
- Clamp the rolled-back count at zero.

### No API or backend changes

This is entirely client-side error handling.

### How this was tested

- `npm run build` passes; all 10 routes generate.
- `npx eslint src` reports 34 existing problems (7 errors, 27 warnings); no new lint issues were introduced by the patch.
- The implementation and upvote state-machine behavior were verified during development.

### Note on tests

The project has no frontend test runner (`package.json` has no `test` script or testing dependency), so no automated tests were added.

### Checklist

- [x] Changes are scoped to a single purpose
- [x] Code follows existing conventions
- [x] Existing functionality remains unchanged
- [x] PR description clearly explains what and why