### PR TITLE
fix(backend): persist add-on inventory in database with atomic decrement (#19087)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# maven
+target/
+Backend/target/
+

--- a/Backend/pom.xml
+++ b/Backend/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.4</version>
+        <relativePath/>
+    </parent>
+    <groupId>com.sandeep</groupId>
+    <artifactId>Eventra-Backend</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>Eventra-Backend</name>
+    <description>Eventra-Backend - Event Management Platform API</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/Backend/src/main/java/com/sandeep/eventrabackend/controller/UpgradeController.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/controller/UpgradeController.java
@@ -1,0 +1,43 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.service.UpgradeService;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Controller mapping ticket upgrade and add-on allocation REST endpoints (#16283, #19087).
+ */
+@RestController
+@RequestMapping("/api/upgrades")
+public class UpgradeController {
+
+    private final UpgradeService upgradeService;
+
+    public UpgradeController(UpgradeService upgradeService) {
+        this.upgradeService = upgradeService;
+    }
+
+    @PostMapping("/ticket/{ticketId}")
+    public ResponseEntity<String> upgrade(@PathVariable String ticketId, @RequestParam String targetTier) {
+        boolean success = upgradeService.upgradeTicket(ticketId, targetTier);
+        if (success) {
+            return ResponseEntity.ok("Ticket upgraded successfully to " + targetTier);
+        }
+        return ResponseEntity.badRequest().body("Failed to upgrade ticket.");
+    }
+
+    @PostMapping("/addon/{addonId}/allocate")
+    public ResponseEntity<String> allocateAddon(@PathVariable String addonId) {
+        boolean success = upgradeService.allocateAddon(addonId);
+        if (success) {
+            return ResponseEntity.ok("Add-on allocated successfully.");
+        }
+        return ResponseEntity.badRequest().body("Add-on allocation failed or quota depleted.");
+    }
+
+    @GetMapping("/addon/{addonId}/remaining")
+    public ResponseEntity<Integer> getRemainingQuota(@PathVariable String addonId) {
+        int remaining = upgradeService.getRemainingAddonQuota(addonId);
+        return ResponseEntity.ok(remaining);
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/model/AddonInventory.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/model/AddonInventory.java
@@ -1,0 +1,44 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+
+/**
+ * Entity representing persisted add-on quotas and inventory (#19087).
+ */
+@Entity
+@Table(name = "addon_inventory")
+public class AddonInventory {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private String id;
+
+    @Column(name = "remaining", nullable = false)
+    private Integer remaining;
+
+    public AddonInventory() {}
+
+    public AddonInventory(String id, Integer remaining) {
+        this.id = id;
+        this.remaining = remaining;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Integer getRemaining() {
+        return remaining;
+    }
+
+    public void setRemaining(Integer remaining) {
+        this.remaining = remaining;
+    }
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/repository/AddonInventoryRepository.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/repository/AddonInventoryRepository.java
@@ -1,0 +1,26 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.AddonInventory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface providing atomic database updates for add-on inventory (#19087).
+ */
+@Repository
+public interface AddonInventoryRepository extends JpaRepository<AddonInventory, String> {
+
+    /**
+     * Atomically decrements remaining add-on count by 1 if current count is greater than 0.
+     * Prevents race conditions and overselling across concurrent requests and multiple instances.
+     *
+     * @param addonId The unique identifier of the add-on.
+     * @return The number of rows updated (1 if successfully decremented, 0 if quota is depleted).
+     */
+    @Modifying
+    @Query("UPDATE AddonInventory a SET a.remaining = a.remaining - 1 WHERE a.id = :addonId AND a.remaining > 0")
+    int decrementRemainingIfPositive(@Param("addonId") String addonId);
+}

--- a/Backend/src/main/java/com/sandeep/eventrabackend/service/UpgradeService.java
+++ b/Backend/src/main/java/com/sandeep/eventrabackend/service/UpgradeService.java
@@ -1,0 +1,60 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.model.AddonInventory;
+import com.sandeep.eventrabackend.repository.AddonInventoryRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Dynamic Ticket Upgrade and Perks Allocation Service (#16283, #19087).
+ * Uses JPA repository with atomic database updates to ensure quota persistence across restarts
+ * and consistent limits across horizontally-scaled application instances.
+ */
+@Service
+public class UpgradeService {
+
+    private final AddonInventoryRepository addonInventoryRepository;
+    private final Map<String, String> ticketTiers = new ConcurrentHashMap<>();
+
+    public UpgradeService(AddonInventoryRepository addonInventoryRepository) {
+        this.addonInventoryRepository = addonInventoryRepository;
+        ticketTiers.put("TICKET_01", "GENERAL");
+    }
+
+    @PostConstruct
+    public void initInventory() {
+        // Idempotent initial seed of default add-on quotas if not already present in database
+        if (!addonInventoryRepository.existsById("VIP_LOUNGE_PASS")) {
+            addonInventoryRepository.save(new AddonInventory("VIP_LOUNGE_PASS", 15));
+        }
+    }
+
+    @Transactional
+    public boolean upgradeTicket(String ticketId, String targetTier) {
+        if (!ticketTiers.containsKey(ticketId)) {
+            return false;
+        }
+
+        ticketTiers.put(ticketId, targetTier);
+        return true;
+    }
+
+    @Transactional
+    public boolean allocateAddon(String addonId) {
+        int updated = addonInventoryRepository.decrementRemainingIfPositive(addonId);
+        return updated > 0;
+    }
+
+    public int getRemainingAddonQuota(String addonId) {
+        return addonInventoryRepository.findById(addonId)
+                .map(AddonInventory::getRemaining)
+                .orElse(0);
+    }
+
+    public String getTicketTier(String ticketId) {
+        return ticketTiers.get(ticketId);
+    }
+}

--- a/Backend/src/test/java/com/sandeep/eventrabackend/service/UpgradeServiceTest.java
+++ b/Backend/src/test/java/com/sandeep/eventrabackend/service/UpgradeServiceTest.java
@@ -1,0 +1,80 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.model.AddonInventory;
+import com.sandeep.eventrabackend.repository.AddonInventoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UpgradeServiceTest {
+
+    @Mock
+    private AddonInventoryRepository addonInventoryRepository;
+
+    @InjectMocks
+    private UpgradeService upgradeService;
+
+    @Test
+    @DisplayName("Should initialize VIP_LOUNGE_PASS inventory on startup if not already existing")
+    void testInitInventoryWhenNotExists() {
+        when(addonInventoryRepository.existsById("VIP_LOUNGE_PASS")).thenReturn(false);
+
+        upgradeService.initInventory();
+
+        verify(addonInventoryRepository, times(1)).save(any(AddonInventory.class));
+    }
+
+    @Test
+    @DisplayName("Should skip inventory initialization on startup if record already exists")
+    void testInitInventoryWhenAlreadyExists() {
+        when(addonInventoryRepository.existsById("VIP_LOUNGE_PASS")).thenReturn(true);
+
+        upgradeService.initInventory();
+
+        verify(addonInventoryRepository, never()).save(any(AddonInventory.class));
+    }
+
+    @Test
+    @DisplayName("Should return true when add-on inventory decrement succeeds")
+    void testAllocateAddonSuccess() {
+        when(addonInventoryRepository.decrementRemainingIfPositive("VIP_LOUNGE_PASS")).thenReturn(1);
+
+        boolean result = upgradeService.allocateAddon("VIP_LOUNGE_PASS");
+
+        assertTrue(result);
+        verify(addonInventoryRepository, times(1)).decrementRemainingIfPositive("VIP_LOUNGE_PASS");
+    }
+
+    @Test
+    @DisplayName("Should return false when add-on inventory is depleted (decrement returns 0)")
+    void testAllocateAddonDepleted() {
+        when(addonInventoryRepository.decrementRemainingIfPositive("VIP_LOUNGE_PASS")).thenReturn(0);
+
+        boolean result = upgradeService.allocateAddon("VIP_LOUNGE_PASS");
+
+        assertFalse(result);
+        verify(addonInventoryRepository, times(1)).decrementRemainingIfPositive("VIP_LOUNGE_PASS");
+    }
+
+    @Test
+    @DisplayName("Should return correct remaining quota from repository")
+    void testGetRemainingAddonQuota() {
+        AddonInventory inventory = new AddonInventory("VIP_LOUNGE_PASS", 10);
+        when(addonInventoryRepository.findById("VIP_LOUNGE_PASS")).thenReturn(Optional.of(inventory));
+
+        int remaining = upgradeService.getRemainingAddonQuota("VIP_LOUNGE_PASS");
+
+        assertEquals(10, remaining);
+    }
+}


### PR DESCRIPTION
## Description
Resolves #19087

I looked into the add-on allocation flow in `UpgradeService` and noticed that inventory quotas (like `VIP_LOUNGE_PASS`) were being kept in a local `ConcurrentHashMap`. 

Because of this:
- Every time the Spring Boot app restarted, the remaining count reset back to the hardcoded default (15), which allowed limited passes to be oversold.
- In multi-instance deployments, each instance had its own separate counter rather than sharing a single source of truth.
- The `@Transactional` annotation on `allocateAddon` wasn't actually protecting anything since no database resource was involved.

### What I did:

1. **Created `AddonInventory` JPA Entity & Repository**: Mapped a table with `id` and `remaining` count.
2. **Atomic DB Decrement**: Added a `@Modifying` conditional update query (`UPDATE AddonInventory a SET a.remaining = a.remaining - 1 WHERE a.id = :addonId AND a.remaining > 0`). This ensures that even under high concurrency across multiple servers, we never decrement below 0 or oversell.
3. **Refactored `UpgradeService`**: Switched from the in-memory map to the repository. Added an idempotent startup check so default quotas (`VIP_LOUNGE_PASS = 15`) are only seeded if they don't already exist in the database.
4. **Added REST Endpoints in `UpgradeController`**: Exposed endpoints to allocate an add-on and check remaining quota.
5. **Added Unit Tests (`UpgradeServiceTest`)**: Wrote 5 tests to cover startup seeding, successful decrement, quota depletion handling, and balance retrieval.

### How I tested it:

- Ran `mvn test` inside the `Backend` directory — all 5 unit tests passed cleanly with zero failures.
- Ran `npm run build` to ensure no frontend regressions.

https://github.com/user-attachments/assets/e14f68ee-48cc-4eef-8578-c0dc92c2ed03

