### PR TITLE
fix(hackathons): handle registration errors, add auth guard, and sync server state (#19093)

### DIFF
--- a/src/app/hackathons/[id]/page.jsx
+++ b/src/app/hackathons/[id]/page.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { 
   Trophy, 
   MapPin, 
@@ -25,6 +25,7 @@ import { CardSkeleton } from "@/components/ui/Skeleton";
 
 export default function HackathonDetailPage() {
   const params = useParams();
+  const router = useRouter();
   const hackathonId = params?.id;
 
   const [hackathon, setHackathon] = useState(null);
@@ -34,24 +35,51 @@ export default function HackathonDetailPage() {
   const [registered, setRegistered] = useState(false);
 
   useEffect(() => {
+    let isMounted = true;
     async function loadHackathon() {
       setLoading(true);
+      setActionError("");
+      setRegistered(false);
       try {
         const data = await getHackathonById(hackathonId);
-        setHackathon(data);
+        if (isMounted) {
+          setHackathon(data);
+          if (data) {
+            setRegistered(Boolean(data.isRegistered || data.registered || data.hasRegistered));
+          }
+        }
       } catch (err) {
-        console.warn("Failed to load hackathon details", err);
+        if (isMounted) {
+          console.warn("Failed to load hackathon details", err);
+          setActionError("Could not load hackathon information.");
+        }
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     }
 
     if (hackathonId) {
       loadHackathon();
     }
+
+    return () => {
+      isMounted = false;
+    };
   }, [hackathonId]);
 
   const handleRegister = async () => {
+    if (!hackathon || registered || isRegistering) return;
+
+    // Check auth token before attempting registration
+    const token = typeof window !== "undefined" ? localStorage.getItem("eventra_token") : null;
+    if (!token) {
+      setActionError("You must be logged in to register for this hackathon.");
+      router.push(`/login?redirect=/hackathons/${hackathonId}`);
+      return;
+    }
+
     setIsRegistering(true);
     setActionError("");
     try {
@@ -251,6 +279,7 @@ export default function HackathonDetailPage() {
                 <button
                   onClick={handleRegister}
                   disabled={isRegistering}
+                  aria-busy={isRegistering}
                   className="w-full py-3.5 px-6 bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm rounded-2xl shadow-md shadow-amber-200 transition-all flex items-center justify-center gap-2 cursor-pointer disabled:opacity-50"
                 >
                   <Trophy className="w-4 h-4" />
@@ -261,10 +290,21 @@ export default function HackathonDetailPage() {
               {actionError && (
                 <div
                   role="alert"
-                  className="p-3 bg-red-50 border border-red-200 text-red-700 rounded-2xl text-xs flex items-start gap-2 font-medium"
+                  aria-live="polite"
+                  className="p-3 bg-red-50 border border-red-200 text-red-700 rounded-2xl text-xs flex flex-col gap-2 font-medium"
                 >
-                  <AlertCircle className="w-4 h-4 shrink-0 text-red-600 mt-px" />
-                  <span>{actionError}</span>
+                  <div className="flex items-start gap-2">
+                    <AlertCircle className="w-4 h-4 shrink-0 text-red-600 mt-0.5" />
+                    <span>{actionError}</span>
+                  </div>
+                  {actionError.toLowerCase().includes("logged in") && (
+                    <Link
+                      href={`/login?redirect=/hackathons/${hackathonId}`}
+                      className="text-xs font-bold text-red-800 underline hover:text-red-900 ml-6"
+                    >
+                      Sign In Now →
+                    </Link>
+                  )}
                 </div>
               )}
 

--- a/src/components/ui/DetailDrawer.jsx
+++ b/src/components/ui/DetailDrawer.jsx
@@ -5,30 +5,30 @@ import Image from "next/image";
 import Link from "next/link";
 import { 
   X, 
-  Calendar, 
   MapPin, 
-  Users, 
   Clock, 
   Trophy, 
-  Award, 
-  Sparkles, 
+  Users, 
   FolderKanban, 
   Heart, 
   Code2, 
   ArrowUpRight, 
   CheckCircle2, 
-  ExternalLink
+  ExternalLink,
+  AlertCircle
 } from "lucide-react";
 import { registerForEvent, registerForHackathon, upvoteProject } from "@/lib/api";
 
 export default function DetailDrawer({ isOpen, onClose, type, data }) {
   const [actionDone, setActionDone] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
+  const [actionError, setActionError] = useState("");
   const [upvotes, setUpvotes] = useState(data?.upvotes || 0);
 
   React.useEffect(() => {
-    setActionDone(false);
+    setActionDone(Boolean(data?.isRegistered || data?.registered || data?.hasRegistered || data?.hasUpvoted));
     setActionLoading(false);
+    setActionError("");
     setUpvotes(data?.upvotes || 0);
   }, [data, isOpen]);
 
@@ -65,6 +65,7 @@ export default function DetailDrawer({ isOpen, onClose, type, data }) {
 
   const handleAction = async () => {
     setActionLoading(true);
+    setActionError("");
     try {
       if (type === "event") {
         await registerForEvent(data.id);
@@ -78,7 +79,8 @@ export default function DetailDrawer({ isOpen, onClose, type, data }) {
         setActionDone(true);
       }
     } catch (err) {
-      setActionDone(true);
+      console.warn("Action error", err);
+      setActionError(err?.message || "Action could not be completed. Please try again.");
     } finally {
       setActionLoading(false);
     }
@@ -266,6 +268,17 @@ export default function DetailDrawer({ isOpen, onClose, type, data }) {
                   </span>
                 )}
               </button>
+            )}
+
+            {actionError && (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="p-2.5 bg-red-50 border border-red-200 text-red-700 rounded-xl text-xs flex items-start gap-2 font-medium"
+              >
+                <AlertCircle className="w-4 h-4 shrink-0 text-red-600 mt-0.5" />
+                <span>{actionError}</span>
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Description
Resolves #19093

While testing the hackathon registration flow on `/hackathons/[id]`, I noticed a couple of UX and error handling issues:
1. When unauthenticated users tried to click "Register Team / Submit", the API failed silently in the background and only logged a warning in the console without giving any visual feedback to the user.
2. If the API returned an error (such as a 400 when registration deadlines passed, or capacity limits), the catch block swallowed the error, making the button silently revert so users couldn't tell why registration didn't go through.
3. The page was not checking `isRegistered` from the initial hackathon response, so already-registered users didn't see their confirmed status on page load.

### What was done

- **Auth Guard & Redirect**: Added a check for active user session before triggering registration. Unauthenticated visitors are now smoothly redirected to `/login?redirect=/hackathons/[id]` with a clear notice to sign in.
- **Surface API & Network Errors**: Replaced the swallowed `console.warn` with an accessible error alert (`role="alert"` / `aria-live="polite"`) right below the register button so users can see exact server error messages (like deadline passed, capacity reached, etc.).
- **Server State Sync**: Initialized the registration state from `hackathon.isRegistered` / `registered` so returning users immediately see their "Registration Confirmed!" badge without resetting.
- **Button Loading States**: Added `isRegistering` disabled guards and `aria-busy` attributes to prevent duplicate submissions while the request is in flight.
- **Detail Drawer Fix**: Handled error states in `DetailDrawer.jsx` as well so it doesn't falsely mark registration as completed on API errors.

### Testing & Verification

- Tested locally on `localhost:3000`:
  - Verified clicking register while logged out redirects to login with the redirect query param.
  - Verified rejected registrations (e.g. `API Error 400: Registration deadline has passed for this hackathon`) now render a clean red error alert instead of silently reverting.
  - Verified already registered hackathons load with the confirmed status.
- Ran `npm run build` and confirmed the build passes with 0 errors.

https://github.com/user-attachments/assets/14379ac3-c4f1-4f48-ad53-08045b50adce

